### PR TITLE
Only realize component if changed while summarizing [0.10]

### DIFF
--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -381,7 +381,9 @@ export class RemotedComponentContext extends ComponentContext {
             });
 
         if (initSnapshotValue && typeof initSnapshotValue !== "string") {
-            // set on construction if possible
+            // This will allow the summarizer to avoid calling realize if there
+            // are no changes to the component.  If the initSnapshotValue is a
+            // string, the summarizer cannot avoid calling realize.
             this.summaryTracker.setBaseTree(initSnapshotValue);
         }
     }

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -148,7 +148,14 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
         if (!this.componentRuntimeDeferred) {
             this.componentRuntimeDeferred = new Deferred<IComponentRuntime>();
             const details = await this.getInitialSnapshotDetails();
-            this.summaryTracker.setBaseTree(details.snapshot);
+            if (details.snapshot && !this.summaryTracker.baseTree) {
+                // do not overwrite if refreshed!
+                // local - will always give undefined tree, so never enter here
+                // remote - will give the tree at the time of construction (initial),
+                // which may be older than the refreshed one, but never newer than
+                // the refreshed or one set at constructor (in case of summarizer)
+                this.summaryTracker.setBaseTree(details.snapshot);
+            }
             const factory = await this._hostRuntime.IComponentRegistry.get(details.pkg);
 
             // During this call we will invoke the instantiate method - which will call back into us
@@ -237,18 +244,18 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
      * Notifies the object to take snapshot of a component.
      */
     public async snapshot(fullTree: boolean = false): Promise<ITree> {
-        await this.realize();
-
-        const { pkg } = await this.getInitialSnapshotDetails();
-
-        const componentAttributes = { pkg };
-
         // base ID still being set means previous snapshot is still valid
         const baseId = this.summaryTracker.getBaseId();
         if (baseId && !fullTree) {
             return { id: baseId, entries: [] };
         }
         this.summaryTracker.reset();
+
+        await this.realize();
+
+        const { pkg } = await this.getInitialSnapshotDetails();
+
+        const componentAttributes = { pkg };
 
         const entries = await this.componentRuntime.snapshotInternal(fullTree);
 
@@ -372,6 +379,11 @@ export class RemotedComponentContext extends ComponentContext {
             () => {
                 throw new Error("Already attached");
             });
+
+        if (initSnapshotValue && typeof initSnapshotValue !== "string") {
+            // set on construction if possible
+            this.summaryTracker.setBaseTree(initSnapshotValue);
+        }
     }
 
     public generateAttachMessage(): IAttachMessage {


### PR DESCRIPTION
Previously the inner snapshot call at the component level was always realizing the component, even if it remained unchanged.  It has been changed to only call realize if a change has occurred.

Additionally, the base tree is now set (when possible) in the remote component context constructor.  Further, the base tree is only updated during the realize call if there is not a newer one (set by refreshBaseSummary) and if the one returned from the initial snapshot details is truthy (which correctly never happens for local).

These changes combined, allow the summarizer to only realize/load a component if it has been changed.