### PR TITLE
Improvement on telemetry for AFD URL

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
@@ -385,7 +385,6 @@ export class OdspDocumentService implements IDocumentService {
                         url2!,
                         20000,
                     ).then((connection) => {
-                        logger.sendTelemetryEvent({ eventName: "UsedAfdUrl" });
                         // Refresh AFD cache
                         const cacheResult = this.writeLocalStorage(lastAfdConnectionTimeMsKey, Date.now().toString());
                         if (cacheResult) {


### PR DESCRIPTION
After viewing the AFD-related telemetry in Kusto, I think we should have more detailed telemetry events to help us understand and debug issues.
There should be at most ONE generic telemetry events, which may contain the time taken on the first connection attempt if retry is applicable. We can use the event(s) to determine what happened during connection and how the connection is wired.

Here is a breakdown on what telemetry event(s) will be sent based on what happened.

If we don’t have cache:
• Non AFD (1st try):
o Success - UsedNonAfdUrl
o Failed without AFD retry: FailedNonAfdUrl-NoAfdFallback
• AFD (after non AFD connection attempt):
o Success - UsedAfdUrl, WaitOnNonAfdAttempt (duration)
• If successfully cached decision - CachedAfdUrl
o Failed - FailedAfdUrlFallback, WaitOnNonAfdAttempt (duration)

If we have valid cache:
• AFD (1st try):
o Success - UsedAfdUrlDueToCache
o Failed without non AFD retry: FailedAfdUrl-NoNonAfdFallback
• Non AFD (after AFD connection attempt):
o Success: UsedNonAfdUrlFallback, WaitOnAfdAttempt (duration)
o Failed: FailedNonAfdUrlFallback, WaitOnAfdAttempt (duration)

This way, we can easily pull stats such as AFD vs non AFD connection by counting (UsedAfdUrl + UsedAfdUrlDueToCache) vs UsedNonAfdUrl, and analyze failure based on the type of failure event on the correlationId.

Also, changed cache from 8 to 6 hours.