### PR TITLE
Map: Breaking snapshots into multiple blobs

### DIFF
--- a/packages/components/owned-map/src/ownedMap.ts
+++ b/packages/components/owned-map/src/ownedMap.ts
@@ -11,7 +11,6 @@ import { IComponentRuntime, IObjectStorageService } from "@microsoft/fluid-runti
 import { debug } from "./debug";
 import { OwnedMapFactory } from "./ownedMapFactory";
 
-const snapshotFileName = "header";
 const ownerPath = "owner";
 
 /**
@@ -45,20 +44,7 @@ export class OwnedSharedMap extends SharedMap implements ISharedMap {
     }
 
     public snapshot(): ITree {
-        const tree: ITree = {
-            entries: [
-                {
-                    mode: FileMode.File,
-                    path: snapshotFileName,
-                    type: TreeEntry[TreeEntry.Blob],
-                    value: {
-                        contents: this.serialize(),
-                        encoding: "utf-8",
-                    },
-                },
-            ],
-            id: null,
-        };
+        const tree = super.snapshot();
 
         if (this.getOwner()) {
             tree.entries.push({
@@ -95,9 +81,15 @@ export class OwnedSharedMap extends SharedMap implements ISharedMap {
         }
     }
 
-    protected async getOwnerSnapshot(storage: IObjectStorageService): Promise<void> {
+    /**
+     * {@inheritDoc @microsoft/fluid-shared-object-base#SharedObject.loadCore}
+     */
+    protected async loadCore(
+            branchId: string,
+            storage: IObjectStorageService) {
         const owner = await storage.read(ownerPath);
         this.owner = fromBase64ToUtf8(owner);
+        return super.loadCore(branchId, storage);
     }
 
     protected setOwner(): string | undefined {

--- a/packages/loader/utils/src/blobs.ts
+++ b/packages/loader/utils/src/blobs.ts
@@ -197,3 +197,16 @@ export class TreeTreeEntry implements ITreeEntry {
      */
     constructor(public readonly path: string, public readonly value: ITree) {}
 }
+
+export function addBlobToTree(tree: ITree, blobName: string, content: object) {
+    tree.entries.push(
+        {
+            mode: FileMode.File,
+            path: blobName,
+            type: TreeEntry[TreeEntry.Blob],
+            value: {
+                contents: JSON.stringify(content),
+                encoding: "utf-8",
+            },
+        });
+}

--- a/packages/runtime/map/src/directory.ts
+++ b/packages/runtime/map/src/directory.ts
@@ -29,7 +29,12 @@ import {
     IValueOpEmitter,
     IValueTypeOperationValue,
 } from "./interfaces";
-import { ILocalValue, LocalValueMaker, ValueTypeLocalValue, valueTypes } from "./localValues";
+import {
+    ILocalValue,
+    LocalValueMaker,
+    ValueTypeLocalValue,
+    valueTypes,
+} from "./localValues";
 import { pkgVersion } from "./packageVersion";
 
 // path-browserify only supports posix functionality but doesn't have a path.posix to enforce it.  But we need to
@@ -569,10 +574,7 @@ export class SharedDirectory extends SharedObject implements ISharedDirectory {
         subdirsToSerialize.set(this.root, serializableDirectoryData);
 
         for (const [currentSubDir, currentSubDirObject] of subdirsToSerialize) {
-            const subDirStorage = currentSubDir.getSerializableStorage();
-            if (subDirStorage) {
-                currentSubDirObject.storage = subDirStorage;
-            }
+            currentSubDirObject.storage = currentSubDir.getSerializableStorage();
 
             for (const [subdirName, subdir] of currentSubDir.subdirectories()) {
                 if (!currentSubDirObject.subdirectories) {
@@ -1023,7 +1025,7 @@ class SubDirectory implements IDirectory {
             params,
         );
 
-        // TODO ideally we could use makeSerializable in this case as well. But the interval
+        // TODO ideally we could use makeSerialized in this case as well. But the interval
         // collection has assumptions of attach being called prior. Given the IComponentSerializer it
         // may be possible to remove custom value type serialization entirely.
         const transformedValue = params

--- a/packages/runtime/map/src/directory.ts
+++ b/packages/runtime/map/src/directory.ts
@@ -32,6 +32,7 @@ import {
 import {
     ILocalValue,
     LocalValueMaker,
+    makeSerializable,
     ValueTypeLocalValue,
     valueTypes,
 } from "./localValues";
@@ -993,7 +994,8 @@ class SubDirectory implements IDirectory {
         }
 
         const localValue = this.directory.localValueMaker.fromInMemory(value);
-        const serializableValue = localValue.makeSerializable(
+        const serializableValue = makeSerializable(
+            localValue,
             this.runtime.IComponentSerializer,
             this.runtime.IComponentHandleContext,
             this.directory.handle);
@@ -1375,7 +1377,8 @@ class SubDirectory implements IDirectory {
         }
         const serializedStorage: { [key: string]: ISerializableValue } = {};
         for (const [key, localValue] of this._storage) {
-            serializedStorage[key] = localValue.makeSerializable(
+            serializedStorage[key] = makeSerializable(
+                localValue,
                 this.runtime.IComponentSerializer,
                 this.runtime.IComponentHandleContext,
                 this.directory.handle);

--- a/packages/runtime/map/src/interfaces.ts
+++ b/packages/runtime/map/src/interfaces.ts
@@ -294,7 +294,7 @@ export interface ISerializedValue {
     type: string;
 
     /**
-     * The JSONable representation of the value.
+     * String representation of the value.
      */
     value: string;
 }

--- a/packages/runtime/map/src/interfaces.ts
+++ b/packages/runtime/map/src/interfaces.ts
@@ -287,6 +287,18 @@ export interface ISerializableValue {
     value: any;
 }
 
+export interface ISerializedValue {
+    /**
+     * A type annotation to help indicate how the value serializes.
+     */
+    type: string;
+
+    /**
+     * The JSONable representation of the value.
+     */
+    value: string;
+}
+
 /**
  * ValueTypes handle ops slightly differently from SharedObjects or plain JS objects.  Since the Map/Directory doesn't
  * know how to handle the ValueType's ops, those ops are instead passed along to the ValueType for processing.

--- a/packages/runtime/map/src/localValues.ts
+++ b/packages/runtime/map/src/localValues.ts
@@ -29,16 +29,16 @@ import {
 /**
  * A local value to be stored in a container type DDS.
  */
-export abstract class ILocalValue {
+export interface ILocalValue {
     /**
      * Type indicator of the value stored within.
      */
-    public readonly type: string;
+    readonly type: string;
 
     /**
      * The in-memory value stored within.
      */
-    public readonly value: any;
+    readonly value: any;
 
     /**
      * Retrieve the serialized form of the value stored within.
@@ -47,30 +47,23 @@ export abstract class ILocalValue {
      * @param bind - Container type's handle
      * @returns The serialized form of the contained value
      */
-    public abstract makeSerialized(
+    makeSerialized(
         serializer: IComponentSerializer,
         context: IComponentHandleContext,
         bind: IComponentHandle,
     ): ISerializedValue;
+}
 
-    /**
-     * Retrieve the serialized form of the value stored within.
-     * @param serializer - Component runtime's serializer
-     * @param context - Component runtime's handle context
-     * @param bind - Container type's handle
-     * @returns The serialized form of the contained value
-     */
-    public makeSerializable(
+export function makeSerializable(
+        localValue: ILocalValue,
         serializer: IComponentSerializer,
         context: IComponentHandleContext,
-        bind: IComponentHandle,
-    ): ISerializableValue {
-        const value = this.makeSerialized(serializer, context, bind);
-        return {
-            type: value.type,
-            value: value.value && JSON.parse(value.value),
-        };
-    }
+        bind: IComponentHandle): ISerializableValue {
+    const value = localValue.makeSerialized(serializer, context, bind);
+    return {
+        type: value.type,
+        value: value.value && JSON.parse(value.value),
+    };
 }
 
 /**
@@ -83,13 +76,12 @@ export const valueTypes: ReadonlyArray<IValueType<any>> = [
 /**
  * Manages a contained plain value.  May also contain shared object handles.
  */
-export class PlainLocalValue extends ILocalValue {
+export class PlainLocalValue implements ILocalValue {
     /**
      * Create a new PlainLocalValue.
      * @param value - The value to store, which may contain shared object handles
      */
     constructor(public readonly value: any) {
-        super();
     }
 
     /**
@@ -122,14 +114,13 @@ export class PlainLocalValue extends ILocalValue {
  * SharedLocalValue exists for supporting older documents and is now deprecated.
  * @deprecated
  */
-export class SharedLocalValue extends ILocalValue {
+export class SharedLocalValue implements ILocalValue {
     /**
      * Create a new SharedLocalValue.
      * @param value - The shared object to store
      * @deprecated
      */
     constructor(public readonly value: ISharedObject) {
-        super();
     }
 
     /**
@@ -160,14 +151,13 @@ export class SharedLocalValue extends ILocalValue {
  *
  * @alpha
  */
-export class ValueTypeLocalValue extends ILocalValue {
+export class ValueTypeLocalValue implements ILocalValue {
     /**
      * Create a new ValueTypeLocalValue.
      * @param value - The instance of the value type stored within
      * @param valueType - The type object of the value type stored within
      */
     constructor(public readonly value: any, private readonly valueType: IValueType<any>) {
-        super();
     }
 
     /**

--- a/packages/runtime/map/src/map.ts
+++ b/packages/runtime/map/src/map.ts
@@ -27,7 +27,7 @@ import {
 import {
     valueTypes,
 } from "./localValues";
-import { IMapDataObjectSerializable, IMapDataObjectSerialized, MapKernel } from "./mapKernel";
+import { IMapDataObjectSerializable, MapKernel } from "./mapKernel";
 import { pkgVersion } from "./packageVersion";
 
 interface IMapSerializationFormat {
@@ -261,18 +261,6 @@ export class SharedMap extends SharedObject implements ISharedMap {
         return super.on(event, listener);
     }
 
-    public getSerializableStorage(): IMapDataObjectSerializable {
-        return this.kernel.getSerializableStorage();
-    }
-
-    public getSerializedStorage(): IMapDataObjectSerialized {
-        return this.kernel.getSerializedStorage();
-    }
-
-    public serialize(): string {
-        return this.kernel.serialize();
-    }
-
     /**
      * {@inheritDoc @microsoft/fluid-shared-object-base#SharedObject.snapshot}
      */
@@ -287,7 +275,7 @@ export class SharedMap extends SharedObject implements ISharedMap {
             id: null,
         };
 
-        const data = this.getSerializedStorage();
+        const data = this.kernel.getSerializedStorage();
 
         // If single property exceeds this size, it goes into its own blob
         const MinValueSizeSeparateSnapshotBlob = 8 * 1024;
@@ -349,6 +337,10 @@ export class SharedMap extends SharedObject implements ISharedMap {
         addBlobToTree(tree, snapshotFileName, header);
 
         return tree;
+    }
+
+    protected getSerializableStorage(): IMapDataObjectSerializable {
+        return this.kernel.getSerializableStorage();
     }
 
     /**

--- a/packages/runtime/map/src/map.ts
+++ b/packages/runtime/map/src/map.ts
@@ -352,7 +352,7 @@ export class SharedMap extends SharedObject implements ISharedMap {
         return tree;
     }
 
-    protected getSerializableStorage(): IMapDataObjectSerializable {
+    public getSerializableStorage(): IMapDataObjectSerializable {
         return this.kernel.getSerializableStorage();
     }
 
@@ -372,8 +372,8 @@ export class SharedMap extends SharedObject implements ISharedMap {
             this.kernel.populateFromSerializable(newFormat.content);
             await Promise.all(newFormat.blobs.map(async (value) => {
                 const blob = await storage.read(value);
-                const data2 = fromBase64ToUtf8(blob);
-                this.kernel.populateFromSerializable(JSON.parse(data2) as IMapDataObjectSerializable);
+                const blobData = fromBase64ToUtf8(blob);
+                this.kernel.populateFromSerializable(JSON.parse(blobData) as IMapDataObjectSerializable);
             }));
         } else {
             this.kernel.populateFromSerializable(json as IMapDataObjectSerializable);

--- a/packages/runtime/map/src/map.ts
+++ b/packages/runtime/map/src/map.ts
@@ -19,6 +19,7 @@ import {
     ISharedObjectFactory,
     SharedObject,
 } from "@microsoft/fluid-shared-object-base";
+import * as assert from "assert";
 import { debug } from "./debug";
 import {
     ISharedMap,
@@ -277,12 +278,18 @@ export class SharedMap extends SharedObject implements ISharedMap {
 
         const data = this.kernel.getSerializedStorage();
 
+        // Remove it (make it true) to enable new format
+        const enableNewFormat = false;
+
+        // Remove this (make it 1) to enable formatting
+        const disableMultiplier = enableNewFormat ? 1 : 1024 * 1024;
+
         // If single property exceeds this size, it goes into its own blob
-        const MinValueSizeSeparateSnapshotBlob = 8 * 1024;
+        const MinValueSizeSeparateSnapshotBlob = 8 * 1024 * disableMultiplier;
 
         // Maximum blob size for multiple map properties
         // Should be bigger than MinValueSizeSeparateSnapshotBlob
-        const MaxSnapshotBlobSize = 16 * 1024;
+        const MaxSnapshotBlobSize = 16 * 1024 * disableMultiplier;
 
         // Partitioning algorithm:
         // 1) Split large (over MinValueSizeSeparateSnapshotBlob = 8K) properties into their own blobs.
@@ -329,12 +336,18 @@ export class SharedMap extends SharedObject implements ISharedMap {
             }
         }
 
-        const header: IMapSerializationFormat = {
-            blobs,
-            content: headerBlob,
-        };
-
-        addBlobToTree(tree, snapshotFileName, header);
+        if (enableNewFormat) {
+            const header: IMapSerializationFormat = {
+                blobs,
+                content: headerBlob,
+            };
+            addBlobToTree(tree, snapshotFileName, header);
+        } else {
+            // For now, new code is disabled. Once ability to load snapshots in new format is deployed
+            // and build is propagated to all users, we can enable new format.
+            assert(counter === 0);
+            addBlobToTree(tree, snapshotFileName, headerBlob);
+        }
 
         return tree;
     }

--- a/packages/runtime/map/src/mapKernel.ts
+++ b/packages/runtime/map/src/mapKernel.ts
@@ -6,7 +6,7 @@
 import { IComponentHandle } from "@microsoft/fluid-component-core-interfaces";
 import { ISequencedDocumentMessage } from "@microsoft/fluid-protocol-definitions";
 import { IComponentRuntime } from "@microsoft/fluid-runtime-definitions";
-import { parseHandles, serializableHandles, ValueType } from "@microsoft/fluid-shared-object-base";
+import { makeHandlesSerializable, parseHandles, ValueType } from "@microsoft/fluid-shared-object-base";
 import { EventEmitter } from "events";
 import {
     ISerializableValue,
@@ -346,7 +346,7 @@ export class MapKernel {
         // TODO ideally we could use makeSerialized in this case as well. But the interval
         // collection has assumptions of attach being called prior. Given the IComponentSerializer it
         // may be possible to remove custom value type serialization entirely.
-        const transformedValue = serializableHandles(
+        const transformedValue = makeHandlesSerializable(
             params,
             this.runtime.IComponentSerializer,
             this.runtime.IComponentHandleContext,
@@ -709,7 +709,7 @@ export class MapKernel {
      */
     private makeMapValueOpEmitter(key: string): IValueOpEmitter {
         const emit = (opName: string, previousValue: any, params: any) => {
-            const translatedParams = serializableHandles(
+            const translatedParams = makeHandlesSerializable(
                 params,
                 this.runtime.IComponentSerializer,
                 this.runtime.IComponentHandleContext,

--- a/packages/runtime/map/src/mapKernel.ts
+++ b/packages/runtime/map/src/mapKernel.ts
@@ -19,6 +19,7 @@ import {
 import {
     ILocalValue,
     LocalValueMaker,
+    makeSerializable,
     ValueTypeLocalValue,
 } from "./localValues";
 
@@ -315,7 +316,8 @@ export class MapKernel {
         }
 
         const localValue = this.localValueMaker.fromInMemory(value);
-        const serializableValue = localValue.makeSerializable(
+        const serializableValue = makeSerializable(
+            localValue,
             this.runtime.IComponentSerializer,
             this.runtime.IComponentHandleContext,
             this.handle);
@@ -415,7 +417,8 @@ export class MapKernel {
     public getSerializableStorage(): IMapDataObjectSerializable {
         const serializableMapData: IMapDataObjectSerializable = {};
         this.data.forEach((localValue, key) => {
-            serializableMapData[key] = localValue.makeSerializable(
+            serializableMapData[key] = makeSerializable(
+                localValue,
                 this.runtime.IComponentSerializer,
                 this.runtime.IComponentHandleContext,
                 this.handle);

--- a/packages/runtime/map/src/test/directory.spec.ts
+++ b/packages/runtime/map/src/test/directory.spec.ts
@@ -30,7 +30,9 @@ function serialize(directory: map.ISharedDirectory): string {
     assert(tree.entries.length === 1);
     assert(tree.entries[0].path === "header");
     assert(tree.entries[0].type === TreeEntry[TreeEntry.Blob]);
-    return (tree.entries[0].value as IBlob).contents;
+    const contents = (tree.entries[0].value as IBlob).contents;
+    // return JSON.stringify((JSON.parse(contents) as IDirectoryNewStorageFormat).content);
+    return contents;
 }
 
 describe("Routerlicious", () => {
@@ -326,15 +328,18 @@ describe("Routerlicious", () => {
                 assert(tree.entries[0].path === "blob0");
                 assert(tree.entries[1].path === "blob1");
                 assert(tree.entries[2].path === "header");
+                assert((tree.entries[0].value as IBlob).contents.length >= 1024);
+                assert((tree.entries[1].value as IBlob).contents.length >= 1024);
+                assert((tree.entries[2].value as IBlob).contents.length <= 200);
 
                 const testDirectory2 = directoryFactory.create(runtime, "test");
                 const storage = MockSharedObjectServices.createFromTree(tree);
                 await (testDirectory2 as SharedDirectory).load("branchId", storage);
 
-                assert.equal(testDirectory.get("first"), "second");
-                assert.equal(testDirectory.get("long1"), longWord);
-                assert.equal(testDirectory.getWorkingDirectory("/nested").get("deepKey1"), "deepValue1");
-                assert.equal(testDirectory.getWorkingDirectory("/nested").get("long2"), logWord2);
+                assert.equal(testDirectory2.get("first"), "second");
+                assert.equal(testDirectory2.get("long1"), longWord);
+                assert.equal(testDirectory2.getWorkingDirectory("/nested").get("deepKey1"), "deepValue1");
+                assert.equal(testDirectory2.getWorkingDirectory("/nested").get("long2"), logWord2);
             });
         });
 

--- a/packages/runtime/map/src/test/map.spec.ts
+++ b/packages/runtime/map/src/test/map.spec.ts
@@ -9,7 +9,6 @@ import { MockRuntime, MockSharedObjectServices } from "@microsoft/fluid-test-run
 
 import * as assert from "assert";
 import * as map from "../";
-import { SharedMap } from "../map";
 
 describe("Routerlicious", () => {
     describe("Map", () => {
@@ -159,7 +158,7 @@ describe("Routerlicious", () => {
                     const subMap = factory.create(runtime, "subMap");
                     sharedMap.set("object", subMap.handle);
 
-                    const parsed = (sharedMap as SharedMap).getSerializableStorage();
+                    const parsed = (sharedMap as any).getSerializableStorage();
 
                     sharedMap.forEach((value, key) => {
                         if (!value.IComponentHandle) {
@@ -180,7 +179,7 @@ describe("Routerlicious", () => {
                     const subMap = factory.create(runtime, "subMap");
                     sharedMap.set("object", subMap.handle);
 
-                    const parsed = (sharedMap as SharedMap).getSerializableStorage();
+                    const parsed = (sharedMap as any).getSerializableStorage();
 
                     sharedMap.forEach((value, key) => {
                         if (!value || !value.IComponentHandle) {
@@ -204,7 +203,7 @@ describe("Routerlicious", () => {
                     };
                     sharedMap.set("object", containingObject);
 
-                    const serialized = JSON.stringify((sharedMap as SharedMap).getSerializableStorage());
+                    const serialized = JSON.stringify((sharedMap as any).getSerializableStorage());
                     // tslint:disable-next-line: max-line-length
                     assert.equal(serialized, `{"object":{"type":"Plain","value":{"subMapHandle":{"type":"__fluid_handle__","url":"subMap"},"nestedObj":{"subMap2Handle":{"type":"__fluid_handle__","url":"subMap2"}}}}}`);
                 });

--- a/packages/runtime/map/src/test/map.spec.ts
+++ b/packages/runtime/map/src/test/map.spec.ts
@@ -9,6 +9,7 @@ import { MockRuntime, MockSharedObjectServices } from "@microsoft/fluid-test-run
 
 import * as assert from "assert";
 import * as map from "../";
+import { SharedMap } from "../map";
 
 describe("Routerlicious", () => {
     describe("Map", () => {
@@ -158,7 +159,7 @@ describe("Routerlicious", () => {
                     const subMap = factory.create(runtime, "subMap");
                     sharedMap.set("object", subMap.handle);
 
-                    const parsed = (sharedMap as any).getSerializableStorage();
+                    const parsed = (sharedMap as SharedMap).getSerializableStorage();
 
                     sharedMap.forEach((value, key) => {
                         if (!value.IComponentHandle) {
@@ -179,7 +180,7 @@ describe("Routerlicious", () => {
                     const subMap = factory.create(runtime, "subMap");
                     sharedMap.set("object", subMap.handle);
 
-                    const parsed = (sharedMap as any).getSerializableStorage();
+                    const parsed = (sharedMap as SharedMap).getSerializableStorage();
 
                     sharedMap.forEach((value, key) => {
                         if (!value || !value.IComponentHandle) {

--- a/packages/runtime/map/src/test/map.spec.ts
+++ b/packages/runtime/map/src/test/map.spec.ts
@@ -208,7 +208,26 @@ describe("Routerlicious", () => {
                     assert.equal(serialized, `{"object":{"type":"Plain","value":{"subMapHandle":{"type":"__fluid_handle__","url":"subMap"},"nestedObj":{"subMap2Handle":{"type":"__fluid_handle__","url":"subMap2"}}}}}`);
                 });
 
-                it("serialize format for small maps", async () => {
+                it("old serialization format", async () => {
+                    sharedMap.set("key", "value");
+
+                    const tree = sharedMap.snapshot();
+                    assert(tree.entries.length === 1);
+                    const content = JSON.stringify({
+                        key: {
+                            type: "Plain",
+                            value: "value",
+                        },
+                    });
+                    assert(tree.entries.length === 1);
+                    assert((tree.entries[0].value as IBlob).contents === content);
+
+                    const services = new MockSharedObjectServices({header: content});
+                    const map2 = await factory.load(runtime, "mapId", services, "branchId");
+                    assert(map2.get("key") === "value");
+                });
+
+                it.skip("new serialization format for small maps", async () => {
                     sharedMap.set("key", "value");
 
                     const tree = sharedMap.snapshot();
@@ -230,7 +249,7 @@ describe("Routerlicious", () => {
                     assert(map2.get("key") === "value");
                 });
 
-                it("serialize format for big maps", async () => {
+                it.skip("new serialization format for big maps", async () => {
                     sharedMap.set("key", "value");
 
                     // 40K char string

--- a/packages/runtime/map/src/test/map.spec.ts
+++ b/packages/runtime/map/src/test/map.spec.ts
@@ -4,7 +4,9 @@
  */
 
 import { IComponentHandle } from "@microsoft/fluid-component-core-interfaces";
-import { MockRuntime } from "@microsoft/fluid-test-runtime-utils";
+import { IBlob } from "@microsoft/fluid-protocol-definitions";
+import { MockRuntime, MockSharedObjectServices } from "@microsoft/fluid-test-runtime-utils";
+
 import * as assert from "assert";
 import * as map from "../";
 import { SharedMap } from "../map";
@@ -157,8 +159,7 @@ describe("Routerlicious", () => {
                     const subMap = factory.create(runtime, "subMap");
                     sharedMap.set("object", subMap.handle);
 
-                    const serialized = (sharedMap as SharedMap).serialize();
-                    const parsed = JSON.parse(serialized);
+                    const parsed = (sharedMap as SharedMap).getSerializableStorage();
 
                     sharedMap.forEach((value, key) => {
                         if (!value.IComponentHandle) {
@@ -179,8 +180,7 @@ describe("Routerlicious", () => {
                     const subMap = factory.create(runtime, "subMap");
                     sharedMap.set("object", subMap.handle);
 
-                    const serialized = (sharedMap as SharedMap).serialize();
-                    const parsed = JSON.parse(serialized);
+                    const parsed = (sharedMap as SharedMap).getSerializableStorage();
 
                     sharedMap.forEach((value, key) => {
                         if (!value || !value.IComponentHandle) {
@@ -204,9 +204,81 @@ describe("Routerlicious", () => {
                     };
                     sharedMap.set("object", containingObject);
 
-                    const serialized = (sharedMap as SharedMap).serialize();
+                    const serialized = JSON.stringify((sharedMap as SharedMap).getSerializableStorage());
                     // tslint:disable-next-line: max-line-length
                     assert.equal(serialized, `{"object":{"type":"Plain","value":{"subMapHandle":{"type":"__fluid_handle__","url":"subMap"},"nestedObj":{"subMap2Handle":{"type":"__fluid_handle__","url":"subMap2"}}}}}`);
+                });
+
+                it("serialize format for small maps", async () => {
+                    sharedMap.set("key", "value");
+
+                    const tree = sharedMap.snapshot();
+                    assert(tree.entries.length === 1);
+                    const content = JSON.stringify({
+                        blobs: [],
+                        content: {
+                            key: {
+                                type: "Plain",
+                                value: "value",
+                            },
+                        },
+                    });
+                    assert(tree.entries.length === 1);
+                    assert((tree.entries[0].value as IBlob).contents === content);
+
+                    const services = new MockSharedObjectServices({header: content});
+                    const map2 = await factory.load(runtime, "mapId", services, "branchId");
+                    assert(map2.get("key") === "value");
+                });
+
+                it("serialize format for big maps", async () => {
+                    sharedMap.set("key", "value");
+
+                    // 40K char string
+                    let longString = "01234567890";
+                    for (let i = 0; i < 12; i++) {
+                        longString = longString + longString;
+                    }
+                    sharedMap.set("longValue", longString);
+                    sharedMap.set("zzz", "the end");
+
+                    const tree = sharedMap.snapshot();
+                    assert(tree.entries.length === 2);
+                    const content1 = JSON.stringify({
+                        blobs: ["blob0"],
+                        content: {
+                            key: {
+                                type: "Plain",
+                                value: "value",
+                            },
+                            zzz: {
+                                type: "Plain",
+                                value: "the end",
+                            },
+                        },
+                    });
+                    const content2 = JSON.stringify({
+                        longValue: {
+                            type: "Plain",
+                            value: longString,
+                        },
+                    });
+
+                    assert(tree.entries.length === 2);
+                    assert(tree.entries[1].path === "header");
+                    assert((tree.entries[1].value as IBlob).contents === content1);
+
+                    assert(tree.entries[0].path === "blob0");
+                    assert((tree.entries[0].value as IBlob).contents === content2);
+
+                    const services = new MockSharedObjectServices({
+                        header: content1,
+                        blob0: content2,
+                    });
+                    const map2 = await factory.load(runtime, "mapId", services, "branchId");
+                    assert(map2.get("key") === "value");
+                    assert(map2.get("longValue") === longString);
+                    assert(map2.get("zzz") === "the end");
                 });
             });
 

--- a/packages/runtime/runtime-test-utils/src/mocks.ts
+++ b/packages/runtime/runtime-test-utils/src/mocks.ts
@@ -26,10 +26,13 @@ import {
 } from "@microsoft/fluid-core-utils";
 import * as git from "@microsoft/fluid-gitresources";
 import {
+    IBlob,
     IDocumentMessage,
     ISequencedDocumentMessage,
+    ITree,
     ITreeEntry,
     MessageType,
+    TreeEntry,
 } from "@microsoft/fluid-protocol-definitions";
 import {
     IChannel,
@@ -472,6 +475,15 @@ export class MockObjectStorageService implements IObjectStorageService {
  * Mock implementation of ISharedObjectServices
  */
 export class MockSharedObjectServices implements ISharedObjectServices {
+    public static createFromTree(tree: ITree) {
+        const contents: {[key: string]: string} = {};
+        for (const entry of tree.entries) {
+            assert(entry.type === TreeEntry[TreeEntry.Blob]);
+            contents[entry.path] = (entry.value as IBlob).contents;
+        }
+        return new MockSharedObjectServices(contents);
+    }
+
     public deltaConnection = new MockEmptyDeltaConnection();
     public objectStorage: MockObjectStorageService;
 

--- a/packages/runtime/runtime-test-utils/src/mocks.ts
+++ b/packages/runtime/runtime-test-utils/src/mocks.ts
@@ -36,6 +36,7 @@ import {
     IComponentRuntime,
     IDeltaConnection,
     IDeltaHandler,
+    IObjectStorageService,
     ISharedObjectServices,
 } from "@microsoft/fluid-runtime-definitions";
 import { IHistorian } from "@microsoft/fluid-server-services-client";
@@ -434,5 +435,47 @@ export class MockHistorian implements IHistorian {
     public async getFullTree(sha: string): Promise<any> {
         assert(false, "getFullTree");
         return null;
+    }
+}
+
+/**
+ * Mock implementation of IDeltaConnection
+ */
+export class MockEmptyDeltaConnection implements IDeltaConnection {
+    public state = ConnectionState.Disconnected;
+
+    public attach(handler) {
+    }
+
+    public submit(messageContent: any): number {
+        assert(false);
+        return 0;
+    }
+}
+
+/**
+ * Mock implementation of IObjectStorageService
+ */
+export class MockObjectStorageService implements IObjectStorageService {
+    public constructor(private readonly contents: {[key: string]: string}) {
+    }
+
+    public async read(path: string): Promise<string> {
+        const content = this.contents[path];
+        // Do we have such blob?
+        assert(content !== undefined);
+        return fromUtf8ToBase64(content);
+    }
+}
+
+/**
+ * Mock implementation of ISharedObjectServices
+ */
+export class MockSharedObjectServices implements ISharedObjectServices {
+    public deltaConnection = new MockEmptyDeltaConnection();
+    public objectStorage: MockObjectStorageService;
+
+    public constructor(contents: {[key: string]: string}) {
+        this.objectStorage = new MockObjectStorageService(contents);
     }
 }

--- a/packages/runtime/sequence/src/sequence.ts
+++ b/packages/runtime/sequence/src/sequence.ts
@@ -14,7 +14,7 @@ import {
     TreeEntry,
 } from "@microsoft/fluid-protocol-definitions";
 import { IChannelAttributes, IComponentRuntime, IObjectStorageService } from "@microsoft/fluid-runtime-definitions";
-import { parseHandles, serializeHandles, SharedObject } from "@microsoft/fluid-shared-object-base";
+import { parseHandles, serializableHandles, SharedObject } from "@microsoft/fluid-shared-object-base";
 import * as assert from "assert";
 import { debug } from "./debug";
 import {
@@ -314,7 +314,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
     }
 
     public submitSequenceMessage(message: MergeTree.IMergeTreeOp) {
-        const translated = serializeHandles(
+        const translated = serializableHandles(
             message,
             this.runtime.IComponentSerializer,
             this.runtime.IComponentHandleContext,

--- a/packages/runtime/sequence/src/sequence.ts
+++ b/packages/runtime/sequence/src/sequence.ts
@@ -14,7 +14,7 @@ import {
     TreeEntry,
 } from "@microsoft/fluid-protocol-definitions";
 import { IChannelAttributes, IComponentRuntime, IObjectStorageService } from "@microsoft/fluid-runtime-definitions";
-import { parseHandles, serializableHandles, SharedObject } from "@microsoft/fluid-shared-object-base";
+import { makeHandlesSerializable, parseHandles, SharedObject } from "@microsoft/fluid-shared-object-base";
 import * as assert from "assert";
 import { debug } from "./debug";
 import {
@@ -314,7 +314,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
     }
 
     public submitSequenceMessage(message: MergeTree.IMergeTreeOp) {
-        const translated = serializableHandles(
+        const translated = makeHandlesSerializable(
             message,
             this.runtime.IComponentSerializer,
             this.runtime.IComponentHandleContext,

--- a/packages/runtime/shared-object-common/src/sharedObject.ts
+++ b/packages/runtime/shared-object-common/src/sharedObject.ts
@@ -132,8 +132,6 @@ export abstract class SharedObject extends EventEmitterWithErrorHandling impleme
 
         this.services = services;
 
-        await this.getOwnerSnapshot(services.objectStorage);
-
         await this.loadCore(
             branchId,
             services.objectStorage);
@@ -214,15 +212,6 @@ export abstract class SharedObject extends EventEmitterWithErrorHandling impleme
      * @returns The owner of the object if it is an OwnedSharedObject, otherwise undefined
      */
     protected setOwner(): string | undefined {
-        return;
-    }
-
-    /**
-     * Reads and sets the owner from storage if this is an ownedSharedObject
-     *
-     * @param storage - The storage used by the shared object
-     */
-    protected async getOwnerSnapshot(storage: IObjectStorageService): Promise<void> {
         return;
     }
 

--- a/packages/runtime/shared-object-common/src/utils.ts
+++ b/packages/runtime/shared-object-common/src/utils.ts
@@ -16,20 +16,43 @@ import {
  * @param serializer - The serializer that knows how to convert handles into serializable format
  * @param context - The handle context for the container
  * @param bind - Bind any other handles we find in the object against this given handle.
- * @returns The fully-plain object
+ * @returns Result of strigifying an object
  */
 export function serializeHandles(
     value: any,
     serializer: IComponentSerializer,
     context: IComponentHandleContext,
     bind: IComponentHandle,
-) {
+): string | undefined {
     return value !== undefined
-        ? JSON.parse(serializer.stringify(
+        ? serializer.stringify(
             value,
             context,
-            bind))
+            bind)
         : value;
+}
+
+/**
+ * Given a mostly-plain object that may have handle objects embedded within, will return a fully-plain object
+ * where the handle objects have been replaced with a serializable form.
+ * @param value - The mostly-plain object
+ * @param serializer - The serializer that knows how to convert handles into serializable format
+ * @param context - The handle context for the container
+ * @param bind - Bind any other handles we find in the object against this given handle.
+ * @returns The fully-plain object
+ */
+export function serializableHandles(
+    value: any,
+    serializer: IComponentSerializer,
+    context: IComponentHandleContext,
+    bind: IComponentHandle,
+): object | undefined {
+    const serialized = serializeHandles(
+        value,
+        serializer,
+        context,
+        bind);
+    return serialized !== undefined ? JSON.parse(serialized) : undefined;
 }
 
 /**

--- a/packages/runtime/shared-object-common/src/utils.ts
+++ b/packages/runtime/shared-object-common/src/utils.ts
@@ -10,7 +10,7 @@ import {
 } from "@microsoft/fluid-component-core-interfaces";
 
 /**
- * Given a mostly-plain object that may have handle objects embedded within, will return a fully-plain object
+ * Given a mostly-plain object that may have handle objects embedded within, return a string representation of an object
  * where the handle objects have been replaced with a serializable form.
  * @param value - The mostly-plain object
  * @param serializer - The serializer that knows how to convert handles into serializable format
@@ -41,7 +41,7 @@ export function serializeHandles(
  * @param bind - Bind any other handles we find in the object against this given handle.
  * @returns The fully-plain object
  */
-export function serializableHandles(
+export function makeHandlesSerializable(
     value: any,
     serializer: IComponentSerializer,
     context: IComponentHandleContext,

--- a/packages/test/end-to-end/src/test/sharedInterval.spec.ts
+++ b/packages/test/end-to-end/src/test/sharedInterval.spec.ts
@@ -291,7 +291,7 @@ describe("SharedInterval", () => {
             // SharedString snapshots as a blob
             const snapshotBlob = outerString2.snapshot().entries[0].value as IBlob;
             // Since it's based on a map kernel, its contents parse as
-            // an IMapDataObject with the "comments" member we set
+            // an IMapDataObjectSerializable with the "comments" member we set
             const parsedSnapshot = JSON.parse(snapshotBlob.contents);
             // LocalIntervalCollection serializes as an array of ISerializedInterval, let's get the first comment
             const serializedInterval1FromSnapshot =


### PR DESCRIPTION
Break out large map properties into its own blobs when generating snapshots.

Please provide feedback on "serialized" vs. "serializable" part of the change. I tried to stay with one type, but I'm not sure it's cleaner (I can post iteration with that).