### PR TITLE
Added retry for secondary AFD url for delta stream socket.

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
@@ -170,8 +170,10 @@ export class OdspDocumentService implements IDocumentService {
             webSocketToken ? webSocketToken : websocketEndpoint.socketToken,
             io,
             client,
-            websocketEndpoint.deltaStreamSocketUrl,
             mode,
+            websocketEndpoint.deltaStreamSocketUrl,
+            websocketEndpoint.deltaStreamSocketUrl2,
+            this.logger,
         ).then((connection) => {
             connection.on("server_disconnect", (socketError: IOdspSocketError) => {
                 const error = OdspDocumentService.errorObjectFromOdspError(socketError);
@@ -180,8 +182,7 @@ export class OdspDocumentService implements IDocumentService {
                 connection.emit("disconnect", error);
             });
             return connection;
-        })
-        .catch((error) => {
+        }).catch((error) => {
             // Test if it's NetworkError with IOdspSocketError.
             // Note that there might be no IOdspSocketError on it in case we hit socket.io protocol errors!
             // So we test canRetry property first - if it false, that means protocol is broken and reconnecting will not help.

--- a/packages/drivers/odsp-socket-storage/src/contracts.ts
+++ b/packages/drivers/odsp-socket-storage/src/contracts.ts
@@ -113,6 +113,9 @@ export interface ISocketStorageDiscovery {
     storageToken: string;
 
     deltaStreamSocketUrl: string;
+
+    // The AFD URL for PushChannel
+    deltaStreamSocketUrl2?: string;
     socketToken: string;
 }
 

--- a/packages/drivers/routerlicious-socket-storage/src/documentService.ts
+++ b/packages/drivers/routerlicious-socket-storage/src/documentService.ts
@@ -109,8 +109,8 @@ export class DocumentService implements api.IDocumentService {
             this.tokenProvider.token,
             io,
             client,
-            this.ordererUrl,
-            mode);
+            mode,
+            this.ordererUrl);
     }
 
     public async branch(): Promise<string> {

--- a/packages/drivers/socket-storage-shared/package.json
+++ b/packages/drivers/socket-storage-shared/package.json
@@ -21,6 +21,7 @@
   "author": "Microsoft",
   "repository": "microsoft/FluidFramework",
   "dependencies": {
+    "@microsoft/fluid-container-definitions": "^0.10.0",
     "@microsoft/fluid-core-utils": "^0.11.0",
     "@microsoft/fluid-protocol-definitions": "^0.11.0",
     "@types/debug": "^0.0.31",

--- a/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
+++ b/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { BatchManager, NetworkError } from "@microsoft/fluid-core-utils";
+import { ITelemetryLogger } from "@microsoft/fluid-container-definitions";
+import { BatchManager, NetworkError, TelemetryNullLogger } from "@microsoft/fluid-core-utils";
 import {
     ConnectionMode,
     IClient,
@@ -47,7 +48,8 @@ function createErrorObject(handler: string, error: any, canRetry = true) {
  */
 export class DocumentDeltaConnection extends EventEmitter implements IDocumentDeltaConnection {
     /**
-     * Create a DocumentDeltaConnection
+     * Create a DocumentDeltaConnection.
+     * If url #1 fails to connect, will try url #2 if applicable.
      *
      * @param tenantId - the ID of the tenant
      * @param id - document ID
@@ -55,6 +57,7 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
      * @param io - websocket library
      * @param client - information about the client
      * @param url - websocket URL
+     * @param url2 - alternate websocket URL
      */
     // tslint:disable-next-line: max-func-body-length
     public static async create(
@@ -63,8 +66,73 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
         token: string | null,
         io: SocketIOClientStatic,
         client: IClient,
+        mode: ConnectionMode,
         url: string,
-        mode: ConnectionMode): Promise<IDocumentDeltaConnection> {
+        url2?: string,
+        telemetryLogger?: ITelemetryLogger): Promise<IDocumentDeltaConnection> {
+            // tslint:disable-next-line: strict-boolean-expressions
+            const hasUrl2 = !!url2;
+
+            // Create null logger if telemetry logger is not available from caller
+            const logger = telemetryLogger ? telemetryLogger : new TelemetryNullLogger();
+
+            return this.createImpl(
+                tenantId,
+                id,
+                token,
+                io,
+                client,
+                url,
+                mode,
+                hasUrl2 ? 15000 : 20000,
+            // tslint:disable-next-line: promise-function-async
+            ).catch((error) => {
+                if (error instanceof NetworkError && hasUrl2) {
+                    if (error.canRetry) {
+                        debug(`Socket connection error on non-AFD URL. Error was [${error}]. Retry on AFD URL: ${url}`);
+                        logger.sendTelemetryEvent({ eventName: "UseAfdUrl" });
+
+                        return this.createImpl(
+                            tenantId,
+                            id,
+                            token,
+                            io,
+                            client,
+                            // tslint:disable-next-line: no-non-null-assertion
+                            url2!,
+                            mode,
+                            20000,
+                        );
+                    }
+                }
+
+                logger.sendTelemetryEvent({ eventName: "FailedAfdUrl" });
+
+                throw error;
+            });
+    }
+
+    /**
+     * Create a DocumentDeltaConnection
+     *
+     * @param tenantId - the ID of the tenant
+     * @param id - document ID
+     * @param token - authorization token for storage service
+     * @param io - websocket library
+     * @param client - information about the client
+     * @param url - websocket URL
+     * @param timeoutMs - timeout for socket connection attempt in milliseconds
+     */
+    // tslint:disable-next-line: max-func-body-length
+    private static async createImpl(
+        tenantId: string,
+        id: string,
+        token: string | null,
+        io: SocketIOClientStatic,
+        client: IClient,
+        url: string,
+        mode: ConnectionMode,
+        timeoutMs: number): Promise<IDocumentDeltaConnection> {
 
         // Note on multiplex = false:
         // Temp fix to address issues on SPO. Scriptor hits same URL for Fluid & Notifications.
@@ -80,6 +148,7 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
                 },
                 reconnection: false,
                 transports: ["websocket"],
+                timeout: timeoutMs,
             });
 
         const connectMessage: IConnect = {


### PR DESCRIPTION
Merging to master.

This change allows socket connection to retry on a second url returned by join session, if applicable. The first url is supposed to be a non-AFD url to Push, and the second url is an AFD one. In the event the user can't connect to the non-AFD endpoint (due to firewalls, etc.), it will retry on the second url.