### PR TITLE
Cherry pick 61de68 from release/10.0

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspDeltaStorageService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDeltaStorageService.ts
@@ -30,11 +30,10 @@ export class OdspDeltaStorageService implements api.IDocumentDeltaStorageService
         from?: number,
         to?: number,
     ): Promise<api.ISequencedDocumentMessage[]> {
-        if (this.ops !== undefined && from !== undefined) {
-            const returnOps = this.ops;
-            this.ops = undefined;
-
-            return returnOps.filter((op) => op.sequenceNumber > from).map((op) => op.op);
+        const ops = this.ops;
+        this.ops = undefined;
+        if (ops !== undefined && from !== undefined) {
+            return ops.filter((op) => op.sequenceNumber > from).map((op) => op.op);
         }
         this.ops = undefined;
 

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
@@ -37,6 +37,8 @@ export class OdspDocumentService implements IDocumentService {
 
     private storageManager?: OdspDocumentStorageManager;
 
+    private readonly getStorageToken: (refresh: boolean) => Promise<string | null>;
+
     /**
      * @param appId - app id used for telemetry for network requests
      * @param hashedDocumentId - A unique identifer for the document. The "hashed" here implies that the contents of this string
@@ -61,13 +63,23 @@ export class OdspDocumentService implements IDocumentService {
         driveId: string,
         itemId: string,
         private readonly snapshotStorageUrl: string,
-        readonly getStorageToken: (siteUrl: string, refresh: boolean) => Promise<string | null>,
+        getStorageToken: (siteUrl: string, refresh: boolean) => Promise<string | null>,
         readonly getWebsocketToken: () => Promise<string | null>,
         private readonly logger: ITelemetryLogger,
         private readonly storageFetchWrapper: IFetchWrapper,
         private readonly deltasFetchWrapper: IFetchWrapper,
         private readonly socketIOClientP: Promise<SocketIOClientStatic>,
     ) {
+        this.getStorageToken = (refresh: boolean) => {
+            if (refresh) {
+                // Potential perf issue:
+                // Host should optimize and provide non-expired tokens on all critical paths.
+                // Exceptions: race conditions around expiration, revoked tokens, host that does not care (fluid-fetcher)
+                this.logger.sendTelemetryEvent({eventName: "StorageTokenRefresh"});
+            }
+            return getStorageToken(this.siteUrl, refresh);
+        };
+
         this.websocketEndpointRequestThrottler = new SinglePromise(() =>
             getSocketStorageDiscovery(
                 appId,
@@ -75,7 +87,7 @@ export class OdspDocumentService implements IDocumentService {
                 itemId,
                 siteUrl,
                 logger,
-                getStorageToken,
+                this.getStorageToken,
             ),
         );
     }
@@ -94,7 +106,7 @@ export class OdspDocumentService implements IDocumentService {
             this.snapshotStorageUrl,
             latestSha,
             this.storageFetchWrapper,
-            (refresh: boolean) => this.getStorageToken(this.siteUrl, refresh),
+            this.getStorageToken,
             this.logger,
             true,
         );
@@ -115,7 +127,7 @@ export class OdspDocumentService implements IDocumentService {
               // any other requests are result of catching up on missing ops and are coming after websocket is established (or reconnected),
               // and thus we already have fresh join session call.
               // That said, tools like Fluid-fetcher will hit it, so that's valid code path.
-              this.logger.sendErrorEvent({ eventName: "OdspOpStreamPerf" });
+              this.logger.sendErrorEvent({ eventName: "ExtraJoinSessionCall" });
 
               this.websocketEndpointP = this.websocketEndpointRequestThrottler.response;
             }
@@ -128,7 +140,7 @@ export class OdspDocumentService implements IDocumentService {
             urlProvider,
             this.deltasFetchWrapper,
             this.storageManager ? this.storageManager.ops : undefined,
-            (refresh: boolean) => this.getStorageToken(this.siteUrl, refresh),
+            this.getStorageToken,
         );
     }
 

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentServiceFactory.ts
@@ -45,7 +45,7 @@ export class OdspDocumentServiceFactory implements IDocumentServiceFactory {
       resolvedUrl.endpoints.snapshotStorageUrl,
       this.getStorageToken,
       this.getWebsocketToken,
-      ChildLogger.create(this.logger, "OdspDriver"),
+      ChildLogger.create(this.logger, "fluid:telemetry:OdspDriver"),
       this.storageFetchWrapper,
       this.deltasFetchWrapper,
       Promise.resolve(getSocketIo()),

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentServiceFactoryWithCodeSplit.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentServiceFactoryWithCodeSplit.ts
@@ -47,7 +47,7 @@ export class OdspDocumentServiceFactoryWithCodeSplit implements IDocumentService
       resolvedUrl.endpoints.snapshotStorageUrl,
       this.getStorageToken,
       this.getWebsocketToken,
-      ChildLogger.create(this.logger, "OdspDriver"),
+      ChildLogger.create(this.logger, "fluid:telemetry:OdspDriver"),
       this.storageFetchWrapper,
       this.deltasFetchWrapper,
       import("./getSocketIo").then((m) => m.getSocketIo()),

--- a/packages/loader/container-definitions/src/logger.ts
+++ b/packages/loader/container-definitions/src/logger.ts
@@ -4,7 +4,6 @@
  */
 
 export type TelemetryEventCategory = "generic" | "error" | "performance";
-export type TelemetryPerfType = "start" | "end" | "cancel" | "progress";
 export type TelemetryEventPropertyType = string | number | boolean | object | undefined;
 
 // Name of the error event property indicating if error was raised through Container.emit("error");
@@ -58,7 +57,6 @@ export interface ITelemetryPerformanceEvent {
     eventName: string;
     duration?: number;            // Duration of event (optional)
     tick?: number;                // Event time, relative to start of page load. Filled in by logger if not specified.
-    perfType?: TelemetryPerfType;
     [index: string]: TelemetryEventPropertyType;
 }
 
@@ -92,7 +90,7 @@ export interface ITelemetryLogger extends ITelemetryBaseLogger {
      * Send error telemetry event
      * @param event - Event to send
      */
-    sendPerformanceEvent(event: ITelemetryPerformanceEvent): void;
+    sendPerformanceEvent(event: ITelemetryPerformanceEvent, error?: any): void;
 
     /**
      * Helper method to log generic errors

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -72,6 +72,9 @@ import { PrefetchDocumentStorageService } from "./prefetchDocumentStorageService
 import { isSystemMessage, ProtocolOpHandler } from "./protocol";
 import { Quorum, QuorumProxy } from "./quorum";
 
+// tslint:disable-next-line:no-var-requires
+const performanceNow = require("performance-now") as (() => number);
+
 const PackageNotFactoryError = "Code package does not implement IRuntimeFactory";
 
 export class Container extends EventEmitterWithErrorHandling implements IContainer {
@@ -138,7 +141,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         });
     }
 
-    public subLogger: ITelemetryLogger;
+    public subLogger: TelemetryLogger;
     private readonly logger: ITelemetryLogger;
 
     private pendingClientId: string | undefined;
@@ -164,6 +167,9 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
     private codeQuorumKey;
     private protocolHandler: ProtocolOpHandler | undefined;
     private connectionDetailsP: Promise<IConnectionDetails | null> | undefined;
+
+    private firstConnection = true;
+    private readonly connectionTransitionTimes: number[] = [];
 
     public get id(): string {
         return this._id;
@@ -497,6 +503,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
 
     private connectToDeltaStream() {
         if (!this.connectionDetailsP) {
+            this.connectionTransitionTimes[ConnectionState.Disconnected] = performanceNow();
             this.connectionDetailsP = this._deltaManager!.connect("Document loading");
         }
         return this.connectionDetailsP;
@@ -524,7 +531,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         const connect = connectionValues.indexOf("open") !== -1;
         const pause = connectionValues.indexOf("pause") !== -1;
 
-        const perfEvent = PerformanceEvent.start(this.logger, { eventName: "ContextLoadProgress", stage: "start" });
+        const perfEvent = PerformanceEvent.start(this.logger, { eventName: "Load" });
 
         const storageP = this.service.connectToStorage().then((storage) => {
             this.storageService = new PrefetchDocumentStorageService(storage);
@@ -590,7 +597,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
                 this.protocolHandler = protocolHandler;
                 this.blobManager = blobManager;
 
-                perfEvent.reportProgress({ stage: "BeforeContextLoad" });
+                perfEvent.reportProgress({}, "beforeContextLoad");
 
                 // Initialize document details - if loading a snapshot use that - otherwise we need to wait on
                 // the initial details
@@ -602,8 +609,6 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
 
                     this._existing = details!.existing;
                     this._parentBranch = details!.parentBranch;
-
-                    perfEvent.reportProgress({ stage: "AfterSocketConnect" });
                 }
 
                 await this.loadContext(attributes, storage, tree);
@@ -614,11 +619,10 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
                 this.loaded = true;
 
                 if (connect && !pause) {
-                    perfEvent.reportProgress({ stage: "resuming" });
                     this.resume();
                 }
 
-                perfEvent.end({ stage: "Loaded" });
+                perfEvent.end({}, tree ? "end" : "end_NoSnapshot");
             });
     }
 
@@ -657,7 +661,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
             values,
             (key, value) => this.submitMessage(MessageType.Propose, { key, value }),
             (sequenceNumber) => this.submitMessage(MessageType.Reject, sequenceNumber),
-            this.subLogger);
+            ChildLogger.create(this.subLogger, "ProtocolHandler"));
 
         // Track membership changes and update connection state accordingly
         protocol.quorum.on("addMember", (clientId, details) => {
@@ -783,7 +787,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         this._deltaManager = new DeltaManager(
             this.service,
             clientDetails,
-            ChildLogger.create(this.logger, "DeltaManager"),
+            ChildLogger.create(this.subLogger, "DeltaManager"),
             this.canReconnect,
         );
 
@@ -873,9 +877,43 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         }
     }
 
+    private logConnectionStateChangeTelemetry(value: ConnectionState, reason: string) {
+        // We do not have good correlation ID to match server activity.
+        // Add couple IDs here
+        this.subLogger.setProperties({
+            SocketClientId: this.clientId,
+            SocketDocumentId: this._deltaManager!.socketDocumentId,
+            SocketPendingClientId: value === ConnectionState.Connecting ? this.pendingClientId : undefined,
+        });
+
+        // Log actual event
+        const time = performanceNow();
+        this.connectionTransitionTimes[value] = time;
+        const duration = time - this.connectionTransitionTimes[this.connectionState];
+        this.logger.sendPerformanceEvent({
+            eventName: `ConnectionStateChange_${ConnectionState[value]}`,
+            from: ConnectionState[this.connectionState],
+            duration,
+            reason,
+        });
+
+        if (value === ConnectionState.Connected) {
+            // We just logged event with disconnected/connecting -> connected time
+            // Log extra event recording disconnected -> connected time, as well as provide some extra info.
+            // We can group that info in previous event, but it's easier to analyze telemetry if these are
+            // two separate events (actually - three!).
+            this.logger.sendPerformanceEvent({
+                eventName: this.firstConnection ? "ConnectionStateChange_InitialConnect" : "ConnectionStateChange_Reconnect",
+                duration: time - this.connectionTransitionTimes[this.connectionState],
+                reason,
+            });
+            this.firstConnection = false;
+        }
+    }
+
     private setConnectionState(value: ConnectionState.Disconnected, reason: string);
     private setConnectionState(
-        value: ConnectionState.Connecting | ConnectionState.Connected,
+        value: ConnectionState,
         reason: string,
         clientId: string,
         version: string,
@@ -892,13 +930,6 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
             // Already in the desired state - exit early
             return;
         }
-
-        this.logger.sendPerformanceEvent({
-            eventName: "ConnectionStateChange",
-            from: ConnectionState[this.connectionState],
-            reason,
-            to: ConnectionState[value],
-        });
 
         this._connectionState = value;
         this._version = version;
@@ -920,6 +951,9 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
             // Important as we process our own joinSession message through delta request
             this.pendingClientId = undefined;
         }
+
+        // Report telemetry after we set client id!
+        this.logConnectionStateChangeTelemetry(value, reason);
 
         if (!this.loaded) {
             // If not fully loaded return early

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -157,6 +157,13 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
          return this.inQuorum && this.connectionMode === "write";
     }
 
+    public get socketDocumentId(): string | undefined {
+        if (this.connection) {
+            return this.connection.details.claims.documentId;
+        }
+        return undefined;
+   }
+
     constructor(
         private readonly service: IDocumentService,
         private readonly client: IClient | null,
@@ -376,15 +383,17 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         }
     }
 
-    public async getDeltas(reason: string, fromInitial: number, to?: number): Promise<ISequencedDocumentMessage[]> {
+    public async getDeltas(
+            telemetryEventSuffix: string,
+            fromInitial: number,
+            to?: number): Promise<ISequencedDocumentMessage[]> {
         let retry: number = 0;
         let from: number = fromInitial;
         const allDeltas: ISequencedDocumentMessage[] = [];
 
         const telemetryEvent = PerformanceEvent.start(this.logger, {
-            eventName: "GetDeltas",
+            eventName: `GetDeltas_${telemetryEventSuffix}`,
             from,
-            reason,
             to,
         });
 
@@ -435,7 +444,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
                 logNetworkFailure(
                     this.logger,
                     {
-                        eventName: "GetDeltasError",
+                        eventName: "GetDeltas_Error",
                         fetchTo,
                         from,
                         retry: retry + 1,
@@ -578,7 +587,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
                 this.clientSequenceNumberObserved = 0;
 
                 // If we retried more than once, log an event about how long it took
-                if (this.connectRepeatCount > 2) {
+                if (this.connectRepeatCount > 1) {
                     this.logger.sendTelemetryEvent({
                             attempts: this.connectRepeatCount,
                             duration: (performanceNow() - this.connectStartTime).toFixed(0),
@@ -677,7 +686,6 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         // we quite often get protocol errors before / after observing nack/disconnect
         // we do not want to run through same sequence twice.
         if (connection !== this.connection) {
-            this.logger.sendTelemetryEvent({eventName: "DeltaConnectionReconnectIgnored", reason});
             return;
         }
 
@@ -695,7 +703,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         if (this.clientType !== Browser || !this.reconnect || this.closed || !canRetryOnError(error)) {
             this.closeOnConnectionError(error);
         } else {
-            this.logger.sendTelemetryEvent({eventName: "DeltaConnectionReconnect", reason});
+            this.logger.sendTelemetryEvent({ eventName: "DeltaConnectionReconnect", reason }, error);
             this.connectCore(reason, InitialReconnectDelay, mode);
         }
     }
@@ -717,7 +725,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
             }
         }
         if (messages && messages.length > 0) {
-            this.catchUp("enqueInitalOps", messages);
+            this.catchUp("InitalOps", messages);
         }
     }
 
@@ -859,16 +867,15 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         }
 
         this.pending.push(message);
-        this.fetchMissingDeltas("HandleOutOfOrderMessage", this.lastQueuedSequenceNumber, message.sequenceNumber);
+        this.fetchMissingDeltas("OutOfOrderMessage", this.lastQueuedSequenceNumber, message.sequenceNumber);
     }
 
     /**
      * Retrieves the missing deltas between the given sequence numbers
      */
-    private fetchMissingDeltas(reason: string, from: number, to?: number) {
+    private fetchMissingDeltas(telemetryEventSuffix: string, from: number, to?: number) {
         // Exit out early if we're already fetching deltas
         if (this.fetching) {
-            this.logger.sendTelemetryEvent({eventName: "fetchMissingDeltasAlreadyFetching", from: from!, reason});
             return;
         }
 
@@ -879,11 +886,11 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
 
         this.fetching = true;
 
-        this.getDeltas(reason, from, to).then(
+        this.getDeltas(telemetryEventSuffix, from, to).then(
             (messages) => {
                 this.fetching = false;
                 this.emit("caughtUp");
-                this.catchUp(reason, messages);
+                this.catchUp(telemetryEventSuffix, messages);
             });
     }
 
@@ -929,12 +936,11 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         };
     }
 
-    private catchUp(reason: string, messages: ISequencedDocumentMessage[]): void {
+    private catchUp(telemetryEventSuffix: string, messages: ISequencedDocumentMessage[]): void {
         this.logger.sendPerformanceEvent({
-            eventName: "CatchUp",
+            eventName: `CatchUp_${telemetryEventSuffix}`,
             messageCount: messages.length,
             pendingCount: this.pending.length,
-            reason,
         });
 
         // Apply current operations

--- a/packages/loader/container-loader/src/protocol.ts
+++ b/packages/loader/container-loader/src/protocol.ts
@@ -9,6 +9,7 @@ import {
     ISequencedProposal,
     ITelemetryLogger,
 } from "@microsoft/fluid-container-definitions";
+import { DebugLogger } from "@microsoft/fluid-core-utils";
 import {
     IClientJoin,
     IDocumentAttributes,
@@ -22,7 +23,6 @@ import {
     MessageType,
     SummaryType,
 } from "@microsoft/fluid-protocol-definitions";
-import { debug } from "./debug";
 import { Quorum } from "./quorum";
 
 export interface IScribeProtocolState {
@@ -61,7 +61,7 @@ export class ProtocolOpHandler {
         values: [string, ICommittedProposal][],
         sendProposal: (key: string, value: any) => number,
         sendReject: (sequenceNumber: number) => void,
-        private readonly logger?: ITelemetryLogger,
+        private readonly logger: ITelemetryLogger = DebugLogger.create("fluid:ProtocolHandler"),
     ) {
         this.quorum = new Quorum(minimumSequenceNumber, members, proposals, values, sendProposal, sendReject, logger);
     }
@@ -105,33 +105,24 @@ export class ProtocolOpHandler {
                 break;
 
             case MessageType.Summarize:
-                if (this.logger) {
-                    this.logger.sendTelemetryEvent({
-                        eventName: "Summarize",
-                        summaryContent: message.contents as ISummaryContent,
-                    });
-                }
-                debug("MessageType.Summarize", message.contents);
+                this.logger.sendTelemetryEvent({
+                    eventName: "Summarize",
+                    summaryContent: message.contents as ISummaryContent,
+                });
                 break;
 
             case MessageType.SummaryAck:
-                if (this.logger) {
-                    this.logger.sendTelemetryEvent({
-                        eventName: "SummaryAck",
-                        summaryAck: message.contents as ISummaryAck,
-                    });
-                }
-                debug("MessageType.SummaryAck", message.contents);
+                this.logger.sendTelemetryEvent({
+                    eventName: "SummaryAck",
+                    summaryAck: message.contents as ISummaryAck,
+                });
                 break;
 
             case MessageType.SummaryNack:
-                if (this.logger) {
-                    this.logger.sendTelemetryEvent({
-                        eventName: "SummaryNack",
-                        summaryNack: message.contents as ISummaryNack,
-                    });
-                }
-                debug("MessageType.SummaryNack", message.contents);
+                this.logger.sendTelemetryEvent({
+                    eventName: "SummaryNack",
+                    summaryNack: message.contents as ISummaryNack,
+                });
                 break;
 
             default:

--- a/packages/loader/utils/src/logger.ts
+++ b/packages/loader/utils/src/logger.ts
@@ -11,7 +11,6 @@ import {
     ITelemetryLogger,
     ITelemetryPerformanceEvent,
     TelemetryEventPropertyType,
-    TelemetryPerfType,
 } from "@microsoft/fluid-container-definitions";
 import * as registerDebug from "debug";
 import { pkgName, pkgVersion } from "./packageVersion";
@@ -49,7 +48,7 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
         return name.replace("@", "").replace("/", "-");
     }
 
-    protected static prepareErrorObject(event: ITelemetryBaseEvent, error: any) {
+    public static prepareErrorObject(event: ITelemetryBaseEvent, error: any) {
         if (error === null || typeof error !== "object") {
             // tslint:disable-next-line:no-unsafe-any
             event.error = error;
@@ -89,7 +88,7 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
 
     protected constructor(
         private readonly namespace?: string,
-        private readonly properties?: object) {
+        private properties?: object) {
     }
 
     /**
@@ -98,6 +97,10 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
      * @param event - the event to send
      */
     public abstract send(event: ITelemetryBaseEvent): void;
+
+    public setProperties(properties: object) {
+        this.properties = {...this.properties, ...properties};
+    }
 
     /**
      * Send a telemetry event with the logger
@@ -128,8 +131,9 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
      * Send error telemetry event
      * @param event - Event to send
      */
-    public sendPerformanceEvent(event: ITelemetryPerformanceEvent): void {
+    public sendPerformanceEvent(event: ITelemetryPerformanceEvent, error?: any): void {
         const perfEvent: ITelemetryBaseEvent = { ...event, category: "performance" };
+        TelemetryLogger.prepareErrorObject(perfEvent, error);
 
         if (event.duration) {
             perfEvent.duration = TelemetryLogger.formatTick(event.duration);
@@ -213,7 +217,7 @@ export class TelemetryNullLogger implements ITelemetryLogger {
     }
     public sendErrorEvent(event: ITelemetryErrorEvent, error?: any) {
     }
-    public sendPerformanceEvent(event: ITelemetryPerformanceEvent): void {
+    public sendPerformanceEvent(event: ITelemetryPerformanceEvent, error?: any): void {
     }
     public logGenericError(eventName: string, error: any) {
     }
@@ -428,15 +432,15 @@ export class PerformanceEvent {
         }
     }
 
-    public reportProgress(props?: object): void {
-        this.reportEvent("progress", props);
+    public reportProgress(props?: object, eventNameSuffix: string = "update"): void {
+        this.reportEvent(eventNameSuffix, props);
     }
 
-    public end(props?: object): void {
-        this.reportEvent("end", props);
+    public end(props?: object, eventNameSuffix = "end"): void {
+        this.reportEvent(eventNameSuffix, props);
 
         if (this.startMark) {
-            const endMark = `${this.event!.eventName}-end`;
+            const endMark = `${this.event!.eventName}-${eventNameSuffix}`;
             window.performance.mark(endMark);
             window.performance.measure(`${this.event!.eventName}`, this.startMark, endMark);
             this.startMark = undefined;
@@ -445,27 +449,28 @@ export class PerformanceEvent {
         this.event = undefined;
     }
 
-    public cancel(props?: object): void {
-        this.reportEvent("cancel", props);
+    public cancel(props?: object, error?: any): void {
+        this.reportEvent("cancel", props, error);
         this.event = undefined;
     }
 
-    public reportEvent(perfType: TelemetryPerfType, props?: object): void {
+    public reportEvent(eventNameSuffix: string, props?: object, error?: any): void {
         if (!this.event) {
             this.logger.sendErrorEvent({
                 eventName: "PerformanceEventAfterStop",
                 perfEventName: this.event!.eventName,
-                perfType,
+                eventNameSuffix,
             });
             return;
         }
 
         const tick = performanceNow();
-        const event: ITelemetryPerformanceEvent = {...this.event, ...props, perfType, tick};
-        if (perfType !== "start") {
+        const event: ITelemetryPerformanceEvent = {...this.event, ...props, tick};
+        event.eventName = `${event.eventName}_${eventNameSuffix}`;
+        if (eventNameSuffix !== "start") {
             event.duration = tick - this.startTime;
         }
 
-        this.logger.sendPerformanceEvent(event);
+        this.logger.sendPerformanceEvent(event, error);
     }
 }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -529,7 +529,6 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         this.logger = context.logger;
 
         this.deltaManager.on("allSentOpsAckd", () => {
-            this.logger.debugAssert(this.connected, { eventName: "allSentOpsAckd in disconnected state" });
             this.updateDocumentDirtyState(false);
         });
 
@@ -1085,7 +1084,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
                 ...treeWithStats.summaryStats,
             };
         } catch (ex) {
-            this.logger.logException({ eventName: "GenerateSummaryExceptionError" }, ex);
+            this.logger.logException({ eventName: "Summarizer:GenerateSummaryExceptionError" }, ex);
             throw ex;
         } finally {
             // Restart the delta manager


### PR DESCRIPTION
Logging improvements (#177)

Changes in logging structure based on observing telemetry from dogfooders.

1) The main reason for these changes - make it easier to have initial triage decisions based on looking at event counts. To support that, I chose not to add some information as properties, but as a suffix on event name itself. For example, all perf events will have _start, _end or _cancel suffixes, making it easier to count them and see discrepancies / failures right from initial triage screen.
2) Added namespaces and clarified names in couple places.
3) Added telemetry for using expired tokens (and thus needing extra roundtrip to get data, in addition to fetching new token).
4) Include snapshot properties (count of trees, blobs, ops).
5) Extra event on first being connected, to easier measure user experience
6) cancel events for perf events can contain error information
7) Handling of getLatest was slightly incorrect in case of using expired token - we would fall back to fetching trees one by one. Fixed.