### PR TITLE
Draft: Access Component Registry via Requests, and add Catalog concept

### DIFF
--- a/packages/runtime/container-runtime/src/requestHandlers.ts
+++ b/packages/runtime/container-runtime/src/requestHandlers.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { IComponent, IComponentLoadable, IResponse } from "@microsoft/fluid-component-core-interfaces";
-import { IHostRuntime } from "@microsoft/fluid-runtime-definitions";
+import { IComponent, IComponentLoadable, IRequest, IResponse } from "@microsoft/fluid-component-core-interfaces";
+import { ComponentFactoryTypes, ComponentRegistryTypes, IHostRuntime } from "@microsoft/fluid-runtime-definitions";
 import { RequestParser } from "./requestParser";
 
 /**
@@ -46,25 +46,79 @@ export function createLoadableComponentRuntimeRequestHandler(component: ICompone
     };
 }
 
-export const serviceRoutePathRoot = "_services";
+export const systemRoutePathRoot = "_";
+export const serviceRoutePathPart = "services";
 export function createServiceRuntimeRequestHandler(
     serviceId: string, component: IComponent): RuntimeRequestHandler {
     return async (request: RequestParser, runtime: IHostRuntime) => {
-        if (request.pathParts.length >= 2
-            && request.pathParts[0] === serviceRoutePathRoot
-            && request.pathParts[1] === serviceId) {
+        if (request.pathParts.length >= 3
+            && request.pathParts[0] === systemRoutePathRoot
+            && request.pathParts[1] === serviceRoutePathPart
+            && request.pathParts[2] === serviceId) {
 
-            if (request.pathParts.length === 2) {
+            if (request.pathParts.length === 3) {
                 return createComponentResponse(component);
             }
 
             if (component.IComponentRouter) {
-                return component.IComponentRouter.request(request.createSubRequest(2));
+                return component.IComponentRouter.request(request.createSubRequest(3));
             }
 
             return { status: 400, mimeType: "text/plain", value: `${request.url} service is not a router` };
         }
 
         return undefined;
+    };
+}
+
+export const catalogRoutePathPart = "catalog";
+export function createCatalogRuntimeRequestHandler(
+    catalogId: string, component: ComponentRegistryTypes & IComponent): RuntimeRequestHandler {
+    return async (request: RequestParser, runtime: IHostRuntime) => {
+        if (request.pathParts.length >= 3
+            && request.pathParts[0] === systemRoutePathRoot
+            && request.pathParts[1] === catalogRoutePathPart
+            && request.pathParts[2] === catalogId) {
+
+            if (request.pathParts.length === 3) {
+                return createComponentResponse(component);
+            } else if (component.IComponentRouter) {
+                return component.IComponentRouter.request(request.createSubRequest(3));
+            } else {
+                let registry = component;
+                let factory: ComponentFactoryTypes & IComponent;
+                for (let i = 3; i < request.pathParts.length; i++) {
+                    if (registry === undefined) {
+                        return {
+                            status: 400,
+                            mimeType: "text/plain",
+                            value: `${request.createSubRequest(i - 1).url} is not a registry`,
+                        };
+                    }
+                    factory = await registry.get(request.pathParts[i]);
+                    registry = factory.IComponentRegistry;
+                }
+                if (factory !== undefined) {
+                    return createComponentResponse(factory);
+                }
+                return {
+                    status: 404,
+                    mimeType: "text/plain",
+                    value: `${request.url} factory does not exist`,
+                };
+            }
+        }
+
+        return undefined;
+    };
+}
+export function createCatalogRequest(catalogId: string, ...pkgsOrPathParts: string[]): IRequest {
+    return {
+        url: [
+            systemRoutePathRoot,
+            catalogRoutePathPart,
+            encodeURIComponent(catalogId),
+            ...pkgsOrPathParts.map(encodeURIComponent),
+        ].join("/"),
     };
 }

--- a/packages/runtime/runtime-definitions/src/components.ts
+++ b/packages/runtime/runtime-definitions/src/components.ts
@@ -33,7 +33,6 @@ import {
 
 import { EventEmitter } from "events";
 import { IChannel } from ".";
-import { IProvideComponentRegistry } from "./componentRegistry";
 
 /**
  * Represents the runtime for the component. Contains helper functions/state of the component.
@@ -310,7 +309,7 @@ export interface IHostRuntime extends
     EventEmitter,
     IProvideComponentSerializer,
     IProvideComponentHandleContext,
-    IProvideComponentRegistry {
+    IComponentRouter {
     readonly id: string;
     readonly existing: boolean;
     readonly options: any;


### PR DESCRIPTION
The goal here is to be more flexible in how registries are defined and accessed. This allows multiple root level registries that i'm calling catalogs. The catalogs themselves can also be accessed, and provide features that are catalog specific.