### PR TITLE
Properly propagate disconnected events on container / connection clos…

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentDeltaConnection.ts
@@ -230,5 +230,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
 
         OdspDocumentDeltaConnection.removeSocketIoReference(this.socketReferenceKey);
         this.socketReferenceKey = undefined;
+
+        this.emit("disconnect", "client closing connection");
     }
 }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -341,6 +341,8 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
             this.protocolHandler.close();
         }
 
+        assert(this.connectionState === ConnectionState.Disconnected, "disconnect event was not raised!");
+
         this.emit("closed");
 
         this.removeAllListeners();

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -589,7 +589,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         }
         this.closed = true;
 
-        const error = errorArg !== undefined ? errorArg : new Error("Container closed")
+        const error = errorArg !== undefined ? errorArg : new Error("Container closed");
 
         // Note: "disconnect" & "nack" do not have error object
         if (error !== undefined) {

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -583,13 +583,11 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
     /**
      * Closes the connection and clears inbound & outbound queues.
      */
-    public close(errorArg?: any): void {
+    public close(error?: any): void {
         if (this.closed) {
             return;
         }
         this.closed = true;
-
-        const error = errorArg !== undefined ? errorArg : new Error("Container closed");
 
         // Note: "disconnect" & "nack" do not have error object
         if (error !== undefined) {
@@ -604,7 +602,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         this.disconnectFromDeltaStream("Disconnect on close");
 
         if (this.connecting) {
-            this.connecting.reject(error);
+            this.connecting.reject(error !== undefined ? error : new Error("Container closed"));
             this.connecting = undefined;
         }
 


### PR DESCRIPTION
Properly propagate disconnected events on container / connection closure when underlying socket is left open for future reuse

We were never correctly raising disconnected event on closure of OdspDocumentDeltaConnection (IDocumentDeltaConnection). But because underlying socket was closed, we were getting "disconnect" event pretty quickly (though still asynchronously, and thus with some chance of hitting same problem).

With socket ODSP reuse in 0.11, we do not close socket for 2 seconds as result of connection closure, in an attempt to reuse same socket on reconnect. As result, disconnected events do not flow through the system, and DeltaManager is left in inconsistent state (no connection, but connected state). Bohemia attempts to submit an op in this state and we hit undefined dereference.

The fix is to make sure DeltaManager always stays in consistent state and raises disconnect events on connection closure. It already does it on disconnectFromDeltaStream() path, so reusing it.
Also making sure that OdspDocumentDeltaConnection  raises connection on closure, and Container validates state is consistent on closure.
