### PR TITLE
Quick fix to surface 404s (file not found) to the app.

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -413,13 +413,8 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         return root;
     }
 
-    private async getVersion(version: string): Promise<IVersion[]> {
-        try {
-            return await this.storageService!.getVersions(version, 1);
-        } catch (error) {
-            this.logger.logException({ eventName: "GetVersionsFailed" }, error);
-            return [];
-        }
+    private getVersion(version: string): Promise<IVersion[]> {
+        return this.storageService!.getVersions(version, 1);
     }
 
     private connectToDeltaStream() {


### PR DESCRIPTION
Failures on web socket and storage are ignored and retried (until we fix error handling properly).
This is regresison of optmizing boot path, we were failing on connection to delta storage before, now this call is not present on critical code path