### PR TITLE
Add support for new odsp summary tree format

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentStorageManager.ts
@@ -164,9 +164,10 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
             commits[decodeURIComponent(key)] = hierarchicalTree.commits[key];
         }
 
-        if (commits && commits[".protocol"] && commits[".app"]) {
+        if (commits && commits[".app"]) {
             // the latest snapshot is a summary
-            return this.readSummaryTree(tree.sha, commits[".protocol"] as string, commits[".app"] as string);
+            // attempt to read .protocol from commits for backwards compat
+            return this.readSummaryTree(tree.sha, commits[".protocol"] || hierarchicalTree.trees[".protocol"], commits[".app"] as string);
         }
 
         if (hierarchicalTree.blobs) {
@@ -237,13 +238,13 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
                     eventName: "treesLatestStart",
                     perfType: "start",
                     tick: treesLatestStartTime,
-                  });
+                });
 
                 // TODO: This snapshot will return deltas, which we currently aren't using. We need to enable this flag to go down the "optimized"
                 // snapshot code path. We should leverage the fact that these deltas are returned to speed up the deltas fetch.
                 const { headers, url } = getUrlAndHeadersWithAuth(`${this.snapshotUrl}/trees/latest?deltas=1&channels=1&blobs=2`, storageToken);
 
-                const {trees, blobs, ops, sha} = await this.fetchWrapper.get<IOdspSnapshot>(url, this.documentId, headers);
+                const { trees, blobs, ops, sha } = await this.fetchWrapper.get<IOdspSnapshot>(url, this.documentId, headers);
 
                 const treesLatestEndTime = performance.now();
                 this.logger.send({
@@ -252,7 +253,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
                     perfType: "end",
                     duration: treesLatestEndTime - treesLatestStartTime,
                     tick: treesLatestEndTime,
-                  });
+                });
 
                 if (trees) {
                     this.initTreesCache(trees);
@@ -373,28 +374,40 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
     /**
      * Reads a summary tree
      * @param snapshotTreeId - Id of the snapshot
-     * @param protocolTreeId - Id of the protocol tree
+     * @param protocolTreeOrId - Protocol snapshot tree or id of the protocol tree
      * @param appTreeId - Id of the app tree
      */
-    private async readSummaryTree(snapshotTreeId: string, protocolTreeId: string, appTreeId: string): Promise<api.ISnapshotTree> {
+    private async readSummaryTree(snapshotTreeId: string, protocolTreeOrId: api.ISnapshotTree | string, appTreeId: string): Promise<api.ISnapshotTree> {
         // load the app and protocol trees and return them
-        const trees = await Promise.all([
-            this.readTree(protocolTreeId),
-            this.readTree(appTreeId),
-        ]);
+        let hierarchicalProtocolTree: api.ISnapshotTree;
+        let appTree: resources.ITree | null;
 
-        // merge trees
-        const protocolTree = trees[0];
-        if (!protocolTree) {
-            throw new Error("Invalid protocol tree");
+        if (typeof (protocolTreeOrId) === "string") {
+            // backwards compat for older summaries
+            const trees = await Promise.all([
+                this.readTree(protocolTreeOrId),
+                this.readTree(appTreeId),
+            ]);
+
+            const protocolTree = trees[0];
+            if (!protocolTree) {
+                throw new Error("Invalid protocol tree");
+            }
+
+            appTree = trees[1];
+
+            hierarchicalProtocolTree = buildHierarchy(protocolTree);
+
+        } else {
+            appTree = await this.readTree(appTreeId);
+
+            hierarchicalProtocolTree = protocolTreeOrId;
         }
 
-        const appTree = trees[1];
         if (!appTree) {
             throw new Error("Invalid app tree");
         }
 
-        const hierarchicalProtocolTree = buildHierarchy(protocolTree);
         const hierarchicalAppTree = buildHierarchy(appTree);
 
         if (hierarchicalProtocolTree.blobs) {


### PR DESCRIPTION
The newer format has the ".protocol" tree as a normal tree, instead of having it in a separate commit.

Previously the server made new summaries by writing the .protocol tree and then writing the final summary tree (2 requests to SPO). Now the server will write the summary with just 1 request. This is beneficial for the files antler graph (should lead to less contention).

The server will be updated once the client picks up this change.