### PR TITLE
Fix two TS definition issues in server packages

### DIFF
--- a/packages/drivers/socket-storage-shared/package.json
+++ b/packages/drivers/socket-storage-shared/package.json
@@ -23,15 +23,15 @@
   "dependencies": {
     "@prague/protocol-definitions": "^0.10.0",
     "@prague/utils": "^0.10.0",
+    "@types/debug": "^0.0.31",
+    "@types/node": "^10.12.12",
+    "@types/socket.io-client": "^1.4.32",
     "debug": "^4.1.1",
     "comlink": "^4.0.2"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.3.11",
     "@microsoft/fluid-build-common": "^0.10.0",
-    "@types/debug": "^0.0.31",
-    "@types/node": "^10.12.12",
-    "@types/socket.io-client": "^1.4.32",
     "concurrently": "^4.1.0",
     "rimraf": "^2.6.2",
     "tslint": "^5.11.0",

--- a/packages/server/memory-orderer/package.json
+++ b/packages/server/memory-orderer/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@prague/container-loader": "^0.10.0",
     "@microsoft/fluid-server-lambdas": "^0.10.0",
+    "@microsoft/fluid-server-services-client": "^0.10.0",
     "@prague/protocol-definitions": "^0.10.0",
     "@microsoft/fluid-server-services-core": "^0.10.0",
     "@prague/utils": "^0.10.0",

--- a/packages/server/memory-orderer/src/localOrderer.ts
+++ b/packages/server/memory-orderer/src/localOrderer.ts
@@ -13,6 +13,7 @@ import {
     ScribeLambda,
     ScriptoriumLambda,
 } from "@microsoft/fluid-server-lambdas";
+import { IGitManager } from "@microsoft/fluid-server-services-client";
 import {
     IContext,
     IDatabaseManager,
@@ -30,7 +31,6 @@ import {
 import { ProtocolOpHandler } from "@prague/container-loader";
 import { IClient, IServiceConfiguration } from "@prague/protocol-definitions";
 import * as assert from "assert";
-import { IGitManager } from "../../services-client/dist";
 import { ILocalOrdererSetup } from "./interfaces";
 import { LocalKafka } from "./localKafka";
 import { LocalLambdaController } from "./localLambdaController";


### PR DESCRIPTION
localOrderer uses a relative path reference to a file in a separate package rather than to the package itself. This causes problems when directly installing it.

Update socket-storage-shared to include typing definitions as a dependency rather than a devDependency. It's a required reference for its own d.ts definitions so needs to be installed with the package.