### PR TITLE
updates yo fluid tip to point to @microsoft instead of @prague

### DIFF
--- a/docs/get-started/_yo-fluid-content.md
+++ b/docs/get-started/_yo-fluid-content.md
@@ -18,6 +18,6 @@ yo fluid
 ```
 
 > [!TIP]
-> if you get an error when running `yo fluid` saying that a generator cannot be found, try using `yo @prague/fluid` instead.
+> if you get an error when running `yo fluid` saying that a generator cannot be found, try using `yo @microsoft/fluid` instead.
 
 Now you're ready to <xref:build-a-component>!


### PR DESCRIPTION
Minor update that I noticed while building a new project, updates the tip that failing to execute the generator via 'yo fluid' may be fixed with 'yo @microsoft/fluid' (still said @prague, which no longer works)