### PR TITLE
Handle Document Idle In Deli

### DIFF
--- a/packages/server/lambdas/src/deli/clientSeqManager.ts
+++ b/packages/server/lambdas/src/deli/clientSeqManager.ts
@@ -23,7 +23,7 @@ const SequenceNumberComparer: IComparer<IClientSequenceNumber> = {
 export class ClientSequenceNumberManager {
     private clientNodeMap = new Map<string, IHeapNode<IClientSequenceNumber>>();
     private clientSeqNumbers = new Heap<IClientSequenceNumber>(SequenceNumberComparer);
-    private lastUpdate = 0;
+    private lastUpdate = -1;
     private recentIdleEnd: number | undefined;
 
     constructor(
@@ -153,7 +153,7 @@ export class ClientSequenceNumberManager {
             // if the gap between the last update, and this update
             // is greater than the client timeout then we were idle
             // so track the end time of this idle period
-            if (timestamp - this.lastUpdate > this.idleTimeout) {
+            if (this.lastUpdate >= 0 && timestamp - this.lastUpdate > this.idleTimeout) {
                 this.recentIdleEnd = timestamp;
             }
             this.lastUpdate = timestamp;

--- a/packages/server/lambdas/src/deli/lambda.ts
+++ b/packages/server/lambdas/src/deli/lambda.ts
@@ -180,8 +180,8 @@ export class DeliLambda implements IPartitionLambda {
                 }
 
                 // Return early but start a timer to create consolidated message.
+                this.clearNoopConsolidationTimer();
                 if (ticketedMessage.send === SendType.Later) {
-                    this.clearNoopConsolidationTimer();
                     this.setNoopConsolidationTimer();
                     continue;
                 }

--- a/packages/server/lambdas/src/deli/lambda.ts
+++ b/packages/server/lambdas/src/deli/lambda.ts
@@ -181,6 +181,7 @@ export class DeliLambda implements IPartitionLambda {
 
                 // Return early but start a timer to create consolidated message.
                 if (ticketedMessage.send === SendType.Later) {
+                    this.clearNoopConsolidationTimer();
                     this.setNoopConsolidationTimer();
                     continue;
                 }
@@ -205,6 +206,7 @@ export class DeliLambda implements IPartitionLambda {
 
         // Start a timer to check inactivity on the document. To trigger idle client leave message,
         // we send a noop back to alfred. The noop should trigger a client leave message if there are any.
+        this.clearIdleTimer();
         this.setIdleTimer();
     }
 
@@ -641,11 +643,10 @@ export class DeliLambda implements IPartitionLambda {
     }
 
     private setIdleTimer() {
-        if (this.noActiveClients || this.idleTimer !== undefined) {
+        if (this.noActiveClients) {
             return;
         }
         this.idleTimer = setTimeout(() => {
-            this.idleTimer = undefined;
             if (!this.noActiveClients) {
                 const noOpMessage = this.createOpMessage(MessageType.NoOp);
                 this.sendToAlfred(noOpMessage);
@@ -661,11 +662,10 @@ export class DeliLambda implements IPartitionLambda {
     }
 
     private setNoopConsolidationTimer() {
-        if (this.noActiveClients && this.noopTimer !== undefined) {
+        if (this.noActiveClients) {
             return;
         }
         this.noopTimer = setTimeout(() => {
-            this.noopTimer = undefined;
             if (!this.noActiveClients) {
                 const noOpMessage = this.createOpMessage(MessageType.NoOp);
                 this.sendToAlfred(noOpMessage);

--- a/packages/server/lambdas/src/deli/lambda.ts
+++ b/packages/server/lambdas/src/deli/lambda.ts
@@ -95,6 +95,10 @@ export class DeliLambda implements IPartitionLambda {
         private activityTimeout: number,
         private noOpConsolidationTimeout: number) {
 
+        this.clientSeqManager = new ClientSequenceNumberManager(
+            clientTimeout / 2,
+            clientTimeout);
+
         // Instantiate existing clients
         if (dbObject.clients) {
             for (const client of dbObject.clients) {
@@ -140,10 +144,6 @@ export class DeliLambda implements IPartitionLambda {
 
         this.logOffset = dbObject.logOffset;
         this.checkpointContext = new CheckpointContext(this.tenantId, this.documentId, collection, context);
-
-        this.clientSeqManager = new ClientSequenceNumberManager(
-            clientTimeout / 2,
-            clientTimeout);
     }
 
     public handler(rawMessage: IKafkaMessage): void {

--- a/packages/server/lambdas/src/deli/lambdaFactory.ts
+++ b/packages/server/lambdas/src/deli/lambdaFactory.ts
@@ -17,8 +17,8 @@ import { Provider } from "nconf";
 import { NoOpLambda } from "../utils";
 import { DeliLambda } from "./lambda";
 
-// We expire clients after 5 minutes of no activity
-export const ClientSequenceTimeout = 5 * 60 * 1000;
+// We expire clients after 2 minutes of no activity
+export const ClientSequenceTimeout = 2 * 60 * 1000;
 
 // Timeout for sending no-ops to trigger inactivity checker.
 export const ActivityCheckingTimeout = 30 * 1000;

--- a/packages/server/lambdas/src/test/deli/clientSeqManager.spec.ts
+++ b/packages/server/lambdas/src/test/deli/clientSeqManager.spec.ts
@@ -1,0 +1,121 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as assert from "assert";
+import { IClientSequenceNumber } from "../../deli/checkpointContext";
+import { ClientSequenceNumberManager } from "../../deli/clientSeqManager";
+import { ClientSequenceTimeout } from "../../deli/lambdaFactory";
+
+describe("Routerlicious.Deli.ClientSequenceNumberManager", () => {
+
+    describe("getIdleClient", () => {
+        it("No clients idle", () => {
+            const manager = new ClientSequenceNumberManager(ClientSequenceTimeout);
+
+            manager.upsertClient("c1", 0, 0, Date.now(), true);
+            manager.upsertClient("c2", 0, 0, Date.now(), true);
+
+            const idleClient = manager.getIdleClient();
+            assert.equal(idleClient, undefined);
+        });
+
+        it("Client is idle", () => {
+            const manager = new ClientSequenceNumberManager(ClientSequenceTimeout);
+
+            manager.upsertClient("c1", 0, 0, Date.now(), true);
+            const c1 = manager.get("c1");
+            manager.upsertClient("c2", 0, 0, Date.now(), true);
+            const c2 = manager.get("c2");
+
+            while (c1.lastUpdate - c2.lastUpdate <= ClientSequenceTimeout) {
+                // don't let full idle engage
+                c1.lastUpdate += ClientSequenceTimeout - 1;
+                updateClient(manager, c1);
+            }
+
+            const idleClient = manager.getIdleClient();
+            assert.notEqual(idleClient, undefined);
+            assert.equal(idleClient.clientId, c2.clientId);
+        });
+
+        it("No update before timeout or full idle", () => {
+            const manager = new ClientSequenceNumberManager(ClientSequenceTimeout);
+
+            manager.upsertClient("c1", 0, 0, Date.now(), true);
+            const c1 = manager.get("c1");
+            manager.upsertClient("c2", 0, 0, Date.now(), true);
+            const c2 = manager.get("c2");
+
+            while (c2.lastUpdate > manager.lastFullIdlePeriod.start - ClientSequenceTimeout) {
+                // make sure full idle starts
+                c1.lastUpdate += ClientSequenceTimeout + 1;
+                updateClient(manager, c1);
+            }
+
+            const idleClient = manager.getIdleClient();
+            assert.notEqual(idleClient, undefined);
+            assert.equal(idleClient.clientId, c2.clientId);
+        });
+
+        it("Update before timeout and before full idle", () => {
+            const manager = new ClientSequenceNumberManager(ClientSequenceTimeout);
+
+            manager.upsertClient("c1", 0, 0, Date.now(), true);
+            const c1 = manager.get("c1");
+            manager.upsertClient("c2", 0, 0, Date.now(), true);
+
+            // make sure full idle starts
+            c1.lastUpdate += ClientSequenceTimeout + 1;
+            updateClient(manager, c1);
+
+            const idleClient = manager.getIdleClient();
+            assert.equal(idleClient, undefined);
+        });
+
+        it("Last update after full idle and before timeout", () => {
+            const manager = new ClientSequenceNumberManager(ClientSequenceTimeout);
+
+            manager.upsertClient("c1", 0, 0, Date.now(), true);
+            const c1 = manager.get("c1");
+            manager.upsertClient("c2", 0, 0, Date.now(), true);
+            const c2 = manager.get("c2");
+
+            // enter full idle
+            c1.lastUpdate += ClientSequenceTimeout + 1;
+            updateClient(manager, c1);
+
+            // move c2 passed full idle
+            c2.lastUpdate = c1.lastUpdate + 1;
+            updateClient(manager, c2);
+
+            while (c1.lastUpdate - c2.lastUpdate <= ClientSequenceTimeout) {
+                // don't let full idle engage again
+                c1.lastUpdate += ClientSequenceTimeout - 1;
+                updateClient(manager, c1);
+            }
+
+            const idleClient = manager.getIdleClient();
+            assert.notEqual(idleClient, undefined);
+            assert.equal(idleClient.clientId, c2.clientId);
+        });
+    });
+});
+
+function updateClient(
+    manager: ClientSequenceNumberManager,
+    client: IClientSequenceNumber,
+    incrementSeqs: boolean = true,
+) {
+    if (incrementSeqs) {
+        client.clientSequenceNumber++;
+        client.referenceSequenceNumber++;
+    }
+    manager.upsertClient(
+        client.clientId,
+        client.clientSequenceNumber,
+        client.referenceSequenceNumber,
+        client.lastUpdate,
+        client.canEvict);
+}


### PR DESCRIPTION
Currently if there are no messages sent for the clientIdleTimeout then the next message sent will cause the oldest client to get kickout out on the next message, as no clients will have time to respond to say they are still in the collab window.

This change moves finding the idle client to deli's ClientSequenceNumberManager, and adds an idle timeout, so if no messages are sent, the document is considered idle. The next message will put the ClientSequenceNumberManager in a recently idle state. While recently idle, not client will be kicked out. this gives clients time to no-op when a message is sent after a long duration of no messages.