### PR TITLE
Gateway: reenable spo route

### DIFF
--- a/packages/hosts/tiny-web-host/package.json
+++ b/packages/hosts/tiny-web-host/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@microsoft/fluid-base-host": "^0.10.0",
     "@microsoft/fluid-web-code-loader": "^0.10.0",
+    "@microsoft/fluid-odsp-driver": "^0.10.0",
     "@microsoft/fluid-odsp-utils": "^0.10.0",
     "@microsoft/fluid-protocol-definitions": "^0.10.0",
     "@microsoft/fluid-routerlicious-host": "^0.10.0",

--- a/packages/hosts/tiny-web-host/src/odspUtils.ts
+++ b/packages/hosts/tiny-web-host/src/odspUtils.ts
@@ -3,13 +3,16 @@
  * Licensed under the MIT License.
  */
 
-import { getODSPFluidResolvedUrl, IClientConfig, IODSPTokens } from "@microsoft/fluid-odsp-utils";
+import { OdspUrlResolver } from "@microsoft/fluid-odsp-driver";
+import { getDriveItemByFileName, IClientConfig, IODSPTokens } from "@microsoft/fluid-odsp-utils";
 import { IFluidResolvedUrl } from "@microsoft/fluid-protocol-definitions";
 
 const spoTenants = new Map<string, string>([
     ["spo", "microsoft-my.sharepoint.com"],
     ["spo-df", "microsoft-my.sharepoint-df.com"],
 ]);
+
+const pushSrv = "pushchannel.1drv.ms";
 
 export function isSpoTenant(tenantId: string) {
     return spoTenants.has(tenantId);
@@ -19,11 +22,11 @@ export function getSpoServer(tenantId: string) {
     return spoTenants.get(tenantId);
 }
 
-export async function spoJoinSession(
+export async function spoGetResolvedUrl(
     tenantId: string,
     id: string,
     serverTokens: { [server: string]: IODSPTokens } | undefined,
-    clientConfig: IClientConfig): Promise<IFluidResolvedUrl> {
+    clientConfig: IClientConfig) {
 
     const server = getSpoServer(tenantId);
     if (server === undefined) {
@@ -33,9 +36,25 @@ export async function spoJoinSession(
     if (tokens === undefined) {
         return Promise.reject(`Missing tokens for ${server}`);
     }
+    const socketTokens = serverTokens ? serverTokens[pushSrv] : undefined;
+    if (socketTokens === undefined) {
+        return Promise.reject(`Missing tokens for ${pushSrv}`);
+    }
     // Only .b items can be fluid
     const encoded = encodeURIComponent(`${id}.b`);
 
-    // tslint:disable-next-line: no-unsafe-any
-    return getODSPFluidResolvedUrl(server, `drive/root:/r11s/${encoded}:`, tokens, clientConfig, true);
+    const filePath = `/r11s/${encoded}`;
+    const { drive, item } = await getDriveItemByFileName(server, "", filePath, clientConfig, tokens, true);
+    const odspUrlResolver = new OdspUrlResolver();
+    // TODO: pass path
+    const encodedDrive = encodeURIComponent(drive);
+    const encodedItem = encodeURIComponent(item);
+    const path = "";
+    const request = { url: `https://${server}/?driveId=${encodedDrive}&itemId=${encodedItem}&path=${encodeURIComponent(path)}` };
+    const resolved = await odspUrlResolver.resolve(request) as IFluidResolvedUrl;
+    // For now pass the token via the resolved url, so that we can fake the token call back for the driver.
+    resolved.tokens.storageToken = tokens.accessToken;
+    resolved.tokens.socketToken = socketTokens.accessToken;
+
+    return resolved;
 }

--- a/packages/hosts/tiny-web-host/src/urlResolver.ts
+++ b/packages/hosts/tiny-web-host/src/urlResolver.ts
@@ -7,7 +7,7 @@ import { IClientConfig, IODSPTokens } from "@microsoft/fluid-odsp-utils";
 import { IFluidResolvedUrl, IUser, ScopeType } from "@microsoft/fluid-protocol-definitions";
 import { generateToken, IAlfredTenant } from "@microsoft/fluid-server-services-core";
 import { parse } from "url";
-import { getSpoServer, isSpoTenant, spoJoinSession } from "./odspUtils";
+import { getSpoServer, isSpoTenant, spoGetResolvedUrl } from "./odspUtils";
 
 // tslint:disable: restrict-plus-operands prefer-template no-unsafe-any
 
@@ -38,7 +38,7 @@ async function spoResolveUrl(
     const tokens: { [server: string]: IODSPTokens } = {};
     tokens[server] = odspToken;
 
-    const resolvedP = spoJoinSession(tenantId, documentId,
+    const resolvedP = spoGetResolvedUrl(tenantId, documentId,
         tokens, clientConfig);
     const fullTreeP = Promise.resolve(undefined);
     return [resolvedP, fullTreeP];

--- a/packages/server/gateway/src/childLoader.ts
+++ b/packages/server/gateway/src/childLoader.ts
@@ -71,8 +71,9 @@ class KeyValueLoader {
             });
 
         const documentServiceFactories: IDocumentServiceFactory[] = [];
+        // TODO: figure out how to pass clientId and token here
         documentServiceFactories.push(new OdspDocumentServiceFactory(
-            "Server-Gateway",
+            "Fake app-id",
             (siteUrl: string) => Promise.resolve("fake token"),
             () => Promise.resolve("fake token"),
             new BaseTelemetryNullLogger()));

--- a/packages/server/gateway/src/controllers/loaderFramed.ts
+++ b/packages/server/gateway/src/controllers/loaderFramed.ts
@@ -33,13 +33,14 @@ import { IHostServices } from "./services";
 
 export async function initialize(
     url: string,
-    resolved: IResolvedUrl,
+    resolved: IFluidResolvedUrl,
     cache: IGitCache,
     pkg: IResolvedPackage,
     scriptIds: string[],
     npm: string,
     jwt: string,
     config: any,
+    clientId: string,
     scope: IComponent,
     innerSession: boolean = false,
     outerSession: boolean = true,
@@ -89,10 +90,11 @@ export async function initialize(
         }
     } else {
         const documentServiceFactories: IDocumentServiceFactory[] = [];
+        // TODO: need to be support refresh token
         documentServiceFactories.push(new OdspDocumentServiceFactory(
-            "Server-Gateway",
-            (siteUrl: string) => Promise.resolve("fake token"),
-            () => Promise.resolve("fake token"),
+            clientId,
+            (siteUrl: string) => Promise.resolve(resolved.tokens.storageToken) ,
+            () => Promise.resolve(resolved.tokens.socketToken),
             new BaseTelemetryNullLogger()));
 
         documentServiceFactories.push(new RouterliciousDocumentServiceFactory(

--- a/packages/server/gateway/src/gateway-odsp-utils.ts
+++ b/packages/server/gateway/src/gateway-odsp-utils.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { getODSPFluidResolvedUrl, IClientConfig, IODSPTokens } from "@microsoft/fluid-odsp-utils";
+import { OdspUrlResolver } from "@microsoft/fluid-odsp-driver";
+import { getDriveItemByFileName, IClientConfig, IODSPTokens } from "@microsoft/fluid-odsp-utils";
 import { IFluidResolvedUrl } from "@microsoft/fluid-protocol-definitions";
 import { URL } from "url";
 
@@ -11,6 +12,8 @@ const spoTenants = new Map<string, string>([
     ["spo", "microsoft-my.sharepoint.com"],
     ["spo-df", "microsoft-my.sharepoint-df.com"],
 ]);
+
+const pushSrv = "pushchannel.1drv.ms";
 
 export function isSpoTenant(tenantId: string) {
     return spoTenants.has(tenantId);
@@ -35,7 +38,7 @@ export function saveSpoTokens(req, params, accessToken: string, refreshToken: st
     }
     try {
         const url = new URL(params.scope);
-        if (url.protocol === "https:" && isSpoServer(url.hostname)) {
+        if (url.protocol === "https:" && (isSpoServer(url.hostname) || url.hostname === pushSrv)) {
             req.session.tokens[url.hostname] = { accessToken, refreshToken };
         }
     } catch (e) {
@@ -43,27 +46,34 @@ export function saveSpoTokens(req, params, accessToken: string, refreshToken: st
         console.error(e);
     }
 }
+
 export function spoEnsureLoggedIn() {
     return (req, res, next) => {
         const tenantId = req.params.tenantId;
         if (isSpoTenant(tenantId)) {
             if (!req.session
                 || !req.session.tokens
-                || !req.session.tokens[getSpoServer(tenantId)]) {
+                || !req.session.tokens[getSpoServer(tenantId)]
+                || !req.session.tokens[getSpoServer(tenantId)].accessToken) {
 
                 req.session.returnTo = req.originalUrl || req.url;
                 return res.redirect(`/login_${req.params.tenantId}`);
+            }
+
+            if (!req.session.tokens[pushSrv]) {
+                req.session.returnTo = req.originalUrl || req.url;
+                return res.redirect(`/login_pushsrv`);
             }
         }
         next();
     };
 }
 
-export async function spoJoinSession(
+export async function spoGetResolvedUrl(
     tenantId: string,
     id: string,
     serverTokens: { [server: string]: IODSPTokens } | undefined,
-    clientConfig: IClientConfig): Promise<IFluidResolvedUrl> {
+    clientConfig: IClientConfig) {
 
     const server = getSpoServer(tenantId);
     if (server === undefined) {
@@ -73,7 +83,23 @@ export async function spoJoinSession(
     if (tokens === undefined) {
         return Promise.reject(`Missing tokens for ${server}`);
     }
+    const socketTokens = serverTokens ? serverTokens[pushSrv] : undefined;
+    if (socketTokens === undefined) {
+        return Promise.reject(`Missing tokens for ${pushSrv}`);
+    }
     // Only .b items can be fluid
     const encoded = encodeURIComponent(`${id}.b`);
-    return getODSPFluidResolvedUrl(server, `drive/root:/r11s/${encoded}:`, tokens, clientConfig, true);
+
+    const filePath = `/r11s/${encoded}`;
+    const { drive, item } = await getDriveItemByFileName(server, "", filePath, clientConfig, tokens, true);
+    const odspUrlResolver = new OdspUrlResolver();
+    // TODO: pass path
+    const path = "";
+    const request = { url: `https://${server}/?driveId=${encodeURIComponent(drive)}&itemId=${encodeURIComponent(item)}&path=${encodeURIComponent(path)}` };
+    const resolved = await odspUrlResolver.resolve(request) as IFluidResolvedUrl;
+    // For now pass the token via the resolved url, so that we can fake the token call back for the driver.
+    resolved.tokens.storageToken = tokens.accessToken;
+    resolved.tokens.socketToken = socketTokens.accessToken;
+
+    return resolved;
 }

--- a/packages/server/gateway/src/gateway-urlresolver.ts
+++ b/packages/server/gateway/src/gateway-urlresolver.ts
@@ -11,7 +11,7 @@ import { Provider } from "nconf";
 import { parse } from "url";
 // tslint:disable-next-line:no-submodule-imports
 import * as uuid from "uuid/v4";
-import { isSpoTenant, spoJoinSession } from "./gateway-odsp-utils";
+import { isSpoTenant, spoGetResolvedUrl } from "./gateway-odsp-utils";
 import { IAlfred } from "./interfaces";
 import { getToken, IAlfredUser } from "./utils";
 
@@ -26,7 +26,7 @@ function spoResolveUrl(
         clientId: microsoftConfiguration.clientId,
         clientSecret: microsoftConfiguration.secret,
     };
-    const resolvedP = spoJoinSession(tenantId, documentId,
+    const resolvedP = spoGetResolvedUrl(tenantId, documentId,
         request.session.tokens, clientConfig);
     const fullTreeP = Promise.resolve(undefined);
     return [resolvedP, fullTreeP];

--- a/packages/server/gateway/src/routes/home.ts
+++ b/packages/server/gateway/src/routes/home.ts
@@ -40,8 +40,6 @@ export function create(config: Provider, ensureLoggedIn: any): Router {
         "/login_spo",
         passport.authenticate("openidconnect", {
             scope: [
-                "profile",
-                "email",
                 "offline_access",
                 "https://microsoft-my.sharepoint.com/AllSites.Write",
             ],
@@ -52,10 +50,18 @@ export function create(config: Provider, ensureLoggedIn: any): Router {
         "/login_spo-df",
         passport.authenticate("openidconnect", {
             scope: [
-                "profile",
-                "email",
                 "offline_access",
                 "https://microsoft-my.sharepoint-df.com/AllSites.Write",
+            ],
+        },
+    ));
+
+    router.get(
+        "/login_pushsrv",
+        passport.authenticate("openidconnect", {
+            scope: [
+                "offline_access",
+                "https://pushchannel.1drv.ms/PushChannel.ReadWrite.All",
             ],
         },
     ));

--- a/packages/server/gateway/src/routes/loader.ts
+++ b/packages/server/gateway/src/routes/loader.ts
@@ -169,6 +169,7 @@ export function create(
                         {
                             cache: fullTree ? JSON.stringify(fullTree.cache) : undefined,
                             chaincode: JSON.stringify(pkg),
+                            clientId: config.get("login:microsoft").clientId,
                             config: workerConfig,
                             jwt: jwtToken,
                             npm: config.get("worker:npm"),
@@ -180,9 +181,9 @@ export function create(
                             user: getUserDetails(request),
                         });
                 }, (error) => {
-                    response.status(400).end(safeStringify(error, undefined, 2));
+                    response.status(400).end(`ERROR: ${error.stack}\n${safeStringify(error, undefined, 2)}`);
                 }).catch((error) => {
-                    response.status(500).end(safeStringify(error, undefined, 2));
+                    response.status(500).end(`ERROR: ${error.stack}\n${safeStringify(error, undefined, 2)}`);
                 });
             }
         });

--- a/packages/server/gateway/src/routes/loaderFramed.ts
+++ b/packages/server/gateway/src/routes/loaderFramed.ts
@@ -169,6 +169,7 @@ export function create(
                         {
                             cache: fullTree ? JSON.stringify(fullTree.cache) : undefined,
                             chaincode: JSON.stringify(pkg),
+                            clientId: config.get("login:microsoft").clientId,
                             config: workerConfig,
                             jwt: jwtToken,
                             npm: config.get("worker:npm"),
@@ -180,9 +181,9 @@ export function create(
                             user: getUserDetails(request),
                         });
                 }, (error) => {
-                    response.status(400).end(safeStringify(error, undefined, 2));
+                    response.status(400).end(`ERROR: ${error.stack}\n${safeStringify(error, undefined, 2)}`);
                 }).catch((error) => {
-                    response.status(500).end(safeStringify(error, undefined, 2));
+                    response.status(500).end(`ERROR: ${error.stack}\n${safeStringify(error, undefined, 2)}`);
                 });
             }
         });

--- a/packages/server/gateway/views/loader.hjs
+++ b/packages/server/gateway/views/loader.hjs
@@ -25,6 +25,7 @@
         var jwt = "{{ jwt }}";
         var npm = "{{ npm }}";
         var config = {{{ config }}};
+        var clientId = "{{ clientId }}";
 
         {{#scripts}}
         var scriptIds = [
@@ -46,6 +47,7 @@
             npm,
             jwt,
             config,
+            clientId,
             user.accessToken);
     </script>
 {{/scripts}}

--- a/packages/server/gateway/views/loaderFramed.hjs
+++ b/packages/server/gateway/views/loaderFramed.hjs
@@ -25,6 +25,7 @@
         var jwt = "{{ jwt }}";
         var npm = "{{ npm }}";
         var config = {{{ config }}};
+        var clientId = "{{ clientId }}";
 
         {{#scripts}}
         var scriptIds = [
@@ -45,7 +46,8 @@
             scriptIds,
             npm,
             jwt,
-            config);
+            config,
+            clientId);
     </script>
 {{/scripts}}
 

--- a/packages/utils/odsp-utils/package.json
+++ b/packages/utils/odsp-utils/package.json
@@ -20,8 +20,6 @@
   "repository": "microsoft/FluidFramework",
   "license": "MIT",
   "dependencies": {
-    "@microsoft/fluid-container-definitions": "^0.10.0",
-    "@microsoft/fluid-protocol-definitions": "^0.10.0",
     "request": "^2.88.0"
   },
   "devDependencies": {

--- a/packages/utils/odsp-utils/src/odsp-utils.ts
+++ b/packages/utils/odsp-utils/src/odsp-utils.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidResolvedUrl } from "@microsoft/fluid-protocol-definitions";
 import * as request from "request";
 
 export interface IODSPTokens {
@@ -22,6 +21,7 @@ export interface IODSPDriveItem {
 }
 
 interface IRequestResult {
+    href: string;
     status: number;
     data: any;
 }
@@ -29,7 +29,7 @@ interface IRequestResult {
 function createRequestResult(response: request.Response, body: any): IRequestResult {
     // console.log(JSON.stringify(response, undefined, 2));
     // console.log(JSON.stringify(body, undefined, 2));
-    return { status: response.statusCode, data: body };
+    return { href: response.request.uri.href, status: response.statusCode, data: body };
 }
 
 function createRequestError(msg: string, requestResult: IRequestResult) {
@@ -39,7 +39,7 @@ function createRequestError(msg: string, requestResult: IRequestResult) {
 }
 
 function getRefreshAccessTokenBody(server: string, clientConfig: IClientConfig, lastRefreshToken: string) {
-    return `scope=offline_access https://${server}/AllSite.Write`
+    return `scope=offline_access https://${server}/AllSites.Write`
         + `&client_id=${clientConfig.clientId}`
         + `&client_secret=${clientConfig.clientSecret}`
         + `&grant_type=refresh_token`
@@ -73,6 +73,7 @@ export async function postTokenRequest(postBody: string): Promise<IODSPTokens> {
 
 async function refreshAccessToken(server: string, clientConfig: IClientConfig, tokens: IODSPTokens) {
     console.log("Refreshing access token");
+    tokens.accessToken = "";
     const odspTokens = await postTokenRequest(getRefreshAccessTokenBody(server, clientConfig, tokens.refreshToken));
     tokens.accessToken = odspTokens.accessToken;
     tokens.refreshToken = odspTokens.refreshToken;
@@ -120,7 +121,7 @@ async function getAsync(
     });
 }
 
-async function postAsync(
+async function putAsync(
     server: string,
     clientConfig: IClientConfig,
     tokens: IODSPTokens,
@@ -129,73 +130,10 @@ async function postAsync(
 
     return requestWithRefresh(server, clientConfig, tokens, async (token: string) => {
         return new Promise((resolve, reject) => {
-            // console.log(`GET: ${url}`);
-            request.post({ url, headers, auth: { bearer: token } }, getRequestHandler(resolve, reject));
-        });
-    });
-}
-
-async function putAsync(
-    server: string,
-    clientConfig:
-        IClientConfig,
-    tokens: IODSPTokens,
-    url: string,
-    headers?: any): Promise<IRequestResult> {
-
-    return requestWithRefresh(server, clientConfig, tokens, async (token: string) => {
-        return new Promise((resolve, reject) => {
-            // console.log(`GET: ${url}`);
+            // console.log(`PUT: ${url}`);
             request.put({ url, headers, auth: { bearer: token } }, getRequestHandler(resolve, reject));
         });
     });
-}
-
-export async function getODSPFluidResolvedUrl(
-    server: string,
-    path: string,
-    tokens: IODSPTokens,
-    clientConfig: IClientConfig,
-    create: boolean = false): Promise<IFluidResolvedUrl> {
-
-    const baseUri = `https://${server}/_api/v2.1/${path}`;
-    const joinSessionUri = `${baseUri}/opStream/joinSession`;
-
-    let joinSessionResult = await postAsync(server, clientConfig, tokens, joinSessionUri);
-
-    if (joinSessionResult.status === 308) {
-        // Redirects
-        // TODO: reject for now
-        return Promise.reject(createRequestError("Redirect not supported", joinSessionResult));
-    }
-    if (joinSessionResult.status !== 200) {
-        if (!create) {
-            return Promise.reject(createRequestError("Failed to joinSession", joinSessionResult));
-        }
-        // Try to create it
-        const contentUri = `${baseUri}/content`;
-        const createResult = await putAsync(server, clientConfig, tokens, contentUri);
-        if (createResult.status !== 201) {
-            return Promise.reject(createRequestError("Failed to create file", createResult));
-        }
-
-        joinSessionResult = await postAsync(server, clientConfig, tokens, joinSessionUri);
-        if (joinSessionResult.status !== 200) {
-            return Promise.reject(createRequestError("Failed to joinSession", joinSessionResult));
-        }
-    }
-    const parsedBody = JSON.parse(joinSessionResult.data);
-    return {
-        endpoints: {
-            deltaStorageUrl: parsedBody.deltaStorageUrl,
-            ordererUrl: parsedBody.deltaStreamSocketUrl,
-            storageUrl: parsedBody.snapshotStorageUrl,
-        },
-        tokens: { storageToken: parsedBody.storageToken, socketToken: parsedBody.socketToken },
-        type: "fluid",
-        url: `fluid-odsp://${server}/` +
-            `${encodeURIComponent(parsedBody.runtimeTenantId)}/${encodeURIComponent(parsedBody.id)}`,
-    };
 }
 
 export async function getDriveItemByFileId(
@@ -203,8 +141,8 @@ export async function getDriveItemByFileId(
     account: string,
     uid: string,
     clientConfig: IClientConfig,
-    tokens: IODSPTokens): Promise<IODSPDriveItem> {
-
+    tokens: IODSPTokens,
+): Promise<IODSPDriveItem> {
     const getFileByIdUrl = `https://${server}/${account}/_api/web/GetFileById('${uid}')`;
     const getFileByIdResult = await getAsync(server, clientConfig, tokens,
         getFileByIdUrl, { accept: "application/json" });
@@ -229,10 +167,35 @@ export async function getDriveItemByFileId(
         return Promise.reject(createRequestError("Filename missing from URL from file Id", getFileByIdResult));
     }
 
-    const getDriveItemUrl = `https://${server}/${account}/_api/v2.1/drive/root:/${fileName}`;
-    const getDriveItemResult = await getAsync(server, clientConfig, tokens, getDriveItemUrl);
+    return getDriveItemByFileName(server, account, `/${fileName}`, clientConfig, tokens, false);
+}
+
+export async function getDriveItemByFileName(
+    server: string,
+    account: string,
+    path: string,
+    clientConfig: IClientConfig,
+    tokens: IODSPTokens,
+    create: boolean = false,
+): Promise<IODSPDriveItem> {
+    const accountPath = account ? `/${account}` : "";
+    const getDriveItemUrl = `https://${server}${accountPath}/_api/v2.1/drive/root:${path}`;
+    let getDriveItemResult = await getAsync(server, clientConfig, tokens, getDriveItemUrl);
     if (getDriveItemResult.status !== 200) {
-        return Promise.reject(createRequestError("Unable to get drive/item id from path", getDriveItemResult));
+        if (!create) {
+            return Promise.reject(createRequestError("Unable to get drive/item id from path", getDriveItemResult));
+        }
+        // try createing the file
+        const contentUri = `${getDriveItemUrl}:/content`;
+        const createResult = await putAsync(server, clientConfig, tokens, contentUri);
+        if (createResult.status !== 201) {
+            return Promise.reject(createRequestError("Failed to create file", createResult));
+        }
+
+        getDriveItemResult = await getAsync(server, clientConfig, tokens, getDriveItemUrl);
+        if (getDriveItemResult.status !== 200) {
+            return Promise.reject(createRequestError("Unable to get drive/item id from path", getDriveItemResult));
+        }
     }
     const parsedDriveItemBody = JSON.parse(getDriveItemResult.data);
     return { drive: parsedDriveItemBody.parentReference.driveId, item: parsedDriveItemBody.id };


### PR DESCRIPTION
Wire up the new auth and use the OdspUrlResolver to get the IResolvedUrl.  
This require us to always get the drive/item id first.  So refactor the getDriveItemByFileId to allow for getting the drive item by file name.  Also integrate implicit file create to that code path.

Pipe our clientId to the page so that the driver can put it in the appId query param in the joinSession call (for telemetry purpose).
Enhance error output to include stack on the loader routes.  Also add the url if it is a request error result.
Fixed a bug where we refresh the spo with the wrong scope (AllSite vs AllSites)

TODO:  
If we have a long session, we won't refresh the tokens on reconnect (which was never implemented 
anyway).

