### PR TITLE
Do not try to submit summary op while disconnected [0.10]

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -72,10 +72,6 @@ import { analyzeTasks } from "./taskAnalyzer";
 
 interface ISummaryTreeWithStats {
     summaryStats: ISummaryStats;
-
-    /**
-     * true if the summary op was submitted
-     */
     summaryTree: ISummaryTree;
 }
 
@@ -87,6 +83,10 @@ interface IBufferedChunk {
 
 export interface IGeneratedSummaryData extends ISummaryStats {
     sequenceNumber: number;
+
+    /**
+     * true if the summary op was submitted
+     */
     submitted: boolean;
 }
 

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -282,11 +282,19 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
 
         const summaryEndTime = Date.now();
 
-        summarizingEvent.end({
+        const telemetryProps = {
             ...summaryData,
             opsSinceLastSummary: summaryData.sequenceNumber - this.lastSummarySeqNumber,
             timeSinceLastSummary: summaryEndTime - this.lastSummaryTime,
-        });
+        };
+        if (!summaryData.submitted) {
+            // did not send the summary op
+            summarizingEvent.cancel(telemetryProps);
+            this.cancelPending();
+            return;
+        }
+
+        summarizingEvent.end(telemetryProps);
 
         this.lastSummaryTime = summaryEndTime;
         this.lastSummarySeqNumber = summaryData.sequenceNumber;

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -283,7 +283,8 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
         const summaryEndTime = Date.now();
 
         const telemetryProps = {
-            ...summaryData,
+            sequenceNumber: summaryData.sequenceNumber,
+            ...summaryData.summaryStats,
             opsSinceLastSummary: summaryData.sequenceNumber - this.lastSummarySeqNumber,
             timeSinceLastSummary: summaryEndTime - this.lastSummaryTime,
         };

--- a/packages/runtime/container-runtime/src/test/summarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizer.spec.ts
@@ -76,6 +76,7 @@ describe("Runtime", () => {
                             emitter.emit(generateSummaryEvent);
                             return {
                                 sequenceNumber: lastSeq,
+                                submitted: true,
                                 treeNodeCount: 0,
                                 blobNodeCount: 0,
                                 handleNodeCount: 0,


### PR DESCRIPTION
Since summarizer client never reconnects, we do not try to submit the summary op if disconnected.