### PR TITLE
Delay socket disconnection to allow for smooth reconnects in odsp driver

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentDeltaConnection.ts
@@ -152,6 +152,9 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
                 cleanupListeners();
                 OdspDocumentDeltaConnection.removeSocketIoReference(socketReferenceKey);
 
+                // Test if it's NetworkError with IOdspSocketError.
+                // Note that there might be no IOdspSocketError on it in case we hit socket.io protocol errors!
+                // So we test canRetry property first - if it false, that means protocol is broken and reconnecting will not help.
                 if (errorObject instanceof NetworkError && errorObject.canRetry) {
                     const socketError: IOdspSocketError = (errorObject as any).socketError;
                     if (typeof socketError === "object" && socketError !== null) {

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentDeltaConnection.ts
@@ -347,6 +347,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
         }
 
         socketReference.references--;
+        assert(socketReference.delayDeleteTimeout === undefined);
 
         debug(`Removed socketio reference for ${key}. Remaining references: ${socketReference.references}.`);
 
@@ -363,8 +364,6 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
         }
 
         if (socketReference.references === 0) {
-            assert(socketReference.delayDeleteTimeout === undefined);
-
             socketReference.delayDeleteTimeout = setTimeout(() => {
                 OdspDocumentDeltaConnection.socketIoSockets.delete(key);
 

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
@@ -4,7 +4,7 @@
  */
 
 import { ITelemetryLogger } from "@microsoft/fluid-container-definitions";
-import { NetworkError, SinglePromise } from "@microsoft/fluid-core-utils";
+import { SinglePromise } from "@microsoft/fluid-core-utils";
 import {
     ConnectionMode,
     IClient,
@@ -14,13 +14,12 @@ import {
     IDocumentStorageService,
     IErrorTrackingService,
 } from "@microsoft/fluid-protocol-definitions";
-import { IOdspSocketError, ISocketStorageDiscovery } from "./contracts";
+import { ISocketStorageDiscovery } from "./contracts";
 import { IFetchWrapper } from "./fetchWrapper";
 import { OdspDeltaStorageService } from "./OdspDeltaStorageService";
 import { OdspDocumentDeltaConnection } from "./OdspDocumentDeltaConnection";
 import { OdspDocumentStorageManager } from "./OdspDocumentStorageManager";
 import { OdspDocumentStorageService } from "./OdspDocumentStorageService";
-import { defaultRetryFilter } from "./OdspUtils";
 import { getSocketStorageDiscovery } from "./Vroom";
 
 /**
@@ -28,14 +27,6 @@ import { getSocketStorageDiscovery } from "./Vroom";
  * clients
  */
 export class OdspDocumentService implements IDocumentService {
-    private static errorObjectFromOdspError(socketError: IOdspSocketError) {
-        return new NetworkError(
-            socketError.message,
-            socketError.code,
-            defaultRetryFilter(socketError.code), // canRetry
-            socketError.retryAfter);
-    }
-
     // This should be used to make web socket endpoint requests, it ensures we only have one active join session call at a time.
     private readonly websocketEndpointRequestThrottler: SinglePromise<ISocketStorageDiscovery>;
 
@@ -174,27 +165,7 @@ export class OdspDocumentService implements IDocumentService {
             websocketEndpoint.deltaStreamSocketUrl,
             websocketEndpoint.deltaStreamSocketUrl2,
             this.logger,
-        ).then((connection) => {
-            connection.on("server_disconnect", (socketError: IOdspSocketError) => {
-                const error = OdspDocumentService.errorObjectFromOdspError(socketError);
-                // Raise it as disconnect.
-                // That produces cleaner telemetry (no errors) and keeps protocol simpler (and not driver-specific).
-                connection.emit("disconnect", error);
-            });
-            return connection;
-        }).catch((error) => {
-            // Test if it's NetworkError with IOdspSocketError.
-            // Note that there might be no IOdspSocketError on it in case we hit socket.io protocol errors!
-            // So we test canRetry property first - if it false, that means protocol is broken and reconnecting will not help.
-            if (error instanceof NetworkError && error.canRetry) {
-                const socketError: IOdspSocketError = (error as any).socketError;
-                if (typeof socketError === "object" && socketError !== null) {
-                    throw OdspDocumentService.errorObjectFromOdspError(socketError);
-                }
-            }
-
-            throw error;
-        });
+        );
     }
 
     public async branch(): Promise<string> {

--- a/packages/drivers/odsp-socket-storage/src/OdspUtils.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspUtils.ts
@@ -5,6 +5,7 @@
 
 import { NetworkError, throwNetworkError } from "@microsoft/fluid-core-utils";
 import { default as fetch, RequestInfo as FetchRequestInfo, RequestInit as FetchRequestInit } from "node-fetch";
+import { IOdspSocketError } from "./contracts";
 
 /**
  * returns true when the request should/can be retried
@@ -82,4 +83,12 @@ export function getWithRetryForTokenRefresh<T>(get: (refresh: boolean) => Promis
         // document being opened, though there maybe really bad user experience (consuming thousands of ops)
         throw e;
     });
+}
+
+export function errorObjectFromOdspError(socketError: IOdspSocketError) {
+    return new NetworkError(
+        socketError.message,
+        socketError.code,
+        defaultRetryFilter(socketError.code), // canRetry
+        socketError.retryAfter);
 }


### PR DESCRIPTION
- Delay socket disconnection by 2 seconds after the last socket reference is removed. When receiving a nack, the client will disconnect the document delta connection and create a new one. By adding a delay, the client will be able to reuse the same websocket for the new document delta connection.
- Move `errorObjectFromOdspError` to odsp utils and move some logic from `OdspDocumentService` to `OdspDocumentDeltaConnection`