### PR TITLE
SharedObject interface reduction

### DIFF
--- a/packages/components/owned-map/src/ownedMap.ts
+++ b/packages/components/owned-map/src/ownedMap.ts
@@ -26,7 +26,7 @@ export class OwnedSharedMap extends SharedMap implements ISharedMap {
      * @returns newly create owned shared map (but not attached yet)
      */
     public static create(runtime: IComponentRuntime, id?: string) {
-        return runtime.createChannel(OwnedSharedMap.getIdForCreate(id), OwnedMapFactory.Type) as OwnedSharedMap;
+        return runtime.createChannel(id, OwnedMapFactory.Type) as OwnedSharedMap;
     }
 
     /**

--- a/packages/runtime/cell/src/cell.ts
+++ b/packages/runtime/cell/src/cell.ts
@@ -48,7 +48,7 @@ export class SharedCell extends SharedObject implements ISharedCell {
      * @returns newly create shared map (but not attached yet)
      */
     public static create(runtime: IComponentRuntime, id?: string) {
-        return runtime.createChannel(SharedObject.getIdForCreate(id), CellFactory.Type) as SharedCell;
+        return runtime.createChannel(id, CellFactory.Type) as SharedCell;
     }
 
     /**

--- a/packages/runtime/component-runtime/package.json
+++ b/packages/runtime/component-runtime/package.json
@@ -42,7 +42,8 @@
     "@microsoft/fluid-protocol-definitions": "^0.11.0",
     "@microsoft/fluid-runtime-definitions": "^0.11.0",
     "@microsoft/fluid-shared-object-base": "^0.11.0",
-    "debug": "^4.1.1"
+    "debug": "^4.1.1",
+    "uuid": "^3.3.2"
   },
   "license": "MIT"
 }

--- a/packages/runtime/component-runtime/src/componentRuntime.ts
+++ b/packages/runtime/component-runtime/src/componentRuntime.ts
@@ -35,6 +35,8 @@ import {
 import { ISharedObjectFactory } from "@microsoft/fluid-shared-object-base";
 import * as assert from "assert";
 import { EventEmitter } from "events";
+// tslint:disable-next-line:no-submodule-imports
+import * as uuid from "uuid/v4";
 import { IChannelContext } from "./channelContext";
 import { LocalChannelContext } from "./localChannelContext";
 import { RemoteChannelContext } from "./remoteChannelContext";
@@ -232,7 +234,7 @@ export class ComponentRuntime extends EventEmitter implements IComponentRuntime,
         return channel;
     }
 
-    public createChannel(id: string, type: string): IChannel {
+    public createChannel(id: string = uuid(), type: string): IChannel {
         this.verifyNotClosed();
 
         const context = new LocalChannelContext(

--- a/packages/runtime/consensus-ordered-collection/src/consensusQueue.ts
+++ b/packages/runtime/consensus-ordered-collection/src/consensusQueue.ts
@@ -37,8 +37,7 @@ export class ConsensusQueue<T = any> extends ConsensusOrderedCollection<T> {
      * @returns newly create consensus queue (but not attached yet)
      */
     public static create<T = any>(runtime: IComponentRuntime, id?: string) {
-        return runtime.createChannel(ConsensusOrderedCollection.getIdForCreate(id),
-            ConsensusQueueFactory.Type) as ConsensusQueue<T>;
+        return runtime.createChannel(id, ConsensusQueueFactory.Type) as ConsensusQueue<T>;
     }
 
     /**

--- a/packages/runtime/consensus-ordered-collection/src/consensusStack.ts
+++ b/packages/runtime/consensus-ordered-collection/src/consensusStack.ts
@@ -37,8 +37,7 @@ export class ConsensusStack<T = any> extends ConsensusOrderedCollection<T> {
      * @returns newly create consensus stack (but not attached yet)
      */
     public static create<T = any>(runtime: IComponentRuntime, id?: string) {
-        return runtime.createChannel(ConsensusOrderedCollection.getIdForCreate(id),
-            ConsensusStackFactory.Type) as ConsensusStack<T>;
+        return runtime.createChannel(id, ConsensusStackFactory.Type) as ConsensusStack<T>;
     }
 
     /**

--- a/packages/runtime/consensus-register-collection/src/consensusRegisterCollection.ts
+++ b/packages/runtime/consensus-register-collection/src/consensusRegisterCollection.ts
@@ -85,8 +85,7 @@ export class ConsensusRegisterCollection<T> extends SharedObject implements ICon
      * @returns newly create consensus register collection (but not attached yet)
      */
     public static create<T>(runtime: IComponentRuntime, id?: string) {
-        return runtime.createChannel(SharedObject.getIdForCreate(id),
-            ConsensusRegisterCollectionFactory.Type) as ConsensusRegisterCollection<T>;
+        return runtime.createChannel(id, ConsensusRegisterCollectionFactory.Type) as ConsensusRegisterCollection<T>;
     }
 
     /**

--- a/packages/runtime/ink/src/ink.ts
+++ b/packages/runtime/ink/src/ink.ts
@@ -39,7 +39,7 @@ export class Ink extends SharedObject implements IInk {
      * @returns Newly create Ink object (but not attached yet)
      */
     public static create(runtime: IComponentRuntime, id?: string) {
-        return runtime.createChannel(SharedObject.getIdForCreate(id), InkFactory.Type) as Ink;
+        return runtime.createChannel(id, InkFactory.Type) as Ink;
     }
 
     /**

--- a/packages/runtime/map/src/directory.ts
+++ b/packages/runtime/map/src/directory.ts
@@ -295,7 +295,7 @@ export class SharedDirectory extends SharedObject implements ISharedDirectory {
      * @returns Newly create shared directory (but not attached yet)
      */
     public static create(runtime: IComponentRuntime, id?: string): SharedDirectory {
-        return runtime.createChannel(SharedObject.getIdForCreate(id), DirectoryFactory.Type) as SharedDirectory;
+        return runtime.createChannel(id, DirectoryFactory.Type) as SharedDirectory;
     }
 
     /**

--- a/packages/runtime/map/src/map.ts
+++ b/packages/runtime/map/src/map.ts
@@ -98,7 +98,7 @@ export class SharedMap extends SharedObject implements ISharedMap {
      * @returns Newly create shared map (but not attached yet)
      */
     public static create(runtime: IComponentRuntime, id?: string): SharedMap {
-        return runtime.createChannel(SharedObject.getIdForCreate(id), MapFactory.Type) as SharedMap;
+        return runtime.createChannel(id, MapFactory.Type) as SharedMap;
     }
 
     /**

--- a/packages/runtime/runtime-definitions/src/components.ts
+++ b/packages/runtime/runtime-definitions/src/components.ts
@@ -118,10 +118,10 @@ export interface IComponentRuntime extends EventEmitter, IComponentRouter {
 
     /**
      * Creates a new channel of the given type.
-     * @param id - ID of the channel to be created.
+     * @param id - ID of the channel to be created.  A unique ID will be generated if left undefined.
      * @param type - Type of the channel.
      */
-    createChannel(id: string, type: string): IChannel;
+    createChannel(id: string | undefined, type: string): IChannel;
 
     /**
      * Registers the channel with the component runtime. If the runtime

--- a/packages/runtime/sequence/src/sharedIntervalCollection.ts
+++ b/packages/runtime/sequence/src/sharedIntervalCollection.ts
@@ -89,9 +89,7 @@ export class SharedIntervalCollection<TInterval extends ISerializableInterval = 
      * @returns newly create shared map (but not attached yet)
      */
     public static create(runtime: IComponentRuntime, id?: string) {
-        return runtime.createChannel(
-            SharedObject.getIdForCreate(id),
-            SharedIntervalCollectionFactory.Type) as SharedIntervalCollection;
+        return runtime.createChannel(id, SharedIntervalCollectionFactory.Type) as SharedIntervalCollection;
     }
 
     /**

--- a/packages/runtime/sequence/src/sharedNumberSequence.ts
+++ b/packages/runtime/sequence/src/sharedNumberSequence.ts
@@ -16,7 +16,7 @@ export class SharedNumberSequence extends SharedSequence<number> {
      * @returns newly create shared number sequence (but not attached yet)
      */
     public static create(runtime: IComponentRuntime, id?: string) {
-        return runtime.createChannel(SharedSequence.getIdForCreate(id),
+        return runtime.createChannel(id,
             SharedNumberSequenceFactory.Type) as SharedNumberSequence;
     }
 

--- a/packages/runtime/sequence/src/sharedObjectSequence.ts
+++ b/packages/runtime/sequence/src/sharedObjectSequence.ts
@@ -16,8 +16,7 @@ export class SharedObjectSequence<T> extends SharedSequence<T> {
      * @returns newly create shared object sequence (but not attached yet)
      */
     public static create<T>(runtime: IComponentRuntime, id?: string) {
-        return runtime.createChannel(SharedSequence.getIdForCreate(id),
-            SharedObjectSequenceFactory.Type) as SharedObjectSequence<T>;
+        return runtime.createChannel(id, SharedObjectSequenceFactory.Type) as SharedObjectSequence<T>;
     }
 
     /**

--- a/packages/runtime/sequence/src/sharedString.ts
+++ b/packages/runtime/sequence/src/sharedString.ts
@@ -41,8 +41,7 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
      * @returns newly create shared string (but not attached yet)
      */
     public static create(runtime: IComponentRuntime, id?: string) {
-        return runtime.createChannel(SharedSegmentSequence.getIdForCreate(id),
-            SharedStringFactory.Type) as SharedString;
+        return runtime.createChannel(id, SharedStringFactory.Type) as SharedString;
     }
 
     /**

--- a/packages/runtime/sequence/src/sparsematrix.ts
+++ b/packages/runtime/sequence/src/sparsematrix.ts
@@ -184,8 +184,7 @@ export class SparseMatrix extends SharedSegmentSequence<MatrixSegment> {
      * @returns newly create sparse matrix (but not attached yet)
      */
     public static create(runtime: IComponentRuntime, id?: string) {
-        return runtime.createChannel(SharedSegmentSequence.getIdForCreate(id),
-            SparseMatrixFactory.Type) as SparseMatrix;
+        return runtime.createChannel(id, SparseMatrixFactory.Type) as SparseMatrix;
     }
 
     /**

--- a/packages/runtime/shared-object-common/package.json
+++ b/packages/runtime/shared-object-common/package.json
@@ -39,8 +39,7 @@
     "@types/double-ended-queue": "^2.1.0",
     "@types/node": "^10.12.12",
     "debug": "^4.1.1",
-    "double-ended-queue": "^2.1.0-0",
-    "uuid": "^3.3.2"
+    "double-ended-queue": "^2.1.0-0"
   },
   "license": "MIT"
 }

--- a/packages/runtime/shared-object-common/src/sharedObject.ts
+++ b/packages/runtime/shared-object-common/src/sharedObject.ts
@@ -15,8 +15,6 @@ import {
 } from "@microsoft/fluid-runtime-definitions";
 import * as assert from "assert";
 import * as Deque from "double-ended-queue";
-// tslint:disable-next-line:no-submodule-imports
-import * as uuid from "uuid/v4";
 import { debug } from "./debug";
 import { SharedObjectComponentHandle } from "./handle";
 import { ISharedObject } from "./types";
@@ -31,15 +29,6 @@ export abstract class SharedObject extends EventEmitterWithErrorHandling impleme
      */
     public static is(obj: any): obj is SharedObject {
         return obj && !!(obj as IComponent).ISharedObject;
-    }
-
-    /**
-     * Get an id for a sharedobject for creation
-     * @param id - User-specified id or undefined if it is not specified
-     * @returns Generated id if the parameter `id` is undefined, value of `id` otherwise
-     */
-    protected static getIdForCreate(id?: string): string {
-        return id === undefined ? uuid() : id;
     }
 
     public get ISharedObject() { return this; }

--- a/packages/runtime/shared-object-common/src/sharedObject.ts
+++ b/packages/runtime/shared-object-common/src/sharedObject.ts
@@ -4,7 +4,7 @@
  */
 
 import { IComponentHandle } from "@microsoft/fluid-component-core-interfaces";
-import { ConnectionState, ITelemetryErrorEvent, ITelemetryLogger } from "@microsoft/fluid-container-definitions";
+import { ConnectionState, IComponent, ITelemetryErrorEvent, ITelemetryLogger } from "@microsoft/fluid-container-definitions";
 import { ChildLogger, EventEmitterWithErrorHandling } from "@microsoft/fluid-core-utils";
 import { ISequencedDocumentMessage, ITree, MessageType } from "@microsoft/fluid-protocol-definitions";
 import {
@@ -30,12 +30,7 @@ export abstract class SharedObject extends EventEmitterWithErrorHandling impleme
      * @returns Returns true if the object is a SharedObject
      */
     public static is(obj: any): obj is SharedObject {
-        if (obj !== undefined
-            && obj !== null
-            && obj.__sharedObject__ === true) {
-            return true;
-        }
-        return false;
+        return obj && !!(obj as IComponent).ISharedObject;
     }
 
     /**
@@ -50,12 +45,6 @@ export abstract class SharedObject extends EventEmitterWithErrorHandling impleme
     public get ISharedObject() { return this; }
     public get IChannel() { return this; }
     public get IComponentLoadable() { return this; }
-
-    /**
-     * Marker to clearly identify the object as a shared object
-     */
-    // tslint:disable-next-line:variable-name
-    public readonly __sharedObject__ = true;
 
     public readonly handle: IComponentHandle;
 

--- a/packages/runtime/shared-object-common/src/types.ts
+++ b/packages/runtime/shared-object-common/src/types.ts
@@ -19,11 +19,6 @@ export interface IProvideSharedObject {
  */
 export interface ISharedObject extends IProvideSharedObject, IChannel {
     /**
-     * Marker to clearly identify the object as a shared object
-     */
-    __sharedObject__: boolean;
-
-    /**
      * Attaches an event listener for the given event
      */
     on(event: string | symbol, listener: (...args: any[]) => void): this;


### PR DESCRIPTION
Removing a couple members of SharedObject that aren't really necessary.
1. Using the `IComponent` pattern to identify `SharedObjects` lets us remove the public `__sharedObject__` member and is more consistent with how we identify implementers of any other `IComponent` interface.
2. Moving UUID generation down into the `ComponentRuntime`'s `createChannel` (and out of the `SharedObject`) lets us remove the protected `getIdForCreate` and encourages uniformity in channel ID creation (rather than relying on each DDS to call into `getIdForCreate` to generate the UUID).