### PR TITLE
Logging improvements

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspDeltaStorageService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDeltaStorageService.ts
@@ -30,11 +30,10 @@ export class OdspDeltaStorageService implements api.IDocumentDeltaStorageService
         from?: number,
         to?: number,
     ): Promise<api.ISequencedDocumentMessage[]> {
-        if (this.ops !== undefined && from !== undefined) {
-            const returnOps = this.ops;
-            this.ops = undefined;
-
-            return returnOps.filter((op) => op.sequenceNumber > from).map((op) => op.op);
+        const ops = this.ops;
+        this.ops = undefined;
+        if (ops !== undefined && from !== undefined) {
+            return ops.filter((op) => op.sequenceNumber > from).map((op) => op.op);
         }
         this.ops = undefined;
 

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
@@ -37,6 +37,8 @@ export class OdspDocumentService implements IDocumentService {
 
     private storageManager?: OdspDocumentStorageManager;
 
+    private readonly getStorageToken: (refresh: boolean) => Promise<string | null>;
+
     /**
      * @param appId - app id used for telemetry for network requests
      * @param hashedDocumentId - A unique identifer for the document. The "hashed" here implies that the contents of this string
@@ -61,13 +63,23 @@ export class OdspDocumentService implements IDocumentService {
         driveId: string,
         itemId: string,
         private readonly snapshotStorageUrl: string,
-        readonly getStorageToken: (siteUrl: string, refresh: boolean) => Promise<string | null>,
+        getStorageToken: (siteUrl: string, refresh: boolean) => Promise<string | null>,
         readonly getWebsocketToken: () => Promise<string | null>,
         private readonly logger: ITelemetryLogger,
         private readonly storageFetchWrapper: IFetchWrapper,
         private readonly deltasFetchWrapper: IFetchWrapper,
         private readonly socketIOClientP: Promise<SocketIOClientStatic>,
     ) {
+        this.getStorageToken = (refresh: boolean) => {
+            if (refresh) {
+                // That's usually points to a perf bug:
+                // Hosting app should optimize and provide non-expired tokens on all critical paths.
+                // Exceptions: race conditions around expiration, revoked tokens, host that does not care (fluid-fetcher)
+                this.logger.sendTelemetryEvent({eventName: "StorageTokenRefresh"});
+            }
+            return getStorageToken(this.siteUrl, refresh);
+        };
+
         this.websocketEndpointRequestThrottler = new SinglePromise(() =>
             getSocketStorageDiscovery(
                 appId,
@@ -75,7 +87,7 @@ export class OdspDocumentService implements IDocumentService {
                 itemId,
                 siteUrl,
                 logger,
-                getStorageToken,
+                this.getStorageToken,
             ),
         );
     }
@@ -94,7 +106,7 @@ export class OdspDocumentService implements IDocumentService {
             this.snapshotStorageUrl,
             latestSha,
             this.storageFetchWrapper,
-            (refresh: boolean) => this.getStorageToken(this.siteUrl, refresh),
+            this.getStorageToken,
             this.logger,
             true,
         );
@@ -115,7 +127,7 @@ export class OdspDocumentService implements IDocumentService {
               // any other requests are result of catching up on missing ops and are coming after websocket is established (or reconnected),
               // and thus we already have fresh join session call.
               // That said, tools like Fluid-fetcher will hit it, so that's valid code path.
-              this.logger.sendErrorEvent({ eventName: "OdspOpStreamPerf" });
+              this.logger.sendErrorEvent({ eventName: "ExtraJoinSessionCall" });
 
               this.websocketEndpointP = this.websocketEndpointRequestThrottler.response;
             }
@@ -128,7 +140,7 @@ export class OdspDocumentService implements IDocumentService {
             urlProvider,
             this.deltasFetchWrapper,
             this.storageManager ? this.storageManager.ops : undefined,
-            (refresh: boolean) => this.getStorageToken(this.siteUrl, refresh),
+            this.getStorageToken,
         );
     }
 

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
@@ -72,8 +72,8 @@ export class OdspDocumentService implements IDocumentService {
     ) {
         this.getStorageToken = (refresh: boolean) => {
             if (refresh) {
-                // That's usually points to a perf bug:
-                // Hosting app should optimize and provide non-expired tokens on all critical paths.
+                // Potential perf issue:
+                // Host should optimize and provide non-expired tokens on all critical paths.
                 // Exceptions: race conditions around expiration, revoked tokens, host that does not care (fluid-fetcher)
                 this.logger.sendTelemetryEvent({eventName: "StorageTokenRefresh"});
             }

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentServiceFactory.ts
@@ -45,7 +45,7 @@ export class OdspDocumentServiceFactory implements IDocumentServiceFactory {
       resolvedUrl.endpoints.snapshotStorageUrl,
       this.getStorageToken,
       this.getWebsocketToken,
-      ChildLogger.create(this.logger, "OdspDriver"),
+      ChildLogger.create(this.logger, "fluid:telemetry:OdspDriver"),
       this.storageFetchWrapper,
       this.deltasFetchWrapper,
       Promise.resolve(getSocketIo()),

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentServiceFactoryWithCodeSplit.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentServiceFactoryWithCodeSplit.ts
@@ -47,7 +47,7 @@ export class OdspDocumentServiceFactoryWithCodeSplit implements IDocumentService
       resolvedUrl.endpoints.snapshotStorageUrl,
       this.getStorageToken,
       this.getWebsocketToken,
-      ChildLogger.create(this.logger, "OdspDriver"),
+      ChildLogger.create(this.logger, "fluid:telemetry:OdspDriver"),
       this.storageFetchWrapper,
       this.deltasFetchWrapper,
       import("./getSocketIo").then((m) => m.getSocketIo()),

--- a/packages/loader/container-definitions/src/logger.ts
+++ b/packages/loader/container-definitions/src/logger.ts
@@ -4,7 +4,6 @@
  */
 
 export type TelemetryEventCategory = "generic" | "error" | "performance";
-export type TelemetryPerfType = "start" | "end" | "cancel" | "progress";
 export type TelemetryEventPropertyType = string | number | boolean | object | undefined;
 
 // Name of the error event property indicating if error was raised through Container.emit("error");
@@ -58,7 +57,6 @@ export interface ITelemetryPerformanceEvent {
     eventName: string;
     duration?: number;            // Duration of event (optional)
     tick?: number;                // Event time, relative to start of page load. Filled in by logger if not specified.
-    perfType?: TelemetryPerfType;
     [index: string]: TelemetryEventPropertyType;
 }
 
@@ -92,7 +90,7 @@ export interface ITelemetryLogger extends ITelemetryBaseLogger {
      * Send error telemetry event
      * @param event - Event to send
      */
-    sendPerformanceEvent(event: ITelemetryPerformanceEvent): void;
+    sendPerformanceEvent(event: ITelemetryPerformanceEvent, error?: any): void;
 
     /**
      * Helper method to log generic errors

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -898,11 +898,10 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         });
 
         if (value === ConnectionState.Connected) {
-            // We just logged event with connecting -> connected time
+            // We just logged event with disconnected/connecting -> connected time
             // Log extra event recording disconnected -> connected time, as well as provide some extra info.
             // We can group that info in previous event, but it's easier to analyze telemetry if these are
             // two separate events (actually - three!).
-            assert(this.connectionState === ConnectionState.Connecting);
             this.logger.sendPerformanceEvent({
                 eventName: this.firstConnection ? "ConnectionStateChange_InitialConnect" : "ConnectionStateChange_Reconnect",
                 duration: time - this.connectionTransitionTimes[this.connectionState],

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -622,7 +622,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
                     this.resume();
                 }
 
-                perfEvent.end({}, tree ? "end" : "endNoSnapshot");
+                perfEvent.end({}, tree ? "end" : "end_NoSnapshot");
             });
     }
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -157,6 +157,13 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
          return this.inQuorum && this.connectionMode === "write";
     }
 
+    public get socketDocumentId(): string | undefined {
+        if (this.connection) {
+            return this.connection.details.claims.documentId;
+        }
+        return undefined;
+   }
+
     constructor(
         private readonly service: IDocumentService,
         private readonly client: IClient | null,

--- a/packages/loader/container-loader/src/protocol.ts
+++ b/packages/loader/container-loader/src/protocol.ts
@@ -9,6 +9,7 @@ import {
     ISequencedProposal,
     ITelemetryLogger,
 } from "@microsoft/fluid-container-definitions";
+import { DebugLogger } from "@microsoft/fluid-core-utils";
 import {
     IClientJoin,
     IDocumentAttributes,
@@ -22,7 +23,6 @@ import {
     MessageType,
     SummaryType,
 } from "@microsoft/fluid-protocol-definitions";
-import { debug } from "./debug";
 import { Quorum } from "./quorum";
 
 export interface IScribeProtocolState {
@@ -61,7 +61,7 @@ export class ProtocolOpHandler {
         values: [string, ICommittedProposal][],
         sendProposal: (key: string, value: any) => number,
         sendReject: (sequenceNumber: number) => void,
-        private readonly logger?: ITelemetryLogger,
+        private readonly logger: ITelemetryLogger = DebugLogger.create("fluid:ProtocolHandler"),
     ) {
         this.quorum = new Quorum(minimumSequenceNumber, members, proposals, values, sendProposal, sendReject, logger);
     }
@@ -105,33 +105,24 @@ export class ProtocolOpHandler {
                 break;
 
             case MessageType.Summarize:
-                if (this.logger) {
-                    this.logger.sendTelemetryEvent({
-                        eventName: "Summarize",
-                        summaryContent: message.contents as ISummaryContent,
-                    });
-                }
-                debug("MessageType.Summarize", message.contents);
+                this.logger.sendTelemetryEvent({
+                    eventName: "Summarize",
+                    summaryContent: message.contents as ISummaryContent,
+                });
                 break;
 
             case MessageType.SummaryAck:
-                if (this.logger) {
-                    this.logger.sendTelemetryEvent({
-                        eventName: "SummaryAck",
-                        summaryAck: message.contents as ISummaryAck,
-                    });
-                }
-                debug("MessageType.SummaryAck", message.contents);
+                this.logger.sendTelemetryEvent({
+                    eventName: "SummaryAck",
+                    summaryAck: message.contents as ISummaryAck,
+                });
                 break;
 
             case MessageType.SummaryNack:
-                if (this.logger) {
-                    this.logger.sendTelemetryEvent({
-                        eventName: "SummaryNack",
-                        summaryNack: message.contents as ISummaryNack,
-                    });
-                }
-                debug("MessageType.SummaryNack", message.contents);
+                this.logger.sendTelemetryEvent({
+                    eventName: "SummaryNack",
+                    summaryNack: message.contents as ISummaryNack,
+                });
                 break;
 
             default:

--- a/packages/loader/utils/src/logger.ts
+++ b/packages/loader/utils/src/logger.ts
@@ -88,7 +88,7 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
 
     protected constructor(
         private readonly namespace?: string,
-        private readonly properties?: object) {
+        private properties?: object) {
     }
 
     /**
@@ -97,6 +97,10 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
      * @param event - the event to send
      */
     public abstract send(event: ITelemetryBaseEvent): void;
+
+    public setProperties(properties: object) {
+        this.properties = {...this.properties, ...properties};
+    }
 
     /**
      * Send a telemetry event with the logger

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -529,7 +529,6 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         this.startLeaderElection();
 
         this.deltaManager.on("allSentOpsAckd", () => {
-            this.logger.debugAssert(this.connected, { eventName: "allSentOpsAckd in disconnected state" });
             this.updateDocumentDirtyState(false);
         });
 
@@ -1087,7 +1086,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
 
             return { sequenceNumber, ...treeWithStats.summaryStats };
         } catch (ex) {
-            this.logger.logException({ eventName: "GenerateSummaryExceptionError" }, ex);
+            this.logger.logException({ eventName: "Summarizer:GenerateSummaryExceptionError" }, ex);
             throw ex;
         } finally {
             // Restart the delta manager

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -101,7 +101,6 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
 
         this.logger.sendTelemetryEvent({
             eventName: "RunningSummarizer",
-            clientId: this.runtime.clientId,
             onBehalfOf,
             initSummarySeqNumber: this.lastSummarySeqNumber,
         });
@@ -120,7 +119,6 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
     public stop(reason?: string) {
         this.logger.sendTelemetryEvent({
             eventName: "StoppingSummarizer",
-            clientId: this.runtime.clientId,
             onBehalfOf: this.onBehalfOfClientId,
             reason,
         });
@@ -144,7 +142,6 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
                 if (op.clientId === this.runtime.clientId && op.referenceSequenceNumber === this.lastSummarySeqNumber) {
                     this.logger.sendTelemetryEvent({
                         eventName: "PendingSummaryBroadcast",
-                        clientId: this.runtime.clientId,
                         timeWaitingForBroadcast: Date.now() - this.lastSummaryTime,
                         pendingSummarySequenceNumber: op.sequenceNumber,
                     });
@@ -168,7 +165,6 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
                     this.logger.sendTelemetryEvent({
                         category: op.type === MessageType.SummaryAck ? "generic" : "error",
                         eventName: op.type === MessageType.SummaryAck ? "SummaryAck" : "SummaryNack",
-                        clientId: this.runtime.clientId,
                         timePending: Date.now() - this.lastSummaryTime,
                         summarySequenceNumber: ack.summaryProposal.summarySequenceNumber,
                     });
@@ -191,7 +187,6 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
             if (pendingTime > this.configuration.maxAckWaitTime) {
                 this.logger.sendErrorEvent({
                     eventName: "SummaryAckWaitTimeout",
-                    clientId: this.runtime.clientId,
                     maxAckWaitTime: this.configuration.maxAckWaitTime,
                 });
                 this.cancelPending();
@@ -234,7 +229,7 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
 
     private async summarizeCore(message: string) {
         const summarizingEvent = PerformanceEvent.start(this.logger,
-            { eventName: "Summarizing", message, clientId: this.runtime.clientId });
+            { eventName: "Summarizing", message });
 
         const summaryData = await this.generateSummary();
 


### PR DESCRIPTION
Changes in logging structure based on observing telemetry from dogfooders.

1) The main reason for these changes - make it easier to have initial triage decisions based on looking at event counts. To support that, I chose not to add some information as properties, but as a suffix on event name itself. For example, all perf events will have _start, _end or _cancel suffixes, making it easier to count them and see discrepancies / failures right from initial triage screen.
2) Added namespaces and clarified names in couple places.
3) Added telemetry for using expired tokens (and thus needing extra roundtrip to get data, in addition to fetching new token).
4) Include snapshot properties (count of trees, blobs, ops).
5) Extra event on first being connected, to easier measure user experience
6) cancel events for perf events can contain error information
7) Handling of getLatest was slightly incorrect in case of using expired token - we would fall back to fetching trees one by one. Fixed.

One missing key that I need to add before submission:
We need to add a flag on all events to differentiate main container vs. summarizing container.