### PR TITLE
Give ComponentRegistry Access to IHostRuntime

### DIFF
--- a/packages/components/external-component-loader/src/urlRegistry.ts
+++ b/packages/components/external-component-loader/src/urlRegistry.ts
@@ -11,6 +11,7 @@ import {
     ComponentFactoryTypes,
     IComponentFactory,
     IComponentRegistry,
+    IHostRuntime,
 } from "@microsoft/fluid-runtime-definitions";
 
 /**
@@ -41,7 +42,7 @@ export class UrlRegistry implements IComponentRegistry {
 
     public get IComponentRegistry() { return this; }
 
-    public async get(name: string): Promise<ComponentFactoryTypes> {
+    public async get(name: string, runtime: IHostRuntime): Promise<ComponentFactoryTypes> {
 
         if (!this.urlRegistryMap.has(name)
             && (name.startsWith("http://") || name.startsWith("https://"))) {
@@ -69,7 +70,7 @@ export class UrlRegistry implements IComponentRegistry {
                         componentFactory = fluidExport.IComponentFactory;
                         if (fluidExport.IComponentDefaultFactory) {
                             const registry = fluidExport.IComponentDefaultFactory;
-                            componentFactory =  (await registry.getDefaultFactory()) as IComponentFactory;
+                            componentFactory =  (await registry.getDefaultFactory(runtime)) as IComponentFactory;
                         }
                     } else {
                         const queryable = fluidExport as IComponentQueryableLegacy;

--- a/packages/components/external-component-loader/src/urlRegistry.ts
+++ b/packages/components/external-component-loader/src/urlRegistry.ts
@@ -4,14 +4,13 @@
  */
 
 // tslint:disable: no-console
-import { IComponent, IComponentQueryableLegacy } from "@microsoft/fluid-component-core-interfaces";
+import { IComponent, IComponentQueryableLegacy, IComponentRouter } from "@microsoft/fluid-component-core-interfaces";
 import { IFluidPackage, isFluidPackage } from "@microsoft/fluid-container-definitions";
 import { Deferred } from "@microsoft/fluid-core-utils";
 import {
     ComponentFactoryTypes,
     IComponentFactory,
     IComponentRegistry,
-    IHostRuntime,
 } from "@microsoft/fluid-runtime-definitions";
 
 /**
@@ -42,7 +41,7 @@ export class UrlRegistry implements IComponentRegistry {
 
     public get IComponentRegistry() { return this; }
 
-    public async get(name: string, runtime: IHostRuntime): Promise<ComponentFactoryTypes> {
+    public async get(name: string, router: IComponentRouter): Promise<ComponentFactoryTypes> {
 
         if (!this.urlRegistryMap.has(name)
             && (name.startsWith("http://") || name.startsWith("https://"))) {
@@ -70,7 +69,7 @@ export class UrlRegistry implements IComponentRegistry {
                         componentFactory = fluidExport.IComponentFactory;
                         if (fluidExport.IComponentDefaultFactory) {
                             const registry = fluidExport.IComponentDefaultFactory;
-                            componentFactory =  (await registry.getDefaultFactory(runtime)) as IComponentFactory;
+                            componentFactory =  (await registry.getDefaultFactory(router)) as IComponentFactory;
                         }
                     } else {
                         const queryable = fluidExport as IComponentQueryableLegacy;

--- a/packages/components/shared-text/src/index.ts
+++ b/packages/components/shared-text/src/index.ts
@@ -9,7 +9,7 @@ import "./publicpath";
 
 // import { SharedString } from "@prague/sequence";
 import * as Snapshotter from "@fluid-example/snapshotter-agent";
-import { IComponent, IRequest } from "@microsoft/fluid-component-core-interfaces";
+import { IRequest } from "@microsoft/fluid-component-core-interfaces";
 import { IContainerContext, IRuntime, IRuntimeFactory } from "@microsoft/fluid-container-definitions";
 import { ContainerRuntime } from "@microsoft/fluid-container-runtime";
 import {
@@ -58,7 +58,7 @@ class MyRegistry implements IComponentRegistry {
 
     public get IComponentRegistry() {return this; }
 
-    public async get(name: string, scope?: IComponent): Promise<IComponentFactory> {
+    public async get(name: string, runtime: IHostRuntime): Promise<IComponentFactory> {
         if (name === "@fluid-example/shared-text") {
             return this.sharedTextFactory;
         } else if (name === "@fluid-example/math") {

--- a/packages/components/shared-text/src/index.ts
+++ b/packages/components/shared-text/src/index.ts
@@ -9,7 +9,7 @@ import "./publicpath";
 
 // import { SharedString } from "@prague/sequence";
 import * as Snapshotter from "@fluid-example/snapshotter-agent";
-import { IRequest } from "@microsoft/fluid-component-core-interfaces";
+import { IComponentRouter, IRequest } from "@microsoft/fluid-component-core-interfaces";
 import { IContainerContext, IRuntime, IRuntimeFactory } from "@microsoft/fluid-container-definitions";
 import { ContainerRuntime } from "@microsoft/fluid-container-runtime";
 import {
@@ -58,7 +58,7 @@ class MyRegistry implements IComponentRegistry {
 
     public get IComponentRegistry() {return this; }
 
-    public async get(name: string, runtime: IHostRuntime): Promise<IComponentFactory> {
+    public async get(name: string, router: IComponentRouter): Promise<IComponentFactory> {
         if (name === "@fluid-example/shared-text") {
             return this.sharedTextFactory;
         } else if (name === "@fluid-example/math") {

--- a/packages/components/shared-text/src/index.ts
+++ b/packages/components/shared-text/src/index.ts
@@ -9,7 +9,7 @@ import "./publicpath";
 
 // import { SharedString } from "@prague/sequence";
 import * as Snapshotter from "@fluid-example/snapshotter-agent";
-import { IRequest } from "@microsoft/fluid-component-core-interfaces";
+import { IComponent, IRequest } from "@microsoft/fluid-component-core-interfaces";
 import { IContainerContext, IRuntime, IRuntimeFactory } from "@microsoft/fluid-container-definitions";
 import { ContainerRuntime } from "@microsoft/fluid-container-runtime";
 import {
@@ -58,7 +58,7 @@ class MyRegistry implements IComponentRegistry {
 
     public get IComponentRegistry() {return this; }
 
-    public async get(name: string, cdn?: string): Promise<IComponentFactory> {
+    public async get(name: string, scope?: IComponent): Promise<IComponentFactory> {
         if (name === "@fluid-example/shared-text") {
             return this.sharedTextFactory;
         } else if (name === "@fluid-example/math") {
@@ -74,9 +74,9 @@ class MyRegistry implements IComponentRegistry {
         } else if (name === "@fluid-example/pinpoint-editor") {
             return pinpoint.then((m) => m.fluidExport);
         } else {
-            const scope = `${name.split("/")[0]}:cdn`;
+            const cdnScope = `${name.split("/")[0]}:cdn`;
             const config = {};
-            config[scope] = cdn ? cdn : this.defaultRegistry;
+            config[cdnScope] = this.defaultRegistry;
 
             const codeDetails = {
                 package: name,

--- a/packages/framework/aqueduct/src/helpers/simpleModuleInstantiationFactory.ts
+++ b/packages/framework/aqueduct/src/helpers/simpleModuleInstantiationFactory.ts
@@ -2,11 +2,9 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-
-import { IComponent } from "@microsoft/fluid-component-core-interfaces";
 import { IContainerContext, IRuntime, IRuntimeFactory } from "@microsoft/fluid-container-definitions";
 import { IComponentDefaultFactory } from "@microsoft/fluid-framework-interfaces";
-import { ComponentFactoryTypes, ComponentRegistryTypes, IComponentContext, IComponentFactory } from "@microsoft/fluid-runtime-definitions";
+import { ComponentRegistryTypes, IComponentContext, IComponentFactory, IProvideComponentRegistry } from "@microsoft/fluid-runtime-definitions";
 import { SimpleContainerRuntimeFactory } from "./simpleContainerRuntimeFactory";
 
 /**
@@ -18,7 +16,7 @@ import { SimpleContainerRuntimeFactory } from "./simpleContainerRuntimeFactory";
  *  IComponentRegistry: instantiates a component registry that include the default component and sub-components
  */
 export class SimpleModuleInstantiationFactory implements
-    IComponent,
+    IProvideComponentRegistry,
     IRuntimeFactory,
     IComponentDefaultFactory,
     IComponentFactory {
@@ -29,7 +27,7 @@ export class SimpleModuleInstantiationFactory implements
     }
 
     public get IComponentFactory() { return this; }
-    public get IComponentRegistry() { return this; }
+    public get IComponentRegistry() { return this.registry; }
     public get IRuntimeFactory() { return this; }
     public get IComponentDefaultFactory() { return this; }
 
@@ -37,12 +35,8 @@ export class SimpleModuleInstantiationFactory implements
         return this.registry.get(this.defaultComponentName)!;
     }
 
-    public get(name: string): Promise<ComponentFactoryTypes> | undefined {
-        return this.registry.get(name);
-    }
-
     public instantiateComponent(context: IComponentContext): void {
-        const factoryP = this.get(this.defaultComponentName);
+        const factoryP = this.registry.get(this.defaultComponentName, context.scope);
         if (factoryP === undefined) {
             throw new Error(`No component factory for ${this.defaultComponentName}`);
         }

--- a/packages/framework/aqueduct/src/helpers/simpleModuleInstantiationFactory.ts
+++ b/packages/framework/aqueduct/src/helpers/simpleModuleInstantiationFactory.ts
@@ -4,7 +4,7 @@
  */
 import { IContainerContext, IRuntime, IRuntimeFactory } from "@microsoft/fluid-container-definitions";
 import { IComponentDefaultFactory } from "@microsoft/fluid-framework-interfaces";
-import { ComponentRegistryTypes, IComponentContext, IComponentFactory, IProvideComponentRegistry } from "@microsoft/fluid-runtime-definitions";
+import { ComponentFactoryTypes, ComponentRegistryTypes, IHostRuntime, IProvideComponentRegistry } from "@microsoft/fluid-runtime-definitions";
 import { SimpleContainerRuntimeFactory } from "./simpleContainerRuntimeFactory";
 
 /**
@@ -18,35 +18,19 @@ import { SimpleContainerRuntimeFactory } from "./simpleContainerRuntimeFactory";
 export class SimpleModuleInstantiationFactory implements
     IProvideComponentRegistry,
     IRuntimeFactory,
-    IComponentDefaultFactory,
-    IComponentFactory {
+    IComponentDefaultFactory {
 
     constructor(
         private readonly defaultComponentName: string,
         private readonly registry: ComponentRegistryTypes) {
     }
 
-    public get IComponentFactory() { return this; }
     public get IComponentRegistry() { return this.registry; }
     public get IRuntimeFactory() { return this; }
     public get IComponentDefaultFactory() { return this; }
 
-    public async getDefaultFactory() {
-        return this.registry.get(this.defaultComponentName)!;
-    }
-
-    public instantiateComponent(context: IComponentContext): void {
-        const factoryP = this.registry.get(this.defaultComponentName, context.scope);
-        if (factoryP === undefined) {
-            throw new Error(`No component factory for ${this.defaultComponentName}`);
-        }
-        factoryP.then(
-            (factory) => {
-                factory.instantiateComponent(context);
-            },
-            (error) => {
-                context.error(error);
-            });
+    public async getDefaultFactory(runtime: IHostRuntime): Promise<ComponentFactoryTypes> {
+        return this.registry.get(this.defaultComponentName, runtime)!;
     }
 
     public async instantiateRuntime(context: IContainerContext): Promise<IRuntime> {

--- a/packages/framework/framework-definitions/src/IComponentDefaultFactory.ts
+++ b/packages/framework/framework-definitions/src/IComponentDefaultFactory.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { ComponentFactoryTypes, IHostRuntime } from "@microsoft/fluid-runtime-definitions";
+import { IComponentRouter } from "@microsoft/fluid-component-core-interfaces";
+import { ComponentFactoryTypes } from "@microsoft/fluid-runtime-definitions";
 
 declare module "@microsoft/fluid-component-core-interfaces" {
     export interface IComponent extends Readonly<Partial<IProvideComponentDefaultFactory>> {}
@@ -14,5 +15,5 @@ export interface IProvideComponentDefaultFactory {
 }
 
 export interface IComponentDefaultFactory extends IProvideComponentDefaultFactory {
-    getDefaultFactory(runtime: IHostRuntime): Promise<ComponentFactoryTypes>;
+    getDefaultFactory(router: IComponentRouter): Promise<ComponentFactoryTypes>;
 }

--- a/packages/framework/framework-definitions/src/IComponentDefaultFactory.ts
+++ b/packages/framework/framework-definitions/src/IComponentDefaultFactory.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ComponentFactoryTypes } from "@microsoft/fluid-runtime-definitions";
+import { ComponentFactoryTypes, IHostRuntime } from "@microsoft/fluid-runtime-definitions";
 
 declare module "@microsoft/fluid-component-core-interfaces" {
     export interface IComponent extends Readonly<Partial<IProvideComponentDefaultFactory>> {}
@@ -14,5 +14,5 @@ export interface IProvideComponentDefaultFactory {
 }
 
 export interface IComponentDefaultFactory extends IProvideComponentDefaultFactory {
-    getDefaultFactory(): Promise<ComponentFactoryTypes>;
+    getDefaultFactory(runtime: IHostRuntime): Promise<ComponentFactoryTypes>;
 }

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -193,7 +193,7 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
                 if (!registry) {
                     throw new Error("Factory does not supply the component Registry");
                 }
-                factory = await registry.get(pkg, this.scope);
+                factory = await registry.get(pkg, this.hostRuntime);
                 registry = factory.IComponentRegistry;
             }
 

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -30,13 +30,14 @@ import {
 } from "@microsoft/fluid-protocol-definitions";
 import {
     ComponentFactoryTypes,
+    ComponentRegistryTypes,
     IAttachMessage,
     IComponentContext,
-    IComponentRegistry,
     IComponentRuntime,
     IEnvelope,
     IHostRuntime,
     IInboundSignalMessage,
+    IProvideComponentRegistry,
 } from "@microsoft/fluid-runtime-definitions";
 import * as assert from "assert";
 import { EventEmitter } from "events";
@@ -186,13 +187,13 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
                 this.summaryTracker.setBaseTree(details.snapshot);
             }
             const packages = details.pkg;
-            let registry = this._hostRuntime.IComponentRegistry;
-            let factory: ComponentFactoryTypes & Partial<IComponentRegistry>;
+            let registry: ComponentRegistryTypes = this._hostRuntime.IComponentRegistry;
+            let factory: ComponentFactoryTypes & Partial<IProvideComponentRegistry>;
             for (const pkg of packages) {
                 if (!registry) {
                     throw new Error("Factory does not supply the component Registry");
                 }
-                factory = await registry.get(pkg);
+                factory = await registry.get(pkg, this.scope);
                 registry = factory.IComponentRegistry;
             }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -7,9 +7,10 @@ import { AgentSchedulerFactory } from "@microsoft/fluid-agent-scheduler";
 import {
     IComponent,
     IComponentHandleContext,
+    IComponentRouter,
     IComponentSerializer,
     IRequest,
-    IResponse } from "@microsoft/fluid-component-core-interfaces";
+    IResponse} from "@microsoft/fluid-component-core-interfaces";
 import {
     ConnectionState,
     IAudience,
@@ -348,6 +349,7 @@ const schedulerRuntimeRequestHandler: RuntimeRequestHandler =
  * It will define the component level mappings.
  */
 export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRuntime {
+
     /**
      * Load the components from a snapshot and returns the runtime.
      * @param context - Context of the container.
@@ -458,6 +460,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
     public get IComponentRegistry(): IComponentRegistry {
         return this.registry;
     }
+    public get IComponentRouter() { return this; }
 
     public readonly IComponentSerializer: IComponentSerializer = new ComponentSerializer();
 
@@ -1395,13 +1398,13 @@ export class WrappedComponentRegistry implements IComponentRegistry {
 
     public get IComponentRegistry() { return this; }
 
-    public async get(name: string, runtime: IHostRuntime): Promise<ComponentFactoryTypes> {
+    public async get(name: string, router: IComponentRouter): Promise<ComponentFactoryTypes> {
         if (name === schedulerId) {
             return this.agentScheduler;
         } else if (this.extraRegistries && this.extraRegistries.has(name)) {
             return this.extraRegistries.get(name);
         } else {
-            return this.registry.get(name, runtime);
+            return this.registry.get(name, router);
         }
     }
 }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1395,13 +1395,13 @@ export class WrappedComponentRegistry implements IComponentRegistry {
 
     public get IComponentRegistry() { return this; }
 
-    public async get(name: string): Promise<ComponentFactoryTypes> {
+    public async get(name: string, runtime: IHostRuntime): Promise<ComponentFactoryTypes> {
         if (name === schedulerId) {
             return this.agentScheduler;
         } else if (this.extraRegistries && this.extraRegistries.has(name)) {
             return this.extraRegistries.get(name);
         } else {
-            return this.registry.get(name);
+            return this.registry.get(name, runtime);
         }
     }
 }

--- a/packages/runtime/container-runtime/src/test/componentContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/componentContext.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable: prefer-const
-import { IComponent } from "@microsoft/fluid-component-core-interfaces";
+import { IComponent, IComponentRouter } from "@microsoft/fluid-component-core-interfaces";
 import { IBlob, IDocumentStorageService, ISnapshotTree } from "@microsoft/fluid-protocol-definitions";
 import {
     ComponentFactoryTypes,
@@ -11,7 +11,6 @@ import {
     IComponentFactory,
     IComponentRegistry,
     IComponentRuntime,
-    IHostRuntime,
 } from "@microsoft/fluid-runtime-definitions";
 import { MockRuntime } from "@microsoft/fluid-test-runtime-utils";
 import * as assert from "assert";
@@ -30,7 +29,7 @@ describe("Component Context Tests", () => {
         beforeEach(async () => {
 
             containerRuntime = {
-                IComponentRegistry: { get: (id: string, runtime: IHostRuntime) => {
+                IComponentRegistry: { get: (id: string, runtime: IComponentRouter) => {
                     const factory = {
                         IComponentFactory: {
                             instantiateComponent: (context: IComponentContext) => undefined,
@@ -81,14 +80,14 @@ describe("Component Context Tests", () => {
 
         it("Supplying array of packages in LocalComponentContext should not create exception", async () => {
             containerRuntime = {
-                IComponentRegistry: { get: (id: string, runtime: IHostRuntime) => {
+                IComponentRegistry: { get: (id: string, runtime: IComponentRouter) => {
                     const factory = {
                         IComponentFactory: {
                             instantiateComponent: (context: IComponentContext) => undefined,
                         },
                         instantiateComponent: (context: IComponentContext) =>  undefined,
                     } as ComponentFactoryTypes & Partial<IComponentRegistry>;
-                    factory.IComponentRegistry = { get: (name: string, rt: IHostRuntime) => {
+                    factory.IComponentRegistry = { get: (name: string, r: IComponentRouter) => {
                         return Promise.resolve(factory);
                     }} as IComponentRegistry;
                     return Promise.resolve(factory);
@@ -128,7 +127,7 @@ describe("Component Context Tests", () => {
         beforeEach(async () => {
 
             containerRuntime = {
-                IComponentRegistry: {get: (id: string, runtime: IHostRuntime) => {
+                IComponentRegistry: {get: (id: string, runtime: IComponentRouter) => {
                     const factory = {
                         IComponentFactory: {
                             instantiateComponent: (context: IComponentContext) => undefined,

--- a/packages/runtime/container-runtime/src/test/componentContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/componentContext.spec.ts
@@ -11,6 +11,7 @@ import {
     IComponentFactory,
     IComponentRegistry,
     IComponentRuntime,
+    IHostRuntime,
 } from "@microsoft/fluid-runtime-definitions";
 import { MockRuntime } from "@microsoft/fluid-test-runtime-utils";
 import * as assert from "assert";
@@ -29,7 +30,7 @@ describe("Component Context Tests", () => {
         beforeEach(async () => {
 
             containerRuntime = {
-                IComponentRegistry: { get: (id: string) => {
+                IComponentRegistry: { get: (id: string, runtime: IHostRuntime) => {
                     const factory = {
                         IComponentFactory: {
                             instantiateComponent: (context: IComponentContext) => undefined,
@@ -80,14 +81,14 @@ describe("Component Context Tests", () => {
 
         it("Supplying array of packages in LocalComponentContext should not create exception", async () => {
             containerRuntime = {
-                IComponentRegistry: { get: (id: string) => {
+                IComponentRegistry: { get: (id: string, runtime: IHostRuntime) => {
                     const factory = {
                         IComponentFactory: {
                             instantiateComponent: (context: IComponentContext) => undefined,
                         },
                         instantiateComponent: (context: IComponentContext) =>  undefined,
                     } as ComponentFactoryTypes & Partial<IComponentRegistry>;
-                    factory.IComponentRegistry = { get: (name: string) => {
+                    factory.IComponentRegistry = { get: (name: string, rt: IHostRuntime) => {
                         return Promise.resolve(factory);
                     }} as IComponentRegistry;
                     return Promise.resolve(factory);
@@ -127,7 +128,7 @@ describe("Component Context Tests", () => {
         beforeEach(async () => {
 
             containerRuntime = {
-                IComponentRegistry: {get: (id: string) => {
+                IComponentRegistry: {get: (id: string, runtime: IHostRuntime) => {
                     const factory = {
                         IComponentFactory: {
                             instantiateComponent: (context: IComponentContext) => undefined,

--- a/packages/runtime/runtime-definitions/src/componentRegistry.ts
+++ b/packages/runtime/runtime-definitions/src/componentRegistry.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { IComponent } from "@microsoft/fluid-component-core-interfaces";
 import { ComponentFactoryTypes } from "./componentFactory";
 
 declare module "@microsoft/fluid-component-core-interfaces" {
@@ -10,12 +11,12 @@ declare module "@microsoft/fluid-component-core-interfaces" {
 }
 
 export type ComponentRegistryTypes =
-    IComponentRegistry | { get(name: string): Promise<ComponentFactoryTypes> | undefined };
+    IComponentRegistry | { get(name: string, scope?: IComponent): Promise<ComponentFactoryTypes> | undefined };
 
 export interface IProvideComponentRegistry {
-    IComponentRegistry: IComponentRegistry;
+    IComponentRegistry: ComponentRegistryTypes;
 }
 
 export interface IComponentRegistry extends IProvideComponentRegistry {
-    get(name: string, cdn?: string): Promise<ComponentFactoryTypes> | undefined;
+    get(name: string, scope?: IComponent): Promise<ComponentFactoryTypes> | undefined;
 }

--- a/packages/runtime/runtime-definitions/src/componentRegistry.ts
+++ b/packages/runtime/runtime-definitions/src/componentRegistry.ts
@@ -3,20 +3,20 @@
  * Licensed under the MIT License.
  */
 
-import { IComponent } from "@microsoft/fluid-component-core-interfaces";
 import { ComponentFactoryTypes } from "./componentFactory";
+import { IHostRuntime } from "./components";
 
 declare module "@microsoft/fluid-component-core-interfaces" {
     export interface IComponent extends Readonly<Partial<IProvideComponentRegistry>> {}
 }
 
 export type ComponentRegistryTypes =
-    IComponentRegistry | { get(name: string, scope?: IComponent): Promise<ComponentFactoryTypes> | undefined };
+    IComponentRegistry | { get(name: string, runtime: IHostRuntime): Promise<ComponentFactoryTypes> | undefined };
 
 export interface IProvideComponentRegistry {
     IComponentRegistry: ComponentRegistryTypes;
 }
 
 export interface IComponentRegistry extends IProvideComponentRegistry {
-    get(name: string, scope?: IComponent): Promise<ComponentFactoryTypes> | undefined;
+    get(name: string, runtime: IHostRuntime): Promise<ComponentFactoryTypes> | undefined;
 }

--- a/packages/runtime/runtime-definitions/src/componentRegistry.ts
+++ b/packages/runtime/runtime-definitions/src/componentRegistry.ts
@@ -3,20 +3,20 @@
  * Licensed under the MIT License.
  */
 
+import { IComponentRouter } from "@microsoft/fluid-component-core-interfaces";
 import { ComponentFactoryTypes } from "./componentFactory";
-import { IHostRuntime } from "./components";
 
 declare module "@microsoft/fluid-component-core-interfaces" {
     export interface IComponent extends Readonly<Partial<IProvideComponentRegistry>> {}
 }
 
 export type ComponentRegistryTypes =
-    IComponentRegistry | { get(name: string, runtime: IHostRuntime): Promise<ComponentFactoryTypes> | undefined };
+    IComponentRegistry | { get(name: string, router: IComponentRouter): Promise<ComponentFactoryTypes> | undefined };
 
 export interface IProvideComponentRegistry {
     IComponentRegistry: ComponentRegistryTypes;
 }
 
 export interface IComponentRegistry extends IProvideComponentRegistry {
-    get(name: string, runtime: IHostRuntime): Promise<ComponentFactoryTypes> | undefined;
+    get(name: string, router: IComponentRouter): Promise<ComponentFactoryTypes> | undefined;
 }

--- a/packages/runtime/runtime-definitions/src/components.ts
+++ b/packages/runtime/runtime-definitions/src/components.ts
@@ -310,7 +310,8 @@ export interface IHostRuntime extends
     EventEmitter,
     IProvideComponentSerializer,
     IProvideComponentHandleContext,
-    IProvideComponentRegistry {
+    IProvideComponentRegistry,
+    IComponentRouter {
     readonly id: string;
     readonly existing: boolean;
     readonly options: any;


### PR DESCRIPTION
For they dynamic component loading case if may be necessary for the component registry to issue a request on the runtime in order to get a component factory.