### PR TITLE
Moved logger dependency out of Protocol-op-handler.

### DIFF
--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -8,6 +8,7 @@ import {
     IClientDetails,
     IContentMessage,
     IDisposable,
+    IProcessMessageResult,
     ISequencedDocumentMessage,
     IServiceConfiguration,
     ISignalClient,
@@ -30,10 +31,6 @@ export interface IConnectionDetails {
     initialSignals?: ISignalMessage[];
     maxMessageSize: number;
     serviceConfiguration: IServiceConfiguration;
-}
-
-export interface IProcessMessageResult {
-    immediateNoOp?: boolean;
 }
 
 /**

--- a/packages/loader/container-loader/src/protocol.ts
+++ b/packages/loader/container-loader/src/protocol.ts
@@ -13,9 +13,6 @@ import {
     ISequencedDocumentMessage,
     ISequencedDocumentSystemMessage,
     ISequencedProposal,
-    ISummaryAck,
-    ISummaryContent,
-    ISummaryNack,
     ISummaryTree,
     MessageType,
     SummaryType,
@@ -116,32 +113,15 @@ export class ProtocolOpHandler extends EventEmitter {
                 break;
 
             case MessageType.Summarize:
-                this.emit("message", {
-                    eventName: "Summarize",
-                    message: message.contents as ISummaryContent,
-                    summarySequenceNumber: message.sequenceNumber,
-                    refSequenceNumber: message.referenceSequenceNumber,
-                });
+                this.emit("Summary", message);
                 break;
 
             case MessageType.SummaryAck:
-                const ack = message.contents as ISummaryAck;
-                this.emit("message", {
-                    eventName: "SummaryAck",
-                    message: `handle: ${ack.handle}`,
-                    sequenceNumber: message.sequenceNumber,
-                    summarySequenceNumber: ack.summaryProposal.summarySequenceNumber,
-                });
+                this.emit("Summary", message);
                 break;
 
             case MessageType.SummaryNack:
-                const nack = message.contents as ISummaryNack;
-                this.emit("message", {
-                    eventName: "SummaryNack",
-                    message: nack.errorMessage,
-                    sequenceNumber: message.sequenceNumber,
-                    summarySequenceNumber: nack.summaryProposal.summarySequenceNumber,
-                });
+                this.emit("Summary", message);
                 break;
 
             default:
@@ -206,7 +186,7 @@ export class ProtocolOpHandler extends EventEmitter {
         return summary;
     }
 
-    public on(event: "message", listener: (message: any) => void): this;
+    public on(event: "Summary", listener: (message: ISequencedDocumentMessage) => void): this;
 
     /* tslint:disable:no-unnecessary-override */
     public on(event: string | symbol, listener: (...args: any[]) => void): this {

--- a/packages/loader/container-loader/src/quorum.ts
+++ b/packages/loader/container-loader/src/quorum.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryLogger } from "@microsoft/fluid-container-definitions";
 import { Deferred, doIfNotDisposed, EventForwarder } from "@microsoft/fluid-core-utils";
 import {
     ConnectionState,
@@ -16,13 +15,14 @@ import {
 } from "@microsoft/fluid-protocol-definitions";
 import * as assert from "assert";
 import { EventEmitter } from "events";
-import { debug } from "./debug";
 
 // tslint:disable-next-line: no-submodule-imports no-var-requires
 const cloneDeep = require("lodash/cloneDeep") as <T>(value: T) => T;
 
-// Appends a deferred and rejection count to a sequenced proposal. For locally generated promises this allows us to
-// attach a Deferred which we will resolve once the proposal is either accepted or rejected.
+/**
+ * Appends a deferred and rejection count to a sequenced proposal. For locally generated promises this allows us to
+ * attach a Deferred which we will resolve once the proposal is either accepted or rejected.
+ */
 class PendingProposal implements IPendingProposal, ISequencedProposal {
     public readonly rejections: Set<string>;
     private canReject = true;
@@ -84,9 +84,7 @@ export class Quorum extends EventEmitter implements IQuorum {
         proposals: [number, ISequencedProposal, string[]][],
         values: [string, ICommittedProposal][],
         private readonly sendProposal: (key: string, value: any) => number,
-        private readonly sendReject: (sequenceNumber: number) => void,
-        private readonly logger?: ITelemetryLogger,
-    ) {
+        private readonly sendReject: (sequenceNumber: number) => void) {
         super();
 
         this.members = new Map(members);
@@ -195,9 +193,7 @@ export class Quorum extends EventEmitter implements IQuorum {
     public async propose(key: string, value: any): Promise<void> {
         const clientSequenceNumber = this.sendProposal(key, value);
         if (clientSequenceNumber < 0) {
-            if (this.logger) {
-                this.logger.sendErrorEvent({eventName: "ProposalInDisconnectedState", key });
-            }
+            this.emit("error", {eventName: "ProposalInDisconnectedState", key });
             return Promise.reject(false);
         }
 
@@ -261,6 +257,7 @@ export class Quorum extends EventEmitter implements IQuorum {
         return;
     }
 
+    public on(event: "error", listener: (message: any) => void): this;
     public on(event: "addMember", listener: (clientId: string, details: ISequencedClient) => void): this;
     public on(event: "removeMember", listener: (clientId: string) => void): this;
     public on(event: "addProposal", listener: (proposal: IPendingProposal) => void): this;
@@ -290,11 +287,12 @@ export class Quorum extends EventEmitter implements IQuorum {
      * that the proposal was accepted, then it becomes a committed consensus value.
      * Returns true if immediate no-op is required.
      */
+    // tslint:disable max-func-body-length
     public updateMinimumSequenceNumber(message: ISequencedDocumentMessage): boolean {
         const value = message.minimumSequenceNumber;
         if (this.minimumSequenceNumber !== undefined) {
-            if (value < this.minimumSequenceNumber && this.logger) {
-                this.logger.sendErrorEvent({
+            if (value < this.minimumSequenceNumber) {
+                this.emit("error", {
                     currentValue: this.minimumSequenceNumber,
                     eventName: "QuorumMinSeqNumberError",
                     newValue: value,
@@ -315,7 +313,6 @@ export class Quorum extends EventEmitter implements IQuorum {
         const completed: PendingProposal[] = [];
         for (const [sequenceNumber, proposal] of this.proposals) {
             if (sequenceNumber <= this.minimumSequenceNumber) {
-                debug(`Quorum proposal SN# ${sequenceNumber} Completed`);
                 completed.push(proposal);
             }
         }
@@ -408,6 +405,9 @@ export class Quorum extends EventEmitter implements IQuorum {
     }
 }
 
+/**
+ * Proxies Quorum events.
+ */
 export class QuorumProxy extends EventForwarder implements IQuorum {
     public readonly propose: (key: string, value: any) => Promise<void>;
     public readonly has: (key: string) => boolean;

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { IProcessMessageResult, ITelemetryLogger } from "@microsoft/fluid-container-definitions";
+import { ITelemetryLogger } from "@microsoft/fluid-container-definitions";
 import { DebugLogger } from "@microsoft/fluid-core-utils";
-import { IClient, IDocumentMessage, MessageType } from "@microsoft/fluid-protocol-definitions";
+import { IClient, IDocumentMessage, IProcessMessageResult, MessageType } from "@microsoft/fluid-protocol-definitions";
 import { MockDocumentDeltaConnection, MockDocumentService } from "@microsoft/fluid-test-loader-utils";
 import * as assert from "assert";
 import { EventEmitter } from "events";


### PR DESCRIPTION
Reason: Server takes a dependency on ProtocolOpHandler and Quorum. So we need to move the telemetry part outside.

Next step: Create a fluid-protocol-base package package to share amongst server and client.  