### PR TITLE
Fix Fluid Debugger

### DIFF
--- a/packages/drivers/replay-socket-storage/src/replayDocumentServiceFactory.ts
+++ b/packages/drivers/replay-socket-storage/src/replayDocumentServiceFactory.ts
@@ -19,11 +19,13 @@ export class ReplayDocumentServiceFactory implements IDocumentServiceFactory {
         );
     }
 
-    public readonly protocolName = "prague-replay:";
+    public readonly protocolName;
 
     public constructor(
         private readonly documentServiceFactory: IDocumentServiceFactory,
-        private readonly controller: ReplayController) {}
+        private readonly controller: ReplayController) {
+            this.protocolName = documentServiceFactory.protocolName;
+        }
 
     /**
      * Creates a replay document service which uses the document service of provided


### PR DESCRIPTION
It does not work in 0.9 due to protocol name of replay storage not being prague-odsp