### PR TITLE
updates docs link to loader sample

### DIFF
--- a/docs/get-started/terminology.md
+++ b/docs/get-started/terminology.md
@@ -23,7 +23,7 @@ See [Containers](xref:concepts#containers)
 
 ## Loader
 
-See <https://github.com/Microsoft/FluidFramework/blob/master/samples/hosts/README.md>
+See <https://github.com/microsoft/FluidFramework/blob/master/samples/hosts/literate/README.md>
 
 ## Quorum
 


### PR DESCRIPTION
Original url is now 404, this appears to be the correct url for a sample loader.