### PR TITLE
Introduce 'Audience' to populate connected client list.

### DIFF
--- a/packages/components/client-ui/src/controls/flowView.ts
+++ b/packages/components/client-ui/src/controls/flowView.ts
@@ -23,7 +23,7 @@ import {
 } from "@microsoft/fluid-framework-interfaces";
 import * as types from "@microsoft/fluid-map";
 import * as MergeTree from "@microsoft/fluid-merge-tree";
-import { ISequencedDocumentMessage, IUser } from "@microsoft/fluid-protocol-definitions";
+import { IClient, ISequencedDocumentMessage, IUser } from "@microsoft/fluid-protocol-definitions";
 import { IInboundSignalMessage } from "@microsoft/fluid-runtime-definitions";
 import * as Sequence from "@microsoft/fluid-sequence";
 import { blobUploadHandler } from "../blob";
@@ -2771,8 +2771,7 @@ export class FlowCursor extends Cursor {
         // this would allow a user ID to be put on the wire which can then be mapped
         // back to an email, name, etc...
         const name = user.name;
-        // Name usually contains " ". Otherwise it's a clientId with "-".
-        const nameParts = name.indexOf(" ") !== -1 ? name.split(" ") : name.split("-");
+        const nameParts = name.split(" ");
         let initials = "";
         for (const part of nameParts) {
             initials += part.substring(0, 1);
@@ -3139,6 +3138,13 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
             this.broadcastPresence();
         });
         collabDocument.runtime.getQuorum().on("removeMember", () => {
+            this.updatePresenceCursors();
+        });
+        collabDocument.runtime.getAudience().on("addMember", () => {
+            this.updatePresenceCursors();
+            this.broadcastPresence();
+        });
+        collabDocument.runtime.getAudience().on("removeMember", () => {
             this.updatePresenceCursors();
         });
 
@@ -5189,7 +5195,6 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
     }
 
     private remotePresenceToLocal(clientId: string, remotePresenceInfo: IRemotePresenceInfo, posAdjust = 0) {
-
         const rempos = this.sharedString.resolveRemoteClientPosition(
             remotePresenceInfo.origPos,
             remotePresenceInfo.refseq,
@@ -5197,30 +5202,44 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
         const segoff = this.sharedString.getContainingSegment(rempos);
 
         if (segoff.segment) {
-            const docClient = this.collabDocument.getClient(clientId);
-            const localPresenceInfo = {
-                clientId,
-                fresh: true,
-                localRef: this.sharedString.createPositionReference(
-                    segoff.segment, segoff.offset, MergeTree.ReferenceType.SlideOnRemove),
-                presenceColor: this.presenceVector.has(clientId) ?
-                    this.presenceVector.get(clientId).presenceColor :
-                    presenceColors[this.presenceVector.size % presenceColors.length],
-                shouldShowCursor: () => {
-                    return this.collabDocument.clientId !== clientId;
-                },
-                // Temporary: Use the clientId as name if the user is not a part of the quorum.
-                user: docClient ? docClient.client.user : { name : clientId },
-            } as ILocalPresenceInfo;
-            if (remotePresenceInfo.origMark >= 0) {
-                const markSegoff = this.sharedString.getContainingSegment(remotePresenceInfo.origMark);
-                if (markSegoff.segment) {
-                    localPresenceInfo.markLocalRef =
-                    this.sharedString.createPositionReference(markSegoff.segment,
-                            markSegoff.offset, MergeTree.ReferenceType.SlideOnRemove);
+            const clientInfo = this.getRemoteClientInfo(clientId);
+            if (clientInfo) {
+                const localPresenceInfo = {
+                    clientId,
+                    fresh: true,
+                    localRef: this.sharedString.createPositionReference(
+                        segoff.segment, segoff.offset, MergeTree.ReferenceType.SlideOnRemove),
+                    presenceColor: this.presenceVector.has(clientId) ?
+                        this.presenceVector.get(clientId).presenceColor :
+                        presenceColors[this.presenceVector.size % presenceColors.length],
+                    shouldShowCursor: () => {
+                        return this.collabDocument.clientId !== clientId &&
+                            this.getRemoteClientInfo(clientId) !== undefined;
+                    },
+                    user: clientInfo.user,
+                } as ILocalPresenceInfo;
+                if (remotePresenceInfo.origMark >= 0) {
+                    const markSegoff = this.sharedString.getContainingSegment(remotePresenceInfo.origMark);
+                    if (markSegoff.segment) {
+                        localPresenceInfo.markLocalRef =
+                        this.sharedString.createPositionReference(markSegoff.segment,
+                                markSegoff.offset, MergeTree.ReferenceType.SlideOnRemove);
+                    }
                 }
+                this.updatePresenceVector(localPresenceInfo);
             }
-            this.updatePresenceVector(localPresenceInfo);
+        }
+    }
+
+    private getRemoteClientInfo(clientId: string): IClient {
+        const quorumClient = this.collabDocument.getClient(clientId);
+        if (quorumClient) {
+            return quorumClient.client;
+        } else {
+            const audience = this.collabDocument.getAudience();
+            if (audience.has(clientId)) {
+                return audience.get(clientId);
+            }
         }
     }
 

--- a/packages/components/client-ui/src/controls/flowView.ts
+++ b/packages/components/client-ui/src/controls/flowView.ts
@@ -5236,7 +5236,7 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
         if (quorumClient) {
             return quorumClient.client;
         } else {
-            const audience = this.collabDocument.getAudience();
+            const audience = this.collabDocument.runtime.getAudience().getMembers();
             if (audience.has(clientId)) {
                 return audience.get(clientId);
             }

--- a/packages/drivers/file-socket-storage/src/fileDocumentDeltaConnection.ts
+++ b/packages/drivers/file-socket-storage/src/fileDocumentDeltaConnection.ts
@@ -11,6 +11,7 @@ import {
     IDocumentMessage,
     ISequencedDocumentMessage,
     IServiceConfiguration,
+    ISignalClient,
     ISignalMessage,
     ITokenClaims,
 } from "@microsoft/fluid-protocol-definitions";
@@ -111,6 +112,7 @@ export class ReplayFileDeltaConnection extends EventEmitter implements IDocument
             initialContents: [],
             initialMessages: [],
             initialSignals: [],
+            initialClients: [],
             maxMessageSize: ReplayMaxMessageSize,
             mode,
             parentBranch: null,
@@ -179,6 +181,10 @@ export class ReplayFileDeltaConnection extends EventEmitter implements IDocument
 
     public get initialSignals(): ISignalMessage[] | undefined {
         return this.details.initialSignals;
+    }
+
+    public get initialClients(): ISignalClient[] | undefined {
+        return this.details.initialClients;
     }
 
     public get serviceConfiguration(): IServiceConfiguration {

--- a/packages/drivers/file-socket-storage/src/fileDocumentDeltaConnection.ts
+++ b/packages/drivers/file-socket-storage/src/fileDocumentDeltaConnection.ts
@@ -183,8 +183,8 @@ export class ReplayFileDeltaConnection extends EventEmitter implements IDocument
         return this.details.initialSignals;
     }
 
-    public get initialClients(): ISignalClient[] | undefined {
-        return this.details.initialClients;
+    public get initialClients(): ISignalClient[] {
+        return this.details.initialClients ? this.details.initialClients : [];
     }
 
     public get serviceConfiguration(): IServiceConfiguration {

--- a/packages/drivers/iframe-socket-storage/src/outerDocumentService.ts
+++ b/packages/drivers/iframe-socket-storage/src/outerDocumentService.ts
@@ -24,7 +24,7 @@ import * as Comlink from "comlink";
 import { OuterDeltaStorageService } from "./outerDeltaStorageService";
 import { OuterDocumentStorageService } from "./outerDocumentStorageService";
 
-const protocolVersions = ["^0.2.0", "^0.1.0"];
+const protocolVersions = ["^0.3.0", "^0.2.0", "^0.1.0"];
 
 // tslint:disable-next-line: no-empty-interface
 interface IInnerProxy extends IInnerDocumentDeltaConnectionProxy {
@@ -159,6 +159,7 @@ export class OuterDocumentService implements IDocumentService {
                 initialContents: this.deltaConnection.initialContents,
                 initialMessages: this.deltaConnection.initialMessages,
                 initialSignals: this.deltaConnection.initialSignals,
+                initialClients: this.deltaConnection.initialClients,
                 maxMessageSize: this.deltaConnection.maxMessageSize,
                 mode: this.deltaConnection.mode,
                 parentBranch: this.deltaConnection.parentBranch,

--- a/packages/drivers/replay-socket-storage/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-socket-storage/src/replayDocumentDeltaConnection.ts
@@ -268,8 +268,8 @@ export class ReplayDocumentDeltaConnection extends EventEmitter implements IDocu
         return this.details.initialSignals;
     }
 
-    public get initialClients(): ISignalClient[] | undefined {
-        return this.details.initialClients;
+    public get initialClients(): ISignalClient[] {
+        return this.details.initialClients ? this.details.initialClients : [];
     }
 
     public get serviceConfiguration(): IServiceConfiguration {

--- a/packages/drivers/replay-socket-storage/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-socket-storage/src/replayDocumentDeltaConnection.ts
@@ -13,6 +13,7 @@ import {
     IDocumentStorageService,
     ISequencedDocumentMessage,
     IServiceConfiguration,
+    ISignalClient,
     ISignalMessage,
     ITokenClaims,
     IVersion,
@@ -195,6 +196,7 @@ export class ReplayDocumentDeltaConnection extends EventEmitter implements IDocu
             initialContents: [],
             initialMessages: [],
             initialSignals: [],
+            initialClients: [],
             maxMessageSize: ReplayDocumentDeltaConnection.ReplayMaxMessageSize,
             mode: "write",
             parentBranch: null,
@@ -264,6 +266,10 @@ export class ReplayDocumentDeltaConnection extends EventEmitter implements IDocu
 
     public get initialSignals(): ISignalMessage[] | undefined {
         return this.details.initialSignals;
+    }
+
+    public get initialClients(): ISignalClient[] | undefined {
+        return this.details.initialClients;
     }
 
     public get serviceConfiguration(): IServiceConfiguration {

--- a/packages/drivers/routerlicious-socket-storage/src/wsDeltaConnection.ts
+++ b/packages/drivers/routerlicious-socket-storage/src/wsDeltaConnection.ts
@@ -108,8 +108,8 @@ export class WSDeltaConnection extends EventEmitter implements IDocumentDeltaCon
         return this.details!.initialSignals;
     }
 
-    public get initialClients(): ISignalClient[] | undefined {
-        return this.details!.initialClients;
+    public get initialClients(): ISignalClient[] {
+        return this.details!.initialClients ? this.details!.initialClients : [];
     }
 
     public get serviceConfiguration(): IServiceConfiguration {

--- a/packages/drivers/routerlicious-socket-storage/src/wsDeltaConnection.ts
+++ b/packages/drivers/routerlicious-socket-storage/src/wsDeltaConnection.ts
@@ -13,6 +13,7 @@ import {
     IDocumentMessage,
     ISequencedDocumentMessage,
     IServiceConfiguration,
+    ISignalClient,
     ISignalMessage,
     ITokenClaims,
 } from "@microsoft/fluid-protocol-definitions";
@@ -105,6 +106,10 @@ export class WSDeltaConnection extends EventEmitter implements IDocumentDeltaCon
 
     public get initialSignals(): ISignalMessage[] | undefined {
         return this.details!.initialSignals;
+    }
+
+    public get initialClients(): ISignalClient[] | undefined {
+        return this.details!.initialClients;
     }
 
     public get serviceConfiguration(): IServiceConfiguration {

--- a/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
+++ b/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
@@ -293,8 +293,8 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
      *
      * @returns initial client list sent during the connection
      */
-    public get initialClients(): ISignalClient[] | undefined {
-        return this.details.initialClients;
+    public get initialClients(): ISignalClient[] {
+        return this.details.initialClients ? this.details.initialClients : [];
     }
 
     /**

--- a/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
+++ b/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
@@ -12,6 +12,7 @@ import {
     IDocumentMessage,
     ISequencedDocumentMessage,
     IServiceConfiguration,
+    ISignalClient,
     ISignalMessage,
     ITokenClaims,
 } from "@microsoft/fluid-protocol-definitions";
@@ -19,7 +20,7 @@ import { EventEmitter } from "events";
 import { debug } from "./debug";
 import { IConnect, IConnected } from "./messages";
 
-const protocolVersions = ["^0.2.0", "^0.1.0"];
+const protocolVersions = ["^0.3.0", "^0.2.0", "^0.1.0"];
 
 /**
  * Error raising for socket.io issues
@@ -285,6 +286,15 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
      */
     public get initialSignals(): ISignalMessage[] | undefined {
         return this.details.initialSignals;
+    }
+
+    /**
+     * Get initial client list
+     *
+     * @returns initial client list sent during the connection
+     */
+    public get initialClients(): ISignalClient[] | undefined {
+        return this.details.initialClients;
     }
 
     /**

--- a/packages/drivers/socket-storage-shared/src/innerDocumentDeltaConnection.ts
+++ b/packages/drivers/socket-storage-shared/src/innerDocumentDeltaConnection.ts
@@ -11,6 +11,7 @@ import {
     IDocumentMessage,
     ISequencedDocumentMessage,
     IServiceConfiguration,
+    ISignalClient,
     ISignalMessage,
     ITokenClaims,
 } from "@microsoft/fluid-protocol-definitions";
@@ -140,6 +141,15 @@ export class InnerDocumentDeltaConnection extends EventEmitter implements IDocum
      */
     public get initialSignals(): ISignalMessage[] | undefined {
         return this.details.initialSignals;
+    }
+
+    /**
+     * Get initial client list
+     *
+     * @returns initial client list sent during the connection
+     */
+    public get initialClients(): ISignalClient[] | undefined {
+        return this.details.initialClients;
     }
 
     private readonly tempEmitter: EventEmitter;

--- a/packages/drivers/socket-storage-shared/src/innerDocumentDeltaConnection.ts
+++ b/packages/drivers/socket-storage-shared/src/innerDocumentDeltaConnection.ts
@@ -148,8 +148,8 @@ export class InnerDocumentDeltaConnection extends EventEmitter implements IDocum
      *
      * @returns initial client list sent during the connection
      */
-    public get initialClients(): ISignalClient[] | undefined {
-        return this.details.initialClients;
+    public get initialClients(): ISignalClient[] {
+        return this.details.initialClients ? this.details.initialClients : [];
     }
 
     private readonly tempEmitter: EventEmitter;

--- a/packages/drivers/socket-storage-shared/src/messages.ts
+++ b/packages/drivers/socket-storage-shared/src/messages.ts
@@ -9,6 +9,7 @@ import {
     IContentMessage,
     ISequencedDocumentMessage,
     IServiceConfiguration,
+    ISignalClient,
     ISignalMessage,
     ITokenClaims,
 } from "@microsoft/fluid-protocol-definitions";
@@ -91,6 +92,11 @@ export interface IConnected {
      * Signals sent during the connection
      */
     initialSignals?: ISignalMessage[];
+
+    /**
+     * Prior clients already connected.
+     */
+    initialClients?: ISignalClient[];
 
     /**
      * Protocol version selected by the server to communicate with the client

--- a/packages/drivers/socket-storage-shared/src/outerDocumentDeltaConnection.ts
+++ b/packages/drivers/socket-storage-shared/src/outerDocumentDeltaConnection.ts
@@ -155,8 +155,8 @@ export class OuterDocumentDeltaConnection extends EventEmitter implements IDocum
      *
      * @returns initial client list sent during the connection
      */
-    public get initialClients(): ISignalClient[] | undefined {
-        return this.details.initialClients;
+    public get initialClients(): ISignalClient[] {
+        return this.details.initialClients ? this.details.initialClients : [];
     }
 
     /**

--- a/packages/drivers/socket-storage-shared/src/outerDocumentDeltaConnection.ts
+++ b/packages/drivers/socket-storage-shared/src/outerDocumentDeltaConnection.ts
@@ -10,6 +10,7 @@ import {
     IDocumentMessage,
     ISequencedDocumentMessage,
     IServiceConfiguration,
+    ISignalClient,
     ISignalMessage,
     ITokenClaims,
 } from "@microsoft/fluid-protocol-definitions";
@@ -147,6 +148,15 @@ export class OuterDocumentDeltaConnection extends EventEmitter implements IDocum
      */
     public get initialSignals(): ISignalMessage[] | undefined {
         return this.details.initialSignals;
+    }
+
+    /**
+     * Get initial client list
+     *
+     * @returns initial client list sent during the connection
+     */
+    public get initialClients(): ISignalClient[] | undefined {
+        return this.details.initialClients;
     }
 
     /**

--- a/packages/loader/container-definitions/src/audience.ts
+++ b/packages/loader/container-definitions/src/audience.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IClient } from "@microsoft/fluid-protocol-definitions";
+import { EventEmitter } from "events";
+
+/**
+ * Audience represents all clients connected to the op stream.
+ */
+export interface IAudience extends EventEmitter {
+
+    getMembers(): Map<string, IClient>;
+
+    getMember(clientId: string): IClient | undefined;
+
+}

--- a/packages/loader/container-definitions/src/chaincode.ts
+++ b/packages/loader/container-definitions/src/chaincode.ts
@@ -19,6 +19,7 @@ import {
     MessageType,
 } from "@microsoft/fluid-protocol-definitions";
 import { EventEmitter } from "events";
+import { IAudience } from "./audience";
 import { IBlobManager } from "./blobs";
 import { IQuorum } from "./consensus";
 import { IDeltaManager } from "./deltas";
@@ -214,6 +215,7 @@ export interface IContainerContext extends EventEmitter, IMessageScheduler, IPro
     readonly snapshotFn: (message: string) => Promise<void>;
     readonly closeFn: () => void;
     readonly quorum: IQuorum;
+    readonly audience: IAudience | undefined;
     readonly loader: ILoader;
     readonly codeLoader: ICodeLoader;
     readonly logger: ITelemetryLogger;

--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -8,6 +8,7 @@ import {
     IContentMessage,
     ISequencedDocumentMessage,
     IServiceConfiguration,
+    ISignalClient,
     ISignalMessage,
     ITokenClaims,
     MessageType,
@@ -22,6 +23,7 @@ export interface IConnectionDetails {
     mode: ConnectionMode;
     parentBranch: string | null;
     version: string;
+    initialClients?: ISignalClient[];
     initialMessages?: ISequencedDocumentMessage[];
     initialContents?: IContentMessage[];
     initialSignals?: ISignalMessage[];

--- a/packages/loader/container-definitions/src/index.ts
+++ b/packages/loader/container-definitions/src/index.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+export * from "./audience";
 export * from "./blobs";
 export * from "./chaincode";
 export * from "./consensus";

--- a/packages/loader/container-loader/src/audience.ts
+++ b/packages/loader/container-loader/src/audience.ts
@@ -1,0 +1,51 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { IAudience } from "@microsoft/fluid-container-definitions";
+import { IClient, ISignalClient } from "@microsoft/fluid-protocol-definitions";
+import { EventEmitter } from "events";
+
+/**
+ * Audience represents all clients connected to the op stream.
+ */
+export class Audience extends EventEmitter implements IAudience {
+    private readonly members = new Map<string, IClient>();
+
+    constructor(clients: ISignalClient[]) {
+        super();
+        for (const client of clients) {
+            this.members.set(client.clientId, client.client);
+        }
+    }
+
+    /**
+     * Adds a new client to the audience
+     */
+    public addMember(clientId: string, details: IClient) {
+        this.members.set(clientId, details);
+        this.emit("addMember", clientId, details);
+    }
+
+    /**
+     * Removes a client from the audience
+     */
+    public removeMember(clientId: string) {
+        this.members.delete(clientId);
+        this.emit("removeMember", clientId);
+    }
+
+    /**
+     * Retrieves all the members in the audience
+     */
+    public getMembers(): Map<string, IClient> {
+        return new Map(this.members);
+    }
+
+    /**
+     * Retrieves a specific member of the audience
+     */
+    public getMember(clientId: string): IClient | undefined {
+        return this.members.get(clientId);
+    }
+}

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -11,6 +11,7 @@ import {
 } from "@microsoft/fluid-component-core-interfaces";
 import {
     ConnectionState,
+    IAudience,
     ICodeLoader,
     IContainerContext,
     IDeltaManager,
@@ -119,6 +120,10 @@ export class ContainerContext extends EventEmitter implements IContainerContext 
 
     public get serviceConfiguration(): IServiceConfiguration | undefined {
         return this.container.serviceConfiguration;
+    }
+
+    public get audience(): IAudience | undefined {
+        return this.container.audience;
     }
 
     // tslint:disable-next-line:no-unsafe-any

--- a/packages/loader/container-loader/src/deltaConnection.ts
+++ b/packages/loader/container-loader/src/deltaConnection.ts
@@ -51,6 +51,7 @@ export class DeltaConnection extends EventEmitter {
             claims: connection.claims,
             clientId: connection.clientId,
             existing: connection.existing,
+            initialClients: connection.initialClients,
             initialContents: connection.initialContents,
             initialMessages: connection.initialMessages,
             initialSignals: connection.initialSignals,

--- a/packages/loader/container-loader/src/index.ts
+++ b/packages/loader/container-loader/src/index.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+export * from "./audience";
 export * from "./container";
 export * from "./loader";
 export * from "./networkUtils";

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -41,9 +41,6 @@ interface IParsedUrl {
     version: string | null;
 }
 
-// Protocol version supported by the loader
-// const protocolVersions = ["^0.2.0", "^0.1.0"];
-
 export class RelativeLoader extends EventEmitter implements ILoader {
 
     // Because the loader is passed to the container during construction we need to resolve the target container

--- a/packages/loader/protocol-definitions/src/storage.ts
+++ b/packages/loader/protocol-definitions/src/storage.ts
@@ -4,7 +4,7 @@
  */
 
 import { EventEmitter } from "events";
-import { ConnectionMode, IClient } from "./clients";
+import { ConnectionMode, IClient, ISignalClient } from "./clients";
 import { IServiceConfiguration } from "./config";
 import {
     IContentMessage,
@@ -251,6 +251,11 @@ export interface IDocumentDeltaConnection extends EventEmitter {
      * Signals sent during the connection
      */
     initialSignals?: ISignalMessage[];
+
+    /**
+     * Prior clients already connected.
+     */
+    initialClients?: ISignalClient[];
 
     /**
      * Configuration details provided by the service

--- a/packages/runtime/client-api/src/api/document.ts
+++ b/packages/runtime/client-api/src/api/document.ts
@@ -12,7 +12,6 @@ import { Deferred } from "@microsoft/fluid-core-utils";
 import * as ink from "@microsoft/fluid-ink";
 import { ISharedMap, SharedMap } from "@microsoft/fluid-map";
 import {
-    IClient,
     IDocumentMessage,
     IDocumentServiceFactory,
     ISequencedClient,
@@ -164,11 +163,6 @@ export class Document extends EventEmitter {
     public getClients(): Map<string, ISequencedClient> {
         const quorum = this.runtime.getQuorum();
         return quorum.getMembers();
-    }
-
-    public getAudience(): Map<string, IClient> {
-        const audience = this.runtime.getAudience();
-        return audience.getMembers();
     }
 
     public getClient(clientId: string): ISequencedClient {

--- a/packages/runtime/client-api/src/api/document.ts
+++ b/packages/runtime/client-api/src/api/document.ts
@@ -12,6 +12,7 @@ import { Deferred } from "@microsoft/fluid-core-utils";
 import * as ink from "@microsoft/fluid-ink";
 import { ISharedMap, SharedMap } from "@microsoft/fluid-map";
 import {
+    IClient,
     IDocumentMessage,
     IDocumentServiceFactory,
     ISequencedClient,
@@ -163,6 +164,11 @@ export class Document extends EventEmitter {
     public getClients(): Map<string, ISequencedClient> {
         const quorum = this.runtime.getQuorum();
         return quorum.getMembers();
+    }
+
+    public getAudience(): Map<string, IClient> {
+        const audience = this.runtime.getAudience();
+        return audience.getMembers();
     }
 
     public getClient(clientId: string): ISequencedClient {

--- a/packages/runtime/component-runtime/src/componentRuntime.ts
+++ b/packages/runtime/component-runtime/src/componentRuntime.ts
@@ -6,6 +6,7 @@
 import { IComponentHandle, IComponentHandleContext, IRequest, IResponse } from "@microsoft/fluid-component-core-interfaces";
 import {
     ConnectionState,
+    IAudience,
     IBlobManager,
     IDeltaManager,
     IGenericBlob,
@@ -63,6 +64,7 @@ export class ComponentRuntime extends EventEmitter implements IComponentRuntime,
             context.blobManager,
             context.deltaManager,
             context.getQuorum(),
+            context.getAudience(),
             context.snapshotFn,
             context.closeFn,
             registry,
@@ -134,6 +136,7 @@ export class ComponentRuntime extends EventEmitter implements IComponentRuntime,
         private readonly blobManager: IBlobManager,
         public readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
         private readonly quorum: IQuorum,
+        private readonly audience: IAudience,
         private readonly snapshotFn: (message: string) => Promise<void>,
         private readonly closeFn: () => void,
         private readonly registry: ISharedObjectRegistry,
@@ -336,6 +339,12 @@ export class ComponentRuntime extends EventEmitter implements IComponentRuntime,
         this.verifyNotClosed();
 
         return this.quorum;
+    }
+
+    public getAudience(): IAudience {
+        this.verifyNotClosed();
+
+        return this.audience;
     }
 
     public snapshot(message: string): Promise<void> {

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -6,6 +6,7 @@
 import { IComponent, IRequest, IResponse } from "@microsoft/fluid-component-core-interfaces";
 import {
     ConnectionState,
+    IAudience,
     IBlobManager,
     IDeltaManager,
     IGenericBlob,
@@ -213,6 +214,11 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
     public getQuorum(): IQuorum {
         this.verifyNotClosed();
         return this._hostRuntime.getQuorum();
+    }
+
+    public getAudience(): IAudience {
+        this.verifyNotClosed();
+        return this._hostRuntime.getAudience();
     }
 
     public async getBlobMetadata(): Promise<IGenericBlob[]> {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -7,6 +7,7 @@ import { AgentSchedulerFactory } from "@microsoft/fluid-agent-scheduler";
 import { IComponentHandleContext, IComponentSerializer, IRequest, IResponse } from "@microsoft/fluid-component-core-interfaces";
 import {
     ConnectionState,
+    IAudience,
     IBlobManager,
     IComponentTokenProvider,
     IContainerContext,
@@ -874,6 +875,10 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
 
     public getQuorum(): IQuorum {
         return this.context.quorum;
+    }
+
+    public getAudience(): IAudience {
+        return this.context.audience;
     }
 
     public error(error: any) {

--- a/packages/runtime/runtime-definitions/src/components.ts
+++ b/packages/runtime/runtime-definitions/src/components.ts
@@ -14,6 +14,7 @@ import {
 } from "@microsoft/fluid-component-core-interfaces";
 import {
     ConnectionState,
+    IAudience,
     IBlobManager,
     IDeltaManager,
     IGenericBlob,
@@ -170,6 +171,11 @@ export interface IComponentRuntime extends EventEmitter, IComponentRouter {
     getQuorum(): IQuorum;
 
     /**
+     * Returns the current audience.
+     */
+    getAudience(): IAudience;
+
+    /**
      * Called by distributed data structures in disconnected state to notify about pending local changes.
      * All pending changes are automatically flushed by shared objects on connection.
      */
@@ -219,6 +225,11 @@ export interface IComponentContext extends EventEmitter {
      * Returns the current quorum.
      */
     getQuorum(): IQuorum;
+
+    /**
+     * Returns the current audience.
+     */
+    getAudience(): IAudience;
 
     error(err: any): void;
 
@@ -331,6 +342,11 @@ export interface IHostRuntime extends
      * Returns the current quorum.
      */
     getQuorum(): IQuorum;
+
+    /**
+     * Returns the current audience.
+     */
+    getAudience(): IAudience;
 
     /**
      * Used to raise an unrecoverable error on the runtime.

--- a/packages/runtime/runtime-test-utils/src/mocks.ts
+++ b/packages/runtime/runtime-test-utils/src/mocks.ts
@@ -6,6 +6,7 @@
 import { IComponentHandle, IComponentHandleContext, IRequest, IResponse } from "@microsoft/fluid-component-core-interfaces";
 import {
     ConnectionState,
+    IAudience,
     IDeltaManager,
     IGenericBlob,
     ILoader,
@@ -209,24 +210,35 @@ export class MockRuntime extends EventEmitter
     public getQuorum(): IQuorum {
         return null;
     }
+
+    public getAudience(): IAudience {
+        return null;
+    }
+
     public async snapshot(message: string): Promise<void> {
         return null;
     }
+
     public save(message: string) {
         return;
     }
+
     public async close(): Promise<void> {
         return null;
     }
+
     public async uploadBlob(file: IGenericBlob): Promise<IGenericBlob> {
         return null;
     }
+
     public async getBlob(blobId: string): Promise<IGenericBlob> {
         return null;
     }
+
     public async getBlobMetadata(): Promise<IGenericBlob[]> {
         return null;
     }
+
     public submitMessage(type: MessageType, content: any) {
         return null;
     }

--- a/packages/server/routerlicious/src/alfred/app.ts
+++ b/packages/server/routerlicious/src/alfred/app.ts
@@ -5,7 +5,6 @@
 
 import {
     IAlfredTenant,
-    ICache,
     IDocumentStorage,
     IProducer,
     ITenantManager,
@@ -40,7 +39,6 @@ export function create(
     storage: IDocumentStorage,
     appTenants: IAlfredTenant[],
     mongoManager: MongoManager,
-    cache: ICache,
     producer: IProducer) {
 
     // Maximum REST request size

--- a/packages/server/routerlicious/src/alfred/runner.ts
+++ b/packages/server/routerlicious/src/alfred/runner.ts
@@ -6,7 +6,7 @@
 import { Deferred } from "@microsoft/fluid-core-utils";
 import {
     IAlfredTenant,
-    ICache,
+    IClientManager,
     ICollection,
     IDocumentStorage,
     IOrdererManager,
@@ -33,7 +33,7 @@ export class AlfredRunner implements utils.IRunner {
         private orderManager: IOrdererManager,
         private tenantManager: ITenantManager,
         private storage: IDocumentStorage,
-        private cache: ICache,
+        private clientManager: IClientManager,
         private appTenants: IAlfredTenant[],
         private mongoManager: MongoManager,
         private producer: IProducer,
@@ -51,7 +51,6 @@ export class AlfredRunner implements utils.IRunner {
             this.storage,
             this.appTenants,
             this.mongoManager,
-            this.cache,
             this.producer);
         alfred.set("port", this.port);
 
@@ -66,7 +65,8 @@ export class AlfredRunner implements utils.IRunner {
             this.orderManager,
             this.tenantManager,
             this.storage,
-            this.contentCollection);
+            this.contentCollection,
+            this.clientManager);
 
         // Listen on provided port, on all network interfaces.
         httpServer.listen(this.port);

--- a/packages/server/routerlicious/src/alfred/runnerFactory.ts
+++ b/packages/server/routerlicious/src/alfred/runnerFactory.ts
@@ -75,7 +75,7 @@ export class AlfredResources implements utils.IResources {
         public config: Provider,
         public producer: core.IProducer,
         public redisConfig: any,
-        public cache: core.ICache,
+        public clientManager: core.IClientManager,
         public webSocketLibrary: string,
         public orderManager: core.IOrdererManager,
         public tenantManager: core.ITenantManager,
@@ -118,7 +118,7 @@ export class AlfredResourcesFactory implements utils.IResourcesFactory<AlfredRes
 
         // Redis connection
         const redisClient = redis.createClient(redisConfig.port, redisConfig.host);
-        const redisCache = new services.RedisCache(redisClient);
+        const clientManager = new services.ClientManager(redisClient);
 
         // Database connection
         const mongoUrl = config.get("mongo:endpoint") as string;
@@ -219,7 +219,7 @@ export class AlfredResourcesFactory implements utils.IResourcesFactory<AlfredRes
             config,
             producer,
             redisConfig,
-            redisCache,
+            clientManager,
             webSocketLibrary,
             orderManager,
             tenantManager,
@@ -242,7 +242,7 @@ export class AlfredRunnerFactory implements utils.IRunnerFactory<AlfredResources
             resources.orderManager,
             resources.tenantManager,
             resources.storage,
-            resources.cache,
+            resources.clientManager,
             resources.appTenants,
             resources.mongoManager,
             resources.producer,

--- a/packages/server/routerlicious/src/test/alfred/io.spec.ts
+++ b/packages/server/routerlicious/src/test/alfred/io.spec.ts
@@ -17,6 +17,7 @@ import * as services from "@microsoft/fluid-server-services";
 import * as core from "@microsoft/fluid-server-services-core";
 import {
     MessageFactory,
+    TestClientManager,
     TestCollection,
     TestDbFactory,
     TestKafka,
@@ -42,6 +43,7 @@ describe("Routerlicious", () => {
                 let deliKafka: TestKafka;
                 let testOrderer: core.IOrdererManager;
                 let testTenantManager: TestTenantManager;
+                let testClientManager: core.IClientManager;
                 let contentCollection: TestCollection;
 
                 beforeEach(() => {
@@ -52,6 +54,7 @@ describe("Routerlicious", () => {
                     deliKafka = new TestKafka();
                     const producer = deliKafka.createProducer();
                     testTenantManager = new TestTenantManager(url);
+                    testClientManager = new TestClientManager();
                     const testDbFactory = new TestDbFactory(testData);
                     const mongoManager = new core.MongoManager(testDbFactory);
                     const databaseManager = new core.MongoDatabaseManager(
@@ -79,7 +82,8 @@ describe("Routerlicious", () => {
                         testOrderer,
                         testTenantManager,
                         testStorage,
-                        contentCollection);
+                        contentCollection,
+                        testClientManager);
                 });
 
                 function connectToServer(
@@ -96,7 +100,7 @@ describe("Routerlicious", () => {
                         mode: "read",
                         tenantId,
                         token,
-                        versions: ["^0.1.0"],
+                        versions: ["^0.3.0", "^0.2.0", "^0.1.0"],
                     };
 
                     const deferred = new Deferred<IConnected>();

--- a/packages/server/services-utils/src/index.ts
+++ b/packages/server/services-utils/src/index.ts
@@ -8,6 +8,7 @@ export * from "./conversion";
 export * from "./dns";
 export * from "./errorTrackingService";
 export * from "./logger";
+export * from "./messageGenerator";
 export * from "./port";
 export * from "./random";
 export * from "./runner";

--- a/packages/server/services-utils/src/messageGenerator.ts
+++ b/packages/server/services-utils/src/messageGenerator.ts
@@ -1,0 +1,43 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import {
+    IClient,
+    INack,
+    ISignalClient,
+    ISignalMessage,
+    MessageType,
+} from "@microsoft/fluid-protocol-definitions";
+
+// tslint:disable no-null-keyword
+export function createNackMessage(): INack {
+    return {
+        operation: undefined,
+        sequenceNumber: -1,
+    };
+}
+
+export function createRoomJoinMessage(clientId: string, client: IClient): ISignalMessage {
+    const joinContent: ISignalClient = {
+        clientId,
+        client,
+    };
+    return {
+        clientId: null,
+        content: JSON.stringify({
+            type: MessageType.ClientJoin,
+            content: joinContent,
+        }),
+    };
+}
+
+export function createRoomLeaveMessage(clientId: string): ISignalMessage {
+    return {
+        clientId: null,
+        content: JSON.stringify({
+            type: MessageType.ClientLeave,
+            content: clientId,
+        }),
+    };
+}

--- a/packages/server/services-utils/tsconfig.json
+++ b/packages/server/services-utils/tsconfig.json
@@ -6,6 +6,7 @@
     ],
     "compilerOptions": {
         "strict": true,
+        "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist"
     },

--- a/packages/server/test-utils/src/index.ts
+++ b/packages/server/test-utils/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 export * from "./messageFactory";
+export * from "./testClientManager";
 export * from "./testCollection";
 export * from "./testContext";
 export * from "./testDeltaStorageService";

--- a/packages/server/test-utils/src/testClientManager.ts
+++ b/packages/server/test-utils/src/testClientManager.ts
@@ -1,0 +1,22 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IClient, ISignalClient } from "@microsoft/fluid-protocol-definitions";
+import { IClientManager } from "@microsoft/fluid-server-services-core";
+
+export class TestClientManager implements IClientManager {
+
+    public async addClient(tenantId: string, documentId: string, clientId: string, details: IClient): Promise<void> {
+        return;
+    }
+
+    public async removeClient(tenantId: string, documentId: string, clientId: string): Promise<void> {
+        return;
+    }
+
+    public async getClients(tenantId: string, documentId: string): Promise<ISignalClient[]> {
+        return [];
+    }
+}

--- a/packages/server/test-utils/src/testDocumentDeltaConnection.ts
+++ b/packages/server/test-utils/src/testDocumentDeltaConnection.ts
@@ -13,6 +13,7 @@ import {
     IDocumentMessage,
     ISequencedDocumentMessage,
     IServiceConfiguration,
+    ISignalClient,
     ISignalMessage,
     ITokenClaims,
 } from "@microsoft/fluid-protocol-definitions";
@@ -20,8 +21,7 @@ import * as core from "@microsoft/fluid-server-services-core";
 import { EventEmitter } from "events";
 import { TestWebSocketServer } from "./testWebServer";
 
-const testProtocolVersion = "^0.1.0";
-
+const testProtocolVersions = ["^0.3.0", "^0.2.0", "^0.1.0"];
 export class TestDocumentDeltaConnection extends EventEmitter implements IDocumentDeltaConnection {
     public static async create(
         tenantId: string,
@@ -38,7 +38,7 @@ export class TestDocumentDeltaConnection extends EventEmitter implements IDocume
             mode,
             tenantId,
             token,  // token is going to indicate tenant level information, etc...
-            versions: [testProtocolVersion],
+            versions: testProtocolVersions,
         };
 
         const connection = await new Promise<IConnected>((resolve, reject) => {
@@ -162,8 +162,12 @@ export class TestDocumentDeltaConnection extends EventEmitter implements IDocume
         return this.details.initialSignals;
     }
 
+    public get initialClients(): ISignalClient[] | undefined {
+        return this.details.initialClients;
+    }
+
     public get version(): string {
-        return testProtocolVersion;
+        return "^0.3.0";
     }
 
     public get serviceConfiguration(): IServiceConfiguration {

--- a/packages/server/test-utils/src/testDocumentDeltaConnection.ts
+++ b/packages/server/test-utils/src/testDocumentDeltaConnection.ts
@@ -162,12 +162,12 @@ export class TestDocumentDeltaConnection extends EventEmitter implements IDocume
         return this.details.initialSignals;
     }
 
-    public get initialClients(): ISignalClient[] | undefined {
-        return this.details.initialClients;
+    public get initialClients(): ISignalClient[] {
+        return this.details.initialClients ? this.details.initialClients : [];
     }
 
     public get version(): string {
-        return "^0.3.0";
+        return testProtocolVersions[0];
     }
 
     public get serviceConfiguration(): IServiceConfiguration {


### PR DESCRIPTION
We have 'readonly' clients capable of sending signals now. To get their trusted metadata, we need a different form of quorum. This PR introduces 'Audience', a class represents info about socket connected client.

For routerlicious, alfred manages the list of connected clients in redis. For an in box service, it can be an in memory service.

As a part of join, each client gets a list of all prior clients. Once connected, client gets the updates from "Join"/"Leave" message. Audience class manages all updates for app to use.