### PR TITLE
Move Inner/OuterDocumentDeltaConnection to fluid-iframe-driver

### DIFF
--- a/packages/drivers/iframe-socket-storage/src/index.ts
+++ b/packages/drivers/iframe-socket-storage/src/index.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+export * from "./innerDocumentDeltaConnection";
+export * from "./outerDocumentDeltaConnection";
 export * from "./innerDocumentService";
 export * from "./outerDocumentService";
 export * from "./innerDocumentStorageService";

--- a/packages/drivers/iframe-socket-storage/src/innerDocumentDeltaConnection.ts
+++ b/packages/drivers/iframe-socket-storage/src/innerDocumentDeltaConnection.ts
@@ -4,6 +4,7 @@
  */
 
 import { Deferred } from "@microsoft/fluid-core-utils";
+import { IConnected } from "@microsoft/fluid-driver-base";
 import {
     ConnectionMode,
     IContentMessage,
@@ -17,7 +18,6 @@ import {
 } from "@microsoft/fluid-protocol-definitions";
 import * as Comlink from "comlink";
 import { EventEmitter } from "events";
-import { IConnected } from "./messages";
 
 // tslint:disable: no-non-null-assertion no-console
 

--- a/packages/drivers/iframe-socket-storage/src/innerDocumentService.ts
+++ b/packages/drivers/iframe-socket-storage/src/innerDocumentService.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { InnerDocumentDeltaConnection } from "@microsoft/fluid-driver-base";
 import {
     ConnectionMode,
     IClient,
@@ -13,6 +12,7 @@ import {
     IDocumentStorageService,
 } from "@microsoft/fluid-protocol-definitions";
 import * as Comlink from "comlink";
+import { InnerDocumentDeltaConnection } from "./innerDocumentDeltaConnection";
 import { InnerDocumentStorageService } from "./innerDocumentStorageService";
 import { IOuterProxy } from "./outerDocumentService";
 

--- a/packages/drivers/iframe-socket-storage/src/outerDocumentDeltaConnection.ts
+++ b/packages/drivers/iframe-socket-storage/src/outerDocumentDeltaConnection.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { IConnected } from "@microsoft/fluid-driver-base";
 import {
     ConnectionMode,
     IContentMessage,
@@ -15,7 +16,6 @@ import {
     ITokenClaims,
 } from "@microsoft/fluid-protocol-definitions";
 import { EventEmitter } from "events";
-import { IConnected } from "./messages";
 
 // tslint:disable: no-non-null-assertion no-console
 

--- a/packages/drivers/iframe-socket-storage/src/outerDocumentService.ts
+++ b/packages/drivers/iframe-socket-storage/src/outerDocumentService.ts
@@ -5,9 +5,6 @@
 import { Deferred } from "@microsoft/fluid-core-utils";
 import {
     IConnected,
-    IInnerDocumentDeltaConnectionProxy,
-    IOuterDocumentDeltaConnection,
-    OuterDocumentDeltaConnection,
 } from "@microsoft/fluid-driver-base";
 import {
     ConnectionMode,
@@ -22,6 +19,11 @@ import { DocumentStorageService } from "@microsoft/fluid-routerlicious-driver";
 import * as assert from "assert";
 import * as Comlink from "comlink";
 import { OuterDeltaStorageService } from "./outerDeltaStorageService";
+import {
+    IInnerDocumentDeltaConnectionProxy,
+    IOuterDocumentDeltaConnection,
+    OuterDocumentDeltaConnection,
+} from "./outerDocumentDeltaConnection";
 import { OuterDocumentStorageService } from "./outerDocumentStorageService";
 
 const protocolVersions = ["^0.3.0", "^0.2.0", "^0.1.0"];
@@ -32,8 +34,8 @@ interface IInnerProxy extends IInnerDocumentDeltaConnectionProxy {
 }
 
 export interface IOuterProxy extends IOuterDocumentDeltaConnection,
-                                    IDocumentStorageService,
-                                    IDocumentDeltaStorageService {
+    IDocumentStorageService,
+    IDocumentDeltaStorageService {
     handshake: any;
     connected(): Promise<boolean>;
 }
@@ -75,10 +77,11 @@ export class OuterDocumentService implements IDocumentService {
     private outerDeltaStorageService: IDocumentDeltaStorageService;
     private outerDocumentDeltaConnection: IDocumentDeltaConnection;
 
-    constructor(private readonly storageService: DocumentStorageService,
-                private readonly deltaStorage: IDocumentDeltaStorageService,
-                private readonly deltaConnection: IDocumentDeltaConnection,
-                frame: HTMLIFrameElement,
+    constructor(
+        private readonly storageService: DocumentStorageService,
+        private readonly deltaStorage: IDocumentDeltaStorageService,
+        private readonly deltaConnection: IDocumentDeltaConnection,
+        frame: HTMLIFrameElement,
     ) {
         this.handshake = new Deferred<IInnerProxy>();
 

--- a/packages/drivers/socket-storage-shared/src/index.ts
+++ b/packages/drivers/socket-storage-shared/src/index.ts
@@ -6,5 +6,3 @@
 export * from "./debug";
 export * from "./messages";
 export * from "./documentDeltaConnection";
-export * from "./outerDocumentDeltaConnection";
-export * from "./innerDocumentDeltaConnection";

--- a/packages/server/gateway/src/controllers/loaderFramed.ts
+++ b/packages/server/gateway/src/controllers/loaderFramed.ts
@@ -107,7 +107,7 @@ export async function initialize(
 
         config.moniker = (await Axios.get("/api/v1/moniker")).data;
         config.url = url;
-        privateSession.frameP = createFrame(div, createIFrameHTML(resolved, pkg, scriptIds, scope, config));
+        privateSession.frameP = createFrame(div, createIFrameHTML(resolved, pkg, scriptIds, scope, config, clientId));
         const resolver = new ContainerUrlResolver(
             document.location.origin,
             jwt,
@@ -153,7 +153,8 @@ function createIFrameHTML(resolved: IResolvedUrl,
                           pkg: IResolvedPackage,
                           scriptIds: string[],
                           scope: IComponent,
-                          config: any): string {
+                          config: any,
+                          clientId: string): string {
     const url = window.location.href.split("&privateSession")[0];
     let santizedResolved: IFluidResolvedUrl;
 
@@ -185,6 +186,7 @@ function createIFrameHTML(resolved: IResolvedUrl,
                 undefined, // npm
                 undefined, // jwt
                 ${JSON.stringify(config)}, // config
+                ${JSON.stringify(clientId)}, // clientId
                 ${JSON.stringify(scope)}, // scope
                 true, // innerSession
                 false, // outerSession


### PR DESCRIPTION
The Inner/OuterDocumentDeltaConnection introduce dependency to comlink. which has object uses destructing in object literal, which is not supported by the Edge browser.   Moving it out to the fluid-iframe-driver instead of having them in the fluid-driver-base to avoid the need for the user to transpile if they don't use the iframe support.