### PR TITLE
webpack-component-loader cleanup

### DIFF
--- a/packages/tools/webpack-component-loader/src/loader.ts
+++ b/packages/tools/webpack-component-loader/src/loader.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-// tslint:disable no-string-literal trailing-comma no-shadowed-variable no-floating-promises
-
 import { SimpleModuleInstantiationFactory } from "@microsoft/fluid-aqueduct";
 import { IHostConfig, start as startCore } from "@microsoft/fluid-base-host";
 import { IRequest } from "@microsoft/fluid-component-core-interfaces";
@@ -96,6 +94,7 @@ async function getPkg(packageJson: IPackage, scriptIds: string[], component = fa
 
     if (component) {
         // Wrap the core component in a runtime
+        // tslint:disable-next-line:no-string-literal
         const loadedComponentRaw = window["main"];
         const fluidModule = loadedComponentRaw as IFluidModule;
         const componentFactory = fluidModule.fluidExport.IComponentFactory;
@@ -106,6 +105,7 @@ async function getPkg(packageJson: IPackage, scriptIds: string[], component = fa
                 [legacyPackage, Promise.resolve(componentFactory)],
             ]),
         );
+        // tslint:disable-next-line:no-string-literal
         window["componentMain"] = {
             fluidExport: runtimeFactory,
         };
@@ -134,7 +134,7 @@ async function getPkg(packageJson: IPackage, scriptIds: string[], component = fa
     };
 }
 
-// tslint:disable-next-line: max-func-body-length
+// tslint:disable-next-line:max-func-body-length
 export async function start(
     documentId: string,
     packageJson: IPackage,
@@ -221,6 +221,7 @@ export async function start(
         div.append(leftDiv, rightDiv);
     }
 
+    // tslint:disable-next-line:no-floating-promises
     startCore(
         url,
         await urlResolver.resolve(req),
@@ -240,6 +241,7 @@ export async function start(
 
         // startCore will create a new Loader/Container/Component from the startCore above. This is
         // intentional because we want to emulate two clients collaborating with each other.
+        // tslint:disable-next-line:no-floating-promises
         startCore(
             url,
             await urlResolver.resolve(req),

--- a/packages/tools/webpack-component-loader/src/loader.ts
+++ b/packages/tools/webpack-component-loader/src/loader.ts
@@ -221,8 +221,7 @@ export async function start(
         div.append(leftDiv, rightDiv);
     }
 
-    // tslint:disable-next-line:no-floating-promises
-    startCore(
+    const start1Promise = startCore(
         url,
         await urlResolver.resolve(req),
         pkg,
@@ -234,6 +233,7 @@ export async function start(
         hostConf,
     );
 
+    let start2Promise: Promise<any> = Promise.resolve();
     if (double) {
         // new documentServiceFactory for right div, same everything else
         const docServFac2: IDocumentServiceFactory = new TestDocumentServiceFactory(deltaConn);
@@ -241,8 +241,7 @@ export async function start(
 
         // startCore will create a new Loader/Container/Component from the startCore above. This is
         // intentional because we want to emulate two clients collaborating with each other.
-        // tslint:disable-next-line:no-floating-promises
-        startCore(
+        start2Promise = startCore(
             url,
             await urlResolver.resolve(req),
             pkg,
@@ -254,6 +253,7 @@ export async function start(
             hostConf2,
         );
     }
+    await Promise.all([start1Promise, start2Promise]);
 }
 
 export function getUserToken(bearerSecret: string) {

--- a/packages/tools/webpack-component-loader/src/loader.ts
+++ b/packages/tools/webpack-component-loader/src/loader.ts
@@ -90,8 +90,11 @@ function wrapComponentPackage(packageName: string, packageJson: IFluidPackage) {
     packageJson.name = `${packageJson.name}-dev-server`;
 }
 
-async function getPkg(packageJson: IPackage, scriptIds: string[], component = false): Promise<IResolvedPackage> {
-
+async function getResolvedPackage(
+    packageJson: IPackage,
+    scriptIds: string[],
+    component = false,
+): Promise<IResolvedPackage> {
     // Start the creation of pkg.
     if (!packageJson) {
         return Promise.reject(new Error("No package specified"));
@@ -143,7 +146,7 @@ export async function start(
 
     // Create Package
     const scriptIds: string[] = [];
-    const pkg = await getPkg(packageJson, scriptIds, !!options.component);
+    const pkg = await getResolvedPackage(packageJson, scriptIds, !!options.component);
 
     // Construct a request
     const req: IRequest = {
@@ -154,7 +157,6 @@ export async function start(
     const config = {
         client: {
             permission: [
-
             ],
             type: "browser",
         },
@@ -189,7 +191,7 @@ export async function start(
     }
 
     let documentServiceFactory: IDocumentServiceFactory;
-    let deltaConn: ITestDeltaConnectionServer ;
+    let deltaConn: ITestDeltaConnectionServer;
     if (options.mode !== "local") {
         documentServiceFactory = new RouterliciousDocumentServiceFactory(
             false,
@@ -199,7 +201,6 @@ export async function start(
             undefined,
         );
     } else {
-
         deltaConn = TestDeltaConnectionServer.create(new SessionStorageDbFactory(documentId));
         documentServiceFactory = new TestDocumentServiceFactory(deltaConn);
     }

--- a/packages/tools/webpack-component-loader/src/loader.ts
+++ b/packages/tools/webpack-component-loader/src/loader.ts
@@ -220,11 +220,10 @@ export async function start(
     let rightDiv: HTMLDivElement;
     if (double) {
         leftDiv = document.createElement("div");
-        leftDiv.style.width = "50%";
-        leftDiv.style.cssFloat = "left";
+        leftDiv.style.flexGrow = "1";
         leftDiv.style.border = "1px solid lightgray";
         rightDiv = document.createElement("div");
-        rightDiv.style.marginLeft = "50%";
+        rightDiv.style.flexGrow = "1";
         rightDiv.style.border = "1px solid lightgray";
         div.append(leftDiv, rightDiv);
     }

--- a/packages/tools/webpack-component-loader/src/loader.ts
+++ b/packages/tools/webpack-component-loader/src/loader.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-// tslint:disable no-string-literal trailing-comma no-shadowed-variable no-submodule-imports no-floating-promises
+// tslint:disable no-string-literal trailing-comma no-shadowed-variable no-floating-promises
 
 import { SimpleModuleInstantiationFactory } from "@microsoft/fluid-aqueduct";
 import { IHostConfig, start as startCore } from "@microsoft/fluid-base-host";
@@ -20,6 +20,7 @@ import { DefaultErrorTracking, RouterliciousDocumentServiceFactory } from "@micr
 import { getRandomName } from "@microsoft/fluid-server-services-core";
 import { extractDetails, IResolvedPackage } from "@microsoft/fluid-web-code-loader";
 import * as jwt from "jsonwebtoken";
+// tslint:disable-next-line:no-submodule-imports
 import * as uuid from "uuid/v4";
 import { InsecureUrlResolver } from "./insecureUrlResolver";
 import { SessionStorageDbFactory } from "./sessionStorageTestDb";

--- a/packages/tools/webpack-component-loader/src/routes.ts
+++ b/packages/tools/webpack-component-loader/src/routes.ts
@@ -56,8 +56,7 @@ const fluid = (req: express.Request, res: express.Response,  baseDir: string, op
     <title>${documentId}</title>
 </head>
 <body>
-    <div style="width: 100%; height: 100%;">
-        <div id="content"></div>
+    <div id="content" style="width: 100%; height: 100%; display: flex">
     </div>
 
     <script src="/node_modules/@microsoft/fluid-webpack-component-loader/dist/fluid-loader.bundle.js"></script>


### PR DESCRIPTION
Just some refactoring/cleanup of the webpack-component-loader.  Includes:

1. Scoping or removing tslint exceptions
2. Pulling helpers out of the longer functions for readability
3. Tweaking the HTML/CSS of the rendered content, particularly for the side-by-side rendering.  Using flexbox should be more robust as compared to the layout oddness that comes with float layout.