### PR TITLE
Remove unnecessary import of URL

### DIFF
--- a/packages/drivers/routerlicious-urlResolver/src/urlResolver.ts
+++ b/packages/drivers/routerlicious-urlResolver/src/urlResolver.ts
@@ -14,7 +14,7 @@ import {
     ScopeType,
 } from "@microsoft/fluid-protocol-definitions";
 import { generateToken, IAlfredTenant } from "@microsoft/fluid-server-services-core";
-import { parse, URL } from "url";
+import { parse } from "url";
 
 const r11sServers = [
     "www.wu2-ppe.prague.office-int.com",

--- a/packages/server/gateway/src/gateway-odsp-utils.ts
+++ b/packages/server/gateway/src/gateway-odsp-utils.ts
@@ -10,7 +10,6 @@ import {
     isSpoServer,
     isSpoTenant,
 } from "@fluid-example/tiny-web-host";
-import { URL } from "url";
 
 export function saveSpoTokens(req, params, accessToken: string, refreshToken: string) {
     if (!req.session.tokens) {


### PR DESCRIPTION
This import interacts forces url to be a constructor with webpack. It creates the following error:
The import is also unnecessary.

```
Uncaught (in promise) TypeError: url__WEBPACK_IMPORTED_MODULE_2__.URL is not a constructor...
```