### PR TITLE
Disabling summaries must be explicit, enable by default

### DIFF
--- a/packages/components/shared-text/src/index.ts
+++ b/packages/components/shared-text/src/index.ts
@@ -141,7 +141,7 @@ class SharedTextFactoryComponent implements IComponentFactory, IRuntimeFactory {
             { generateSummaries });
 
         // Registering for tasks to run in headless runner.
-        if (!generateSummaries) {
+        if (generateSummaries === false) {
             runtime.registerTasks(["snapshot", "spell", "translation", "cache"], "1.0");
             waitForFullConnection(runtime).then(() => {
                 // Call snapshot directly from runtime.

--- a/packages/framework/aqueduct/src/helpers/simpleContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/helpers/simpleContainerRuntimeFactory.ts
@@ -21,7 +21,7 @@ export class SimpleContainerRuntimeFactory {
         context: IContainerContext,
         chaincode: string,
         registryEntries: NamedComponentRegistryEntries,
-        generateSummaries: boolean = false,
+        generateSummaries: boolean = true,
         requestHandlers: RuntimeRequestHandler[] = [],
     ): Promise<ContainerRuntime> {
         // debug(`instantiateRuntime(chaincode=${chaincode},registry=${JSON.stringify(registry)})`);

--- a/packages/runtime/client-api/src/api/codeLoader.ts
+++ b/packages/runtime/client-api/src/api/codeLoader.ts
@@ -137,7 +137,7 @@ export class ChaincodeFactory implements IRuntimeFactory {
                 });
         }
 
-        if (!this.runtimeOptions.generateSummaries) {
+        if (this.runtimeOptions.generateSummaries === false) {
             runtime.registerTasks(["snapshot", "spell", "intel", "translation"]);
         }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -127,7 +127,7 @@ const DefaultSummaryConfiguration: ISummaryConfiguration = {
  */
 export interface IContainerRuntimeOptions {
     // Experimental flag that will generate summaries if connected to a service that supports them.
-    // Will eventually become the default and snapshots will be deprecated
+    // This defaults to true and must be explicitly set to false to disable.
     generateSummaries: boolean;
 
     // Experimental flag that will execute tasks in web worker if connected to a service that supports them.
@@ -533,7 +533,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         private readonly context: IContainerContext,
         private readonly registry: IComponentRegistry,
         readonly chunks: [string, string[]][],
-        private readonly runtimeOptions: IContainerRuntimeOptions = { generateSummaries: false, enableWorker: false },
+        private readonly runtimeOptions: IContainerRuntimeOptions = { generateSummaries: true, enableWorker: false },
     ) {
         super();
 
@@ -605,7 +605,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         // Create the SummaryManager and mark the initial state
         this.summaryManager = new SummaryManager(
             context,
-            this.runtimeOptions.generateSummaries || this.loadedFromSummary,
+            this.runtimeOptions.generateSummaries !== false || this.loadedFromSummary,
             this.runtimeOptions.enableWorker,
             this.logger);
         if (this.context.connectionState === ConnectionState.Connected) {


### PR DESCRIPTION
Change runtime options to default to true for generate summaries.
Change logic checking this option to explicitly look for false when checking if disabled.

Did not change end-to-end tests or replay tool, those are still setting to false.