### PR TITLE
Revert SequenceIntervalCollectionValueType Name

### DIFF
--- a/packages/runtime/sequence/src/intervalCollection.ts
+++ b/packages/runtime/sequence/src/intervalCollection.ts
@@ -389,7 +389,7 @@ class SequenceIntervalCollectionFactory
 
 export class SequenceIntervalCollectionValueType
     implements IValueType<IntervalCollection<SequenceInterval>> {
-    public static Name = "sequenceIntervalCollection";
+    public static Name = "sharedStringIntervalCollection";
 
     public get name(): string {
         return SequenceIntervalCollectionValueType.Name;


### PR DESCRIPTION
Revert the serialized name of SequenceIntervalCollectionValueType for back compat.