### PR TITLE
Summarize more frequently [0.10]

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -40,6 +40,7 @@ import {
     ISignalMessage,
     ISnapshotTree,
     ISummaryConfiguration,
+    ISummaryContent,
     ISummaryTree,
     ITree,
     MessageType,
@@ -1125,7 +1126,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
                 return ret;
             }
             const handle = await this.context.storage.uploadSummary(treeWithStats.summaryTree);
-            const summary = {
+            const summary: ISummaryContent = {
                 handle: handle.handle,
                 head: parents[0],
                 message,


### PR DESCRIPTION
Changes summarizer to include quorum ops in its heuristics.  Join, leave, propose, and reject ops now route to handle the same way as regular ops.
One exception is that the summarizer will explicitly ignore leave messages for itself or the client it is on behalf of.  Although it might not be possible to even receive that op, I want to be extra sure that leaving doesn't trigger generating a summary.

Also fixes a bug so that if an op comes in while waiting for ack, it will flag that an op came in.  Once its summary is acked/nacked/timed out/failed to send, it will immediately trigger to start an idle timer if the flag is set.