### PR TITLE
Add telemetry to summarization and unit tests to convertToSummaryTree [0.9]

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -227,7 +227,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         // create logger for components to use
         this.subLogger = DebugLogger.mixinDebugLogger(
             "fluid:telemetry",
-            { documentId: this.id, clientId: this.clientId, [pkgName]: pkgVersion },
+            { documentId: this.id, [pkgName]: pkgVersion },
             logger);
 
         // Prefix all events in this file with container-loader

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -227,7 +227,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         // create logger for components to use
         this.subLogger = DebugLogger.mixinDebugLogger(
             "fluid:telemetry",
-            { documentId: this.id, [pkgName]: pkgVersion },
+            { documentId: this.id, clientId: this.clientId, [pkgName]: pkgVersion },
             logger);
 
         // Prefix all events in this file with container-loader

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -76,6 +76,8 @@ import {
     SummaryTreeConverter,
  } from "./utils";
 
+export { ISummaryStats } from "./utils";
+
 declare module "@prague/component-core-interfaces" {
     export interface IComponent extends Readonly<Partial<IProvideComponentRegistry>> {}
 }

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -16,7 +16,7 @@ import {
 } from "@prague/protocol-definitions";
 import { ChildLogger, Deferred, PerformanceEvent } from "@prague/utils";
 import * as assert from "assert";
-import { ContainerRuntime } from "./containerRuntime";
+import { ContainerRuntime, IGeneratedSummaryData } from "./containerRuntime";
 
 /**
  * Wrapper interface holding summary details for a given op
@@ -30,14 +30,6 @@ interface IOpSummaryDetails {
 
     // The message to include with the summarize
     message: string;
-}
-
-export interface IGeneratedSummaryData {
-    sequenceNumber: number;
-    treeNodeCount: number;
-    blobNodeCount: number;
-    handleNodeCount: number;
-    totalBlobSize: number;
 }
 
 declare module "@prague/component-core-interfaces" {

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -9,13 +9,14 @@ import {
 import { ITelemetryLogger } from "@prague/container-definitions";
 import {
     ISequencedDocumentMessage,
+    ISummaryAck,
     ISummaryConfiguration,
+    ISummaryNack,
     MessageType,
 } from "@prague/protocol-definitions";
-import { ChildLogger, Deferred } from "@prague/utils";
+import { ChildLogger, Deferred, PerformanceEvent } from "@prague/utils";
 import * as assert from "assert";
 import { ContainerRuntime } from "./containerRuntime";
-import { debug } from "./debug";
 
 /**
  * Wrapper interface holding summary details for a given op
@@ -60,9 +61,8 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
     public get ISummarizer() { return this; }
     public get IComponentLoadable() { return this; }
 
-    // Use the current time on initialization since we will be loading off a summary
-    private lastSummaryTime: number = Date.now();
-    private lastSummarySeqNumber: number = 0;
+    private lastSummaryTime: number;
+    private lastSummarySeqNumber: number;
     private summarizing = false;
     private summaryPending = false;
     private idleTimer: NodeJS.Timeout | null = null;
@@ -83,7 +83,7 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
     }
 
     public async run(onBehalfOf: string): Promise<void> {
-        debug(`Summarizing on behalf of ${onBehalfOf}`);
+        this.logger.sendTelemetryEvent({ eventName: "RunningSummarizer", onBehalfOf });
 
         if (!this.runtime.connected) {
             await new Promise((resolve) => this.runtime.once("connected", resolve));
@@ -92,6 +92,10 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
         if (this.runtime.summarizerClientId !== onBehalfOf) {
             return;
         }
+
+        // initialize values (not exact)
+        this.lastSummarySeqNumber = this.runtime.deltaManager.referenceSequenceNumber;
+        this.lastSummaryTime = Date.now();
 
         // start the timer after connecting to the document
         this.resetIdleTimer();
@@ -110,7 +114,10 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
             if (this.summaryPending) {
                 const pendingTime = Date.now() - this.lastSummaryTime;
                 if (pendingTime > this.configuration.maxAckWaitTime) {
-                    this.logger.sendTelemetryEvent({ eventName: "SummaryAckWaitTimeout" });
+                    this.logger.sendTelemetryEvent({
+                        eventName: "SummaryAckWaitTimeout",
+                        maxAckWaitTime: this.configuration.maxAckWaitTime,
+                    });
                     this.summaryPending = false;
                 }
             }
@@ -120,7 +127,6 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
 
             if (lastOpSummaryDetails.shouldSummarize) {
                 // Summarize immediately if requested
-                // tslint:disable-next-line: no-floating-promises
                 this.summarize(lastOpSummaryDetails.message);
             } else if (lastOpSummaryDetails.canStartIdleTimer) {
                 // Otherwise detect when we idle to trigger the snapshot
@@ -134,50 +140,53 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
     private handleSummaryOp(op: ISequencedDocumentMessage) {
         if (op.type === MessageType.SummaryAck || op.type === MessageType.SummaryNack) {
             if (this.summaryPending) {
+                const ack = op.contents as ISummaryAck | ISummaryNack;
+                this.logger.sendTelemetryEvent({
+                    eventName: "PendingSummaryAck",
+                    type: op.type,
+                    timePending: Date.now() - this.lastSummaryTime,
+                    summarySequenceNumber:  ack.summaryProposal.summarySequenceNumber,
+                });
                 this.summaryPending = false;
             }
         }
     }
 
-    private async summarize(message: string) {
-        try {
-            // it shouldn't be possible to enter here if already summarizing or pending
-            assert(!this.summarizing && !this.summaryPending);
+    private summarize(message: string) {
+        // it shouldn't be possible to enter here if already summarizing or pending
+        assert(!this.summarizing && !this.summaryPending);
 
-            // generateSummary could take some time
-            // mark that we are currently summarizing to prevent concurrent summarizing
-            this.summarizing = true;
+        // generateSummary could take some time
+        // mark that we are currently summarizing to prevent concurrent summarizing
+        this.summarizing = true;
+        this.summaryPending = true;
 
-            this.logger.sendTelemetryEvent({
-                eventName: "Summarizing",
-                message,
-            });
-
-            this.summaryPending = true;
-            const summaryStartTime = Date.now();
-            const summaryData = await this.generateSummary();
-            const summaryEndTime = Date.now();
-
-            this.logger.sendTelemetryEvent({
-                ...summaryData,
-                ...{
-                    eventName: "SummaryGenerated",
-                    summarizeDuration: summaryEndTime - summaryStartTime,
-                    opsSinceLastSummary: summaryData.sequenceNumber - this.lastSummarySeqNumber,
-                    timeSinceLastSummary: summaryStartTime - this.lastSummaryTime,
-                },
-            });
-
-            // On success note the time of the snapshot and op sequence number.
-            // Skip on error to cause us to attempt the snapshot again.
-            this.lastSummaryTime = summaryEndTime;
-            this.lastSummarySeqNumber = summaryData.sequenceNumber;
-        } catch (ex) {
-            debug(`Summarize error ${this.runtime.id}`, ex);
-            this.summaryPending = false;
-        } finally {
+        this.summarizeCore(message).finally(() => {
             this.summarizing = false;
-        }
+        }).catch((error) => {
+            this.summaryPending = false;
+            this.logger.sendErrorEvent({ eventName: "SummarizeError" }, error);
+        });
+    }
+
+    private async summarizeCore(message: string) {
+        const summarizingEvent = PerformanceEvent.start(this.logger,
+            { eventName: "Summarizing", stage: "start", message });
+
+        const summaryData = await this.generateSummary();
+
+        const summaryEndTime = Date.now();
+        summarizingEvent.end({
+            stage: "end",
+            ...summaryData,
+            opsSinceLastSummary: summaryData.sequenceNumber - this.lastSummarySeqNumber,
+            timeSinceLastSummary: summaryEndTime - this.lastSummaryTime,
+        });
+
+        // On success note the time of the snapshot and op sequence number.
+        // Skip on error to cause us to attempt the snapshot again.
+        this.lastSummaryTime = summaryEndTime;
+        this.lastSummarySeqNumber = summaryData.sequenceNumber;
     }
 
     private getOpSummaryDetails(op: ISequencedDocumentMessage): IOpSummaryDetails {
@@ -220,11 +229,7 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
         this.clearIdleTimer();
 
         this.idleTimer = setTimeout(
-            () => {
-                debug("Summarizing due to being idle");
-                // tslint:disable-next-line: no-floating-promises
-                this.summarize("idle");
-            },
+            () => this.summarize("idle"),
             this.configuration.idleTime);
     }
 }

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -9,12 +9,10 @@ import {
     ISummaryTree,
     ITree,
     SummaryObject,
-    SummaryTree,
     SummaryType,
 } from "@prague/protocol-definitions";
 import * as assert from "assert";
-import { IGeneratedSummaryData } from "../summarizer";
-import { BlobTreeEntry, convertToSummaryTree, TreeTreeEntry } from "../utils";
+import { BlobTreeEntry, IConvertedSummaryResults, SummaryTreeConverter, TreeTreeEntry } from "../utils";
 
 describe("Runtime", () => {
     describe("Container Runtime", () => {
@@ -42,19 +40,15 @@ describe("Runtime", () => {
             }
 
             describe("Convert to Summary Tree", () => {
-                let summaryData: IGeneratedSummaryData;
-                let rawTree: SummaryTree;
+                let summaryResults: IConvertedSummaryResults;
                 let bufferLength: number;
+                let converter: SummaryTreeConverter;
+
+                before(() => {
+                    converter = new SummaryTreeConverter();
+                });
 
                 beforeEach(() => {
-                    summaryData = {
-                        sequenceNumber: 0,
-                        treeNodeCount: 0,
-                        blobNodeCount: 0,
-                        handleNodeCount: 0,
-                        totalBlobSize: 0,
-                    };
-
                     const base64Content = Buffer.from("test-b64").toString("base64");
                     bufferLength = Buffer.from(base64Content, "base64").byteLength;
                     const inputTree: ITree = {
@@ -73,11 +67,11 @@ describe("Runtime", () => {
                             ] }),
                         ],
                     };
-                    rawTree = convertToSummaryTree(inputTree, summaryData);
+                    summaryResults = converter.convertToSummaryTree(inputTree);
                 });
 
                 it("Should convert correctly", () => {
-                    const summaryTree = assertSummaryTree(rawTree);
+                    const summaryTree = assertSummaryTree(summaryResults.summaryTree);
 
                     // blobs should parse
                     const blob = assertSummaryBlob(summaryTree.tree.b);
@@ -98,10 +92,10 @@ describe("Runtime", () => {
 
                 it("Should calculate summary data correctly", () => {
                     // nodes should count
-                    assert.strictEqual(summaryData.blobNodeCount, 3);
-                    assert.strictEqual(summaryData.handleNodeCount, 1);
-                    assert.strictEqual(summaryData.treeNodeCount, 2);
-                    assert.strictEqual(summaryData.totalBlobSize,
+                    assert.strictEqual(summaryResults.summaryStats.blobNodeCount, 3);
+                    assert.strictEqual(summaryResults.summaryStats.handleNodeCount, 1);
+                    assert.strictEqual(summaryResults.summaryStats.treeNodeCount, 2);
+                    assert.strictEqual(summaryResults.summaryStats.totalBlobSize,
                         bufferLength + Buffer.byteLength("test-blob") + Buffer.byteLength("test-u8"));
                 });
             });

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -1,0 +1,110 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    ISummaryBlob,
+    ISummaryHandle,
+    ISummaryTree,
+    ITree,
+    SummaryObject,
+    SummaryTree,
+    SummaryType,
+} from "@prague/protocol-definitions";
+import * as assert from "assert";
+import { IGeneratedSummaryData } from "../summarizer";
+import { BlobTreeEntry, convertToSummaryTree, TreeTreeEntry } from "../utils";
+
+describe("Runtime", () => {
+    describe("Container Runtime", () => {
+        describe("Utils", () => {
+            function assertSummaryTree(obj: SummaryObject): ISummaryTree {
+                if (obj && obj.type === SummaryType.Tree) {
+                    return obj;
+                } else {
+                    assert.fail("Object should be summary tree");
+                }
+            }
+            function assertSummaryBlob(obj: SummaryObject): ISummaryBlob {
+                if (obj && obj.type === SummaryType.Blob) {
+                    return obj;
+                } else {
+                    assert.fail("Object should be summary blob");
+                }
+            }
+            function assertSummaryHandle(obj: SummaryObject): ISummaryHandle {
+                if (obj && obj.type === SummaryType.Handle) {
+                    return obj;
+                } else {
+                    assert.fail("Object should be summary handle");
+                }
+            }
+
+            describe("Convert to Summary Tree", () => {
+                let summaryData: IGeneratedSummaryData;
+                let rawTree: SummaryTree;
+                let bufferLength: number;
+
+                beforeEach(() => {
+                    summaryData = {
+                        sequenceNumber: 0,
+                        treeNodeCount: 0,
+                        blobNodeCount: 0,
+                        handleNodeCount: 0,
+                        totalBlobSize: 0,
+                    };
+
+                    const base64Content = Buffer.from("test-b64").toString("base64");
+                    bufferLength = Buffer.from(base64Content, "base64").byteLength;
+                    const inputTree: ITree = {
+                        id: null,
+                        entries: [
+                            new TreeTreeEntry("t", {
+                                id: null,
+                                entries: [
+                                    new BlobTreeEntry("bu8", "test-u8"),
+                                    new BlobTreeEntry("b64", base64Content, "base64"),
+                                ],
+                            }),
+                            new BlobTreeEntry("b", "test-blob"),
+                            new TreeTreeEntry("h", { id: "test-handle", entries: [
+                                new BlobTreeEntry("ignore", "this-should-be-ignored"),
+                            ] }),
+                        ],
+                    };
+                    rawTree = convertToSummaryTree(inputTree, summaryData);
+                });
+
+                it("Should convert correctly", () => {
+                    const summaryTree = assertSummaryTree(rawTree);
+
+                    // blobs should parse
+                    const blob = assertSummaryBlob(summaryTree.tree.b);
+                    assert.strictEqual(blob.content, "test-blob");
+
+                    // trees with ids should become handles
+                    const handle = assertSummaryHandle(summaryTree.tree.h);
+                    assert.strictEqual(handle.handleType, SummaryType.Tree);
+                    assert.strictEqual(handle.handle, "test-handle");
+
+                    // subtrees should recurse
+                    const subTree = assertSummaryTree(summaryTree.tree.t);
+                    const subBlobUtf8 = assertSummaryBlob(subTree.tree.bu8);
+                    assert.strictEqual(subBlobUtf8.content, "test-u8");
+                    const subBlobBase64 = assertSummaryBlob(subTree.tree.b64);
+                    assert.strictEqual(subBlobBase64.content.toString("utf-8"), "test-b64");
+                });
+
+                it("Should calculate summary data correctly", () => {
+                    // nodes should count
+                    assert.strictEqual(summaryData.blobNodeCount, 3);
+                    assert.strictEqual(summaryData.handleNodeCount, 1);
+                    assert.strictEqual(summaryData.treeNodeCount, 2);
+                    assert.strictEqual(summaryData.totalBlobSize,
+                        bufferLength + Buffer.byteLength("test-blob") + Buffer.byteLength("test-u8"));
+                });
+            });
+        });
+    });
+});

--- a/packages/runtime/container-runtime/src/test/summarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizer.spec.ts
@@ -53,7 +53,16 @@ describe("Runtime", () => {
                             } as ITelemetryLogger,
                         } as ContainerRuntime,
                         summaryConfig,
-                        async () => { emitter.emit(generateSummaryEvent); },
+                        async () => {
+                            emitter.emit(generateSummaryEvent);
+                            return {
+                                sequenceNumber: lastSeq,
+                                treeNodeCount: 0,
+                                blobNodeCount: 0,
+                                handleNodeCount: 0,
+                                totalBlobSize: 0,
+                            };
+                        },
                     );
                 });
 

--- a/packages/runtime/container-runtime/src/utils.ts
+++ b/packages/runtime/container-runtime/src/utils.ts
@@ -1,0 +1,110 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    FileMode,
+    IBlob,
+    ISummaryBlob,
+    ISummaryTree,
+    ITree,
+    ITreeEntry,
+    SummaryObject,
+    SummaryTree,
+    SummaryType,
+    TreeEntry,
+} from "@prague/protocol-definitions";
+
+import { IGeneratedSummaryData } from "./summarizer";
+
+export function convertToSummaryTree(
+    snapshot: ITree,
+    summaryData: IGeneratedSummaryData,
+    generateFullTreeNoOptimizations?: boolean,
+): SummaryTree {
+    if (snapshot.id && !generateFullTreeNoOptimizations) {
+        summaryData.handleNodeCount++;
+        return {
+            handle: snapshot.id,
+            handleType: SummaryType.Tree,
+            type: SummaryType.Handle,
+        };
+    } else {
+        const summaryTree: ISummaryTree = {
+            tree: {},
+            type: SummaryType.Tree,
+        };
+
+        for (const entry of snapshot.entries) {
+            let value: SummaryObject;
+
+            switch (entry.type) {
+                case TreeEntry[TreeEntry.Blob]:
+                    const blob = entry.value as IBlob;
+                    let content: string | Buffer;
+                    if (blob.encoding === "base64") {
+                        content = Buffer.from(blob.contents, "base64");
+                        summaryData.totalBlobSize += content.byteLength;
+                    } else {
+                        content = blob.contents;
+                        summaryData.totalBlobSize += Buffer.byteLength(content);
+                    }
+                    value = {
+                        content,
+                        type: SummaryType.Blob,
+                    } as ISummaryBlob;
+                    summaryData.blobNodeCount++;
+                    break;
+
+                case TreeEntry[TreeEntry.Tree]:
+                    value = convertToSummaryTree(
+                        entry.value as ITree,
+                        summaryData,
+                        generateFullTreeNoOptimizations);
+                    break;
+
+                case TreeEntry[TreeEntry.Commit]:
+                    // probably should not reach this case and assert so,
+                    // when snapshotting the commits become strings not ITrees
+                    value = convertToSummaryTree(
+                        entry.value as ITree,
+                        summaryData,
+                        generateFullTreeNoOptimizations);
+                    break;
+
+                default:
+                    throw new Error();
+            }
+
+            summaryTree.tree[entry.path] = value;
+        }
+
+        summaryData.treeNodeCount++;
+        return summaryTree;
+    }
+}
+
+export class BlobTreeEntry implements ITreeEntry {
+    public readonly mode = FileMode.File;
+    public readonly type = TreeEntry[TreeEntry.Blob];
+    public readonly value: IBlob;
+
+    constructor(public readonly path: string, contents: string, encoding: string = "utf-8") {
+        this.value = { contents, encoding };
+    }
+}
+
+export class CommitTreeEntry implements ITreeEntry {
+    public readonly mode = FileMode.Commit;
+    public readonly type = TreeEntry[TreeEntry.Commit];
+
+    constructor(public readonly path: string, public readonly value: string) {}
+}
+
+export class TreeTreeEntry implements ITreeEntry {
+    public readonly mode = FileMode.Directory;
+    public readonly type = TreeEntry[TreeEntry.Tree];
+
+    constructor(public readonly path: string, public readonly value: ITree) {}
+}


### PR DESCRIPTION
Add telemetry to summarizer and give Summarizer its own logger namespace.
- Summarizing performance event
  - stages: start, end
  - sequenceNumber - sequence number this summary is for
  - treeNodeCount - number of tree nodes in generated summary
  - blobNodeCount - number of blob nodes in generated summary
  - handleNodeCount - number of handle nodes in generated summary
  - totalBlobSize - total size in bytes of all blob contents
  - duration - time in ms generateSummary() call took
  - opsSinceLastSummary - number of ops between this and previous summarize call
  - timeSinceLastSummary - time in ms between this and previous summarize call
- PendingSummaryAck event
  - type: SummaryAck or SummaryNack
  - timePending: how long in pending state
  - summarySequenceNumber: sequence number of summary being acked
- SummaryAckWaitTimeout event
  - maxAckWaitTime - max time in ms configured to wait for summary ack/nack

Reorganize summarizer code a little bit to eliminate "floating promises" warnings.

Add a few unit tests for convert to summary tree code which was moved to a utils file.