### PR TITLE
Move component registry interfaces to runtime definitions from container definitions

### DIFF
--- a/packages/components/external-component-loader/src/urlRegistry.ts
+++ b/packages/components/external-component-loader/src/urlRegistry.ts
@@ -5,8 +5,7 @@
 // tslint:disable: no-console
 import { IComponent, IComponentQueryableLegacy } from "@prague/component-core-interfaces";
 import { IFluidPackage, IPraguePackage } from "@prague/container-definitions";
-import { ComponentRegistryTypes, IComponentRegistry } from "@prague/container-runtime";
-import { ComponentFactoryTypes, IComponentFactory } from "@prague/runtime-definitions";
+import { ComponentFactoryTypes, ComponentRegistryTypes, IComponentFactory, IComponentRegistry } from "@prague/runtime-definitions";
 import { Deferred } from "@prague/utils";
 
 /**

--- a/packages/components/external-component-loader/src/waterParkModuleInstantiationFactory.ts
+++ b/packages/components/external-component-loader/src/waterParkModuleInstantiationFactory.ts
@@ -7,7 +7,7 @@ import { SimpleContainerRuntimeFactory, SimpleModuleInstantiationFactory } from 
 import {
     IContainerContext, IRuntime,
 } from "@prague/container-definitions";
-import { ComponentRegistryTypes } from "@prague/container-runtime";
+import { ComponentRegistryTypes } from "@prague/runtime-definitions";
 import * as uuid from "uuid";
 import { ExternalComponentLoader, WaterParkLoaderName } from "./waterParkLoader";
 import { ExternalComponentView, WaterParkViewName } from "./waterParkView";

--- a/packages/components/shared-text/src/index.ts
+++ b/packages/components/shared-text/src/index.ts
@@ -9,8 +9,8 @@ import "./publicpath";
 
 import { IRequest } from "@prague/component-core-interfaces";
 import { IContainerContext, IRuntime, IRuntimeFactory } from "@prague/container-definitions";
-import { ContainerRuntime, IComponentRegistry } from "@prague/container-runtime";
-import { IComponentContext, IComponentFactory } from "@prague/runtime-definitions";
+import { ContainerRuntime } from "@prague/container-runtime";
+import { IComponentContext, IComponentFactory, IComponentRegistry } from "@prague/runtime-definitions";
 // import { SharedString } from "@prague/sequence";
 import * as Snapshotter from "@prague/snapshotter";
 import * as sharedTextComponent from "./component";

--- a/packages/framework/aqueduct/src/helpers/simpleContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/helpers/simpleContainerRuntimeFactory.ts
@@ -8,8 +8,8 @@ import {
     IRequest,
 } from "@prague/component-core-interfaces";
 import { IContainerContext } from "@prague/container-definitions";
-import { ComponentRegistryTypes, ContainerRuntime } from "@prague/container-runtime";
-import { IHostRuntime } from "@prague/runtime-definitions";
+import { ContainerRuntime } from "@prague/container-runtime";
+import { ComponentRegistryTypes, IHostRuntime } from "@prague/runtime-definitions";
 
 export class SimpleContainerRuntimeFactory {
     public static readonly defaultComponentId = "default";

--- a/packages/framework/aqueduct/src/helpers/simpleModuleInstantiationFactory.ts
+++ b/packages/framework/aqueduct/src/helpers/simpleModuleInstantiationFactory.ts
@@ -7,8 +7,7 @@ import { IComponent } from "@prague/component-core-interfaces";
 import {
     IContainerContext, IRuntime, IRuntimeFactory,
 } from "@prague/container-definitions";
-import { ComponentRegistryTypes, IComponentRegistry } from "@prague/container-runtime";
-import { ComponentFactoryTypes, IComponentContext, IComponentFactory } from "@prague/runtime-definitions";
+import { ComponentFactoryTypes, ComponentRegistryTypes, IComponentContext, IComponentFactory, IComponentRegistry } from "@prague/runtime-definitions";
 import { SimpleContainerRuntimeFactory } from "./simpleContainerRuntimeFactory";
 
 /**

--- a/packages/runtime/client-api/src/api/codeLoader.ts
+++ b/packages/runtime/client-api/src/api/codeLoader.ts
@@ -14,12 +14,13 @@ import {
     IRuntime,
     IRuntimeFactory,
 } from "@prague/container-definitions";
-import { ContainerRuntime, IComponentRegistry, IContainerRuntimeOptions } from "@prague/container-runtime";
+import { ContainerRuntime, IContainerRuntimeOptions } from "@prague/container-runtime";
 import * as ink from "@prague/ink";
 import * as map from "@prague/map";
 import {
     IComponentContext,
     IComponentFactory,
+    IComponentRegistry,
 } from "@prague/runtime-definitions";
 import * as sequence from "@prague/sequence";
 import { Document } from "./document";

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -45,8 +45,10 @@ import {
 } from "@prague/protocol-definitions";
 import {
     ComponentFactoryTypes,
+    ComponentRegistryTypes,
     FlushMode,
     IAttachMessage,
+    IComponentRegistry,
     IComponentRuntime,
     IEnvelope,
     IHelpMessage,
@@ -78,21 +80,6 @@ import { LeaderElector } from "./leaderElection";
 import { Summarizer } from "./summarizer";
 import { SummaryManager } from "./summaryManager";
 import { analyzeTasks } from "./taskAnalyzer";
-
-declare module "@prague/component-core-interfaces" {
-    export interface IComponent extends Readonly<Partial<IProvideComponentRegistry>> {}
-}
-
-export type ComponentRegistryTypes =
-    IComponentRegistry | { get(name: string): Promise<ComponentFactoryTypes> | undefined };
-
-export interface IProvideComponentRegistry {
-    IComponentRegistry: IComponentRegistry;
-}
-
-export interface IComponentRegistry extends IProvideComponentRegistry {
-    get(name: string): Promise<ComponentFactoryTypes> | undefined;
-}
 
 interface IBufferedChunk {
     type: MessageType;

--- a/packages/runtime/runtime-definitions/src/componentFactory.ts
+++ b/packages/runtime/runtime-definitions/src/componentFactory.ts
@@ -26,3 +26,18 @@ export interface IComponentFactory extends IProvideComponentFactory {
 }
 
 export type ComponentFactoryTypes = IComponentFactory | { instantiateComponent(context: IComponentContext): void; };
+
+declare module "@prague/component-core-interfaces" {
+    export interface IComponent extends Readonly<Partial<IProvideComponentRegistry>> {}
+}
+
+export type ComponentRegistryTypes =
+    IComponentRegistry | { get(name: string): Promise<ComponentFactoryTypes> | undefined };
+
+export interface IProvideComponentRegistry {
+    IComponentRegistry: IComponentRegistry;
+}
+
+export interface IComponentRegistry extends IProvideComponentRegistry {
+    get(name: string): Promise<ComponentFactoryTypes> | undefined;
+}

--- a/packages/runtime/runtime-definitions/src/componentFactory.ts
+++ b/packages/runtime/runtime-definitions/src/componentFactory.ts
@@ -26,18 +26,3 @@ export interface IComponentFactory extends IProvideComponentFactory {
 }
 
 export type ComponentFactoryTypes = IComponentFactory | { instantiateComponent(context: IComponentContext): void; };
-
-declare module "@prague/component-core-interfaces" {
-    export interface IComponent extends Readonly<Partial<IProvideComponentRegistry>> {}
-}
-
-export type ComponentRegistryTypes =
-    IComponentRegistry | { get(name: string): Promise<ComponentFactoryTypes> | undefined };
-
-export interface IProvideComponentRegistry {
-    IComponentRegistry: IComponentRegistry;
-}
-
-export interface IComponentRegistry extends IProvideComponentRegistry {
-    get(name: string): Promise<ComponentFactoryTypes> | undefined;
-}

--- a/packages/runtime/runtime-definitions/src/componentRegistry.ts
+++ b/packages/runtime/runtime-definitions/src/componentRegistry.ts
@@ -1,0 +1,21 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ComponentFactoryTypes } from "./componentFactory";
+
+declare module "@prague/component-core-interfaces" {
+    export interface IComponent extends Readonly<Partial<IProvideComponentRegistry>> {}
+}
+
+export type ComponentRegistryTypes =
+    IComponentRegistry | { get(name: string): Promise<ComponentFactoryTypes> | undefined };
+
+export interface IProvideComponentRegistry {
+    IComponentRegistry: IComponentRegistry;
+}
+
+export interface IComponentRegistry extends IProvideComponentRegistry {
+    get(name: string): Promise<ComponentFactoryTypes> | undefined;
+}

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -9,3 +9,4 @@ export * from "./componentFactory";
 export * from "./components";
 export * from "./protocol";
 export * from "./storage";
+export * from "./componentRegistry";

--- a/packages/server/local-test-server/src/testHost.ts
+++ b/packages/server/local-test-server/src/testHost.ts
@@ -5,8 +5,8 @@
 
 import { PrimedComponent, PrimedComponentFactory, SimpleContainerRuntimeFactory } from "@prague/aqueduct";
 import { IComponentHandle, IComponentLoadable } from "@prague/component-core-interfaces";
-import { IComponentRegistry, WrappedComponentRegistry } from "@prague/container-runtime";
-import { IComponentContext, IComponentFactory, IComponentRuntime } from "@prague/runtime-definitions";
+import { WrappedComponentRegistry } from "@prague/container-runtime";
+import { IComponentContext, IComponentFactory, IComponentRegistry, IComponentRuntime } from "@prague/runtime-definitions";
 import { SharedString, SparseMatrix } from "@prague/sequence";
 import { ISharedObject } from "@prague/shared-object-common";
 import {


### PR DESCRIPTION
1.) Move component registry interfaces to runtime definitions from container definitions so that they can be with IComponentFactories. 
2,) THis is the first part in moving to new subregistry model.