### PR TITLE
Invalidate joinsession result on any error

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentDeltaConnection.ts
@@ -17,7 +17,6 @@ import {
 import * as assert from "assert";
 import { IOdspSocketError } from "./contracts";
 import { debug } from "./debug";
-import { OdspCache } from "./odspCache";
 import { errorObjectFromOdspError } from "./OdspUtils";
 
 const protocolVersions = ["^0.3.0", "^0.2.0", "^0.1.0"];
@@ -50,7 +49,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
      * @param url - websocket URL
      * @param telemetryLogger - optional telemetry logger
      */
-    public static async createDeltaConnection(
+    public static async create(
         tenantId: string,
         webSocketId: string,
         token: string | null,

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentDeltaConnection.ts
@@ -57,7 +57,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
         timeoutMs: number = 20000,
         telemetryLogger: ITelemetryLogger = new TelemetryNullLogger()): Promise<IDocumentDeltaConnection> {
 
-        const socketReferenceKey = `${url},${tenantId},${id}`;
+        const socketReferenceKey = `${url},${tenantId},${webSocketId}`;
 
         const socketReference = OdspDocumentDeltaConnection.getOrCreateSocketIoReference(
             io, timeoutMs, socketReferenceKey, url, tenantId, webSocketId, telemetryLogger);

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
@@ -186,8 +186,6 @@ export class OdspDocumentService implements IDocumentService {
             client,
             mode,
             websocketEndpoint.deltaStreamSocketUrl,
-            this.hashedDocumentId,
-            this.odspCache,
             websocketEndpoint.deltaStreamSocketUrl2,
         );
     }
@@ -244,7 +242,7 @@ export class OdspDocumentService implements IDocumentService {
     // tslint:disable-next-line: max-func-body-length
     private async connectToDeltaStreamWithRetry(
         tenantId: string,
-        id: string,
+        websocketId: string,
         token: string | null,
         io: SocketIOClientStatic,
         client: IClient,
@@ -281,7 +279,7 @@ export class OdspDocumentService implements IDocumentService {
 
                 return OdspDocumentDeltaConnection.create(
                     tenantId,
-                    id,
+                    websocketId,
                     token,
                     io,
                     client,
@@ -306,7 +304,7 @@ export class OdspDocumentService implements IDocumentService {
 
                         return OdspDocumentDeltaConnection.create(
                             tenantId,
-                            id,
+                            websocketId,
                             token,
                             io,
                             client,
@@ -326,7 +324,7 @@ export class OdspDocumentService implements IDocumentService {
                                 eventName: "FailedNonAfdUrlFallback",
                                 duration: endAfd - startAfd,
                             }, retryError);
-
+                            this.odspCache.remove(`${this.hashedDocumentId}/joinsession`);
                             throw retryError;
                         });
                     } else {
@@ -334,7 +332,7 @@ export class OdspDocumentService implements IDocumentService {
                             eventName: "FailedAfdUrl-NoNonAfdFallback",
                         }, connectionError);
                     }
-
+                    this.odspCache.remove(`${this.hashedDocumentId}/joinsession`);
                     throw connectionError;
                 });
             }
@@ -342,7 +340,7 @@ export class OdspDocumentService implements IDocumentService {
             const startNonAfd = performance.now();
             return OdspDocumentDeltaConnection.create(
                 tenantId,
-                id,
+                websocketId,
                 token,
                 io,
                 client,
@@ -360,7 +358,7 @@ export class OdspDocumentService implements IDocumentService {
 
                     return OdspDocumentDeltaConnection.create(
                         tenantId,
-                        id,
+                        websocketId,
                         token,
                         io,
                         client,
@@ -388,7 +386,7 @@ export class OdspDocumentService implements IDocumentService {
                             eventName: "FailedAfdUrlFallback",
                             duration: endNonAfd - startNonAfd,
                         }, retryError);
-
+                        this.odspCache.remove(`${this.hashedDocumentId}/joinsession`);
                         throw retryError;
                     });
                 } else {
@@ -396,7 +394,7 @@ export class OdspDocumentService implements IDocumentService {
                         eventName: "FailedNonAfdUrl-NoAfdFallback",
                     }, connectionError);
                 }
-
+                this.odspCache.remove(`${this.hashedDocumentId}/joinsession`);
                 throw connectionError;
             });
         }

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
@@ -168,7 +168,7 @@ export class OdspDocumentService implements IDocumentService {
 
         const [websocketEndpoint, webSocketToken, io] = await Promise.all([this.websocketEndpointP, this.getWebsocketToken(), this.socketIOClientP]);
 
-        return OdspDocumentDeltaConnection.create(
+        return OdspDocumentDeltaConnection.createDeltaConnection(
             websocketEndpoint.tenantId,
             websocketEndpoint.id,
             // This is workaround for fluid-fetcher. Need to have better long term solution
@@ -177,6 +177,8 @@ export class OdspDocumentService implements IDocumentService {
             client,
             mode,
             websocketEndpoint.deltaStreamSocketUrl,
+            this.hashedDocumentId,
+            this.odspCache,
             websocketEndpoint.deltaStreamSocketUrl2,
             this.logger,
         );

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
@@ -187,7 +187,10 @@ export class OdspDocumentService implements IDocumentService {
             mode,
             websocketEndpoint.deltaStreamSocketUrl,
             websocketEndpoint.deltaStreamSocketUrl2,
-        );
+        ).catch((error) => {
+            this.odspCache.remove(`${this.hashedDocumentId}/joinsession`);
+            throw error;
+        });
     }
 
     public async branch(): Promise<string> {
@@ -324,7 +327,6 @@ export class OdspDocumentService implements IDocumentService {
                                 eventName: "FailedNonAfdUrlFallback",
                                 duration: endAfd - startAfd,
                             }, retryError);
-                            this.odspCache.remove(`${this.hashedDocumentId}/joinsession`);
                             throw retryError;
                         });
                     } else {
@@ -332,7 +334,6 @@ export class OdspDocumentService implements IDocumentService {
                             eventName: "FailedAfdUrl-NoNonAfdFallback",
                         }, connectionError);
                     }
-                    this.odspCache.remove(`${this.hashedDocumentId}/joinsession`);
                     throw connectionError;
                 });
             }
@@ -386,7 +387,6 @@ export class OdspDocumentService implements IDocumentService {
                             eventName: "FailedAfdUrlFallback",
                             duration: endNonAfd - startNonAfd,
                         }, retryError);
-                        this.odspCache.remove(`${this.hashedDocumentId}/joinsession`);
                         throw retryError;
                     });
                 } else {
@@ -394,7 +394,6 @@ export class OdspDocumentService implements IDocumentService {
                         eventName: "FailedNonAfdUrl-NoAfdFallback",
                     }, connectionError);
                 }
-                this.odspCache.remove(`${this.hashedDocumentId}/joinsession`);
                 throw connectionError;
             });
         }

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
@@ -48,6 +48,8 @@ export class OdspDocumentService implements IDocumentService {
 
     private readonly localStorageAvailable: boolean;
 
+    private joinSessionKey: string;
+
     /**
      * @param appId - app id used for telemetry for network requests
      * @param hashedDocumentId - A unique identifer for the document. The "hashed" here implies that the contents of this string
@@ -81,6 +83,8 @@ export class OdspDocumentService implements IDocumentService {
         private readonly odspCache: OdspCache,
     ) {
 
+        this.joinSessionKey = `${this.hashedDocumentId}/joinsession`;
+
         this.logger = DebugLogger.mixinDebugLogger(
             "fluid:telemetry",
             logger,
@@ -105,7 +109,7 @@ export class OdspDocumentService implements IDocumentService {
                 logger,
                 this.getStorageToken,
                 this.odspCache,
-                hashedDocumentId,
+                this.joinSessionKey,
             ),
         );
 
@@ -188,7 +192,7 @@ export class OdspDocumentService implements IDocumentService {
             websocketEndpoint.deltaStreamSocketUrl,
             websocketEndpoint.deltaStreamSocketUrl2,
         ).catch((error) => {
-            this.odspCache.remove(`${this.hashedDocumentId}/joinsession`);
+            this.odspCache.remove(this.joinSessionKey);
             throw error;
         });
     }

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
@@ -48,7 +48,7 @@ export class OdspDocumentService implements IDocumentService {
 
     private readonly localStorageAvailable: boolean;
 
-    private joinSessionKey: string;
+    private readonly joinSessionKey: string;
 
     /**
      * @param appId - app id used for telemetry for network requests

--- a/packages/drivers/odsp-socket-storage/src/OdspUtils.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspUtils.ts
@@ -34,7 +34,7 @@ export function blockList(nonRetriableCodes: number[]): RetryFilter {
 export const defaultRetryFilter = blockList([400, 404]);
 
 // socket error filter for socket erros where 400 is a special retryable error.
-export const socketErrorRetryFilter = blockList([404, 406]);
+export const socketErrorRetryFilter = blockList([401, 403, 404, 406]);
 
 export interface IOdspResponse<T> {
     content: T;

--- a/packages/drivers/odsp-socket-storage/src/OdspUtils.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspUtils.ts
@@ -30,7 +30,7 @@ export function blockList(nonRetriableCodes: number[]): RetryFilter {
 
 // Going safe - only exclude specific codes
 // export const defaultRetryFilter = allowList([408, 409, 429, 500, 503]);
-export const defaultRetryFilter = blockList([400, 404]);
+export const defaultRetryFilter = blockList([404, 406]);
 
 export interface IOdspResponse<T> {
     content: T;

--- a/packages/drivers/odsp-socket-storage/src/OdspUtils.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspUtils.ts
@@ -31,7 +31,9 @@ export function blockList(nonRetriableCodes: number[]): RetryFilter {
 
 // Going safe - only exclude specific codes
 // export const defaultRetryFilter = allowList([408, 409, 429, 500, 503]);
-export const defaultRetryFilter = blockList([404, 406]);
+export const defaultRetryFilter = blockList([400, 404]);
+
+export const socketErrorRetryFilter = blockList([404, 406]);
 
 export interface IOdspResponse<T> {
     content: T;
@@ -100,7 +102,7 @@ export function errorObjectFromOdspError(socketError: IOdspSocketError) {
         socketError.message,
         [
             [INetworkErrorProperties.statusCode, socketError.code],
-            [INetworkErrorProperties.canRetry, defaultRetryFilter(socketError.code)],
+            [INetworkErrorProperties.canRetry, socketErrorRetryFilter(socketError.code)],
             [INetworkErrorProperties.retryAfterSeconds, socketError.retryAfter],
         ],
     );

--- a/packages/drivers/odsp-socket-storage/src/OdspUtils.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspUtils.ts
@@ -33,6 +33,7 @@ export function blockList(nonRetriableCodes: number[]): RetryFilter {
 // export const defaultRetryFilter = allowList([408, 409, 429, 500, 503]);
 export const defaultRetryFilter = blockList([400, 404]);
 
+// socket error filter for socket erros where 400 is a special retryable error.
 export const socketErrorRetryFilter = blockList([404, 406]);
 
 export interface IOdspResponse<T> {

--- a/packages/drivers/odsp-socket-storage/src/Vroom.ts
+++ b/packages/drivers/odsp-socket-storage/src/Vroom.ts
@@ -79,17 +79,16 @@ export async function getSocketStorageDiscovery(
   logger: ITelemetryLogger,
   getVroomToken: (refresh: boolean) => Promise<string | undefined | null>,
   odspCache: OdspCache,
-  documentId: string,
+  joinSessionKey: string,
 ): Promise<ISocketStorageDiscovery> {
-  const odspCacheKey = `${documentId}/joinsession`;
   // We invalidate the cache here because we will take the decision to put the joinsession result
   // again based on the last time it was put in the cache. So if the result is valid and used within
   // an hour we put the same result again with updated time so that we keep using the same result for
   // consecutive join session calls because the server moved. If there is nothing in cache or the
   // response was cached an hour ago, then we make the join session call again.
-  const cachedResult: IOdspJoinSessionCachedItem = odspCache.get(odspCacheKey, true);
+  const cachedResult: IOdspJoinSessionCachedItem = odspCache.get(joinSessionKey, true);
   if (cachedResult && Date.now() - cachedResult.timestamp <= 3600000 && cachedResult.content) {
-    odspCache.put(odspCacheKey, { content: cachedResult.content, timestamp: Date.now() });
+    odspCache.put(joinSessionKey, { content: cachedResult.content, timestamp: Date.now() });
     return cachedResult.content;
   }
   let socketStorageDiscovery: ISocketStorageDiscovery;
@@ -122,7 +121,7 @@ export async function getSocketStorageDiscovery(
     socketStorageDiscovery.tenantId = socketStorageDiscovery.runtimeTenantId;
   }
   // Never expire the joinsession result. On error, the delta connection will invalidate it.
-  odspCache.put(odspCacheKey, { content: socketStorageDiscovery, timestamp: Date.now() });
+  odspCache.put(joinSessionKey, { content: socketStorageDiscovery, timestamp: Date.now() });
 
   return socketStorageDiscovery;
 }

--- a/packages/drivers/odsp-socket-storage/src/odspCache.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspCache.ts
@@ -20,11 +20,17 @@ export class OdspCache {
         return val;
     }
 
-    public put(key: string, value: any, expiryTime: number) {
+    public remove(key: string) {
+        return this.odspCache.delete(key);
+    }
+
+    public put(key: string, value: any, expiryTime?: number) {
         assert(!this.odspCache.has(key), "Insertion rejected because cache already has that key!!");
         this.odspCache.set(key, value);
-        // tslint:disable-next-line: no-floating-promises
-        this.gc(key, expiryTime);
+        if (expiryTime) {
+            // tslint:disable-next-line: no-floating-promises
+            this.gc(key, expiryTime);
+        }
     }
 
     private async gc(key: string, expiryTime: number) {


### PR DESCRIPTION
For issue: https://github.com/microsoft/FluidFramework/issues/410
1.) If any error occurs during connection, we would invalidate the entry from cache for joinsession.
2.) There is an expiry time for joinsession result of 1 hour. Whenever we use the joinsession cached result successfully, we reset the expiry time for the cached result otherwise it is removed from cache.
3.) Remove 400 from socket error block list and add 406.