### PR TITLE
Remove Content Delegation from Map-Like DDSs

### DIFF
--- a/packages/components/owned-map/src/ownedMap.ts
+++ b/packages/components/owned-map/src/ownedMap.ts
@@ -13,7 +13,6 @@ import { OwnedMapFactory } from "./ownedMapFactory";
 
 const snapshotFileName = "header";
 const ownerPath = "owner";
-const contentPath = "content";
 
 /**
  * Implementation of a map shared object
@@ -70,17 +69,6 @@ export class OwnedSharedMap extends SharedMap implements ISharedMap {
                     contents: this.getOwner(),
                     encoding: "utf-8",
                 },
-            });
-        }
-
-        // Add the snapshot of the content to the tree
-        const contentSnapshot = this.snapshotContent();
-        if (contentSnapshot) {
-            tree.entries.push({
-                mode: FileMode.Directory,
-                path: contentPath,
-                type: TreeEntry[TreeEntry.Tree],
-                value: contentSnapshot,
             });
         }
 

--- a/packages/components/owned-map/src/ownedMap.ts
+++ b/packages/components/owned-map/src/ownedMap.ts
@@ -85,17 +85,6 @@ export class OwnedSharedMap extends SharedMap implements ISharedMap {
         return this.owner === member.client.user.id;
     }
 
-    // tslint:disable-next-line: no-suspicious-comment
-    // TODO: Add this as a base component of snapshotter
-    // protected ownerSnapshot() {
-    //     return {
-    //         mode: FileMode.file,
-    //         path: contentPath,
-    //         type: TreeEntry[TreeEntry.Tree],
-    //         value: contentSnapshot,
-    //     }
-    // }
-
     protected processCore(message: ISequencedDocumentMessage, local: boolean): Promise<any> {
         if (this.getMessageOwner(message) !== this.owner) {
             debug("A non owner attempted to modify this object");

--- a/packages/runtime/map/src/map.ts
+++ b/packages/runtime/map/src/map.ts
@@ -235,24 +235,10 @@ export class SharedMap extends SharedObject implements ISharedMap {
 
     protected onConnect(pending: any[]) {
         debug(`Map ${this.id} is now connected`);
-        // REVIEW: Does it matter that the map and content message get out of order?
 
-        // Filter the nonAck and pending messages into a map set and a content set.
-        const mapMessages = [];
-        const contentMessages: any[] = [];
         for (const message of pending) {
-            if (this.kernel.hasHandlerFor(message)) {
-                mapMessages.push(message);
-            } else {
-                contentMessages.push(message);
-            }
-        }
-
-        // Deal with the map messages - for the map it's always last one wins so we just resend
-        for (const message of mapMessages) {
             this.kernel.trySubmitMessage(message);
         }
-
     }
 
     protected async loadCore(

--- a/packages/runtime/map/src/map.ts
+++ b/packages/runtime/map/src/map.ts
@@ -27,17 +27,6 @@ import { MapKernel } from "./mapKernel";
 import { pkgVersion } from "./packageVersion";
 
 const snapshotFileName = "header";
-const contentPath = "content";
-
-export class ContentObjectStorage implements IObjectStorageService {
-    constructor(private readonly storage: IObjectStorageService) {
-    }
-
-    /* tslint:disable:promise-function-async */
-    public read(path: string): Promise<string> {
-        return this.storage.read(`${contentPath}/${path}`);
-    }
-}
 
 /**
  * The factory that defines the map

--- a/packages/runtime/sequence/src/sequence.ts
+++ b/packages/runtime/sequence/src/sequence.ts
@@ -401,20 +401,16 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
                         encoding: "utf-8",
                     },
                 },
+                {
+                    mode: FileMode.Directory,
+                    path: contentPath,
+                    type: TreeEntry[TreeEntry.Tree],
+                    value: this.snapshotMergeTree(),
+                },
+
             ],
             id: null,
         };
-
-        // Add the snapshot of the content to the tree
-        const mergeTreeSnapshot = this.snapshotMergeTree();
-        if (mergeTreeSnapshot) {
-            tree.entries.push({
-                mode: FileMode.Directory,
-                path: contentPath,
-                type: TreeEntry[TreeEntry.Tree],
-                value: mergeTreeSnapshot,
-            });
-        }
 
         return tree;
     }
@@ -422,7 +418,6 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
     protected replaceRange(start: number, end: number, segment: MergeTree.ISegment) {
         // insert first, so local references can slide to the inserted seg
         // if any
-
         const insert = this.client.insertSegmentLocal(end, segment);
         if (insert) {
             const remove = this.client.removeRangeLocal(start, end);

--- a/packages/runtime/sequence/src/sequence.ts
+++ b/packages/runtime/sequence/src/sequence.ts
@@ -146,7 +146,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
         this.intervalMapKernel = new MapKernel(
             this.runtime,
             this.handle,
-            this.submitLocalMessage,
+            (op) => this.submitLocalMessage(op),
             [new SequenceIntervalCollectionValueType()]);
     }
 
@@ -466,7 +466,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
             const msgs = await loader.initialize(
                 branchId,
                 new ContentObjectStorage(storage));
-            msgs.forEach((m) => this.processMergeTree(m));
+            msgs.forEach((m) => this.processMergeTreeMsg(m));
             this.loadFinished();
         } catch (error) {
             this.loadFinished(error);
@@ -480,7 +480,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
         }
 
         if (!handled) {
-            this.processMergeTree(message);
+            this.processMergeTreeMsg(message);
         }
     }
 
@@ -530,7 +530,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
         return mtSnap;
     }
 
-    protected processMergeTree(rawMessage: ISequencedDocumentMessage) {
+    protected processMergeTreeMsg(rawMessage: ISequencedDocumentMessage) {
         const message = parseHandles(
             rawMessage,
             this.runtime.IComponentSerializer,

--- a/packages/runtime/sequence/src/sequence.ts
+++ b/packages/runtime/sequence/src/sequence.ts
@@ -431,15 +431,16 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
     }
 
     protected onConnect(pending: any[]) {
-        // Update merge tree collaboration information with new client ID and then resend pending ops
-        if (this.client.getCollabWindow().collaborating) {
-            this.client.updateCollaboration(this.runtime.clientId);
-        }
 
         for (const message of pending) {
             if (this.intervalMapKernel.hasHandlerFor(message)) {
                 this.intervalMapKernel.trySubmitMessage(message);
             }
+        }
+
+        // Update merge tree collaboration information with new client ID and then resend pending ops
+        if (this.client.getCollabWindow().collaborating) {
+            this.client.updateCollaboration(this.runtime.clientId);
         }
 
         const groupOp = this.client.resetPendingSegmentsToOp();
@@ -500,7 +501,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
         this.loadFinished();
     }
 
-    protected snapshotMergeTree(): ITree {
+    private snapshotMergeTree(): ITree {
         // Are we fully loaded? If not, things will go south
         assert(this.isLoaded);
 
@@ -530,7 +531,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
         return mtSnap;
     }
 
-    protected processMergeTreeMsg(rawMessage: ISequencedDocumentMessage) {
+    private processMergeTreeMsg(rawMessage: ISequencedDocumentMessage) {
         const message = parseHandles(
             rawMessage,
             this.runtime.IComponentSerializer,

--- a/packages/runtime/sequence/src/sequence.ts
+++ b/packages/runtime/sequence/src/sequence.ts
@@ -3,25 +3,40 @@
  * Licensed under the MIT License.
  */
 
-import { ChildLogger, Deferred } from "@microsoft/fluid-core-utils";
-import { IValueChanged } from "@microsoft/fluid-map";
+import { ChildLogger, Deferred, fromBase64ToUtf8 } from "@microsoft/fluid-core-utils";
+import { IValueChanged, MapKernel } from "@microsoft/fluid-map";
 import * as MergeTree from "@microsoft/fluid-merge-tree";
-import { ISequencedDocumentMessage, ITree } from "@microsoft/fluid-protocol-definitions";
+import { FileMode, ISequencedDocumentMessage, ITree, MessageType, TreeEntry } from "@microsoft/fluid-protocol-definitions";
 import { IChannelAttributes, IComponentRuntime, IObjectStorageService } from "@microsoft/fluid-runtime-definitions";
-import { parseHandles, serializeHandles } from "@microsoft/fluid-shared-object-base";
+import { parseHandles, serializeHandles, SharedObject } from "@microsoft/fluid-shared-object-base";
 import * as assert from "assert";
+import { debug } from "./debug";
 import {
     IntervalCollection,
     SequenceInterval,
     SequenceIntervalCollectionValueType,
 } from "./intervalCollection";
 import { SequenceDeltaEvent, SequenceMaintenanceEvent } from "./sequenceDeltaEvent";
-import { ASharedIntervalCollection } from "./sharedIntervalCollection";
+import { ISharedIntervalCollection } from "./sharedIntervalCollection";
 // tslint:disable-next-line: no-var-requires no-require-imports no-submodule-imports
 const cloneDeep = require("lodash/cloneDeep");
 
+const snapshotFileName = "header";
+const contentPath = "content";
+
+class ContentObjectStorage implements IObjectStorageService {
+    constructor(private readonly storage: IObjectStorageService) {
+    }
+
+    /* tslint:disable:promise-function-async */
+    public read(path: string): Promise<string> {
+        return this.storage.read(`${contentPath}/${path}`);
+    }
+}
+
 export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
-    extends ASharedIntervalCollection<SequenceInterval> {
+    extends SharedObject
+    implements ISharedIntervalCollection<SequenceInterval> {
 
     get loaded(): Promise<void> {
         return this.loadedDeferred.promise;
@@ -78,14 +93,14 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
     // Deferred that triggers once the object is loaded
     protected loadedDeferred = new Deferred<void>();
     private messagesSinceMSNChange: ISequencedDocumentMessage[] = [];
-
+    private readonly intervalMapKernel: MapKernel;
     constructor(
         document: IComponentRuntime,
         public id: string,
         attributes: IChannelAttributes,
         public readonly segmentFromSpec: (spec: MergeTree.IJSONSegment) => MergeTree.ISegment,
     ) {
-        super(id, document, attributes, new SequenceIntervalCollectionValueType());
+        super(id, document, attributes);
 
         /* tslint:disable:no-unsafe-any */
         this.client = new MergeTree.Client(
@@ -127,6 +142,12 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
                 default:
             }
         });
+
+        this.intervalMapKernel = new MapKernel(
+            this.runtime,
+            this.handle,
+            this.submitLocalMessage,
+            [new SequenceIntervalCollectionValueType()]);
     }
 
     /**
@@ -136,10 +157,6 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
     public on(
         event: "pre-op" | "op",
         listener: (op: ISequencedDocumentMessage, local: boolean, target: this) => void): this;
-    public on(event: "valueChanged", listener: (changed: IValueChanged,
-                                                local: boolean,
-                                                op: ISequencedDocumentMessage,
-                                                target: this) => void): this;
     public on(event: string | symbol, listener: (...args: any[]) => void): this;
     // tslint:disable-next-line:no-unnecessary-override
     public on(event: string | symbol, listener: (...args: any[]) => void): this {
@@ -290,13 +307,6 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
 
     }
 
-    public sendNACKed() {
-        const groupOp = this.client.resetPendingSegmentsToOp();
-        if (groupOp) {
-            this.submitSequenceMessage(groupOp);
-        }
-    }
-
     public submitSequenceMessage(message: MergeTree.IMergeTreeOp) {
         const translated = serializeHandles(
             message,
@@ -359,6 +369,56 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
         }
     }
 
+    public async waitIntervalCollection(
+        label: string,
+    ): Promise<IntervalCollection<SequenceInterval>> {
+        return this.intervalMapKernel.wait<IntervalCollection<SequenceInterval>>(label);
+    }
+
+    // TODO: fix race condition on creation by putting type on every operation
+    public getIntervalCollection(label: string): IntervalCollection<SequenceInterval> {
+        if (!this.intervalMapKernel.has(label)) {
+            this.intervalMapKernel.createValueType(
+                label,
+                SequenceIntervalCollectionValueType.Name,
+                undefined);
+        }
+
+        const sharedCollection =
+            this.intervalMapKernel.get<IntervalCollection<SequenceInterval>>(label);
+        return sharedCollection;
+    }
+
+    public snapshot(): ITree {
+        const tree: ITree = {
+            entries: [
+                {
+                    mode: FileMode.File,
+                    path: snapshotFileName,
+                    type: TreeEntry[TreeEntry.Blob],
+                    value: {
+                        contents: this.intervalMapKernel.serialize(),
+                        encoding: "utf-8",
+                    },
+                },
+            ],
+            id: null,
+        };
+
+        // Add the snapshot of the content to the tree
+        const mergeTreeSnapshot = this.snapshotMergeTree();
+        if (mergeTreeSnapshot) {
+            tree.entries.push({
+                mode: FileMode.Directory,
+                path: contentPath,
+                type: TreeEntry[TreeEntry.Tree],
+                value: mergeTreeSnapshot,
+            });
+        }
+
+        return tree;
+    }
+
     protected replaceRange(start: number, end: number, segment: MergeTree.ISegment) {
         // insert first, so local references can slide to the inserted seg
         // if any
@@ -370,19 +430,68 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
         }
     }
 
-    protected async loadContent(
+    protected onConnect(pending: any[]) {
+        // Update merge tree collaboration information with new client ID and then resend pending ops
+        if (this.client.getCollabWindow().collaborating) {
+            this.client.updateCollaboration(this.runtime.clientId);
+        }
+
+        for (const message of pending) {
+            if (this.intervalMapKernel.hasHandlerFor(message)) {
+                this.intervalMapKernel.trySubmitMessage(message);
+            }
+        }
+
+        const groupOp = this.client.resetPendingSegmentsToOp();
+        if (groupOp) {
+            this.submitSequenceMessage(groupOp);
+        }
+    }
+
+    protected onDisconnect() {
+        debug(`${this.id} is now disconnected`);
+    }
+
+    protected async loadCore(
         branchId: string,
-        storage: IObjectStorageService): Promise<void> {
+        storage: IObjectStorageService) {
+
+        const header = await storage.read(snapshotFileName);
+
+        const data: string = header ? fromBase64ToUtf8(header) : undefined;
+        this.intervalMapKernel.populate(data);
+
         const loader = this.client.createSnapshotLoader(this.runtime);
         try {
             const msgs = await loader.initialize(
                 branchId,
-                storage);
-            msgs.forEach((m) => this.processContent(m));
+                new ContentObjectStorage(storage));
+            msgs.forEach((m) => this.processMergeTree(m));
             this.loadFinished();
         } catch (error) {
             this.loadFinished(error);
         }
+    }
+
+    protected processCore(message: ISequencedDocumentMessage, local: boolean) {
+        let handled = false;
+        if (message.type === MessageType.Operation) {
+            handled = this.intervalMapKernel.tryProcessMessage(message, local);
+        }
+
+        if (!handled) {
+            this.processMergeTree(message);
+        }
+    }
+
+    protected registerCore() {
+        for (const value of this.intervalMapKernel.values()) {
+            if (SharedObject.is(value)) {
+                value.register();
+            }
+        }
+
+        this.client.startCollaboration(this.runtime.clientId, 0);
     }
 
     protected initializeLocalCore() {
@@ -391,7 +500,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
         this.loadFinished();
     }
 
-    protected snapshotContent(): ITree {
+    protected snapshotMergeTree(): ITree {
         // Are we fully loaded? If not, things will go south
         assert(this.isLoaded);
 
@@ -421,7 +530,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
         return mtSnap;
     }
 
-    protected processContent(rawMessage: ISequencedDocumentMessage) {
+    protected processMergeTree(rawMessage: ISequencedDocumentMessage) {
         const message = parseHandles(
             rawMessage,
             this.runtime.IComponentSerializer,
@@ -439,7 +548,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
             this.on("sequenceDelta", transfromOps);
         }
 
-        this.processMessage(message);
+        this.client.applyMsg(message);
 
         if (needsTransformation) {
             this.removeListener("sequenceDelta", transfromOps);
@@ -456,22 +565,6 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
 
     }
 
-    protected registerContent() {
-        this.client.startCollaboration(this.runtime.clientId, 0);
-    }
-
-    // Need some comment on why we are not using 'pending' content
-    protected onConnectContent(pending: any[]) {
-        // Update merge tree collaboration information with new client ID and then resend pending ops
-        if (this.client.getCollabWindow().collaborating) {
-            this.client.updateCollaboration(this.runtime.clientId);
-        }
-
-        this.sendNACKed();
-
-        return;
-    }
-
     private processMinSequenceNumberChanged(minSeq: number) {
         let index = 0;
         for (; index < this.messagesSinceMSNChange.length; index++) {
@@ -482,10 +575,6 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
         if (index !== 0) {
             this.messagesSinceMSNChange = this.messagesSinceMSNChange.slice(index);
         }
-    }
-
-    private processMessage(message: ISequencedDocumentMessage) {
-        this.client.applyMsg(message);
     }
 
     private loadFinished(error?: any) {

--- a/packages/runtime/sequence/src/sharedIntervalCollection.ts
+++ b/packages/runtime/sequence/src/sharedIntervalCollection.ts
@@ -5,7 +5,7 @@
 
 import { fromBase64ToUtf8 } from "@microsoft/fluid-core-utils";
 import {
-    IValueType, MapKernel,
+    MapKernel,
 } from "@microsoft/fluid-map";
 import {
     FileMode, ISequencedDocumentMessage, ITree, MessageType, TreeEntry,
@@ -56,7 +56,7 @@ export class SharedIntervalCollectionFactory implements ISharedObjectFactory {
         services: ISharedObjectServices,
         branchId: string): Promise<SharedIntervalCollection> {
 
-        const map = new SharedIntervalCollection(id, runtime, this.attributes, new IntervalCollectionValueType());
+        const map = new SharedIntervalCollection(id, runtime, this.attributes);
         await map.load(branchId, services);
 
         return map;
@@ -66,8 +66,7 @@ export class SharedIntervalCollectionFactory implements ISharedObjectFactory {
         const map = new SharedIntervalCollection(
             id,
             runtime,
-            this.attributes,
-            new IntervalCollectionValueType());
+            this.attributes);
         map.initializeLocal();
 
         return map;
@@ -115,14 +114,13 @@ export class SharedIntervalCollection<TInterval extends ISerializableInterval = 
         id: string,
         runtime: IComponentRuntime,
         attributes = SharedIntervalCollectionFactory.Attributes,
-        private readonly valueType: IValueType<IntervalCollection<TInterval>>,
     ) {
         super(id, runtime, attributes);
         this.intervalMapKernel = new MapKernel(
             runtime,
             this.handle,
             (op) => this.submitLocalMessage(op),
-            [valueType],
+            [new IntervalCollectionValueType()],
         );
     }
 
@@ -137,7 +135,7 @@ export class SharedIntervalCollection<TInterval extends ISerializableInterval = 
         if (!this.intervalMapKernel.has(label)) {
             this.intervalMapKernel.createValueType(
                 label,
-                this.valueType.name,
+                IntervalCollectionValueType.Name,
                 undefined);
         }
 

--- a/packages/runtime/sequence/src/sharedIntervalCollection.ts
+++ b/packages/runtime/sequence/src/sharedIntervalCollection.ts
@@ -5,7 +5,7 @@
 
 import { fromBase64ToUtf8 } from "@microsoft/fluid-core-utils";
 import {
-    ContentObjectStorage, IValueType, MapKernel,
+    IValueType, MapKernel,
 } from "@microsoft/fluid-map";
 import {
     FileMode, ISequencedDocumentMessage, ITree, MessageType, TreeEntry,
@@ -29,7 +29,6 @@ import {
 import { pkgVersion } from "./packageVersion";
 
 const snapshotFileName = "header";
-const contentPath = "content";
 
 /**
  * The factory that defines the SharedIntervalCollection
@@ -75,10 +74,38 @@ export class SharedIntervalCollectionFactory implements ISharedObjectFactory {
     }
 }
 
-export abstract class ASharedIntervalCollection<TInterval extends ISerializableInterval> extends SharedObject {
+export interface ISharedIntervalCollection<TInterval extends ISerializableInterval> {
+    waitIntervalCollection(label: string): Promise<IntervalCollection<TInterval>>;
+    getIntervalCollection(label: string): IntervalCollection<TInterval>;
+}
+
+export class SharedIntervalCollection<TInterval extends ISerializableInterval = Interval>
+    extends SharedObject implements ISharedIntervalCollection<TInterval> {
+
+    /**
+     * Create a SharedIntervalCollection
+     *
+     * @param runtime - component runtime the new shared map belongs to
+     * @param id - optional name of the shared map
+     * @returns newly create shared map (but not attached yet)
+     */
+    public static create(runtime: IComponentRuntime, id?: string) {
+        return runtime.createChannel(
+            SharedObject.getIdForCreate(id),
+            SharedIntervalCollectionFactory.Type) as SharedIntervalCollection;
+    }
+
+    /**
+     * Get a factory for SharedIntervalCollection to register with the component.
+     *
+     * @returns a factory that creates and load SharedIntervalCollection
+     */
+    public static getFactory(): ISharedObjectFactory {
+        return new SharedIntervalCollectionFactory();
+    }
 
     public readonly [Symbol.toStringTag]: string = "SharedIntervalCollection";
-    protected readonly intervalMapKernel: MapKernel;
+    private readonly intervalMapKernel: MapKernel;
 
     /**
      * Constructs a new shared SharedIntervalCollection. If the object is non-local an id and service interfaces will
@@ -118,6 +145,7 @@ export abstract class ASharedIntervalCollection<TInterval extends ISerializableI
             this.intervalMapKernel.get<IntervalCollection<TInterval>>(label);
         return sharedCollection;
     }
+
     public snapshot(): ITree {
         const tree: ITree = {
             entries: [
@@ -126,7 +154,7 @@ export abstract class ASharedIntervalCollection<TInterval extends ISerializableI
                     path: snapshotFileName,
                     type: TreeEntry[TreeEntry.Blob],
                     value: {
-                        contents: this.serialize(),
+                        contents: this.intervalMapKernel.serialize(),
                         encoding: "utf-8",
                     },
                 },
@@ -134,22 +162,7 @@ export abstract class ASharedIntervalCollection<TInterval extends ISerializableI
             id: null,
         };
 
-        // Add the snapshot of the content to the tree
-        const contentSnapshot = this.snapshotContent();
-        if (contentSnapshot) {
-            tree.entries.push({
-                mode: FileMode.Directory,
-                path: contentPath,
-                type: TreeEntry[TreeEntry.Tree],
-                value: contentSnapshot,
-            });
-        }
-
         return tree;
-    }
-
-    public serialize() {
-        return this.intervalMapKernel.serialize();
     }
 
     protected onConnect(pending: any[]) {
@@ -171,9 +184,6 @@ export abstract class ASharedIntervalCollection<TInterval extends ISerializableI
         for (const message of mapMessages) {
             this.intervalMapKernel.trySubmitMessage(message);
         }
-
-        // Allow content to catch up
-        this.onConnectContent(contentMessages);
     }
 
     protected onDisconnect() {
@@ -188,11 +198,6 @@ export abstract class ASharedIntervalCollection<TInterval extends ISerializableI
 
         const data: string = header ? fromBase64ToUtf8(header) : undefined;
         this.intervalMapKernel.populate(data);
-
-        const contentStorage = new ContentObjectStorage(storage);
-        await this.loadContent(
-            branchId,
-            contentStorage);
     }
 
     protected async loadContent(
@@ -202,13 +207,8 @@ export abstract class ASharedIntervalCollection<TInterval extends ISerializableI
     }
 
     protected processCore(message: ISequencedDocumentMessage, local: boolean) {
-        let handled = false;
         if (message.type === MessageType.Operation) {
-            handled = this.intervalMapKernel.tryProcessMessage(message, local);
-        }
-
-        if (!handled) {
-            this.processContent(message, local);
+            this.intervalMapKernel.tryProcessMessage(message, local);
         }
     }
 
@@ -218,65 +218,5 @@ export abstract class ASharedIntervalCollection<TInterval extends ISerializableI
                 value.register();
             }
         }
-
-        this.registerContent();
-    }
-
-    // The following three methods enable derived classes to provide custom content that is stored
-    // with the map
-
-    protected registerContent() {
-        return;
-    }
-
-    /**
-     * Processes a content message
-     */
-    protected processContent(message: ISequencedDocumentMessage, local: boolean) {
-        return;
-    }
-
-    /**
-     * Message sent upon reconnecting to the delta stream
-     * Allows Sequence to overwrite nap's default behavior
-     */
-    protected onConnectContent(pending: any[]) {
-        super.onConnect(pending);
-    }
-
-    /**
-     * Snapshots the content
-     */
-    protected snapshotContent(): ITree {
-        return null;
-    }
-}
-
-/**
- * A distributed data structure that stores intervals
- */
-export class SharedIntervalCollection<TInterval extends ISerializableInterval = Interval>
-    extends ASharedIntervalCollection<TInterval> {
-
-    /**
-     * Create a SharedIntervalCollection
-     *
-     * @param runtime - component runtime the new shared map belongs to
-     * @param id - optional name of the shared map
-     * @returns newly create shared map (but not attached yet)
-     */
-    public static create(runtime: IComponentRuntime, id?: string) {
-        return runtime.createChannel(
-            SharedObject.getIdForCreate(id),
-            SharedIntervalCollectionFactory.Type) as SharedIntervalCollection;
-    }
-
-    /**
-     * Get a factory for SharedIntervalCollection to register with the component.
-     *
-     * @returns a factory that creates and load SharedIntervalCollection
-     */
-    public static getFactory(): ISharedObjectFactory {
-        return new SharedIntervalCollectionFactory();
     }
 }


### PR DESCRIPTION
Maps used to play the role of shared object, and supported that via content delegation for messages and snapshots. Map no long plays that role, so removing that pattern in general. Sequence still uses a similar pattern to keep compatibility, but this is now an implementation detail rather than an exposed pattern.