### PR TITLE
Fix chunking reconnect

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -77,12 +77,6 @@ interface ISummaryTreeWithStats {
     summaryTree: ISummaryTree;
 }
 
-interface IBufferedChunk {
-    type: MessageType;
-
-    content: string;
-}
-
 export interface IGeneratedSummaryData {
     sequenceNumber: number;
 
@@ -497,9 +491,6 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
     // on its creation). This is a superset of contexts.
     private readonly contextsDeferred = new Map<string, Deferred<ComponentContext>>();
 
-    // Local copy of sent but unacknowledged chunks.
-    private readonly unackedChunkedMessages: Map<number, IBufferedChunk> = new Map<number, IBufferedChunk>();
-
     private loadedFromSummary: boolean;
 
     private constructor(
@@ -717,8 +708,6 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
                 this.submit(MessageType.Attach, message);
             }
 
-            // Also send any unacked chunk messages
-            this.sendUnackedChunks();
         }
 
         for (const [, componentContext] of this.contexts) {
@@ -984,13 +973,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         // Chunk processing must come first given that we will transform the message to the unchunked version
         // once all pieces are available
         if (message.type === MessageType.ChunkedOp) {
-            const chunkComplete = this.processRemoteChunkedMessage(message);
-            if (chunkComplete && local) {
-                const clientSeqNumber = message.clientSequenceNumber;
-                if (this.unackedChunkedMessages.has(clientSeqNumber)) {
-                    this.unackedChunkedMessages.delete(clientSeqNumber);
-                }
-            }
+            this.processRemoteChunkedMessage(message);
         }
 
         // Old prepare part
@@ -1165,16 +1148,6 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         }
     }
 
-    private sendUnackedChunks() {
-        for (const message of this.unackedChunkedMessages) {
-            debug(`Resending unacked chunks!`);
-            this.submitChunkedMessage(
-                message[1].type,
-                message[1].content,
-                this.context.deltaManager.maxMessageSize);
-        }
-    }
-
     private processRemoteChunkedMessage(message: ISequencedDocumentMessage): boolean {
         const clientId = message.clientId;
         const chunkedContent = message.contents as IChunkedOp;
@@ -1254,11 +1227,6 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
                 batchBegin ? { batch: true } : undefined);
         } else {
             clientSequenceNumber = this.submitChunkedMessage(type, serializedContent, maxOpSize);
-            this.unackedChunkedMessages.set(clientSequenceNumber,
-                {
-                    content: serializedContent,
-                    type,
-                });
         }
 
         return clientSequenceNumber;


### PR DESCRIPTION
There is no need to track un-acked chunks, and it causes issues as the chunk may not make sense anymore, or be out of order. on reconnect the dds's know how to re-construct their un-acked ops, and resubmit.