### PR TITLE
Base-Host: folding loader config parameter into IBaseHostConfig (Part 1)

### DIFF
--- a/packages/hosts/base-host/src/host.ts
+++ b/packages/hosts/base-host/src/host.ts
@@ -16,7 +16,7 @@ import {
 import { Container, Loader } from "@microsoft/fluid-container-loader";
 import { IFluidResolvedUrl, IResolvedUrl } from "@microsoft/fluid-driver-definitions";
 import { IResolvedPackage, WebCodeLoader, WhiteList } from "@microsoft/fluid-web-code-loader";
-import { IHostConfig } from "./hostConfig";
+import { IBaseHostConfig } from "./hostConfig";
 
 async function attach(loader: Loader, url: string, div: HTMLDivElement) {
     const response = await loader.request({ url });
@@ -90,7 +90,7 @@ async function createWebLoader(
     scriptIds: string[],
     config: any,
     scope: IComponent,
-    hostConf: IHostConfig,
+    hostConf: IBaseHostConfig,
     proxyLoaderFactories: Map<string, IProxyLoaderFactory>,
     whiteList?: ICodeWhiteList,
 ): Promise<Loader> {
@@ -150,7 +150,7 @@ export class BaseHost {
         config: any,
         scope: IComponent,
         div: HTMLDivElement,
-        hostConf: IHostConfig,
+        hostConf: IBaseHostConfig,
         proxyLoaderFactories: Map<string, IProxyLoaderFactory>,
     ): Promise<Container> {
         const baseHost = new BaseHost(resolved, pkg, scriptIds, config, scope, hostConf, proxyLoaderFactories);
@@ -164,7 +164,7 @@ export class BaseHost {
         scriptIds: string[],
         config: any,
         scope: IComponent,
-        hostConfig: IHostConfig,
+        hostConfig: IBaseHostConfig,
         proxyLoaderFactories: Map<string, IProxyLoaderFactory>) {
 
         this.loaderP = createWebLoader(

--- a/packages/hosts/base-host/src/host.ts
+++ b/packages/hosts/base-host/src/host.ts
@@ -9,13 +9,12 @@ import {
     IComponentQueryableLegacy,
 } from "@microsoft/fluid-component-core-interfaces";
 import {
-    ICodeWhiteList,
     IFluidCodeDetails,
     IProxyLoaderFactory,
 } from "@microsoft/fluid-container-definitions";
 import { Container, Loader } from "@microsoft/fluid-container-loader";
 import { IFluidResolvedUrl, IResolvedUrl } from "@microsoft/fluid-driver-definitions";
-import { IResolvedPackage, WebCodeLoader, WhiteList } from "@microsoft/fluid-web-code-loader";
+import { IResolvedPackage, WebCodeLoader } from "@microsoft/fluid-web-code-loader";
 import { IBaseHostConfig } from "./hostConfig";
 
 async function attach(loader: Loader, url: string, div: HTMLDivElement) {
@@ -75,28 +74,20 @@ async function registerAttach(loader: Loader, container: Container, uri: string,
 
 /**
  * Create a loader and return it.
+ * @param hostConfig - Config specifying the resolver/factory to be used.
  * @param resolved - A resolved url from a url resolver.
  * @param pkg - A resolved package with cdn links.
  * @param scriptIds - The script tags the chaincode are attached to the view with.
- * @param config - Any config to be provided to loader.
- * @param scope - A component that gives host provided capabilities/configurations
- *  to the component in the container(such as auth).
- * @param hostConf - Config specifying the resolver/factory to be used.
- * @param whiteList - functionality to check the validity of code to be loaded.
  */
 async function createWebLoader(
+    hostConfig: IBaseHostConfig,
     resolved: IResolvedUrl,
     pkg: IResolvedPackage | undefined,
     scriptIds: string[],
-    config: any,
-    scope: IComponent,
-    hostConf: IBaseHostConfig,
-    proxyLoaderFactories: Map<string, IProxyLoaderFactory>,
-    whiteList?: ICodeWhiteList,
 ): Promise<Loader> {
 
     // Create the web loader and prefetch the chaincode we will need
-    const codeLoader = new WebCodeLoader(whiteList);
+    const codeLoader = new WebCodeLoader(hostConfig.whiteList);
     if (pkg) {
         // tslint:disable-next-line: strict-boolean-expressions
         if (pkg.pkg) { // this is an IFluidPackage
@@ -113,6 +104,9 @@ async function createWebLoader(
         // The load takes in an IFluidCodeDetails
         codeLoader.load(pkg.details).catch((error) => console.error("script load error", error));
     }
+
+    const config = hostConfig.config ? hostConfig.config : {};
+
     // we need to extend options, otherwise we nest properties, like client, too deeply
     //
     // tslint:disable-next-line: no-unsafe-any
@@ -120,9 +114,13 @@ async function createWebLoader(
     // tslint:disable-next-line: no-unsafe-any
     config.tokens = (resolved as IFluidResolvedUrl).tokens;
 
+    const scope = hostConfig.scope ? hostConfig.scope : {};
+    const proxyLoaderFactories = hostConfig.proxyLoaderFactories ?
+        hostConfig.proxyLoaderFactories : new Map<string, IProxyLoaderFactory>();
+
     return new Loader(
-        { resolver: hostConf.urlResolver },
-        hostConf.documentServiceFactory,
+        { resolver: hostConfig.urlResolver },
+        hostConfig.documentServiceFactory,
         codeLoader,
         config,
         scope,
@@ -132,50 +130,38 @@ async function createWebLoader(
 export class BaseHost {
     /**
      * Function to load the container from the given url and initialize the chaincode.
+     * @param hostConfig - Config specifying the resolver/factory and other loader settings to be used.
      * @param url - Url of the Fluid component to be loaded.
      * @param resolved - A resolved url from a url resolver.
      * @param pkg - A resolved package with cdn links.
      * @param scriptIds - The script tags the chaincode are attached to the view with.
-     * @param config - Any config to be provided to loader.
-     * @param scope - A component that gives host provided capabilities/configurations
-     *  to the component in the container(such as auth).
      * @param div - The div to load the component into.
-     * @param hostConf - Config specifying the resolver/factory to be used.
      */
     public static async start(
+        hostConfig: IBaseHostConfig,
         url: string,
         resolved: IResolvedUrl,
         pkg: IResolvedPackage | undefined,
         scriptIds: string[],
-        config: any,
-        scope: IComponent,
         div: HTMLDivElement,
-        hostConf: IBaseHostConfig,
-        proxyLoaderFactories: Map<string, IProxyLoaderFactory>,
     ): Promise<Container> {
-        const baseHost = new BaseHost(resolved, pkg, scriptIds, config, scope, hostConf, proxyLoaderFactories);
+        const baseHost = new BaseHost(hostConfig, resolved, pkg, scriptIds);
         return baseHost.loadAndRender(url, div, pkg ? pkg.details : undefined);
     }
 
     private readonly loaderP: Promise<Loader>;
     public constructor(
+        hostConfig: IBaseHostConfig,
         resolved: IResolvedUrl,
         seedPackage: IResolvedPackage | undefined,
         scriptIds: string[],
-        config: any,
-        scope: IComponent,
-        hostConfig: IBaseHostConfig,
-        proxyLoaderFactories: Map<string, IProxyLoaderFactory>) {
+    ) {
 
         this.loaderP = createWebLoader(
+            hostConfig,
             resolved,
             seedPackage,
             scriptIds,
-            config,
-            scope,
-            hostConfig,
-            proxyLoaderFactories,
-            new WhiteList(),
         );
     }
 

--- a/packages/hosts/base-host/src/hostConfig.ts
+++ b/packages/hosts/base-host/src/hostConfig.ts
@@ -10,7 +10,7 @@ import { IDocumentServiceFactory, IUrlResolver } from "@microsoft/fluid-driver-d
  * list of document service factories from which one can be selected based on protocol
  * of resolved url.
  */
-export interface IHostConfig {
+export interface IBaseHostConfig {
     documentServiceFactory: IDocumentServiceFactory | IDocumentServiceFactory[];
     urlResolver: IUrlResolver | IUrlResolver[];
 }

--- a/packages/hosts/base-host/src/hostConfig.ts
+++ b/packages/hosts/base-host/src/hostConfig.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { IComponent } from "@microsoft/fluid-component-core-interfaces";
+import { ICodeWhiteList, IProxyLoaderFactory } from "@microsoft/fluid-container-definitions";
 import { IDocumentServiceFactory, IUrlResolver } from "@microsoft/fluid-driver-definitions";
 
 /**
@@ -13,4 +15,16 @@ import { IDocumentServiceFactory, IUrlResolver } from "@microsoft/fluid-driver-d
 export interface IBaseHostConfig {
     documentServiceFactory: IDocumentServiceFactory | IDocumentServiceFactory[];
     urlResolver: IUrlResolver | IUrlResolver[];
+
+    // Any config to be provided to loader.
+    config?: any;
+
+    // A component that gives host provided capabilities/configurations
+    // to the component in the container(such as auth).
+    scope?: IComponent;
+
+    proxyLoaderFactories?: Map<string, IProxyLoaderFactory>;
+
+    // White List for the code loader
+    whiteList?: ICodeWhiteList;
 }

--- a/packages/hosts/tiny-web-host/src/host.ts
+++ b/packages/hosts/tiny-web-host/src/host.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { BaseHost, IHostConfig } from "@microsoft/fluid-base-host";
+import { BaseHost, IBaseHostConfig } from "@microsoft/fluid-base-host";
 import { IProxyLoaderFactory } from "@microsoft/fluid-container-definitions";
 import { BaseTelemetryNullLogger, configurableUrlResolver } from "@microsoft/fluid-core-utils";
 import {
@@ -116,7 +116,7 @@ async function loadContainer(
         "",
         new Map<string, IResolvedUrl>([[href, resolved]]));
 
-    const hostConf: IHostConfig = {
+    const hostConf: IBaseHostConfig = {
         documentServiceFactory,
         urlResolver: resolver,
     };

--- a/packages/hosts/tiny-web-host/src/host.ts
+++ b/packages/hosts/tiny-web-host/src/host.ts
@@ -4,7 +4,6 @@
  */
 
 import { BaseHost, IBaseHostConfig } from "@microsoft/fluid-base-host";
-import { IProxyLoaderFactory } from "@microsoft/fluid-container-definitions";
 import { BaseTelemetryNullLogger, configurableUrlResolver } from "@microsoft/fluid-core-utils";
 import {
     IDocumentServiceFactory,
@@ -122,16 +121,13 @@ async function loadContainer(
     };
     // tslint:disable-next-line: no-unsafe-any
     return BaseHost.start(
+        hostConf,
         href,
         // tslint:disable-next-line: no-unsafe-any
         resolved, // resolved, IResolvedUrl,
         pkg, // pkg, IResolvedPackage, (gateway/routes/loader has an example (pkgP))
         scriptIds, // scriptIds, string[], defines the id of the script tag added to the page
-        {},
-        {},
         div,
-        hostConf,
-        new Map<string, IProxyLoaderFactory>(),
     );
 }
 

--- a/packages/server/gateway/src/childLoader.ts
+++ b/packages/server/gateway/src/childLoader.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { IHostConfig } from "@microsoft/fluid-base-host";
+import { IBaseHostConfig } from "@microsoft/fluid-base-host";
 import { IComponent } from "@microsoft/fluid-component-core-interfaces";
 import { IProxyLoaderFactory } from "@microsoft/fluid-container-definitions";
 import { Container, Loader } from "@microsoft/fluid-container-loader";
@@ -96,7 +96,7 @@ class KeyValueLoader {
             hostToken,
             new Map<string, IResolvedUrl>([[documentUrl, result.data]]));
 
-        const hostConf: IHostConfig = { documentServiceFactory: documentServiceFactories, urlResolver: resolver };
+        const hostConf: IBaseHostConfig = { documentServiceFactory: documentServiceFactories, urlResolver: resolver };
         config.tokens = (result.data as IFluidResolvedUrl).tokens;
 
         const loader = new Loader(

--- a/packages/server/gateway/src/controllers/loader.ts
+++ b/packages/server/gateway/src/controllers/loader.ts
@@ -144,14 +144,19 @@ export async function initialize(
         jwt,
         new Map<string, IFluidResolvedUrl>([[url, resolved]]));
 
-    const hostConf: IBaseHostConfig = { documentServiceFactory: documentServiceFactories, urlResolver: resolver };
+    const hostConfig: IBaseHostConfig = {
+        documentServiceFactory: documentServiceFactories,
+        urlResolver: resolver,
+        config,
+        scope: services,
+        proxyLoaderFactories: new Map<string, IProxyLoaderFactory>([["webworker", new WebWorkerLoaderFactory()]]),
+    };
 
     // Provide access to all loader services from command line for easier testing as we bring more up
     // tslint:disable-next-line
     window["allServices"] = services;
 
-    const baseHost = new BaseHost(resolved, pkg, scriptIds, config, services, hostConf,
-        new Map<string, IProxyLoaderFactory>([["webworker", new WebWorkerLoaderFactory()]]));
+    const baseHost = new BaseHost(hostConfig, resolved, pkg, scriptIds);
     const loader = await baseHost.getLoader();
     documentFactory.resolveLoader(loader);
 

--- a/packages/server/gateway/src/controllers/loader.ts
+++ b/packages/server/gateway/src/controllers/loader.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { BaseHost, IHostConfig } from "@microsoft/fluid-base-host";
+import { BaseHost, IBaseHostConfig } from "@microsoft/fluid-base-host";
 import { IProxyLoaderFactory } from "@microsoft/fluid-container-definitions";
 import { BaseTelemetryNullLogger } from "@microsoft/fluid-core-utils";
 import {
@@ -144,7 +144,7 @@ export async function initialize(
         jwt,
         new Map<string, IFluidResolvedUrl>([[url, resolved]]));
 
-    const hostConf: IHostConfig = { documentServiceFactory: documentServiceFactories, urlResolver: resolver };
+    const hostConf: IBaseHostConfig = { documentServiceFactory: documentServiceFactories, urlResolver: resolver };
 
     // Provide access to all loader services from command line for easier testing as we bring more up
     // tslint:disable-next-line

--- a/packages/server/gateway/src/controllers/loaderFramed.ts
+++ b/packages/server/gateway/src/controllers/loaderFramed.ts
@@ -34,10 +34,12 @@ export async function initialize(
     const hostConf: IBaseHostConfig = {
         documentServiceFactory: new InnerDocumentServiceFactory(),
         urlResolver: new InnerUrlResolver(resolved),
+        config,
+        scope,
+        proxyLoaderFactories: new Map<string, IProxyLoaderFactory>([["webworker", new WebWorkerLoaderFactory()]]),
     };
 
-    const baseHost = new BaseHost(resolved, pkg, scriptIds, config, scope, hostConf,
-        new Map<string, IProxyLoaderFactory>([["webworker", new WebWorkerLoaderFactory()]]));
+    const baseHost = new BaseHost(hostConf, resolved, pkg, scriptIds);
     const loader = await baseHost.getLoader();
 
     const documentFactory = new DocumentFactory(config.tenantId,

--- a/packages/server/gateway/src/controllers/loaderFramed.ts
+++ b/packages/server/gateway/src/controllers/loaderFramed.ts
@@ -5,7 +5,7 @@
 
 import {
     BaseHost,
-    IHostConfig,
+    IBaseHostConfig,
 } from "@microsoft/fluid-base-host";
 import { IComponent } from "@microsoft/fluid-component-core-interfaces";
 import { IProxyLoaderFactory } from "@microsoft/fluid-container-definitions";
@@ -31,7 +31,7 @@ export async function initialize(
 
     const div = document.getElementById("content") as HTMLDivElement;
 
-    const hostConf: IHostConfig = {
+    const hostConf: IBaseHostConfig = {
         documentServiceFactory: new InnerDocumentServiceFactory(),
         urlResolver: new InnerUrlResolver(resolved),
     };

--- a/packages/tools/webpack-component-loader/src/loader.ts
+++ b/packages/tools/webpack-component-loader/src/loader.ts
@@ -10,7 +10,6 @@ import {
     IFluidModule,
     IFluidPackage,
     IPackage,
-    IProxyLoaderFactory,
     isFluidPackage,
 } from "@microsoft/fluid-container-definitions";
 import { IDocumentServiceFactory, IUrlResolver } from "@microsoft/fluid-driver-definitions";
@@ -221,15 +220,12 @@ export async function start(
     }
 
     const start1Promise = BaseHost.start(
+        hostConf,
         url,
         await urlResolver.resolve(req),
         pkg,
         scriptIds,
-        {},
-        {},
         double ? leftDiv : div,
-        hostConf,
-        new Map<string, IProxyLoaderFactory>(),
     );
 
     let start2Promise: Promise<any> = Promise.resolve();
@@ -241,15 +237,12 @@ export async function start(
         // BaseHost.start will create a new Loader/Container/Component from the startCore above. This is
         // intentional because we want to emulate two clients collaborating with each other.
         start2Promise = BaseHost.start(
+            hostConf2,
             url,
             await urlResolver.resolve(req),
             pkg,
             scriptIds,
-            {},
-            {},
             rightDiv,
-            hostConf2,
-            new Map<string, IProxyLoaderFactory>(),
         );
     }
     await Promise.all([start1Promise, start2Promise]);

--- a/packages/tools/webpack-component-loader/src/loader.ts
+++ b/packages/tools/webpack-component-loader/src/loader.ts
@@ -4,7 +4,7 @@
  */
 
 import { SimpleModuleInstantiationFactory } from "@microsoft/fluid-aqueduct";
-import { BaseHost, IHostConfig } from "@microsoft/fluid-base-host";
+import { BaseHost, IBaseHostConfig } from "@microsoft/fluid-base-host";
 import { IRequest } from "@microsoft/fluid-component-core-interfaces";
 import {
     IFluidModule,
@@ -209,7 +209,7 @@ export async function start(
         deltaConn = TestDeltaConnectionServer.create(new SessionStorageDbFactory(documentId));
         documentServiceFactory = new TestDocumentServiceFactory(deltaConn);
     }
-    const hostConf: IHostConfig = { documentServiceFactory, urlResolver };
+    const hostConf: IBaseHostConfig = { documentServiceFactory, urlResolver };
 
     const double = (options.mode === "local") && !options.single;
     let leftDiv: HTMLDivElement;

--- a/samples/experiments/collab-compose/src/taskpane/taskpane.ts
+++ b/samples/experiments/collab-compose/src/taskpane/taskpane.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IHostConfig, registerAttach } from "@microsoft/fluid-base-host";
+import { registerAttach } from "@microsoft/fluid-base-host";
 import { IComponent } from "@microsoft/fluid-component-core-interfaces";
 import { IFluidCodeDetails, ILoader } from "@microsoft/fluid-container-definitions";
 import { Deferred } from "@microsoft/fluid-core-utils";
@@ -98,13 +98,10 @@ function start(info) {
     true));
 
   const resolver = new ContainerUrlResolver(host, jwtToken);
-
-  const hostConf: IHostConfig = { documentServiceFactory: documentServiceFactories, urlResolver: resolver };
-
   const codeLoader = new WebCodeLoader();
   const loader = new Loader(
     {
-      resolver: hostConf.urlResolver
+      resolver
     },
     documentServiceFactories,
     codeLoader,

--- a/samples/experiments/collab-slide/src/taskpane/taskpane.ts
+++ b/samples/experiments/collab-slide/src/taskpane/taskpane.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { IHostConfig } from "@microsoft/fluid-base-host";
 import { IComponent } from "@microsoft/fluid-component-core-interfaces";
 import { IFluidCodeDetails, ILoader } from "@microsoft/fluid-container-definitions";
 import { Deferred } from "@microsoft/fluid-core-utils";
@@ -93,13 +92,10 @@ function start(info) {
     true));
 
   const resolver = new ContainerUrlResolver(host, jwtToken);
-
-  const hostConf: IHostConfig = { documentServiceFactory: documentServiceFactories, urlResolver: resolver };
-
   const codeLoader = new WebCodeLoader();
   const loader = new Loader(
     {
-      resolver: hostConf.urlResolver
+      resolver
     },
     documentServiceFactories,
     codeLoader,


### PR DESCRIPTION
Rename IHostConfig to IBaseHostConfig
Folding config/scope/proxyLoaderFactories to IBaseHostConfig and make them optional
More of the parameter will be moved.