### PR TITLE
Merging AFD cache and telemetry changes

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentDeltaConnection.ts
@@ -47,7 +47,6 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
      * @param client - information about the client
      * @param mode - mode of the client
      * @param url - websocket URL
-     * @param url2 - alternate websocket URL
      * @param telemetryLogger - optional telemetry logger
      */
     public static async create(
@@ -58,10 +57,8 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
         client: IClient,
         mode: ConnectionMode,
         url: string,
-        url2?: string,
+        timeoutMs: number = 20000,
         telemetryLogger: ITelemetryLogger = new TelemetryNullLogger()): Promise<IDocumentDeltaConnection> {
-        // tslint:disable-next-line: strict-boolean-expressions
-        const hasUrl2 = !!url2;
 
         return this.createForUrlWithTimeout(
             tenantId,
@@ -71,33 +68,9 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
             client,
             url,
             mode,
-            hasUrl2 ? 15000 : 20000,
+            timeoutMs,
             telemetryLogger,
-        ).catch((error) => {
-            if (hasUrl2) {
-                if (error !== null && typeof error === "object" && error.canRetry) {
-                    debug(`Socket connection error on non-AFD URL. Error was [${error}]. Retry on AFD URL: ${url}`);
-                    telemetryLogger.sendTelemetryEvent({ eventName: "UseAfdUrl" });
-
-                    return this.createForUrlWithTimeout(
-                        tenantId,
-                        id,
-                        token,
-                        io,
-                        client,
-                        // tslint:disable-next-line: no-non-null-assertion
-                        url2!,
-                        mode,
-                        20000,
-                        telemetryLogger,
-                    );
-                }
-            }
-
-            telemetryLogger.sendTelemetryEvent({ eventName: "FailedAfdUrl" });
-
-            throw error;
-        });
+        );
     }
 
     // Map of all existing socket io sockets. [url, tenantId, documentId] -> socket

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
@@ -22,11 +22,11 @@ import { OdspDeltaStorageService } from "./OdspDeltaStorageService";
 import { OdspDocumentDeltaConnection } from "./OdspDocumentDeltaConnection";
 import { OdspDocumentStorageManager } from "./OdspDocumentStorageManager";
 import { OdspDocumentStorageService } from "./OdspDocumentStorageService";
+import { isLocalStorageAvailable } from "./OdspUtils";
 import { getSocketStorageDiscovery } from "./Vroom";
 
 const afdUrlConnectExpirationMs = 6 * 60 * 60 * 1000; // 6 hours
 const lastAfdConnectionTimeMsKey = "LastAfdConnectionTimeMs";
-const localStorageTestKey = "LocalStorageTestKey";
 
 /**
  * The DocumentService manages the Socket.IO connection and manages routing requests to connected
@@ -109,7 +109,7 @@ export class OdspDocumentService implements IDocumentService {
             ),
         );
 
-        this.localStorageAvailable = this.testLocalStorageAvailability();
+        this.localStorageAvailable = isLocalStorageAvailable();
     }
 
     /**
@@ -196,21 +196,6 @@ export class OdspDocumentService implements IDocumentService {
 
     public getErrorTrackingService(): IErrorTrackingService {
         return { track: () => null };
-    }
-
-    /**
-     * Tests if localStorage is usable.
-     * Should we move this outside to a library?
-     */
-    private testLocalStorageAvailability(): boolean {
-        try {
-            localStorage.setItem(localStorageTestKey, "v");
-            localStorage.removeItem(localStorageTestKey);
-            return true;
-        } catch (e) {
-            debug(`LocalStorage not available due to ${e}`);
-            return false;
-        }
     }
 
     /**

--- a/packages/drivers/odsp-socket-storage/src/OdspUtils.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspUtils.ts
@@ -6,6 +6,7 @@
 import { INetworkErrorProperties, NetworkError, throwNetworkError } from "@microsoft/fluid-core-utils";
 import { default as fetch, RequestInfo as FetchRequestInfo, RequestInit as FetchRequestInit } from "node-fetch";
 import { IOdspSocketError } from "./contracts";
+import { debug } from "./debug";
 
 /**
  * returns true when the request should/can be retried
@@ -103,4 +104,20 @@ export function errorObjectFromOdspError(socketError: IOdspSocketError) {
             [INetworkErrorProperties.retryAfterSeconds, socketError.retryAfter],
         ],
     );
+}
+
+/**
+ * Tests if localStorage is usable.
+ * Should we move this outside to a library?
+ */
+export function isLocalStorageAvailable(): boolean {
+    const localStorageTestKey = "LocalStorageTestKey";
+    try {
+        localStorage.setItem(localStorageTestKey, "v");
+        localStorage.removeItem(localStorageTestKey);
+        return true;
+    } catch (e) {
+        debug(`LocalStorage not available due to ${e}`);
+        return false;
+    }
 }

--- a/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
+++ b/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryLogger } from "@microsoft/fluid-container-definitions";
-import { BatchManager, INetworkErrorProperties, NetworkError, TelemetryNullLogger } from "@microsoft/fluid-core-utils";
+import { BatchManager, INetworkErrorProperties, NetworkError } from "@microsoft/fluid-core-utils";
 import {
     ConnectionMode,
     IClient,
@@ -48,16 +47,16 @@ export function createErrorObject(handler: string, error: any, canRetry = true) 
  */
 export class DocumentDeltaConnection extends EventEmitter implements IDocumentDeltaConnection {
     /**
-     * Create a DocumentDeltaConnection.
-     * If url #1 fails to connect, will try url #2 if applicable.
+     * Create a DocumentDeltaConnection
      *
      * @param tenantId - the ID of the tenant
      * @param id - document ID
      * @param token - authorization token for storage service
      * @param io - websocket library
      * @param client - information about the client
+     * @param mode - connection mode
      * @param url - websocket URL
-     * @param url2 - alternate websocket URL
+     * @param timeoutMs - timeout for socket connection attempt in milliseconds (default: 20000)
      */
     // tslint:disable-next-line: max-func-body-length
     public static async create(
@@ -68,72 +67,7 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
         client: IClient,
         mode: ConnectionMode,
         url: string,
-        url2?: string,
-        telemetryLogger?: ITelemetryLogger): Promise<IDocumentDeltaConnection> {
-            // tslint:disable-next-line: strict-boolean-expressions
-            const hasUrl2 = !!url2;
-
-            // Create null logger if telemetry logger is not available from caller
-            const logger = telemetryLogger ? telemetryLogger : new TelemetryNullLogger();
-
-            return this.createImpl(
-                tenantId,
-                id,
-                token,
-                io,
-                client,
-                url,
-                mode,
-                hasUrl2 ? 15000 : 20000,
-            // tslint:disable-next-line: promise-function-async
-            ).catch((error) => {
-                if (hasUrl2) {
-                    // tslint:disable-next-line: no-unsafe-any
-                    if (error !== null && typeof error === "object" && error.canRetry) {
-                        debug(`Socket connection error on non-AFD URL. Error was [${error}]. Retry on AFD URL: ${url}`);
-                        logger.sendTelemetryEvent({ eventName: "UseAfdUrl" });
-
-                        return this.createImpl(
-                            tenantId,
-                            id,
-                            token,
-                            io,
-                            client,
-                            // tslint:disable-next-line: no-non-null-assertion
-                            url2!,
-                            mode,
-                            20000,
-                        );
-                    }
-                }
-
-                logger.sendTelemetryEvent({ eventName: "FailedAfdUrl" });
-
-                throw error;
-            });
-    }
-
-    /**
-     * Create a DocumentDeltaConnection
-     *
-     * @param tenantId - the ID of the tenant
-     * @param id - document ID
-     * @param token - authorization token for storage service
-     * @param io - websocket library
-     * @param client - information about the client
-     * @param url - websocket URL
-     * @param timeoutMs - timeout for socket connection attempt in milliseconds
-     */
-    // tslint:disable-next-line: max-func-body-length
-    private static async createImpl(
-        tenantId: string,
-        id: string,
-        token: string | null,
-        io: SocketIOClientStatic,
-        client: IClient,
-        url: string,
-        mode: ConnectionMode,
-        timeoutMs: number): Promise<IDocumentDeltaConnection> {
+        timeoutMs: number = 20000): Promise<IDocumentDeltaConnection> {
 
         const socket = io(
             url,


### PR DESCRIPTION
(Starting over from https://github.com/microsoft/FluidFramework/pull/427)
@vladsud @GaryWilber 

Merging AFD cache and telemetry changes to master:

When AFD URL is used on retry, cache in localStorage and use AFD URL directly. (#308)
Improvement on telemetry for AFD URL (#387)
(Potentially speed up socket connection when the user has to fallback on AFD, as we don't need to try on the non-AFD URL first while cache is valid (potentially saving a socket connection timeout))
Merged with and removed AFD retry logic from changes in OdspDocumentDeltaConnection:

Multiplex socket.io connections (#281)
Delay socket disconnection to allow for smooth reconnects in odsp driver (#367)
Rewired OdspDocumentService to use OdspDocumentDeltaConnection.create instead of DocumentDeltaConnection.create.