### PR TITLE
Nack when exceptions occur while summarizing

### DIFF
--- a/packages/server/lambdas/src/scribe/lambda.ts
+++ b/packages/server/lambdas/src/scribe/lambda.ts
@@ -111,16 +111,25 @@ export class ScribeLambda extends SequencedLambda {
 
                 if (value.operation.type === MessageType.Summarize) {
                     const content = JSON.parse(value.operation.contents) as ISummaryContent;
+                    const summarySequenceNumber = value.operation.sequenceNumber;
 
                     // Process up to the summary op value to get the protocol state at the summary op.
                     // TODO: We should vaidate that we can actually make a summary prior to this call.
                     this.processFromPending(value.operation.referenceSequenceNumber);
-                    await this.summarize(
-                        content,
-                        this.protocolHandler.minimumSequenceNumber,
-                        this.protocolHandler.sequenceNumber,
-                        this.protocolHandler.quorum.snapshot(),
-                        value.operation.sequenceNumber);
+
+                    try {
+                        await this.summarize(
+                            content,
+                            this.protocolHandler.minimumSequenceNumber,
+                            this.protocolHandler.sequenceNumber,
+                            this.protocolHandler.quorum.snapshot(),
+                            summarySequenceNumber);
+                    } catch {
+                        await this.sendSummaryNack(
+                            summarySequenceNumber,
+                            `Failed to summarize the document.`,
+                        );
+                    }
                 }
             }
         }

--- a/packages/server/memory-orderer/src/localOrderer.ts
+++ b/packages/server/memory-orderer/src/localOrderer.ts
@@ -182,6 +182,7 @@ export class LocalOrderer implements IOrderer {
         deliContext: IContext = new LocalContext(),
         clientTimeout: number = ClientSequenceTimeout,
         serviceConfiguration = DefaultServiceConfiguration,
+        scribeNackOnSummarizeException = false,
     ) {
         const documentDetails = await setup.documentP();
 
@@ -202,7 +203,8 @@ export class LocalOrderer implements IOrderer {
             scribeContext,
             deliContext,
             clientTimeout,
-            serviceConfiguration);
+            serviceConfiguration,
+            scribeNackOnSummarizeException);
     }
 
     public rawDeltasKafka: LocalKafka;
@@ -235,6 +237,7 @@ export class LocalOrderer implements IOrderer {
         private deliContext: IContext,
         private clientTimeout: number,
         private serviceConfiguration: IServiceConfiguration,
+        private scribeNackOnSummarizeException: boolean,
     ) {
         this.existing = details.existing;
         this.socketPublisher = new LocalSocketPublisher(this.pubSub);
@@ -298,6 +301,7 @@ export class LocalOrderer implements IOrderer {
         this.deltasKafka = new LocalKafka();
     }
 
+    // tslint:disable-next-line: max-func-body-length
     private setupLambdas() {
         this.scriptoriumLambda = new LocalLambdaController(
             this.deltasKafka,
@@ -375,7 +379,8 @@ export class LocalOrderer implements IOrderer {
                         this.rawDeltasKafka,
                         protocolHandler,
                         protocolHead,
-                        scribeMessages);
+                        scribeMessages,
+                        this.scribeNackOnSummarizeException);
                 });
         }
 


### PR DESCRIPTION
Always nack when exceptions occur while summarizing. Exceptions should only occur within the `gitManager` calls.
In our implementation of `gitManager`, we have built in retry logic for retryable errors. So when it does throw, we should really nack the summary.