### PR TITLE
DeltaQueue pause flow updates

### DIFF
--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -139,6 +139,7 @@ export interface IDeltaQueue<T> extends EventEmitter, IDisposable {
 
     /**
      * Pauses processing on the queue
+     * @returns A promise which resolves when processing has been paused.
      */
     pause(): Promise<void>;
 
@@ -159,6 +160,7 @@ export interface IDeltaQueue<T> extends EventEmitter, IDisposable {
 
     /**
      * System level pause
+     * @returns A promise which resolves when processing has been paused.
      */
     systemPause(): Promise<void>;
 

--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -145,7 +145,7 @@ export interface IDeltaQueue<T> extends EventEmitter, IDisposable {
     /**
      * Resumes processing on the queue
      */
-    resume(): Promise<void>;
+    resume(): void;
 
     /**
      * Peeks at the next message in the queue
@@ -165,5 +165,5 @@ export interface IDeltaQueue<T> extends EventEmitter, IDisposable {
     /**
      * System level resume
      */
-    systemResume(): Promise<void>;
+    systemResume(): void;
 }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -363,7 +363,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
 
         } finally {
             if (this.deltaManager !== undefined) {
-                await this.deltaManager.inbound.systemResume();
+                this.deltaManager.inbound.systemResume();
             }
         }
     }
@@ -421,9 +421,8 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
 
         await this.loadContext(attributes, storage, snapshot);
 
-        await Promise.all([
-            this.deltaManager!.inbound.systemResume(),
-            this.deltaManager!.inboundSignal.systemResume()]);
+        this.deltaManager!.inbound.systemResume();
+        this.deltaManager!.inboundSignal.systemResume();
     }
 
     private async snapshotCore(tagMessage: string, fullTree: boolean = false) {

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -256,9 +256,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
 
         // We are ready to process inbound messages
         if (resume) {
-            // tslint:disable-next-line:no-floating-promises
             this._inbound.systemResume();
-            // tslint:disable-next-line:no-floating-promises
             this._inboundSignal.systemResume();
 
             // If we have pending ops from web socket, then we can use that to start download
@@ -655,7 +653,6 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
             return;
         }
 
-        // tslint:disable-next-line:no-floating-promises
         this._outbound.systemResume();
 
         this.clientSequenceNumber = 0;

--- a/packages/loader/container-loader/src/deltaQueue.ts
+++ b/packages/loader/container-loader/src/deltaQueue.ts
@@ -101,7 +101,6 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
                 }
 
                 this._paused = true;
-                this.emit("pause");
             } else {
                 if (this.pauseDeferred) {
                     this.pauseDeferred.reject(new Error("Resumed while waiting to pause"));
@@ -110,7 +109,6 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
 
                 this._paused = false;
                 this.processDeltas();
-                this.emit("resume");
             }
         }
 
@@ -124,7 +122,6 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
             // Get the next message in the queue, set processing flag in case we are reentrant.
             this.processing = true;
             const next = this.q.shift();
-            this.emit("pre-op", next);
 
             // Process the message.
             try {

--- a/packages/loader/container-loader/src/deltaQueue.ts
+++ b/packages/loader/container-loader/src/deltaQueue.ts
@@ -78,7 +78,7 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
         }
     }
 
-    public async resume(): Promise<void> {
+    public resume(): void {
         this.userPause = false;
         if (!this.paused) {
             this.ensureProcessing();
@@ -94,7 +94,7 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
         }
     }
 
-    public async systemResume(): Promise<void> {
+    public systemResume(): void {
         this.sysPause = false;
         if (!this.paused) {
             this.ensureProcessing();

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -27,9 +27,9 @@ describe("Loader", () => {
 
             async function startDeltaManager() {
                 await deltaManager.connect();
-                await deltaManager.inbound.resume();
-                await deltaManager.outbound.resume();
-                await deltaManager.inboundSignal.resume();
+                deltaManager.inbound.resume();
+                deltaManager.outbound.resume();
+                deltaManager.inboundSignal.resume();
                 deltaManager.updateQuorumJoin();
             }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -264,8 +264,6 @@ class ScheduleManager {
     public resume() {
         this.paused = false;
         if (!this.localPaused) {
-            // resume is only flipping the state but isn't concerned with the promise result
-            // tslint:disable-next-line:no-floating-promises
             this.deltaManager.inbound.systemResume();
         }
     }
@@ -277,12 +275,12 @@ class ScheduleManager {
         }
 
         this.localPaused = localPaused;
-        const promise = localPaused || this.paused
-            ? this.deltaManager.inbound.systemPause()
-            : this.deltaManager.inbound.systemResume();
-
-        // we do not care about "Resumed while waiting to pause" rejections.
-        promise.catch((err) => {});
+        if (localPaused || this.paused) {
+            // tslint:disable-next-line:no-floating-promises
+            this.deltaManager.inbound.systemPause();
+        } else {
+            this.deltaManager.inbound.systemResume();
+        }
     }
 
     private updatePauseState(sequenceNumber: number) {

--- a/packages/server/local-test-server/src/documentEventManager.ts
+++ b/packages/server/local-test-server/src/documentEventManager.ts
@@ -82,7 +82,7 @@ export class DocumentDeltaEventManager {
     public async processIncoming(...docs: IDocumentDeltaEvent[]): Promise<void> {
         const documents = await this.pauseAndValidateDocs(...docs);
         for (const doc of documents) {
-            await doc.deltaManager.inbound.resume();
+            doc.deltaManager.inbound.resume();
         }
         await this.yieldWhileDocumentsHaveWork(
             documents,
@@ -98,7 +98,7 @@ export class DocumentDeltaEventManager {
     public async processOutgoing(...docs: IDocumentDeltaEvent[]): Promise<void> {
         const documents = await this.pauseAndValidateDocs(...docs);
         for (const doc of documents) {
-            await doc.deltaManager.outbound.resume();
+            doc.deltaManager.outbound.resume();
         }
         await this.yieldWhileDocumentsHaveWork(
             documents,
@@ -169,6 +169,7 @@ export class DocumentDeltaEventManager {
     }
 
     private async resumeDocument(doc: IDocumentDeltaEvent) {
-        await Promise.all([doc.deltaManager.inbound.resume(), doc.deltaManager.outbound.resume()]);
+        doc.deltaManager.inbound.resume();
+        doc.deltaManager.outbound.resume();
     }
 }


### PR DESCRIPTION
This change does a few things:

1. Removes unused events from `DeltaQueue`.
2. Makes `resume` and `systemResume` sync, allowing for removal of some floating-promise exceptions.
3. Removes some redundant state-holding members that could have apparently-disagreeing state during some flows.
4. Ensures `processDeltas` reentrancy is not possible via public API surface (e.g. calling `push` from within `worker`).