### PR TITLE
Bugfix: return undefined on empty opList

### DIFF
--- a/packages/runtime/merge-tree/src/client.ts
+++ b/packages/runtime/merge-tree/src/client.ts
@@ -872,10 +872,8 @@ export class Client {
             }
         }
 
-        if (opList.length === 1) {
-            return opList[0];
-        } else {
-            return OpBuilder.createGroupOp(...opList);
+        if (opList.length > 0) {
+            return opList.length === 1 ? opList[0] : OpBuilder.createGroupOp(...opList);
         }
     }
 


### PR DESCRIPTION
A bug was introduced in https://github.com/microsoft/Prague/pull/3490/files where sharedString was sending an empty op array after every connection/reconnection. This should fix the bug.