### PR TITLE
Stop summarizer when parent container disconnects

### DIFF
--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -45,7 +45,11 @@ export interface ISummarizer extends IProvideSummarizer {
      */
     run(onBehalfOf: string): Promise<void>;
 
-    stop();
+    /**
+     * Stops the summarizer by closing its container and resolving its run promise.
+     * @param reason - reason for stopping
+     */
+    stop(reason?: string);
 }
 
 export class Summarizer implements IComponentLoadable, ISummarizer {
@@ -113,11 +117,12 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
         return this.runDeferred.promise;
     }
 
-    public stop() {
+    public stop(reason?: string) {
         this.logger.sendTelemetryEvent({
             eventName: "StoppingSummarizer",
             clientId: this.runtime.clientId,
             onBehalfOf: this.onBehalfOfClientId,
+            reason,
         });
         this.runDeferred.resolve();
         this.runtime.closeFn();
@@ -211,7 +216,7 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
 
         if (this.onBehalfOfClientId !== this.runtime.summarizerClientId) {
             // we are no longer the summarizer, we should close ourself
-            this.stop();
+            this.stop("parent is no longer summarizer");
             return;
         }
 

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -87,7 +87,7 @@ export class SummaryManager extends EventEmitter {
         this.connected = false;
         this.clientId = undefined;
         if (this.runningSummarizer) {
-            this.runningSummarizer.stop();
+            this.runningSummarizer.stop("parent disconnected");
             this.runningSummarizer = undefined;
         }
     }

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -33,6 +33,7 @@ export class SummaryManager extends EventEmitter {
     private readonly heapMembers = new Map<string, IHeapNode<ITrackedClient>>();
     private connected = false;
     private clientId: string;
+    private runningSummarizer?: ISummarizer;
 
     public get summarizer() {
         return this._summarizer;
@@ -85,6 +86,10 @@ export class SummaryManager extends EventEmitter {
 
         this.connected = false;
         this.clientId = undefined;
+        if (this.runningSummarizer) {
+            this.runningSummarizer.stop();
+            this.runningSummarizer = undefined;
+        }
     }
 
     private addHeapNode(clientId: string, client: ISequencedClient) {
@@ -121,6 +126,7 @@ export class SummaryManager extends EventEmitter {
             const doneP = this.createSummarizer()
                 .then((summarizer) => {
                     if (this.shouldSummarize) {
+                        this.runningSummarizer = summarizer;
                         return summarizer.run(this.clientId);
                     }
                 });


### PR DESCRIPTION
Fixes #198.
This adds a `stop()` function to `ISummarizer` which will actually close its container and resolve the summarizer's run promise.  This `stop()` is called in two places:
1. Whenever a client disconnects, its summary manager will stop the running summarizer which it spawned (if there is one).  This roughly means that summarizer containers should be closed when their spawning container leaves the quorum.
2. Right before actually performing a summarize, the summarizer will first verify that its parent container which it is running on behalf of, is still the 0th member of the quorum.  If somehow the parent were to disconnect without the summary manager calling stop, this should ensure that the summarizer doesn't generate another summary, because the new 0th member would have spawned its own summarizer.

Also added clientId to the telemetry events in the Summarizer, and added a StoppingSummarizer event for when stop is called.  Included "onBehalfOf" clientId to the running and stopping events.