### PR TITLE
MergeTree: Do not insert extra node above root in `reloadFromSegments()`

### DIFF
--- a/packages/runtime/merge-tree/src/mergeTree.ts
+++ b/packages/runtime/merge-tree/src/mergeTree.ts
@@ -1401,21 +1401,8 @@ export class MergeTree {
             clockStart = clock();
         }
         if (segments.length > 0) {
-            const block = buildMergeBlock(segments);
-
-            // TODO: Why add another root node on top of the root returned by buildMergeBlock?
-            this.root = this.makeBlock(1);
-            this.root.assignChild(block, 0, false);
-            if (MergeTree.blockUpdateMarkers) {
-                const hierRoot = this.root.hierBlock();
-                hierRoot.addNodeReferences(this, block);
-            }
-            if (this.blockUpdateActions) {
-                this.blockUpdateActions.child(this.root, 0);
-            }
-
+            this.root = buildMergeBlock(segments);
             this.nodeUpdateOrdinals(this.root);
-            this.root.cachedLength = block.cachedLength;
         } else {
             this.root = this.makeBlock(0);
             this.root.cachedLength = 0;


### PR DESCRIPTION
I thought perhaps inserting an additional node above the root in `reloadFromSegments()` was an optimization, given that the tree is likely to grow to the right as the 'body' loads.

However, in an informal comparison of loading 'pp.txt', the differences are slight and the performance of inserting the extra node seems strictly worse.