### PR TITLE
Avoid opstream call in the create new flow

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspDeltaStorageService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDeltaStorageService.ts
@@ -30,7 +30,7 @@ export class OdspDeltaStorageService implements api.IDocumentDeltaStorageService
         from?: number,
         to?: number,
     ): Promise<api.ISequencedDocumentMessage[]> {
-        if (this.ops !== undefined && from) {
+        if (this.ops !== undefined && from !== undefined) {
             const returnOps = this.ops;
             this.ops = undefined;
 


### PR DESCRIPTION
The ODSP driver makes a `trees/latest` call today that populates the initial snapshot and the latest ops in a single request. This enables us to skip an XHR to get the initial ops when connecting to a container. We recently noticed that for new documents, we have an opstream request even though trees/latest returned an (empty) opstream. 

A deeper dive showed that this was because we were checking if the from parameter was provided to get with a falsy check, which meant that we'd skip the branch when the value zero was given to from.