### PR TITLE
WebFlow: Do not steal focus when updating caret position

### DIFF
--- a/packages/components/webflow/src/editor/caret.ts
+++ b/packages/components/webflow/src/editor/caret.ts
@@ -7,6 +7,7 @@ import { CaretEventType, Direction, Dom, getDeltaX, getDeltaY, ICaretEvent } fro
 import { LocalReference } from "@microsoft/fluid-merge-tree";
 import { DocSegmentKind, getDocSegmentKind } from "../document";
 import { clamp } from "../util";
+import { ownsNode } from "../util/event";
 import { updateRef } from "../util/localref";
 import { Tag } from "../util/tag";
 import { eotSegment, Layout } from "../view/layout";
@@ -92,6 +93,11 @@ export class Caret {
     }
 
     public sync() {
+        if (!ownsNode(this.layout.root as HTMLElement, document.activeElement)) {
+            debug("  Caret.sync() ignored -- Editor not focused.");
+            return;
+        }
+
         debug("  Caret.sync()");
         const { node: startNode, nodeOffset: startOffset } = this.positionToNodeOffset(this.startRef);
         const { node: endNode, nodeOffset: endOffset } = this.positionToNodeOffset(this.endRef);

--- a/packages/components/webflow/src/editor/editor.ts
+++ b/packages/components/webflow/src/editor/editor.ts
@@ -7,6 +7,7 @@ import { Caret as CaretUtil, Direction, getDeltaX, getDeltaY, KeyCode, Scheduler
 import { IComponent } from "@microsoft/fluid-component-core-interfaces";
 import { paste } from "../clipboard/paste";
 import { DocSegmentKind, FlowDocument, getDocSegmentKind } from "../document";
+import { ownsNode } from "../util/event";
 import { IFormatterState, RootFormatter } from "../view/formatter";
 import { Layout } from "../view/layout";
 import { Caret } from "./caret";
@@ -78,16 +79,7 @@ export class Editor {
     }
 
     private shouldHandleEvent(e: Event) {
-        const root = this.layout.root;
-        let target = e.target as HTMLElement;
-
-        while (target !== null && target !== root) {
-            if (target.classList.contains(styles.inclusion)) {
-                return false;
-            }
-            target = target.parentElement;
-        }
-        return target === root;
+        return ownsNode(this.root, e.target as Node);
     }
 
     private readonly onKeyDown = (e: KeyboardEvent) => {

--- a/packages/components/webflow/src/util/event.ts
+++ b/packages/components/webflow/src/util/event.ts
@@ -1,0 +1,16 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as styles from "../editor/index.css";
+
+export function ownsNode(root: HTMLElement, node: Node | HTMLElement) {
+    while (node !== null && node !== root) {
+        if ("classList" in node && node.classList.contains(styles.inclusion)) {
+            return false;
+        }
+        node = node.parentElement;
+    }
+    return node === root;
+}


### PR DESCRIPTION
Fixes a bug where layout may steal focus from the active element as a side effect of updating the DOM caret/selection.