### PR TITLE
Add tests for nested handles and handles in SharedIntervalCollection

### DIFF
--- a/packages/runtime/map/src/test/map.spec.ts
+++ b/packages/runtime/map/src/test/map.spec.ts
@@ -98,6 +98,22 @@ describe("Routerlicious", () => {
                     sharedMap.set("test", subMap.handle);
                     assert.equal(sharedMap.get<IComponentHandle>("test").path, subMap.id);
                 });
+
+                it("Should be able to set and retrieve a plain object with nested handles", async () => {
+                    const subMap = factory.create(runtime, "subMap");
+                    const subMap2 = factory.create(runtime, "subMap2");
+                    const containingObject = {
+                        subMapHandle: subMap.handle,
+                        nestedObj: {
+                            subMap2Handle: subMap2.handle,
+                        },
+                    };
+                    sharedMap.set("object", containingObject);
+
+                    const retrieved = sharedMap.get("object");
+                    assert.equal(await retrieved.subMapHandle.get(), subMap);
+                    assert.equal(await retrieved.nestedObj.subMap2Handle.get(), subMap2);
+                });
             });
 
             describe(".forEach()", () => {
@@ -146,7 +162,7 @@ describe("Routerlicious", () => {
                     });
                 });
 
-                it("Should serialize and deserialize an undefined value", () => {
+                it("Should serialize an undefined value", () => {
                     sharedMap.set("first", "second");
                     sharedMap.set("third", "fourth");
                     sharedMap.set("fifth", undefined);
@@ -166,6 +182,21 @@ describe("Routerlicious", () => {
                             assert.equal(parsed[key].value.url, subMap.id);
                         }
                     });
+                });
+
+                it("Should serialize an object with nested handles", async () => {
+                    const subMap = factory.create(runtime, "subMap");
+                    const subMap2 = factory.create(runtime, "subMap2");
+                    const containingObject = {
+                        subMapHandle: subMap.handle,
+                        nestedObj: {
+                            subMap2Handle: subMap2.handle,
+                        },
+                    };
+                    sharedMap.set("object", containingObject);
+
+                    const serialized = (sharedMap as SharedMap).serialize();
+                    assert.equal(serialized, `{"object":{"type":"Plain","value":{"subMapHandle":{"type":"__fluid_handle__","url":"subMap"},"nestedObj":{"subMap2Handle":{"type":"__fluid_handle__","url":"subMap2"}}}}}`);
                 });
             });
 

--- a/packages/runtime/shared-object-common/src/valueType.ts
+++ b/packages/runtime/shared-object-common/src/valueType.ts
@@ -13,7 +13,7 @@ export enum ValueType {
     Shared,
 
     /**
-     * The value is a plain JavaScript object
+     * The value is a plain JavaScript object or handle.  If a plain object, it may contain handles deeper within.
      */
     Plain,
 }

--- a/packages/server/local-test-server/src/test/sharedInterval.spec.ts
+++ b/packages/server/local-test-server/src/test/sharedInterval.spec.ts
@@ -3,15 +3,29 @@
  * Licensed under the MIT License.
  */
 
+import * as api from "@prague/client-api";
+import { IComponentHandle } from "@prague/component-core-interfaces";
+import { ISerializableValue, ISharedMap, SharedMap } from "@prague/map";
 import { IntervalType, LocalReference } from "@prague/merge-tree";
+import { IBlob } from "@prague/protocol-definitions";
 import {
+    ISerializedInterval,
+    SharedIntervalCollection,
     SharedIntervalCollectionView,
     SharedString,
     SharedStringFactory,
     SharedStringInterval,
+    SharedStringIntervalCollectionValueType,
 } from "@prague/sequence";
 import * as assert from "assert";
-import { TestHost } from "../";
+import {
+    DocumentDeltaEventManager,
+    ITestDeltaConnectionServer,
+    TestDeltaConnectionServer,
+    TestDocumentServiceFactory,
+    TestHost,
+    TestResolver,
+} from "..";
 
 const assertIntervalsHelper = (
     sharedString: SharedString,
@@ -191,6 +205,114 @@ describe("SharedInterval", () => {
 
             await TestHost.sync(host1, host2);
             assertIntervalsHelper(sharedString1, intervals1, [{ start: 1, end: 7 }]);
+        });
+    });
+
+    describe("Handles in value types", () => {
+        const id = "fluid://test.com/test/test";
+
+        let testDeltaConnectionServer: ITestDeltaConnectionServer;
+        let documentDeltaEventManager: DocumentDeltaEventManager;
+        let user1Document: api.Document;
+        let user2Document: api.Document;
+        let user3Document: api.Document;
+        let root1: ISharedMap;
+        let root2: ISharedMap;
+        let root3: ISharedMap;
+
+        beforeEach(async () => {
+            testDeltaConnectionServer = TestDeltaConnectionServer.create();
+            documentDeltaEventManager = new DocumentDeltaEventManager(testDeltaConnectionServer);
+            const serviceFactory = new TestDocumentServiceFactory(testDeltaConnectionServer);
+            const resolver = new TestResolver();
+            user1Document = await api.load(
+                id, { resolver }, {}, serviceFactory);
+            documentDeltaEventManager.registerDocuments(user1Document);
+
+            user2Document = await api.load(
+                id, { resolver }, {}, serviceFactory);
+            documentDeltaEventManager.registerDocuments(user2Document);
+
+            user3Document = await api.load(
+                id, { resolver }, {}, serviceFactory);
+            documentDeltaEventManager.registerDocuments(user3Document);
+            root1 = user1Document.getRoot();
+            root2 = user2Document.getRoot();
+            root3 = user3Document.getRoot();
+            await documentDeltaEventManager.pauseProcessing();
+        });
+
+        // This functionality is used in Word and FlowView's "add comment" functionality.
+        it("Can store shared objects in a shared string's interval collection via properties", async () => {
+            root1.set("outerString", user1Document.createString().handle);
+            await documentDeltaEventManager.process(user1Document, user2Document, user3Document);
+
+            const outerString1 = await root1.get<IComponentHandle>("outerString").get<SharedString>();
+            const outerString2 = await root2.get<IComponentHandle>("outerString").get<SharedString>();
+            const outerString3 = await root3.get<IComponentHandle>("outerString").get<SharedString>();
+            assert.ok(outerString1);
+            assert.ok(outerString2);
+            assert.ok(outerString3);
+
+            outerString1.insertText(0, "outer string");
+
+            outerString1.set("comments", undefined, SharedStringIntervalCollectionValueType.Name);
+            await documentDeltaEventManager.process(user1Document, user2Document, user3Document);
+
+            const intervalCollection1 = outerString1.get<SharedIntervalCollection<SharedStringInterval>>("comments");
+            const intervalCollection2 = outerString2.get<SharedIntervalCollection<SharedStringInterval>>("comments");
+            const intervalCollection3 = outerString3.get<SharedIntervalCollection<SharedStringInterval>>("comments");
+            assert.ok(intervalCollection1);
+            assert.ok(intervalCollection2);
+            assert.ok(intervalCollection3);
+
+            intervalCollection1.attach(outerString1.client, "comments");
+            intervalCollection2.attach(outerString2.client, "comments");
+            intervalCollection3.attach(outerString3.client, "comments");
+
+            const comment1Text = user1Document.createString();
+            comment1Text.insertText(0, "a comment...");
+            intervalCollection1.add(0, 3, IntervalType.SlideOnRemove, { story: comment1Text.handle });
+            const comment2Text = user1Document.createString();
+            comment2Text.insertText(0, "another comment...");
+            intervalCollection1.add(5, 7, IntervalType.SlideOnRemove, { story: comment2Text.handle });
+            const nestedMap = user1Document.createMap();
+            nestedMap.set("nestedKey", "nestedValue");
+            intervalCollection1.add(8, 9, IntervalType.SlideOnRemove, { story: nestedMap.handle });
+            await documentDeltaEventManager.process(user1Document, user2Document, user3Document);
+
+            const serialized1 = intervalCollection1.serializeInternal();
+            const serialized2 = intervalCollection2.serializeInternal();
+            const serialized3 = intervalCollection3.serializeInternal();
+            assert.equal(serialized1.length, 3);
+            assert.equal(serialized2.length, 3);
+            assert.equal(serialized3.length, 3);
+
+            const interval1From3 = serialized3[0] as ISerializedInterval;
+            const comment1From3 = await (interval1From3.properties.story as IComponentHandle).get<SharedString>();
+            assert.equal(comment1From3.getText(0, 12), "a comment...");
+            const interval3From3 = serialized3[2] as ISerializedInterval;
+            const mapFrom3 = await (interval3From3.properties.story as IComponentHandle).get<SharedMap>();
+            assert.equal(mapFrom3.get("nestedKey"), "nestedValue");
+
+            // SharedString snapshots as a blob
+            const snapshotBlob = outerString2.snapshot().entries[0].value as IBlob;
+            // Since it's a SharedMap, its contents parse as an IMapDataObject with the "comments" member we set
+            const parsedSnapshot = JSON.parse(snapshotBlob.contents) as { comments: ISerializableValue };
+            // LocalIntervalCollection serializes as an array of ISerializedInterval, let's get the first comment
+            const serializedInterval1FromSnapshot = (parsedSnapshot.comments.value as ISerializedInterval[])[0];
+            // The "story" is the ILocalValue of the handle pointing to the SharedString
+            const handleLocalValueFromSnapshot = serializedInterval1FromSnapshot.properties.story as { type: string };
+            assert.equal(handleLocalValueFromSnapshot.type, "__fluid_handle__");
+        });
+
+        afterEach(async () => {
+            await Promise.all([
+                user1Document.close(),
+                user2Document.close(),
+                user3Document.close(),
+            ]);
+            await testDeltaConnectionServer.webSocketServer.close();
         });
     });
 });


### PR DESCRIPTION
This change adds tests for a couple handle serialization scenarios:

1. **Serialization of handles nested inside plain objects.**  A plain object which has descendant members that are handles is supported currently since the serializer descends into its structure and serializes each member.
2. **Serialization of handles held as members of value types.**  A value type with handle members will similarly be descended into and serialized.  This is used by flowView's `createComment` by placing the handle in the interval properties.  It may also be used by Word, though needs confirmation.