### PR TITLE
follow up to leave 'message' for client not in quorum

### DIFF
--- a/packages/loader/container-loader/src/quorum.ts
+++ b/packages/loader/container-loader/src/quorum.ts
@@ -164,9 +164,10 @@ export class Quorum extends EventEmitter implements IQuorum {
     public removeMember(clientId: string) {
         if (!this.members.has(clientId) && this.logger) {
             this.logger.sendErrorEvent({ eventName: "removeMemberNotFound", clientId });
+        } else {
+            this.members.delete(clientId);
+            this.emit("removeMember", clientId);
         }
-        this.members.delete(clientId);
-        this.emit("removeMember", clientId);
     }
 
     /**


### PR DESCRIPTION
I missed one commit in PR #36 (merged as 3c103f).
Following up.
This change allows us to move forward past protocol breaking ops that happen due to 2 ordring sessions created by SPO.
The change will not be ported to 10.0 / master, as Gary is fixing the issue on server side