### PR TITLE
Telemetry changes:

### DIFF
--- a/packages/loader/container-definitions/src/logger.ts
+++ b/packages/loader/container-definitions/src/logger.ts
@@ -37,6 +37,7 @@ export interface ITelemetryBaseLogger {
  */
 export interface ITelemetryGenericEvent {
     eventName: string;
+    category?: TelemetryEventCategory;
     [index: string]: TelemetryEventPropertyType;
 }
 
@@ -44,20 +45,15 @@ export interface ITelemetryGenericEvent {
  * Error telemetry event.
  * Maps to category = "error"
  */
-export interface ITelemetryErrorEvent {
-    eventName: string;
-    [index: string]: TelemetryEventPropertyType;
-}
+export type ITelemetryErrorEvent = ITelemetryGenericEvent;
 
 /**
  * Performance telemetry event.
  * Maps to category = "performance"
  */
-export interface ITelemetryPerformanceEvent {
-    eventName: string;
+export interface ITelemetryPerformanceEvent extends ITelemetryGenericEvent {
     duration?: number;            // Duration of event (optional)
     tick?: number;                // Event time, relative to start of page load. Filled in by logger if not specified.
-    [index: string]: TelemetryEventPropertyType;
 }
 
 /**

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -598,8 +598,6 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
                 this.protocolHandler = protocolHandler;
                 this.blobManager = blobManager;
 
-                perfEvent.reportProgress({}, "beforeContextLoad");
-
                 // Initialize document details - if loading a snapshot use that - otherwise we need to wait on
                 // the initial details
                 if (tree) {
@@ -894,6 +892,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         const time = performanceNow();
         this.connectionTransitionTimes[value] = time;
         const duration = time - this.connectionTransitionTimes[oldState];
+
         this.logger.sendPerformanceEvent({
             eventName: `ConnectionStateChange_${ConnectionState[value]}`,
             from: ConnectionState[oldState],
@@ -908,8 +907,8 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
             // two separate events (actually - three!).
             this.logger.sendPerformanceEvent({
                 eventName: this.firstConnection ? "ConnectionStateChange_InitialConnect" : "ConnectionStateChange_Reconnect",
-                duration: time - this.connectionTransitionTimes[oldState],
-                reason,
+                duration: time - this.connectionTransitionTimes[ConnectionState.Disconnected],
+                durationCatchUp: time - this.connectionTransitionTimes[ConnectionState.Connecting],
             });
             this.firstConnection = false;
         }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -264,10 +264,8 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
             {
                 documentId: this.id,
                 canReconnect, // differentiating summarizer container from main container
-                package: {
-                    name: TelemetryLogger.sanitizePkgName(pkgName),
-                    version: pkgVersion,
-                },
+                packageName: TelemetryLogger.sanitizePkgName(pkgName),
+                packageVersion: pkgVersion,
             },
             logger);
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -457,7 +457,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
 
                 if (!canRetry || !canRetryOnError(error)) {
                     // It's game over scenario.
-                    telemetryEvent.cancel({ reason: "error" }, error);
+                    telemetryEvent.cancel({category: "error"}, error);
                     this.closeOnConnectionError(error);
                     return [];
                 }
@@ -479,6 +479,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
                 // One (last) successful connection is sufficient, even if user was disconnected all prior attempts
                 if (success && retry >= 100) {
                     telemetryEvent.cancel({
+                        category: "error",
                         reason: "too many retries",
                         retry,
                         requests,
@@ -696,7 +697,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
                 }
 
                 // Log error once - we get too many errors in logs when we are offline,
-                // and unfortunately there is no way to detect that.
+                // and unfortunately there is no reliable way to detect that.
                 if (this.connectRepeatCount === 1) {
                     logNetworkFailure(
                         this.logger,

--- a/packages/loader/utils/src/logger.ts
+++ b/packages/loader/utils/src/logger.ts
@@ -71,9 +71,6 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
         }
 
         // Collect stack if we were not able to extract it from error
-        if (fetchStack || event.stack !== undefined) {
-            event.stackFromError = (event.stack !== undefined);
-        }
         if (event.stack === undefined && fetchStack) {
             event.stack = TelemetryLogger.getStack();
         }

--- a/packages/loader/utils/src/logger.ts
+++ b/packages/loader/utils/src/logger.ts
@@ -375,7 +375,8 @@ export class DebugLogger extends TelemetryLogger {
      */
     public send(event: ITelemetryBaseEvent): void {
         const newEvent: { [index: string]: TelemetryEventPropertyType } = this.prepareEvent(event);
-        let logger = newEvent.category === "error" ? this.debugErr : this.debug;
+        const isError = newEvent.category === "error";
+        let logger = isError ? this.debugErr : this.debug;
 
         // Use debug's coloring schema for base of the event
         const index = event.eventName.lastIndexOf(TelemetryLogger.eventNamespaceSeparator);
@@ -408,6 +409,11 @@ export class DebugLogger extends TelemetryLogger {
 
         if (payload === "{}") {
             payload = "";
+        }
+
+        // Force errors out, to help with diagnostics
+        if (isError) {
+            logger.enabled = true;
         }
 
         // print multi-line.

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -291,7 +291,7 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
         };
         if (!summaryData.submitted) {
             // did not send the summary op
-            summarizingEvent.cancel(telemetryProps);
+            summarizingEvent.cancel({...telemetryProps, category: "error"});
             this.cancelPending();
             return;
         }


### PR DESCRIPTION
1) Earlier added telemetry to track connection times was wrong and reported zeros
2) We are not correctly propagating "connected" state for view-only mode (found by code inspection)
3) Add extra properties to differentiate summarizing container vs. main container.
4) error to be output to console all the time, not just when localStorage.debug is set and points to fluid Most users outside of framework do not know about it and have hard time diagnose issues.
5) Typo in telemetry names and functions Name is incorrect, off by one erorr when reporting seq # in telemetry
6) Better propagation of event names / reason for op fetching in on catchup scenarios