### PR TITLE
Adding caching in odsp driver for getLatest/joinsession.

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
@@ -16,6 +16,7 @@ import {
 } from "@microsoft/fluid-protocol-definitions";
 import { ISocketStorageDiscovery } from "./contracts";
 import { IFetchWrapper } from "./fetchWrapper";
+import { OdspCache } from "./odspCache";
 import { OdspDeltaStorageService } from "./OdspDeltaStorageService";
 import { OdspDocumentDeltaConnection } from "./OdspDocumentDeltaConnection";
 import { OdspDocumentStorageManager } from "./OdspDocumentStorageManager";
@@ -68,6 +69,7 @@ export class OdspDocumentService implements IDocumentService {
         private readonly storageFetchWrapper: IFetchWrapper,
         private readonly deltasFetchWrapper: IFetchWrapper,
         private readonly socketIOClientP: Promise<SocketIOClientStatic>,
+        private readonly odspCache: OdspCache,
     ) {
         this.getStorageToken = (refresh: boolean) => {
             if (refresh) {
@@ -87,6 +89,8 @@ export class OdspDocumentService implements IDocumentService {
                 siteUrl,
                 logger,
                 this.getStorageToken,
+                this.odspCache,
+                hashedDocumentId,
             ),
         );
     }
@@ -108,6 +112,7 @@ export class OdspDocumentService implements IDocumentService {
             this.getStorageToken,
             this.logger,
             true,
+            this.odspCache,
         );
 
         return new OdspDocumentStorageService(this.storageManager);

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentServiceFactory.ts
@@ -8,6 +8,7 @@ import { IDocumentService, IDocumentServiceFactory, IResolvedUrl } from "@micros
 import { IOdspResolvedUrl } from "./contracts";
 import { FetchWrapper, IFetchWrapper } from "./fetchWrapper";
 import { getSocketIo } from "./getSocketIo";
+import { OdspCache } from "./odspCache";
 import { OdspDocumentService } from "./OdspDocumentService";
 
 /**
@@ -33,6 +34,7 @@ export class OdspDocumentServiceFactory implements IDocumentServiceFactory {
     private readonly logger: ITelemetryBaseLogger,
     private readonly storageFetchWrapper: IFetchWrapper = new FetchWrapper(),
     private readonly deltasFetchWrapper: IFetchWrapper = new FetchWrapper(),
+    private readonly odspCache: OdspCache = new OdspCache(),
   ) {}
 
   public async createDocumentService(resolvedUrl: IResolvedUrl): Promise<IDocumentService> {
@@ -50,6 +52,7 @@ export class OdspDocumentServiceFactory implements IDocumentServiceFactory {
       this.storageFetchWrapper,
       this.deltasFetchWrapper,
       Promise.resolve(getSocketIo()),
+      this.odspCache,
     );
   }
 }

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentServiceFactoryWithCodeSplit.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentServiceFactoryWithCodeSplit.ts
@@ -7,6 +7,7 @@ import { ChildLogger } from "@microsoft/fluid-core-utils";
 import { IDocumentService, IDocumentServiceFactory, IResolvedUrl } from "@microsoft/fluid-protocol-definitions";
 import { IOdspResolvedUrl } from "./contracts";
 import { FetchWrapper, IFetchWrapper } from "./fetchWrapper";
+import { OdspCache } from "./odspCache";
 import { OdspDocumentService } from "./OdspDocumentService";
 
 /**
@@ -35,6 +36,7 @@ export class OdspDocumentServiceFactoryWithCodeSplit implements IDocumentService
     private readonly logger: ITelemetryBaseLogger,
     private readonly storageFetchWrapper: IFetchWrapper = new FetchWrapper(),
     private readonly deltasFetchWrapper: IFetchWrapper = new FetchWrapper(),
+    private readonly odspCache: OdspCache = new OdspCache(),
   ) {}
 
   public async createDocumentService(resolvedUrl: IResolvedUrl): Promise<IDocumentService> {
@@ -52,6 +54,7 @@ export class OdspDocumentServiceFactoryWithCodeSplit implements IDocumentService
       this.storageFetchWrapper,
       this.deltasFetchWrapper,
       import("./getSocketIo").then((m) => m.getSocketIo()),
+      this.odspCache,
     );
   }
 }

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentStorageManager.ts
@@ -249,6 +249,9 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
 
                         const response = await this.fetchWrapper.get<IOdspSnapshot>(url, this.documentId, headers);
                         odspSnapshot = response.content;
+                        // We are storing the getLatest response in cache for 10s so that other containers initializing in the same timeframe can use this
+                        // result. We are choosing a small time period as the summarizes are generated frequently and if that is the case then we don't
+                        // want to use the same getLatest result.
                         this.odspCache.put(odspCacheKey, odspSnapshot, 10000);
 
                         const props = {

--- a/packages/drivers/odsp-socket-storage/src/Vroom.ts
+++ b/packages/drivers/odsp-socket-storage/src/Vroom.ts
@@ -82,6 +82,8 @@ export async function getSocketStorageDiscovery(
   documentId: string,
 ): Promise<ISocketStorageDiscovery> {
   const odspCacheKey = `${documentId}/joinsession`;
+  // It is necessary to invalidate the cache here once we use the previous result because we do not
+  // want to keep using the same expired result. So if we delete it we would ask for new join session result.
   let socketStorageDiscovery: ISocketStorageDiscovery = odspCache.get(odspCacheKey, true);
   if (!socketStorageDiscovery) {
     const event = PerformanceEvent.start(logger, { eventName: "JoinSession" });

--- a/packages/drivers/odsp-socket-storage/src/Vroom.ts
+++ b/packages/drivers/odsp-socket-storage/src/Vroom.ts
@@ -82,7 +82,7 @@ export async function getSocketStorageDiscovery(
   documentId: string,
 ): Promise<ISocketStorageDiscovery> {
   const odspCacheKey = `${documentId}/joinsession`;
-  let socketStorageDiscovery: ISocketStorageDiscovery = odspCache.get(odspCacheKey);
+  let socketStorageDiscovery: ISocketStorageDiscovery = odspCache.get(odspCacheKey, true);
   if (!socketStorageDiscovery) {
     const event = PerformanceEvent.start(logger, { eventName: "JoinSession" });
     let response: IOdspResponse<ISocketStorageDiscovery>;
@@ -107,7 +107,10 @@ export async function getSocketStorageDiscovery(
     if (socketStorageDiscovery.runtimeTenantId && !socketStorageDiscovery.tenantId) {
       socketStorageDiscovery.tenantId = socketStorageDiscovery.runtimeTenantId;
     }
-    odspCache.put(odspCacheKey, socketStorageDiscovery, 900000);
+    // We are storing the joinsession response in cache for 16 mins so that other join session calls in the same timeframe can use this
+    // result. We are choosing 16 mins as the push server could change to different one after 15 mins. So to avoid any race condition,
+    // we are choosing 16 mins.
+    odspCache.put(odspCacheKey, socketStorageDiscovery, 960000);
   }
   return socketStorageDiscovery;
 }

--- a/packages/drivers/odsp-socket-storage/src/index.ts
+++ b/packages/drivers/odsp-socket-storage/src/index.ts
@@ -17,3 +17,4 @@ export * from "./OdspDocumentServiceFactory";
 export * from "./OdspDocumentServiceFactoryWithCodeSplit";
 export * from "./OdspDocumentService";
 export * from "./OdspDocumentDeltaConnection";
+export * from "./odspCache";

--- a/packages/drivers/odsp-socket-storage/src/odspCache.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspCache.ts
@@ -14,16 +14,16 @@ export class OdspCache {
         return this.odspCache.get(key);
     }
 
-    public put(key: string, value: any, time: number) {
+    public put(key: string, value: any, expiryTime: number) {
         this.odspCache.set(key, value);
         // tslint:disable-next-line: no-floating-promises
-        this.gc(key, time);
+        this.gc(key, expiryTime);
     }
 
-    private async gc(key: string, time: number) {
+    private async gc(key: string, expiryTime: number) {
         // tslint:disable-next-line: no-string-based-set-timeout
         const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
-        await delay(time);
+        await delay(expiryTime);
         this.odspCache.delete(key);
     }
 }

--- a/packages/drivers/odsp-socket-storage/src/odspCache.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspCache.ts
@@ -1,0 +1,29 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export class OdspCache {
+    private readonly odspCache: Map<string, any>;
+
+    constructor() {
+        this.odspCache = new Map<string, any>();
+    }
+
+    public get(key: string) {
+        return this.odspCache.get(key);
+    }
+
+    public put(key: string, value: any, time: number) {
+        this.odspCache.set(key, value);
+        // tslint:disable-next-line: no-floating-promises
+        this.gc(key, time);
+    }
+
+    private async gc(key: string, time: number) {
+        // tslint:disable-next-line: no-string-based-set-timeout
+        const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
+        await delay(time);
+        this.odspCache.delete(key);
+    }
+}

--- a/packages/drivers/odsp-socket-storage/src/odspCache.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspCache.ts
@@ -10,8 +10,12 @@ export class OdspCache {
         this.odspCache = new Map<string, any>();
     }
 
-    public get(key: string) {
-        return this.odspCache.get(key);
+    public get(key: string, removeKey: boolean = false) {
+        const val = this.odspCache.get(key);
+        if (removeKey && val) {
+            this.odspCache.delete(key);
+        }
+        return val;
     }
 
     public put(key: string, value: any, expiryTime: number) {
@@ -24,6 +28,8 @@ export class OdspCache {
         // tslint:disable-next-line: no-string-based-set-timeout
         const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
         await delay(expiryTime);
-        this.odspCache.delete(key);
+        if (this.odspCache.has(key)) {
+            this.odspCache.delete(key);
+        }
     }
 }

--- a/packages/drivers/odsp-socket-storage/src/odspCache.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspCache.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import * as assert from "assert";
+
 export class OdspCache {
     private readonly odspCache: Map<string, any>;
 
@@ -19,6 +21,7 @@ export class OdspCache {
     }
 
     public put(key: string, value: any, expiryTime: number) {
+        assert(!this.odspCache.has(key), "Insertion rejected because cache already has that key!!");
         this.odspCache.set(key, value);
         // tslint:disable-next-line: no-floating-promises
         this.gc(key, expiryTime);

--- a/packages/hosts/tiny-web-host/src/host.ts
+++ b/packages/hosts/tiny-web-host/src/host.ts
@@ -6,7 +6,8 @@
 import { IHostConfig, start } from "@microsoft/fluid-base-host";
 import { BaseTelemetryNullLogger, configurableUrlResolver } from "@microsoft/fluid-core-utils";
 import { FluidAppOdspUrlResolver } from "@microsoft/fluid-fluidapp-odsp-urlresolver";
-import { OdspDocumentServiceFactory, OdspUrlResolver } from "@microsoft/fluid-odsp-driver";
+import { OdspDocumentServiceFactory } from "@microsoft/fluid-odsp-driver";
+import { OdspUrlResolver } from "@microsoft/fluid-odsp-urlresolver";
 import { IDocumentServiceFactory, IFluidResolvedUrl, IResolvedUrl } from "@microsoft/fluid-protocol-definitions";
 import { DefaultErrorTracking, RouterliciousDocumentServiceFactory } from "@microsoft/fluid-routerlicious-driver";
 import { ContainerUrlResolver } from "@microsoft/fluid-routerlicious-host";


### PR DESCRIPTION
1.) Implement a simple cache that starts a timer to delete a key after a certain time when it is added in cache.
2.) Both getlatest/joinsession will first check in cache whether the required result is present or not.