### PR TITLE
Remove unused jsonwebtoken reference from server-services-core

### DIFF
--- a/packages/server/services-core/package.json
+++ b/packages/server/services-core/package.json
@@ -23,7 +23,6 @@
     "@microsoft/fluid-gitresources": "^0.11.0",
     "@microsoft/fluid-protocol-definitions": "^0.11.0",
     "@microsoft/fluid-server-services-client": "^0.11.0",
-    "@types/jsonwebtoken": "^8.3.0",
     "@types/nconf": "^0.0.37",
     "@types/node": "^10.12.12",
     "debug": "^4.1.1",
@@ -32,7 +31,6 @@
   "devDependencies": {
     "@microsoft/fluid-build-common": "^0.11.0",
     "concurrently": "^4.1.0",
-    "jsonwebtoken": "^8.4.0",
     "rimraf": "^2.6.2",
     "tslint": "^5.11.0",
     "typescript": "~3.4.5"


### PR DESCRIPTION
The dependency and dev dependency were backwards anyway.  The types should have been dev dependency and the main package should have been a dependency.  Turns out we didn't need it at all.