### PR TITLE
Move OuterDocumentDeltaConnection out of OuterDocumentService

### DIFF
--- a/packages/drivers/iframe-socket-storage/src/innerDocumentServiceFactory.ts
+++ b/packages/drivers/iframe-socket-storage/src/innerDocumentServiceFactory.ts
@@ -11,15 +11,11 @@ import { InnerDocumentService } from "./innerDocumentService";
  */
 export class InnerDocumentServiceFactory implements IDocumentServiceFactory {
     public readonly protocolName = "fluid:";
-    private innerDocumentServiceP: Promise<IDocumentService> | undefined;
     constructor() {
 
     }
 
     public async createDocumentService(resolvedUrl: IResolvedUrl): Promise<IDocumentService> {
-        if (!this.innerDocumentServiceP) {
-            this.innerDocumentServiceP = InnerDocumentService.create();
-        }
-        return this.innerDocumentServiceP;
+        return InnerDocumentService.create();
     }
 }

--- a/packages/drivers/iframe-socket-storage/src/innerDocumentServiceFactory.ts
+++ b/packages/drivers/iframe-socket-storage/src/innerDocumentServiceFactory.ts
@@ -11,11 +11,16 @@ import { InnerDocumentService } from "./innerDocumentService";
  */
 export class InnerDocumentServiceFactory implements IDocumentServiceFactory {
     public readonly protocolName = "fluid:";
+    private innerDocumentServiceP: Promise<IDocumentService> | undefined;
     constructor() {
 
     }
 
     public async createDocumentService(resolvedUrl: IResolvedUrl): Promise<IDocumentService> {
-        return InnerDocumentService.create();
+        if (!this.innerDocumentServiceP) {
+
+            this.innerDocumentServiceP = InnerDocumentService.create();
+        }
+        return this.innerDocumentServiceP;
     }
 }

--- a/packages/drivers/iframe-socket-storage/src/innerDocumentServiceFactory.ts
+++ b/packages/drivers/iframe-socket-storage/src/innerDocumentServiceFactory.ts
@@ -18,7 +18,6 @@ export class InnerDocumentServiceFactory implements IDocumentServiceFactory {
 
     public async createDocumentService(resolvedUrl: IResolvedUrl): Promise<IDocumentService> {
         if (!this.innerDocumentServiceP) {
-
             this.innerDocumentServiceP = InnerDocumentService.create();
         }
         return this.innerDocumentServiceP;

--- a/packages/drivers/iframe-socket-storage/src/outerDocumentService.ts
+++ b/packages/drivers/iframe-socket-storage/src/outerDocumentService.ts
@@ -43,69 +43,60 @@ export class OuterDocumentService implements IDocumentService {
     public static async create(
         documentService: IDocumentService, frame: HTMLIFrameElement): Promise<OuterDocumentService> {
 
-        const [storage, deltaStorage] = await Promise.all([documentService.connectToStorage(),
-        documentService.connectToDeltaStorage()]);
+        const [storage, deltaStorage, deltaConnection] = await Promise.all([
+            documentService.connectToStorage(),
+            documentService.connectToDeltaStorage(),
+            documentService.connectToDeltaStream(undefined as unknown as IClient),
+        ]);
 
         return new OuterDocumentService(
             storage as DocumentStorageService,
             deltaStorage,
-            documentService,
+            deltaConnection,
             frame,
         );
 
     }
 
-    private deltaConnection: IDocumentDeltaConnection | undefined;
-    private readonly proxiedFunctionsFromInnerFrameP: Promise<IInnerProxy>;
-    private getProxyFromOuterDocumentDeltaConnection!: (IOuterDocumentDeltaConnection) => any;
+    private readonly handshake: Deferred<IInnerProxy>;
     private outerDocumentStorageService: IDocumentStorageService;
     private outerDeltaStorageService: IDocumentDeltaStorageService;
+    private outerDocumentDeltaConnection: IDocumentDeltaConnection;
 
     constructor(private readonly storageService: DocumentStorageService,
                 private readonly deltaStorage: IDocumentDeltaStorageService,
-                private readonly documentService: IDocumentService,
+                private readonly deltaConnection: IDocumentDeltaConnection,
                 frame: HTMLIFrameElement,
     ) {
+        this.handshake = new Deferred<IInnerProxy>();
+
         this.outerDocumentStorageService = this.createDocumentStorageService(storageService);
         this.outerDeltaStorageService = this.createDeltaStorageService(deltaStorage);
+        this.outerDocumentDeltaConnection = this.createDocumentDeltaConnection(undefined as unknown as IClient);
 
         // Host guarantees that frame and contentwindow are both loaded
         const iframeContentWindow = frame!.contentWindow!;
 
-        const handshake = new Deferred<IInnerProxy>();
-        // tslint:disable-next-line: promise-must-complete
-        this.proxiedFunctionsFromInnerFrameP = handshake.promise;
-
         const connected = async () => {
+            console.log("OuterDocumentService.connected");
             return true;
         };
 
-        // Put a callback in place to get the outerProxy from outerDocumentDeltaConnection
-        // tslint:disable-next-line: promise-must-complete
-        const deltaConnectionProxyP = new Promise<IOuterDocumentDeltaConnection>((resolve) => {
-            this.getProxyFromOuterDocumentDeltaConnection = resolve;
-        });
+        console.log("OuterDocumentService.DeltaConnected");
+        const outerDocumentServiceProxy: IOuterProxy = {
+            ...(this.outerDocumentDeltaConnection as OuterDocumentDeltaConnection)
+                .getOuterDocumentDeltaConnection(),
+            ...(this.outerDocumentStorageService as OuterDocumentStorageService)
+                .getOuterDocumentStorageServiceProxy(),
+            ...(this.outerDeltaStorageService as OuterDeltaStorageService)
+                .getOuterDocumentDeltaStorageProxy(),
+            handshake: this.handshake,
+            connected,
+        };
 
-        deltaConnectionProxyP
-            .then(async (deltaConnectionProxy) => {
-
-                const outerDocumentServiceProxy: IOuterProxy = {
-                    ...deltaConnectionProxy,
-                    ...(this.outerDocumentStorageService as OuterDocumentStorageService)
-                        .getOuterDocumentStorageServiceProxy(),
-                    ...(this.outerDeltaStorageService as OuterDeltaStorageService)
-                        .getOuterDocumentDeltaStorageProxy(),
-                    handshake,
-                    connected,
-                };
-
-                iframeContentWindow.window.postMessage("EndpointExposed", "*");
-                const endpoint = Comlink.windowEndpoint(iframeContentWindow);
-                Comlink.expose(outerDocumentServiceProxy, endpoint);
-            })
-            .catch((err) => {
-                console.error(err);
-            });
+        iframeContentWindow.window.postMessage("EndpointExposed", "*");
+        const endpoint = Comlink.windowEndpoint(iframeContentWindow);
+        Comlink.expose(outerDocumentServiceProxy, endpoint);
     }
 
     /**
@@ -132,29 +123,7 @@ export class OuterDocumentService implements IDocumentService {
      * @returns returns the document delta stream service for routerlicious driver.
      */
     public async connectToDeltaStream(client: IClient): Promise<IDocumentDeltaConnection> {
-        this.deltaConnection = await this.documentService.connectToDeltaStream(client);
-        assert((this.deltaConnection as any).socket !== undefined);
-
-        const connection: IConnected = {
-            claims: this.deltaConnection.claims,
-            clientId: this.deltaConnection.clientId,
-            existing: this.deltaConnection.existing,
-            initialContents: this.deltaConnection.initialContents,
-            initialMessages: this.deltaConnection.initialMessages,
-            initialSignals: this.deltaConnection.initialSignals,
-            maxMessageSize: this.deltaConnection.maxMessageSize,
-            parentBranch: this.deltaConnection.parentBranch,
-            serviceConfiguration: this.deltaConnection.serviceConfiguration,
-            version: this.deltaConnection.version,
-            supportedVersions: protocolVersions,
-        };
-
-        return OuterDocumentDeltaConnection.create(
-            this.deltaConnection,
-            connection,
-            this.proxiedFunctionsFromInnerFrameP,
-            this.getProxyFromOuterDocumentDeltaConnection,
-        );
+        return this.createDocumentDeltaConnection(client);
     }
 
     public async branch(): Promise<string> {
@@ -164,6 +133,38 @@ export class OuterDocumentService implements IDocumentService {
     public getErrorTrackingService() {
         throw new Error("Outer Document Service: getErrorTrackingService not implemented");
         return null;
+    }
+
+    private createDocumentDeltaConnection(client: IClient): IDocumentDeltaConnection {
+        if (!this.outerDocumentDeltaConnection) {
+            // tslint:disable-next-line: promise-must-complete
+            const proxiedFunctionsFromInnerFrameP = this.handshake.promise;
+
+            assert((this.deltaConnection as any).socket !== undefined);
+            console.log(client);
+
+            const connection: IConnected = {
+                claims: this.deltaConnection.claims,
+                clientId: this.deltaConnection.clientId,
+                existing: this.deltaConnection.existing,
+                initialContents: this.deltaConnection.initialContents,
+                initialMessages: this.deltaConnection.initialMessages,
+                initialSignals: this.deltaConnection.initialSignals,
+                maxMessageSize: this.deltaConnection.maxMessageSize,
+                parentBranch: this.deltaConnection.parentBranch,
+                serviceConfiguration: this.deltaConnection.serviceConfiguration,
+                version: this.deltaConnection.version,
+                supportedVersions: protocolVersions,
+            };
+
+            this.outerDocumentDeltaConnection = OuterDocumentDeltaConnection.create(
+                this.deltaConnection,
+                connection,
+                proxiedFunctionsFromInnerFrameP,
+            );
+        }
+
+        return this.outerDocumentDeltaConnection;
     }
 
     private createDocumentStorageService(storageService: DocumentStorageService) {

--- a/packages/drivers/iframe-socket-storage/src/outerDocumentService.ts
+++ b/packages/drivers/iframe-socket-storage/src/outerDocumentService.ts
@@ -8,6 +8,7 @@ import {
     IDocumentDeltaStorageService,
     IDocumentService,
     IDocumentStorageService,
+    ScopeType,
 } from "@prague/protocol-definitions";
 import { DocumentStorageService } from "@prague/routerlicious-socket-storage";
 import {
@@ -42,11 +43,19 @@ export interface IOuterProxy extends IOuterDocumentDeltaConnection,
 export class OuterDocumentService implements IDocumentService {
     public static async create(
         documentService: IDocumentService, frame: HTMLIFrameElement): Promise<OuterDocumentService> {
+        const client: IClient = {
+            permission: [],
+            scopes: [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite],
+            type: "browser",
+            user: {
+                id: "iframe-user",
+            },
+        };
 
         const [storage, deltaStorage, deltaConnection] = await Promise.all([
             documentService.connectToStorage(),
             documentService.connectToDeltaStorage(),
-            documentService.connectToDeltaStream(undefined as unknown as IClient),
+            documentService.connectToDeltaStream(client),
         ]);
 
         return new OuterDocumentService(

--- a/packages/drivers/iframe-socket-storage/src/outerDocumentService.ts
+++ b/packages/drivers/iframe-socket-storage/src/outerDocumentService.ts
@@ -78,11 +78,9 @@ export class OuterDocumentService implements IDocumentService {
         const iframeContentWindow = frame!.contentWindow!;
 
         const connected = async () => {
-            console.log("OuterDocumentService.connected");
             return true;
         };
 
-        console.log("OuterDocumentService.DeltaConnected");
         const outerDocumentServiceProxy: IOuterProxy = {
             ...(this.outerDocumentDeltaConnection as OuterDocumentDeltaConnection)
                 .getOuterDocumentDeltaConnection(),
@@ -137,7 +135,6 @@ export class OuterDocumentService implements IDocumentService {
 
     private createDocumentDeltaConnection(client: IClient): IDocumentDeltaConnection {
         if (!this.outerDocumentDeltaConnection) {
-            // tslint:disable-next-line: promise-must-complete
             const proxiedFunctionsFromInnerFrameP = this.handshake.promise;
 
             assert((this.deltaConnection as any).socket !== undefined);

--- a/packages/drivers/socket-storage-shared/src/outerDocumentDeltaConnection.ts
+++ b/packages/drivers/socket-storage-shared/src/outerDocumentDeltaConnection.ts
@@ -38,18 +38,16 @@ export class OuterDocumentDeltaConnection extends EventEmitter implements IDocum
      *
      * @param id - document ID
      */
-    public static async create(
+    public static create(
         documentDeltaConnection: IDocumentDeltaConnection,
         connection: IConnected,
         proxiedFunctionsFromInnerFrameP: Promise<IInnerDocumentDeltaConnectionProxy>,
-        proxyCallback: (IOuterDocumentDeltaConnection) => any,
-    ): Promise<IDocumentDeltaConnection> {
+    ): IDocumentDeltaConnection {
 
         const deltaConnection = new OuterDocumentDeltaConnection(
             connection,
             documentDeltaConnection,
             proxiedFunctionsFromInnerFrameP,
-            proxyCallback,
         );
 
         return deltaConnection;
@@ -150,37 +148,8 @@ export class OuterDocumentDeltaConnection extends EventEmitter implements IDocum
         public details: IConnected,
         private readonly connection: IDocumentDeltaConnection,
         private readonly proxiedFunctionsFromInnerFrameP: Promise<IInnerDocumentDeltaConnectionProxy>,
-        proxyCallback: (IOuterDocumentDeltaConnection) => any) {
+        ) {
         super();
-
-        // Test
-        async function add(a: number, b: number): Promise<number> {
-            return a + b;
-        }
-
-        // function getDetails(): IConnected {
-        //     return details;
-        // }
-        const getDetails = async () => details;
-
-        const submit = async (messages: IDocumentMessage[]) => {
-            this.connection.submit(messages);
-        };
-
-        const submitSignal = async (message: IDocumentMessage) => {
-            this.connection.submitSignal(message);
-        };
-
-        const outerMethodsToProxy: IOuterDocumentDeltaConnection = {
-            add,
-            getDetails,
-            submit,
-            submitSignal,
-        };
-
-        // this has to happen before the innerProxyP resolution
-        // tslint:disable-next-line: no-unsafe-any
-        proxyCallback(outerMethodsToProxy);
 
         // This cannot be an await, must be a then
         // Or else it causes a deadlock
@@ -227,6 +196,33 @@ export class OuterDocumentDeltaConnection extends EventEmitter implements IDocum
             .catch((err) => {
                 console.error(err);
             });
+    }
+
+    public getOuterDocumentDeltaConnection(): IOuterDocumentDeltaConnection {
+
+        // Test
+        async function add(a: number, b: number): Promise<number> {
+            return a + b;
+        }
+
+        const getDetails = async () => this.details;
+
+        const submit = async (messages: IDocumentMessage[]) => {
+            this.connection.submit(messages);
+        };
+
+        const submitSignal = async (message: IDocumentMessage) => {
+            this.connection.submitSignal(message);
+        };
+
+        const outerMethodsToProxy: IOuterDocumentDeltaConnection = {
+            add,
+            getDetails,
+            submit,
+            submitSignal,
+        };
+
+        return outerMethodsToProxy;
     }
 
     /**


### PR DESCRIPTION
DocumentDeltaConnection was an anti-pattern, relying too heavily on OuterDocumentService