### PR TITLE
Adding headers to response for fetchwrapper.

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspDeltaStorageService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDeltaStorageService.ts
@@ -47,7 +47,7 @@ export class OdspDeltaStorageService implements api.IDocumentDeltaStorageService
             const { url, headers } = getUrlAndHeadersWithAuth(baseUrl, storageToken);
 
             const response = await this.fetchWrapper.get<IDeltaStorageGetResponse>(url, url, headers);
-            const deltaStorageResponse = response.body;
+            const deltaStorageResponse = response.content;
 
             const operations: api.ISequencedDocumentMessage[] | ISequencedDeltaOpMessage[] = deltaStorageResponse.value;
             if (operations.length > 0 && "op" in operations[0]) {

--- a/packages/drivers/odsp-socket-storage/src/OdspDeltaStorageService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDeltaStorageService.ts
@@ -47,8 +47,9 @@ export class OdspDeltaStorageService implements api.IDocumentDeltaStorageService
             const { url, headers } = getUrlAndHeadersWithAuth(baseUrl, storageToken);
 
             const response = await this.fetchWrapper.get<IDeltaStorageGetResponse>(url, url, headers);
+            const deltaStorageResponse = response.body;
 
-            const operations: api.ISequencedDocumentMessage[] | ISequencedDeltaOpMessage[] = response.value;
+            const operations: api.ISequencedDocumentMessage[] | ISequencedDeltaOpMessage[] = deltaStorageResponse.value;
             if (operations.length > 0 && "op" in operations[0]) {
                 return (operations as ISequencedDeltaOpMessage[]).map((operation) => operation.op);
             }

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentStorageManager.ts
@@ -89,7 +89,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
 
                 return this.fetchWrapper.get<resources.IBlob>(url, blobid, headers);
             });
-            blob = response.body;
+            blob = response.content;
         }
 
         if (blob && this.attributesBlobHandles.has(blobid)) {
@@ -114,7 +114,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
             const { url, headers } = getUrlAndHeadersWithAuth(`${this.snapshotUrl}/contents${getQueryString({ ref: version.id, path })}`, storageToken);
 
             const response = await this.fetchWrapper.get<resources.IBlob>(url, version.id, headers);
-            return response.body;
+            return response.content;
         });
     }
 
@@ -243,7 +243,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
                     const eventInner = PerformanceEvent.start(this.logger, { eventName: "TreesLatest" });
 
                     const response = await this.fetchWrapper.get<IOdspSnapshot>(url, this.documentId, headers);
-                    const { trees, blobs, ops, sha } = response.body;
+                    const { trees, blobs, ops, sha } = response.content;
 
                     if (trees) {
                         this.initTreesCache(trees);
@@ -259,8 +259,8 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
                         trees: trees ? trees.length : 0,
                         blobs: blobs ? blobs.length : 0,
                         ops: ops.length,
-                        sprequestguid: response.headers.has("sprequestguid") ? response.headers.get("sprequestguid") : undefined,
-                        contentsize: response.headers.has("content-length") ? response.headers.get("content-length") : undefined,
+                        sprequestguid: response.headers.get("sprequestguid"),
+                        contentsize: response.headers.get("content-length"),
                     };
                     eventInner.end(props);
                     event.end(props);
@@ -280,7 +280,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
             // fetch the latest snapshot versions for the document
             const response = await this.fetchWrapper
                 .get<IDocumentStorageGetVersionsResponse>(url, this.documentId, headers);
-            const versionsResponse = response.body;
+            const versionsResponse = response.content;
             if (!versionsResponse) {
                 throwNetworkError("getVersions returned no response", 400);
             }
@@ -366,7 +366,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
                 const storageToken = await this.getStorageToken(refresh);
 
                 const response = await fetchSnapshot(this.snapshotUrl!, storageToken, this.appId, this.fetchWrapper, id, this.fetchFullSnapshot);
-                const odspSnapshot: IOdspSnapshot = response.body;
+                const odspSnapshot: IOdspSnapshot = response.content;
                 // odspSnapshot contain "trees" when the request is made for latest or the root of the tree, for all other cases it will contain "tree" which is the fetched tree with the id
                 if (odspSnapshot) {
                     if (odspSnapshot.trees) {
@@ -478,7 +478,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
             const postBody = JSON.stringify(snapshot);
 
             const response = await this.fetchWrapper.post<ISnapshotResponse>(url, postBody, headers);
-            return response.body;
+            return response.content;
         });
     }
 

--- a/packages/drivers/odsp-socket-storage/src/OdspUtils.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspUtils.ts
@@ -32,6 +32,11 @@ export function blockList(nonRetriableCodes: number[]): RetryFilter {
 // export const defaultRetryFilter = allowList([408, 409, 429, 500, 503]);
 export const defaultRetryFilter = blockList([400, 404]);
 
+export interface IOdspResponse<T> {
+    body: T;
+    headers: any;
+}
+
 /**
  * A utility function to do fetch with support for retries
  * @param url - fetch requestInfo, can be a string
@@ -44,7 +49,7 @@ export function fetchHelper(
     retryFilter: RetryFilter = defaultRetryFilter,
 ): Promise<any> {
     // node-fetch and dom has conflicting typing, force them to work by casting for now
-    return fetch(requestInfo as FetchRequestInfo, requestInit as FetchRequestInit).then((fetchResponse) => {
+    return fetch(requestInfo as FetchRequestInfo, requestInit as FetchRequestInit).then(async (fetchResponse) => {
         const response = fetchResponse as any as Response;
         // Let's assume we can retry.
         if (!response) {
@@ -59,7 +64,11 @@ export function fetchHelper(
         // always ends up with this error - I'd guess 1% of op request end up here...
         // It always succeeds on retry.
         try {
-            return response.json() as any;
+            const res = {
+                headers: response.headers,
+                body: await response.json() as any,
+            };
+            return res;
         } catch (e) {
             throwNetworkError(`Error while parsing fetch response`, 400, true, response);
         }

--- a/packages/drivers/odsp-socket-storage/src/OdspUtils.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspUtils.ts
@@ -33,8 +33,8 @@ export function blockList(nonRetriableCodes: number[]): RetryFilter {
 export const defaultRetryFilter = blockList([400, 404]);
 
 export interface IOdspResponse<T> {
-    body: T;
-    headers: any;
+    content: T;
+    headers: Map<string, string>;
 }
 
 /**
@@ -66,7 +66,7 @@ export function fetchHelper(
         try {
             const res = {
                 headers: response.headers,
-                body: await response.json() as any,
+                content: await response.json() as any,
             };
             return res;
         } catch (e) {

--- a/packages/drivers/odsp-socket-storage/src/Vroom.ts
+++ b/packages/drivers/odsp-socket-storage/src/Vroom.ts
@@ -6,7 +6,7 @@
 import { ITelemetryLogger } from "@microsoft/fluid-container-definitions";
 import { PerformanceEvent, throwNetworkError } from "@microsoft/fluid-core-utils";
 import { ISocketStorageDiscovery } from "./contracts";
-import { fetchHelper, getWithRetryForTokenRefresh } from "./OdspUtils";
+import { fetchHelper, getWithRetryForTokenRefresh, IOdspResponse } from "./OdspUtils";
 
 function getOrigin(url: string) {
   return new URL(url).origin;
@@ -35,7 +35,7 @@ export async function fetchJoinSession(
   additionalParams: string,
   method: string,
   getVroomToken: (refresh: boolean) => Promise<string | undefined | null>,
-): Promise<ISocketStorageDiscovery> {
+): Promise<IOdspResponse<ISocketStorageDiscovery>> {
   return getWithRetryForTokenRefresh(async (refresh: boolean) => {
     const token = await getVroomToken(refresh);
     if (!token) {
@@ -80,9 +80,9 @@ export async function getSocketStorageDiscovery(
 ): Promise<ISocketStorageDiscovery> {
   const event = PerformanceEvent.start(logger, { eventName: "JoinSession" });
   let socketStorageDiscovery: ISocketStorageDiscovery;
-
+  let response: IOdspResponse<ISocketStorageDiscovery>;
   try {
-    socketStorageDiscovery = await fetchJoinSession(
+    response = await fetchJoinSession(
       appId,
       driveId,
       itemId,
@@ -96,7 +96,7 @@ export async function getSocketStorageDiscovery(
     event.cancel({}, error);
     throw error;
   }
-
+  socketStorageDiscovery = response.body;
   event.end();
 
   if (socketStorageDiscovery.runtimeTenantId && !socketStorageDiscovery.tenantId) {

--- a/packages/drivers/odsp-socket-storage/src/Vroom.ts
+++ b/packages/drivers/odsp-socket-storage/src/Vroom.ts
@@ -96,7 +96,7 @@ export async function getSocketStorageDiscovery(
     event.cancel({}, error);
     throw error;
   }
-  socketStorageDiscovery = response.body;
+  socketStorageDiscovery = response.content;
   event.end();
 
   if (socketStorageDiscovery.runtimeTenantId && !socketStorageDiscovery.tenantId) {

--- a/packages/drivers/odsp-socket-storage/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-socket-storage/src/fetchSnapshot.ts
@@ -7,6 +7,7 @@ import { IOdspSnapshot } from "./contracts";
 import { IFetchWrapper } from "./fetchWrapper";
 import { getQueryString } from "./getQueryString";
 import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth";
+import { IOdspResponse } from "./OdspUtils";
 
 /**
  * Fetches a snapshot from the server with a given version id.
@@ -25,7 +26,7 @@ export async function fetchSnapshot(
     storageFetchWrapper: IFetchWrapper,
     versionId: string,
     fetchFullSnapshot: boolean,
-): Promise<IOdspSnapshot> {
+): Promise<IOdspResponse<IOdspSnapshot>> {
     const path = `/trees/${versionId}`;
     let queryParams: { [key: string]: string } = {};
 

--- a/packages/drivers/odsp-socket-storage/src/fetchWrapper.ts
+++ b/packages/drivers/odsp-socket-storage/src/fetchWrapper.ts
@@ -3,22 +3,22 @@
  * Licensed under the MIT License.
  */
 
-import { fetchHelper } from "./OdspUtils";
+import { fetchHelper, IOdspResponse } from "./OdspUtils";
 
 export interface IFetchWrapper {
-    get<T>(url: string, id: string, headers: HeadersInit): Promise<T>;
-    post<T>(url: string, postBody: string, headers: HeadersInit): Promise<T>;
+    get<T>(url: string, id: string, headers: HeadersInit): Promise<IOdspResponse<T>>;
+    post<T>(url: string, postBody: string, headers: HeadersInit): Promise<IOdspResponse<T>>;
 }
 
 /**
  * Get responses with retry for requests.
  */
 export class FetchWrapper implements IFetchWrapper {
-    public get<T>(url: string, _: string, headers: HeadersInit): Promise<T> {
+    public get<T>(url: string, _: string, headers: HeadersInit): Promise<IOdspResponse<T>> {
         return fetchHelper(url, { headers });
     }
 
-    public post<T>(url: string, postBody: string, headers: HeadersInit): Promise<T> {
+    public post<T>(url: string, postBody: string, headers: HeadersInit): Promise<IOdspResponse<T>> {
         return fetchHelper(
             url,
             {

--- a/packages/drivers/odsp-socket-storage/src/test/deltaStorageService.spec.ts
+++ b/packages/drivers/odsp-socket-storage/src/test/deltaStorageService.spec.ts
@@ -66,7 +66,10 @@ describe("DeltaStorageService", () => {
             const fetchWrapperMock: IFetchWrapper = {
                 get: (url: string, _: string, headers: HeadersInit) => new Promise(
                     (resolve, reject) => {
-                        resolve(expectedDeltaFeedResponse);
+                        resolve({
+                            content: expectedDeltaFeedResponse,
+                            headers: new Map(),
+                        });
                     }),
                 post: (url: string, postBody: string, headers: HeadersInit) => new Promise(
                     (resolve, reject) => {
@@ -123,7 +126,10 @@ describe("DeltaStorageService", () => {
             const fetchWrapperMock: IFetchWrapper = {
                 get: (url: string, _: string, headers: HeadersInit) => new Promise(
                     (resolve, reject) => {
-                        resolve(expectedDeltaFeedResponse);
+                        resolve({
+                            content: expectedDeltaFeedResponse,
+                            headers: new Map(),
+                        });
                     }),
                 post: (url: string, postBody: string, headers: HeadersInit) => new Promise(
                     (resolve, reject) => {

--- a/packages/loader/utils/src/network.ts
+++ b/packages/loader/utils/src/network.ts
@@ -24,7 +24,8 @@ export function throwNetworkError(
         response?: Response) {
     let message = errorMessage;
     if (response) {
-        message = `${message}, msg = ${response.statusText}, type = ${response.type}, sprequestguid = ${response.headers.get("sprequestguid")}`;
+        message = `${message}, msg = ${response.statusText}, type = ${response.type},
+            sprequestguid = ${response.headers.get("sprequestguid")}`;
     }
     throw new NetworkError(message, statusCode, canRetry);
 }

--- a/packages/loader/utils/src/network.ts
+++ b/packages/loader/utils/src/network.ts
@@ -24,7 +24,7 @@ export function throwNetworkError(
         response?: Response) {
     let message = errorMessage;
     if (response) {
-        message = `${message}, msg = ${response.statusText}, type = ${response.type}`;
+        message = `${message}, msg = ${response.statusText}, type = ${response.type}, sprequestguid = ${response.headers.get("sprequestguid")}`;
     }
     throw new NetworkError(message, statusCode, canRetry);
 }


### PR DESCRIPTION
Issue #382 
1.) FetchHelper now also returns the headers whcih can be used for telemetry.
2.) Get latest telemetry now include sprequestguid and content size.
3.) Adding IOdspReponse for odsp driver so that every reponse is in such form with body as request interface and headers for info about the network call.