### PR TITLE
Relax quorum assert for now in 0.9, to allow corrupted documents to move along

### DIFF
--- a/packages/loader/container-loader/src/quorum.ts
+++ b/packages/loader/container-loader/src/quorum.ts
@@ -162,7 +162,9 @@ export class Quorum extends EventEmitter implements IQuorum {
      * Removes a client from the quorum
      */
     public removeMember(clientId: string) {
-        assert(this.members.has(clientId), `this.members.has(${clientId})`);
+        if (!this.members.has(clientId) && this.logger) {
+            this.logger.sendErrorEvent({ eventName: "removeMemberNotFound", clientId });
+        }
         this.members.delete(clientId);
         this.emit("removeMember", clientId);
     }


### PR DESCRIPTION
Note: This is for 0.9.
We should discuss separately if it makes sense to have such change in master / 10.0
We need to get to the bottom of how it happens that file contains leave messages for non-existing members.