### PR TITLE
Summarizer refresh base snapshot on SummaryAck [0.10]

### DIFF
--- a/packages/loader/container-definitions/src/chaincode.ts
+++ b/packages/loader/container-definitions/src/chaincode.ts
@@ -218,7 +218,7 @@ export interface IContainerContext extends EventEmitter, IMessageScheduler, IPro
     error(err: any): void;
     requestSnapshot(tagMessage: string): Promise<void>;
     reloadContext(): void;
-    refreshBaseSnapshot(snapshot: ISnapshotTree): void;
+    refreshBaseSummary(snapshot: ISnapshotTree): void;
 }
 
 export interface IProvideComponentTokenProvider {

--- a/packages/loader/container-definitions/src/chaincode.ts
+++ b/packages/loader/container-definitions/src/chaincode.ts
@@ -218,6 +218,7 @@ export interface IContainerContext extends EventEmitter, IMessageScheduler, IPro
     error(err: any): void;
     requestSnapshot(tagMessage: string): Promise<void>;
     reloadContext(): void;
+    refreshBaseSnapshot(snapshot: ISnapshotTree): void;
 }
 
 export interface IProvideComponentTokenProvider {

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -177,10 +177,10 @@ export class ContainerContext extends EventEmitter implements IContainerContext 
         this.logger = container.subLogger;
     }
 
-    public refreshBaseSnapshot(snapshot: ISnapshotTree) {
+    public refreshBaseSummary(snapshot: ISnapshotTree) {
         this._baseSnapshot = snapshot;
         // need to notify runtime of the update
-        this.emit("refreshBaseSnapshot", snapshot);
+        this.emit("refreshBaseSummary", snapshot);
     }
 
     public async snapshot(tagMessage: string, fullTree: boolean = false): Promise<ITree | null> {

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -144,6 +144,10 @@ export class ContainerContext extends EventEmitter implements IContainerContext 
         return this;
     }
 
+    public get baseSnapshot() {
+        return this._baseSnapshot;
+    }
+
     // Back compat flag - can remove in 0.6
     public legacyMessaging = true;
 
@@ -154,7 +158,7 @@ export class ContainerContext extends EventEmitter implements IContainerContext 
         public readonly scope: IComponent,
         public readonly codeLoader: ICodeLoader,
         public readonly chaincode: IRuntimeFactory,
-        public readonly baseSnapshot: ISnapshotTree | null,
+        private _baseSnapshot: ISnapshotTree | null,
         private readonly attributes: IDocumentAttributes,
         public readonly blobManager: BlobManager | undefined,
         public readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
@@ -171,6 +175,12 @@ export class ContainerContext extends EventEmitter implements IContainerContext 
     ) {
         super();
         this.logger = container.subLogger;
+    }
+
+    public refreshBaseSnapshot(snapshot: ISnapshotTree) {
+        this._baseSnapshot = snapshot;
+        // need to notify runtime of the update
+        this.emit("refreshBaseSnapshot", snapshot);
     }
 
     public async snapshot(tagMessage: string, fullTree: boolean = false): Promise<ITree | null> {

--- a/packages/loader/utils/src/index.ts
+++ b/packages/loader/utils/src/index.ts
@@ -17,4 +17,5 @@ export * from "./rangeTracker";
 export * from "./rateLimiter";
 export * from "./safeParser";
 export * from "./serializer";
+export * from "./summaryTracker";
 export * from "./utils";

--- a/packages/loader/utils/src/summaryTracker.ts
+++ b/packages/loader/utils/src/summaryTracker.ts
@@ -6,18 +6,30 @@
 import { ISnapshotTree } from "@microsoft/fluid-protocol-definitions";
 
 /**
+ * Initial - this is the initial state of the tracker, which means that
+ * no changes have come in, but the base summary has not been set yet.
+ * Invalid - when a change comes in, the baseId cannot be used.
+ * Valid - no changes have come in since the last reset, and the
+ * base summary has been set.
+ */
+export enum SummaryTrackerState {
+    Initial = 0,
+    Invalid = -1,
+    Valid = 1,
+}
+
+/**
  * Responsible for tracking changes related to base summary tree usage.
  * It basically tracks 2 things: whether there have been any changes since
  * the base summary, and whether the base summary has been refreshed.
  * Only if both things are true can the baseId be reused during summarization.
+ * This is represented by 3 states in the SummaryTrackerState enum.
  */
 export class SummaryTracker {
-    public get unchangedSinceBase() { return this._unchangedSinceBase; }
-    public get baseIsLatest() { return this._baseIsLatest; }
+    public get state() { return this._state; }
     public get baseTree() { return this._baseSnapshotTree; }
 
-    private _unchangedSinceBase = true;
-    private _baseIsLatest = false;
+    private _state: SummaryTrackerState = SummaryTrackerState.Initial;
     private _baseSnapshotTree: ISnapshotTree | null = null;
 
     /**
@@ -25,7 +37,7 @@ export class SummaryTracker {
      * returns null otherwise
      */
     public getBaseId(): string | null {
-        if (this._unchangedSinceBase && this._baseIsLatest && this._baseSnapshotTree) {
+        if (this._state === SummaryTrackerState.Valid && this._baseSnapshotTree) {
             return this._baseSnapshotTree.id;
         } else {
             return null;
@@ -36,25 +48,28 @@ export class SummaryTracker {
      * Indicate that a change has occurred since the base
      */
     public trackChange() {
-        if (this._unchangedSinceBase) {
-            this._unchangedSinceBase = false;
+        if (this._state !== SummaryTrackerState.Invalid) {
+            this._state = SummaryTrackerState.Invalid;
         }
     }
 
     /**
-     * Resets to initial state: base is not latest, but there are no changes
+     * Resets to initial state: there are no changes, but base not yet set
      */
     public resetChangeTracker() {
-        this._unchangedSinceBase = true;
-        this._baseIsLatest = false;
+        if (this._state !== SummaryTrackerState.Initial) {
+            this._state = SummaryTrackerState.Initial;
+        }
     }
 
     /**
-     * Sets the base summary and marks that it is latest
+     * Sets the base summary and sets state as valid if initial
      * @param snapshot - base summary to set
      */
     public refreshBaseSummary(snapshot: ISnapshotTree | null) {
         this._baseSnapshotTree = snapshot;
-        this._baseIsLatest = true;
+        if (this._state === SummaryTrackerState.Initial) {
+            this._state = SummaryTrackerState.Valid;
+        }
     }
 }

--- a/packages/loader/utils/src/summaryTracker.ts
+++ b/packages/loader/utils/src/summaryTracker.ts
@@ -1,0 +1,60 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ISnapshotTree } from "@microsoft/fluid-protocol-definitions";
+
+/**
+ * Responsible for tracking changes related to base summary tree usage.
+ * It basically tracks 2 things: whether there have been any changes since
+ * the base summary, and whether the base summary has been refreshed.
+ * Only if both things are true can the baseId be reused during summarization.
+ */
+export class SummaryTracker {
+    public get unchangedSinceBase() { return this._unchangedSinceBase; }
+    public get baseIsLatest() { return this._baseIsLatest; }
+    public get baseTree() { return this._baseSnapshotTree; }
+
+    private _unchangedSinceBase = true;
+    private _baseIsLatest = false;
+    private _baseSnapshotTree: ISnapshotTree | null = null;
+
+    /**
+     * Gets the baseId if it can be reused during summarization;
+     * returns null otherwise
+     */
+    public getBaseId(): string | null {
+        if (this._unchangedSinceBase && this._baseIsLatest && this._baseSnapshotTree) {
+            return this._baseSnapshotTree.id;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Indicate that a change has occurred since the base
+     */
+    public trackChange() {
+        if (this._unchangedSinceBase) {
+            this._unchangedSinceBase = false;
+        }
+    }
+
+    /**
+     * Resets to initial state: base is not latest, but there are no changes
+     */
+    public resetChangeTracker() {
+        this._unchangedSinceBase = true;
+        this._baseIsLatest = false;
+    }
+
+    /**
+     * Sets the base summary and marks that it is latest
+     * @param snapshot - base summary to set
+     */
+    public refreshBaseSummary(snapshot: ISnapshotTree | null) {
+        this._baseSnapshotTree = snapshot;
+        this._baseIsLatest = true;
+    }
+}

--- a/packages/loader/utils/src/summaryTracker.ts
+++ b/packages/loader/utils/src/summaryTracker.ts
@@ -45,28 +45,30 @@ export class SummaryTracker {
     }
 
     /**
-     * Indicate that a change has occurred since the base
+     * Indicate that a change has occurred since the base.
+     * Set state to invalid.
      */
-    public trackChange() {
+    public invalidate() {
         if (this._state !== SummaryTrackerState.Invalid) {
             this._state = SummaryTrackerState.Invalid;
         }
     }
 
     /**
-     * Resets to initial state: there are no changes, but base not yet set
+     * Resets state to initial.
      */
-    public resetChangeTracker() {
+    public reset() {
         if (this._state !== SummaryTrackerState.Initial) {
             this._state = SummaryTrackerState.Initial;
         }
     }
 
     /**
-     * Sets the base summary and sets state as valid if initial
+     * Sets the base summary tree.
+     * Set state to valid if not invalid.
      * @param snapshot - base summary to set
      */
-    public refreshBaseSummary(snapshot: ISnapshotTree | null) {
+    public setBaseTree(snapshot: ISnapshotTree | null) {
         this._baseSnapshotTree = snapshot;
         if (this._state === SummaryTrackerState.Initial) {
             this._state = SummaryTrackerState.Valid;

--- a/packages/runtime/component-runtime/src/channelContext.ts
+++ b/packages/runtime/component-runtime/src/channelContext.ts
@@ -27,6 +27,8 @@ export interface IChannelContext {
     snapshot(fullTree?: boolean): Promise<ITree>;
 
     isRegistered(): boolean;
+
+    refreshBaseSnapshot(snapshot: ISnapshotTree);
 }
 
 export function createServiceEndpoints(

--- a/packages/runtime/component-runtime/src/channelContext.ts
+++ b/packages/runtime/component-runtime/src/channelContext.ts
@@ -28,7 +28,7 @@ export interface IChannelContext {
 
     isRegistered(): boolean;
 
-    refreshBaseSnapshot(snapshot: ISnapshotTree);
+    refreshBaseSummary(snapshot: ISnapshotTree);
 }
 
 export function createServiceEndpoints(

--- a/packages/runtime/component-runtime/src/channelContext.ts
+++ b/packages/runtime/component-runtime/src/channelContext.ts
@@ -54,7 +54,7 @@ export function createServiceEndpoints(
     };
 }
 
-export function snapshotChannel(channel: IChannel, baseId?: string) {
+export function snapshotChannel(channel: IChannel, baseId: string | null) {
     const snapshot = channel.snapshot();
 
     // Add in the object attributes to the returned tree
@@ -70,7 +70,7 @@ export function snapshotChannel(channel: IChannel, baseId?: string) {
     });
 
     // If baseId exists then the previous snapshot is still valid
-    snapshot.id = baseId === undefined ? null : baseId;
+    snapshot.id = baseId;
 
     return snapshot;
 }

--- a/packages/runtime/component-runtime/src/componentRuntime.ts
+++ b/packages/runtime/component-runtime/src/componentRuntime.ts
@@ -586,16 +586,16 @@ export class ComponentRuntime extends EventEmitter implements IComponentRuntime,
             this.emit("leader", clientId);
         });
 
-        this.componentContext.on("refreshBaseSnapshot",
-            (snapshot: ISnapshotTree) => this.refreshBaseSnapshot(snapshot));
+        this.componentContext.on("refreshBaseSummary",
+            (snapshot: ISnapshotTree) => this.refreshBaseSummary(snapshot));
     }
 
-    private refreshBaseSnapshot(snapshot: ISnapshotTree) {
+    private refreshBaseSummary(snapshot: ISnapshotTree) {
         // propogate updated tree to all channels
         for (const key of Object.keys(snapshot.trees)) {
             const channel = this.contexts.get(key);
             if (channel) {
-                channel.refreshBaseSnapshot(snapshot.trees[key]);
+                channel.refreshBaseSummary(snapshot.trees[key]);
             }
         }
     }

--- a/packages/runtime/component-runtime/src/componentRuntime.ts
+++ b/packages/runtime/component-runtime/src/componentRuntime.ts
@@ -19,6 +19,7 @@ import {
     FileMode,
     IDocumentMessage,
     ISequencedDocumentMessage,
+    ISnapshotTree,
     ITreeEntry,
     MessageType,
     TreeEntry,
@@ -584,6 +585,19 @@ export class ComponentRuntime extends EventEmitter implements IComponentRuntime,
         this.componentContext.on("leader", (clientId: string) => {
             this.emit("leader", clientId);
         });
+
+        this.componentContext.on("refreshBaseSnapshot",
+            (snapshot: ISnapshotTree) => this.refreshBaseSnapshot(snapshot));
+    }
+
+    private refreshBaseSnapshot(snapshot: ISnapshotTree) {
+        // propogate updated tree to all channels
+        for (const key of Object.keys(snapshot.trees)) {
+            const channel = this.contexts.get(key);
+            if (channel) {
+                channel.refreshBaseSnapshot(snapshot.trees[key]);
+            }
+        }
     }
 
     private verifyNotClosed() {

--- a/packages/runtime/component-runtime/src/localChannelContext.ts
+++ b/packages/runtime/component-runtime/src/localChannelContext.ts
@@ -91,7 +91,7 @@ export class LocalChannelContext implements IChannelContext {
         this.attached = true;
     }
 
-    public refreshBaseSnapshot(snapshot: ISnapshotTree) {
+    public refreshBaseSummary(snapshot: ISnapshotTree) {
         this.baseId = snapshot.id === null ? undefined : snapshot.id;
     }
 }

--- a/packages/runtime/component-runtime/src/localChannelContext.ts
+++ b/packages/runtime/component-runtime/src/localChannelContext.ts
@@ -68,9 +68,9 @@ export class LocalChannelContext implements IChannelContext {
         const baseId = this.summaryTracker.getBaseId();
         if (baseId !== null && !fullTree) {
             return { id: baseId, entries: [] };
-        } else {
-            this.summaryTracker.resetChangeTracker();
         }
+        this.summaryTracker.resetChangeTracker();
+
         return this.getAttachSnapshot();
     }
 

--- a/packages/runtime/component-runtime/src/localChannelContext.ts
+++ b/packages/runtime/component-runtime/src/localChannelContext.ts
@@ -4,7 +4,7 @@
  */
 
 import { ConnectionState } from "@microsoft/fluid-container-definitions";
-import { IDocumentStorageService, ISequencedDocumentMessage, ITree, MessageType } from "@microsoft/fluid-protocol-definitions";
+import { IDocumentStorageService, ISequencedDocumentMessage, ISnapshotTree, ITree, MessageType } from "@microsoft/fluid-protocol-definitions";
 import { IChannel, IComponentContext, IComponentRuntime } from "@microsoft/fluid-runtime-definitions";
 import * as assert from "assert";
 import { createServiceEndpoints, IChannelContext, snapshotChannel } from "./channelContext";
@@ -89,5 +89,9 @@ export class LocalChannelContext implements IChannelContext {
         this.channel.connect(services);
 
         this.attached = true;
+    }
+
+    public refreshBaseSnapshot(snapshot: ISnapshotTree) {
+        this.baseId = snapshot.id === null ? undefined : snapshot.id;
     }
 }

--- a/packages/runtime/component-runtime/src/localChannelContext.ts
+++ b/packages/runtime/component-runtime/src/localChannelContext.ts
@@ -58,7 +58,7 @@ export class LocalChannelContext implements IChannelContext {
 
     public processOp(message: ISequencedDocumentMessage, local: boolean): void {
         assert(this.attached);
-        this.summaryTracker.trackChange();
+        this.summaryTracker.invalidate();
 
         // tslint:disable-next-line: no-non-null-assertion
         this.connection!.process(message, local);
@@ -69,7 +69,7 @@ export class LocalChannelContext implements IChannelContext {
         if (baseId !== null && !fullTree) {
             return { id: baseId, entries: [] };
         }
-        this.summaryTracker.resetChangeTracker();
+        this.summaryTracker.reset();
 
         return this.getAttachSnapshot();
     }
@@ -95,6 +95,6 @@ export class LocalChannelContext implements IChannelContext {
     }
 
     public refreshBaseSummary(snapshot: ISnapshotTree) {
-        this.summaryTracker.refreshBaseSummary(snapshot);
+        this.summaryTracker.setBaseTree(snapshot);
     }
 }

--- a/packages/runtime/component-runtime/src/remoteChannelContext.ts
+++ b/packages/runtime/component-runtime/src/remoteChannelContext.ts
@@ -92,7 +92,7 @@ export class RemoteChannelContext implements IChannelContext {
         return snapshotChannel(channel, this.baseId);
     }
 
-    public refreshBaseSnapshot(snapshot: ISnapshotTree) {
+    public refreshBaseSummary(snapshot: ISnapshotTree) {
         this.baseSnapshot = snapshot;
         this.baseId = this.baseSnapshot.id === null ? undefined : this.baseSnapshot.id;
     }

--- a/packages/runtime/component-runtime/src/remoteChannelContext.ts
+++ b/packages/runtime/component-runtime/src/remoteChannelContext.ts
@@ -89,9 +89,8 @@ export class RemoteChannelContext implements IChannelContext {
         const baseId = this.summaryTracker.getBaseId();
         if (baseId !== null && !fullTree) {
             return { id: baseId, entries: [] };
-        } else {
-            this.summaryTracker.resetChangeTracker();
         }
+        this.summaryTracker.resetChangeTracker();
         const channel = await this.getChannel();
         return snapshotChannel(channel, baseId);
     }

--- a/packages/runtime/component-runtime/src/remoteChannelContext.ts
+++ b/packages/runtime/component-runtime/src/remoteChannelContext.ts
@@ -45,8 +45,7 @@ export class RemoteChannelContext implements IChannelContext {
         private readonly extraBlobs: Map<string, string>,
         private readonly branch: string,
         private readonly attributes: RequiredIChannelAttributes | undefined,
-    ) {
-    }
+    ) {}
 
     public getChannel(): Promise<IChannel> {
         if (!this.channelP) {
@@ -146,6 +145,7 @@ export class RemoteChannelContext implements IChannelContext {
         }
         this.pending = undefined;
         this.isLoaded = true;
+        this.baseId = this.baseSnapshot.id == null ? undefined : this.baseSnapshot.id;
 
         // Because have some await between we created the service and here, the connection state might have changed
         // and we don't propagate the connection state when we are not loaded.  So we have to set it again here.

--- a/packages/runtime/component-runtime/src/remoteChannelContext.ts
+++ b/packages/runtime/component-runtime/src/remoteChannelContext.ts
@@ -46,7 +46,7 @@ export class RemoteChannelContext implements IChannelContext {
         private readonly branch: string,
         private readonly attributes: RequiredIChannelAttributes | undefined,
     ) {
-        this.summaryTracker.refreshBaseSummary(baseSnapshot);
+        this.summaryTracker.setBaseTree(baseSnapshot);
     }
 
     public getChannel(): Promise<IChannel> {
@@ -73,7 +73,7 @@ export class RemoteChannelContext implements IChannelContext {
     }
 
     public processOp(message: ISequencedDocumentMessage, local: boolean): void {
-        this.summaryTracker.trackChange();
+        this.summaryTracker.invalidate();
 
         if (this.isLoaded) {
             // tslint:disable-next-line: no-non-null-assertion
@@ -90,13 +90,13 @@ export class RemoteChannelContext implements IChannelContext {
         if (baseId !== null && !fullTree) {
             return { id: baseId, entries: [] };
         }
-        this.summaryTracker.resetChangeTracker();
+        this.summaryTracker.reset();
         const channel = await this.getChannel();
         return snapshotChannel(channel, baseId);
     }
 
     public refreshBaseSummary(snapshot: ISnapshotTree) {
-        this.summaryTracker.refreshBaseSummary(snapshot);
+        this.summaryTracker.setBaseTree(snapshot);
     }
 
     private getAttributesFromBaseTree(): Promise<RequiredIChannelAttributes> {

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -181,11 +181,6 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
         raiseConnectedEvent(this, value, clientId);
     }
 
-    // Called after a snapshot to update the base ID
-    public updateBaseId(id: string) {
-        this.baseId = id;
-    }
-
     public process(message: ISequencedDocumentMessage, local: boolean): void {
         this.verifyNotClosed();
 
@@ -326,6 +321,13 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
     }
 
     public abstract generateAttachMessage(): IAttachMessage;
+
+    public refreshBaseSnapshot(snapshot: ISnapshotTree) {
+        this._baseSnapshot = snapshot;
+        this.baseId = this._baseSnapshot.id === null ? undefined : this._baseSnapshot.id;
+        // need to notify runtime of the update
+        this.emit("refreshBaseSnapshot", snapshot);
+    }
 
     protected abstract getSnapshotDetails(): Promise<ISnapshotDetails>;
 

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -322,11 +322,11 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
 
     public abstract generateAttachMessage(): IAttachMessage;
 
-    public refreshBaseSnapshot(snapshot: ISnapshotTree) {
+    public refreshBaseSummary(snapshot: ISnapshotTree) {
         this._baseSnapshot = snapshot;
         this.baseId = this._baseSnapshot.id === null ? undefined : this._baseSnapshot.id;
         // need to notify runtime of the update
-        this.emit("refreshBaseSnapshot", snapshot);
+        this.emit("refreshBaseSummary", snapshot);
     }
 
     protected abstract getSnapshotDetails(): Promise<ISnapshotDetails>;

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -148,7 +148,7 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
         if (!this.componentRuntimeDeferred) {
             this.componentRuntimeDeferred = new Deferred<IComponentRuntime>();
             const details = await this.getInitialSnapshotDetails();
-            this.summaryTracker.refreshBaseSummary(details.snapshot);
+            this.summaryTracker.setBaseTree(details.snapshot);
             const factory = await this._hostRuntime.IComponentRegistry.get(details.pkg);
 
             // During this call we will invoke the instantiate method - which will call back into us
@@ -186,7 +186,7 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
         this.verifyNotClosed();
 
         // component has been modified and will need to regenerate its snapshot
-        this.summaryTracker.trackChange();
+        this.summaryTracker.invalidate();
 
         if (this.loaded) {
             return this.componentRuntime.process(message, local);
@@ -248,7 +248,7 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
         if (baseId && !fullTree) {
             return { id: baseId, entries: [] };
         }
-        this.summaryTracker.resetChangeTracker();
+        this.summaryTracker.reset();
 
         const entries = await this.componentRuntime.snapshotInternal(fullTree);
 
@@ -305,7 +305,7 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
 
         if (this.pending.length > 0) {
             // component has been modified and will need to regenerate its snapshot
-            this.summaryTracker.trackChange();
+            this.summaryTracker.invalidate();
 
             // Apply all pending ops
             for (const op of this.pending) {
@@ -326,7 +326,7 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
     public abstract generateAttachMessage(): IAttachMessage;
 
     public refreshBaseSummary(snapshot: ISnapshotTree) {
-        this.summaryTracker.refreshBaseSummary(snapshot);
+        this.summaryTracker.setBaseTree(snapshot);
         // need to notify runtime of the update
         this.emit("refreshBaseSummary", snapshot);
     }

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -13,7 +13,12 @@ import {
     ILoader,
     IQuorum,
 } from "@microsoft/fluid-container-definitions";
-import { Deferred, raiseConnectedEvent, readAndParse } from "@microsoft/fluid-core-utils";
+import {
+    Deferred,
+    raiseConnectedEvent,
+    readAndParse,
+    SummaryTracker,
+} from "@microsoft/fluid-core-utils";
 import {
     IDocumentMessage,
     IDocumentStorageService,
@@ -114,18 +119,15 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
     }
 
     public get baseSnapshot(): ISnapshotTree {
-        return this._baseSnapshot;
+        return this.summaryTracker.baseTree;
     }
 
-    // Tracks the base snapshot ID. If no ops effect this component then the id value can be returned on a
-    // snapshot call
-    protected baseId?: string;
     protected componentRuntime: IComponentRuntime;
+    protected readonly summaryTracker = new SummaryTracker();
     private closed = false;
     private loaded = false;
     private pending: ISequencedDocumentMessage[] = [];
     private componentRuntimeDeferred: Deferred<IComponentRuntime>;
-    private _baseSnapshot: ISnapshotTree;
 
     constructor(
         private readonly _hostRuntime: ContainerRuntime,
@@ -145,9 +147,8 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
     public async realize(): Promise<IComponentRuntime> {
         if (!this.componentRuntimeDeferred) {
             this.componentRuntimeDeferred = new Deferred<IComponentRuntime>();
-            const details = await this.getSnapshotDetails();
-            this._baseSnapshot = details.snapshot;
-            this.baseId = details.snapshot && details.snapshot.id ? details.snapshot.id : undefined;
+            const details = await this.getInitialSnapshotDetails();
+            this.summaryTracker.refreshBaseSummary(details.snapshot);
             const factory = await this._hostRuntime.IComponentRegistry.get(details.pkg);
 
             // During this call we will invoke the instantiate method - which will call back into us
@@ -185,7 +186,7 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
         this.verifyNotClosed();
 
         // component has been modified and will need to regenerate its snapshot
-        this.baseId = undefined;
+        this.summaryTracker.trackChange();
 
         if (this.loaded) {
             return this.componentRuntime.process(message, local);
@@ -238,20 +239,23 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
     public async snapshot(fullTree: boolean = false): Promise<ITree> {
         await this.realize();
 
-        const { pkg } = await this.getSnapshotDetails();
+        const { pkg } = await this.getInitialSnapshotDetails();
 
         const componentAttributes = { pkg };
 
         // base ID still being set means previous snapshot is still valid
-        if (this.baseId && !fullTree) {
-            return { id: this.baseId, entries: [] };
+        const baseId = this.summaryTracker.getBaseId();
+        if (baseId && !fullTree) {
+            return { id: baseId, entries: [] };
+        } else {
+            this.summaryTracker.resetChangeTracker();
         }
 
         const entries = await this.componentRuntime.snapshotInternal(fullTree);
 
         entries.push(new BlobTreeEntry(".component", JSON.stringify(componentAttributes)));
 
-        return { entries, id: this.baseId === undefined ? null : this.baseId };
+        return { entries, id: baseId };
     }
 
     public async request(request: IRequest): Promise<IResponse> {
@@ -302,7 +306,7 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
 
         if (this.pending.length > 0) {
             // component has been modified and will need to regenerate its snapshot
-            this.baseId = undefined;
+            this.summaryTracker.trackChange();
 
             // Apply all pending ops
             for (const op of this.pending) {
@@ -323,13 +327,12 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
     public abstract generateAttachMessage(): IAttachMessage;
 
     public refreshBaseSummary(snapshot: ISnapshotTree) {
-        this._baseSnapshot = snapshot;
-        this.baseId = this._baseSnapshot.id === null ? undefined : this._baseSnapshot.id;
+        this.summaryTracker.refreshBaseSummary(snapshot);
         // need to notify runtime of the update
         this.emit("refreshBaseSummary", snapshot);
     }
 
-    protected abstract getSnapshotDetails(): Promise<ISnapshotDetails>;
+    protected abstract getInitialSnapshotDetails(): Promise<ISnapshotDetails>;
 
     private submitOp(type: MessageType, content: any): number {
         this.verifyNotClosed();
@@ -355,7 +358,7 @@ export class RemotedComponentContext extends ComponentContext {
 
     constructor(
         id: string,
-        private readonly snapshotValue: ISnapshotTree | string,
+        private readonly initSnapshotValue: ISnapshotTree | string,
         runtime: ContainerRuntime,
         storage: IDocumentStorageService,
         scope: IComponent,
@@ -376,15 +379,19 @@ export class RemotedComponentContext extends ComponentContext {
         throw new Error("Cannot attach remote component");
     }
 
-    protected async getSnapshotDetails(): Promise<ISnapshotDetails> {
+    // Only refers to the initial snapshot value, not necessarily the baseSnapshot.
+    // This should only be called during realize to get the baseSnapshot,
+    // or it can be called at any time to get the pkg, but that assumes the
+    // pkg can never change for a component.
+    protected async getInitialSnapshotDetails(): Promise<ISnapshotDetails> {
         if (!this.details) {
             let tree: ISnapshotTree;
 
-            if (typeof this.snapshotValue === "string") {
-                const commit = (await this.storage.getVersions(this.snapshotValue, 1))[0];
+            if (typeof this.initSnapshotValue === "string") {
+                const commit = (await this.storage.getVersions(this.initSnapshotValue, 1))[0];
                 tree = await this.storage.getSnapshotTree(commit);
             } else {
-                tree = this.snapshotValue;
+                tree = this.initSnapshotValue;
             }
 
             if (tree === null || tree.blobs[".component"] === undefined) {
@@ -431,9 +438,7 @@ export class LocalComponentContext extends ComponentContext {
         snapshot.entries.push(new BlobTreeEntry(".component", JSON.stringify(componentAttributes)));
 
         // base ID still being set means previous snapshot is still valid
-        if (this.baseId) {
-            snapshot.id = this.baseId === undefined ? null : this.baseId;
-        }
+        snapshot.id = this.summaryTracker.getBaseId();
 
         const message: IAttachMessage = {
             id: this.id,
@@ -444,7 +449,7 @@ export class LocalComponentContext extends ComponentContext {
         return message;
     }
 
-    protected async getSnapshotDetails(): Promise<ISnapshotDetails> {
+    protected async getInitialSnapshotDetails(): Promise<ISnapshotDetails> {
         return {
             pkg: this.pkg,
             snapshot: undefined,

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -247,9 +247,8 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
         const baseId = this.summaryTracker.getBaseId();
         if (baseId && !fullTree) {
             return { id: baseId, entries: [] };
-        } else {
-            this.summaryTracker.resetChangeTracker();
         }
+        this.summaryTracker.resetChangeTracker();
 
         const entries = await this.componentRuntime.snapshotInternal(fullTree);
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -544,8 +544,8 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
             this.clearPartialChunks(clientId);
         });
 
-        this.context.on("refreshBaseSnapshot",
-            (snapshot: ISnapshotTree) => this.refreshBaseSnapshot(snapshot));
+        this.context.on("refreshBaseSummary",
+            (snapshot: ISnapshotTree) => this.refreshBaseSummary(snapshot));
 
         const summaryConfiguration = context.serviceConfiguration
             ? { ...DefaultSummaryConfiguration, ...context.serviceConfiguration.summary }
@@ -560,7 +560,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
             this,
             summaryConfiguration,
             () => this.generateSummary(!this.loadedFromSummary),
-            (snapshot) => this.context.refreshBaseSnapshot(snapshot));
+            (snapshot) => this.context.refreshBaseSummary(snapshot));
 
         // Create the SummaryManager and mark the initial state
         this.summaryManager = new SummaryManager(
@@ -919,14 +919,14 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         return this.dirtyDocument;
     }
 
-    private refreshBaseSnapshot(snapshot: ISnapshotTree) {
+    private refreshBaseSummary(snapshot: ISnapshotTree) {
         // currently only is called from summaries
         this.loadedFromSummary = true;
         // propogate updated tree to all components
         for (const key of Object.keys(snapshot.trees)) {
             if (this.contexts.has(key)) {
                 const component = this.contexts.get(key);
-                component.refreshBaseSnapshot(snapshot.trees[key]);
+                component.refreshBaseSummary(snapshot.trees[key]);
             }
         }
     }

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -69,7 +69,7 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
         private readonly runtime: ContainerRuntime,
         private readonly configuration: ISummaryConfiguration,
         private readonly generateSummary: () => Promise<IGeneratedSummaryData>,
-        private readonly refreshBaseSnapshot: (snapshot: ISnapshotTree) => void,
+        private readonly refreshBaseSummary: (snapshot: ISnapshotTree) => void,
     ) {
         this.logger = ChildLogger.create(this.runtime.logger, "Summarizer");
 
@@ -159,7 +159,7 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
                             this.logger.sendErrorEvent({ eventName: "SummarizerFailedToGetVersion" });
                         } else {
                             const snapshot = await this.runtime.storage.getSnapshotTree(versions[0]);
-                            this.refreshBaseSnapshot(snapshot);
+                            this.refreshBaseSummary(snapshot);
                         }
                     }
                     this.summaryPending = false;

--- a/packages/runtime/container-runtime/src/test/summarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizer.spec.ts
@@ -67,8 +67,8 @@ describe("Runtime", () => {
                                 sendTelemetryEvent: (event) => {},
                             } as ITelemetryLogger,
                             storage: {
-                                getSnapshotTree: () => Promise.resolve(null),
-                                getVersions: (versionId, count) => Promise.resolve([]),
+                                getSnapshotTree: () => Promise.resolve({}),
+                                getVersions: (versionId, count) => Promise.resolve([{}]),
                             } as IDocumentStorageService,
                         } as ContainerRuntime,
                         summaryConfig,

--- a/packages/runtime/container-runtime/src/test/summarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizer.spec.ts
@@ -74,6 +74,7 @@ describe("Runtime", () => {
                                 totalBlobSize: 0,
                             };
                         },
+                        () => {},
                     );
 
                     summarizer.run(summarizerClientId).catch((reason) => assert.fail(JSON.stringify(reason)));


### PR DESCRIPTION
This change gives the summarizer a way to refresh their baseSnapshot and update baseIds all the way down on summary ack.  I think in the future we may want to expand on this to occur at the container level for all clients, but for now it is just the summarizer.

The flow is that the context layers have a `refreshBaseSummary(ISnapshotTree)` method which will update their baseSnapshot and baseId, then raise "refreshBaseSummary" events.
The runtime layers listen to the events and propagate by calling refreshBaseSummary on all their child layer contexts.

-- `ContainerContext` updates baseSnapshot and raises event
---- `ContainerRuntime` listens and propagates
------ `ComponentContext` updates baseSnapshot & baseId and raises event
-------- `ComponentRuntime` listens and propagates
---------- `ChannelContext` updates baseSnapshot & baseId

Additionally, now baseId is initialized in RemoteChannelContexts, so they should be able to reuse handles the first time.