### PR TITLE
Add option to yo fluid without a container

### DIFF
--- a/packages/components/pinpoint-editor/package.json
+++ b/packages/components/pinpoint-editor/package.json
@@ -16,7 +16,7 @@
     "tsc": "tsc",
     "build:esnext": "tsc --project ./tsconfig.esnext.json",
     "tslint": "tslint --project tsconfig.json --format verbose",
-    "start": "webpack-dev-server --config webpack.config.js --package package.json --env.component",
+    "start": "webpack-dev-server --config webpack.config.js --package package.json --env.component --env.mode local",
     "start:localhost": "webpack-dev-server --config webpack.config.js --package package.json --env.component --env.mode localhost",
     "start:live": "webpack-dev-server --config webpack.config.js --package package.json --env.component --env.mode live",
     "webpack": "webpack --config webpack.config.js"

--- a/packages/tools/webpack-component-loader/src/routes.ts
+++ b/packages/tools/webpack-component-loader/src/routes.ts
@@ -27,12 +27,14 @@ export const after = (app: express.Application, server: WebpackDevServer, baseDi
     options.npm = options.npm ? options.npm : config.get("fluid:webpack:npm");
     // tslint:enable: no-unsafe-any
 
+    console.log(options);
+
     if ((options.mode === "live" || options.mode === undefined) && !(options.tenantId && options.tenantSecret)) {
         throw new Error("You must provide a tenantId and tenantSecret to connect to a live server");
     } else if ((options.tenantId || options.tenantSecret) && !(options.tenantId && options.tenantSecret)) {
         throw new Error("tenantId and tenantSecret must be provided together");
     }
-    console.log(options);
+
     app.get("/file*", (req, res) => {
         // tslint:disable-next-line: non-literal-fs-path no-unsafe-any
         const buffer = fs.readFileSync(req.params[0].substr(1));

--- a/tools/generator-fluid/app/index.js
+++ b/tools/generator-fluid/app/index.js
@@ -36,6 +36,13 @@ module.exports = class extends Generator {
         choices: ["react", "vanillaJS"],
       },
       {
+        type: "list",
+        name: "template",
+        message: "Do you want to customize your container (advanced)?",
+        default: "no",
+        choices: ["no", "yes"],
+      },
+      {
         type: "input",
         name: "description",
         message: "Component Description",

--- a/tools/generator-fluid/app/index.js
+++ b/tools/generator-fluid/app/index.js
@@ -73,9 +73,26 @@ module.exports = class extends Generator {
       this._copyContainer();
     }
 
+    let entryFilePath;
+    if (this.answers.container === "yes") {
+      entryFilePath = "./src/index.ts";
+    } else {
+      entryFilePath = this.answers.template === "react" ? "./src/main.tsx" : "./src/main.ts";
+    }
+    this.fs.copyTpl(
+      this.templatePath("webpack.config.js"), // FROM
+      this.destinationPath("./webpack.config.js"), // TO Base Folder
+      { entryFilePath },
+    );
+
     this.fs.copy(
-      this.templatePath("webpack.*.js"), // FROM
-      this.destinationPath("./"), // TO Base Folder
+      this.templatePath("webpack.dev.js"), // FROM
+      this.destinationPath("./webpack.dev.js"), // TO Base Folder
+    );
+
+    this.fs.copy(
+      this.templatePath("webpack.prod.js"), // FROM
+      this.destinationPath("./webpack.prod.js"), // TO Base Folder
     );
 
     this.fs.copy(

--- a/tools/generator-fluid/app/templates/package.json
+++ b/tools/generator-fluid/app/templates/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "build": "webpack --env.production && npm run tsc",
     "dev": "webpack --env.development",
-    "start": "webpack-dev-server --config webpack.config.js --package package.json",
+    "start:component": "webpack-dev-server --config webpack.config.js --package package.json --env.component --env.mode local",
+    "start:container": "webpack-dev-server --config webpack.config.js --package package.json",
     "start:localhost": "webpack-dev-server --config webpack.config.js --package package.json --env.mode localhost",
     "start:live": "webpack-dev-server --config webpack.config.js --package package.json --env.mode live",
     "verdaccio": "npm publish --registry https://packages.wu2.prague.office-int.com",

--- a/tools/generator-fluid/app/templates/webpack.config.js
+++ b/tools/generator-fluid/app/templates/webpack.config.js
@@ -12,10 +12,11 @@ const componentName = pkg.name.slice(1);
 
 module.exports = env => {
     const isProduction = env && env.production;
+    const isComponent = env && env.component;
 
     return merge({
         entry: {
-            main: "./src/index.ts"
+            main: isComponent ? "./src/main.tsx" : "./src/index.ts",
         },
         resolve: {
             extensions: [".ts", ".tsx", ".js"],
@@ -23,7 +24,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: "ts-loader",
             }]
         },
         output: {
@@ -33,7 +34,7 @@ module.exports = env => {
             // https://github.com/webpack/webpack/issues/5767
             // https://github.com/webpack/webpack/issues/7939
             devtoolNamespace: componentName,
-            libraryTarget: "umd"
+            libraryTarget: "umd",
         },
         devServer: {
             publicPath: '/dist',

--- a/tools/generator-fluid/app/templates/webpack.config.js
+++ b/tools/generator-fluid/app/templates/webpack.config.js
@@ -12,11 +12,10 @@ const componentName = pkg.name.slice(1);
 
 module.exports = env => {
     const isProduction = env && env.production;
-    const isComponent = env && env.component;
 
     return merge({
         entry: {
-            main: isComponent ? "./src/main.tsx" : "./src/index.ts",
+            main: "<%= entryFilePath %>",
         },
         resolve: {
             extensions: [".ts", ".tsx", ".js"],

--- a/tools/generator-fluid/test/testApp.js
+++ b/tools/generator-fluid/test/testApp.js
@@ -12,68 +12,146 @@ describe("Yo fluid", function () {
     this.timeout(10000);
 
     describe("React", () => {
-        beforeEach(() => {
-            return helpers.run(path.join(__dirname, "../app/index.js"))
-                .withPrompts({
-                    name: "foobar",
-                    template: "react",
-                    description: "Fluid starter project",
-                    path: "./foobar",
-                });
-        })
-        it("Produces the expected files", async () => {
-            const expectedFiles = [
-                "src/main.tsx",
-                "src/index.ts",
-                ".gitignore",
-                ".npmignore",
-                ".npmrc",
-                "package.json",
-                "README.md",
-                "tsconfig.json",
-                "webpack.config.js",
-                "webpack.dev.js",
-                "webpack.prod.js",
-            ]
-            assert.file(expectedFiles);
+        describe("With container", () => {
+            beforeEach(() => {
+                return helpers.run(path.join(__dirname, "../app/index.js"))
+                    .withPrompts({
+                        name: "foobar",
+                        template: "react",
+                        container: "yes",
+                        description: "Fluid starter project",
+                        path: "./foobar",
+                    });
+            });
 
-            const unexpectedFiles = [
-                "src/main.ts",
-            ]
-            assert.noFile(unexpectedFiles);
+            it("Produces the expected files", async () => {
+                const expectedFiles = [
+                    "src/main.tsx",
+                    "src/index.ts",
+                    ".gitignore",
+                    ".npmignore",
+                    ".npmrc",
+                    "package.json",
+                    "README.md",
+                    "tsconfig.json",
+                    "webpack.config.js",
+                    "webpack.dev.js",
+                    "webpack.prod.js",
+                ]
+                assert.file(expectedFiles);
+
+                const unexpectedFiles = [
+                    "src/main.ts",
+                ]
+                assert.noFile(unexpectedFiles);
+            });
+        });
+
+        describe("Without container", () => {
+            beforeEach(() => {
+                return helpers.run(path.join(__dirname, "../app/index.js"))
+                    .withPrompts({
+                        name: "foobar",
+                        template: "react",
+                        container: "no",
+                        description: "Fluid starter project",
+                        path: "./foobar",
+                    });
+            });
+
+            it("Produces the expected files", async () => {
+                const expectedFiles = [
+                    "src/main.tsx",
+                    ".gitignore",
+                    ".npmignore",
+                    ".npmrc",
+                    "package.json",
+                    "README.md",
+                    "tsconfig.json",
+                    "webpack.config.js",
+                    "webpack.dev.js",
+                    "webpack.prod.js",
+                ]
+                assert.file(expectedFiles);
+
+                const unexpectedFiles = [
+                    "src/main.ts",
+                    "src/index.ts",
+                ]
+                assert.noFile(unexpectedFiles);
+            });
         });
     });
 
     describe("Vanilla", () => {
-        beforeEach(() => {
-            return helpers.run(path.join(__dirname, "../app/index.js"))
-                .withPrompts({
-                    name: "foobar",
-                    template: "vanillaJS",
-                    description: "Fluid starter project",
-                    path: "./foobar",
-                });
-        })
-        it("Produces the expected files", async () => {
-            const expectedFiles = [
-                "src/main.ts",
-                "src/index.ts",
-                ".gitignore",
-                ".npmignore",
-                ".npmrc",
-                "package.json",
-                "README.md",
-                "tsconfig.json",
-                "webpack.config.js",
-                "webpack.dev.js",
-                "webpack.prod.js",
-            ]
-            assert.file(expectedFiles);
+        describe("With container", () => {
+            beforeEach(() => {
+                return helpers.run(path.join(__dirname, "../app/index.js"))
+                    .withPrompts({
+                        name: "foobar",
+                        template: "vanillaJS",
+                        container: "yes",
+                        description: "Fluid starter project",
+                        path: "./foobar",
+                    });
+            });
 
-            const unexpectedFiles = [
-                "src/main.tsx",
-            ]
-            assert.noFile(unexpectedFiles);
+            it("Produces the expected files", async () => {
+                const expectedFiles = [
+                    "src/main.ts",
+                    "src/index.ts",
+                    ".gitignore",
+                    ".npmignore",
+                    ".npmrc",
+                    "package.json",
+                    "README.md",
+                    "tsconfig.json",
+                    "webpack.config.js",
+                    "webpack.dev.js",
+                    "webpack.prod.js",
+                ]
+                assert.file(expectedFiles);
+
+                const unexpectedFiles = [
+                    "src/main.tsx",
+                ]
+                assert.noFile(unexpectedFiles);
+            });
+        });
+
+        describe("Without container", () => {
+            beforeEach(() => {
+                return helpers.run(path.join(__dirname, "../app/index.js"))
+                    .withPrompts({
+                        name: "foobar",
+                        template: "vanillaJS",
+                        container: "no",
+                        description: "Fluid starter project",
+                        path: "./foobar",
+                    });
+            });
+
+            it("Produces the expected files", async () => {
+                const expectedFiles = [
+                    "src/main.ts",
+                    ".gitignore",
+                    ".npmignore",
+                    ".npmrc",
+                    "package.json",
+                    "README.md",
+                    "tsconfig.json",
+                    "webpack.config.js",
+                    "webpack.dev.js",
+                    "webpack.prod.js",
+                ]
+                assert.file(expectedFiles);
+
+                const unexpectedFiles = [
+                    "src/main.tsx",
+                    "src/index.ts",
+                ]
+                assert.noFile(unexpectedFiles);
+            });
         });
     });
 });


### PR DESCRIPTION
Yo fluid's primary purpose is to bootstrap new developers into writing a fluid component.  Currently, the output includes both that component but also a `SimpleModuleInstantiationFactory` to create a container around that component.  This is additional mental overhead for a new developer who shouldn't touch this file anyway.  Since we support loading a component directly in `fluid-webpack-component-loader`, let's take advantage of that to simplify the yo fluid output for new developers.