### PR TITLE
Disabling summaries must be explicit, enable by default [0.11]

### DIFF
--- a/packages/components/shared-text/src/index.ts
+++ b/packages/components/shared-text/src/index.ts
@@ -131,8 +131,7 @@ class SharedTextFactoryComponent implements IComponentFactory, IRuntimeFactory {
                     Promise.resolve(new MyRegistry(context, "https://pragueauspkn-3873244262.azureedge.net")),
                 ],
             ],
-            [SharedTextFactoryComponent.containerRequestHandler],
-            { generateSummaries: true });
+            [SharedTextFactoryComponent.containerRequestHandler]);
 
         // On first boot create the base component
         if (!runtime.existing) {

--- a/packages/components/shared-text/src/index.ts
+++ b/packages/components/shared-text/src/index.ts
@@ -125,8 +125,6 @@ class SharedTextFactoryComponent implements IComponentFactory, IRuntimeFactory {
      * Instantiates a new chaincode host
      */
     public async instantiateRuntime(context: IContainerContext): Promise<IRuntime> {
-        const generateSummaries = true;
-
         const runtime = await ContainerRuntime.load(
             context,
             [
@@ -138,19 +136,7 @@ class SharedTextFactoryComponent implements IComponentFactory, IRuntimeFactory {
                 ],
             ],
             [SharedTextFactoryComponent.containerRequestHandler],
-            { generateSummaries });
-
-        // Registering for tasks to run in headless runner.
-        if (generateSummaries === false) {
-            runtime.registerTasks(["snapshot", "spell", "translation", "cache"], "1.0");
-            waitForFullConnection(runtime).then(() => {
-                // Call snapshot directly from runtime.
-                if (runtime.clientType === "snapshot") {
-                    console.log(`@fluid-example/shared-text running ${runtime.clientType}`);
-                    Snapshotter.run(runtime);
-                }
-            });
-        }
+            { generateSummaries: true });
 
         // On first boot create the base component
         if (!runtime.existing) {

--- a/packages/components/shared-text/src/index.ts
+++ b/packages/components/shared-text/src/index.ts
@@ -141,7 +141,7 @@ class SharedTextFactoryComponent implements IComponentFactory, IRuntimeFactory {
             { generateSummaries });
 
         // Registering for tasks to run in headless runner.
-        if (!generateSummaries) {
+        if (generateSummaries === false) {
             runtime.registerTasks(["snapshot", "spell", "translation", "cache"], "1.0");
             waitForFullConnection(runtime).then(() => {
                 // Call snapshot directly from runtime.

--- a/packages/components/shared-text/src/index.ts
+++ b/packages/components/shared-text/src/index.ts
@@ -7,8 +7,6 @@
 // tslint:disable-next-line:no-import-side-effect
 import "./publicpath";
 
-// import { SharedString } from "@prague/sequence";
-import * as Snapshotter from "@fluid-example/snapshotter-agent";
 import { IRequest } from "@microsoft/fluid-component-core-interfaces";
 import { IContainerContext, IRuntime, IRuntimeFactory } from "@microsoft/fluid-container-definitions";
 import { ContainerRuntime } from "@microsoft/fluid-container-runtime";
@@ -20,8 +18,6 @@ import {
     NamedComponentRegistryEntries,
 } from "@microsoft/fluid-runtime-definitions";
 import * as sharedTextComponent from "./component";
-// import { GraphIQLView } from "./graphql";
-import { waitForFullConnection } from "./utils";
 
 const math = import(/* webpackChunkName: "math", webpackPrefetch: true */ "@fluid-example/math");
 // const monaco = import(/* webpackChunkName: "monaco", webpackPrefetch: true */ "@fluid-example/monaco");

--- a/packages/framework/aqueduct/src/helpers/simpleContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/helpers/simpleContainerRuntimeFactory.ts
@@ -21,7 +21,7 @@ export class SimpleContainerRuntimeFactory {
         context: IContainerContext,
         chaincode: string,
         registryEntries: NamedComponentRegistryEntries,
-        generateSummaries: boolean = false,
+        generateSummaries: boolean = true,
         requestHandlers: RuntimeRequestHandler[] = [],
     ): Promise<ContainerRuntime> {
         // debug(`instantiateRuntime(chaincode=${chaincode},registry=${JSON.stringify(registry)})`);

--- a/packages/runtime/client-api/src/api/codeLoader.ts
+++ b/packages/runtime/client-api/src/api/codeLoader.ts
@@ -137,10 +137,6 @@ export class ChaincodeFactory implements IRuntimeFactory {
                 });
         }
 
-        if (this.runtimeOptions.generateSummaries === false) {
-            runtime.registerTasks(["snapshot", "spell", "intel", "translation"]);
-        }
-
         return runtime;
     }
 }

--- a/packages/runtime/client-api/src/api/codeLoader.ts
+++ b/packages/runtime/client-api/src/api/codeLoader.ts
@@ -137,7 +137,7 @@ export class ChaincodeFactory implements IRuntimeFactory {
                 });
         }
 
-        if (!this.runtimeOptions.generateSummaries) {
+        if (this.runtimeOptions.generateSummaries === false) {
             runtime.registerTasks(["snapshot", "spell", "intel", "translation"]);
         }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -127,7 +127,7 @@ const DefaultSummaryConfiguration: ISummaryConfiguration = {
  */
 export interface IContainerRuntimeOptions {
     // Experimental flag that will generate summaries if connected to a service that supports them.
-    // Will eventually become the default and snapshots will be deprecated
+    // This defaults to true and must be explicitly set to false to disable.
     generateSummaries: boolean;
 
     // Experimental flag that will execute tasks in web worker if connected to a service that supports them.
@@ -533,7 +533,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         private readonly context: IContainerContext,
         private readonly registry: IComponentRegistry,
         readonly chunks: [string, string[]][],
-        private readonly runtimeOptions: IContainerRuntimeOptions = { generateSummaries: false, enableWorker: false },
+        private readonly runtimeOptions: IContainerRuntimeOptions = { generateSummaries: true, enableWorker: false },
     ) {
         super();
 
@@ -605,7 +605,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         // Create the SummaryManager and mark the initial state
         this.summaryManager = new SummaryManager(
             context,
-            this.runtimeOptions.generateSummaries || this.loadedFromSummary,
+            this.runtimeOptions.generateSummaries !== false || this.loadedFromSummary,
             this.runtimeOptions.enableWorker,
             this.logger);
         if (this.context.connectionState === ConnectionState.Connected) {


### PR DESCRIPTION
Change runtime options to default to true for generate summaries.
Change logic checking this option to explicitly look for false when checking if disabled.

Did not change end-to-end tests or replay tool, those are still setting to false.