### PR TITLE
Add performance trace class; use it for generate summary

### DIFF
--- a/packages/loader/utils/src/index.ts
+++ b/packages/loader/utils/src/index.ts
@@ -21,3 +21,4 @@ export * from "./serializer";
 export * from "./summaryTracker";
 export * from "./utils";
 export * from "./timer";
+export * from "./trace";

--- a/packages/loader/utils/src/trace.ts
+++ b/packages/loader/utils/src/trace.ts
@@ -16,7 +16,7 @@ export class Trace {
     }
 
     protected lastTick: number;
-    protected constructor(protected readonly startTick: number) {
+    protected constructor(public readonly startTick: number) {
         this.lastTick = startTick;
     }
 

--- a/packages/loader/utils/src/trace.ts
+++ b/packages/loader/utils/src/trace.ts
@@ -1,0 +1,52 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// tslint:disable-next-line:no-var-requires
+const performanceNow = require("performance-now") as (() => number);
+
+/**
+ * Helper class for tracing performance of events
+ */
+export class Trace {
+    public static start(): Trace {
+        const startTick = performanceNow();
+        return new Trace(startTick);
+    }
+
+    protected lastTick: number;
+    protected constructor(protected readonly startTick: number) {
+        this.lastTick = startTick;
+    }
+
+    public trace(): ITraceEvent {
+        const tick = performanceNow();
+        const event = {
+            totalTimeElapsed: tick - this.startTick,
+            duration: tick - this.lastTick,
+            tick,
+        };
+        this.lastTick = tick;
+        return event;
+    }
+}
+
+/**
+ * Event in a performance trace including time elapsed.
+ */
+export interface ITraceEvent {
+    /**
+     * Total time elapsed since the start of the Trace.
+     */
+    readonly totalTimeElapsed: number;
+    /**
+     * Time elapsed since the last trace event.
+     */
+    readonly duration: number;
+    /**
+     * This number represents a relative time which should
+     * be consistent for all trace ticks.
+     */
+    readonly tick: number;
+}

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -34,6 +34,7 @@ import {
     isSystemType,
     raiseConnectedEvent,
     readAndParse,
+    Trace,
 } from "@microsoft/fluid-core-utils";
 import {
     Browser,
@@ -87,34 +88,30 @@ interface ISummaryTreeWithStats {
     summaryTree: ISummaryTree;
 }
 
-/**
- * Base interface for all possible results of generate summary attempt.
- */
 export interface IGeneratedSummaryData {
-    referenceSequenceNumber: number;
-
-    /**
-     * true if the summary op was submitted
-     */
-    submitted: boolean;
-
-    summaryMessage?: ISummaryContent;
-
-    /**
-     * computed stats of generated summary tree
-     */
-    summaryStats?: ISummaryStats;
-
-    /**
-     * only set if uploaded to storage
-     */
-    handle?: string;
-
-    /**
-     * only set if submitted summary op
-     */
-    clientSequenceNumber?: number;
+    summaryStats: ISummaryStats;
+    getVersionDuration?: number;
+    generateDuration?: number;
 }
+
+export interface IUploadedSummaryData {
+    handle: string;
+    uploadDuration?: number;
+}
+
+export interface IUnsubmittedSummaryData extends Partial<IGeneratedSummaryData>, Partial<IUploadedSummaryData> {
+    referenceSequenceNumber: number;
+    submitted: false;
+}
+
+export interface ISubmittedSummaryData extends IGeneratedSummaryData, IUploadedSummaryData {
+    referenceSequenceNumber: number;
+    submitted: true;
+    clientSequenceNumber: number;
+    submitOpDuration?: number;
+}
+
+export type GenerateSummaryData = IUnsubmittedSummaryData | ISubmittedSummaryData;
 
 // Consider idle 5s of no activity. And snapshot if a minute has gone by with no snapshot.
 const IdleDetectionTime = 5000;
@@ -1079,7 +1076,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         deferred.resolve(context);
     }
 
-    private async generateSummary(fullTree: boolean = false): Promise<IGeneratedSummaryData> {
+    private async generateSummary(fullTree: boolean = false): Promise<GenerateSummaryData> {
         const message =
             `Summary @${this.deltaManager.referenceSequenceNumber}:${this.deltaManager.minimumSequenceNumber}`;
 
@@ -1100,27 +1097,33 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         try {
             await this.scheduleManager.pause();
 
-            const ret: IGeneratedSummaryData = {
+            const attemptData: IUnsubmittedSummaryData = {
                 referenceSequenceNumber: this.deltaManager.referenceSequenceNumber,
                 submitted: false,
             };
 
             if (!this.connected) {
                 // if summarizer loses connection it will never reconnect
-                return ret;
+                return attemptData;
             }
 
             // TODO in the future we can have stored the latest summary by listening to the summary ack message
             // after loading from the beginning of the snapshot
+            const trace = Trace.start();
             const versions = await this.context.storage.getVersions(this.id, 1);
             const parents = versions.map((version) => version.id);
             const parent = parents[0];
+            const getVersionDuration = trace.trace().duration;
 
             const treeWithStats = await this.summarize(fullTree);
-            ret.summaryStats = treeWithStats.summaryStats;
+            const generateData: IGeneratedSummaryData = {
+                summaryStats: treeWithStats.summaryStats,
+                getVersionDuration,
+                generateDuration: trace.trace().duration,
+            };
 
             if (!this.connected) {
-                return ret;
+                return { ...attemptData, ...generateData };
             }
 
             const handle = await this.context.storage.uploadSummary(treeWithStats.summaryTree);
@@ -1130,17 +1133,25 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
                 message,
                 parents,
             };
-            ret.handle = handle.handle;
+            const uploadData: IUploadedSummaryData = {
+                handle: handle.handle,
+                uploadDuration: trace.trace().duration,
+            };
 
             if (!this.connected) {
-                return ret;
+                return { ...attemptData, ...generateData, ...uploadData };
             }
 
-            ret.clientSequenceNumber = this.submit(MessageType.Summarize, summaryMessage);
-            ret.summaryMessage = summaryMessage;
-            ret.submitted = true;
+            const clientSequenceNumber = this.submit(MessageType.Summarize, summaryMessage);
 
-            return ret;
+            return {
+                ...attemptData,
+                ...generateData,
+                ...uploadData,
+                submitted: true,
+                clientSequenceNumber,
+                submitOpDuration: trace.trace().duration,
+            };
         } finally {
             // Restart the delta manager
             this.scheduleManager.resume();

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -89,26 +89,26 @@ interface ISummaryTreeWithStats {
 }
 
 export interface IGeneratedSummaryData {
-    summaryStats: ISummaryStats;
-    getVersionDuration?: number;
-    generateDuration?: number;
+    readonly summaryStats: ISummaryStats;
+    readonly getVersionDuration?: number;
+    readonly generateDuration?: number;
 }
 
 export interface IUploadedSummaryData {
-    handle: string;
-    uploadDuration?: number;
+    readonly handle: string;
+    readonly uploadDuration?: number;
 }
 
 export interface IUnsubmittedSummaryData extends Partial<IGeneratedSummaryData>, Partial<IUploadedSummaryData> {
-    referenceSequenceNumber: number;
-    submitted: false;
+    readonly referenceSequenceNumber: number;
+    readonly submitted: false;
 }
 
 export interface ISubmittedSummaryData extends IGeneratedSummaryData, IUploadedSummaryData {
-    referenceSequenceNumber: number;
-    submitted: true;
-    clientSequenceNumber: number;
-    submitOpDuration?: number;
+    readonly referenceSequenceNumber: number;
+    readonly submitted: true;
+    readonly clientSequenceNumber: number;
+    readonly submitOpDuration?: number;
 }
 
 export type GenerateSummaryData = IUnsubmittedSummaryData | ISubmittedSummaryData;

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -480,7 +480,7 @@ export class RunningSummarizer implements IDisposable {
             opsSinceLastSummary: summaryData.referenceSequenceNumber - this.heuristics.lastAcked.refSequenceNumber,
         };
         telemetryProps.summaryStats = undefined;
-        summaryData.referenceSequenceNumber = undefined;
+        telemetryProps.referenceSequenceNumber = undefined;
 
         if (summaryData.submitted) {
             summarizingEvent.end(telemetryProps);

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -18,8 +18,7 @@ import {
     ISummaryConfiguration,
     MessageType,
 } from "@microsoft/fluid-protocol-definitions";
-import * as assert from "assert";
-import { ContainerRuntime, IGeneratedSummaryData } from "./containerRuntime";
+import { ContainerRuntime, GenerateSummaryData } from "./containerRuntime";
 import { RunWhileConnectedCoordinator } from "./runWhileConnectedCoordinator";
 import { IClientSummaryWatcher, ISummaryAckMessage, SummaryCollection } from "./summaryCollection";
 
@@ -46,7 +45,7 @@ export class Summarizer implements IComponentRouter, IComponentRunnable, ICompon
         public readonly url: string,
         private readonly runtime: ContainerRuntime,
         private readonly configurationGetter: () => ISummaryConfiguration,
-        private readonly generateSummaryCore: () => Promise<IGeneratedSummaryData>,
+        private readonly generateSummaryCore: () => Promise<GenerateSummaryData>,
         private readonly refreshBaseSummary: (snapshot: ISnapshotTree) => void,
     ) {
         this.logger = ChildLogger.create(this.runtime.logger, "Summarizer");
@@ -155,7 +154,7 @@ export class Summarizer implements IComponentRouter, IComponentRunnable, ICompon
         }
     }
 
-    private async generateSummary(): Promise<IGeneratedSummaryData | undefined> {
+    private async generateSummary(): Promise<GenerateSummaryData | undefined> {
         if (this.onBehalfOfClientId !== this.runtime.summarizerClientId) {
             // we are no longer the summarizer, we should stop ourself
             this.stop("parentNoLongerSummarizer");
@@ -242,7 +241,7 @@ export class RunningSummarizer implements IDisposable {
         logger: ITelemetryLogger,
         summaryWatcher: IClientSummaryWatcher,
         configuration: ISummaryConfiguration,
-        generateSummary: () => Promise<IGeneratedSummaryData | undefined>,
+        generateSummary: () => Promise<GenerateSummaryData | undefined>,
         handleSuccessfulSummary: (ack: ISummaryAckMessage) => Promise<void>,
         lastOpSeqNumber: number,
         firstAck: ISummaryAttempt,
@@ -278,7 +277,7 @@ export class RunningSummarizer implements IDisposable {
         private readonly logger: ITelemetryLogger,
         private readonly summaryWatcher: IClientSummaryWatcher,
         private readonly configuration: ISummaryConfiguration,
-        private readonly generateSummary: () => Promise<IGeneratedSummaryData | undefined>,
+        private readonly generateSummary: () => Promise<GenerateSummaryData | undefined>,
         private readonly handleSuccessfulSummary: (ack: ISummaryAckMessage) => Promise<void>,
         lastOpSeqNumber: number,
         firstAck: ISummaryAttempt,
@@ -404,8 +403,6 @@ export class RunningSummarizer implements IDisposable {
             // did not send the summary op
             return;
         }
-        // must be set if submitted
-        assert(summaryData.clientSequenceNumber);
 
         this.heuristics.lastSent = {
             refSequenceNumber: summaryData.referenceSequenceNumber,
@@ -450,7 +447,7 @@ export class RunningSummarizer implements IDisposable {
         }
     }
 
-    private async generateSummaryWithLogging(message: string): Promise<IGeneratedSummaryData | undefined> {
+    private async generateSummaryWithLogging(message: string): Promise<GenerateSummaryData | undefined> {
         const summarizingEvent = PerformanceEvent.start(this.logger, {
             eventName: "Summarizing",
             message,
@@ -460,7 +457,7 @@ export class RunningSummarizer implements IDisposable {
         });
 
         // wait for generate/send summary
-        let summaryData: IGeneratedSummaryData | undefined;
+        let summaryData: GenerateSummaryData | undefined;
         try {
             summaryData = await this.generateSummary();
         } catch (error) {
@@ -476,13 +473,14 @@ export class RunningSummarizer implements IDisposable {
         }
 
         const telemetryProps = {
-            refSequenceNumber: summaryData.referenceSequenceNumber,
-            handle: summaryData.handle,
-            clientSequenceNumber: summaryData.clientSequenceNumber,
+            ...summaryData,
             ...summaryData.summaryStats,
+            refSequenceNumber: summaryData.referenceSequenceNumber,
             opsSinceLastAttempt: summaryData.referenceSequenceNumber - this.heuristics.lastSent.refSequenceNumber,
             opsSinceLastSummary: summaryData.referenceSequenceNumber - this.heuristics.lastAcked.refSequenceNumber,
         };
+        telemetryProps.summaryStats = undefined;
+        summaryData.referenceSequenceNumber = undefined;
 
         if (summaryData.submitted) {
             summarizingEvent.end(telemetryProps);

--- a/packages/runtime/container-runtime/src/test/summarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizer.spec.ts
@@ -92,7 +92,11 @@ describe("Runtime", () => {
                 async function emitNextOp(increment: number = 1) {
                     await flushPromises();
                     lastRefSeq += increment;
-                    summarizer.handleOp(undefined, { sequenceNumber: lastRefSeq } as ISequencedDocumentMessage);
+                    const op: Partial<ISequencedDocumentMessage> = {
+                        sequenceNumber: lastRefSeq,
+                        timestamp: Date.now(),
+                    };
+                    summarizer.handleOp(undefined, op as ISequencedDocumentMessage);
                     await Promise.resolve();
                 }
 
@@ -123,7 +127,7 @@ describe("Runtime", () => {
                     await refreshBaseSummaryDeferred.promise;
                     refreshBaseSummaryDeferred = new Deferred();
 
-                    await Promise.resolve(); // let finally of summarize run
+                    await flushPromises(); // let finally of summarize run
                 }
 
                 async function flushPromises(count: number = 1) {

--- a/packages/runtime/container-runtime/src/test/summarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizer.spec.ts
@@ -68,12 +68,15 @@ describe("Runtime", () => {
                             }
                             return {
                                 referenceSequenceNumber: lastRefSeq,
-                                clientSequenceNumber: lastClientSeq,
                                 submitted: true,
-                                treeNodeCount: 0,
-                                blobNodeCount: 0,
-                                handleNodeCount: 0,
-                                totalBlobSize: 0,
+                                summaryStats: {
+                                    treeNodeCount: 0,
+                                    blobNodeCount: 0,
+                                    handleNodeCount: 0,
+                                    totalBlobSize: 0,
+                                },
+                                handle: "test-handle",
+                                clientSequenceNumber: lastClientSeq,
                             };
                         },
                         async () => { refreshBaseSummaryDeferred.resolve(); },


### PR DESCRIPTION
Fixes issue #550.
Adds a Trace class in core-utils which uses performance-now to trace high-density time duration.  This is similar to how PerformanceEvent works, but without the overhead of logging telemetry events.

Uses the class to track individual parts of the generateSummary call.
- getVersionDuration (time spent getting parent version from storage)
- generateDuration (actual time generating summary on client)
- uploadDuration (time uploading the summary to storage)
- submitOpDuration (time spent sending op to server; NOT time spent waiting for broadcast)

Also broke out the resulting type into different parts so we do not need to assert clientSequenceNumber is defined.