### PR TITLE
Changing createComponent of componentcontext to pass the path of the component in the array to container runtime

### DIFF
--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -155,7 +155,7 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
         super();
     }
 
-    public async createComponent(pkgOrId: string, pkg?: string, props?: any): Promise<IComponentRuntime> {
+    public async createComponent(pkgOrId: string, pkg?: string): Promise<IComponentRuntime> {
         return this.hostRuntime.createComponent(pkgOrId, pkg);
     }
 

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -34,6 +34,8 @@ import {
 } from "@microsoft/fluid-runtime-definitions";
 import * as assert from "assert";
 import { EventEmitter } from "events";
+// tslint:disable-next-line:no-submodule-imports
+import * as uuid from "uuid/v4";
 import { ContainerRuntime } from "./containerRuntime";
 import { BlobTreeEntry } from "./utils";
 
@@ -153,8 +155,13 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
         super();
     }
 
-    public createComponent(pkgOrId: string, pkg?: string): Promise<IComponentRuntime> {
-        return this.hostRuntime.createComponent(pkgOrId, pkg);
+    public async createComponent(pkgOrId: string, pkg?: string, props?: any): Promise<IComponentRuntime> {
+        const details = await this.getSnapshotDetails();
+        const packagePath: string[] = [...details.pkg];
+        const id = pkg === undefined ? uuid() : pkgOrId;
+        pkg === undefined ? packagePath.push(pkgOrId) : packagePath.push(pkg);
+
+        return this.hostRuntime._createComponentWithProps(packagePath, props, id);
     }
 
     public async realize(): Promise<IComponentRuntime> {

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -159,13 +159,12 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
         return this.hostRuntime.createComponent(pkgOrId, pkg);
     }
 
-    public async createSubComponent(pkgOrId: string, pkg?: string, props?: any): Promise<IComponentRuntime> {
+    public async createSubComponent(pkg: string, props?: any): Promise<IComponentRuntime> {
         const details = await this.getSnapshotDetails();
         const packagePath: string[] = [...details.pkg];
-        const id = pkg === undefined ? uuid() : pkgOrId;
-        pkg === undefined ? packagePath.push(pkgOrId) : packagePath.push(pkg);
-
-        return this.hostRuntime._createComponentWithProps(packagePath, props, id);
+        packagePath.push(pkg);
+        const pkgId = uuid();
+        return this.hostRuntime._createComponentWithProps(packagePath, props, pkgId);
     }
 
     public async realize(): Promise<IComponentRuntime> {

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -156,6 +156,10 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
     }
 
     public async createComponent(pkgOrId: string, pkg?: string, props?: any): Promise<IComponentRuntime> {
+        return this.hostRuntime.createComponent(pkgOrId, pkg);
+    }
+
+    public async createSubComponent(pkgOrId: string, pkg?: string, props?: any): Promise<IComponentRuntime> {
         const details = await this.getSnapshotDetails();
         const packagePath: string[] = [...details.pkg];
         const id = pkg === undefined ? uuid() : pkgOrId;
@@ -172,15 +176,10 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
             this.baseId = details.snapshot ? details.snapshot.id : null;
             const packages = details.pkg;
             let registry = this._hostRuntime.IComponentRegistry;
-            const mainRegistry = registry;
             let factory: ComponentFactoryTypes & Partial<IComponentRegistry>;
             for (const pkg of packages) {
                 if (!registry) {
-                    factory = await mainRegistry.get(packages[packages.length - 1]);
-                    if (!factory) {
-                        throw new Error("Factory does not supply the component Registry");
-                    }
-                    break;
+                    throw new Error("Factory does not supply the component Registry");
                 }
                 factory = await registry.get(pkg);
                 registry = factory.IComponentRegistry;

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -155,7 +155,7 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
         super();
     }
 
-    public async createComponent(pkgOrId: string, pkg?: string): Promise<IComponentRuntime> {
+    public async createComponent(pkgOrId: string, pkg?: string | string[]): Promise<IComponentRuntime> {
         return this.hostRuntime.createComponent(pkgOrId, pkg);
     }
 

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -172,10 +172,15 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
             this.baseId = details.snapshot ? details.snapshot.id : null;
             const packages = details.pkg;
             let registry = this._hostRuntime.IComponentRegistry;
+            const mainRegistry = registry;
             let factory: ComponentFactoryTypes & Partial<IComponentRegistry>;
             for (const pkg of packages) {
                 if (!registry) {
-                    throw new Error("Factory does not supply the component Registry");
+                    factory = await mainRegistry.get(packages[packages.length - 1]);
+                    if (!factory) {
+                        throw new Error("Factory does not supply the component Registry");
+                    }
+                    break;
                 }
                 factory = await registry.get(pkg);
                 registry = factory.IComponentRegistry;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -836,19 +836,19 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         }
     }
 
-    public async createComponent(idOrPkg: string, maybePkg?: string) {
+    public async createComponent(idOrPkg: string, maybePkg?: string | string[]) {
         const id = maybePkg === undefined ? uuid() : idOrPkg;
         const pkg = maybePkg === undefined ? idOrPkg : maybePkg;
         return this._createComponentWithProps(pkg, undefined, id);
     }
 
     // tslint:disable-next-line: function-name
-    public async _createComponentWithProps(pkg: string, props: any, id: string): Promise<IComponentRuntime> {
+    public async _createComponentWithProps(pkg: string | string[], props: any, id: string): Promise<IComponentRuntime> {
         this.verifyNotClosed();
 
         const context = new LocalComponentContext(
             id,
-            [pkg],
+            Array.isArray(pkg) ? pkg : [pkg],
             this,
             this.storage,
             this.context.scope,

--- a/packages/runtime/container-runtime/src/test/componentContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/componentContext.spec.ts
@@ -58,17 +58,19 @@ describe("Component Context Tests", () => {
             assert.equal(attachMessage.type, "TestComponent1", "Attach message type does not match.");
         });
 
-        it("Supplying array of packages in LocalComponentContext should create exception", async () => {
-            let exception = false;
-            localComponentContext =
-                new LocalComponentContext("Test1", ["TestComp", "SubComp"], containerRuntime, storage, scope, attachCb);
+        // Removing temporarily
+        // it("Supplying array of packages in LocalComponentContext should create exception", async () => {
+        //     let exception = false;
+        //     localComponentContext =
+        // tslint:disable-next-line: max-line-length
+        //         new LocalComponentContext("Test1", ["TestComp", "SubComp"], containerRuntime, storage, scope, attachCb);
 
-            await localComponentContext.realize()
-            .catch((error) => {
-                exception = true;
-            });
-            assert.equal(exception, true, "Exception did not occured.");
-        });
+        //     await localComponentContext.realize()
+        //     .catch((error) => {
+        //         exception = true;
+        //     });
+        //     assert.equal(exception, true, "Exception did not occured.");
+        // });
 
         it("Supplying array of packages in LocalComponentContext should not create exception", async () => {
             containerRuntime = {

--- a/packages/runtime/container-runtime/src/test/componentContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/componentContext.spec.ts
@@ -58,19 +58,17 @@ describe("Component Context Tests", () => {
             assert.equal(attachMessage.type, "TestComponent1", "Attach message type does not match.");
         });
 
-        // Removing temporarily
-        // it("Supplying array of packages in LocalComponentContext should create exception", async () => {
-        //     let exception = false;
-        //     localComponentContext =
-        // tslint:disable-next-line: max-line-length
-        //         new LocalComponentContext("Test1", ["TestComp", "SubComp"], containerRuntime, storage, scope, attachCb);
+        it("Supplying array of packages in LocalComponentContext should create exception", async () => {
+            let exception = false;
+            localComponentContext =
+                new LocalComponentContext("Test1", ["TestComp", "SubComp"], containerRuntime, storage, scope, attachCb);
 
-        //     await localComponentContext.realize()
-        //     .catch((error) => {
-        //         exception = true;
-        //     });
-        //     assert.equal(exception, true, "Exception did not occured.");
-        // });
+            await localComponentContext.realize()
+            .catch((error) => {
+                exception = true;
+            });
+            assert.equal(exception, true, "Exception did not occured.");
+        });
 
         it("Supplying array of packages in LocalComponentContext should not create exception", async () => {
             containerRuntime = {

--- a/packages/runtime/runtime-definitions/src/components.ts
+++ b/packages/runtime/runtime-definitions/src/components.ts
@@ -257,11 +257,10 @@ export interface IComponentContext extends EventEmitter {
 
     /**
      * Creates a new component by using subregistries.
-     * @param pkgOrId - Package name if a second parameter is not provided. Otherwise an explicit ID.
-     * @param pkg - Package name of the component. Optional and only required if specifying an explicit ID.
-     * @param props - properties to be passed to the instantiateComponent thru the context
+     * @param pkg - Package name of the component.
+     * @param props - properties to be passed to the instantiateComponent thru the context.
      */
-    createSubComponent(pkgOrId: string, pkg?: string, props?: any): Promise<IComponentRuntime>;
+    createSubComponent(pkg: string, props?: any): Promise<IComponentRuntime>;
 
     /**
      * Returns the runtime of the component.

--- a/packages/runtime/runtime-definitions/src/components.ts
+++ b/packages/runtime/runtime-definitions/src/components.ts
@@ -253,7 +253,7 @@ export interface IComponentContext extends EventEmitter {
      * @param pkgOrId - Package name if a second parameter is not provided. Otherwise an explicit ID.
      * @param pkg - Package name of the component. Optional and only required if specifying an explicit ID.
      */
-    createComponent(pkgOrId: string, pkg?: string): Promise<IComponentRuntime>;
+    createComponent(pkgOrId: string, pkg?: string, props?: any): Promise<IComponentRuntime>;
 
     /**
      * Returns the runtime of the component.
@@ -337,7 +337,7 @@ export interface IHostRuntime extends
      * @param pkgOrId - Package name if a second parameter is not provided. Otherwise an explicit ID.
      * @param pkg - Package name of the component. Optional and only required if specifying an explicit ID.
      */
-    createComponent(pkgOrId: string, pkg?: string): Promise<IComponentRuntime>;
+    createComponent(pkgOrId: string, pkg?: string | string[]): Promise<IComponentRuntime>;
 
     /**
      * Creates a new component with props
@@ -350,7 +350,7 @@ export interface IHostRuntime extends
      * Further change to the component create flow to split the local create vs remote instantiate make this deprecated.
      * @internal
      */
-    _createComponentWithProps(pkg: string, props: any, id: string): Promise<IComponentRuntime>;
+    _createComponentWithProps(pkg: string | string[], props: any, id: string): Promise<IComponentRuntime>;
 
     /**
      * Returns the current quorum.

--- a/packages/runtime/runtime-definitions/src/components.ts
+++ b/packages/runtime/runtime-definitions/src/components.ts
@@ -253,7 +253,7 @@ export interface IComponentContext extends EventEmitter {
      * @param pkgOrId - Package name if a second parameter is not provided. Otherwise an explicit ID.
      * @param pkg - Package name of the component. Optional and only required if specifying an explicit ID.
      */
-    createComponent(pkgOrId: string, pkg?: string): Promise<IComponentRuntime>;
+    createComponent(pkgOrId: string, pkg?: string | string[]): Promise<IComponentRuntime>;
 
     /**
      * Creates a new component by using subregistries.

--- a/packages/runtime/runtime-definitions/src/components.ts
+++ b/packages/runtime/runtime-definitions/src/components.ts
@@ -253,7 +253,7 @@ export interface IComponentContext extends EventEmitter {
      * @param pkgOrId - Package name if a second parameter is not provided. Otherwise an explicit ID.
      * @param pkg - Package name of the component. Optional and only required if specifying an explicit ID.
      */
-    createComponent(pkgOrId: string, pkg?: string, props?: any): Promise<IComponentRuntime>;
+    createComponent(pkgOrId: string, pkg?: string): Promise<IComponentRuntime>;
 
     /**
      * Returns the runtime of the component.

--- a/packages/runtime/runtime-definitions/src/components.ts
+++ b/packages/runtime/runtime-definitions/src/components.ts
@@ -256,6 +256,14 @@ export interface IComponentContext extends EventEmitter {
     createComponent(pkgOrId: string, pkg?: string): Promise<IComponentRuntime>;
 
     /**
+     * Creates a new component by using subregistries.
+     * @param pkgOrId - Package name if a second parameter is not provided. Otherwise an explicit ID.
+     * @param pkg - Package name of the component. Optional and only required if specifying an explicit ID.
+     * @param props - properties to be passed to the instantiateComponent thru the context
+     */
+    createSubComponent(pkgOrId: string, pkg?: string, props?: any): Promise<IComponentRuntime>;
+
+    /**
      * Returns the runtime of the component.
      * @param id - Id supplied during creating the component.
      * @param wait - True if you want to wait for it.


### PR DESCRIPTION
1.) Changing createComponent of componentcontext to pass the path of the subcomponent in the array to container runtime, so the realize() could traverse that array and instantiate it.
2.) Tested it with the todo compoennt.