### PR TITLE
Component Factory Inversion Pattern

### DIFF
--- a/packages/components/pond/package.json
+++ b/packages/components/pond/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@microsoft/fluid-aqueduct": "^0.12.0",
     "@microsoft/fluid-component-core-interfaces": "^0.12.0",
+    "@microsoft/fluid-component-runtime": "^0.12.0",
     "@microsoft/fluid-map": "^0.12.0",
     "@microsoft/fluid-runtime-definitions": "^0.12.0",
     "react": "^16.8.3",

--- a/packages/components/pond/src/index.tsx
+++ b/packages/components/pond/src/index.tsx
@@ -57,6 +57,22 @@ export class Pond extends PrimedComponent implements IComponentHTMLVisual {
   }
 
   protected async componentHasInitialized() {
+    const factoryRequest = {
+      url: "/_registry",
+      headers: {
+        pkg: ClickerName,
+      },
+    };
+    const factory = await this.context.hostRuntime.request(factoryRequest);
+    if (factory.status === 200) {
+      alert("factory");
+      // const f = (factory.value as IComponent).IComponentCreator;
+      // if (f) {
+      //   const c = await f.createComponent(this.context) as Clicker;
+      //   this.root.set(this.clickerKey, c.handle);
+      // }
+    }
+
     const clicker2 = await this.root.get<IComponentHandle>(this.clickerKey).get<IComponent>();
     this.clicker2Render = clicker2.IComponentHTMLVisual;
 
@@ -129,4 +145,6 @@ export const fluidExport = new SimpleModuleInstantiationFactory(
   PondName,
   new Map([
     [PondName, Promise.resolve(Pond.getFactory())],
+    // TODO: only here because we don't know how to do sub-registry lookup
+    [ClickerName, Promise.resolve(Clicker.getFactory())],
   ]));

--- a/packages/components/pond/src/index.tsx
+++ b/packages/components/pond/src/index.tsx
@@ -40,7 +40,24 @@ export class Pond extends PrimedComponent implements IComponentHTMLVisual {
    * Do setup work here
    */
   protected async componentInitializingFirstTime() {
-    await this.createSubComponent<Clicker>(this.clickerKey, ClickerName);
+    // await this.createSubComponent<Clicker>(this.clickerKey, ClickerName);
+    // ...replaced with
+    const factoryRequest = {
+      url: "/_registry",
+      headers: {
+        pkg: ClickerName,
+      },
+    };
+    const factory = await this.context.hostRuntime.request(factoryRequest);
+    if (factory.status === 200) {
+      alert("factory");
+      const f = (factory.value as IComponent).IComponentCreator;
+      if (f) {
+        const c = await f.createComponent(this.context) as Clicker;
+        this.root.set(this.clickerKey, c.handle);
+      }
+    }
+
     await this.createSubComponent<ClickerWithInitialValue>(
       this.clickerWithInitialValueKey,
       ClickerWithInitialValueName,
@@ -57,22 +74,6 @@ export class Pond extends PrimedComponent implements IComponentHTMLVisual {
   }
 
   protected async componentHasInitialized() {
-    const factoryRequest = {
-      url: "/_registry",
-      headers: {
-        pkg: ClickerName,
-      },
-    };
-    const factory = await this.context.hostRuntime.request(factoryRequest);
-    if (factory.status === 200) {
-      alert("factory");
-      // const f = (factory.value as IComponent).IComponentCreator;
-      // if (f) {
-      //   const c = await f.createComponent(this.context) as Clicker;
-      //   this.root.set(this.clickerKey, c.handle);
-      // }
-    }
-
     const clicker2 = await this.root.get<IComponentHandle>(this.clickerKey).get<IComponent>();
     this.clicker2Render = clicker2.IComponentHTMLVisual;
 

--- a/packages/components/pond/src/index.tsx
+++ b/packages/components/pond/src/index.tsx
@@ -42,16 +42,22 @@ export class Pond extends PrimedComponent implements IComponentHTMLVisual {
   protected async componentInitializingFirstTime() {
     // await this.createSubComponent<Clicker>(this.clickerKey, ClickerName);
     // ...replaced with
+
+    // craft the factory request
     const factoryRequest = {
       url: "/_registry",
       headers: {
         pkg: ClickerName,
       },
     };
+
+    // request the factory
     const factory = await this.context.hostRuntime.request(factoryRequest);
     if (factory.status === 200) {
+      // If the factory exist we'll see if it supports component creator pattern
       const f = (factory.value as IComponent).IComponentCreator;
       if (f) {
+        // If it support the pattern we will create the component and set it to the root as a handle
         const c = await f.createComponent(this.context) as Clicker;
         this.root.set(this.clickerKey, c.handle);
       }

--- a/packages/components/pond/src/index.tsx
+++ b/packages/components/pond/src/index.tsx
@@ -50,7 +50,6 @@ export class Pond extends PrimedComponent implements IComponentHTMLVisual {
     };
     const factory = await this.context.hostRuntime.request(factoryRequest);
     if (factory.status === 200) {
-      alert("factory");
       const f = (factory.value as IComponent).IComponentCreator;
       if (f) {
         const c = await f.createComponent(this.context) as Clicker;
@@ -58,11 +57,26 @@ export class Pond extends PrimedComponent implements IComponentHTMLVisual {
       }
     }
 
-    await this.createSubComponent<ClickerWithInitialValue>(
-      this.clickerWithInitialValueKey,
-      ClickerWithInitialValueName,
-      { initialValue: 100 },
-    );
+    // await this.createSubComponent<ClickerWithInitialValue>(
+    //   this.clickerWithInitialValueKey,
+    //   ClickerWithInitialValueName,
+    //   { initialValue: 100 },
+    // );
+    // ...replaced with
+    const factoryRequest2 = {
+      url: "/_registry",
+      headers: {
+        pkg: ClickerWithInitialValueName,
+      },
+    };
+    const factory2 = await this.context.hostRuntime.request(factoryRequest2);
+    if (factory2.status === 200) {
+      const f = (factory2.value as IComponent).IComponentClickerWithInitialValueCreator;
+      if (f) {
+        const c = await f.createClickerComponent({initialValue: 100}, this.context) as Clicker;
+        this.root.set(this.clickerWithInitialValueKey, c.handle);
+      }
+    }
   }
 
   async createSubComponent<T extends PrimedComponent>(rootKey: string, pkgName: string, props?: any) {
@@ -148,4 +162,5 @@ export const fluidExport = new SimpleModuleInstantiationFactory(
     [PondName, Promise.resolve(Pond.getFactory())],
     // TODO: only here because we don't know how to do sub-registry lookup
     [ClickerName, Promise.resolve(Clicker.getFactory())],
+    [ClickerWithInitialValueName, Promise.resolve(ClickerWithInitialValue.getFactory())],
   ]));

--- a/packages/framework/aqueduct/src/helpers/sharedComponentFactory.ts
+++ b/packages/framework/aqueduct/src/helpers/sharedComponentFactory.ts
@@ -3,14 +3,35 @@
  * Licensed under the MIT License.
  */
 
-import { IRequest } from "@microsoft/fluid-component-core-interfaces";
+import { IComponent, IRequest } from "@microsoft/fluid-component-core-interfaces";
 import { ComponentRuntime, ISharedObjectRegistry } from "@microsoft/fluid-component-runtime";
 import { ComponentRegistry } from "@microsoft/fluid-container-runtime";
 import { IComponentContext, IComponentFactory, IComponentRegistry, IComponentRuntime, IProvideComponentRegistry, NamedComponentRegistryEntries } from "@microsoft/fluid-runtime-definitions";
 import { ISharedObjectFactory } from "@microsoft/fluid-shared-object-base";
 import { SharedComponent } from "../components/sharedComponent";
 
-export class SharedComponentFactory implements IComponentFactory, Partial<IProvideComponentRegistry>  {
+declare module "@microsoft/fluid-component-core-interfaces" {
+    export interface IComponent extends Readonly<Partial<IProvideComponentCreator>> {
+    }
+}
+
+export interface IProvideComponentCreator {
+    readonly IComponentCreator: IComponentCreator;
+}
+
+/**
+ * A component that implements a collection of components.  Typically, the
+ * components in the collection would be like-typed.
+ */
+export interface IComponentCreator extends IProvideComponentCreator {
+    createComponent(context: IComponentContext): Promise<IComponent>;
+}
+
+export class SharedComponentFactory implements IComponentFactory, Partial<IProvideComponentRegistry> {
+
+    // TODO: This is here for now but should be piped through.
+    public registryName: string = "";
+
     private readonly sharedObjectRegistry: ISharedObjectRegistry;
     private readonly registry: IComponentRegistry | undefined;
 

--- a/packages/framework/aqueduct/src/helpers/sharedComponentFactory.ts
+++ b/packages/framework/aqueduct/src/helpers/sharedComponentFactory.ts
@@ -32,7 +32,7 @@ export class SharedComponentFactory implements IComponentFactory, Partial<IProvi
     // TODO: This is here for now but should be piped through.
     public registryName: string = "";
 
-    private readonly sharedObjectRegistry: ISharedObjectRegistry;
+    public readonly sharedObjectRegistry: ISharedObjectRegistry;
     private readonly registry: IComponentRegistry | undefined;
 
     constructor(

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -74,6 +74,7 @@ import { DocumentStorageServiceProxy } from "./documentStorageServiceProxy";
 import {
     componentRuntimeRequestHandler,
     createLoadableComponentRuntimeRequestHandler,
+    createRegistryRoutingRequestHandler,
     RuntimeRequestHandler,
 } from "./requestHandlers";
 import { RequestParser } from "./requestParser";
@@ -379,6 +380,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         runtime.requestHandler = new RuntimeRequestHandlerBuilder();
         runtime.requestHandler.pushHandler(
             createLoadableComponentRuntimeRequestHandler(runtime.summarizer),
+            createRegistryRoutingRequestHandler(componentRegistry),
             schedulerRuntimeRequestHandler,
             ...requestHandlers);
 

--- a/packages/runtime/container-runtime/src/requestHandlers.ts
+++ b/packages/runtime/container-runtime/src/requestHandlers.ts
@@ -87,7 +87,7 @@ export function createRegistryRoutingRequestHandler(registry: IComponentRegistry
             if (factory) {
                 // If the response is an IFactory we need to update the registry name to reflect this registry entry
                 const iFactory = (factory as IComponent).IComponentFactory;
-                if (iFactory && iFactory.registryName && iFactory.registryName !== pkg) {
+                if (iFactory && iFactory.hasOwnProperty("registryName") && iFactory.registryName !== pkg) {
                     iFactory.registryName = pkg;
                 }
                 return { status: 200, mimeType: "fluid/component", value: factory };

--- a/packages/runtime/container-runtime/src/test/componentContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/componentContext.spec.ts
@@ -41,7 +41,7 @@ describe("Component Context Tests", () => {
                 new LocalComponentContext("Test1", ["TestComponent1"], containerRuntime, storage, scope, attachCb);
 
             // tslint:disable-next-line: no-floating-promises
-            localComponentContext.realize();
+            localComponentContext.realizeFromRegistry();
             localComponentContext.bindRuntime(new MockRuntime());
             const attachMessage = localComponentContext.generateAttachMessage();
 
@@ -66,7 +66,7 @@ describe("Component Context Tests", () => {
             localComponentContext =
                 new LocalComponentContext("Test1", ["TestComp", "SubComp"], containerRuntime, storage, scope, attachCb);
 
-            await localComponentContext.realize()
+            await localComponentContext.realizeFromRegistry()
             .catch((error) => {
                 exception = true;
             });
@@ -85,7 +85,7 @@ describe("Component Context Tests", () => {
                 new LocalComponentContext("Test1", ["TestComp", "SubComp"], containerRuntime, storage, scope, attachCb);
 
             // tslint:disable-next-line: no-floating-promises
-            localComponentContext.realize();
+            localComponentContext.realizeFromRegistry();
             localComponentContext.bindRuntime(new MockRuntime());
 
             const attachMessage = localComponentContext.generateAttachMessage();

--- a/packages/runtime/runtime-definitions/src/componentFactory.ts
+++ b/packages/runtime/runtime-definitions/src/componentFactory.ts
@@ -18,6 +18,13 @@ export interface IProvideComponentFactory {
  * The interface implemented by a component module.
  */
 export interface IComponentFactory extends IProvideComponentFactory {
+    
+    /**
+     * This is kinda hacky and basically provides a default registry name that we are allowed to override
+     * It's optional because I don't want to update every IComponentFactory atm
+     */
+    registryName?: string;
+    
     /**
      * Generates runtime for the component from the component context. Once created should be bound to the context.
      * @param context - Context for the component.

--- a/packages/runtime/runtime-definitions/src/components.ts
+++ b/packages/runtime/runtime-definitions/src/components.ts
@@ -359,6 +359,14 @@ export interface IHostRuntime extends
      */
     _createComponentWithProps(pkg: string | string[], props: any, id: string): Promise<IComponentRuntime>;
 
+    // /**
+    //  * Used for creating a component when you already have a factory
+    //  */
+    // createComponentDirect(
+    //     pkg: string,
+    //     creationFn: (context: IComponentContext) => void,
+    // ): Promise<IComponentRuntime>;
+
     /**
      * Returns the current quorum.
      */

--- a/packages/runtime/runtime-definitions/src/components.ts
+++ b/packages/runtime/runtime-definitions/src/components.ts
@@ -359,6 +359,14 @@ export interface IHostRuntime extends
      */
     _createComponentWithProps(pkg: string | string[], props: any, id: string): Promise<IComponentRuntime>;
 
+    /**
+     * Used for creating a component when you already have a factory
+     */
+    createComponentDirect(
+        pkg: string,
+        creationFn: (context: IComponentContext) => void,
+    ): Promise<IComponentRuntime>;
+
     // /**
     //  * Used for creating a component when you already have a factory
     //  */


### PR DESCRIPTION
This is a Draft PR as an initial proposal for factory inversion. Since this changes component loading I updated the pond as my simple component loading playground.

I plan on working through some of the hiccups but wanted to share my initial thoughts.

Things I like:
- Factory get pattern enables easy get if you know the factory type
- Feels natural to get the factory and call create on it.
- Route request handler made it easy to interject a "_registry" route

Things I don't like:
- I don't like the `requestName` on the `IComponentFactory` but I also don't like the pattern of I ask the registry for `requestName` then have to provide `requestName` to the registry. It seems broken to me. Need to think about this a bit more.

Things I'm unsure of:
- Primarily supports global registry pattern. Sub-registry pattern isn't really flushed out. Similar to above I'm not sure how to reconcile who should provide the registryName and when. 
- Using headers for pkg name instead of path. We don't really use headers anywhere but we've been very, very, loose with what you can use as a registry name. Since we need to support non-url happy characters mainly `/` headers seems like a nicer fit.
