### PR TITLE
MergeTree: Update snapshot loader to support new format

### DIFF
--- a/packages/runtime/merge-tree/src/ops.ts
+++ b/packages/runtime/merge-tree/src/ops.ts
@@ -111,6 +111,27 @@ export interface IJSONSegment {
     props?: Object;
 }
 
+/**
+ * Used during snapshotting to record the metadata required to merge segments above the MSN
+ * to the raw output of `ISegment.toJSONObject()`.  (Note that IJSONSegment may be a raw
+ * string or array, which is why this interface wraps the original IJSONSegment instead of
+ * extending it.)
+ */
+export interface IJSONSegmentWithMergeInfo {
+    json: IJSONSegment;
+    client?: string;
+    seq?: number;
+    removedClient?: string;
+    removedSeq?: number;
+}
+
+/**
+ * Returns true if the given 'spec' is an IJSONSegmentWithMergeInfo.
+ */
+export function hasMergeInfo(spec: IJSONSegment | IJSONSegmentWithMergeInfo): spec is IJSONSegmentWithMergeInfo {
+    return spec !== null && typeof spec === "object" && "json" in spec;
+}
+
 export type IMergeTreeOp = IMergeTreeInsertMsg | IMergeTreeRemoveMsg | IMergeTreeAnnotateMsg | IMergeTreeGroupMsg;
 
 // tslint:disable-next-line:interface-name
@@ -123,6 +144,7 @@ export interface MergeTreeChunk {
     totalLengthChars: number;
     totalSegmentCount: number;
     chunkSequenceNumber: number;
+    chunkMinSequenceNumber?: number;
     // back-compat name: change to segments
-    segmentTexts: IJSONSegment[];
+    segmentTexts: (IJSONSegment | IJSONSegmentWithMergeInfo)[];
 }

--- a/packages/runtime/merge-tree/src/ops.ts
+++ b/packages/runtime/merge-tree/src/ops.ts
@@ -129,7 +129,7 @@ export interface IJSONSegmentWithMergeInfo {
  * Returns true if the given 'spec' is an IJSONSegmentWithMergeInfo.
  */
 export function hasMergeInfo(spec: IJSONSegment | IJSONSegmentWithMergeInfo): spec is IJSONSegmentWithMergeInfo {
-    return spec !== null && typeof spec === "object" && "json" in spec;
+    return !!spec && typeof spec === "object" && "json" in spec;
 }
 
 export type IMergeTreeOp = IMergeTreeInsertMsg | IMergeTreeRemoveMsg | IMergeTreeAnnotateMsg | IMergeTreeGroupMsg;

--- a/packages/runtime/merge-tree/src/snapshot.ts
+++ b/packages/runtime/merge-tree/src/snapshot.ts
@@ -25,6 +25,9 @@ interface SnapshotHeader {
     indexOffset?: number;
     segmentsOffset?: number;
     seq: number;
+    // TODO: Make 'minSeq' non-optional once the new snapshot format becomes the default?
+    //       (See https://github.com/microsoft/FluidFramework/issues/84)
+    minSeq?: number;
 }
 
 // first three are index entry

--- a/packages/runtime/merge-tree/src/snapshotLoader.ts
+++ b/packages/runtime/merge-tree/src/snapshotLoader.ts
@@ -60,9 +60,10 @@ export class SnapshotLoader {
                 ? this.client.getOrAddShortClientId(spec.client)
                 : NonCollabClient;
 
-            if (spec.seq !== undefined) {
-                seg.seq = spec.seq;
-            }
+            seg.seq = spec.seq !== undefined
+                ? spec.seq
+                : UniversalSequenceNumber;
+
             if (spec.removedSeq !== undefined) {
                 seg.removedSeq = spec.removedSeq;
             }
@@ -71,6 +72,7 @@ export class SnapshotLoader {
             }
         } else {
             seg = this.client.specToSegment(spec);
+            seg.seq = UniversalSequenceNumber;
 
             // `specToSegment()` initializes `seg` with the LocalClientId.  We must overwrite this with
             // `NonCollabClient`.

--- a/packages/runtime/merge-tree/src/snapshotLoader.ts
+++ b/packages/runtime/merge-tree/src/snapshotLoader.ts
@@ -9,8 +9,8 @@ import { IComponentRuntime, IObjectStorageService } from "@microsoft/fluid-runti
 import * as assert from "assert";
 import { Client } from "./client";
 import { NonCollabClient, UniversalSequenceNumber } from "./constants";
-import { MergeTree } from "./mergeTree";
-import { MergeTreeChunk } from "./ops";
+import { ISegment, MergeTree } from "./mergeTree";
+import { hasMergeInfo, IJSONSegment, IJSONSegmentWithMergeInfo, MergeTreeChunk } from "./ops";
 import { Snapshot } from "./snapshot";
 
 export class SnapshotLoader {
@@ -48,6 +48,38 @@ export class SnapshotLoader {
         return this.loadTardis(rawMessages, branch);
     }
 
+    private readonly specToSegment = (spec: IJSONSegment | IJSONSegmentWithMergeInfo) => {
+        let seg: ISegment;
+
+        if (hasMergeInfo(spec)) {
+            seg = this.client.specToSegment(spec.json);
+
+            // `specToSegment()` initializes `seg` with the LocalClientId.  Overwrite this with
+            // the `spec` client (if specified).  Otherwise overwrite with `NonCollabClient`.
+            seg.clientId = spec.client !== undefined
+                ? this.client.getOrAddShortClientId(spec.client)
+                : NonCollabClient;
+
+            if (spec.seq !== undefined) {
+                seg.seq = spec.seq;
+            }
+            if (spec.removedSeq !== undefined) {
+                seg.removedSeq = spec.removedSeq;
+            }
+            if (spec.removedClient !== undefined) {
+                seg.removedClientId = this.client.getOrAddShortClientId(spec.removedClient);
+            }
+        } else {
+            seg = this.client.specToSegment(spec);
+
+            // `specToSegment()` initializes `seg` with the LocalClientId.  We must overwrite this with
+            // `NonCollabClient`.
+            seg.clientId = NonCollabClient;
+        }
+
+        return seg;
+    }
+
     private loadHeader(
         header: string,
         branchId: string): MergeTreeChunk {
@@ -56,11 +88,7 @@ export class SnapshotLoader {
             header,
             this.runtime.IComponentSerializer,
             this.runtime.IComponentHandleContext);
-        const segs = chunk.segmentTexts.map((spec) => {
-            const seg = this.client.specToSegment(spec);
-            seg.seq = UniversalSequenceNumber;
-            return seg;
-        });
+        const segs = chunk.segmentTexts.map(this.specToSegment);
         this.mergeTree.reloadFromSegments(segs);
 
         // tslint:disable-next-line: no-suspicious-comment
@@ -69,7 +97,12 @@ export class SnapshotLoader {
 
         this.client.startCollaboration(
             this.runtime.clientId,
-            /* minSeq: */ chunk.chunkSequenceNumber,
+            // tslint:disable-next-line:no-suspicious-comment
+            // TODO: Make 'minSeq' non-optional once the new snapshot format becomes the default?
+            //       (See https://github.com/microsoft/FluidFramework/issues/84)
+            /* minSeq: */ chunk.chunkMinSequenceNumber !== undefined
+                ? chunk.chunkMinSequenceNumber
+                : chunk.chunkSequenceNumber,
             /* currentSeq: */ chunk.chunkSequenceNumber,
             branching);
 
@@ -104,13 +137,41 @@ export class SnapshotLoader {
             { eventName: "Mismatch in totalSegmentCount" });
 
         // Deserialize each chunk segment and append it to the end of the MergeTree.
-        this.mergeTree.insertSegments(
-            this.mergeTree.root.cachedLength,
-            chunk2.segmentTexts.map((s) => this.client.specToSegment(s)),
-            UniversalSequenceNumber,
-            NonCollabClient,
-            UniversalSequenceNumber,
-            undefined);
+        const segs = chunk2.segmentTexts.map(this.specToSegment);
+
+        // Helper to insert segments at the end of the MergeTree.
+        const mergeTree = this.mergeTree;
+        const append = (segments: ISegment[], cli: number, seq: number) => {
+            mergeTree.insertSegments(
+                mergeTree.root.cachedLength,
+                segments,
+                /* refSeq: */ UniversalSequenceNumber,
+                cli,
+                seq,
+                undefined);
+        };
+
+        // Helpers to batch-insert segments that are below the min seq
+        const batch: ISegment[] = [];
+        const flushBatch = () => {
+            if (batch.length > 0) { append(batch, NonCollabClient, UniversalSequenceNumber); }
+        };
+
+        for (const seg of segs) {
+            const cli = seg.clientId;
+            const seq = seg.seq;
+
+            // If the segment can be batch inserted, add it to the 'batch' array.  Otherwise, flush
+            // any batched segments and then insert the current segment individually.
+            if (cli === NonCollabClient && seq === UniversalSequenceNumber) {
+                batch.push(seg);
+            } else {
+                flushBatch();
+                append([seg], cli, seq);
+            }
+        }
+
+        flushBatch();
     }
 
     // If loading from a snapshot load tardis messages


### PR DESCRIPTION
Backwards-compatible changes to snapshot loader to support "blue" segments.