### PR TITLE
Add back dependency on jsonwebtoken

### DIFF
--- a/packages/server/services-core/package.json
+++ b/packages/server/services-core/package.json
@@ -26,10 +26,12 @@
     "@types/nconf": "^0.0.37",
     "@types/node": "^10.12.12",
     "debug": "^4.1.1",
+    "jsonwebtoken": "^8.4.0",
     "uuid": "^3.3.2"
   },
   "devDependencies": {
     "@microsoft/fluid-build-common": "^0.11.0",
+    "@types/jsonwebtoken": "^8.3.0",
     "concurrently": "^4.1.0",
     "rimraf": "^2.6.2",
     "tslint": "^5.11.0",


### PR DESCRIPTION
Turns out we actually did need the jsonwebtoken dependency, so this reverts PR #566 and fixes the backwards dev dependency.