### PR TITLE
Fluid-Build: Fix couple of tslint done detection issue

### DIFF
--- a/tools/fluid-build/package.json
+++ b/tools/fluid-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluid-build",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Fluid Build tool",
   "private": true,
   "main": "dist/fluidBuild.js",

--- a/tools/fluid-build/src/fluidBuild.ts
+++ b/tools/fluid-build/src/fluidBuild.ts
@@ -64,7 +64,7 @@ async function inferRoot() {
 
 function versionCheck() {
     const pkg = require(path.join(__dirname, "..", "package.json"));
-    const builtVersion = "0.0.1";
+    const builtVersion = "0.0.2";
     if (pkg.version > builtVersion) {
         console.log(`WARNING: fluid-build is out of date, please rebuild (built: ${builtVersion}, package: ${pkg.version})\n`);
     }

--- a/tools/fluid-build/src/tasks/concurrentNpmTask.ts
+++ b/tools/fluid-build/src/tasks/concurrentNpmTask.ts
@@ -15,7 +15,7 @@ export class ConcurrentNPMTask extends NPMTask {
     };
 
     protected async runTask(q: AsyncPriorityQueue<TaskExec>): Promise<BuildResult> {
-        logVerbose(`Begin Concurrent Child Tasks: ${this.node.pkg.nameColored} - ${this.command}`);
+        this.logVerboseTask(`Begin Concurrent Child Tasks`);
         const taskP = new Array<Promise<BuildResult>>();
         for (const task of this.subTasks) {
             taskP.push(task.run(q));
@@ -31,7 +31,7 @@ export class ConcurrentNPMTask extends NPMTask {
                 retResult = BuildResult.Success;
             }
         }
-        logVerbose(`End Concurrent Child Tasks: ${this.node.pkg.nameColored} - ${this.command}`);
+        this.logVerboseTask(`End Concurrent Child Tasks`);
         return retResult;
     }
 }

--- a/tools/fluid-build/src/tasks/leaf/leafTask.ts
+++ b/tools/fluid-build/src/tasks/leaf/leafTask.ts
@@ -114,14 +114,14 @@ export abstract class LeafTask extends Task {
     }
 
     protected async runTask(q: AsyncPriorityQueue<TaskExec>): Promise<BuildResult> {
-        logVerbose(`Begin Leaf Task: ${this.node.pkg.nameColored} - ${this.command}`);
+        this.logVerboseTask("Begin Leaf Task");
         const result = await this.buildDependentTask(q);
         if (result === BuildResult.Failed) {
             return BuildResult.Failed;
         }
 
         return new Promise((resolve, reject) => {
-            logVerbose(`Queue Leaf Task: ${this.node.pkg.nameColored} - [${this.parentCount}] ${this.command}`);
+            this.logVerboseTask(`[${this.parentCount}] Queue Leaf Task`);
             q.push({ task: this, resolve }, -this.parentCount);
         });
     }
@@ -133,7 +133,7 @@ export abstract class LeafTask extends Task {
         const leafIsUpToDate = await this.checkDependentTasksIsUpToDate() && await this.checkLeafIsUpToDate();
         if (leafIsUpToDate) {
             this.node.buildContext.taskStats.leafUpToDateCount++;
-            logVerbose(`Skipping Leaf Task: ${this.node.pkg.nameColored} - ${this.command}`);
+            this.logVerboseTask(`Skipping Leaf Task`);
         }
 
         return leafIsUpToDate;
@@ -224,6 +224,10 @@ export abstract class LeafTask extends Task {
 
     protected logVerboseDependency(child: BuildPackage, dep: string) {
         logVerbose(`Task Dependency: ${this.node.pkg.nameColored} ${this.executable} -> ${child.pkg.nameColored} ${dep}`);
+    }
+
+    protected logVerboseTask(msg: string) {
+        logVerbose(`Task: ${this.node.pkg.nameColored} ${this.executable}: ${msg}`);
     }
 };
 

--- a/tools/fluid-build/src/tasks/leaf/tsLintTask.ts
+++ b/tools/fluid-build/src/tasks/leaf/tsLintTask.ts
@@ -6,6 +6,7 @@
 import { LeafTask, LeafWithDoneFileTask } from "./leafTask";
 import { TscTask } from "./tscTask";
 import { readFileAsync } from "../../common/utils";
+import { existsSync } from "fs";
 
 export class TsLintTask extends LeafWithDoneFileTask {
     private tscTask: TscTask | undefined;
@@ -26,10 +27,15 @@ export class TsLintTask extends LeafWithDoneFileTask {
                     return undefined;
                 }
                 doneFileContent.tsBuildInfoFile = tsBuildInfo;
-                doneFileContent.tslintJson = await readFileAsync(this.configFileFullPath, "utf8");
+                const configFile = this.configFileFullPath;
+                if (existsSync(configFile)) {
+                    // Include the config file if it exists so that we can detect changes
+                    doneFileContent.tslintJson = await readFileAsync(this.configFileFullPath, "utf8");
+                }
             }
             return JSON.stringify(doneFileContent);
-        } catch {
+        } catch(e) {
+            this.logVerboseTask(`error generating done file content ${e}`);
             return undefined;
         }
     }

--- a/tools/fluid-build/src/tasks/leaf/tscTask.ts
+++ b/tools/fluid-build/src/tasks/leaf/tscTask.ts
@@ -135,12 +135,15 @@ export class TscTask extends LeafTask {
         if (existsSync(this.getPackageFileFullPath(tsBuildInfoFileLib))) {
             return tsBuildInfoFileLib;
         }
-        return tsBuildInfoFileRoot;
+        return undefined;
     }
 
     private get tsBuildInfoFileFullPath() {
         if (this._tsBuildInfoFullPath === undefined) {
-            this._tsBuildInfoFullPath = this.getPackageFileFullPath(this.tsBuildInfoFile);
+            const infoFile = this.tsBuildInfoFile;
+            if (infoFile) {
+                this._tsBuildInfoFullPath = this.getPackageFileFullPath(infoFile);
+            }
         }
         return this._tsBuildInfoFullPath;
     }
@@ -159,10 +162,15 @@ export class TscTask extends LeafTask {
     public async readTsBuildInfo(): Promise<ITsBuildInfo | undefined> {
         if (this._tsBuildInfo === undefined) {
             const tsBuildInfoFileFullPath = this.tsBuildInfoFileFullPath;
-            try {
-                this._tsBuildInfo = JSON.parse(await readFileAsync(tsBuildInfoFileFullPath, "utf8"));
-            } catch {
-                logVerbose(`${this.node.pkg.nameColored}: Unable to load ${tsBuildInfoFileFullPath}`)
+            if (tsBuildInfoFileFullPath) {
+                try {
+                    this._tsBuildInfo = JSON.parse(await readFileAsync(tsBuildInfoFileFullPath, "utf8"));
+                    return this._tsBuildInfo;
+                } catch {
+                    logVerbose(`${this.node.pkg.nameColored}: Unable to load ${tsBuildInfoFileFullPath}`);
+                }
+            } else {
+                logVerbose(`${this.node.pkg.nameColored}: ${this.tsBuildInfoFileName} file not found`);
             }
         }
         return this._tsBuildInfo;

--- a/tools/fluid-build/src/tasks/npmTask.ts
+++ b/tools/fluid-build/src/tasks/npmTask.ts
@@ -51,7 +51,7 @@ export class NPMTask extends Task {
         return true;
     }
     protected async runTask(q: AsyncPriorityQueue<TaskExec>): Promise<BuildResult> {
-        logVerbose(`Begin Child Tasks: ${this.node.pkg.nameColored} - ${this.command}`);
+        this.logVerboseTask(`Begin Child Tasks`);
         let retResult = BuildResult.UpToDate;
         for (const task of this.subTasks) {
             const result = await task.run(q);
@@ -63,7 +63,11 @@ export class NPMTask extends Task {
                 retResult = BuildResult.Success;
             }
         }
-        logVerbose(`End Child Tasks: ${this.node.pkg.nameColored} - ${this.command}`);
+        this.logVerboseTask(`End Child Tasks`);
         return retResult;
+    }
+
+    protected logVerboseTask(msg: string) {
+        logVerbose(`Task: ${this.node.pkg.nameColored} ${this.command}: ${msg}`);
     }
 };


### PR DESCRIPTION
- Fix issue where the done file can't be generated because we don't
have a tslint.json file
- Fix issue where when we build from clean, the cached infered
tsbuildinfo file doesn't exist and infered in the wrong location