### PR TITLE
Fluid-Build: Add matched only mode for clean/force/rebuild and default to it

### DIFF
--- a/tools/fluid-build/src/common/logging.ts
+++ b/tools/fluid-build/src/common/logging.ts
@@ -13,9 +13,9 @@ export function logVerbose(msg: string) {
 }
 
 export function logStatus(msg: string) {
-    if (!options.logtime) { 
-        console.log(msg); 
-        return; 
+    if (!options.logtime) {
+        console.log(msg);
+        return;
     }
     const date = new Date();
     let hours = date.getHours().toString();

--- a/tools/fluid-build/src/fluidBuild.ts
+++ b/tools/fluid-build/src/fluidBuild.ts
@@ -66,7 +66,7 @@ function versionCheck() {
     const pkg = require(path.join(__dirname, "..", "package.json"));
     const builtVersion = "0.0.2";
     if (pkg.version > builtVersion) {
-        console.log(`WARNING: fluid-build is out of date, please rebuild (built: ${builtVersion}, package: ${pkg.version})\n`);
+        console.warn(`WARNING: fluid-build is out of date, please rebuild (built: ${builtVersion}, package: ${pkg.version})\n`);
     }
 }
 
@@ -81,13 +81,13 @@ async function main() {
 
     const root = options.root;
     if (!root) {
-        console.log(`ERROR: Unknown repo root. Specify it with --root or environment variable _FLUID_ROOT_`);
+        console.error(`ERROR: Unknown repo root. Specify it with --root or environment variable _FLUID_ROOT_`);
         process.exit(-2);
         return;
     }
     const resolvedRoot = path.resolve(root);
     if (!existsSync(resolvedRoot)) {
-        console.log(`ERROR: Repo root '${resolvedRoot}' not exist.`);
+        console.error(`ERROR: Repo root '${resolvedRoot}' not exist.`);
         process.exit(-3);
         return;
     }
@@ -105,17 +105,17 @@ async function main() {
             packages.forEach((pkg) => {
                 if (regExp.test(pkg.name)) {
                     matched = true;
-                    pkg.markForBuild = true;
+                    pkg.setMatched();
                 }
             });
         });
 
         if (!matched) {
-            console.log("ERROR: No package matched");
+            console.error("ERROR: No package matched");
             process.exit(-4)
         }
     } else {
-        packages.forEach((pkg) => pkg.markForBuild = true);
+        packages.forEach((pkg) => pkg.setMatched());
     }
 
     if (options.depcheck) {

--- a/tools/fluid-build/src/npmDepChecker.ts
+++ b/tools/fluid-build/src/npmDepChecker.ts
@@ -79,10 +79,10 @@ export class NpmDepChecker {
                 }
             } else if (!depCheckRecord.found) {
                 if (this.dev.indexOf(name) != -1) {
-                    console.warn(`${this.pkg.nameColored}: WARNING: misplaced dependency ${name}`);
+                    console.warn(`${this.pkg.nameColored}: warning: misplaced dependency ${name}`);
                     this.pkg.packageJson.devDependencies[name] = this.pkg.packageJson.dependencies[name];
                 } else {
-                    console.warn(`${this.pkg.nameColored}: WARNING: unused dependency ${name}`);
+                    console.warn(`${this.pkg.nameColored}: warning: unused dependency ${name}`);
                 }
                 changed = true;
                 delete this.pkg.packageJson.dependencies[name];
@@ -98,7 +98,7 @@ export class NpmDepChecker {
                 const name = dep.substring("@types/".length);
                 if ((!this.pkg.packageJson.dependencies || this.pkg.packageJson.dependencies[name] === undefined)
                     && (!this.pkg.packageJson.devDependencies || this.pkg.packageJson.devDependencies[name] === undefined)) {
-                    console.warn(`${this.pkg.nameColored}: WARNING: unused type dependency ${dep}`);
+                    console.warn(`${this.pkg.nameColored}: warning: unused type dependency ${dep}`);
                     delete this.pkg.packageJson.devDependencies[dep];
                     delete this.pkg.packageJson.dependencies[dep];
                     changed = true;

--- a/tools/fluid-build/src/npmPackage.ts
+++ b/tools/fluid-build/src/npmPackage.ts
@@ -84,8 +84,8 @@ export class Package {
 
     public readonly packageJson: Readonly<IPackage>;
     private readonly packageId = Package.packageCount++;
-
-    public markForBuild = false;
+    private _matched: boolean = false;
+    private _markForBuild: boolean = false;
 
     constructor(private readonly packageJsonFileName: string) {
         this.packageJson = require(packageJsonFileName);
@@ -102,6 +102,23 @@ export class Package {
 
     public get version(): string {
         return this.packageJson.version;
+    }
+
+    public get matched() {
+        return this._matched;
+    }
+
+    public setMatched() {
+        this._matched = true;
+        this._markForBuild = true;
+    }
+
+    public get markForBuild() {
+        return this._markForBuild;
+    }
+
+    public setMarkForBuild() {
+        this._markForBuild = true;
     }
 
     public get dependencies() {

--- a/tools/fluid-build/src/tasks/task.ts
+++ b/tools/fluid-build/src/tasks/task.ts
@@ -46,7 +46,7 @@ export abstract class Task {
 
     public async isUpToDate(): Promise<boolean> {
         // Always not up to date if forced
-        if (options.force) { return false; }
+        if (this.forced) { return false; }
 
         if (this.isUpToDateP === undefined) {
             this.isUpToDateP = this.checkIsUpToDate();
@@ -64,4 +64,8 @@ export abstract class Task {
     public abstract collectLeafTasks(leafTasks: LeafTask[]): void;
     protected abstract async checkIsUpToDate(): Promise<boolean>;
     protected abstract async runTask(q: AsyncPriorityQueue<TaskExec>): Promise<BuildResult>;
+
+    public get forced() {
+        return options.force && (options.matchedOnly !== true || this.package.matched);
+    }
 };


### PR DESCRIPTION
When --clean --force or --rebuild is specify, it applies to all the dependencies too.
Change it so that it only apply to matched package (if specified) and add a flag -d/--dep to apply those to the dependent packages as well.