### PR TITLE
MergeTree: Pass both current and min seq numbers to startCollab

### DIFF
--- a/packages/runtime/merge-tree/src/client.ts
+++ b/packages/runtime/merge-tree/src/client.ts
@@ -997,10 +997,10 @@ export class Client {
         let segmentWindow = this.getCollabWindow();
         return this.mergeTree.getLength(segmentWindow.currentSeq, segmentWindow.clientId);
     }
-    startCollaboration(longClientId: string | undefined,  minSeq = 0, branchId = 0) {
+    startCollaboration(longClientId: string | undefined,  minSeq = 0, currentSeq = 0, branchId = 0) {
         this.longClientId = longClientId ? longClientId : "original";
         this.addLongClientId(this.longClientId , branchId);
-        this.mergeTree.startCollaboration(this.getShortClientId(this.longClientId), minSeq, branchId);
+        this.mergeTree.startCollaboration(this.getShortClientId(this.longClientId), minSeq, currentSeq, branchId);
     }
     updateCollaboration(longClientId: string) {
         const oldClientId = this.longClientId;

--- a/packages/runtime/merge-tree/src/mergeTree.ts
+++ b/packages/runtime/merge-tree/src/mergeTree.ts
@@ -1404,11 +1404,11 @@ export class MergeTree {
     }
 
     // for now assume min starts at zero
-    startCollaboration(localClientId: number, minSeq: number, branchId: number) {
+    startCollaboration(localClientId: number, minSeq: number, currentSeq: number, branchId: number) {
         this.collabWindow.clientId = localClientId;
         this.collabWindow.minSeq = minSeq;
         this.collabWindow.collaborating = true;
-        this.collabWindow.currentSeq = minSeq;
+        this.collabWindow.currentSeq = currentSeq;
         this.localBranchId = branchId;
         this.segmentsToScour = new Collections.Heap<LRUSegment>([], LRUSegmentComparer);
         this.pendingSegments = Collections.ListMakeHead<SegmentGroup>();
@@ -1425,7 +1425,7 @@ export class MergeTree {
 
     private addToLRUSet(segment: ISegment, seq: number) {
         // only skip adding segments who's parents are
-        // explitly needing scour, not false or undefined
+        // explicitly needing scour, not false or undefined
         if (segment.parent.needsScour !== true) {
             // sequence should be always above current.
             assert(seq > this.collabWindow.currentSeq, "addToLRUSet");
@@ -2422,7 +2422,7 @@ export class MergeTree {
         }
     }
 
-    // visit segments starting from node's right siblings, then up to node's parent
+    // visit segments starting from node's left siblings, then up to node's parent
     leftExcursion<TClientData>(node: IMergeNode, leafAction: ISegmentAction<TClientData>) {
         const actions = { leaf: leafAction };
         let go = true;

--- a/packages/runtime/merge-tree/src/snapshotLoader.ts
+++ b/packages/runtime/merge-tree/src/snapshotLoader.ts
@@ -68,7 +68,10 @@ export class SnapshotLoader {
         const branching = branchId === this.runtime.documentId ? 0 : 1;
 
         this.client.startCollaboration(
-            this.runtime.clientId, chunk.chunkSequenceNumber, branching);
+            this.runtime.clientId,
+            /* minSeq: */ chunk.chunkSequenceNumber,
+            /* currentSeq: */ chunk.chunkSequenceNumber,
+            branching);
 
         return chunk;
     }

--- a/packages/runtime/merge-tree/src/test/mergeTree.annotate.deltaCallback.spec.ts
+++ b/packages/runtime/merge-tree/src/test/mergeTree.annotate.deltaCallback.spec.ts
@@ -27,7 +27,8 @@ describe("MergeTree", () => {
         currentSequenceNumber = 0;
         mergeTree.startCollaboration(
             localClientId,
-            currentSequenceNumber,
+            /* minSeq: */ currentSequenceNumber,
+            /* currentSeq: */ currentSequenceNumber,
             branchId);
     });
 

--- a/packages/runtime/merge-tree/src/test/mergeTree.annotate.spec.ts
+++ b/packages/runtime/merge-tree/src/test/mergeTree.annotate.spec.ts
@@ -91,7 +91,8 @@ describe("MergeTree", () => {
             beforeEach(() => {
                 mergeTree.startCollaboration(
                     localClientId,
-                    currentSequenceNumber,
+                    /* minSeq: */ currentSequenceNumber,
+                    /* currentSeq: */ currentSequenceNumber,
                     branchId);
             });
             describe("local first", () => {

--- a/packages/runtime/merge-tree/src/test/mergeTree.insert.deltaCallback.spec.ts
+++ b/packages/runtime/merge-tree/src/test/mergeTree.insert.deltaCallback.spec.ts
@@ -26,7 +26,8 @@ describe("MergeTree", () => {
         currentSequenceNumber = 0;
         mergeTree.startCollaboration(
             localClientId,
-            currentSequenceNumber,
+            /* minSeq: */ currentSequenceNumber,
+            /* currentSeq: */ currentSequenceNumber,
             branchId);
     });
 

--- a/packages/runtime/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
+++ b/packages/runtime/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
@@ -37,7 +37,8 @@ const treeFactories: ITestTreeFactory[] = [
                 undefined);
             mergeTree.startCollaboration(
                 localClientId,
-                UniversalSequenceNumber,
+                /* minSeq: */ UniversalSequenceNumber,
+                /* currentSeq: */ UniversalSequenceNumber,
                 branchId);
             return {
                 initialText,
@@ -92,7 +93,8 @@ const treeFactories: ITestTreeFactory[] = [
 
             mergeTree.startCollaboration(
                 localClientId,
-                UniversalSequenceNumber,
+                /* minSeq: */ UniversalSequenceNumber,
+                /* currentSeq: */ UniversalSequenceNumber,
                 branchId);
             return {
                 initialText,
@@ -154,7 +156,8 @@ const treeFactories: ITestTreeFactory[] = [
 
             mergeTree.startCollaboration(
                 localClientId,
-                UniversalSequenceNumber,
+                /* minSeq: */ UniversalSequenceNumber,
+                /* currentSeq: */ UniversalSequenceNumber,
                 branchId);
 
             return {

--- a/packages/runtime/merge-tree/src/test/mergeTree.markRangeRemoved.deltaCallback.spec.ts
+++ b/packages/runtime/merge-tree/src/test/mergeTree.markRangeRemoved.deltaCallback.spec.ts
@@ -25,7 +25,8 @@ describe("MergeTree", () => {
         currentSequenceNumber = 0;
         mergeTree.startCollaboration(
             localClientId,
-            currentSequenceNumber,
+            /* minSeq: */ currentSequenceNumber,
+            /* currentSeq: */ currentSequenceNumber,
             branchId);
     });
 

--- a/packages/runtime/sequence/src/sequence.ts
+++ b/packages/runtime/sequence/src/sequence.ts
@@ -493,7 +493,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
             }
         }
 
-        this.client.startCollaboration(this.runtime.clientId, 0);
+        this.client.startCollaboration(this.runtime.clientId);
     }
 
     protected initializeLocalCore() {

--- a/packages/runtime/sequence/src/test/testFarm.ts
+++ b/packages/runtime/sequence/src/test/testFarm.ts
@@ -883,7 +883,7 @@ export function TestPack(verbose = true) {
             }else{
                 clientsB[i].insertTextLocal(0, initString);
             }
-            clientsB[i].startCollaboration(`FredB${i}`, 0, 1);
+            clientsB[i].startCollaboration(`FredB${i}`, /* minSeq: */ 0, /* currentSeq: */ 0, /* branchId: */ 1);
         }
         for (let i = 0; i < clientCountB; i++) {
             let clientB = clientsB[i];
@@ -898,7 +898,7 @@ export function TestPack(verbose = true) {
         serverA.startCollaboration("theServerA");
         serverA.addClients(clientsA);
         serverA.addListeners([serverB]);
-        serverB.startCollaboration("theServerB", 0, 1);
+        serverB.startCollaboration("theServerB", /* minSeq: */ 0, /* currentSeq: */ 0, /* branchId: */ 1);
         serverB.addClients(clientsB);
         serverB.addUpstreamClients(clientsA);
 


### PR DESCRIPTION
While refactoring to support both old and new snapshots, this small incremental change fell out nicely.