### PR TITLE
Clients are missing ops on connection, causing long connection delays on SPO

### DIFF
--- a/packages/drivers/iframe-socket-storage/src/outerDocumentService.ts
+++ b/packages/drivers/iframe-socket-storage/src/outerDocumentService.ts
@@ -155,24 +155,25 @@ export class OuterDocumentService implements IDocumentService {
             assert((this.deltaConnection as any).socket !== undefined);
             console.log(client);
 
+            const deltaConnection = this.deltaConnection;
             const connection: IConnected = {
-                claims: this.deltaConnection.claims,
-                clientId: this.deltaConnection.clientId,
-                existing: this.deltaConnection.existing,
-                initialContents: this.deltaConnection.initialContents,
-                initialMessages: this.deltaConnection.initialMessages,
-                initialSignals: this.deltaConnection.initialSignals,
-                initialClients: this.deltaConnection.initialClients,
-                maxMessageSize: this.deltaConnection.maxMessageSize,
-                mode: this.deltaConnection.mode,
-                parentBranch: this.deltaConnection.parentBranch,
-                serviceConfiguration: this.deltaConnection.serviceConfiguration,
-                version: this.deltaConnection.version,
+                claims: deltaConnection.claims,
+                clientId: deltaConnection.clientId,
+                existing: deltaConnection.existing,
+                get initialClients() { return deltaConnection.initialClients; },
+                get initialContents() { return deltaConnection.initialContents; },
+                get initialMessages() { return deltaConnection.initialMessages; },
+                get initialSignals() { return deltaConnection.initialSignals; },
+                maxMessageSize: deltaConnection.maxMessageSize,
+                mode: deltaConnection.mode,
+                parentBranch: deltaConnection.parentBranch,
+                serviceConfiguration: deltaConnection.serviceConfiguration,
+                version: deltaConnection.version,
                 supportedVersions: protocolVersions,
             };
 
             this.outerDocumentDeltaConnection = OuterDocumentDeltaConnection.create(
-                this.deltaConnection,
+                deltaConnection,
                 connection,
                 proxiedFunctionsFromInnerFrameP,
             );

--- a/packages/drivers/routerlicious-socket-storage/src/wsDeltaConnection.ts
+++ b/packages/drivers/routerlicious-socket-storage/src/wsDeltaConnection.ts
@@ -17,7 +17,6 @@ import {
     ISignalMessage,
     ITokenClaims,
 } from "@microsoft/fluid-protocol-definitions";
-import * as assert from "assert";
 import { EventEmitter } from "events";
 import * as ws from "isomorphic-ws";
 import * as url from "url";
@@ -46,13 +45,6 @@ export class WSDeltaConnection extends EventEmitter implements IDocumentDeltaCon
         client: IClient,
         urlStr: string,
         mode: ConnectionMode): Promise<IDocumentDeltaConnection> {
-
-        // This code is currently not used.
-        // If we ever switch to using raw sockets, we need to implement early op handlers similar to how
-        // DocumentDeltaConnection class implements them.
-        // Due to asynchrony / continuations, we have to keep early handlers and accumulate ops until
-        // caller asks for initialMessages / initialContents / initialSignals
-        assert(false, "non implemented functionality in WSDeltaConnection, see comment in code above");
 
         return new Promise<IDocumentDeltaConnection>((resolve, reject) => {
             const connection = new WSDeltaConnection(tenantId, id, token, client, urlStr, mode);

--- a/packages/drivers/routerlicious-socket-storage/src/wsDeltaConnection.ts
+++ b/packages/drivers/routerlicious-socket-storage/src/wsDeltaConnection.ts
@@ -17,6 +17,7 @@ import {
     ISignalMessage,
     ITokenClaims,
 } from "@microsoft/fluid-protocol-definitions";
+import * as assert from "assert";
 import { EventEmitter } from "events";
 import * as ws from "isomorphic-ws";
 import * as url from "url";
@@ -45,6 +46,13 @@ export class WSDeltaConnection extends EventEmitter implements IDocumentDeltaCon
         client: IClient,
         urlStr: string,
         mode: ConnectionMode): Promise<IDocumentDeltaConnection> {
+
+        // This code is currently not used.
+        // If we ever switch to using raw sockets, we need to implement early op handlers similar to how
+        // DocumentDeltaConnection class implements them.
+        // Due to asynchrony / continuations, we have to keep early handlers and accumulate ops until
+        // caller asks for initialMessages / initialContents / initialSignals
+        assert(false, "non implemented functionality in WSDeltaConnection, see comment in code above");
 
         return new Promise<IDocumentDeltaConnection>((resolve, reject) => {
             const connection = new WSDeltaConnection(tenantId, id, token, client, urlStr, mode);

--- a/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
+++ b/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
@@ -133,8 +133,11 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
                 this.socket.emit(submitType, this.clientId, work);
             });
 
+        // tslint:disable-next-line:no-non-null-assertion
         this.socket.on("op", this.earlyOpHandler!);
+        // tslint:disable-next-line:no-non-null-assertion
         this.socket.on("op-content", this.earlyContentHandler!);
+        // tslint:disable-next-line:no-non-null-assertion
         this.socket.on("signal", this.earlySignalHandler!);
     }
 
@@ -368,17 +371,17 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
         this.socket.disconnect();
     }
 
-    private earlyOpHandler? = (documentId: string, msgs: ISequencedDocumentMessage[]) => {
+    private earlyOpHandler ? = (documentId: string, msgs: ISequencedDocumentMessage[]) => {
         debug("Queued early ops", msgs.length);
         this.queuedMessages.push(...msgs);
     }
 
-    private earlyContentHandler? = (msg: IContentMessage) => {
+    private earlyContentHandler ? = (msg: IContentMessage) => {
         debug("Queued early contents");
         this.queuedContents.push(msg);
     }
 
-    private earlySignalHandler? = (msg: ISignalMessage) => {
+    private earlySignalHandler ? = (msg: ISignalMessage) => {
         debug("Queued early signals");
         this.queuedSignals.push(msg);
     }

--- a/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
+++ b/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
@@ -298,6 +298,8 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
      * @param listener - listener for the event
      */
     public on(event: string, listener: (...args: any[]) => void): this {
+        assert(this.listeners(event).length === 0, "re-registration of events is not implemented");
+
         // Register for the event on socket.io
         this.socket.on(
             event,

--- a/packages/loader/container-loader/src/deltaConnection.ts
+++ b/packages/loader/container-loader/src/deltaConnection.ts
@@ -29,6 +29,31 @@ export class DeltaConnection extends EventEmitter {
     }
 
     public get details(): IConnectionDetails {
+        // Populate details on demand.
+        // This is required not to miss any ops!
+        // DeltaConnection.connect() is async, and as result there is a time window where runtime has not yet installed
+        // its op handler, and driver already removed its earlyOpHandler.
+        // As result, we raise op events without nobody listening for them!
+        // Given that some storage implementations may have slow propagation of ops form delta stream to storage, that
+        // can affect user experience in rather visible ways.
+        // Work around for it - drivers can continue to accumulate ops until
+        // initialMessages / initialSignals / initialContents are fetched
+        if (this._details === undefined) {
+            this._details = {
+                claims: this.connection.claims,
+                clientId: this.connection.clientId,
+                existing: this.connection.existing,
+                initialClients: this.connection.initialClients,
+                initialContents: this.connection.initialContents,
+                initialMessages: this.connection.initialMessages,
+                initialSignals: this.connection.initialSignals,
+                maxMessageSize: this.connection.maxMessageSize,
+                mode: this.connection.mode,
+                parentBranch: this.connection.parentBranch,
+                serviceConfiguration: this.connection.serviceConfiguration,
+                version: this.connection.version,
+            };
+        }
         return this._details;
     }
 
@@ -40,27 +65,12 @@ export class DeltaConnection extends EventEmitter {
         return this._connected;
     }
 
-    private readonly _details: IConnectionDetails;
+    private _details: IConnectionDetails | undefined;
     private _nacked = false;
     private _connected = true;
 
     private constructor(private readonly connection: IDocumentDeltaConnection) {
         super();
-
-        this._details = {
-            claims: connection.claims,
-            clientId: connection.clientId,
-            existing: connection.existing,
-            initialClients: connection.initialClients,
-            initialContents: connection.initialContents,
-            initialMessages: connection.initialMessages,
-            initialSignals: connection.initialSignals,
-            maxMessageSize: connection.maxMessageSize,
-            mode: connection.mode,
-            parentBranch: connection.parentBranch,
-            serviceConfiguration: connection.serviceConfiguration,
-            version: connection.version,
-        };
 
         // listen for new messages
         connection.on("op", (documentId: string, messages: ISequencedDocumentMessage[]) => {

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -649,11 +649,6 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
             (connection) => {
                 this.connection = connection;
 
-                // WARNING:
-                // after we ask for connection.details, DocumentDeltaConnection will unregister its early
-                // op / content / signal handlers. Any new ops / signals that are coming in will go to aether
-                // unless we register handlers (synchronously!) right away.
-
                 // back-compat for newer clients and old server. If the server does not have mode, we reset to write.
                 this.connectionMode = connection.details.mode ? connection.details.mode : "write";
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -648,6 +648,12 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
             mode).then(
             (connection) => {
                 this.connection = connection;
+
+                // WARNING:
+                // after we ask for connection.details, DocumentDeltaConnection will unregister its early
+                // op / content / signal handlers. Any new ops / signals that are coming in will go to aether
+                // unless we register handlers (synchronously!) right away.
+
                 // back-compat for newer clients and old server. If the server does not have mode, we reset to write.
                 this.connectionMode = connection.details.mode ? connection.details.mode : "write";
 


### PR DESCRIPTION
There is a timeframe when we are already connected to websocket and lower layers unsubscribed early op handlers, but due to async / continuations, DeltaManager did not have a chance to subscribe its own op handler. As result, we are missing ops, and because PUSH flushes them to storage very infrequently, client is sitting there and asking for missing ops for very long time (30+ seconds).

The fix is to keep early handlers until someone is asking for early ops.
This also requires layers in between not to ask for early ops.

Need to follow up with OuterDocumentService.createDocumentDeltaConnection which has same problem.
WS socket implementation has same issue (there is no early op handler at all there), but given code is not currently used, I've added assert and comment making sure we address that problem if we every switch to raw sockets.