### PR TITLE
Container handle errors during reload context [0.10]

### DIFF
--- a/packages/loader/container-definitions/src/chaincode.ts
+++ b/packages/loader/container-definitions/src/chaincode.ts
@@ -217,7 +217,7 @@ export interface IContainerContext extends EventEmitter, IMessageScheduler, IPro
 
     error(err: any): void;
     requestSnapshot(tagMessage: string): Promise<void>;
-    reloadContext(): void;
+    reloadContext(): Promise<void>;
     refreshBaseSummary(snapshot: ISnapshotTree): void;
 }
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -384,12 +384,9 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
     }
 
     public reloadContext(): Promise<void> {
-        // errors will emit error and reject promise
-        return new Promise((resolve, reject) => {
-            this.reloadContextCore().then(resolve, (error) => {
-                this.raiseCriticalError(error);
-                reject(error);
-            });
+        return this.reloadContextCore().catch((error) => {
+            this.raiseCriticalError(error);
+            throw error;
         });
     }
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -383,7 +383,17 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         this.emit("error", error);
     }
 
-    private async reloadContext(): Promise<void> {
+    public reloadContext(): Promise<void> {
+        // errors will emit error and reject promise
+        return new Promise((resolve, reject) => {
+            this.reloadContextCore().then(resolve, (error) => {
+                this.raiseCriticalError(error);
+                reject(error);
+            });
+        });
+    }
+
+    private async reloadContextCore(): Promise<void> {
         await Promise.all([
             this.deltaManager!.inbound.systemPause(),
             this.deltaManager!.inboundSignal.systemPause()]);
@@ -714,7 +724,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
                         return;
                     }
 
-                    this.reloadContext().catch((error) => this.raiseCriticalError(error));
+                    this.reloadContext();
                 }
             });
 

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -245,8 +245,8 @@ export class ContainerContext extends EventEmitter implements IContainerContext 
         return;
     }
 
-    public reloadContext() {
-        this.container.reloadContext();
+    public reloadContext(): Promise<void> {
+        return this.container.reloadContext();
     }
 
     private async load() {


### PR DESCRIPTION
This is in response to issue #283.
Also add await for DeltaQueue pause/resume calls in reloadContext().

Calls to reloadContext return a promise that resolves when the context is reloaded, or rejects if an error is encountered.  If an error is encountered, the Container will also emit an error event.