### PR TITLE
Added a clear method to SharedIntervalCollection.

### DIFF
--- a/packages/runtime/sequence/src/intervalCollection.ts
+++ b/packages/runtime/sequence/src/intervalCollection.ts
@@ -587,7 +587,7 @@ export class IntervalCollectionView<TInterval extends ISerializableInterval> ext
 
     /* tslint:disable:no-unnecessary-override */
     public on(
-        event: "addInterval",
+        event: "addInterval" | "clear",
         listener: (interval: ISerializedInterval, local: boolean, op: ISequencedDocumentMessage) => void): this {
         return super.on(event, listener);
     }

--- a/packages/runtime/sequence/src/sharedIntervalCollection.ts
+++ b/packages/runtime/sequence/src/sharedIntervalCollection.ts
@@ -105,6 +105,14 @@ export abstract class ASharedIntervalCollection<TInterval extends ISerializableI
         return this.intervalMapKernel.wait<IntervalCollection<TInterval>>(label);
     }
 
+    public clearIntervalCollection(label: string): void {
+        if (this.intervalMapKernel.has(label)) {
+            const sharedCollection: IntervalCollection<TInterval> =
+                this.intervalMapKernel.get<IntervalCollection<TInterval>>(label);
+            sharedCollection.clear();
+        }
+    }
+
     // TODO: fix race condition on creation by putting type on every operation
     public getIntervalCollection(label: string): IntervalCollection<TInterval> {
         if (!this.intervalMapKernel.has(label)) {


### PR DESCRIPTION
SharedIntervalCollection currently has no way of clearing out its intervals, so I added a method to do so. I wasn't entirely sure what the proper methodology is, so I put in two ways of doing so, one commented out. Will clear out the comments if this goes forward. (Related to #415)