### PR TITLE
0.10: Ensure audience exists while loading the document

### DIFF
--- a/packages/loader/container-loader/src/audience.ts
+++ b/packages/loader/container-loader/src/audience.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 import { IAudience } from "@microsoft/fluid-container-definitions";
-import { IClient, ISignalClient } from "@microsoft/fluid-protocol-definitions";
+import { IClient } from "@microsoft/fluid-protocol-definitions";
 import { EventEmitter } from "events";
 
 /**
@@ -11,13 +11,6 @@ import { EventEmitter } from "events";
  */
 export class Audience extends EventEmitter implements IAudience {
     private readonly members = new Map<string, IClient>();
-
-    constructor(clients: ISignalClient[]) {
-        super();
-        for (const client of clients) {
-            this.members.set(client.clientId, client.client);
-        }
-    }
 
     /**
      * Adds a new client to the audience

--- a/packages/loader/container-loader/src/audience.ts
+++ b/packages/loader/container-loader/src/audience.ts
@@ -41,4 +41,14 @@ export class Audience extends EventEmitter implements IAudience {
     public getMember(clientId: string): IClient | undefined {
         return this.members.get(clientId);
     }
+
+    /**
+     * Clears the audience
+     */
+    public clear(): void {
+        const clientIds = this.members.keys();
+        for (const clientId of clientIds) {
+            this.removeMember(clientId);
+        }
+    }
 }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -220,6 +220,9 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         return this._existing;
     }
 
+    /**
+     * Retrieves the audience associated with the document
+     */
     public get audience(): Audience | undefined {
         return this._audience;
     }
@@ -585,6 +588,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
 
                 this.protocolHandler = protocolHandler;
                 this.blobManager = blobManager;
+                this._audience = new Audience();
 
                 perfEvent.reportProgress({ stage: "BeforeContextLoad" });
 
@@ -806,7 +810,9 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
 
                 // back-compat for new client and old server.
                 const priorClients = details.initialClients ? details.initialClients : [];
-                this._audience = new Audience(priorClients);
+                for (const client of priorClients) {
+                    this._audience!.addMember(client.clientId, client.client);
+                }
             });
 
             this._deltaManager.on("disconnect", (reason: string) => {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -157,7 +157,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
     private _parentBranch: string | undefined | null;
     private _connectionState = ConnectionState.Disconnected;
     private _serviceConfiguration: IServiceConfiguration | undefined;
-    private _audience: Audience | undefined;
+    private readonly _audience: Audience;
 
     private context: ContainerContext | undefined;
     private pkg: string | IFluidCodeDetails | undefined;
@@ -223,7 +223,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
     /**
      * Retrieves the audience associated with the document
      */
-    public get audience(): Audience | undefined {
+    public get audience(): Audience {
         return this._audience;
     }
 
@@ -250,6 +250,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         const [, documentId] = id.split("/");
         this._id = decodeURI(documentId);
         this._scopes = this.getScopes(options);
+        this._audience = new Audience();
 
         // create logger for components to use
         this.subLogger = DebugLogger.mixinDebugLogger(
@@ -588,7 +589,6 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
 
                 this.protocolHandler = protocolHandler;
                 this.blobManager = blobManager;
-                this._audience = new Audience();
 
                 perfEvent.reportProgress({ stage: "BeforeContextLoad" });
 
@@ -809,9 +809,11 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
                 }
 
                 // back-compat for new client and old server.
+                this._audience.clear();
+
                 const priorClients = details.initialClients ? details.initialClients : [];
                 for (const client of priorClients) {
-                    this._audience!.addMember(client.clientId, client.client);
+                    this._audience.addMember(client.clientId, client.client);
                 }
             });
 

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -122,7 +122,7 @@ export class ContainerContext extends EventEmitter implements IContainerContext 
         return this.container.serviceConfiguration;
     }
 
-    public get audience(): IAudience | undefined {
+    public get audience(): IAudience {
         return this.container.audience;
     }
 


### PR DESCRIPTION
Before `this._audience` was only set after the document connected to the delta stream.
Now audience will be created in a blank state. Once connected, the `addMember` event will be fired for the clients in the document.