### PR TITLE
Match pending summary ack with sent summary

### DIFF
--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -17,6 +17,8 @@
     "tsc": "tsc",
     "tsc:watch": "tsc --watch",
     "build:esnext": "tsc --project ./tsconfig.esnext.json",
+    "test": "mocha --recursive dist/test",
+    "test:coverage": "nyc npm test -- --reporter mocha-junit-reporter --reporter-options mochaFile=nyc/junit-report.xml",
     "tslint": "tslint --project tsconfig.json --format verbose"
   },
   "author": "Microsoft",

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -14,14 +14,12 @@ import {
 } from "@microsoft/fluid-container-definitions";
 import { Deferred, raiseConnectedEvent, readAndParse } from "@microsoft/fluid-core-utils";
 import {
-    FileMode,
     IDocumentMessage,
     IDocumentStorageService,
     ISequencedDocumentMessage,
     ISnapshotTree,
     ITree,
     MessageType,
-    TreeEntry,
 } from "@microsoft/fluid-protocol-definitions";
 import {
     IAttachMessage,
@@ -34,6 +32,7 @@ import {
 import * as assert from "assert";
 import { EventEmitter } from "events";
 import { ContainerRuntime } from "./containerRuntime";
+import { BlobTreeEntry } from "./utils";
 
 interface ISnapshotDetails {
     pkg: string;
@@ -244,15 +243,7 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
         const entries = await this.componentRuntime.snapshotInternal();
         const snapshot = { entries, id: undefined };
 
-        snapshot.entries.push({
-            mode: FileMode.File,
-            path: ".component",
-            type: TreeEntry[TreeEntry.Blob],
-            value: {
-                contents: JSON.stringify(componentAttributes),
-                encoding: "utf-8",
-            },
-        });
+        snapshot.entries.push(new BlobTreeEntry(".component", JSON.stringify(componentAttributes)));
 
         // base ID still being set means previous snapshot is still valid
         if (this.baseId) {
@@ -429,15 +420,7 @@ export class LocalComponentContext extends ComponentContext {
         const entries = this.componentRuntime.getAttachSnapshot();
         const snapshot = { entries, id: undefined };
 
-        snapshot.entries.push({
-            mode: FileMode.File,
-            path: ".component",
-            type: TreeEntry[TreeEntry.Blob],
-            value: {
-                contents: JSON.stringify(componentAttributes),
-                encoding: "utf-8",
-            },
-        });
+        snapshot.entries.push(new BlobTreeEntry(".component", JSON.stringify(componentAttributes)));
 
         // base ID still being set means previous snapshot is still valid
         if (this.baseId) {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -67,8 +67,6 @@ import { SummaryManager } from "./summaryManager";
 import { analyzeTasks } from "./taskAnalyzer";
 import { BlobTreeEntry, CommitTreeEntry, ISummaryStats, SummaryTreeConverter } from "./utils";
 
-export { ISummaryStats } from "./utils";
-
 export interface IGeneratedSummaryData extends ISummaryStats {
     sequenceNumber: number;
 }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -67,10 +67,6 @@ import { SummaryManager } from "./summaryManager";
 import { analyzeTasks } from "./taskAnalyzer";
 import { BlobTreeEntry, CommitTreeEntry, ISummaryStats, SummaryTreeConverter } from "./utils";
 
-export interface IGeneratedSummaryData extends ISummaryStats {
-    sequenceNumber: number;
-}
-
 interface ISummaryTreeWithStats {
     summaryStats: ISummaryStats;
     summaryTree: ISummaryTree;
@@ -80,6 +76,10 @@ interface IBufferedChunk {
     type: MessageType;
 
     content: string;
+}
+
+export interface IGeneratedSummaryData extends ISummaryStats {
+    sequenceNumber: number;
 }
 
 // Consider idle 5s of no activity. And snapshot if a minute has gone by with no snapshot.
@@ -1078,7 +1078,11 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
 
             this.submit(MessageType.Summarize, summary);
 
-            return { sequenceNumber, ...treeWithStats.summaryStats };
+            // notify summarizer while still paused
+            return {
+                sequenceNumber,
+                ...treeWithStats.summaryStats,
+            };
         } catch (ex) {
             this.logger.logException({ eventName: "GenerateSummaryExceptionError" }, ex);
             throw ex;

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -4,3 +4,4 @@
  */
 
 export * from "./containerRuntime";
+export * from "./utils";


### PR DESCRIPTION
This is a follow-up change for the summarizer waiting for summary ack.  Now instead of waiting for any summary ack/nack, it waits specifically for the one corresponding to its own pending summary op.  It does this by listening to the broadcast summary op, and getting its sequence number (matching by client id and reference sequence number).  Then it can match to the summary ack/nack using the summary sequence number, since that alone is unique.

Also made it so the Container Runtime unit tests are actually executed.

Side note: I also tested matching the broadcast summary op to the pending op via the summary handle rather than the reference sequence number, and that also seemed to work fine with some brief local testing.  If that is preferable, let me know and I can update the PR.