### PR TITLE
Add option to disable auto-reconnect on disconnect, and reconnect method on container

### DIFF
--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -112,7 +112,7 @@ export interface IDeltaManager<T, U> extends EventEmitter, IDeltaSender, IDispos
 
     close(): void;
 
-    connect(reason: string): Promise<IConnectionDetails>;
+    connect(requestedMode?: ConnectionMode): Promise<IConnectionDetails>;
 
     getDeltas(reason: string, from: number, to?: number): Promise<ISequencedDocumentMessage[]>;
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -421,6 +421,13 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         });
     }
 
+    /**
+     * Connect the deltaManager.  Useful when the autoConnect flag is set to false.
+     */
+    public async reconnect() {
+        return this._deltaManager!.connect();
+    }
+
     private async reloadContextCore(): Promise<void> {
         await Promise.all([
             this.deltaManager!.inbound.systemPause(),
@@ -1009,7 +1016,6 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         } else if (value === ConnectionState.Disconnected) {
             // Important as we process our own joinSession message through delta request
             this.pendingClientId = undefined;
-            this.connectionDetailsP = undefined;
         }
 
         // Report telemetry after we set client id!

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -254,6 +254,26 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         return this._parentBranch;
     }
 
+    /**
+     * Controls whether the container will automatically reconnect to the delta stream after receiving a disconnect.
+     */
+    public set autoReconnect(value: boolean) {
+        if (!this._deltaManager) {
+            throw new Error("Can't set autoReconnect prior to load");
+        }
+        this._deltaManager.autoReconnect = value;
+    }
+
+    /**
+     * Controls whether the container will automatically reconnect to the delta stream after receiving a disconnect.
+     */
+    public get autoReconnect() {
+        if (!this._deltaManager) {
+            throw new Error("Can't access autoReconnect prior to load");
+        }
+        return this._deltaManager.autoReconnect;
+    }
+
     constructor(
         id: string,
         public readonly options: any,
@@ -989,6 +1009,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         } else if (value === ConnectionState.Disconnected) {
             // Important as we process our own joinSession message through delta request
             this.pendingClientId = undefined;
+            this.connectionDetailsP = undefined;
         }
 
         // Report telemetry after we set client id!

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -760,6 +760,10 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         this.connectFirstConnection = false;
     }
 
+    /**
+     * Disconnect the current connection.
+     * @param reason - Text description of disconnect reason to emit with disconnect event
+     */
     private disconnectFromDeltaStream(reason: string) {
         const connection = this.connection;
         if (!connection) {

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -789,6 +789,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
      * @param connection - The connection that wants to reconnect - no-op if it's different from this.connection
      * @param mode - Read or write
      * @param error - The error that prompted the reconnect
+     * @param autoReconnect - Whether to attempt reconnection automatically after error handling
      * @returns A promise that resolves when the connection is reestablished or we stop trying
      */
     private async reconnectOnError(
@@ -796,7 +797,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         connection: DeltaConnection,
         mode: ConnectionMode,
         error?: any,
-        reconnect: boolean = true,
+        autoReconnect: boolean = true,
     ) {
         // we quite often get protocol errors before / after observing nack/disconnect
         // we do not want to run through same sequence twice.
@@ -816,7 +817,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
             return;
         }
 
-        if (reconnect) {
+        if (autoReconnect) {
             const delay = this.getRetryDelayFromError(error);
             if (delay !== undefined) {
                 this.emitDelayInfo(retryFor.DELTASTREAM, delay);

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -721,7 +721,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
             // ("server_disconnect", ODSP-specific) is mapped to "disconnect"
             // tslint:disable-next-line:no-floating-promises
             this.reconnectOnError(
-                `Reconnecting on disconnect: ${disconnectReason}`,
+                `Got disconnect: ${disconnectReason}, autoReconnect: ${this.autoReconnect}`,
                 connection,
                 this.systemConnectionMode,
                 disconnectReason,

--- a/packages/loader/container-loader/src/deltaManagerProxy.ts
+++ b/packages/loader/container-loader/src/deltaManagerProxy.ts
@@ -12,6 +12,7 @@ import {
 } from "@microsoft/fluid-container-definitions";
 import { EventForwarder } from "@microsoft/fluid-core-utils";
 import {
+    ConnectionMode,
     IClientDetails,
     IDocumentMessage,
     ISequencedDocumentMessage,
@@ -148,8 +149,8 @@ export class DeltaManagerProxy
         return this.deltaManager.close();
     }
 
-    public async connect(reason: string): Promise<IConnectionDetails> {
-        return this.deltaManager.connect(reason);
+    public async connect(requestedMode: ConnectionMode): Promise<IConnectionDetails> {
+        return this.deltaManager.connect(requestedMode);
     }
 
     public async getDeltas(


### PR DESCRIPTION
This change adds an `autoReconnect` flag accessible on the container which defaults to true, but can be set to false to disable autoreconnection when a disconnect is received.  In this case, the container will remain disconnected until `reconnect()` is called on the container.

Fixes #451 