### PR TITLE
Intervals for summary configuration [0.9]

### DIFF
--- a/packages/drivers/file-socket-storage/src/fileDocumentDeltaConnection.ts
+++ b/packages/drivers/file-socket-storage/src/fileDocumentDeltaConnection.ts
@@ -111,9 +111,18 @@ export class ReplayFileDeltaConnection extends EventEmitter implements IDocument
                 blockSize: 64436,
                 maxMessageSize:  16 * 1024,
                 summary: {
-                    idleTime: 5000,
-                    maxOps: 1000,
-                    maxTime: 5000 * 12,
+                    intervals: [
+                        {
+                            maxOps: 50,
+                            maxTime: 300000 * 12,
+                            idleTime: 300000,
+                        },
+                        {
+                            maxOps: 1000,
+                            maxTime: 5000 * 12,
+                            idleTime: 5000,
+                        },
+                    ],
                     maxAckWaitTime: 600000,
                 },
             },

--- a/packages/drivers/replay-socket-storage/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-socket-storage/src/replayDocumentDeltaConnection.ts
@@ -200,9 +200,18 @@ export class ReplayDocumentDeltaConnection extends EventEmitter implements IDocu
                 blockSize: 64436,
                 maxMessageSize:  16 * 1024,
                 summary: {
-                    idleTime: 5000,
-                    maxOps: 1000,
-                    maxTime: 5000 * 12,
+                    intervals: [
+                        {
+                            maxOps: 50,
+                            maxTime: 300000 * 12,
+                            idleTime: 300000,
+                        },
+                        {
+                            maxOps: 1000,
+                            maxTime: 5000 * 12,
+                            idleTime: 5000,
+                        },
+                    ],
                     maxAckWaitTime: 600000,
                 },
             },

--- a/packages/loader/container-loader/src/protocol.ts
+++ b/packages/loader/container-loader/src/protocol.ts
@@ -108,6 +108,8 @@ export class ProtocolOpHandler {
                 if (this.logger) {
                     this.logger.sendTelemetryEvent({
                         eventName: "Summarize",
+                        clientId: message.clientId,
+                        sequenceNumber: message.sequenceNumber,
                         summaryContent: message.contents as ISummaryContent,
                     });
                 }

--- a/packages/loader/protocol-definitions/src/config.ts
+++ b/packages/loader/protocol-definitions/src/config.ts
@@ -9,13 +9,20 @@
 // * maxTime(ms) have passed with pending ops to summarize
 // * maxOps are waiting to summarize
 export interface ISummaryConfiguration {
-    idleTime: number;
-
-    maxTime: number;
-
-    maxOps: number;
+    intervals: ISummaryConfigurationInterval[];
 
     maxAckWaitTime: number;
+
+    // deprecated in favor of intervals
+    idleTime?: number;
+    maxTime?: number;
+    maxOps?: number;
+}
+
+export interface ISummaryConfigurationInterval {
+    maxOps: number;
+    idleTime: number;
+    maxTime: number;
 }
 
 /**

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -9,12 +9,12 @@ import {
 import {
     ISequencedDocumentMessage,
     ISummaryConfiguration,
+    ISummaryConfigurationInterval,
     MessageType,
 } from "@prague/protocol-definitions";
 import { Deferred } from "@prague/utils";
 import * as assert from "assert";
 import { ContainerRuntime } from "./containerRuntime";
-import { debug } from "./debug";
 
 /**
  * Wrapper interface holding summary details for a given op
@@ -23,12 +23,37 @@ interface IOpSummaryDetails {
     // Whether we should summarize at the given op
     shouldSummarize: boolean;
 
-    // Whether we can start idle timer
-    canStartIdleTimer: boolean;
+    // If defined, the idle time, otherwise no idle timer
+    idleTime?: number;
 
     // The message to include with the summarize
     message: string;
 }
+
+const aggressiveIdleTimeout = 5000; // summarize after 5 sec without receiving an op
+const passiveIdleTimeout = 300000; // summarize after 5 min without receiving an op
+const activeToIdleRatio = 12; // idle time x12 = active time, summarize on receiving an op past active time
+
+const OldDefaultInterval: ISummaryConfigurationInterval = {
+    maxOps: 1000,
+    maxTime: aggressiveIdleTimeout * activeToIdleRatio,
+    idleTime: aggressiveIdleTimeout,
+};
+
+export const DefaultSummaryConfiguration: ISummaryConfiguration = {
+    // immediately summarize > 1000 ops
+    intervals: [
+        {
+            maxOps: 50, // slowly summarize <= 50 ops
+            maxTime: passiveIdleTimeout * activeToIdleRatio,
+            idleTime: passiveIdleTimeout,
+        },
+        OldDefaultInterval, // aggressively summarize <= 1000 ops
+    ],
+
+    // Wait 10 minutes for summary ack
+    maxAckWaitTime: 600000,
+};
 
 declare module "@prague/component-core-interfaces" {
     export interface IComponent extends Readonly<Partial<IProvideSummarizer>> { }
@@ -51,7 +76,6 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
     public get ISummarizer() { return this; }
     public get IComponentLoadable() { return this; }
 
-    // Use the current time on initialization since we will be loading off a summary
     private lastSummaryTime: number = Date.now();
     private lastSummarySeqNumber: number = 0;
     private summarizing = false;
@@ -60,20 +84,26 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
     private lastOp: ISequencedDocumentMessage | null = null;
     private lastOpSummaryDetails: IOpSummaryDetails | null = null;
     private readonly runDeferred = new Deferred<void>();
+    private readonly configuration: ISummaryConfiguration;
 
     constructor(
         public readonly url: string,
         private readonly runtime: ContainerRuntime,
-        private readonly configuration: ISummaryConfiguration,
+        configuration: ISummaryConfiguration | undefined,
         private readonly generateSummary: () => Promise<void>,
     ) {
+        this.configuration = this.initializeConfig(configuration);
         this.runtime.on("disconnected", () => {
             this.runDeferred.resolve();
         });
     }
 
     public async run(onBehalfOf: string): Promise<void> {
-        debug(`Summarizing on behalf of ${onBehalfOf}`);
+        this.runtime.logger.sendTelemetryEvent({ eventName: "RunningSummarizer", onBehalfOf });
+
+        // initialize to current time and seq number
+        this.lastSummaryTime = Date.now();
+        this.lastSummarySeqNumber = this.runtime.deltaManager.referenceSequenceNumber;
 
         if (!this.runtime.connected) {
             await new Promise((resolve) => this.runtime.once("connected", resolve));
@@ -83,44 +113,58 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
             return;
         }
 
-        // start the timer after connecting to the document
-        this.resetIdleTimer();
-
         // listen for summary ops
         this.runtime.deltaManager.inbound.on("op", (op) => this.handleSummaryOp(op as ISequencedDocumentMessage));
 
-        this.runtime.on("batchEnd", (error: any, op: ISequencedDocumentMessage) => {
-            if (error) {
-                return;
-            }
+        // after connecting, decide whether to do initial summarize or idle timer
+        const opCountSinceConnected = this.runtime.deltaManager.referenceSequenceNumber - this.lastSummarySeqNumber;
+        const interval = this.findInterval(opCountSinceConnected);
+        if (interval) {
+            this.resetIdleTimer(interval.idleTime);
+        } else {
+            // tslint:disable-next-line: no-floating-promises
+            this.summarize("");
+        }
 
-            this.clearIdleTimer();
-
-            // clear pending if timeout waiting for server ack
-            if (this.summaryPending) {
-                const pendingTime = Date.now() - this.lastSummaryTime;
-                if (pendingTime > this.configuration.maxAckWaitTime) {
-                    this.runtime.logger.sendTelemetryEvent({ eventName: "SummaryAckWaitTimeout" });
-                    debug("Summarizer timed out while waiting for SummaryAck/SummaryNack from server.");
-                    this.summaryPending = false;
-                }
-            }
-
-            // Get the summary details for the given op
-            this.lastOp = op;
-            this.lastOpSummaryDetails = this.getOpSummaryDetails(op);
-
-            if (this.lastOpSummaryDetails.shouldSummarize) {
-                // Summarize immediately if requested
-                // tslint:disable-next-line: no-floating-promises
-                this.summarize(this.lastOpSummaryDetails.message);
-            } else if (this.lastOpSummaryDetails.canStartIdleTimer) {
-                // Otherwise detect when we idle to trigger the snapshot
-                this.resetIdleTimer();
-            }
-        });
+        // listen for regular ops
+        this.runtime.on("batchEnd", (error: any, op: ISequencedDocumentMessage) => this.handleOp(error, op));
 
         return this.runDeferred.promise;
+    }
+
+    private initializeConfig(configuration?: ISummaryConfiguration): ISummaryConfiguration {
+        let initializedConfig = DefaultSummaryConfiguration;
+        if (configuration) {
+            // merge passed config with defaults
+            initializedConfig = { ...initializedConfig, ...configuration };
+
+            // for back-compat; remove when server changes config to use intervals
+            // will convert top-level interface properties to a single interval
+            if (!configuration.intervals && configuration.maxOps) {
+                initializedConfig.intervals = [{
+                    ...OldDefaultInterval,
+                    ...{
+                        maxOps: configuration.maxOps,
+                        maxTime: configuration.maxTime,
+                        idleTime: configuration.idleTime,
+                    },
+                }];
+            }
+        }
+
+        // sort ascending
+        initializedConfig.intervals = initializedConfig.intervals.sort((a, b) => a.maxOps - b.maxOps);
+
+        return initializedConfig;
+    }
+
+    private findInterval(opCount: number): ISummaryConfigurationInterval | undefined {
+        // these are sorted ascending in constructor
+        for (const interval of this.configuration.intervals) {
+            if (interval.maxOps >= opCount) {
+                return interval;
+            }
+        }
     }
 
     private handleSummaryOp(op: ISequencedDocumentMessage) {
@@ -140,7 +184,7 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
             // mark that we are currently summarizing to prevent concurrent summarizing
             this.summarizing = true;
 
-            debug(`Summarizing: ${message}`);
+            this.runtime.logger.sendTelemetryEvent({ eventName: "Summarizing", message });
 
             const summarySequenceNumber = this.lastOp ? this.lastOp.sequenceNumber : 1;
 
@@ -151,11 +195,41 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
             // Skip on error to cause us to attempt the snapshot again.
             this.lastSummaryTime = Date.now();
             this.lastSummarySeqNumber = summarySequenceNumber;
-        } catch (ex) {
-            debug(`Summarize error ${this.runtime.id}`, ex);
+        } catch (error) {
+            this.runtime.logger.sendErrorEvent({ eventName: "ErrorDuringSummarize" }, error);
             this.summaryPending = false;
         } finally {
             this.summarizing = false;
+        }
+    }
+
+    private handleOp(error: any, op: ISequencedDocumentMessage) {
+        if (error) {
+            return;
+        }
+
+        this.clearIdleTimer();
+
+        // clear pending if timeout waiting for server ack
+        if (this.summaryPending) {
+            const pendingTime = Date.now() - this.lastSummaryTime;
+            if (pendingTime > this.configuration.maxAckWaitTime) {
+                this.runtime.logger.sendErrorEvent({ eventName: "SummaryAckWaitTimeout" });
+                this.summaryPending = false;
+            }
+        }
+
+        // Get the summary details for the given op
+        this.lastOp = op;
+        this.lastOpSummaryDetails = this.getOpSummaryDetails(op);
+
+        if (this.lastOpSummaryDetails.shouldSummarize) {
+            // Summarize immediately if requested
+            // tslint:disable-next-line: no-floating-promises
+            this.summarize(this.lastOpSummaryDetails.message);
+        } else if (this.lastOpSummaryDetails.idleTime) {
+            // Otherwise detect when we idle to trigger the snapshot
+            this.resetIdleTimer(this.lastOpSummaryDetails.idleTime);
         }
     }
 
@@ -165,25 +239,32 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
             return {
                 message: "",
                 shouldSummarize: false,
-                canStartIdleTimer: false,
             };
         } else if (op.type === MessageType.Save) {
             // Forced summary.
             return {
                 message: `;${op.clientId}: ${op.contents}`,
                 shouldSummarize: true,
-                canStartIdleTimer: true,
             };
         } else {
             // Summarize if it has been above the max time between summaries.
             const timeSinceLastSummary = Date.now() - this.lastSummaryTime;
             const opCountSinceLastSummary = op.sequenceNumber - this.lastSummarySeqNumber;
-            return {
-                message: "",
-                shouldSummarize: (timeSinceLastSummary > this.configuration.maxTime) ||
-                    (opCountSinceLastSummary > this.configuration.maxOps),
-                canStartIdleTimer: true,
-            };
+
+            const interval = this.findInterval(opCountSinceLastSummary);
+
+            if (interval) {
+                return {
+                    message: "",
+                    shouldSummarize: timeSinceLastSummary > interval.maxTime,
+                    idleTime: interval.idleTime,
+                };
+            } else {
+                return {
+                    message: "",
+                    shouldSummarize: true,
+                };
+            }
         }
     }
 
@@ -195,15 +276,14 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
         this.idleTimer = null;
     }
 
-    private resetIdleTimer() {
+    private resetIdleTimer(idleTime: number) {
         this.clearIdleTimer();
 
         this.idleTimer = setTimeout(
             () => {
-                debug("Summarizing due to being idle");
                 // tslint:disable-next-line: no-floating-promises
                 this.summarize("idle");
             },
-            this.configuration.idleTime);
+            idleTime);
     }
 }

--- a/packages/runtime/container-runtime/src/test/summarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizer.spec.ts
@@ -4,17 +4,23 @@
  */
 
 import { IDeltaManager, IDeltaQueue, ITelemetryLogger } from "@prague/container-definitions";
-import { IDocumentMessage, ISequencedDocumentMessage, ISummaryConfiguration, MessageType } from "@prague/protocol-definitions";
+import {
+    IDocumentMessage,
+    ISequencedDocumentMessage,
+    ISummaryConfiguration,
+    ISummaryConfigurationInterval,
+    MessageType,
+} from "@prague/protocol-definitions";
 import * as assert from "assert";
 import { EventEmitter } from "events";
 import * as sinon from "sinon";
 import { ContainerRuntime } from "../containerRuntime";
-import { Summarizer } from "../summarizer";
+import { DefaultSummaryConfiguration, Summarizer } from "../summarizer";
 
 describe("Runtime", () => {
     describe("Container Runtime", () => {
         describe("Summarizer", () => {
-            describe("Summary Schedule", () => {
+            describe("Summary schedule with single interval", () => {
                 let clock: sinon.SinonFakeTimers;
                 let emitter: EventEmitter;
                 let summarizer: Summarizer;
@@ -23,7 +29,7 @@ describe("Runtime", () => {
                 const batchEndEvent = "batchEnd";
                 const generateSummaryEvent = "generateSummary";
                 const summaryOpEvent = "op";
-                const summaryConfig: ISummaryConfiguration = {
+                const summaryConfig = {
                     idleTime: 5000, // 5 sec (idle)
                     maxTime: 5000 * 12, // 1 min (active)
                     maxOps: 1000, // 1k ops (active)
@@ -47,12 +53,14 @@ describe("Runtime", () => {
                             summarizerClientId,
                             deltaManager: {
                                 inbound: emitter as IDeltaQueue<ISequencedDocumentMessage>,
+                                get referenceSequenceNumber() { return lastSeq; },
                             } as IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
                             logger: {
+                                sendErrorEvent: (event) => {},
                                 sendTelemetryEvent: (event) => {},
                             } as ITelemetryLogger,
                         } as ContainerRuntime,
-                        summaryConfig,
+                        summaryConfig as ISummaryConfiguration,
                         async () => { emitter.emit(generateSummaryEvent); },
                     );
                 });
@@ -178,6 +186,241 @@ describe("Runtime", () => {
                     // should not run because still pending
                     clock.tick(summaryConfig.maxAckWaitTime);
                     await emitNextOp(summaryConfig.maxOps + 1);
+                    assert.strictEqual(runCount, 1);
+
+                    // should run because pending timeout
+                    clock.tick(1);
+                    await emitNextOp();
+                    assert.strictEqual(runCount, 2);
+                });
+            });
+
+            describe("Summary schedule with default configs", () => {
+                let clock: sinon.SinonFakeTimers;
+                let emitter: EventEmitter;
+                let summarizer: Summarizer;
+                const summarizerClientId = "test";
+                let lastSeq = 0;
+                const batchEndEvent = "batchEnd";
+                const generateSummaryEvent = "generateSummary";
+                const summaryOpEvent = "op";
+                let passiveInterval: ISummaryConfigurationInterval;
+                let aggressiveInterval: ISummaryConfigurationInterval;
+                let aggressiveMinOps: number;
+
+                before(() => {
+                    clock = sinon.useFakeTimers();
+                    const sorted = DefaultSummaryConfiguration.intervals.sort((a, b) => a.maxOps - b.maxOps);
+                    passiveInterval = sorted[0];
+                    aggressiveInterval = sorted[sorted.length - 1];
+                    if (sorted.length > 1) {
+                        aggressiveMinOps = sorted[sorted.length - 2].maxOps;
+                    } else {
+                        aggressiveMinOps = 0;
+                    }
+                });
+
+                beforeEach(() => {
+                    clock.reset();
+                    lastSeq = 0;
+                    emitter = new EventEmitter();
+                    summarizer = new Summarizer(
+                        "",
+                        {
+                            on: (event, listener) => emitter.on(event, listener),
+                            off: (event, listener) => emitter.off(event, listener),
+                            connected: true,
+                            summarizerClientId,
+                            deltaManager: {
+                                inbound: emitter as IDeltaQueue<ISequencedDocumentMessage>,
+                                get referenceSequenceNumber() { return lastSeq; },
+                            } as IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
+                            logger: {
+                                sendErrorEvent: (event) => {},
+                                sendTelemetryEvent: (event) => {},
+                            } as ITelemetryLogger,
+                        } as ContainerRuntime,
+                        undefined,
+                        async () => { emitter.emit(generateSummaryEvent); },
+                    );
+                });
+
+                after(() => {
+                    clock.restore();
+                });
+
+                function generateNextOp(increment: number = 1): Partial<ISequencedDocumentMessage> {
+                    lastSeq += increment;
+                    return {
+                        sequenceNumber: lastSeq,
+                    };
+                }
+
+                async function emitNextOp(increment: number = 1) {
+                    emitter.emit(batchEndEvent, undefined, generateNextOp(increment));
+                    await Promise.resolve();
+                }
+
+                it("Should summarize after max ops when not pending", async () => {
+                    let runCount = 0;
+                    summarizer.run(summarizerClientId).catch((reason) => assert.fail(JSON.stringify(reason)));
+                    emitter.on(generateSummaryEvent, () => runCount++);
+                    await emitNextOp();
+
+                    // too early, should not run yet
+                    await emitNextOp(aggressiveInterval.maxOps - 1);
+                    assert.strictEqual(runCount, 0);
+
+                    // now should run
+                    await emitNextOp(1);
+                    assert.strictEqual(runCount, 1);
+
+                    // should not run, because our summary hasnt been acked/nacked yet
+                    await emitNextOp(aggressiveInterval.maxOps + 1);
+                    assert.strictEqual(runCount, 1);
+
+                    // should run, because another op has come in, and our summary has been acked
+                    emitter.emit(summaryOpEvent, { type: MessageType.SummaryAck });
+                    await emitNextOp();
+                    assert.strictEqual(runCount, 2);
+                });
+
+                it("Should summarize after passive idle time with few ops when not pending", async () => {
+                    let runCount = 0;
+                    summarizer.run(summarizerClientId).catch((reason) => assert.fail(JSON.stringify(reason)));
+                    emitter.on(generateSummaryEvent, () => runCount++);
+                    await emitNextOp();
+
+                    // too early, should not run yet
+                    clock.tick(passiveInterval.idleTime - 1);
+                    await Promise.resolve();
+                    assert.strictEqual(runCount, 0);
+
+                    // now should run
+                    clock.tick(1);
+                    await Promise.resolve();
+                    assert.strictEqual(runCount, 1);
+
+                    // should not run, because our summary hasnt been acked/nacked yet
+                    await emitNextOp();
+                    clock.tick(passiveInterval.idleTime);
+                    await Promise.resolve();
+                    assert.strictEqual(runCount, 1);
+
+                    // should run, because another op has come in, and our summary has been acked
+                    emitter.emit(summaryOpEvent, { type: MessageType.SummaryAck });
+                    await emitNextOp();
+                    clock.tick(passiveInterval.idleTime + 1);
+                    await Promise.resolve();
+                    assert.strictEqual(runCount, 2);
+                });
+
+                it("Should summarize after aggressive idle time with many ops when not pending", async () => {
+                    let runCount = 0;
+                    summarizer.run(summarizerClientId).catch((reason) => assert.fail(JSON.stringify(reason)));
+                    emitter.on(generateSummaryEvent, () => runCount++);
+                    await emitNextOp(aggressiveMinOps + 1);
+
+                    // too early, should not run yet
+                    clock.tick(aggressiveInterval.idleTime - 1);
+                    await Promise.resolve();
+                    assert.strictEqual(runCount, 0);
+
+                    // now should run
+                    clock.tick(1);
+                    await Promise.resolve();
+                    assert.strictEqual(runCount, 1);
+
+                    // should not run, because our summary hasnt been acked/nacked yet
+                    await emitNextOp(aggressiveMinOps + 1);
+                    clock.tick(aggressiveInterval.idleTime);
+                    await Promise.resolve();
+                    assert.strictEqual(runCount, 1);
+
+                    // should run, because another op has come in, and our summary has been acked
+                    emitter.emit(summaryOpEvent, { type: MessageType.SummaryAck });
+                    await emitNextOp();
+                    clock.tick(aggressiveInterval.idleTime + 1);
+                    await Promise.resolve();
+                    assert.strictEqual(runCount, 2);
+                });
+
+                it("Should summarize after passive active time with few ops", async () => {
+                    let runCount = 0;
+                    const idlesPerActive = Math.floor((passiveInterval.maxTime + 1) / (passiveInterval.idleTime - 1));
+                    const remainingTime = (passiveInterval.maxTime + 1) % (passiveInterval.idleTime - 1);
+                    summarizer.run(summarizerClientId).catch((reason) => assert.fail(JSON.stringify(reason)));
+                    emitter.on(generateSummaryEvent, () => runCount++);
+                    await emitNextOp();
+
+                    // too early should not run yet
+                    for (let i = 0; i < idlesPerActive; i++) {
+                        // prevent idle from triggering with periodic ops
+                        clock.tick(passiveInterval.idleTime - 1);
+                        await emitNextOp();
+                    }
+                    clock.tick(remainingTime - 1);
+                    await emitNextOp();
+                    assert.strictEqual(runCount, 0);
+
+                    // now should run
+                    clock.tick(1);
+                    await emitNextOp();
+                    assert.strictEqual(runCount, 1);
+                });
+
+                it("Should summarize after aggressive active time with few ops when not pending", async () => {
+                    let runCount = 0;
+                    const idlesPerActive = Math.floor(
+                        (aggressiveInterval.maxTime + 1) / (aggressiveInterval.idleTime - 1));
+                    const remainingTime = (aggressiveInterval.maxTime + 1) % (aggressiveInterval.idleTime - 1);
+                    summarizer.run(summarizerClientId).catch((reason) => assert.fail(JSON.stringify(reason)));
+                    emitter.on(generateSummaryEvent, () => runCount++);
+                    await emitNextOp(aggressiveMinOps + 1);
+
+                    // too early should not run yet
+                    for (let i = 0; i < idlesPerActive; i++) {
+                        // prevent idle from triggering with periodic ops
+                        clock.tick(aggressiveInterval.idleTime - 1);
+                        await emitNextOp();
+                    }
+                    clock.tick(remainingTime - 1);
+                    await emitNextOp();
+                    assert.strictEqual(runCount, 0);
+
+                    // now should run
+                    clock.tick(1);
+                    await emitNextOp();
+                    assert.strictEqual(runCount, 1);
+
+                    // should not run because our summary hasnt been acked/nacked yet
+                    for (let i = 0; i < idlesPerActive; i++) {
+                        // prevent idle from triggering with periodic ops
+                        clock.tick(aggressiveInterval.idleTime - 1);
+                        await emitNextOp();
+                    }
+                    clock.tick(remainingTime);
+                    await emitNextOp(aggressiveMinOps);
+                    assert.strictEqual(runCount, 1);
+
+                    // should run, because another op has come in, and our summary has been acked
+                    emitter.emit(summaryOpEvent, { type: MessageType.SummaryAck });
+                    await emitNextOp();
+                    assert.strictEqual(runCount, 2);
+                });
+
+                it("Should summarize after pending timeout", async () => {
+                    let runCount = 0;
+                    summarizer.run(summarizerClientId).catch((reason) => assert.fail(JSON.stringify(reason)));
+                    emitter.on(generateSummaryEvent, () => runCount++);
+
+                    // first run to start pending
+                    await emitNextOp(aggressiveInterval.maxOps + 1);
+                    assert.strictEqual(runCount, 1);
+
+                    // should not run because still pending
+                    clock.tick(DefaultSummaryConfiguration.maxAckWaitTime);
+                    await emitNextOp(aggressiveInterval.maxOps + 1);
                     assert.strictEqual(runCount, 1);
 
                     // should run because pending timeout

--- a/packages/server/local-test-server/src/testDeltaConnectionServer.ts
+++ b/packages/server/local-test-server/src/testDeltaConnectionServer.ts
@@ -257,9 +257,18 @@ export function register(
                         blockSize: 64436,
                         maxMessageSize:  16 * 1024,
                         summary: {
-                            idleTime: 5000,
-                            maxOps: 1000,
-                            maxTime: 5000 * 12,
+                            intervals: [
+                                {
+                                    maxOps: 50,
+                                    maxTime: 300000 * 12,
+                                    idleTime: 300000,
+                                },
+                                {
+                                    maxOps: 1000,
+                                    maxTime: 5000 * 12,
+                                    idleTime: 5000,
+                                },
+                            ],
                             maxAckWaitTime: 600000,
                         },
                     },

--- a/packages/server/memory-orderer/src/localNode.ts
+++ b/packages/server/memory-orderer/src/localNode.ts
@@ -34,9 +34,18 @@ const DefaultServiceConfiguration: IServiceConfiguration = {
     blockSize: 64436,
     maxMessageSize:  16 * 1024,
     summary: {
-        idleTime: 5000,
-        maxOps: 1000,
-        maxTime: 5000 * 12,
+        intervals: [
+            {
+                maxOps: 50,
+                maxTime: 300000 * 12,
+                idleTime: 300000,
+            },
+            {
+                maxOps: 1000,
+                maxTime: 5000 * 12,
+                idleTime: 5000,
+            },
+        ],
         maxAckWaitTime: 600000,
     },
 };

--- a/packages/server/memory-orderer/src/localOrderer.ts
+++ b/packages/server/memory-orderer/src/localOrderer.ts
@@ -57,9 +57,18 @@ const DefaultServiceConfiguration: IServiceConfiguration = {
     blockSize: 64436,
     maxMessageSize: 16 * 1024,
     summary: {
-        idleTime: 5000,
-        maxOps: 1000,
-        maxTime: 5000 * 12,
+        intervals: [
+            {
+                maxOps: 50,
+                maxTime: 300000 * 12,
+                idleTime: 300000,
+            },
+            {
+                maxOps: 1000,
+                maxTime: 5000 * 12,
+                idleTime: 5000,
+            },
+        ],
         maxAckWaitTime: 600000,
     },
 };

--- a/packages/server/routerlicious/src/alfred/utils.ts
+++ b/packages/server/routerlicious/src/alfred/utils.ts
@@ -61,9 +61,18 @@ export const DefaultServiceConfiguration: IServiceConfiguration = {
     blockSize: 64436,
     maxMessageSize:  16 * 1024,
     summary: {
-        idleTime: 5000,
-        maxOps: 1000,
-        maxTime: 5000 * 12,
+        intervals: [
+            {
+                maxOps: 50,
+                maxTime: 300000 * 12,
+                idleTime: 300000,
+            },
+            {
+                maxOps: 1000,
+                maxTime: 5000 * 12,
+                idleTime: 5000,
+            },
+        ],
         maxAckWaitTime: 600000,
     },
 };


### PR DESCRIPTION
Add intervals for summary configuration and more telemetry events in the summarizer.

This is a work in progress, as there is still more telemetry to add, and probably could clean up the tests some.