### PR TITLE
Addressing issues around closing connections & error handling

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentStorageManager.ts
@@ -276,10 +276,10 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
             const versionsResponse = await this.fetchWrapper
                 .get<IDocumentStorageGetVersionsResponse>(url, this.documentId, headers);
             if (!versionsResponse) {
-                throwNetworkError("getVersions returned no response", 400);
+                throwNetworkError("getVersions returned no response", 400, true);
             }
             if (!Array.isArray(versionsResponse.value)) {
-                throwNetworkError("getVersions returned non-array response", 400);
+                throwNetworkError("getVersions returned non-array response", 400, true);
             }
             return versionsResponse.value.map((version) => {
                 // Parse the date from the message
@@ -346,7 +346,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
 
     private checkSnapshotUrl() {
         if (!this.snapshotUrl) {
-            throwNetworkError("Method not supported because no snapshotUrl was provided", 400);
+            throwNetworkError("Method not supported because no snapshotUrl was provided", 400, false);
         }
     }
 

--- a/packages/drivers/odsp-socket-storage/src/Vroom.ts
+++ b/packages/drivers/odsp-socket-storage/src/Vroom.ts
@@ -39,7 +39,7 @@ export async function fetchJoinSession(
   return getWithRetryForTokenRefresh(async (refresh: boolean) => {
     const token = await getVroomToken(refresh);
     if (!token) {
-      throwNetworkError("Failed to acquire Vroom token", 400);
+      throwNetworkError("Failed to acquire Vroom token", 400, true);
     }
 
     const siteOrigin = getOrigin(siteUrl);

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -316,9 +316,9 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
             this.protocolHandler.close();
         }
 
-        this.removeAllListeners();
-
         this.emit("closed");
+
+        this.removeAllListeners();
     }
 
     public async request(path: IRequest): Promise<IResponse> {

--- a/packages/loader/utils/src/network.ts
+++ b/packages/loader/utils/src/network.ts
@@ -22,8 +22,8 @@ export class NetworkError extends Error implements INetworkError {
 
 export function throwNetworkError(
         errorMessage: string,
-        statusCode?: number,
-        canRetry: boolean = false,
+        statusCode: number,
+        canRetry: boolean,
         response?: Response) {
     let message = errorMessage;
     if (response) {


### PR DESCRIPTION
There is mismatch in expectations around default argument of throwNetowrError(canRetry = false) and call sites.. As result, we generated fatal error when token was not provided to us when SPO had outage. Instead, we should retry.
Removing default value altogether to avoid confusion, and fixing couple similar places.

Also closing properly connection when container is closed and raising closed event.
