### PR TITLE
Summarizer telemetry and cleanup [0.10]

### DIFF
--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -85,6 +85,9 @@ export interface IDeltaManager<T, U> extends EventEmitter, IDeltaSender, IDispos
     // The last sequence number processed by the delta manager
     referenceSequenceNumber: number;
 
+    // The initial sequence number set when attaching the op handler
+    initialSequenceNumber: number;
+
     // Type of client
     clientType: string;
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -284,7 +284,8 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
             resume: boolean) {
         debug("Attached op handler", sequenceNumber);
 
-        this.baseSequenceNumber = this.initSequenceNumber = sequenceNumber;
+        this.initSequenceNumber = sequenceNumber;
+        this.baseSequenceNumber = sequenceNumber;
         this.minSequenceNumber = minSequenceNumber;
         this.lastQueuedSequenceNumber = sequenceNumber;
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -89,6 +89,9 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
     private lastQueuedSequenceNumber: number = 0;
     private baseSequenceNumber: number = 0;
 
+    // the sequence number we initially loaded from
+    private initSequenceNumber: number = 0;
+
     private readonly _inboundPending: DeltaQueue<ISequencedDocumentMessage>;
     private readonly _inbound: DeltaQueue<ISequencedDocumentMessage>;
     private readonly _inboundSignal: DeltaQueue<ISignalMessage>;
@@ -130,6 +133,10 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
 
     public get inboundSignal(): IDeltaQueue<ISignalMessage> {
         return this._inboundSignal;
+    }
+
+    public get initialSequenceNumber(): number {
+        return this.initSequenceNumber;
     }
 
     public get referenceSequenceNumber(): number {
@@ -277,7 +284,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
             resume: boolean) {
         debug("Attached op handler", sequenceNumber);
 
-        this.baseSequenceNumber = sequenceNumber;
+        this.baseSequenceNumber = this.initSequenceNumber = sequenceNumber;
         this.minSequenceNumber = minSequenceNumber;
         this.lastQueuedSequenceNumber = sequenceNumber;
 

--- a/packages/loader/container-loader/src/deltaManagerProxy.ts
+++ b/packages/loader/container-loader/src/deltaManagerProxy.ts
@@ -102,6 +102,10 @@ export class DeltaManagerProxy
         return this.deltaManager.referenceSequenceNumber;
     }
 
+    public get initialSequenceNumber(): number {
+        return this.deltaManager.initialSequenceNumber;
+    }
+
     public get clientType(): string {
         return this.deltaManager.clientType;
     }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1113,9 +1113,11 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
             // after loading from the beginning of the snapshot
             const versions = await this.context.storage.getVersions(this.id, 1);
             const parents = versions.map((version) => version.id);
+            generateSummaryEvent.reportProgress({}, "loadedVersions");
 
             const treeWithStats = await this.summarize(fullTree);
             ret.summaryStats = treeWithStats.summaryStats;
+            generateSummaryEvent.reportProgress({}, "generatedTree");
 
             if (!this.connected) {
                 return ret;
@@ -1127,6 +1129,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
                 message,
                 parents,
             };
+            generateSummaryEvent.reportProgress({}, "uploadedTree");
 
             if (!this.connected) {
                 return ret;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -469,6 +469,12 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         return this.summaryManager.summarizer;
     }
 
+    private get summaryConfiguration() {
+        return this.context.serviceConfiguration
+            ? { ...DefaultSummaryConfiguration, ...this.context.serviceConfiguration.summary }
+            : DefaultSummaryConfiguration;
+    }
+
     // Components tracked by the Domain
     private closed = false;
     private readonly pendingAttach = new Map<string, IAttachMessage>();
@@ -556,10 +562,6 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         this.context.on("refreshBaseSummary",
             (snapshot: ISnapshotTree) => this.refreshBaseSummary(snapshot));
 
-        const summaryConfiguration = context.serviceConfiguration
-            ? { ...DefaultSummaryConfiguration, ...context.serviceConfiguration.summary }
-            : DefaultSummaryConfiguration;
-
         // We always create the summarizer in the case that we are asked to generate summaries. But this may
         // want to be on demand instead.
         // Don't use optimizations when generating summaries with a document loaded using snapshots.
@@ -567,7 +569,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         this.summarizer = new Summarizer(
             "/_summarizer",
             this,
-            summaryConfiguration,
+            () => this.summaryConfiguration,
             () => this.generateSummary(!this.loadedFromSummary),
             (snapshot) => this.context.refreshBaseSummary(snapshot));
 

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -323,14 +323,28 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
                 shouldSummarize: true,
                 canStartIdleTimer: true,
             };
+        }
+
+        // Summarize if it has been above the max time between summaries.
+        const timeSinceLastSummary = Date.now() - this.lastSummaryTime;
+        const opCountSinceLastSummary = op.sequenceNumber - this.lastSummarySeqNumber;
+
+        if (timeSinceLastSummary > this.configuration.maxTime) {
+            return {
+                message: "maxTime",
+                shouldSummarize: true,
+                canStartIdleTimer: true,
+            };
+        } else if (opCountSinceLastSummary > this.configuration.maxOps) {
+            return {
+                message: "maxOps",
+                shouldSummarize: true,
+                canStartIdleTimer: true,
+            };
         } else {
-            // Summarize if it has been above the max time between summaries.
-            const timeSinceLastSummary = Date.now() - this.lastSummaryTime;
-            const opCountSinceLastSummary = op.sequenceNumber - this.lastSummarySeqNumber;
             return {
                 message: "",
-                shouldSummarize: (timeSinceLastSummary > this.configuration.maxTime) ||
-                    (opCountSinceLastSummary > this.configuration.maxOps),
+                shouldSummarize: false,
                 canStartIdleTimer: true,
             };
         }

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -98,7 +98,7 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
         }
 
         // initialize values (not exact)
-        this.lastSummarySeqNumber = this.runtime.deltaManager.referenceSequenceNumber;
+        this.lastSummarySeqNumber = this.runtime.deltaManager.initialSequenceNumber;
         this.lastSummaryTime = Date.now();
 
         this.logger.sendTelemetryEvent({

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -386,7 +386,7 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
     }
 
     private summarizeTimerHandler(time: number, count: number) {
-        this.logger.sendTelemetryEvent({
+        this.logger.sendErrorEvent({
             eventName: "SummarizeTimeout",
             timeoutTime: time,
             timeoutCount: count,

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -112,8 +112,14 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
     public async run(onBehalfOf: string): Promise<void> {
         this.onBehalfOfClientId = onBehalfOf;
 
-        if (!this.runtime.connected && !this.everConnected) {
-            await new Promise((resolve) => this.runtime.once("connected", resolve));
+        if (!this.runtime.connected) {
+            if (!this.everConnected) {
+                await new Promise((resolve) => this.runtime.once("connected", resolve));
+            } else {
+                // we will not try to reconnect, so we are done running
+                this.logger.sendTelemetryEvent({ eventName: "DisconnectedBeforeRun" });
+                return;
+            }
         }
 
         if (this.runtime.summarizerClientId !== onBehalfOf) {

--- a/packages/runtime/container-runtime/src/test/summarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizer.spec.ts
@@ -74,7 +74,7 @@ describe("Runtime", () => {
                                 getVersions: (versionId, count) => Promise.resolve([{}]),
                             } as IDocumentStorageService,
                         } as ContainerRuntime,
-                        summaryConfig,
+                        () => summaryConfig,
                         async () => {
                             emitter.emit(generateSummaryEvent);
                             if (shouldDeferGenerateSummary) {

--- a/packages/runtime/container-runtime/src/test/summarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizer.spec.ts
@@ -62,7 +62,7 @@ describe("Runtime", () => {
                             connected: true,
                             summarizerClientId,
                             deltaManager: {
-                                referenceSequenceNumber: 0,
+                                initialSequenceNumber: 0,
                                 inbound: emitter as IDeltaQueue<ISequencedDocumentMessage>,
                             } as IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
                             logger: {
@@ -231,7 +231,7 @@ describe("Runtime", () => {
                     assert.strictEqual(runCount, 1);
 
                     // should not run because still pending
-                    clock.tick(summaryConfig.maxAckWaitTime);
+                    clock.tick(summaryConfig.maxAckWaitTime - 1);
                     await emitNextOp(summaryConfig.maxOps + 1);
                     assert.strictEqual(runCount, 1);
 

--- a/packages/server/routerlicious/src/test/agent/testDocument.ts
+++ b/packages/server/routerlicious/src/test/agent/testDocument.ts
@@ -80,6 +80,8 @@ export class TestDeltaManager
 
     public minimumSequenceNumber: number;
 
+    public initialSequenceNumber: number;
+
     public inbound = new TestDeltaQueue<ISequencedDocumentMessage>();
 
     public outbound = new TestDeltaQueue<IDocumentMessage[]>();


### PR DESCRIPTION
Several small fixes to improve telemetry around summaries.

1. **Telemetry Precision:** Add `initialSequenceNumber` to DeltaManager, which tracks the reference sequence number at the time that the protocol handler was set.  This is useful to know what op we initially loaded from and is used by the summarizer as the initial value of `lastSummarySequenceNumber`.
2. **Add Telemetry:** When summarizing from idle, there is a message "idle" that gets added to the telemetry event.  Added "maxTime" and "maxOps" for when the summary was triggered from maximum active timeout and maximum number of ops respectively.  Previously these were empty string.
3. **Add Telemetry:** Add a performance event around the `generateSummary()` call in ContainerRuntime.  This resembles the one in Summarizer, but has more information and stages.  It reports progress after each step: "start", "loadedVersions", "generatedTree", "uploadedTree", and "end" (submitted op).  It also includes the `fullTree` argument in the start event, and the handle in the end.
4. **Performance/Functionality:** Use actual timer instead of op event for the timeout when waiting for the summary ack.  This way it will timeout even if no ops are coming in.
5. **Add Telemetry:** Add a timer for summarizing timeout which can fire multiple times, backing off, up to a max.  It will not cause an error, but will report events to telemetry.  After 20 sec it will trigger the first time, then after 40 more sec it will trigger again, then continue to double up to 5 times (20 + 40 + 80 + 160 + 320 = 620 sec total).
6. **Refactor:** consolidated the various timers in Summarizer to use a Timer class which basically just reuses the wrapper functions around clearTimeout and setTimeout acting like a single object.
7. **Performance/Functionality:** Prevent premature disconnects which lead to the runDeferred resolving too early.  Now the Summarizer will try to make sure that it has at least been connected once before letting a disconnect event cause the runDeferred to complete.  This was needed because the Container propagates its connection state after loading, which sometimes can be disconnected or connecting (or connected for readonly), but it is a race condition.  We should consider removing this initial propagation altogether.
8. **Performance/Functionality:** After runDeferred completes, now it will do some cleanup: clearing the various timeouts and resetting some of the state.  (A summarizer can still not be reran though).
9. **Bug Fix:** Change the summary configuration argument to a getter so we can defer getting it from the ContainerRuntime until after we are surely connected.  It was a race condition before, causing it to use the default sometimes.