### PR TITLE
Remove legacy code2 proposal

### DIFF
--- a/packages/hosts/base-host/src/host.ts
+++ b/packages/hosts/base-host/src/host.ts
@@ -10,6 +10,7 @@ import {
 } from "@microsoft/fluid-component-core-interfaces";
 import {
     ICodeWhiteList,
+    IFluidCodeDetails,
     IFluidResolvedUrl,
     IProxyLoaderFactory,
     IResolvedUrl,
@@ -45,7 +46,7 @@ async function attach(loader: Loader, url: string, div: HTMLDivElement) {
     }
 }
 
-async function initializeChaincode(document: Container, pkg: IResolvedPackage): Promise<void> {
+async function initializeChaincode(document: Container, pkg?: IFluidCodeDetails): Promise<void> {
     if (!pkg) {
         return;
     }
@@ -59,16 +60,13 @@ async function initializeChaincode(document: Container, pkg: IResolvedPackage): 
     }
 
     // And then make the proposal if a code proposal has not yet been made
-    if (!quorum.has("code2")) {
+    if (!quorum.has("code")) {
         // We propose both code and code2. code2 is the legacy format of just a string. code is the new object
         // based format.
-        await Promise.all([
-            quorum.propose("code", pkg.details),
-            quorum.propose("code2", pkg.parsed.full),
-        ]);
+        await quorum.propose("code", pkg);
     }
 
-    console.log(`Code is ${quorum.get("code2")}`);
+    console.log(`Code is ${quorum.get("code")}`);
 }
 
 async function registerAttach(loader: Loader, container: Container, uri: string, div: HTMLDivElement) {
@@ -91,7 +89,7 @@ async function registerAttach(loader: Loader, container: Container, uri: string,
  */
 async function createWebLoader(
     resolved: IResolvedUrl,
-    pkg: IResolvedPackage,
+    pkg: IResolvedPackage | undefined,
     scriptIds: string[],
     config: any,
     scope: IComponent,
@@ -103,6 +101,7 @@ async function createWebLoader(
     // Create the web loader and prefetch the chaincode we will need
     const codeLoader = new WebCodeLoader(whiteList);
     if (pkg) {
+        // tslint:disable-next-line: strict-boolean-expressions
         if (pkg.pkg) { // this is an IFluidPackage
             await codeLoader.seed({
                 package: pkg.pkg,
@@ -149,7 +148,7 @@ export class BaseHost {
     public static async start(
         url: string,
         resolved: IResolvedUrl,
-        pkg: IResolvedPackage,
+        pkg: IResolvedPackage | undefined,
         scriptIds: string[],
         config: any,
         scope: IComponent,
@@ -158,13 +157,13 @@ export class BaseHost {
         proxyLoaderFactories: Map<string, IProxyLoaderFactory>,
     ): Promise<Container> {
         const baseHost = new BaseHost(resolved, pkg, scriptIds, config, scope, hostConf, proxyLoaderFactories);
-        return baseHost.loadAndRender(url, div, pkg);
+        return baseHost.loadAndRender(url, div, pkg ? pkg.details : undefined);
     }
 
     private readonly loaderP: Promise<Loader>;
     public constructor(
         resolved: IResolvedUrl,
-        seedPackage: IResolvedPackage,
+        seedPackage: IResolvedPackage | undefined,
         scriptIds: string[],
         config: any,
         scope: IComponent,
@@ -187,7 +186,7 @@ export class BaseHost {
         return this.loaderP;
     }
 
-    public async loadAndRender(url: string, div: HTMLDivElement, pkg?: IResolvedPackage) {
+    public async loadAndRender(url: string, div: HTMLDivElement, pkg?: IFluidCodeDetails) {
         const loader = await this.getLoader();
         const container = await loader.resolve({ url });
         await registerAttach(
@@ -198,6 +197,7 @@ export class BaseHost {
 
         // If this is a new document we will go and instantiate the chaincode. For old documents we assume a legacy
         // package.
+        // tslint:disable-next-line: strict-boolean-expressions
         if (!container.existing) {
             await initializeChaincode(container, pkg)
                 .catch((error) => console.error("chaincode error", error));

--- a/packages/hosts/base-host/src/host.ts
+++ b/packages/hosts/base-host/src/host.ts
@@ -61,8 +61,6 @@ async function initializeChaincode(document: Container, pkg?: IFluidCodeDetails)
 
     // And then make the proposal if a code proposal has not yet been made
     if (!quorum.has("code")) {
-        // We propose both code and code2. code2 is the legacy format of just a string. code is the new object
-        // based format.
         await quorum.propose("code", pkg);
     }
 

--- a/packages/hosts/base-host/tsconfig.json
+++ b/packages/hosts/base-host/tsconfig.json
@@ -6,7 +6,6 @@
     ],
     "compilerOptions": {
         "strict": true,
-        "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist"
     },

--- a/packages/server/gateway/src/controllers/loader.ts
+++ b/packages/server/gateway/src/controllers/loader.ts
@@ -94,7 +94,7 @@ export async function initialize(
     url: string,
     resolved: IFluidResolvedUrl,
     cache: IGitCache,
-    pkg: IResolvedPackage,
+    pkg: IResolvedPackage | undefined,
     scriptIds: string[],
     jwt: string,
     config: any,
@@ -114,7 +114,7 @@ export async function initialize(
         IPackageManager: packageManager,
     };
 
-    if ( user.accounts ) {
+    if (user.accounts) {
         for (const account of user.accounts) {
             if (account.provider === "msa") {
                 const mailServices = new MailServices(account.accessToken);
@@ -157,7 +157,7 @@ export async function initialize(
     console.log(`Loading ${url}`);
 
     const div = document.getElementById("content") as HTMLDivElement;
-    const container = await baseHost.loadAndRender(url, div, pkg);
+    const container = await baseHost.loadAndRender(url, div, pkg ? pkg.details : undefined);
 
     container.on("error", (error) => {
         console.error(error);

--- a/packages/server/gateway/src/controllers/loaderFramed.ts
+++ b/packages/server/gateway/src/controllers/loaderFramed.ts
@@ -61,7 +61,7 @@ export async function initialize(
     url: string,
     resolved: IFluidResolvedUrl,
     cache: IGitCache,
-    pkg: IResolvedPackage,
+    pkg: IResolvedPackage | undefined,
     scriptIds: string[],
     jwt: string,
     config: any,
@@ -98,13 +98,13 @@ export async function initialize(
 
         documentFactory.resolveLoader(loader);
 
-        await baseHost.loadAndRender(url, div, pkg);
+        await baseHost.loadAndRender(url, div, pkg ? pkg.details : undefined);
     } else {
         const documentServiceFactories: IDocumentServiceFactory[] = [];
         // TODO: need to be support refresh token
         documentServiceFactories.push(new OdspDocumentServiceFactory(
             clientId,
-            (siteUrl: string) => Promise.resolve(resolved.tokens.storageToken) ,
+            (siteUrl: string) => Promise.resolve(resolved.tokens.storageToken),
             () => Promise.resolve(resolved.tokens.socketToken),
             new BaseTelemetryNullLogger()));
 
@@ -136,6 +136,6 @@ export async function initialize(
             privateSession.frame,
             options,
             { resolver },
-            )).createDocumentServiceFromRequest({ url });
+        )).createDocumentServiceFromRequest({ url });
     }
 }

--- a/packages/server/local-test-server/src/testDataStore.ts
+++ b/packages/server/local-test-server/src/testDataStore.ts
@@ -96,11 +96,11 @@ async function initializeChaincode(container: Container, pkg: IFluidCodeDetails)
     }
 
     // And then make the proposal if a code proposal has not yet been made
-    if (!quorum.has("code2")) {
-        await quorum.propose("code2", pkg);
+    if (!quorum.has("code")) {
+        await quorum.propose("code", pkg);
     }
 
-    debug(`Code is ${quorum.get("code2")}`);
+    debug(`Code is ${quorum.get("code")}`);
 }
 
 async function attach<T>(

--- a/packages/server/services/src/storage.ts
+++ b/packages/server/services/src/storage.ts
@@ -101,7 +101,7 @@ export class DocumentStorage implements IDocumentStorage {
                         [string, { value: string }][];
 
                     for (const quorumValue of quorumValues) {
-                        if (quorumValue[0] === "code2") {
+                        if (quorumValue[0] === "code") {
                             code = quorumValue[1].value;
                             break;
                         }

--- a/packages/tools/replay-tool/src/replayMessages.ts
+++ b/packages/tools/replay-tool/src/replayMessages.ts
@@ -600,7 +600,7 @@ export class ReplayTool {
 
         const content = await this.generateMainSnapshot(dir, final);
         if (content.snapshot === undefined) {
-            // Snapshots are not created if there is no "code2" proposal
+            // Snapshots are not created if there is no "code" proposal
             // It takes some number of ops to get there (join, propose)
             // Do not report a failure if document is almost empty.
             if (op >= 4) {

--- a/samples/hosts/literate/README.md
+++ b/samples/hosts/literate/README.md
@@ -300,8 +300,8 @@ And then finally if no code has been proposed we go and make the proposal.
 
 ```typescript
 // And then make the proposal if a code proposal has not yet been made
-if (!quorum.has("code2")) {
-    await quorum.propose("code2", pkg);
+if (!quorum.has("code")) {
+    await quorum.propose("code", pkg);
 }
 ```
 


### PR DESCRIPTION
This doesn't remove loading file that only has "code2" proposal, only the proposal itself.
So new documents that is created now may not load on (very) old loader that only support loading "code2" proposal.