### PR TITLE
Add createDirectory to Document

### DIFF
--- a/packages/runtime/client-api/src/api/document.ts
+++ b/packages/runtime/client-api/src/api/document.ts
@@ -12,7 +12,7 @@ import {
 } from "@prague/container-definitions";
 import { Container, Loader } from "@prague/container-loader";
 import { IContainerRuntimeOptions } from "@prague/container-runtime";
-import { ISharedMap, SharedMap } from "@prague/map";
+import { ISharedDirectory, ISharedMap, SharedDirectory, SharedMap } from "@prague/map";
 import {
     IDocumentMessage,
     IDocumentServiceFactory,
@@ -141,6 +141,13 @@ export class Document extends EventEmitter {
      */
     public createMap(): ISharedMap {
         return SharedMap.create(this.runtime);
+    }
+
+    /**
+     * Creates a new shared directory
+     */
+    public createDirectory(): ISharedDirectory {
+        return SharedDirectory.create(this.runtime);
     }
 
     /**


### PR DESCRIPTION
This is to facilitate Word moving to 0.9.  Longer-term we'll probably want to move away from having a separate create* method for each DDS, but I'm choosing to follow the existing convention for this change for now (and we should convert to whatever new approach in one go later).