### PR TITLE
Add propertyGetters for telemetry events [0.10]

### DIFF
--- a/packages/loader/container-definitions/src/logger.ts
+++ b/packages/loader/container-definitions/src/logger.ts
@@ -11,16 +11,19 @@ export type TelemetryEventPropertyType = string | number | boolean | object | un
 // to raise all telemetry errors to user in non-production builds in addition to raising all container events)
 export const TelemetryEventRaisedOnContainer = "criticalErrorRaisedOnContainer";
 
+export interface ITelemetryProperties {
+    [index: string]: TelemetryEventPropertyType;
+}
+
 /**
  * Base interface for logging telemetry statements.
  * Can contain any number of properties that get serialized as json payload.
  * @param category - category of the event, like "error", "performance", "generic", etc.
  * @param eventName - name of the event.
  */
-export interface ITelemetryBaseEvent {
+export interface ITelemetryBaseEvent extends ITelemetryProperties {
     category: TelemetryEventCategory;
     eventName: string;
-    [index: string]: TelemetryEventPropertyType;
 }
 
 /**
@@ -35,29 +38,26 @@ export interface ITelemetryBaseLogger {
  * Informational (non-error) telemetry event
  * Maps to category = "generic"
  */
-export interface ITelemetryGenericEvent {
+export interface ITelemetryGenericEvent extends ITelemetryProperties {
     eventName: string;
-    [index: string]: TelemetryEventPropertyType;
 }
 
 /**
  * Error telemetry event.
  * Maps to category = "error"
  */
-export interface ITelemetryErrorEvent {
+export interface ITelemetryErrorEvent extends ITelemetryProperties {
     eventName: string;
-    [index: string]: TelemetryEventPropertyType;
 }
 
 /**
  * Performance telemetry event.
  * Maps to category = "performance"
  */
-export interface ITelemetryPerformanceEvent {
+export interface ITelemetryPerformanceEvent extends ITelemetryProperties {
     eventName: string;
     duration?: number;            // Duration of event (optional)
     tick?: number;                // Event time, relative to start of page load. Filled in by logger if not specified.
-    [index: string]: TelemetryEventPropertyType;
 }
 
 /**

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -268,6 +268,13 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
                     version: pkgVersion,
                 },
             },
+            {
+                clientId: () => this.clientId,
+                socketDocumentId: () => this._deltaManager!.socketDocumentId,
+                pendingClientId: () => {
+                    return this._connectionState === ConnectionState.Connecting ? this.pendingClientId : undefined;
+                },
+            },
             logger);
 
         // Prefix all events in this file with container-loader
@@ -878,14 +885,6 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
     }
 
     private logConnectionStateChangeTelemetry(value: ConnectionState, reason: string) {
-        // We do not have good correlation ID to match server activity.
-        // Add couple IDs here
-        this.subLogger.setProperties({
-            SocketClientId: this.clientId,
-            SocketDocumentId: this._deltaManager!.socketDocumentId,
-            SocketPendingClientId: value === ConnectionState.Connecting ? this.pendingClientId : undefined,
-        });
-
         // Log actual event
         const time = performanceNow();
         this.connectionTransitionTimes[value] = time;

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -139,12 +139,12 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
             result = await setter();
         } catch (error) {
             // send error event for exceptions
-            this.logger.sendErrorEvent({ eventName, clientId: this.runtime.clientId }, error);
+            this.logger.sendErrorEvent({ eventName }, error);
             success = false;
         }
         if (success && !validator(result)) {
             // send error event when result is invalid
-            this.logger.sendErrorEvent({ eventName, clientId: this.runtime.clientId });
+            this.logger.sendErrorEvent({ eventName });
             success = false;
         }
         return { result, success };


### PR DESCRIPTION
Add an optional propertyGetters arg to the various telemetry loggers creation which will offer functions to add to the event.  These can be overridden per event, by setting the same property names on the event.

Removed setProperties which was used in Container; replaced the subLogger creation with getters for clientId, socketDocumentId, and pendingClientId.