### PR TITLE
Use performance-now package in odsp driver

### DIFF
--- a/packages/drivers/odsp-socket-storage/package.json
+++ b/packages/drivers/odsp-socket-storage/package.json
@@ -32,6 +32,7 @@
     "@microsoft/fluid-protocol-definitions": "^0.11.0",
     "debug": "^4.1.1",
     "node-fetch": "^2.2.1",
+    "performance-now": "^2.1.0",
     "sha.js": "^2.4.11",
     "socket.io-client": "^2.1.1"
   },

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
@@ -25,7 +25,7 @@ import { OdspDocumentStorageService } from "./OdspDocumentStorageService";
 import { isLocalStorageAvailable } from "./OdspUtils";
 import { getSocketStorageDiscovery } from "./Vroom";
 
-// tslint:disable-next-line:no-var-requires
+// tslint:disable-next-line:no-require-imports no-var-requires
 const performanceNow = require("performance-now") as (() => number);
 
 const afdUrlConnectExpirationMs = 6 * 60 * 60 * 1000; // 6 hours

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
@@ -25,6 +25,9 @@ import { OdspDocumentStorageService } from "./OdspDocumentStorageService";
 import { isLocalStorageAvailable } from "./OdspUtils";
 import { getSocketStorageDiscovery } from "./Vroom";
 
+// tslint:disable-next-line:no-var-requires
+const performanceNow = require("performance-now") as (() => number);
+
 const afdUrlConnectExpirationMs = 6 * 60 * 60 * 1000; // 6 hours
 const lastAfdConnectionTimeMsKey = "LastAfdConnectionTimeMs";
 
@@ -282,7 +285,7 @@ export class OdspDocumentService implements IDocumentService {
             // Use AFD URL if in cache
             if (afdCacheValid && hasUrl2) {
                 debug("Connecting to AFD URL directly due to valid cache.");
-                const startAfd = performance.now();
+                const startAfd = performanceNow();
 
                 return OdspDocumentDeltaConnection.create(
                     tenantId,
@@ -303,7 +306,7 @@ export class OdspDocumentService implements IDocumentService {
 
                     return connection;
                 }).catch((connectionError) => {
-                    const endAfd = performance.now();
+                    const endAfd = performanceNow();
                     localStorage.removeItem(lastAfdConnectionTimeMsKey);
                     // Retry on non-AFD URL
                     if (this.canRetryOnError(connectionError)) {
@@ -342,7 +345,7 @@ export class OdspDocumentService implements IDocumentService {
                 });
             }
 
-            const startNonAfd = performance.now();
+            const startNonAfd = performanceNow();
             return OdspDocumentDeltaConnection.create(
                 tenantId,
                 websocketId,
@@ -357,7 +360,7 @@ export class OdspDocumentService implements IDocumentService {
                 logger.sendTelemetryEvent({ eventName: "UsedNonAfdUrl" });
                 return connection;
             }).catch((connectionError) => {
-                const endNonAfd = performance.now();
+                const endNonAfd = performanceNow();
                 if (hasUrl2 && this.canRetryOnError(connectionError)) {
                     debug(`Socket connection error on non-AFD URL. Error was [${connectionError}]. Retry on AFD URL: ${url2}`);
 


### PR DESCRIPTION
`performance.now()` doesn't work from node.js