### PR TITLE
Fix inheritDoc reference

### DIFF
--- a/packages/runtime/map/src/directory.ts
+++ b/packages/runtime/map/src/directory.ts
@@ -369,7 +369,7 @@ export class SharedDirectory extends SharedObject implements ISharedDirectory {
     }
 
     /**
-     * {@inheritDoc SharedObject.snapshot}
+     * {@inheritDoc @prague/shared-object-common#SharedObject.snapshot}
      */
     public snapshot(): ITree {
         const tree: ITree = {


### PR DESCRIPTION
Need to use package syntax for external inheritDoc references.