### PR TITLE
Prevent summarizer from pending timeout while still generating summary [0.10]

### DIFF
--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -229,12 +229,13 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
         this.clearIdleTimer();
 
         // clear pending if timeout waiting for server ack
-        if (this.summaryPending) {
+        if (this.summaryPending && !this.summarizing) {
             const pendingTime = Date.now() - this.lastSummaryTime;
             if (pendingTime > this.configuration.maxAckWaitTime) {
                 this.logger.sendErrorEvent({
                     eventName: "SummaryAckWaitTimeout",
                     maxAckWaitTime: this.configuration.maxAckWaitTime,
+                    pendingSummarySequenceNumber: this.pendingSummarySequenceNumber,
                 });
                 this.cancelPending();
             }


### PR DESCRIPTION
Fixes a bug: if an op comes in while summarizing that was more than the summary ack wait timeout since the previously generated summary (not the current one), then it could cause an ack wait timeout.

Basically the fix is to not allow ack wait timeouts while still generating the summary.  The bug was caused by using the previous value of lastSummaryTime before setting it for the current submitted summary op.  Since generating is async, control can be given up so that it processes the incoming ops before completing the submit of the summary op.

Rough flow:
1. start generating summary
2. op comes in, but summarizer inbound ops are paused
3. finish generating summary, unpause, next will set lastSummaryTime after await
4. if op from (2) is processed first, it will it will use old lastSummaryTime and can timeout

Added a test to cover this specific scenario.