### PR TITLE
Some PRs failing: Mismatch between types/node-fetch & DOM types.

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspUtils.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspUtils.ts
@@ -42,7 +42,7 @@ export function fetchHelper(
     requestInit: RequestInit | undefined,
     retryFilter: RetryFilter = defaultRetryFilter,
 ): Promise<any> {
-    return fetch(requestInfo, requestInit).then((response: Response) => {
+    return fetch(requestInfo, requestInit).then((response) => {
         // Let's assume we can retry.
         if (!response) {
             throwNetworkError(`No response from the server`, 400, true, response);


### PR DESCRIPTION
Some PRs started to fail with this error:
src/OdspUtils.ts(45,18): error TS2345: Argument of type 'RequestInfo' is not assignable to parameter of type 'import("/usr/src/server/node_modules/@types/node-fetch/index").RequestInfo'.

This is related to me adding type info on request argument, but not clear why it started to happen how.
It's easy to force this issue locally by adding this dependency to this package:
 "@types/node-fetch": "^2.5.2"

Basically we get two definitions of same thing from two different modules:
typescript\lib\lib.dom.d.ts
@types\node-fetch\index.d.ts

It's not clear why types\node-fetch is picked up by default occasionally.
The right fix would be to add dependency to types\node-fetch across layers that are involved, which is a bit involved fix for no apparent gain - my might want to do it, but I'm unblocking PRs for now.