### PR TITLE
Protect against undefined map/directory keys, and subdirectory names

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,5 +1,9 @@
 # 0.11 Breaking Changes
 
+- [Undefined keys and subdirectory names on SharedMap and SharedDirectory throw](#Undefined-keys-and-subdirectory-names-on-SharedMap-and-SharedDirectory-throw)
+
+## Undefined keys and subdirectory names on SharedMap and SharedDirectory throw
+Previously, attempting to set `undefined` as a key on a SharedMap or SharedDirectory, or creating a subdirectory with name `undefined` would appear to succeed but would cause inconsistencies in snapshotting.  This will now throw immediately upon trying to set an `undefined` key or subdirectory name.
 
 # 0.10 Breaking Changes
 

--- a/packages/runtime/map/src/directory.ts
+++ b/packages/runtime/map/src/directory.ts
@@ -985,9 +985,9 @@ class SubDirectory implements IDirectory {
      * {@inheritDoc IDirectory.set}
      */
     public set<T = any>(key: string, value: T): this {
-        // Undefined keys can't be serialized to JSON in the manner we currently snapshot.
-        if (key === undefined) {
-            throw new Error("Undefined keys are not supported");
+        // Undefined/null keys can't be serialized to JSON in the manner we currently snapshot.
+        if (key === undefined || key === null) {
+            throw new Error("Undefined and null keys are not supported");
         }
 
         const localValue = this.directory.localValueMaker.fromInMemory(value);
@@ -1058,9 +1058,9 @@ class SubDirectory implements IDirectory {
      * {@inheritDoc IDirectory.createSubDirectory}
      */
     public createSubDirectory(subdirName: string): IDirectory {
-        // Undefined subdirectory names can't be serialized to JSON in the manner we currently snapshot.
-        if (subdirName === undefined) {
-            throw new Error("SubDirectory name may not be undefined");
+        // Undefined/null subdirectory names can't be serialized to JSON in the manner we currently snapshot.
+        if (subdirName === undefined || subdirName === null) {
+            throw new Error("SubDirectory name may not be undefined or null");
         }
 
         if (subdirName.indexOf(posix.sep) !== -1) {

--- a/packages/runtime/map/src/directory.ts
+++ b/packages/runtime/map/src/directory.ts
@@ -985,6 +985,10 @@ class SubDirectory implements IDirectory {
      * {@inheritDoc IDirectory.set}
      */
     public set<T = any>(key: string, value: T): this {
+        if (key === undefined) {
+            throw new Error("Undefined keys are not supported");
+        }
+
         const localValue = this.directory.localValueMaker.fromInMemory(value);
         const serializableValue = localValue.makeSerializable(
             this.runtime.IComponentSerializer,
@@ -1053,8 +1057,12 @@ class SubDirectory implements IDirectory {
      * {@inheritDoc IDirectory.createSubDirectory}
      */
     public createSubDirectory(subdirName: string): IDirectory {
+        if (subdirName === undefined) {
+            throw new Error("SubDirectory name may not be undefined");
+        }
+
         if (subdirName.indexOf(posix.sep) !== -1) {
-            throw new Error(`SubDirectory names may not contain ${posix.sep}`);
+            throw new Error(`SubDirectory name may not contain ${posix.sep}`);
         }
 
         this.createSubDirectoryCore(subdirName, true, null);

--- a/packages/runtime/map/src/directory.ts
+++ b/packages/runtime/map/src/directory.ts
@@ -985,6 +985,7 @@ class SubDirectory implements IDirectory {
      * {@inheritDoc IDirectory.set}
      */
     public set<T = any>(key: string, value: T): this {
+        // Undefined keys can't be serialized to JSON in the manner we currently snapshot.
         if (key === undefined) {
             throw new Error("Undefined keys are not supported");
         }
@@ -1057,6 +1058,7 @@ class SubDirectory implements IDirectory {
      * {@inheritDoc IDirectory.createSubDirectory}
      */
     public createSubDirectory(subdirName: string): IDirectory {
+        // Undefined subdirectory names can't be serialized to JSON in the manner we currently snapshot.
         if (subdirName === undefined) {
             throw new Error("SubDirectory name may not be undefined");
         }

--- a/packages/runtime/map/src/mapKernel.ts
+++ b/packages/runtime/map/src/mapKernel.ts
@@ -4,7 +4,6 @@
  */
 
 import { IComponentHandle } from "@microsoft/fluid-component-core-interfaces";
-import { safelyParseJSON } from "@microsoft/fluid-core-utils";
 import { ISequencedDocumentMessage } from "@microsoft/fluid-protocol-definitions";
 import { IComponentRuntime } from "@microsoft/fluid-runtime-definitions";
 import { parseHandles, serializeHandles, ValueType } from "@microsoft/fluid-shared-object-base";
@@ -408,7 +407,7 @@ export class MapKernel {
      * @param data - A JSON string containing serialized map data
      */
     public populate(data: string): void {
-        const json = safelyParseJSON(data) as IMapDataObject;
+        const json = JSON.parse(data) as IMapDataObject;
         for (const [key, serializable] of Object.entries(json)) {
             const localValue = {
                 key,

--- a/packages/runtime/map/src/mapKernel.ts
+++ b/packages/runtime/map/src/mapKernel.ts
@@ -304,9 +304,9 @@ export class MapKernel {
      * {@inheritDoc ISharedMap.set}
      */
     public set(key: string, value: any) {
-        // Undefined keys can't be serialized to JSON in the manner we currently snapshot.
-        if (key === undefined) {
-            throw new Error("Undefined keys are not supported");
+        // Undefined/null keys can't be serialized to JSON in the manner we currently snapshot.
+        if (key === undefined || key === null) {
+            throw new Error("Undefined and null keys are not supported");
         }
 
         const localValue = this.localValueMaker.fromInMemory(value);

--- a/packages/runtime/map/src/mapKernel.ts
+++ b/packages/runtime/map/src/mapKernel.ts
@@ -304,6 +304,10 @@ export class MapKernel {
      * {@inheritDoc ISharedMap.set}
      */
     public set(key: string, value: any) {
+        if (key === undefined) {
+            throw new Error("Undefined keys are not supported");
+        }
+
         const localValue = this.localValueMaker.fromInMemory(value);
         const serializableValue = localValue.makeSerializable(
             this.runtime.IComponentSerializer,

--- a/packages/runtime/map/src/mapKernel.ts
+++ b/packages/runtime/map/src/mapKernel.ts
@@ -304,6 +304,7 @@ export class MapKernel {
      * {@inheritDoc ISharedMap.set}
      */
     public set(key: string, value: any) {
+        // Undefined keys can't be serialized to JSON in the manner we currently snapshot.
         if (key === undefined) {
             throw new Error("Undefined keys are not supported");
         }

--- a/packages/runtime/map/src/test/directory.spec.ts
+++ b/packages/runtime/map/src/test/directory.spec.ts
@@ -45,6 +45,12 @@ describe("Routerlicious", () => {
             assert.equal(testDirectory.get("testKey2"), "testValue2");
         });
 
+        it("Rejects an undefined key set", () => {
+            assert.throws(() => {
+                testDirectory.set(undefined, "testValue");
+            }, "Should throw for key of undefined");
+        });
+
         it("Can set and get keys two levels deep", () => {
             const fooDirectory = testDirectory.createSubDirectory("foo");
             const barDirectory = testDirectory.createSubDirectory("bar");
@@ -260,6 +266,12 @@ describe("Routerlicious", () => {
                 assert.equal(testSubdir.get("testKey3"), undefined);
                 testSubdir.set("fromSubdir", "testValue4");
                 assert.equal(testDirectory.getWorkingDirectory("foo").get("fromSubdir"), "testValue4");
+            });
+
+            it("Rejects subdirectories with undefined names", () => {
+                assert.throws(() => {
+                    testDirectory.createSubDirectory(undefined);
+                }, "Should throw for undefined subdirectory name");
             });
 
             describe(".wait()", () => {

--- a/packages/runtime/map/src/test/directory.spec.ts
+++ b/packages/runtime/map/src/test/directory.spec.ts
@@ -45,10 +45,13 @@ describe("Routerlicious", () => {
             assert.equal(testDirectory.get("testKey2"), "testValue2");
         });
 
-        it("Rejects an undefined key set", () => {
+        it("Rejects a undefined and null key set", () => {
             assert.throws(() => {
                 testDirectory.set(undefined, "testValue");
             }, "Should throw for key of undefined");
+            assert.throws(() => {
+                testDirectory.set(null, "testValue");
+            }, "Should throw for key of null");
         });
 
         it("Can set and get keys two levels deep", () => {
@@ -268,10 +271,13 @@ describe("Routerlicious", () => {
                 assert.equal(testDirectory.getWorkingDirectory("foo").get("fromSubdir"), "testValue4");
             });
 
-            it("Rejects subdirectories with undefined names", () => {
+            it("Rejects subdirectories with undefined and null names", () => {
                 assert.throws(() => {
                     testDirectory.createSubDirectory(undefined);
                 }, "Should throw for undefined subdirectory name");
+                assert.throws(() => {
+                    testDirectory.createSubDirectory(null);
+                }, "Should throw for null subdirectory name");
             });
 
             describe(".wait()", () => {

--- a/packages/runtime/map/src/test/map.spec.ts
+++ b/packages/runtime/map/src/test/map.spec.ts
@@ -49,7 +49,7 @@ describe("Routerlicious", () => {
                 let called2: boolean = false;
                 dummyMap.on("op", (agr1, arg2, arg3) => called1 = true);
                 dummyMap.on("valueChanged", (agr1, arg2, arg3, arg4) => called2 = true);
-                dummyMap.set("dwyane", "johnson");
+                dummyMap.set("marco", "polo");
                 assert.equal(called1, false, "op");
                 assert.equal(called2, true, "valueChanged");
             });
@@ -113,6 +113,12 @@ describe("Routerlicious", () => {
                     const retrieved = sharedMap.get("object");
                     assert.equal(await retrieved.subMapHandle.get(), subMap);
                     assert.equal(await retrieved.nestedObj.subMap2Handle.get(), subMap2);
+                });
+
+                it("Should reject an undefined key set", () => {
+                    assert.throws(() => {
+                        sharedMap.set(undefined, "one");
+                    }, "Should throw for key of undefined");
                 });
             });
 

--- a/packages/runtime/map/src/test/map.spec.ts
+++ b/packages/runtime/map/src/test/map.spec.ts
@@ -115,10 +115,13 @@ describe("Routerlicious", () => {
                     assert.equal(await retrieved.nestedObj.subMap2Handle.get(), subMap2);
                 });
 
-                it("Should reject an undefined key set", () => {
+                it("Should reject undefined and null key sets", () => {
                     assert.throws(() => {
                         sharedMap.set(undefined, "one");
                     }, "Should throw for key of undefined");
+                    assert.throws(() => {
+                        sharedMap.set(null, "two");
+                    }, "Should throw for key of null");
                 });
             });
 


### PR DESCRIPTION
Undefined keys and subdirectory names cannot be safely serialized/deserialized through JSON since they will be converted to string "undefined" in the process.  Demo of this behavior here:
https://jsfiddle.net/cfy7zbmh/

Undefined values can be handled since they are omitted from the JSON string, making it possible to discern them from the string "undefined".