### PR TITLE
Extend rather than nest config

### DIFF
--- a/packages/hosts/base-host/src/host.ts
+++ b/packages/hosts/base-host/src/host.ts
@@ -90,17 +90,18 @@ export async function registerAttach(loader: Loader, container: Container, uri: 
 
 export function createLoader(
     resolved: IResolvedUrl,
-    config: any,
+    options: any,
     scope: IComponent,
     codeLoader: ICodeLoader,
     hostConf: IHostConfig,
 ): Loader {
 
-    const options = {
-        blockUpdateMarkers: true,
-        config,
-        tokens: (resolved as IFluidResolvedUrl).tokens,
-    };
+    // we need to extend options, otherwise we nest properties, like client, too deeply
+    //
+    // tslint:disable-next-line: no-unsafe-any
+    options.blockUpdateMarkers = true;
+    // tslint:disable-next-line: no-unsafe-any
+    options.tokens = (resolved as IFluidResolvedUrl).tokens;
 
     return new Loader(
         { resolver: hostConf.urlResolver },


### PR DESCRIPTION
The client details, like type come in via the create loader options. Nesting this another level meant they couldn't be found. this change extends, rather than nests the incoming options.