### PR TITLE
Mission op callback

### DIFF
--- a/packages/drivers/file-socket-storage/src/fileDocumentService.ts
+++ b/packages/drivers/file-socket-storage/src/fileDocumentService.ts
@@ -35,7 +35,7 @@ export class FileDocumentService implements api.IDocumentService {
     public async connectToDeltaStream(
             client: api.IClient,
             mode: api.ConnectionMode,
-            callback: (connection: api.IDocumentDeltaConnection) => void) {
+            callback: (connection: api.IDocumentDeltaConnection) => void): Promise<void> {
         callback(this.deltaConnection);
     }
 

--- a/packages/drivers/file-socket-storage/src/fileDocumentService.ts
+++ b/packages/drivers/file-socket-storage/src/fileDocumentService.ts
@@ -33,9 +33,10 @@ export class FileDocumentService implements api.IDocumentService {
      * @returns returns the delta stream service.
      */
     public async connectToDeltaStream(
-        client: api.IClient,
-        mode: api.ConnectionMode): Promise<api.IDocumentDeltaConnection> {
-        return this.deltaConnection;
+            client: api.IClient,
+            mode: api.ConnectionMode,
+            callback: (connection: api.IDocumentDeltaConnection) => void) {
+        callback(this.deltaConnection);
     }
 
     public async branch(): Promise<string> {

--- a/packages/drivers/iframe-socket-storage/src/innerDocumentDeltaConnection.ts
+++ b/packages/drivers/iframe-socket-storage/src/innerDocumentDeltaConnection.ts
@@ -23,7 +23,7 @@ import { EventEmitter } from "events";
 
 export interface IOuterDocumentDeltaConnectionProxy {
     handshake: Deferred<any>;
-    getDetails(): Promise<IConnected>;
+    getDetails(): IConnected;
     submit(messages: IDocumentMessage[]): Promise<void>;
     submitSignal(message: IDocumentMessage): Promise<void>;
     add(a: number, b: number): Promise<number>;
@@ -38,9 +38,9 @@ export class InnerDocumentDeltaConnection extends EventEmitter implements IDocum
      *
      * @param id - document ID
      */
-    public static async create(
+    public static create(
         connection: IConnected,
-        outerProxy: IOuterDocumentDeltaConnectionProxy): Promise<IDocumentDeltaConnection> {
+        outerProxy: IOuterDocumentDeltaConnectionProxy): IDocumentDeltaConnection {
 
         // tslint:disable-next-line: no-unsafe-any
         const deltaConnection = new InnerDocumentDeltaConnection(connection, outerProxy);

--- a/packages/drivers/iframe-socket-storage/src/innerDocumentService.ts
+++ b/packages/drivers/iframe-socket-storage/src/innerDocumentService.ts
@@ -71,9 +71,13 @@ export class InnerDocumentService implements IDocumentService {
      *
      * @returns returns the document delta stream service for routerlicious driver.
      */
-    public async connectToDeltaStream(client: IClient, mode: ConnectionMode): Promise<IDocumentDeltaConnection> {
-        const connection = await this.outerProxy.getDetails();
-        return InnerDocumentDeltaConnection.create(connection, this.outerProxy);
+    public async connectToDeltaStream(
+            client: IClient,
+            mode: ConnectionMode,
+            callback: (connectionArg: IDocumentDeltaConnection) => void) {
+        return this.outerProxy.getDetails((connection) => {
+            callback(InnerDocumentDeltaConnection.create(connection, this.outerProxy));
+        });
     }
 
     public async branch(): Promise<string> {

--- a/packages/drivers/iframe-socket-storage/src/innerDocumentService.ts
+++ b/packages/drivers/iframe-socket-storage/src/innerDocumentService.ts
@@ -74,10 +74,8 @@ export class InnerDocumentService implements IDocumentService {
     public async connectToDeltaStream(
             client: IClient,
             mode: ConnectionMode,
-            callback: (connectionArg: IDocumentDeltaConnection) => void) {
-        return this.outerProxy.getDetails((connection) => {
-            callback(InnerDocumentDeltaConnection.create(connection, this.outerProxy));
-        });
+            callback: (connectionArg: IDocumentDeltaConnection) => void): Promise<void> {
+        callback(InnerDocumentDeltaConnection.create(this.outerProxy.getDetails(), this.outerProxy));
     }
 
     public async branch(): Promise<string> {

--- a/packages/drivers/iframe-socket-storage/src/outerDocumentDeltaConnection.ts
+++ b/packages/drivers/iframe-socket-storage/src/outerDocumentDeltaConnection.ts
@@ -26,7 +26,7 @@ export interface IInnerDocumentDeltaConnectionProxy {
 
 export interface IOuterDocumentDeltaConnection {
     add(a: number, b: number): Promise<number>;
-    getDetails(callback: (connection: IConnected) => void): Promise<void>;
+    getDetails(): IConnected;
     submit(messages: IDocumentMessage[]): Promise<void>;
     submitSignal(message: IDocumentMessage): Promise<void>;
 }
@@ -225,7 +225,7 @@ export class OuterDocumentDeltaConnection extends EventEmitter implements IDocum
             return a + b;
         }
 
-        const getDetails = async () => this.details;
+        const getDetails = () => this.details;
 
         const submit = async (messages: IDocumentMessage[]) => {
             this.connection.submit(messages);

--- a/packages/drivers/iframe-socket-storage/src/outerDocumentDeltaConnection.ts
+++ b/packages/drivers/iframe-socket-storage/src/outerDocumentDeltaConnection.ts
@@ -26,7 +26,7 @@ export interface IInnerDocumentDeltaConnectionProxy {
 
 export interface IOuterDocumentDeltaConnection {
     add(a: number, b: number): Promise<number>;
-    getDetails(): Promise<IConnected>;
+    getDetails(callback: (connection: IConnected) => void): Promise<void>;
     submit(messages: IDocumentMessage[]): Promise<void>;
     submitSignal(message: IDocumentMessage): Promise<void>;
 }

--- a/packages/drivers/iframe-socket-storage/src/outerDocumentService.ts
+++ b/packages/drivers/iframe-socket-storage/src/outerDocumentService.ts
@@ -69,7 +69,6 @@ export class OuterDocumentService implements IDocumentService {
             deltaConnection,
             frame,
         );
-
     }
 
     private readonly handshake: Deferred<IInnerProxy>;
@@ -135,8 +134,11 @@ export class OuterDocumentService implements IDocumentService {
      *
      * @returns returns the document delta stream service for routerlicious driver.
      */
-    public async connectToDeltaStream(client: IClient, mode: ConnectionMode): Promise<IDocumentDeltaConnection> {
-        return this.createDocumentDeltaConnection(client);
+    public async connectToDeltaStream(
+            client: IClient,
+            mode: ConnectionMode,
+            callback: (connection: IDocumentDeltaConnection) => void) {
+        callback(this.createDocumentDeltaConnection(client));
     }
 
     public async branch(): Promise<string> {

--- a/packages/drivers/iframe-socket-storage/src/outerDocumentService.ts
+++ b/packages/drivers/iframe-socket-storage/src/outerDocumentService.ts
@@ -57,16 +57,17 @@ export class OuterDocumentService implements IDocumentService {
             },
         };
 
-        const [storage, deltaStorage, deltaConnection] = await Promise.all([
+        let deltaConnection: IDocumentDeltaConnection | undefined;
+        const [storage, deltaStorage] = await Promise.all([
             documentService.connectToStorage(),
             documentService.connectToDeltaStorage(),
-            documentService.connectToDeltaStream(client, mode),
+            documentService.connectToDeltaStream(client, mode, (connection) => { deltaConnection = connection; }),
         ]);
 
         return new OuterDocumentService(
             storage as DocumentStorageService,
             deltaStorage,
-            deltaConnection,
+            deltaConnection!,
             frame,
         );
     }
@@ -137,7 +138,7 @@ export class OuterDocumentService implements IDocumentService {
     public async connectToDeltaStream(
             client: IClient,
             mode: ConnectionMode,
-            callback: (connection: IDocumentDeltaConnection) => void) {
+            callback: (connection: IDocumentDeltaConnection) => void): Promise<void> {
         callback(this.createDocumentDeltaConnection(client));
     }
 

--- a/packages/drivers/iframe-socket-storage/src/outerDocumentServiceFactory.ts
+++ b/packages/drivers/iframe-socket-storage/src/outerDocumentServiceFactory.ts
@@ -34,7 +34,7 @@ export class OuterDocumentServiceFactory implements IDocumentServiceFactory {
         documentServiceP
             .then((documentService) => {
                 return Promise.all([
-                    documentService.connectToDeltaStream(clientDetails!, mode),
+                    documentService.connectToDeltaStream(clientDetails!, mode, () => {}),
                     documentService.connectToDeltaStorage(),
                     documentService.connectToStorage(),
                 ]);

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
@@ -169,7 +169,7 @@ export class OdspDocumentService implements IDocumentService {
     public async connectToDeltaStream(
             client: IClient,
             mode: ConnectionMode,
-            callback: (connection: IDocumentDeltaConnection) => void) {
+            callback: (connection: IDocumentDeltaConnection) => void): Promise<void> {
         // We should refresh our knowledge before attempting to reconnect
         this.websocketEndpointP = this.websocketEndpointRequestThrottler.response;
 
@@ -300,8 +300,8 @@ export class OdspDocumentService implements IDocumentService {
             client: IClient,
             mode: ConnectionMode,
             url: string,
-            url2?: string,
-            callback: (connection: IDocumentDeltaConnection) => void) {
+            url2: string | undefined,
+            callback: (connection: IDocumentDeltaConnection) => void): Promise<void> {
         // tslint:disable-next-line: strict-boolean-expressions
         const hasUrl2 = !!url2;
 
@@ -325,7 +325,7 @@ export class OdspDocumentService implements IDocumentService {
                 // tslint:disable-next-line: no-non-null-assertion
                 url2!,
                 20000,
-                (connection: IDocumentDeltaConnection) {
+                (connection) => {
                     logger.sendTelemetryEvent({
                         eventName: "UsedAfdUrl",
                         fromCache: true,
@@ -352,13 +352,13 @@ export class OdspDocumentService implements IDocumentService {
                         mode,
                         url,
                         20000,
-                        (connection: IDocumentDeltaConnection) {
+                        (connection) => {
                             logger.sendPerformanceEvent({
                                 eventName: "UsedNonAfdUrlFallback",
                                 duration: endAfd - startAfd,
                             }, connectionError);
                             callback(connection);
-                        }).catch(retryError => {
+                        }).catch((retryError) => {
                             logger.sendPerformanceEvent({
                                 eventName: "FailedNonAfdUrlFallback",
                                 duration: endAfd - startAfd,
@@ -379,7 +379,7 @@ export class OdspDocumentService implements IDocumentService {
             mode,
             url,
             hasUrl2 ? 15000 : 20000,
-            (connection: IDocumentDeltaConnection) {
+            (connection) => {
                 logger.sendTelemetryEvent({ eventName: "UsedNonAfdUrl" });
                 callback(connection);
             }).catch((connectionError) => {
@@ -388,7 +388,7 @@ export class OdspDocumentService implements IDocumentService {
                     logger.sendErrorEvent({
                         eventName: "FailedNonAfdUrl-NoAfdFallback",
                     }, connectionError);
-                        throw connectionError;
+                    throw connectionError;
                 }
                 debug(`Socket connection error on non-AFD URL. Error was [${connectionError}]. Retry on AFD URL: ${url2}`);
 
@@ -402,7 +402,7 @@ export class OdspDocumentService implements IDocumentService {
                     // tslint:disable-next-line: no-non-null-assertion
                     url2!,
                     20000,
-                    (connection: IDocumentDeltaConnection) {
+                    (connection) => {
                         // Refresh AFD cache
                         const cacheResult = this.writeLocalStorage(lastAfdConnectionTimeMsKey, Date.now().toString());
                         if (cacheResult) {
@@ -415,7 +415,7 @@ export class OdspDocumentService implements IDocumentService {
                             fromCache: false,
                         }, connectionError);
                         callback(connection);
-                    }).catch(retryError => {
+                    }).catch((retryError) => {
                         logger.sendPerformanceEvent({
                             eventName: "FailedAfdUrlFallback",
                             duration: endNonAfd - startNonAfd,

--- a/packages/drivers/replay-socket-storage/src/replayDocumentService.ts
+++ b/packages/drivers/replay-socket-storage/src/replayDocumentService.ts
@@ -60,7 +60,7 @@ export class ReplayDocumentService implements api.IDocumentService {
     public async connectToDeltaStream(
             client: api.IClient,
             mode: api.ConnectionMode,
-            callback: (connection: api.IDocumentDeltaConnection) => void) {
+            callback: (connection: api.IDocumentDeltaConnection) => void): Promise<void> {
         callback(this.deltaStorage);
     }
 

--- a/packages/drivers/replay-socket-storage/src/replayDocumentService.ts
+++ b/packages/drivers/replay-socket-storage/src/replayDocumentService.ts
@@ -58,9 +58,10 @@ export class ReplayDocumentService implements api.IDocumentService {
      * @returns returns the delta stream service which replay ops from --from to --to arguments.
      */
     public async connectToDeltaStream(
-        client: api.IClient,
-        mode: api.ConnectionMode): Promise<api.IDocumentDeltaConnection> {
-        return this.deltaStorage;
+            client: api.IClient,
+            mode: api.ConnectionMode,
+            callback: (connection: api.IDocumentDeltaConnection) => void) {
+        callback(this.deltaStorage);
     }
 
     public async branch(): Promise<string> {

--- a/packages/drivers/replay-socket-storage/src/storageImplementations.ts
+++ b/packages/drivers/replay-socket-storage/src/storageImplementations.ts
@@ -149,7 +149,7 @@ export class StaticStorageDocumentService implements IDocumentService {
     public async connectToDeltaStream(
             client: IClient,
             mode: ConnectionMode,
-            callback: (connection: IDocumentDeltaConnection) => void) {
+            callback: (connection: IDocumentDeltaConnection) => void): Promise<void> {
         // We have no delta stream, so make it not return forever...
         // tslint:disable-next-line:promise-must-complete
         return new Promise(() => {});

--- a/packages/drivers/replay-socket-storage/src/storageImplementations.ts
+++ b/packages/drivers/replay-socket-storage/src/storageImplementations.ts
@@ -146,7 +146,10 @@ export class StaticStorageDocumentService implements IDocumentService {
         return new EmptyDeltaStorageService();
     }
 
-    public async connectToDeltaStream(client: IClient, mode: ConnectionMode): Promise<IDocumentDeltaConnection> {
+    public async connectToDeltaStream(
+            client: IClient,
+            mode: ConnectionMode,
+            callback: (connection: IDocumentDeltaConnection) => void) {
         // We have no delta stream, so make it not return forever...
         // tslint:disable-next-line:promise-must-complete
         return new Promise(() => {});

--- a/packages/drivers/routerlicious-socket-storage/src/documentService.ts
+++ b/packages/drivers/routerlicious-socket-storage/src/documentService.ts
@@ -103,7 +103,7 @@ export class DocumentService implements api.IDocumentService {
     public async connectToDeltaStream(
             client: api.IClient,
             mode: api.ConnectionMode,
-            callback: (connection: api.IDocumentDeltaConnection) => void) {
+            callback: (connection: api.IDocumentDeltaConnection) => void): Promise<void> {
         return DocumentDeltaConnection.create(
             this.tenantId,
             this.documentId,

--- a/packages/drivers/routerlicious-socket-storage/src/documentService.ts
+++ b/packages/drivers/routerlicious-socket-storage/src/documentService.ts
@@ -101,8 +101,9 @@ export class DocumentService implements api.IDocumentService {
      * @returns returns the document delta stream service for routerlicious driver.
      */
     public async connectToDeltaStream(
-        client: api.IClient,
-        mode: api.ConnectionMode): Promise<api.IDocumentDeltaConnection> {
+            client: api.IClient,
+            mode: api.ConnectionMode,
+            callback: (connection: api.IDocumentDeltaConnection) => void) {
         return DocumentDeltaConnection.create(
             this.tenantId,
             this.documentId,
@@ -110,7 +111,9 @@ export class DocumentService implements api.IDocumentService {
             io,
             client,
             mode,
-            this.ordererUrl);
+            this.ordererUrl,
+            20000, // timeout
+            callback);
     }
 
     public async branch(): Promise<string> {

--- a/packages/drivers/routerlicious-socket-storage/src/documentService2.ts
+++ b/packages/drivers/routerlicious-socket-storage/src/documentService2.ts
@@ -47,7 +47,7 @@ export class DocumentService2 extends DocumentService {
     public async connectToDeltaStream(
             client: api.IClient,
             mode: api.ConnectionMode,
-            callback: (connection: api.IDocumentDeltaConnection) => void) {
+            callback: (connection: api.IDocumentDeltaConnection) => void): Promise<void> {
         return WSDeltaConnection.create(
             this.tenantId,
             this.documentId,

--- a/packages/drivers/routerlicious-socket-storage/src/documentService2.ts
+++ b/packages/drivers/routerlicious-socket-storage/src/documentService2.ts
@@ -45,14 +45,16 @@ export class DocumentService2 extends DocumentService {
      * @returns returns the delta stream service.
      */
     public async connectToDeltaStream(
-        client: api.IClient,
-        mode: api.ConnectionMode): Promise<api.IDocumentDeltaConnection> {
+            client: api.IClient,
+            mode: api.ConnectionMode,
+            callback: (connection: api.IDocumentDeltaConnection) => void) {
         return WSDeltaConnection.create(
             this.tenantId,
             this.documentId,
             this.tokenProvider.token,
             client,
             this.ordererUrl,
-            mode);
+            mode,
+            callback);
     }
 }

--- a/packages/drivers/routerlicious-socket-storage/src/wsDeltaConnection.ts
+++ b/packages/drivers/routerlicious-socket-storage/src/wsDeltaConnection.ts
@@ -51,8 +51,12 @@ export class WSDeltaConnection extends EventEmitter implements IDocumentDeltaCon
             const connection = new WSDeltaConnection(tenantId, id, token, client, urlStr, mode);
 
             const resolveHandler = () => {
-                callback(connection);
-                resolve();
+                try {
+                    callback(connection);
+                    resolve();
+                } catch (error) {
+                    reject(error);
+                }
                 connection.removeListener("disconnected", rejectHandler);
             };
 

--- a/packages/drivers/routerlicious-socket-storage/src/wsDeltaConnection.ts
+++ b/packages/drivers/routerlicious-socket-storage/src/wsDeltaConnection.ts
@@ -45,9 +45,9 @@ export class WSDeltaConnection extends EventEmitter implements IDocumentDeltaCon
         client: IClient,
         urlStr: string,
         mode: ConnectionMode,
-        callback: (connection: IDocumentDeltaConnection) => void) {
+        callback: (connection: IDocumentDeltaConnection) => void): Promise<void> {
 
-        return new Promise<IDocumentDeltaConnection>((resolve, reject) => {
+        return new Promise<void>((resolve, reject) => {
             const connection = new WSDeltaConnection(tenantId, id, token, client, urlStr, mode);
 
             const resolveHandler = () => {

--- a/packages/drivers/routerlicious-socket-storage/src/wsDeltaConnection.ts
+++ b/packages/drivers/routerlicious-socket-storage/src/wsDeltaConnection.ts
@@ -44,13 +44,15 @@ export class WSDeltaConnection extends EventEmitter implements IDocumentDeltaCon
         token: string,
         client: IClient,
         urlStr: string,
-        mode: ConnectionMode): Promise<IDocumentDeltaConnection> {
+        mode: ConnectionMode,
+        callback: (connection: IDocumentDeltaConnection) => void) {
 
         return new Promise<IDocumentDeltaConnection>((resolve, reject) => {
             const connection = new WSDeltaConnection(tenantId, id, token, client, urlStr, mode);
 
             const resolveHandler = () => {
-                resolve(connection);
+                callback(connection);
+                resolve();
                 connection.removeListener("disconnected", rejectHandler);
             };
 

--- a/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
+++ b/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
@@ -68,7 +68,7 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
             mode: ConnectionMode,
             url: string,
             timeoutMs: number,
-            callback: (connection: IDocumentDeltaConnection) => void) {
+            callback: (connection: IDocumentDeltaConnection) => void): Promise<void> {
         // Note on multiplex = false:
         // Temp fix to address issues on SPO. Scriptor hits same URL for Fluid & Notifications.
         // As result Socket.io reuses socket (as there is no collision on namespaces).
@@ -95,7 +95,7 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
             versions: protocolVersions,
         };
 
-        return new Promise<IConnected>((resolve, reject) => {
+        return new Promise<void>((resolve, reject) => {
             // Listen for ops sent before we receive a response to connect_document
             const queuedMessages: ISequencedDocumentMessage[] = [];
             const queuedContents: IContentMessage[] = [];
@@ -122,7 +122,7 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
             // Listen for connection issues
             socket.on("connect_error", (error) => {
                 debug(`Socket connection error: [${error}]`);
-                    reject(createErrorObject("connect_error", error));
+                reject(createErrorObject("connect_error", error));
             });
 
             // Listen for timeouts
@@ -180,7 +180,7 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
                 debug(`Error in documentDeltaConection: ${error}`);
                 // This includes "Invalid namespace" error, which we consider critical (reconnecting will not help)
                 socket.disconnect();
-                    reject(createErrorObject("error", error, error !== "Invalid namespace"));
+                reject(createErrorObject("error", error, error !== "Invalid namespace"));
             }));
 
             socket.on("connect_document_error", ((error) => {
@@ -188,7 +188,7 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
                 // In this case we disconnect the socket and indicate that we were unable to create the
                 // DocumentDeltaConnection.
                 socket.disconnect();
-                    reject(createErrorObject("connect_document_error", error));
+                reject(createErrorObject("connect_document_error", error));
             }));
 
             socket.emit("connect_document", connectMessage);

--- a/packages/loader/container-loader/src/deltaConnection.ts
+++ b/packages/loader/container-loader/src/deltaConnection.ts
@@ -20,12 +20,11 @@ import {
 import { EventEmitter } from "events";
 
 export class DeltaConnection extends EventEmitter {
-    public async static connect(
+    public static async connect(
             service: IDocumentService,
             client: IClient,
             mode: ConnectionMode,
-            callback: (connection: DeltaConnection) => void,
-            errorCallback: (connection: DeltaConnection) => void) {
+            callback: (connection: DeltaConnection) => void): Promise<void> {
         return service.connectToDeltaStream(
             client,
             mode,

--- a/packages/loader/container-loader/src/deltaConnection.ts
+++ b/packages/loader/container-loader/src/deltaConnection.ts
@@ -20,12 +20,18 @@ import {
 import { EventEmitter } from "events";
 
 export class DeltaConnection extends EventEmitter {
-    public static async connect(
-        service: IDocumentService,
-        client: IClient,
-        mode: ConnectionMode) {
-        const connection = await service.connectToDeltaStream(client, mode);
-        return new DeltaConnection(connection);
+    public async static connect(
+            service: IDocumentService,
+            client: IClient,
+            mode: ConnectionMode,
+            callback: (connection: DeltaConnection) => void,
+            errorCallback: (connection: DeltaConnection) => void) {
+        return service.connectToDeltaStream(
+            client,
+            mode,
+            (connection) => {
+                callback(new DeltaConnection(connection));
+            });
     }
 
     public get details(): IConnectionDetails {

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -645,8 +645,8 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         DeltaConnection.connect(
             this.service,
             this.client!,
-            mode).then(
-            (connection) => {
+            mode,
+            (connection: DeltaConnection) => {
                 this.connection = connection;
                 // back-compat for newer clients and old server. If the server does not have mode, we reset to write.
                 this.connectionMode = connection.details.mode ? connection.details.mode : "write";
@@ -738,9 +738,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
                     connection.details.initialSignals,
                     this.connectFirstConnection);
                 this.connectFirstConnection = false;
-
-            },
-            (error) => {
+            }).catch ((error) => {
                 // Socket.io error when we connect to wrong socket, or hit some multiplexing bug
                 if (!canRetryOnError(error)) {
                     this.closeOnConnectionError(error);

--- a/packages/loader/protocol-definitions/src/storage.ts
+++ b/packages/loader/protocol-definitions/src/storage.ts
@@ -298,7 +298,10 @@ export interface IDocumentService {
     /**
      * Subscribes to the document delta stream
      */
-    connectToDeltaStream(client: IClient, mode: ConnectionMode): Promise<IDocumentDeltaConnection>;
+    connectToDeltaStream(
+        client: IClient,
+        mode: ConnectionMode,
+        callback: (connection: IDocumentDeltaConnection) => void): Promise<void>;
 
     /**
      * Creates a branch of the document with the given ID. Returns the new ID.

--- a/packages/server/local-test-server/src/testDocumentService.ts
+++ b/packages/server/local-test-server/src/testDocumentService.ts
@@ -68,8 +68,9 @@ export class TestDocumentService implements api.IDocumentService {
      * @param client - client data
      */
     public async connectToDeltaStream(
-        client: api.IClient,
-        mode: api.ConnectionMode): Promise<api.IDocumentDeltaConnection> {
+            client: api.IClient,
+            mode: api.ConnectionMode,
+            callback: (connection: api.IDocumentDeltaConnection) => void) {
         // socketStorage.DocumentDeltaStorageService?
         return TestDocumentDeltaConnection.create(
             this.tenantId,
@@ -77,7 +78,8 @@ export class TestDocumentService implements api.IDocumentService {
             this.tokenProvider.token,
             client,
             this.testDeltaConnectionServer.webSocketServer,
-            mode);
+            mode,
+            callback);
     }
 
     /**

--- a/packages/server/local-test-server/src/testDocumentService.ts
+++ b/packages/server/local-test-server/src/testDocumentService.ts
@@ -70,7 +70,7 @@ export class TestDocumentService implements api.IDocumentService {
     public async connectToDeltaStream(
             client: api.IClient,
             mode: api.ConnectionMode,
-            callback: (connection: api.IDocumentDeltaConnection) => void) {
+            callback: (connection: api.IDocumentDeltaConnection) => void): Promise<void> {
         // socketStorage.DocumentDeltaStorageService?
         return TestDocumentDeltaConnection.create(
             this.tenantId,

--- a/packages/server/test-utils/src/testDocumentDeltaConnection.ts
+++ b/packages/server/test-utils/src/testDocumentDeltaConnection.ts
@@ -30,7 +30,7 @@ export class TestDocumentDeltaConnection extends EventEmitter implements IDocume
             client: IClient,
             webSocketServer: core.IWebSocketServer,
             mode: ConnectionMode,
-            callback: (connection: IDocumentDeltaConnection) => void) {
+            callback: (connection: IDocumentDeltaConnection) => void): Promise<void> {
         const socket = (webSocketServer as TestWebSocketServer).createConnection();
 
         const connectMessage: IConnect = {
@@ -42,7 +42,7 @@ export class TestDocumentDeltaConnection extends EventEmitter implements IDocume
             versions: testProtocolVersions,
         };
 
-        return new Promise<IConnected>((resolve, reject) => {
+        return new Promise<void>((resolve, reject) => {
             // Listen for ops sent before we receive a response to connect_document
             const queuedMessages: ISequencedDocumentMessage[] = [];
             const queuedContents: IContentMessage[] = [];

--- a/packages/tools/fluid-fetch/src/fluidFetchMessages.ts
+++ b/packages/tools/fluid-fetch/src/fluidFetchMessages.ts
@@ -55,7 +55,7 @@ async function loadAllSequencedMessages(
     console.log("Retrieving messages from web socket");
     timeStart = Date.now();
     const mode: ConnectionMode = "write";
-    let deltaStream: IDocumentDeltaConnection;
+    let deltaStream: IDocumentDeltaConnection | undefined;
     await documentService.connectToDeltaStream(client, mode, (connection) => {
         deltaStream = connection;
     });

--- a/packages/tools/fluid-fetch/src/fluidFetchMessages.ts
+++ b/packages/tools/fluid-fetch/src/fluidFetchMessages.ts
@@ -6,6 +6,7 @@
 import {
     ConnectionMode,
     IClient,
+    IDocumentDeltaConnection,
     IDocumentService,
     ISequencedDocumentMessage,
     MessageType,
@@ -54,7 +55,13 @@ async function loadAllSequencedMessages(
     console.log("Retrieving messages from web socket");
     timeStart = Date.now();
     const mode: ConnectionMode = "write";
-    const deltaStream = await documentService.connectToDeltaStream(client, mode);
+    let deltaStream: IDocumentDeltaConnection;
+    await documentService.connectToDeltaStream(client, mode, (connection) => {
+        deltaStream = connection;
+    });
+    if (!deltaStream) {
+        throw new Error("Error in logic: deltaStream is empty");
+    }
     const initialMessages = deltaStream.initialMessages;
     deltaStream.disconnect();
     console.log(`${Math.floor((Date.now() - timeStart) / 1000)} seconds to connect to web socket`);


### PR DESCRIPTION
This is alternative implementation to https://github.com/microsoft/FluidFramework/pull/428
Or rather starting point (see notes below for what's left).

Implement early op registration through callback.
I use promises to handle errros. The alternative way is to use two callback (success & error path)
Missing part: catching exceptions thrown while calling callback and propagating them to the promise rejection.

I chose promise to return void to force all initialization to be in callback, to make it possible to consolidate error handling through promise rejection, and to force users to do all registration in one place