### PR TITLE
Webpack-Component-Loader: Fix path to the fluid-loader bundle

### DIFF
--- a/packages/tools/webpack-component-loader/src/routes.ts
+++ b/packages/tools/webpack-component-loader/src/routes.ts
@@ -52,7 +52,7 @@ const fluid = (req: express.Request, res: express.Response,  baseDir: string, op
         <div id="content"></div>
     </div>
 
-    <script src="node_modules/@microsoft/fluid-webpack-component-loader/dist/fluid-loader.bundle.js"></script>
+    <script src="/node_modules/@microsoft/fluid-webpack-component-loader/dist/fluid-loader.bundle.js"></script>
     <script>
         var pkgJson = ${JSON.stringify(packageJson)};
         var options = ${JSON.stringify(options)};


### PR DESCRIPTION
Reference to the fluid-loader bundle need to be absolute because the url may not be the root and have paths into the container