### PR TITLE
Updates to .devcontainer to use pre-created dev env image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,11 +3,9 @@
 	"name": "Node.js 10",
 	// "dockerFile": "Dockerfile",
 
-	"dockerComposeFile": "docker-compose.yml",
+	"image": "docker.io/dumbnose/devenv",
 
 	"service": "development",
-
-	"workspaceFolder": "/workspace",
 
 	"settings": { 
 		"terminal.integrated.shell.linux": "/usr/bin/zsh"
@@ -28,6 +26,7 @@
 	// 	"-u",
 	// 	"node"
 	// ],
+	"runArgs": ["-v","//var/run/docker.sock:/var/run/docker.sock"],
 
 	"extensions": [
 		"dbaeumer.vscode-eslint",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"name": "Node.js 10",
 	// "dockerFile": "Dockerfile",
 
-	"image": "docker.io/dumbnose/devenv",
+	"image": "prague.azurecr.io/devenv",
 
 	"service": "development",
 

--- a/.devcontainer/devenv/.zshrc
+++ b/.devcontainer/devenv/.zshrc
@@ -1,0 +1,98 @@
+# If you come from bash you might have to change your $PATH.
+# export PATH=$HOME/bin:/usr/local/bin:$PATH
+
+# Path to your oh-my-zsh installation.
+  export ZSH="/home/node/.oh-my-zsh"
+
+# Set name of the theme to load --- if set to "random", it will
+# load a random theme each time oh-my-zsh is loaded, in which case,
+# to know which specific one was loaded, run: echo $RANDOM_THEME
+# See https://github.com/robbyrussell/oh-my-zsh/wiki/Themes
+ZSH_THEME="robbyrussell"
+
+# Set list of themes to pick from when loading at random
+# Setting this variable when ZSH_THEME=random will cause zsh to load
+# a theme from this variable instead of looking in ~/.oh-my-zsh/themes/
+# If set to an empty array, this variable will have no effect.
+# ZSH_THEME_RANDOM_CANDIDATES=( "robbyrussell" "agnoster" )
+
+# Uncomment the following line to use case-sensitive completion.
+# CASE_SENSITIVE="true"
+
+# Uncomment the following line to use hyphen-insensitive completion.
+# Case-sensitive completion must be off. _ and - will be interchangeable.
+# HYPHEN_INSENSITIVE="true"
+
+# Uncomment the following line to disable bi-weekly auto-update checks.
+# DISABLE_AUTO_UPDATE="true"
+
+# Uncomment the following line to change how often to auto-update (in days).
+# export UPDATE_ZSH_DAYS=13
+
+# Uncomment the following line to disable colors in ls.
+# DISABLE_LS_COLORS="true"
+
+# Uncomment the following line to disable auto-setting terminal title.
+# DISABLE_AUTO_TITLE="true"
+
+# Uncomment the following line to enable command auto-correction.
+# ENABLE_CORRECTION="true"
+
+# Uncomment the following line to display red dots whilst waiting for completion.
+# COMPLETION_WAITING_DOTS="true"
+
+# Uncomment the following line if you want to disable marking untracked files
+# under VCS as dirty. This makes repository status check for large repositories
+# much, much faster.
+# DISABLE_UNTRACKED_FILES_DIRTY="true"
+
+# Uncomment the following line if you want to change the command execution time
+# stamp shown in the history command output.
+# You can set one of the optional three formats:
+# "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
+# or set a custom format using the strftime function format specifications,
+# see 'man strftime' for details.
+# HIST_STAMPS="mm/dd/yyyy"
+
+# Would you like to use another custom folder than $ZSH/custom?
+# ZSH_CUSTOM=/path/to/new-custom-folder
+
+# Which plugins would you like to load?
+# Standard plugins can be found in ~/.oh-my-zsh/plugins/*
+# Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
+# Example format: plugins=(rails git textmate ruby lighthouse)
+# Add wisely, as too many plugins slow down shell startup.
+plugins=(
+  git docker npm node vscode docker-compose zsh-syntax-highlighting zsh-autosuggestions
+)
+
+source $ZSH/oh-my-zsh.sh
+
+# User configuration
+
+# export MANPATH="/usr/local/man:$MANPATH"
+
+# You may need to manually set your language environment
+# export LANG=en_US.UTF-8
+
+# Preferred editor for local and remote sessions
+# if [[ -n $SSH_CONNECTION ]]; then
+#   export EDITOR='vim'
+# else
+#   export EDITOR='mvim'
+# fi
+
+# Compilation flags
+# export ARCHFLAGS="-arch x86_64"
+
+# ssh
+# export SSH_KEY_PATH="~/.ssh/rsa_id"
+
+# Set personal aliases, overriding those provided by oh-my-zsh libs,
+# plugins, and themes. Aliases can be placed here, though oh-my-zsh
+# users are encouraged to define aliases within the ZSH_CUSTOM folder.
+# For a full list of active aliases, run `alias`.
+#
+# Example aliases
+# alias zshconfig="mate ~/.zshrc"
+# alias ohmyzsh="mate ~/.oh-my-zsh"

--- a/.devcontainer/devenv/Dockerfile
+++ b/.devcontainer/devenv/Dockerfile
@@ -1,0 +1,78 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM node:10.16.0
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Configure apt and install packages
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils 2>&1 \ 
+    #
+    # Verify git and needed tools are installed
+    && apt-get install -y git procps \
+    #
+    # Remove outdated yarn from /opt and install via package 
+    # so it can be easily updated via apt-get upgrade yarn
+    && rm -rf /opt/yarn-* \
+    && rm -f /usr/local/bin/yarn \
+    && rm -f /usr/local/bin/yarnpkg \
+    && apt-get install -y curl apt-transport-https lsb-release \
+    && curl -sS https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/pubkey.gpg | apt-key add - 2>/dev/null \
+    && echo "deb https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update \
+    && apt-get -y install --no-install-recommends yarn \
+    #
+    # Install eslint globally
+    && npm install -g eslint \
+    #
+    # zsh
+    # https://jilles.me/badassify-your-terminal-and-shell/
+    # https://billgrant.io/post/2019-05-05-vsremote/
+    && apt-get install -y zsh \ 
+        wget \
+        vim \
+    #
+    # Install Docker CE CLI
+    && apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release \
+    && curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | apt-key add - 2>/dev/null \
+    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" \
+    && apt-get update \
+    && apt-get install -y docker-ce-cli \
+    #
+    # Install Docker Compose
+    && curl -sSL "https://github.com/docker/compose/releases/download/1.24.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose \
+    && chmod +x /usr/local/bin/docker-compose \
+    # Add sudo support for the non-root user
+    && apt-get install -y sudo \
+    && echo node ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/node\
+    && chmod 0440 /etc/sudoers.d/node \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Fluid specific dependencies
+RUN apt-get update && apt-get install -y \
+        python \
+        make \
+        git \
+        curl \
+        g++
+
+# terminal colors with xterm
+ENV TERM xterm
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog
+
+USER node
+
+RUN sh -c "$(curl -fsSL https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" \
+    &&  git clone https://github.com/zsh-users/zsh-syntax-highlighting ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting \
+    && git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
+COPY .zshrc /home/node/.zshrc

--- a/.devcontainer/devenv/build-devenv
+++ b/.devcontainer/devenv/build-devenv
@@ -1,1 +1,1 @@
-docker build -t dumbnose/devenv .
+docker build -t prague.azurecr.io/devenv .

--- a/.devcontainer/devenv/build-devenv
+++ b/.devcontainer/devenv/build-devenv
@@ -1,0 +1,1 @@
+docker build -t dumbnose/devenv .

--- a/.devcontainer/devenv/push-devenv
+++ b/.devcontainer/devenv/push-devenv
@@ -1,0 +1,1 @@
+docker push docker.io/dumbnose/devenv 

--- a/.devcontainer/devenv/push-devenv
+++ b/.devcontainer/devenv/push-devenv
@@ -1,1 +1,1 @@
-docker push docker.io/dumbnose/devenv 
+docker push prague.azurecr.io/devenv 


### PR DESCRIPTION
Trying to streamline the Remote - Container dev experience by pre-creating a dev environment container image.  The .devcontainer/devenv folder has the assets to build / push the devenv image to prague.azurecr.io.  The .devcontainer/devcontainer.json file is updated to reference that image.