### PR TITLE
Stop supporting setting the version in the headers to loader.resolve

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -6,6 +6,7 @@
 - [`Stream` renamed to `Ink`](#stream-renamed-to-ink)
 - [`insertSiblingSegment` change to `insertAtReferencePosition`](#insertAtReferencePosition)
 - [`.createValueType` replaces third argument to `.set`](#.createValueType-replaces-third-argument-to-.set)
+- [Version can no longer be sent as a request header](#version-cannot-be-sent-as-request-header)
 
 ## `@prague/tiny-web-host` prague -> fluid changes
 `loadPragueComponent`, `loadIFramedPragueComponent`, and `isPragueUrl` from `@prague/tiny-web-host` have been renamed to `loadFluidComponent`, `loadIFramedFluidComponent`, and `isFluidUrl`, respectively.
@@ -47,6 +48,9 @@ After:
 ```typescript
 myMap.createValueType("myKey", CounterValueType.Name, 0);
 ```
+
+## version cannot be sent as request header
+When loading a container, there was support for setting the version using either a query parameter or request.header.version as arguments to `loader.request`. Going forward we will only respect the version argument in the query string and the request.header.version argument will be ignored.
 
 # 0.9 Breaking Changes (August 26, 2019)
 

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -231,8 +231,8 @@ export class Loader extends EventEmitter implements ILoader {
 
         let canCache = true;
         let canReconnect = true;
-        let connection = !parsed!.version ? "open" : "close";
-        let version = parsed!.version;
+        let connection = !parsed.version ? "open" : "close";
+        let version = parsed.version;
         let fromSequenceNumber = -1;
 
         if (request.headers) {
@@ -254,8 +254,6 @@ export class Loader extends EventEmitter implements ILoader {
             if (request.headers["fluid-sequence-number"]) {
                 fromSequenceNumber = request.headers["fluid-sequence-number"] as number;
             }
-
-            version = version || request.headers.version as string;
         }
 
         debug(`${canCache} ${connection} ${version}`);

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -232,7 +232,7 @@ export class Loader extends EventEmitter implements ILoader {
         let canCache = true;
         let canReconnect = true;
         let connection = !parsed.version ? "open" : "close";
-        let version = parsed.version;
+        const version = parsed.version;
         let fromSequenceNumber = -1;
 
         if (request.headers) {


### PR DESCRIPTION
Right now, you can set the version of the container to open using either query string parameters or request headers. The current implementation has some weird side effects, specifically around trying to load a "null" version via a query string. For simplicity, we should only support one mechanism for setting the version and that should be the query string.

Resolves #73 