### PR TITLE
Safeguard against other falsey baseIds in SummaryTracker [0.10]

### DIFF
--- a/packages/loader/utils/src/summaryTracker.ts
+++ b/packages/loader/utils/src/summaryTracker.ts
@@ -37,7 +37,7 @@ export class SummaryTracker {
      * returns null otherwise
      */
     public getBaseId(): string | null {
-        if (this._state === SummaryTrackerState.Valid && this._baseSnapshotTree) {
+        if (this._state === SummaryTrackerState.Valid && this._baseSnapshotTree && this._baseSnapshotTree.id) {
             return this._baseSnapshotTree.id;
         } else {
             return null;


### PR DESCRIPTION
id gets set to empty string during flatten -> buildHierarchy flow.  This will safeguard since we are strict-checking null.