### PR TITLE
Support for blob handles

### DIFF
--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -28,7 +28,8 @@
     "@microsoft/fluid-framework-interfaces": "^0.11.0",
     "@microsoft/fluid-map": "^0.11.0",
     "@microsoft/fluid-runtime-definitions": "^0.11.0",
-    "@microsoft/fluid-shared-object-base": "^0.11.0"
+    "@microsoft/fluid-shared-object-base": "^0.11.0",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.4.4",

--- a/packages/framework/aqueduct/src/components/blobHandle.ts
+++ b/packages/framework/aqueduct/src/components/blobHandle.ts
@@ -1,0 +1,52 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    IComponentHandle,
+    IComponentHandleContext,
+    IComponentRouter,
+    IRequest,
+    IResponse,
+} from "@microsoft/fluid-component-core-interfaces";
+import { ISharedDirectory } from "@microsoft/fluid-map";
+
+/**
+ * This class represents blob (long string)
+ * This object is used only when creating (writing) new blob and serialization purposes.
+ * De-serialization process goes through ComponentHandle and request flow:
+ * PrimedComponent.request() recognizes requests in the form of '/blobs/<id>'
+ * and loads blob.
+ */
+export class BlobHandle implements IComponentHandle {
+    public get IComponentRouter(): IComponentRouter { return this; }
+    public get IComponentHandleContext(): IComponentHandleContext { return this; }
+    public get IComponentHandle(): IComponentHandle { return this; }
+
+    public get isAttached(): boolean {
+        return true;
+    }
+
+    constructor(
+        public readonly path: string,
+        private readonly directory: ISharedDirectory,
+        public readonly routeContext: IComponentHandleContext,
+    ) {
+    }
+
+    public async get(): Promise<any> {
+        return this.directory.get<string>(this.path);
+    }
+
+    public attach(): void {
+    }
+
+    public bind(handle: IComponentHandle) {
+        throw new Error("Cannot bind to blob handle");
+    }
+
+    public async request(request: IRequest): Promise<IResponse> {
+        return { status: 404, mimeType: "text/plain", value: `${request.url} not found` };
+    }
+}

--- a/packages/framework/aqueduct/src/components/index.ts
+++ b/packages/framework/aqueduct/src/components/index.ts
@@ -5,3 +5,4 @@
 
 export { PrimedComponent } from "./primedComponent";
 export { SharedComponent } from "./sharedComponent";
+export { BlobHandle } from "./blobHandle";

--- a/packages/framework/aqueduct/src/components/primedComponent.ts
+++ b/packages/framework/aqueduct/src/components/primedComponent.ts
@@ -23,13 +23,13 @@ export abstract class PrimedComponent extends SharedComponent {
     private internalRoot: ISharedDirectory | undefined;
     private internalTaskManager: ITaskManager | undefined;
     private readonly rootDirectoryId = "root";
-    private readonly bigBlogs = "bigBlobs/";
+    private readonly bigBlobs = "bigBlobs/";
 
     public async request(request: IRequest): Promise<IResponse> {
         const url = request.url;
         if (this.internalTaskManager && url.startsWith(this.taskManager.url)) {
             return this.internalTaskManager.request(request);
-        } else if (url.startsWith(this.bigBlogs)) {
+        } else if (url.startsWith(this.bigBlobs)) {
             const value = this.root.get<string>(url);
             if (value === undefined) {
                 return { mimeType: "fluid/component", status: 404, value: `request ${url} not found` };
@@ -70,7 +70,7 @@ export abstract class PrimedComponent extends SharedComponent {
      * In future blobs would be implemented as first class citizen, using blob storage APIs
      */
     public async writeBlob(blob: string): Promise<IComponentHandle> {
-        const path = `${this.bigBlogs}${uuid()}`;
+        const path = `${this.bigBlobs}${uuid()}`;
         this.root.set(path, blob);
         return new BlobHandle(path, this.root, this.runtime.IComponentHandleContext);
     }

--- a/packages/framework/aqueduct/src/components/primedComponent.ts
+++ b/packages/framework/aqueduct/src/components/primedComponent.ts
@@ -23,7 +23,7 @@ export abstract class PrimedComponent extends SharedComponent {
     private internalRoot: ISharedDirectory | undefined;
     private internalTaskManager: ITaskManager | undefined;
     private readonly rootDirectoryId = "root";
-    private readonly bigBlogs = "blobs/";
+    private readonly bigBlogs = "bigBlobs/";
 
     public async request(request: IRequest): Promise<IResponse> {
         const url = request.url;

--- a/packages/framework/aqueduct/src/components/primedComponent.ts
+++ b/packages/framework/aqueduct/src/components/primedComponent.ts
@@ -3,9 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { IRequest, IResponse } from "@microsoft/fluid-component-core-interfaces";
+import { IComponentHandle, IRequest, IResponse } from "@microsoft/fluid-component-core-interfaces";
 import { ISharedDirectory, MapFactory, SharedDirectory } from "@microsoft/fluid-map";
 import { ITaskManager } from "@microsoft/fluid-runtime-definitions";
+// tslint:disable-next-line:no-submodule-imports
+import * as uuid from "uuid/v4";
+import { BlobHandle } from "./blobHandle";
 import { SharedComponent } from "./sharedComponent";
 
 /**
@@ -20,11 +23,18 @@ export abstract class PrimedComponent extends SharedComponent {
     private internalRoot: ISharedDirectory | undefined;
     private internalTaskManager: ITaskManager | undefined;
     private readonly rootDirectoryId = "root";
+    private readonly bigBlogs = "blobs/";
 
     public async request(request: IRequest): Promise<IResponse> {
         const url = request.url;
-        if (this.internalTaskManager && url && url.startsWith(this.taskManager.url)) {
+        if (this.internalTaskManager && url.startsWith(this.taskManager.url)) {
             return this.internalTaskManager.request(request);
+        } else if (url.startsWith(this.bigBlogs)) {
+            const value = this.root.get<string>(url);
+            if (value === undefined) {
+                return { mimeType: "fluid/component", status: 404, value: `request ${url} not found` };
+            }
+            return { mimeType: "fluid/component", status: 200, value };
         } else {
             return super.request(request);
         }
@@ -51,6 +61,18 @@ export abstract class PrimedComponent extends SharedComponent {
         }
 
         return this.internalTaskManager;
+    }
+
+    /**
+     * Temporary implementation of blobs.
+     * Currently blobs are stored as properties on root map and we rely
+     * on map doing proper snapshot blob partitioning to reuse non-changing big properties.
+     * In future blobs would be implemented as first class citizen, using blob storage APIs
+     */
+    public async writeBlob(blob: string): Promise<IComponentHandle> {
+        const path = `${this.bigBlogs}${uuid()}`;
+        this.root.set(path, blob);
+        return new BlobHandle(path, this.root, this.runtime.IComponentHandleContext);
     }
 
     /**

--- a/packages/loader/utils/src/componentHandle.ts
+++ b/packages/loader/utils/src/componentHandle.ts
@@ -13,6 +13,8 @@ import {
 
 /**
  * Handle to a dynamically loaded component
+ * This class is used to represent generic IComponent (through request handler on ComponentRuntime),
+ * as well as shared objects (see ComponentRuntime.request for details)
  */
 export class ComponentHandle implements IComponentHandle {
     public get IComponentRouter() { return this; }

--- a/packages/runtime/shared-object-common/src/handle.ts
+++ b/packages/runtime/shared-object-common/src/handle.ts
@@ -13,6 +13,11 @@ import { ISharedObject } from "./types";
 
 /**
  * Component handle for shared object
+ * This object is used for already loaded (in-memory) shared object
+ * and is used only for serialization purposes.
+ * De-serialization process goes through ComponentHandle and request flow:
+ * ComponentRuntime.request() recognizes requests in the form of '/<shared object id>'
+ * and loads shared object.
  */
 export class SharedObjectComponentHandle implements IComponentHandle {
     /**

--- a/packages/test/end-to-end/src/test/primedComponent.spec.ts
+++ b/packages/test/end-to-end/src/test/primedComponent.spec.ts
@@ -8,7 +8,7 @@ import { IComponentHandle } from "@microsoft/fluid-component-core-interfaces";
 import { TestHost } from "@microsoft/fluid-local-test-server";
 import * as assert from "assert";
 
-const PrimiedType = "@microsoft/fluid-primsedComponent";
+const PrimedType = "@microsoft/fluid-primedComponent";
 
 /**
  * My sample component
@@ -28,7 +28,7 @@ describe("PrimedComponent", () => {
             host = new TestHost([
                 [PrimiedType, Promise.resolve(factory)],
             ]);
-            component = await host.createAndAttachComponent(componentId, PrimiedType);
+            component = await host.createAndAttachComponent(componentId, PrimedType);
         });
 
         afterEach(async () => { await host.close(); });

--- a/packages/test/end-to-end/src/test/primedComponent.spec.ts
+++ b/packages/test/end-to-end/src/test/primedComponent.spec.ts
@@ -1,0 +1,53 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { PrimedComponent, PrimedComponentFactory } from "@microsoft/fluid-aqueduct";
+import { IComponentHandle } from "@microsoft/fluid-component-core-interfaces";
+import { TestHost } from "@microsoft/fluid-local-test-server";
+import * as assert from "assert";
+
+const PrimiedType = "@microsoft/fluid-primsedComponent";
+
+/**
+ * My sample component
+ */
+class Component extends PrimedComponent {
+}
+
+describe("PrimedComponent", () => {
+
+    describe("Blob support", () => {
+        const componentId = "id";
+        let host: TestHost;
+        let component: Component;
+
+        beforeEach(async () => {
+            const factory = new PrimedComponentFactory(Component, []);
+            host = new TestHost([
+                [PrimiedType, Promise.resolve(factory)],
+            ]);
+            component = await host.createAndAttachComponent(componentId, PrimiedType);
+        });
+
+        afterEach(async () => { await host.close(); });
+
+        it("Blob support", async () => {
+            const handle = await component.writeBlob("aaaa");
+            assert(await handle.get<string>() === "aaaa");
+            component.root.set("key", handle);
+
+            const handle2 = component.root.get<IComponentHandle>("key");
+            const value2 = await handle2.get<string>();
+            assert(value2 === "aaaa");
+
+            const host2 = host.clone();
+            await TestHost.sync(host, host2);
+            const component2 = await host2.getComponent<Component>(componentId);
+            const value = await component2.root.get<IComponentHandle>("key").get<string>();
+            assert(value === "aaaa");
+            await host2.close();
+        });
+    });
+});

--- a/packages/test/end-to-end/src/test/primedComponent.spec.ts
+++ b/packages/test/end-to-end/src/test/primedComponent.spec.ts
@@ -26,7 +26,7 @@ describe("PrimedComponent", () => {
         beforeEach(async () => {
             const factory = new PrimedComponentFactory(Component, []);
             host = new TestHost([
-                [PrimiedType, Promise.resolve(factory)],
+                [PrimedType, Promise.resolve(factory)],
             ]);
             component = await host.createAndAttachComponent(componentId, PrimedType);
         });


### PR DESCRIPTION
This is temporal (Ignite+30 timeframe) support for large blobs (images).
It's implemented as API on PrimedComponent through storing large blobs as properties on root map.
This work replies on PR #597 for efficient storage

In the future, we will need to move this support into runtime and switch to leveraging blob APIs.
I'm taking conservative approach here for Ignite+ 30 timeframe (leveraging functionality that is proven to work), as blobs API needs some thinking and testing around GC, offline, etc.