### PR TITLE
Refactor SummaryManager [0.10]

### DIFF
--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -155,9 +155,8 @@ export class SummaryManager extends EventEmitter {
             case SummaryManagerState.Off: {
                 if (this.shouldSummarize) {
                     this.start();
-                } else {
-                    return;
                 }
+                return;
             }
             case SummaryManagerState.Starting: {
                 // cannot take any action until summarizer is created
@@ -165,9 +164,7 @@ export class SummaryManager extends EventEmitter {
                 return;
             }
             case SummaryManagerState.Running: {
-                if (this.shouldSummarize) {
-                    return;
-                } else {
+                if (!this.shouldSummarize) {
                     // only need to check defined in case we are between
                     // finally and then states; stopping should trigger
                     // a change in states when the running summarizer closes
@@ -175,6 +172,7 @@ export class SummaryManager extends EventEmitter {
                         this.runningSummarizer.stop(this.getStopReason());
                     }
                 }
+                return;
             }
             default: {
                 return;

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -220,17 +220,13 @@ export class SummaryManager extends EventEmitter {
 
         const runningSummarizerEvent = PerformanceEvent.start(this.logger, { eventName: "RunningSummarizer" });
         this.runningSummarizer = summarizer;
-        this.runningSummarizer.run(this.clientId).finally(() => {
-            this.runningSummarizer = undefined;
-        }).then(() => {
+        // tslint:disable-next-line: no-floating-promises
+        this.runningSummarizer.run(this.clientId).then(() => {
             runningSummarizerEvent.end();
-            if (this.shouldSummarize) {
-                this.start();
-            } else {
-                this.state = SummaryManagerState.Off;
-            }
         }, (error) => {
             runningSummarizerEvent.cancel({}, error);
+        }).finally(() => {
+            this.runningSummarizer = undefined;
             if (this.shouldSummarize) {
                 this.start();
             } else {

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -26,17 +26,47 @@ class ClientComparer implements IComparer<ITrackedClient> {
     }
 }
 
-export class SummaryManager extends EventEmitter {
-    private _summarizer: string;
+class QuorumHeap {
     private readonly heap = new Heap<ITrackedClient>((new ClientComparer()));
     private readonly heapMembers = new Map<string, IHeapNode<ITrackedClient>>();
-    private connected = false;
-    private clientId: string;
-    private runningSummarizer?: ISummarizer;
+
+    public addClient(clientId: string, client: ISequencedClient) {
+        const heapNode = this.heap.add({ clientId, sequenceNumber: client.sequenceNumber });
+        this.heapMembers.set(clientId, heapNode);
+    }
+
+    public removeClient(clientId: string) {
+        const member = this.heapMembers.get(clientId);
+        if (member) {
+            this.heap.remove(member);
+            this.heapMembers.delete(clientId);
+        }
+    }
+
+    public getFirstClientId(): string | undefined {
+        return this.heap.count() > 0 ? this.heap.peek().value.clientId : undefined;
+    }
+}
+
+enum SummaryManagerState {
+    Off = 0,
+    Starting = 1,
+    Running = 2,
+}
+
+const defaultMaxRestarts = 5;
+
+export class SummaryManager extends EventEmitter {
     private readonly logger: ITelemetryLogger;
+    private readonly quorumHeap = new QuorumHeap();
+    private summarizerClientId?: string;
+    private clientId?: string;
+    private connected = false;
+    private state = SummaryManagerState.Off;
+    private runningSummarizer?: ISummarizer;
 
     public get summarizer() {
-        return this._summarizer;
+        return this.summarizerClientId;
     }
 
     private get shouldSummarize() {
@@ -45,33 +75,35 @@ export class SummaryManager extends EventEmitter {
 
     constructor(
         private readonly context: IContainerContext,
-        private readonly generateSummaries: boolean,
+        private readonly summariesEnabled: boolean,
         parentLogger: ITelemetryLogger,
+        private readonly maxRestarts: number = defaultMaxRestarts,
     ) {
         super();
 
         this.logger = ChildLogger.create(parentLogger, "SummaryManager");
 
+        this.connected = context.connected;
+        if (this.connected) {
+            this.clientId = context.clientId;
+        }
+
         const members = context.quorum.getMembers();
-        for (const [clientId, member] of members) {
-            this.addHeapNode(clientId, member);
+        for (const [clientId, client] of members) {
+            this.quorumHeap.addClient(clientId, client);
         }
 
         context.quorum.on("addMember", (clientId: string, details: ISequencedClient) => {
-            this.addHeapNode(clientId, details);
-            this.computeSummarizer();
+            this.quorumHeap.addClient(clientId, details);
+            this.refreshSummarizer();
         });
 
         context.quorum.on("removeMember", (clientId: string) => {
-            this.heap.remove(this.heapMembers.get(clientId));
-            this.computeSummarizer();
+            this.quorumHeap.removeClient(clientId);
+            this.refreshSummarizer();
         });
-    }
 
-    public on(event: "summarizer", listener: (clientId: string) => void): this;
-    // tslint:disable-next-line:no-unnecessary-override
-    public on(event: string | symbol, listener: (...args: any[]) => void): this {
-        return super.on(event, listener);
+        this.refreshSummarizer();
     }
 
     public setConnected(clientId: string) {
@@ -81,8 +113,7 @@ export class SummaryManager extends EventEmitter {
 
         this.connected = true;
         this.clientId = clientId;
-
-        this.computeSummarizer(true);
+        this.refreshSummarizer();
     }
 
     public setDisconnected() {
@@ -92,83 +123,123 @@ export class SummaryManager extends EventEmitter {
 
         this.connected = false;
         this.clientId = undefined;
-        if (this.runningSummarizer) {
-            this.runningSummarizer.stop("parentDisconnected");
-            this.runningSummarizer = undefined;
+        this.refreshSummarizer();
+    }
+
+    public on(event: "summarizer", listener: (clientId: string) => void): this;
+    // tslint:disable-next-line:no-unnecessary-override
+    public on(event: string | symbol, listener: (...args: any[]) => void): this {
+        return super.on(event, listener);
+    }
+
+    private getStopReason(): string | undefined {
+        if (!this.connected) {
+            return "parentNotConnected";
+        } else if (this.clientId !== this.summarizer) {
+            return "parentShouldNotSummarize";
+        } else {
+            this.logger.sendErrorEvent({ eventName: "shouldNotStop" });
+            return undefined;
         }
     }
 
-    private addHeapNode(clientId: string, client: ISequencedClient) {
-        const heapNode = this.heap.add({ clientId, sequenceNumber: client.sequenceNumber });
-        this.heapMembers.set(clientId, heapNode);
+    private refreshSummarizer() {
+        // compute summarizer
+        const newSummarizerClientId = this.quorumHeap.getFirstClientId();
+        if (newSummarizerClientId !== this.summarizerClientId) {
+            this.summarizerClientId = newSummarizerClientId;
+            this.emit("summarizer", newSummarizerClientId);
+        }
+
+        // transition states
+        switch (this.state) {
+            case SummaryManagerState.Off: {
+                if (this.shouldSummarize) {
+                    this.start();
+                } else {
+                    return;
+                }
+            }
+            case SummaryManagerState.Starting: {
+                // cannot take any action until summarizer is created
+                // state transition will occur after creation
+                return;
+            }
+            case SummaryManagerState.Running: {
+                if (this.shouldSummarize) {
+                    return;
+                } else {
+                    // only need to check defined in case we are between
+                    // finally and then states; stopping should trigger
+                    // a change in states when the running summarizer closes
+                    if (this.runningSummarizer) {
+                        this.runningSummarizer.stop(this.getStopReason());
+                    }
+                }
+            }
+            default: {
+                return;
+            }
+        }
     }
 
-    /**
-     * Updates the current summarizer. In the case of force does not exit early in case the summarizer has not changed.
-     * This is used when transitioning to a connected state where we want to start a new summarizer
-     */
-    private computeSummarizer(force = false) {
-        const clientId = this.heap.count() > 0 ? this.heap.peek().value.clientId : undefined;
-
-        // Do not start if we are already the summarizer, unless force is passed.
-        // Force will be passed if we think we are not already summarizing, which might
-        // happen if we are not yet connected the first time through computeSummarizer.
-        if (!force && clientId === this._summarizer) {
+    private start(attempt: number = 1) {
+        if (attempt > this.maxRestarts) {
+            this.logger.sendErrorEvent({ eventName: "MaxRestarts", maxRestarts: this.maxRestarts });
+            this.state = SummaryManagerState.Off;
             return;
         }
 
-        this._summarizer = clientId;
-        this.emit("summarizer", clientId);
+        this.state = SummaryManagerState.Starting;
 
-        // To maintain back compat with snapshots we will not summarize unless asked. But will still run the
-        // code to elect and detect the summarizer for testing + code coverage.
-        if (!this.generateSummaries) {
-            // summaries disabled
+        // if we should never summarize, lock in starting state
+        if (!this.summariesEnabled) {
             return;
         }
-
-        // Make sure that the summarizer client does not load another summarizer.
         if (this.context.configuration && !this.context.configuration.canReconnect) {
+            // Make sure that the summarizer client does not load another summarizer.
             return;
         }
 
-        // if we are connected and the elected summarizer client, start a summarizer
-        if (this.shouldSummarize && !this.runningSummarizer) {
-            const runSummarizerEvent = PerformanceEvent.start(this.logger, { eventName: "RunningSummarizer" });
-            this.startSummarizer().then(
-                (message: string) => {
-                    runSummarizerEvent.end({ message });
-                    this.computeSummarizer(this.connected);
-                },
-                (error) => {
-                    runSummarizerEvent.cancel({}, error);
-                    this.computeSummarizer(this.connected);
-                });
-        }
+        this.createSummarizer().then((summarizer) => {
+            if (this.shouldSummarize) {
+                this.run(summarizer);
+            } else {
+                summarizer.stop(this.getStopReason());
+                this.state = SummaryManagerState.Off;
+            }
+        }, (error) => {
+            this.logger.sendErrorEvent({ eventName: "CreateSummarizerError" }, error);
+            if (this.shouldSummarize) {
+                this.start(attempt + 1);
+            } else {
+                this.state = SummaryManagerState.Off;
+            }
+        });
     }
 
-    private async startSummarizer(): Promise<string> {
-        const summarizer = await this.createSummarizer();
+    private run(summarizer: ISummarizer) {
+        this.state = SummaryManagerState.Running;
 
-        // synchronous block where the summarizer actually runs
-        if (!this.shouldSummarize) {
-            summarizer.stop("parentShouldNotSummarize");
-            return "shouldNotSummarize";
-        }
-
-        if (this.runningSummarizer) {
-            summarizer.stop("parentAlreadyRunningSummarizer");
-            return "alreadyRunningSummarizer";
-        }
-
+        const runningSummarizerEvent = PerformanceEvent.start(this.logger, { eventName: "RunningSummarizer" });
         this.runningSummarizer = summarizer;
-        try {
-            await summarizer.run(this.clientId);
-        } finally {
+        this.runningSummarizer.run(this.clientId).finally(() => {
             this.runningSummarizer = undefined;
-        }
-
-        return "runComplete";
+        }).then(() => {
+            runningSummarizerEvent.end();
+            if (this.shouldSummarize) {
+                this.start();
+            } else {
+                this.state = SummaryManagerState.Off;
+            }
+        }, (error) => {
+            runningSummarizerEvent.cancel({}, error);
+            if (this.shouldSummarize) {
+                this.start();
+            } else {
+                this.state = SummaryManagerState.Off;
+            }
+        });
     }
 
     private async createSummarizer(): Promise<ISummarizer> {

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -138,7 +138,6 @@ export class SummaryManager extends EventEmitter {
         } else if (this.clientId !== this.summarizer) {
             return "parentShouldNotSummarize";
         } else {
-            this.logger.sendErrorEvent({ eventName: "shouldNotStop" });
             return undefined;
         }
     }


### PR DESCRIPTION
Because of the multiple points of entry and async nature of SummaryManager, there were loopholes causing overlap in states.  In order to make it easier to prevent bad summary states (multiple summarizers, no summarizers) and easier to understand, I've refactored it as a simpler state machine.  If we want to optimize states/transitions, we can do so from this (hopefully) stable starting point.

The states are based off the SummaryManagerState enum:
- Off: When the SummaryManager is not running a summarizer.  In this state, the client is either not the elected summarizer or disconnected.
- Starting: When SummaryManager should summarize it enters this state.  This state is spent creating the summarizer (async).
- Running: After creating the summarizer, if the client should still summarize, it enters this state.  It will remain in this state until the summarizer client it spawned has closed.

Transitions between states only occur by promise fulfillment or `refreshSummarizer()` calls (previously `computeSummarizer()`).  This will refresh the calculated summarizer client ID, and then try to switch between states.

If elected the summarizer, the client will perpetually get stuck in the Starting state if summaries are disabled or the client itself is a spawned summarizer client.