### PR TITLE
fix some demo links

### DIFF
--- a/packages/server/gateway/views/demos/dec2017.hjs
+++ b/packages/server/gateway/views/demos/dec2017.hjs
@@ -14,20 +14,20 @@
 
             <h3>Routerlicious</h3>
             <ul class="list-unstyled">
-                <li><a href="/loader/fluid/{{sharedTextMoniker}}?chaincode=@chaincode/shared-text@{{version}}&spellchecking=disabled&template=pp.txt">Pride and Prejudice</a></li>
-                <li><a href="/loader/fluid/{{sharedTextPageInkMoniker}}?chaincode=@chaincode/shared-text@{{version}}&pageInk=true&template=pp.txt">Pride and Prejudice (page ink)</a></li>
+                <li><a href="/loader/fluid/{{sharedTextMoniker}}?chaincode=@fluid-example/shared-text@{{version}}&spellchecking=disabled&template=pp.txt">Pride and Prejudice</a></li>
+                <li><a href="/loader/fluid/{{sharedTextPageInkMoniker}}?chaincode=@fluid-example/shared-text@{{version}}&pageInk=true&template=pp.txt">Pride and Prejudice (page ink)</a></li>
                 <li><a href="http://prague-grafana.westus2.cloudapp.azure.com/dashboard/db/latency-summary">Performance Metrics</a></li>
-                <li><a href="/loader/fluid/{{canvasMoniker}}?chaincode=@chaincode/canvas@{{version}}">Ink</a></li>
+                <li><a href="/loader/fluid/{{canvasMoniker}}?chaincode=@fluid-example/canvas@{{version}}">Ink</a></li>
             </ul>
 
             <h3>Intelligent Services</h3>
             <ul class="list-unstyled">
-                <li><a href="/loader/fluid/{{scribeMoniker}}?chaincode=@chaincode/scribe@{{version}}">Scribe</a></li>
+                <li><a href="/loader/fluid/{{scribeMoniker}}?chaincode=@fluid-example/scribe@{{version}}">Scribe</a></li>
             </ul>
 
             <h3>Versioning and Branching</h3>
             <ul class="list-unstyled">
-                <li><a href="/loader/fluid/{{emptyMoniker}}?chaincode=@chaincode/shared-text@{{version}}">Starter Document</a></li>
+                <li><a href="/loader/fluid/{{emptyMoniker}}?chaincode=@fluid-example/shared-text@{{version}}">Starter Document</a></li>
             </ul>
 
             <h3>Distributed Data Type Apps (DEPRECATED)</h3>

--- a/packages/server/gateway/views/demos/fall2018.hjs
+++ b/packages/server/gateway/views/demos/fall2018.hjs
@@ -16,7 +16,7 @@
             </p>
             <h3>Demo</h3>
             <ul class="list-unstyled">
-                <li><a href="/loader/fluid/{{componentsMoniker}}?chaincode=@chaincode/shared-text@{{version}}&template=pp.txt" target="_blank">Prague Pride and Prejudice</a></li>
+                <li><a href="/loader/fluid/{{componentsMoniker}}?chaincode=@fluid-example/shared-text@{{version}}&template=pp.txt" target="_blank">Prague Pride and Prejudice</a></li>
             </ul>
 
             <p>
@@ -56,7 +56,7 @@
             <h4>Pinpoint Maps</h4>
             <ul class="list-unstyled">
                 <li><a href="https://www.wsj.com/articles/when-napoleon-met-his-waterloo-he-was-out-of-town-1433894903" target="_blank">WSJ Article</a></li>
-                <li><a href="/loader/fluid/{{napoleonMoniker}}?chaincode=@chaincode/shared-text@{{version}}&template=napoleon.txt" target="_blank">Prague Starter Article</a></li>
+                <li><a href="/loader/fluid/{{napoleonMoniker}}?chaincode=@fluid-example/shared-text@{{version}}&template=napoleon.txt" target="_blank">Prague Starter Article</a></li>
                 <li><a href="/loader/fluid/{{pinpointMoniker}}?chaincode=@chaincode/pinpoint-editor@0.6.15" target="_blank">Pinpoint Editor</a></li>
             </ul>
             <p>
@@ -134,7 +134,7 @@
                 The Monaco code editor is also available as a Prague document.
             </p>
             <ul class="list-unstyled">
-                <li><a href="/loader/fluid/{{monacoMoniker}}?chaincode=@chaincode/monaco@{{version}}" target="_blank">Monaco</a></li>
+                <li><a href="/loader/fluid/{{monacoMoniker}}?chaincode=@fluid-example/monaco@{{version}}" target="_blank">Monaco</a></li>
             </ul>
 
             <h2>SharePoint (DEPRECATED)</h2>

--- a/packages/server/gateway/views/demos/retreat.hjs
+++ b/packages/server/gateway/views/demos/retreat.hjs
@@ -22,7 +22,7 @@
 
             <ul class="list-unstyled">
                 <li><a href="https://docs.google.com/document/d/1Ed3_Bgmfj4L1tvjjh8geSHNZMbh_X6SaRd1uZGSQSio/edit" target="_blank">Google Docs Pride and Prejudice</a></li>
-                <li><a href="/loader/fluid/{{sharedTextMoniker}}?chaincode=@chaincode/shared-text@{{version}}&template=pp.txt" target="_blank">Prague Pride and Prejudice</a></li>
+                <li><a href="/loader/fluid/{{sharedTextMoniker}}?chaincode=@fluid-example/shared-text@{{version}}&template=pp.txt" target="_blank">Prague Pride and Prejudice</a></li>
             </ul>
 
             <h2>Augmentation Loop</h2>
@@ -36,8 +36,8 @@
                 Open one link in the left browser and the other in the right. Ctrl+B will bold text and Ctrl+U will underline.
             </p>
             <ul class="list-unstyled">
-                <li><a href="/loader/fluid/{{translateMoniker}}?chaincode=@chaincode/shared-text@{{version}}&languageFrom=en&languageTo=el" target="_blank">Greek</a></li>
-                <li><a href="/loader/fluid/{{translateMoniker}}?chaincode=@chaincode/shared-text@{{version}}&languageFrom=en&languageTo=es" target="_blank">Spanish</a></li>
+                <li><a href="/loader/fluid/{{translateMoniker}}?chaincode=@fluid-example/shared-text@{{version}}&languageFrom=en&languageTo=el" target="_blank">Greek</a></li>
+                <li><a href="/loader/fluid/{{translateMoniker}}?chaincode=@fluid-example/shared-text@{{version}}&languageFrom=en&languageTo=es" target="_blank">Spanish</a></li>
             </ul>
 
             <h3>Automatic</h3>
@@ -47,7 +47,7 @@
                 otherwise the browser may stop it from running JavaScript which will pause the demo.
             </p>
             <ul class="list-unstyled">
-                <li><a href="/loader/fluid/{{scribeMoniker}}?chaincode=@chaincode/scribe@{{version}}&language=el,es&speed=100&text=/public/literature/translate-demo.txt" target="_blank">Scribe</a></li>
+                <li><a href="/loader/fluid/{{scribeMoniker}}?chaincode=@fluid-example/scribe@{{version}}&language=el,es&speed=100&text=/public/literature/translate-demo.txt" target="_blank">Scribe</a></li>
             </ul>
 
             <h2>Feature Differentiation</h2>
@@ -71,7 +71,7 @@
             </p>
 
             <ul class="list-unstyled">
-                <li><a href="/loader/fluid/{{emptyMoniker}}?chaincode=@chaincode/shared-text@{{version}}" target="_blank">Starter Document</a></li>
+                <li><a href="/loader/fluid/{{emptyMoniker}}?chaincode=@fluid-example/shared-text@{{version}}" target="_blank">Starter Document</a></li>
             </ul>
         </div>
 

--- a/packages/server/gateway/views/demos/spring2019.hjs
+++ b/packages/server/gateway/views/demos/spring2019.hjs
@@ -112,7 +112,7 @@ function getRandomValues(length: number): number[] {
 
 
     <h3>Inking Canvas</h3>
-    <li class="list-unstyled"><a href="/loader/fluid/{{inkMoniker}}?chaincode=@chaincode/canvas@{{version}}" target="_blank">Canvas Chaincode</a></li>
+    <li class="list-unstyled"><a href="/loader/fluid/{{inkMoniker}}?chaincode=@fluid-example/canvas@{{version}}" target="_blank">Canvas Chaincode</a></li>
 </div>
 
 {{/content}}

--- a/packages/server/gateway/views/demos/winter2019.hjs
+++ b/packages/server/gateway/views/demos/winter2019.hjs
@@ -18,7 +18,7 @@
 
     <h3>Data, Code, Components Bindings</h3>
     <p>Open the link below and add in a Monaco and Chart Component</p>
-    <li class="list-unstyled"><a href="/loader/fluid/{{chartMonacoMoniker}}?chaincode=@chaincode/shared-text@{{version}}" target="_blank">Data +
+    <li class="list-unstyled"><a href="/loader/fluid/{{chartMonacoMoniker}}?chaincode=@fluid-example/shared-text@{{version}}" target="_blank">Data +
             Code Bindings</a></li>
 
     <h3>Yo Fluid - Bootstrapper</h3>
@@ -47,7 +47,7 @@
     <ul class="list-unstyled">
         <li><a href="https://docs.google.com/document/d/1Ed3_Bgmfj4L1tvjjh8geSHNZMbh_X6SaRd1uZGSQSio/edit"
                 target="_blank">Google Docs Pride and Prejudice</a></li>
-        <li><a href="/loader/fluid/{{sharedTextMoniker}}?chaincode=@chaincode/shared-text@{{version}}&template=pp.txt" target="_blank">Prague Pride and Prejudice</a></li>
+        <li><a href="/loader/fluid/{{sharedTextMoniker}}?chaincode=@fluid-example/shared-text@{{version}}&template=pp.txt" target="_blank">Prague Pride and Prejudice</a></li>
     </ul>
 
     <h2>Augmentation Loop</h2>
@@ -60,7 +60,7 @@
         otherwise the browser may stop it from running JavaScript which will pause the demo.
     </p>
     <ul class="list-unstyled">
-        <li><a href="/loader/fluid/{{scribeMoniker}}?chaincode=@chaincode/scribe@{{version}}&speed=10&text=/public/literature/resume.txt" target="_blank">Scribe</a></li>
+        <li><a href="/loader/fluid/{{scribeMoniker}}?chaincode=@fluid-example/scribe@{{version}}&speed=10&text=/public/literature/resume.txt" target="_blank">Scribe</a></li>
     </ul>
 
     <h3>Augmentation</h3>
@@ -69,16 +69,16 @@
         underline.
     </p>
     <ul class="list-unstyled">
-        <li><a href="/loader/fluid/{{translateMoniker}}?chaincode=@chaincode/shared-text@{{version}}&languageFrom=en&languageTo=el"
+        <li><a href="/loader/fluid/{{translateMoniker}}?chaincode=@fluid-example/shared-text@{{version}}&languageFrom=en&languageTo=el"
                 target="_blank">Greek</a></li>
-        <li><a href="/loader/fluid/{{translateMoniker}}?chaincode=@chaincode/shared-text@{{version}}&languageFrom=en&languageTo=es"
+        <li><a href="/loader/fluid/{{translateMoniker}}?chaincode=@fluid-example/shared-text@{{version}}&languageFrom=en&languageTo=es"
                 target="_blank">Spanish</a></li>
     </ul>
 
     <h2>Performance</h2>
 
     <h3>Inking Canvas</h3>
-    <li class="list-unstyled"><a href="/loader/fluid/{{inkMoniker}}?chaincode=@chaincode/canvas@{{version}}"
+    <li class="list-unstyled"><a href="/loader/fluid/{{inkMoniker}}?chaincode=@fluid-example/canvas@{{version}}"
             target="_blank">Canvas Chaincode</a></li>
 
     <h3>Fast Load</h3>


### PR DESCRIPTION
Fix some demo `@chaincode` links that are pinned to current version (which doesn't exist for `@chaincode` packages)