### PR TITLE
Port various summary changes to master

### DIFF
--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -85,6 +85,9 @@ export interface IDeltaManager<T, U> extends EventEmitter, IDeltaSender, IDispos
     // The last sequence number processed by the delta manager
     referenceSequenceNumber: number;
 
+    // The initial sequence number set when attaching the op handler
+    initialSequenceNumber: number;
+
     // Type of client
     clientType: string;
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -871,9 +871,9 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         // We do not have good correlation ID to match server activity.
         // Add couple IDs here
         this.subLogger.setProperties({
-            SocketClientId: this.clientId,
-            SocketDocumentId: this._deltaManager!.socketDocumentId,
-            SocketPendingClientId: value === ConnectionState.Connecting ? this.pendingClientId : undefined,
+            clientId: this.clientId,
+            socketDocumentId: this._deltaManager!.socketDocumentId,
+            pendingClientId: value === ConnectionState.Connecting ? this.pendingClientId : undefined,
         });
 
         // Log actual event

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -93,6 +93,9 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
     private lastQueuedSequenceNumber: number = 0;
     private baseSequenceNumber: number = 0;
 
+    // the sequence number we initially loaded from
+    private initSequenceNumber: number = 0;
+
     private readonly _inboundPending: DeltaQueue<ISequencedDocumentMessage>;
     private readonly _inbound: DeltaQueue<ISequencedDocumentMessage>;
     private readonly _inboundSignal: DeltaQueue<ISignalMessage>;
@@ -136,6 +139,10 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
 
     public get inboundSignal(): IDeltaQueue<ISignalMessage> {
         return this._inboundSignal;
+    }
+
+    public get initialSequenceNumber(): number {
+        return this.initSequenceNumber;
     }
 
     public get referenceSequenceNumber(): number {
@@ -283,6 +290,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
             resume: boolean) {
         debug("Attached op handler", sequenceNumber);
 
+        this.initSequenceNumber = sequenceNumber;
         this.baseSequenceNumber = sequenceNumber;
         this.minSequenceNumber = minSequenceNumber;
         this.lastQueuedSequenceNumber = sequenceNumber;

--- a/packages/loader/container-loader/src/deltaManagerProxy.ts
+++ b/packages/loader/container-loader/src/deltaManagerProxy.ts
@@ -102,6 +102,10 @@ export class DeltaManagerProxy
         return this.deltaManager.referenceSequenceNumber;
     }
 
+    public get initialSequenceNumber(): number {
+        return this.deltaManager.initialSequenceNumber;
+    }
+
     public get clientType(): string {
         return this.deltaManager.clientType;
     }

--- a/packages/loader/utils/src/blobs.ts
+++ b/packages/loader/utils/src/blobs.ts
@@ -148,3 +148,52 @@ export function buildHierarchy(flatTree: git.ITree): ISnapshotTree {
 
     return root;
 }
+
+/**
+ * Basic implementation of a blob ITreeEntry
+ */
+export class BlobTreeEntry implements ITreeEntry {
+    public readonly mode = FileMode.File;
+    public readonly type = TreeEntry[TreeEntry.Blob];
+    public readonly value: IBlob;
+
+    /**
+     * Creates a blob ITreeEntry
+     * @param path - path of entry
+     * @param contents - blob contents
+     * @param encoding - encoding of contents; defaults to utf-8
+     */
+    constructor(public readonly path: string, contents: string, encoding: string = "utf-8") {
+        this.value = { contents, encoding };
+    }
+}
+
+/**
+ * Basic implementation of a commit ITreeEntry
+ */
+export class CommitTreeEntry implements ITreeEntry {
+    public readonly mode = FileMode.Commit;
+    public readonly type = TreeEntry[TreeEntry.Commit];
+
+    /**
+     * Creates a commit ITreeEntry
+     * @param path - path of entry
+     * @param value - commit value
+     */
+    constructor(public readonly path: string, public readonly value: string) {}
+}
+
+/**
+ * Basic implementation of a tree ITreeEntry
+ */
+export class TreeTreeEntry implements ITreeEntry {
+    public readonly mode = FileMode.Directory;
+    public readonly type = TreeEntry[TreeEntry.Tree];
+
+    /**
+     * Creates a tree ITreeEntry
+     * @param path - path of entry
+     * @param value - subtree
+     */
+    constructor(public readonly path: string, public readonly value: ITree) {}
+}

--- a/packages/runtime/component-runtime/src/channelContext.ts
+++ b/packages/runtime/component-runtime/src/channelContext.ts
@@ -4,14 +4,13 @@
  */
 
 import { ConnectionState } from "@microsoft/fluid-container-definitions";
+import { BlobTreeEntry } from "@microsoft/fluid-core-utils";
 import {
-    FileMode,
     IDocumentStorageService,
     ISequencedDocumentMessage,
     ISnapshotTree,
     ITree,
     MessageType,
-    TreeEntry,
 } from "@microsoft/fluid-protocol-definitions";
 import { IChannel, IEnvelope } from "@microsoft/fluid-runtime-definitions";
 import { ChannelDeltaConnection } from "./channelDeltaConnection";
@@ -59,15 +58,7 @@ export function snapshotChannel(channel: IChannel, baseId: string | null) {
 
     // Add in the object attributes to the returned tree
     const objectAttributes = channel.attributes;
-    snapshot.entries.push({
-        mode: FileMode.File,
-        path: ".attributes",
-        type: TreeEntry[TreeEntry.Blob],
-        value: {
-            contents: JSON.stringify(objectAttributes),
-            encoding: "utf-8",
-        },
-    });
+    snapshot.entries.push(new BlobTreeEntry(".attributes", JSON.stringify(objectAttributes)));
 
     // If baseId exists then the previous snapshot is still valid
     snapshot.id = baseId;

--- a/packages/runtime/component-runtime/src/componentRuntime.ts
+++ b/packages/runtime/component-runtime/src/componentRuntime.ts
@@ -19,7 +19,14 @@ import {
     IQuorum,
     ITelemetryLogger,
 } from "@microsoft/fluid-container-definitions";
-import { buildHierarchy, ChildLogger, Deferred, flatten, raiseConnectedEvent, TreeTreeEntry } from "@microsoft/fluid-core-utils";
+import {
+    buildHierarchy,
+    ChildLogger,
+    Deferred,
+    flatten,
+    raiseConnectedEvent,
+    TreeTreeEntry,
+} from "@microsoft/fluid-core-utils";
 import {
     IDocumentMessage,
     ISequencedDocumentMessage,

--- a/packages/runtime/component-runtime/src/componentRuntime.ts
+++ b/packages/runtime/component-runtime/src/componentRuntime.ts
@@ -19,15 +19,13 @@ import {
     IQuorum,
     ITelemetryLogger,
 } from "@microsoft/fluid-container-definitions";
-import { buildHierarchy, ChildLogger, Deferred, flatten, raiseConnectedEvent } from "@microsoft/fluid-core-utils";
+import { buildHierarchy, ChildLogger, Deferred, flatten, raiseConnectedEvent, TreeTreeEntry } from "@microsoft/fluid-core-utils";
 import {
-    FileMode,
     IDocumentMessage,
     ISequencedDocumentMessage,
     ISnapshotTree,
     ITreeEntry,
     MessageType,
-    TreeEntry,
 } from "@microsoft/fluid-protocol-definitions";
 import {
     IAttachMessage,
@@ -467,12 +465,7 @@ export class ComponentRuntime extends EventEmitter implements IComponentRuntime,
                 const snapshot = await value.snapshot(fullTree);
 
                 // And then store the tree
-                return {
-                    mode: FileMode.Directory,
-                    path: key,
-                    type: TreeEntry[TreeEntry.Tree],
-                    value: snapshot,
-                };
+                return new TreeTreeEntry(key, snapshot);
             }));
 
         return entries;
@@ -491,12 +484,7 @@ export class ComponentRuntime extends EventEmitter implements IComponentRuntime,
                 const snapshot = value.getAttachSnapshot();
 
                 // And then store the tree
-                entries.push({
-                    mode: FileMode.Directory,
-                    path: objectId,
-                    type: TreeEntry[TreeEntry.Tree],
-                    value: snapshot,
-                });
+                entries.push(new TreeTreeEntry(objectId, snapshot));
             }
         }
 

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -14,6 +14,7 @@ import {
     IQuorum,
 } from "@microsoft/fluid-container-definitions";
 import {
+    BlobTreeEntry,
     Deferred,
     raiseConnectedEvent,
     readAndParse,
@@ -42,7 +43,6 @@ import { EventEmitter } from "events";
 // tslint:disable-next-line:no-submodule-imports
 import * as uuid from "uuid/v4";
 import { ContainerRuntime } from "./containerRuntime";
-import { BlobTreeEntry } from "./utils";
 
 // Snapshot Format Version to be used in component attributes.
 const currentSnapshotFormatVersion = "0.1";

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -177,7 +177,14 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
         if (!this.componentRuntimeDeferred) {
             this.componentRuntimeDeferred = new Deferred<IComponentRuntime>();
             const details = await this.getInitialSnapshotDetails();
-            this.summaryTracker.setBaseTree(details.snapshot);
+            if (details.snapshot && !this.summaryTracker.baseTree) {
+                // do not overwrite if refreshed!
+                // local - will always give undefined tree, so never enter here
+                // remote - will give the tree at the time of construction (initial),
+                // which may be older than the refreshed one, but never newer than
+                // the refreshed or one set at constructor (in case of summarizer)
+                this.summaryTracker.setBaseTree(details.snapshot);
+            }
             const packages = details.pkg;
             let registry = this._hostRuntime.IComponentRegistry;
             let factory: ComponentFactoryTypes & Partial<IComponentRegistry>;
@@ -275,6 +282,13 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
      * Notifies the object to take snapshot of a component.
      */
     public async snapshot(fullTree: boolean = false): Promise<ITree> {
+        // base ID still being set means previous snapshot is still valid
+        const baseId = this.summaryTracker.getBaseId();
+        if (baseId && !fullTree) {
+            return { id: baseId, entries: [] };
+        }
+        this.summaryTracker.reset();
+
         await this.realize();
 
         const { pkg } = await this.getInitialSnapshotDetails();
@@ -283,13 +297,6 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
             pkg: JSON.stringify(pkg),
             snapshotFormatVersion: currentSnapshotFormatVersion,
         };
-
-        // base ID still being set means previous snapshot is still valid
-        const baseId = this.summaryTracker.getBaseId();
-        if (baseId && !fullTree) {
-            return { id: baseId, entries: [] };
-        }
-        this.summaryTracker.reset();
 
         const entries = await this.componentRuntime.snapshotInternal(fullTree);
 
@@ -417,6 +424,13 @@ export class RemotedComponentContext extends ComponentContext {
             () => {
                 throw new Error("Already attached");
             });
+
+        if (initSnapshotValue && typeof initSnapshotValue !== "string") {
+            // This will allow the summarizer to avoid calling realize if there
+            // are no changes to the component.  If the initSnapshotValue is a
+            // string, the summarizer cannot avoid calling realize.
+            this.summaryTracker.setBaseTree(initSnapshotValue);
+        }
     }
 
     public generateAttachMessage(): IAttachMessage {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -25,7 +25,9 @@ import {
     ITelemetryLogger,
 } from "@microsoft/fluid-container-definitions";
 import {
+    BlobTreeEntry,
     buildHierarchy,
+    CommitTreeEntry,
     ComponentSerializer,
     Deferred,
     flatten,
@@ -68,8 +70,8 @@ import { debug } from "./debug";
 import { DocumentStorageServiceProxy } from "./documentStorageServiceProxy";
 import { Summarizer } from "./summarizer";
 import { SummaryManager } from "./summaryManager";
+import { ISummaryStats, SummaryTreeConverter } from "./summaryTreeConverter";
 import { analyzeTasks } from "./taskAnalyzer";
-import { BlobTreeEntry, CommitTreeEntry, ISummaryStats, SummaryTreeConverter } from "./utils";
 
 interface ISummaryTreeWithStats {
     summaryStats: ISummaryStats;
@@ -565,7 +567,9 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
 
         // Create the SummaryManager and mark the initial state
         this.summaryManager = new SummaryManager(
-            context, this.runtimeOptions.generateSummaries || this.loadedFromSummary);
+            context,
+            this.runtimeOptions.generateSummaries || this.loadedFromSummary,
+            this.logger);
         if (this.context.connectionState === ConnectionState.Connected) {
             this.summaryManager.setConnected(this.context.clientId);
         }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -84,8 +84,15 @@ interface IBufferedChunk {
     content: string;
 }
 
-export interface IGeneratedSummaryData extends ISummaryStats {
+export interface IGeneratedSummaryData {
     sequenceNumber: number;
+
+    /**
+     * true if the summary op was submitted
+     */
+    submitted: boolean;
+
+    summaryStats?: ISummaryStats;
 }
 
 // Consider idle 5s of no activity. And snapshot if a minute has gone by with no snapshot.
@@ -1081,15 +1088,28 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
 
         try {
             await this.scheduleManager.pause();
+            const sequenceNumber = this.deltaManager.referenceSequenceNumber;
 
+            const ret: IGeneratedSummaryData = {
+                sequenceNumber,
+                submitted: false,
+                summaryStats: undefined,
+            };
+
+            if (!this.connected) {
+                return ret;
+            }
             // TODO in the future we can have stored the latest summary by listening to the summary ack message
             // after loading from the beginning of the snapshot
             const versions = await this.context.storage.getVersions(this.id, 1);
             const parents = versions.map((version) => version.id);
 
-            const sequenceNumber = this.deltaManager.referenceSequenceNumber;
             const treeWithStats = await this.summarize(fullTree);
+            ret.summaryStats = treeWithStats.summaryStats;
 
+            if (!this.connected) {
+                return ret;
+            }
             const handle = await this.context.storage.uploadSummary(treeWithStats.summaryTree);
             const summary = {
                 handle: handle.handle,
@@ -1098,13 +1118,14 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
                 parents,
             };
 
+            if (!this.connected) {
+                return ret;
+            }
+            // if summarizer loses connection it will never reconnect
             this.submit(MessageType.Summarize, summary);
+            ret.submitted = true;
 
-            // notify summarizer while still paused
-            return {
-                sequenceNumber,
-                ...treeWithStats.summaryStats,
-            };
+            return ret;
         } catch (ex) {
             this.logger.logException({ eventName: "Summarizer:GenerateSummaryExceptionError" }, ex);
             throw ex;

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -4,4 +4,4 @@
  */
 
 export * from "./containerRuntime";
-export * from "./utils";
+export * from "./summaryTreeConverter";

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -50,7 +50,7 @@ export interface ISummarizer extends IProvideSummarizer {
      * Stops the summarizer by closing its container and resolving its run promise.
      * @param reason - reason for stopping
      */
-    stop(reason?: string);
+    stop(reason?: string): void;
 }
 
 export class Summarizer implements IComponentLoadable, ISummarizer {

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -17,6 +17,10 @@ import {
 import * as assert from "assert";
 import { ContainerRuntime, IGeneratedSummaryData } from "./containerRuntime";
 
+// send some telemetry if generate summary takes too long
+const maxSummarizeTimeoutTime = 20000; // 20 sec
+const maxSummarizeTimeoutCount = 5; // double and resend 5 times
+
 /**
  * Wrapper interface holding summary details for a given op
  */
@@ -63,42 +67,85 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
     private summarizing = false;
     private summaryPending = false;
     private pendingSummarySequenceNumber?: number;
-    private idleTimer: NodeJS.Timeout | null = null;
+    private idleTimer: Timer;
+    private pendingAckTimer: Timer;
+    private readonly summarizeTimer: Timer;
     private readonly runDeferred = new Deferred<void>();
     private readonly logger: ITelemetryLogger;
+    private configuration: ISummaryConfiguration;
 
     private deferBroadcast: Deferred<void>;
     private deferAck: Deferred<void>;
 
     private onBehalfOfClientId: string;
+    private everConnected = false;
 
     constructor(
         public readonly url: string,
         private readonly runtime: ContainerRuntime,
-        private readonly configuration: ISummaryConfiguration,
+        private readonly configurationGetter: () => ISummaryConfiguration,
         private readonly generateSummary: () => Promise<IGeneratedSummaryData>,
         private readonly refreshBaseSummary: (snapshot: ISnapshotTree) => void,
     ) {
         this.logger = ChildLogger.create(this.runtime.logger, "Summarizer");
 
+        // try to determine if the runtime has ever been connected
+        if (this.runtime.connected) {
+            this.everConnected = true;
+        } else {
+            this.runtime.once("connected", () => this.everConnected = true);
+        }
         this.runtime.on("disconnected", () => {
+            // sometimes the initial connection state is raised as disconnected
+            if (!this.everConnected) {
+                return;
+            }
+            this.logger.sendTelemetryEvent({ eventName: "SummarizerDisconnected" });
             this.runDeferred.resolve();
         });
+
+        this.summarizeTimer = new Timer(
+            () => this.summarizeTimerHandler(maxSummarizeTimeoutTime, 1),
+            maxSummarizeTimeoutTime);
     }
 
     public async run(onBehalfOf: string): Promise<void> {
         this.onBehalfOfClientId = onBehalfOf;
 
         if (!this.runtime.connected) {
-            await new Promise((resolve) => this.runtime.once("connected", resolve));
+            if (!this.everConnected) {
+                const waitConnected = new Promise((resolve) => this.runtime.once("connected", resolve));
+                await Promise.race([waitConnected, this.runDeferred.promise]);
+            } else {
+                // we will not try to reconnect, so we are done running
+                this.logger.sendTelemetryEvent({ eventName: "DisconnectedBeforeRun" });
+                return;
+            }
         }
 
         if (this.runtime.summarizerClientId !== onBehalfOf) {
             return;
         }
 
+        // need to wait until we are connected
+        this.configuration = this.configurationGetter();
+
+        this.idleTimer = new Timer(
+            () => this.summarize("idle"),
+            this.configuration.idleTime);
+
+        this.pendingAckTimer = new Timer(
+            () => {
+                this.logger.sendErrorEvent({
+                    eventName: "SummaryAckWaitTimeout",
+                    maxAckWaitTime: this.configuration.maxAckWaitTime,
+                    pendingSummarySequenceNumber: this.pendingSummarySequenceNumber,
+                });
+                this.cancelPending();
+            }, this.configuration.maxAckWaitTime);
+
         // initialize values (not exact)
-        this.lastSummarySeqNumber = this.runtime.deltaManager.referenceSequenceNumber;
+        this.lastSummarySeqNumber = this.runtime.deltaManager.initialSequenceNumber;
         this.lastSummaryTime = Date.now();
 
         this.logger.sendTelemetryEvent({
@@ -108,14 +155,19 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
         });
 
         // start the timer after connecting to the document
-        this.resetIdleTimer();
+        this.idleTimer.start();
 
         // listen for summary ops
         this.runtime.deltaManager.inbound.on("op", (op) => this.handleSummaryOp(op as ISequencedDocumentMessage));
 
         this.runtime.on("batchEnd", (error: any, op: ISequencedDocumentMessage) => this.handleOp(error, op));
 
-        return this.runDeferred.promise;
+        await this.runDeferred.promise;
+
+        // cleanup
+        this.idleTimer.clear();
+        this.summarizeTimer.clear();
+        this.cancelPending();
     }
 
     public stop(reason?: string) {
@@ -139,12 +191,12 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
             result = await setter();
         } catch (error) {
             // send error event for exceptions
-            this.logger.sendErrorEvent({ eventName, clientId: this.runtime.clientId }, error);
+            this.logger.sendErrorEvent({ eventName }, error);
             success = false;
         }
         if (success && !validator(result)) {
             // send error event when result is invalid
-            this.logger.sendErrorEvent({ eventName, clientId: this.runtime.clientId });
+            this.logger.sendErrorEvent({ eventName });
             success = false;
         }
         return { result, success };
@@ -216,6 +268,7 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
                         }
                     }
                     this.summaryPending = false;
+                    this.pendingAckTimer.clear();
                 }
             }
         }
@@ -226,20 +279,7 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
             return;
         }
 
-        this.clearIdleTimer();
-
-        // clear pending if timeout waiting for server ack
-        if (this.summaryPending && !this.summarizing) {
-            const pendingTime = Date.now() - this.lastSummaryTime;
-            if (pendingTime > this.configuration.maxAckWaitTime) {
-                this.logger.sendErrorEvent({
-                    eventName: "SummaryAckWaitTimeout",
-                    maxAckWaitTime: this.configuration.maxAckWaitTime,
-                    pendingSummarySequenceNumber: this.pendingSummarySequenceNumber,
-                });
-                this.cancelPending();
-            }
-        }
+        this.idleTimer.clear();
 
         // Get the summary details for the given op
         const lastOpSummaryDetails = this.getOpSummaryDetails(op);
@@ -249,7 +289,7 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
             this.summarize(lastOpSummaryDetails.message);
         } else if (lastOpSummaryDetails.canStartIdleTimer) {
             // Otherwise detect when we idle to trigger the snapshot
-            this.resetIdleTimer();
+            this.idleTimer.start();
         }
     }
 
@@ -268,45 +308,46 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
         this.summarizing = true;
         this.startPending();
 
-        this.summarizeCore(message).finally(() => {
-            this.summarizing = false;
-        }).catch((error) => {
-            this.logger.sendErrorEvent({ eventName: "SummarizeError" }, error);
-            this.cancelPending();
-        });
-    }
-
-    private async summarizeCore(message: string) {
         const summarizingEvent = PerformanceEvent.start(this.logger,
             { eventName: "Summarizing", stage: "start", message });
 
-        const summaryData = await this.generateSummary();
+        this.summarizeTimer.start();
 
-        const summaryEndTime = Date.now();
+        this.generateSummary().finally(() => {
+            // always leave summarizing state
+            this.summarizing = false;
+            this.summarizeTimer.clear();
+        }).then((summaryData) => {
+            const summaryEndTime = Date.now();
 
-        const telemetryProps = {
-            sequenceNumber: summaryData.sequenceNumber,
-            ...summaryData.summaryStats,
-            opsSinceLastSummary: summaryData.sequenceNumber - this.lastSummarySeqNumber,
-            timeSinceLastSummary: summaryEndTime - this.lastSummaryTime,
-        };
-        if (!summaryData.submitted) {
-            // did not send the summary op
-            summarizingEvent.cancel(telemetryProps);
+            const telemetryProps = {
+                sequenceNumber: summaryData.sequenceNumber,
+                ...summaryData.summaryStats,
+                opsSinceLastSummary: summaryData.sequenceNumber - this.lastSummarySeqNumber,
+                timeSinceLastSummary: summaryEndTime - this.lastSummaryTime,
+            };
+            if (!summaryData.submitted) {
+                // did not send the summary op
+                summarizingEvent.cancel({...telemetryProps, category: "error"});
+                this.cancelPending();
+                return;
+            }
+
+            summarizingEvent.end(telemetryProps);
+
+            this.lastSummaryTime = summaryEndTime;
+            this.lastSummarySeqNumber = summaryData.sequenceNumber;
+
+            // Because summarizing is async, the incoming op stream will be resumed before
+            // we update our lastSummarySeqNumber.  We use this to defer the broadcast listeners
+            // until we are sure that no summary ops are handled before lastSummarySeqNumber is
+            // set here.
+            this.deferBroadcast.resolve();
+            this.pendingAckTimer.start();
+        }, (error) => {
+            summarizingEvent.cancel({}, error);
             this.cancelPending();
-            return;
-        }
-
-        summarizingEvent.end(telemetryProps);
-
-        this.lastSummaryTime = summaryEndTime;
-        this.lastSummarySeqNumber = summaryData.sequenceNumber;
-
-        // Because summarizing is async, the incoming op stream will be resumed before
-        // we update our lastSummarySeqNumber.  We use this to defer the broadcast listeners
-        // until we are sure that no summary ops are handled before lastSummarySeqNumber is
-        // set here.
-        this.deferBroadcast.resolve();
+        });
     }
 
     private getOpSummaryDetails(op: ISequencedDocumentMessage): IOpSummaryDetails {
@@ -324,16 +365,43 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
                 shouldSummarize: true,
                 canStartIdleTimer: true,
             };
-        } else {
-            // Summarize if it has been above the max time between summaries.
-            const timeSinceLastSummary = Date.now() - this.lastSummaryTime;
-            const opCountSinceLastSummary = op.sequenceNumber - this.lastSummarySeqNumber;
+        }
+
+        // Summarize if it has been above the max time between summaries.
+        const timeSinceLastSummary = Date.now() - this.lastSummaryTime;
+        const opCountSinceLastSummary = op.sequenceNumber - this.lastSummarySeqNumber;
+
+        if (timeSinceLastSummary > this.configuration.maxTime) {
             return {
-                message: "",
-                shouldSummarize: (timeSinceLastSummary > this.configuration.maxTime) ||
-                    (opCountSinceLastSummary > this.configuration.maxOps),
+                message: "maxTime",
+                shouldSummarize: true,
                 canStartIdleTimer: true,
             };
+        } else if (opCountSinceLastSummary > this.configuration.maxOps) {
+            return {
+                message: "maxOps",
+                shouldSummarize: true,
+                canStartIdleTimer: true,
+            };
+        } else {
+            return {
+                message: "",
+                shouldSummarize: false,
+                canStartIdleTimer: true,
+            };
+        }
+    }
+
+    private summarizeTimerHandler(time: number, count: number) {
+        this.logger.sendErrorEvent({
+            eventName: "SummarizeTimeout",
+            timeoutTime: time,
+            timeoutCount: count,
+        });
+        if (count < maxSummarizeTimeoutCount) {
+            // double and start a new timer
+            const nextTime = time * 2;
+            this.summarizeTimer.start(() => this.summarizeTimerHandler(nextTime, count + 1), nextTime);
         }
     }
 
@@ -346,24 +414,44 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
 
     private cancelPending() {
         this.summaryPending = false;
+        this.pendingAckTimer.clear();
         // release all deferred summary op/ack/nack handlers
-        this.deferBroadcast.resolve();
-        this.deferAck.resolve();
+        if (this.deferBroadcast) {
+            this.deferBroadcast.resolve();
+        }
+        if (this.deferAck) {
+            this.deferAck.resolve();
+        }
+    }
+}
+
+class Timer {
+    public get hasTimer() {
+        return !!this.timer;
     }
 
-    private clearIdleTimer() {
-        if (!this.idleTimer) {
+    private timer?: NodeJS.Timeout;
+
+    constructor(
+        private readonly defaultHandler: () => void,
+        private readonly defaultTimeout: number) {}
+
+    public start(handler: () => void = this.defaultHandler, timeout: number = this.defaultTimeout) {
+        this.clear();
+        this.timer = setTimeout(() => this.wrapHandler(handler), timeout);
+    }
+
+    public clear() {
+        if (!this.timer) {
             return;
         }
-        clearTimeout(this.idleTimer);
-        this.idleTimer = null;
+        clearTimeout(this.timer);
+        this.timer = undefined;
     }
 
-    private resetIdleTimer() {
-        this.clearIdleTimer();
-
-        this.idleTimer = setTimeout(
-            () => this.summarize("idle"),
-            this.configuration.idleTime);
+    private wrapHandler(handler: () => void) {
+        // run clear first, in case the handler decides to start again
+        this.clear();
+        handler();
     }
 }

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -283,11 +283,20 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
 
         const summaryEndTime = Date.now();
 
-        summarizingEvent.end({
-            ...summaryData,
+        const telemetryProps = {
+            sequenceNumber: summaryData.sequenceNumber,
+            ...summaryData.summaryStats,
             opsSinceLastSummary: summaryData.sequenceNumber - this.lastSummarySeqNumber,
             timeSinceLastSummary: summaryEndTime - this.lastSummaryTime,
-        });
+        };
+        if (!summaryData.submitted) {
+            // did not send the summary op
+            summarizingEvent.cancel(telemetryProps);
+            this.cancelPending();
+            return;
+        }
+
+        summarizingEvent.end(telemetryProps);
 
         this.lastSummaryTime = summaryEndTime;
         this.lastSummarySeqNumber = summaryData.sequenceNumber;

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -229,12 +229,13 @@ export class Summarizer implements IComponentLoadable, ISummarizer {
         this.clearIdleTimer();
 
         // clear pending if timeout waiting for server ack
-        if (this.summaryPending) {
+        if (this.summaryPending && !this.summarizing) {
             const pendingTime = Date.now() - this.lastSummaryTime;
             if (pendingTime > this.configuration.maxAckWaitTime) {
                 this.logger.sendErrorEvent({
                     eventName: "SummaryAckWaitTimeout",
                     maxAckWaitTime: this.configuration.maxAckWaitTime,
+                    pendingSummarySequenceNumber: this.pendingSummarySequenceNumber,
                 });
                 this.cancelPending();
             }

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -4,11 +4,10 @@
  */
 
 import { IComponent, IRequest } from "@microsoft/fluid-component-core-interfaces";
-import { IContainerContext } from "@microsoft/fluid-container-definitions";
-import { Heap, IComparer, IHeapNode } from "@microsoft/fluid-core-utils";
+import { IContainerContext, ITelemetryLogger } from "@microsoft/fluid-container-definitions";
+import { ChildLogger, Heap, IComparer, IHeapNode } from "@microsoft/fluid-core-utils";
 import { ISequencedClient } from "@microsoft/fluid-protocol-definitions";
 import { EventEmitter } from "events";
-import { debug } from "./debug";
 import { ISummarizer } from "./summarizer";
 
 interface ITrackedClient {
@@ -34,6 +33,7 @@ export class SummaryManager extends EventEmitter {
     private connected = false;
     private clientId: string;
     private runningSummarizer?: ISummarizer;
+    private readonly logger: ITelemetryLogger;
 
     public get summarizer() {
         return this._summarizer;
@@ -43,8 +43,14 @@ export class SummaryManager extends EventEmitter {
         return this.connected && this.clientId === this.summarizer;
     }
 
-    constructor(private readonly context: IContainerContext, private readonly generateSummaries: boolean) {
+    constructor(
+        private readonly context: IContainerContext,
+        private readonly generateSummaries: boolean,
+        parentLogger: ITelemetryLogger,
+    ) {
         super();
+
+        this.logger = ChildLogger.create(parentLogger, "SummaryManager");
 
         const members = context.quorum.getMembers();
         for (const [clientId, member] of members) {
@@ -103,6 +109,10 @@ export class SummaryManager extends EventEmitter {
      */
     private computeSummarizer(force = false) {
         const clientId = this.heap.count() > 0 ? this.heap.peek().value.clientId : undefined;
+
+        // Do not start if we are already the summarizer, unless force is passed.
+        // Force will be passed if we think we are not already summarizing, which might
+        // happen if we are not yet connected the first time through computeSummarizer.
         if (!force && clientId === this._summarizer) {
             return;
         }
@@ -110,6 +120,7 @@ export class SummaryManager extends EventEmitter {
         this._summarizer = clientId;
         this.emit("summarizer", clientId);
 
+        // do not start if we are not the summarizer or not connected
         if (this._summarizer !== this.clientId || !this.connected) {
             return;
         }
@@ -134,10 +145,10 @@ export class SummaryManager extends EventEmitter {
                 () => {
                     // In the future we will respawn the summarizer - for now we simply stop
                     // this.computeSummarizer(this.connected)
-                    debug("summary generation complete");
+                    this.logger.sendTelemetryEvent({ eventName: "RunningSummarizerCompleted" });
                 },
                 (error) => {
-                    debug("summary generation error", error);
+                    this.logger.sendErrorEvent({ eventName: "RunningSummarizerFailed" }, error);
                 });
         }
 
@@ -146,7 +157,7 @@ export class SummaryManager extends EventEmitter {
     private async createSummarizer() {
         // We have been elected the summarizer. Some day we may be able to summarize with a live document but for
         // now we play it safe and launch a second copy.
-        debug(`${this.clientId} elected summarizer`);
+        this.logger.sendTelemetryEvent({ eventName: "CreatingSummarizer" });
 
         const loader = this.context.loader;
 

--- a/packages/runtime/container-runtime/src/summaryTreeConverter.ts
+++ b/packages/runtime/container-runtime/src/summaryTreeConverter.ts
@@ -4,12 +4,10 @@
  */
 
 import {
-    FileMode,
     IBlob,
     ISummaryBlob,
     ISummaryTree,
     ITree,
-    ITreeEntry,
     SummaryObject,
     SummaryTree,
     SummaryType,
@@ -122,28 +120,4 @@ export class SummaryTreeConverter {
             return summaryTree;
         }
     }
-}
-
-export class BlobTreeEntry implements ITreeEntry {
-    public readonly mode = FileMode.File;
-    public readonly type = TreeEntry[TreeEntry.Blob];
-    public readonly value: IBlob;
-
-    constructor(public readonly path: string, contents: string, encoding: string = "utf-8") {
-        this.value = { contents, encoding };
-    }
-}
-
-export class CommitTreeEntry implements ITreeEntry {
-    public readonly mode = FileMode.Commit;
-    public readonly type = TreeEntry[TreeEntry.Commit];
-
-    constructor(public readonly path: string, public readonly value: string) {}
-}
-
-export class TreeTreeEntry implements ITreeEntry {
-    public readonly mode = FileMode.Directory;
-    public readonly type = TreeEntry[TreeEntry.Tree];
-
-    constructor(public readonly path: string, public readonly value: ITree) {}
 }

--- a/packages/runtime/container-runtime/src/test/componentContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/componentContext.spec.ts
@@ -4,7 +4,7 @@
  */
 // tslint:disable: prefer-const
 import { IComponent } from "@microsoft/fluid-component-core-interfaces";
-import { IDocumentStorageService, ISnapshotTree } from "@microsoft/fluid-protocol-definitions";
+import { IBlob, IDocumentStorageService, ISnapshotTree } from "@microsoft/fluid-protocol-definitions";
 import {
     ComponentFactoryTypes,
     IComponentContext,
@@ -14,7 +14,6 @@ import {
 } from "@microsoft/fluid-runtime-definitions";
 import { MockRuntime } from "@microsoft/fluid-test-runtime-utils";
 import * as assert from "assert";
-import { BlobTreeEntry } from "..";
 import { IComponentAttributes, LocalComponentContext, RemotedComponentContext } from "../componentContext";
 import { ContainerRuntime } from "../containerRuntime";
 import { DocumentStorageServiceProxy } from "../documentStorageServiceProxy";
@@ -51,9 +50,9 @@ describe("Component Context Tests", () => {
             localComponentContext.bindRuntime(new MockRuntime());
             const attachMessage = localComponentContext.generateAttachMessage();
 
-            const blob = attachMessage.snapshot.entries[0] as BlobTreeEntry;
+            const blob = attachMessage.snapshot.entries[0].value as IBlob;
 
-            const contents = JSON.parse(blob.value.contents) as IComponentAttributes;
+            const contents = JSON.parse(blob.contents) as IComponentAttributes;
             const componentAttributes: IComponentAttributes = {
                 pkg: JSON.stringify(["TestComponent1"]),
                 snapshotFormatVersion: "0.1",
@@ -102,8 +101,8 @@ describe("Component Context Tests", () => {
             localComponentContext.bindRuntime(new MockRuntime());
 
             const attachMessage = localComponentContext.generateAttachMessage();
-            const blob = attachMessage.snapshot.entries[0] as BlobTreeEntry;
-            const contents = JSON.parse(blob.value.contents) as IComponentAttributes;
+            const blob = attachMessage.snapshot.entries[0].value as IBlob;
+            const contents = JSON.parse(blob.contents) as IComponentAttributes;
             const componentAttributes: IComponentAttributes = {
                 pkg: JSON.stringify(["TestComp", "SubComp"]),
                 snapshotFormatVersion: "0.1",
@@ -161,9 +160,9 @@ describe("Component Context Tests", () => {
                 new DocumentStorageServiceProxy(storage, blobCache),
                 scope);
             const snapshot = await remotedComponentContext.snapshot(true);
-            const blob = snapshot.entries[0] as BlobTreeEntry;
+            const blob = snapshot.entries[0].value as IBlob;
 
-            const contents = JSON.parse(blob.value.contents) as IComponentAttributes;
+            const contents = JSON.parse(blob.contents) as IComponentAttributes;
             assert.equal(contents.pkg, componentAttributes.pkg, "Remote Component package does not match.");
             assert.equal(
                 contents.snapshotFormatVersion,
@@ -191,9 +190,9 @@ describe("Component Context Tests", () => {
                 new DocumentStorageServiceProxy(storage, blobCache),
                 scope);
             const snapshot = await remotedComponentContext.snapshot(true);
-            const blob = snapshot.entries[0] as BlobTreeEntry;
+            const blob = snapshot.entries[0].value as IBlob;
 
-            const contents = JSON.parse(blob.value.contents) as IComponentAttributes;
+            const contents = JSON.parse(blob.contents) as IComponentAttributes;
             assert.equal(
                 contents.pkg,
                 JSON.stringify([componentAttributes.pkg]),

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { BlobTreeEntry, TreeTreeEntry } from "@microsoft/fluid-core-utils";
 import {
     ISummaryBlob,
     ISummaryHandle,
@@ -12,7 +13,7 @@ import {
     SummaryType,
 } from "@microsoft/fluid-protocol-definitions";
 import * as assert from "assert";
-import { BlobTreeEntry, IConvertedSummaryResults, SummaryTreeConverter, TreeTreeEntry } from "../utils";
+import { IConvertedSummaryResults, SummaryTreeConverter } from "../summaryTreeConverter";
 
 describe("Runtime", () => {
     describe("Container Runtime", () => {

--- a/packages/runtime/container-runtime/src/test/summarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizer.spec.ts
@@ -76,6 +76,7 @@ describe("Runtime", () => {
                             emitter.emit(generateSummaryEvent);
                             return {
                                 sequenceNumber: lastSeq,
+                                submitted: true,
                                 treeNodeCount: 0,
                                 blobNodeCount: 0,
                                 handleNodeCount: 0,

--- a/packages/runtime/container-runtime/src/test/summarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizer.spec.ts
@@ -62,7 +62,7 @@ describe("Runtime", () => {
                             connected: true,
                             summarizerClientId,
                             deltaManager: {
-                                referenceSequenceNumber: 0,
+                                initialSequenceNumber: 0,
                                 inbound: emitter as IDeltaQueue<ISequencedDocumentMessage>,
                             } as IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
                             logger: {
@@ -74,7 +74,7 @@ describe("Runtime", () => {
                                 getVersions: (versionId, count) => Promise.resolve([{}]),
                             } as IDocumentStorageService,
                         } as ContainerRuntime,
-                        summaryConfig,
+                        () => summaryConfig,
                         async () => {
                             emitter.emit(generateSummaryEvent);
                             if (shouldDeferGenerateSummary) {
@@ -231,7 +231,7 @@ describe("Runtime", () => {
                     assert.strictEqual(runCount, 1);
 
                     // should not run because still pending
-                    clock.tick(summaryConfig.maxAckWaitTime);
+                    clock.tick(summaryConfig.maxAckWaitTime - 1);
                     await emitNextOp(summaryConfig.maxOps + 1);
                     assert.strictEqual(runCount, 1);
 

--- a/packages/server/routerlicious/src/test/agent/testDocument.ts
+++ b/packages/server/routerlicious/src/test/agent/testDocument.ts
@@ -85,6 +85,8 @@ export class TestDeltaManager
 
     public minimumSequenceNumber: number;
 
+    public initialSequenceNumber: number;
+
     public inbound = new TestDeltaQueue<ISequencedDocumentMessage>();
 
     public outbound = new TestDeltaQueue<IDocumentMessage[]>();


### PR DESCRIPTION
Port the following 5 PRs from 0.10 to master:
- #244 - summary cleanup (move reusable ITree classes up)
- #263 - check if disconnected in generate summary
- #276 - prevent invalid pending summary timeouts
- #327 - lots of telemetry-related summary cleanup
- #328 - do not load/realize components unless necessary