### PR TITLE
Remove recursion from connectCore

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -522,7 +522,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         return versions[0];
     }
 
-    private connectToDeltaStream() {
+    private async connectToDeltaStream() {
         if (!this.connectionDetailsP) {
             this.connectionTransitionTimes[ConnectionState.Disconnected] = performanceNow();
             this.connectionDetailsP = this._deltaManager!.connect();

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -525,7 +525,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
     private connectToDeltaStream() {
         if (!this.connectionDetailsP) {
             this.connectionTransitionTimes[ConnectionState.Disconnected] = performanceNow();
-            this.connectionDetailsP = this._deltaManager!.connect("Document loading");
+            this.connectionDetailsP = this._deltaManager!.connect();
         }
         return this.connectionDetailsP;
     }

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -591,6 +591,8 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         let delay = InitialReconnectDelay;
         let connectRepeatCount = 0;
         const connectStartTime = performanceNow();
+
+        // This loop will keep trying to connect until successful, with a delay between each iteration.
         while (connection === undefined) {
             if (this.closed) {
                 return;
@@ -640,6 +642,11 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         this.setupNewSuccessfulConnection(connection);
     }
 
+    /**
+     * Once we've successfully gotten a DeltaConnection, we need to set up state, attach event listeners, and process
+     * initial messages.
+     * @param connection - the newly established connection
+     */
     private setupNewSuccessfulConnection(connection: DeltaConnection) {
         this.connection = connection;
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -286,16 +286,14 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
     public async connect(reason: string): Promise<IConnectionDetails> {
         assert(!this.closed);
 
-        if (this.connecting) {
-            assert(!this.connection);
-            return this.connecting.promise;
-        }
         if (this.connection) {
             return this.connection.details;
         }
 
-        this.connecting = new Deferred<IConnectionDetails>();
-        this.connectCore(reason, InitialReconnectDelay, this.connectionMode);
+        if (!this.connecting) {
+            this.connecting = new Deferred<IConnectionDetails>();
+            this.connectCore(reason, InitialReconnectDelay, this.connectionMode);
+        }
 
         return this.connecting.promise;
     }

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -26,7 +26,7 @@ describe("Loader", () => {
             const submitEvent = "test-submit";
 
             async function startDeltaManager() {
-                await deltaManager.connect("test");
+                await deltaManager.connect();
                 await deltaManager.inbound.resume();
                 await deltaManager.outbound.resume();
                 await deltaManager.inboundSignal.resume();


### PR DESCRIPTION
Current implementation of `connectCore` floats a new `connectCore` promise with a recursive call each time it fails to connect.  These floating promises are what necessitate the `connecting` Deferred and some of the various error handling paths, since there is otherwise no reference or error propagation path to hold onto for eventual completion of the connection.

This change does not attempt to remove the connecting deferred or alter error paths, but I believe it is a necessary prerequisite for doing so.  The immediate benefits of this change are to make the `connectCore` flow easier to follow, remove a couple members from `DeltaManager` and clean up some tslint exceptions (floating promise, async promise function, non-null assertion).