### PR TITLE
Base Host API refactor and clean up

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspUtils.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspUtils.ts
@@ -72,7 +72,7 @@ export function blockList(nonRetriableCodes: number[]): RetryFilter {
 // export const defaultRetryFilter = allowList([408, 409, 429, 500, 503]);
 export const defaultRetryFilter = blockList([400, 401, 403, 404]);
 
-// socket error filter for socket erros where 400 is a special retryable error.
+// socket error filter for socket errors where 400 is a special retryable error.
 export const socketErrorRetryFilter = blockList([401, 403, 404, 406]);
 
 export interface IOdspResponse<T> {

--- a/packages/hosts/base-host/src/host.ts
+++ b/packages/hosts/base-host/src/host.ts
@@ -164,7 +164,6 @@ export async function createWebLoader(
  * @param resolved - A resolved url from a url resolver.
  * @param pkg - A resolved package with cdn links.
  * @param scriptIds - The script tags the chaincode are attached to the view with.
- * @param npm - path from where the packages can be fetched.
  * @param config - Any config to be provided to loader.
  * @param scope - A component that gives host provided capabilities/configurations
  *  to the component in the container(such as auth).
@@ -176,7 +175,6 @@ export async function start(
     resolved: IResolvedUrl,
     pkg: IResolvedPackage,
     scriptIds: string[],
-    npm: string,
     config: any,
     scope: IComponent,
     div: HTMLDivElement,

--- a/packages/hosts/base-host/src/hostConfig.ts
+++ b/packages/hosts/base-host/src/hostConfig.ts
@@ -7,7 +7,7 @@ import { IDocumentServiceFactory, IUrlResolver } from "@microsoft/fluid-protocol
 
 /**
  * Host config that contains a url resolver to resolve the url and then provides a
- * list of document service factories from which one can be selcted based on protocol
+ * list of document service factories from which one can be selected based on protocol
  * of resolved url.
  */
 export interface IHostConfig {

--- a/packages/hosts/tiny-web-host/src/host.ts
+++ b/packages/hosts/tiny-web-host/src/host.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IHostConfig, start } from "@microsoft/fluid-base-host";
+import { BaseHost, IHostConfig } from "@microsoft/fluid-base-host";
 import { IProxyLoaderFactory } from "@microsoft/fluid-container-definitions";
 import { BaseTelemetryNullLogger, configurableUrlResolver } from "@microsoft/fluid-core-utils";
 import { FluidAppOdspUrlResolver } from "@microsoft/fluid-fluidapp-odsp-urlresolver";
@@ -117,7 +117,7 @@ async function loadContainer(
         urlResolver: resolver,
     };
     // tslint:disable-next-line: no-unsafe-any
-    return start(
+    return BaseHost.start(
         href,
         // tslint:disable-next-line: no-unsafe-any
         resolved, // resolved, IResolvedUrl,

--- a/packages/hosts/tiny-web-host/src/host.ts
+++ b/packages/hosts/tiny-web-host/src/host.ts
@@ -18,8 +18,6 @@ import { IOdspTokenApi, IRouterliciousTokenApi, ITokenApis } from "./utils";
 // tslint:disable-next-line: no-var-requires no-require-imports
 const packageJson = require("../package.json");
 
-const npm = "https://pragueauspkn-3873244262.azureedge.net";
-
 // This is insecure, but is being used for the time being for ease of use during the hackathon.
 const appTenants = [
     {
@@ -125,7 +123,6 @@ async function loadContainer(
         resolved, // resolved, IResolvedUrl,
         pkg, // pkg, IResolvedPackage, (gateway/routes/loader has an example (pkgP))
         scriptIds, // scriptIds, string[], defines the id of the script tag added to the page
-        npm, // string,
         {},
         {},
         div,

--- a/packages/loader/loader-web/src/webLoader.ts
+++ b/packages/loader/loader-web/src/webLoader.ts
@@ -312,7 +312,7 @@ export class WebCodeLoader implements ICodeLoader {
 
         const fullPkg = typeof details.package === "string"
             ? details.package // just return it if it's a string e.g. "@fluid-example/clicker@0.1.1"
-            : !details.package.version // if it doesn't exist, let's make it from the packge detals
+            : !details.package.version // if it doesn't exist, let's make it from the package details
                 ? `${details.package.name}` // e.g. @fluid-example/clicker
                 : `${details.package.name}@${details.package.version}`; // rebuild e.g. @fluid-example/clicker@0.1.1
         const parsed = extractDetails(fullPkg);

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -830,7 +830,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         // If flush mode is already manual we are either
         // nested in another orderSequentially, or
         // the app is flushing manually, in which
-        // case this invokation doesn't own
+        // case this invocation doesn't own
         // flushing.
         if (this.flushMode === FlushMode.Manual) {
             callback();
@@ -925,7 +925,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
     private refreshBaseSummary(snapshot: ISnapshotTree) {
         // currently only is called from summaries
         this.loadedFromSummary = true;
-        // propogate updated tree to all components
+        // propagate updated tree to all components
         for (const key of Object.keys(snapshot.trees)) {
             if (this.contexts.has(key)) {
                 const component = this.contexts.get(key);

--- a/packages/server/gateway/src/controllers/services.ts
+++ b/packages/server/gateway/src/controllers/services.ts
@@ -10,7 +10,7 @@ import {
 } from "@microsoft/fluid-host-service-interfaces";
 
 /**
- * Host services provides a collection of intefaces exposed by a gateway host
+ * Host services provides a collection of interfaces exposed by a gateway host
  */
 // tslint:disable-next-line:no-empty-interface
 export interface IHostServices extends

--- a/packages/server/gateway/src/routes/loader.ts
+++ b/packages/server/gateway/src/routes/loader.ts
@@ -171,7 +171,6 @@ export function create(
                             clientId: config.get("login:microsoft").clientId,
                             config: workerConfig,
                             jwt: jwtToken,
-                            npm: config.get("worker:npm"),
                             partials: defaultPartials,
                             resolved: JSON.stringify(resolved),
                             scripts,

--- a/packages/server/gateway/views/loader.hjs
+++ b/packages/server/gateway/views/loader.hjs
@@ -23,7 +23,6 @@
         var url = "{{ url }}";
         var resolved = {{{ resolved }}};
         var jwt = "{{ jwt }}";
-        var npm = "{{ npm }}";
         var config = {{{ config }}};
         var clientId = "{{ clientId }}";
 
@@ -44,7 +43,6 @@
             cache,
             chaincode,
             scriptIds,
-            npm,
             jwt,
             config,
             clientId,

--- a/packages/server/gateway/views/loaderFramed.hjs
+++ b/packages/server/gateway/views/loaderFramed.hjs
@@ -38,7 +38,6 @@
         var url = "{{ url }}";
         var resolved = {{{ resolved }}};
         var jwt = "{{ jwt }}";
-        var npm = "{{ npm }}";
         var config = {{{ config }}};
         var clientId = "{{ clientId }}";
 
@@ -48,7 +47,6 @@
             cache,
             chaincode,
             scriptIds,
-            npm,
             jwt,
             config,
             clientId,
@@ -81,7 +79,6 @@
         var url = "{{ url }}";
         var resolved = {{{ resolved }}};
         var jwt = "{{ jwt }}";
-        var npm = "{{ npm }}";
         var config = {{{ config }}};
         var clientId = "{{ clientId }}";
 
@@ -102,7 +99,6 @@
             cache,
             chaincode,
             scriptIds,
-            npm,
             jwt,
             config,
             clientId);

--- a/packages/tools/webpack-component-loader/src/loader.ts
+++ b/packages/tools/webpack-component-loader/src/loader.ts
@@ -165,15 +165,6 @@ function getUrlResolver(options: IRouteOptions): IUrlResolver {
     }
 }
 
-function getNpm(options: IRouteOptions): string {
-    if (options.mode === "localhost") {
-        return "http://localhost:3002";
-    }
-
-    // local, live
-    return options.npm;
-}
-
 // Invoked by `start()` when the 'double' option is enabled to create the side-by-side panes.
 function makeSideBySideDiv() {
     const div = document.createElement("div");
@@ -201,7 +192,6 @@ export async function start(
     };
 
     const urlResolver = getUrlResolver(options);
-    const npm = getNpm(options);
 
     let documentServiceFactory: IDocumentServiceFactory;
     let deltaConn: ITestDeltaConnectionServer;
@@ -233,7 +223,6 @@ export async function start(
         await urlResolver.resolve(req),
         pkg,
         scriptIds,
-        npm,
         {},
         {},
         double ? leftDiv : div,
@@ -254,7 +243,6 @@ export async function start(
             await urlResolver.resolve(req),
             pkg,
             scriptIds,
-            npm,
             {},
             {},
             rightDiv,

--- a/packages/tools/webpack-component-loader/src/loader.ts
+++ b/packages/tools/webpack-component-loader/src/loader.ts
@@ -4,7 +4,7 @@
  */
 
 import { SimpleModuleInstantiationFactory } from "@microsoft/fluid-aqueduct";
-import { IHostConfig, start as startCore } from "@microsoft/fluid-base-host";
+import { BaseHost, IHostConfig } from "@microsoft/fluid-base-host";
 import { IRequest } from "@microsoft/fluid-component-core-interfaces";
 import {
     IFluidModule,
@@ -218,7 +218,7 @@ export async function start(
         div.append(leftDiv, rightDiv);
     }
 
-    const start1Promise = startCore(
+    const start1Promise = BaseHost.start(
         url,
         await urlResolver.resolve(req),
         pkg,
@@ -236,9 +236,9 @@ export async function start(
         const docServFac2: IDocumentServiceFactory = new TestDocumentServiceFactory(deltaConn);
         const hostConf2 = { documentServiceFactory: docServFac2, urlResolver };
 
-        // startCore will create a new Loader/Container/Component from the startCore above. This is
+        // BaseHost.start will create a new Loader/Container/Component from the startCore above. This is
         // intentional because we want to emulate two clients collaborating with each other.
-        start2Promise = startCore(
+        start2Promise = BaseHost.start(
             url,
             await urlResolver.resolve(req),
             pkg,


### PR DESCRIPTION
Split the base-host's start into a two phase process:
- BaseHost creation and configuration via a new BaseHost class
- load and render to a div (with pkg proposal if it is new) using the BaseHost

The loader created can be returned from the BaseHost object.
This allow us to stop exporting initializeChaincode/registerAttach/createWebLoader

Also clean up unused `npm` arguments.
