### PR TITLE
change backward slash to forward slash in debug launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -339,7 +339,7 @@
             "env": {
                 "TS_NODE_PROJECT": "${fileDirname}/../../tsconfig.json",
             },
-            "args": ["--no-timeouts", "--exit", "--require", "ts-node\\register","${file}", ],
+            "args": ["--no-timeouts", "--exit", "--require", "ts-node/register","${file}", ],
             "cwd": "${workspaceFolder}"
         },
         {


### PR DESCRIPTION
This fixes "Debug Current Test" on unix-like systems and I think it will still work on windows