### PR TITLE
Ink op concealment

### DIFF
--- a/packages/components/client-ui/src/controls/canvasCommon.ts
+++ b/packages/components/client-ui/src/controls/canvasCommon.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IPen, IStylusOperation } from "@microsoft/fluid-ink";
+import { IInkPoint, IPen } from "@microsoft/fluid-ink";
 import { IPoint, IVector, Point, Vector } from "../ui";
 import { SegmentCircleInclusive } from "./overlayCanvas";
 import { Circle, IShape, Polygon } from "./shapes/index";
@@ -15,14 +15,14 @@ import { Circle, IShape, Polygon } from "./shapes/index";
  * Besides circles, a trapezoid that serves as a bounding box of two stroke point is also returned.
  */
 export function getShapes(
-    startPoint: IStylusOperation,
-    endPoint: IStylusOperation,
+    startPoint: IInkPoint,
+    endPoint: IInkPoint,
     pen: IPen,
     circleInclusive: SegmentCircleInclusive): IShape[] {
 
     const dirVector = new Vector(
-        endPoint.point.x - startPoint.point.x,
-        endPoint.point.y - startPoint.point.y);
+        endPoint.x - startPoint.x,
+        endPoint.y - startPoint.y);
     const len = dirVector.length();
 
     const shapes = new Array<IShape>();
@@ -39,7 +39,7 @@ export function getShapes(
     // Just draws a circle on small values??
     if (len + Math.min(widthAtStart, widthAtEnd) <= Math.max(widthAtStart, widthAtEnd)) {
         const center = widthAtStart >= widthAtEnd ? startPoint : endPoint;
-        shapes.push(new Circle({ x: center.point.x, y: center.point.y }, widthAtEnd));
+        shapes.push(new Circle({ x: center.x, y: center.y }, widthAtEnd));
         return shapes;
     }
 
@@ -56,35 +56,35 @@ export function getShapes(
 
         normalizedLateralVector = Vector.normalize(Vector.rotate(dirVector, -angle));
         trapezoidP0 = new Point(
-            startPoint.point.x + widthAtStart * normalizedLateralVector.x,
-            startPoint.point.y + widthAtStart * normalizedLateralVector.y);
+            startPoint.x + widthAtStart * normalizedLateralVector.x,
+            startPoint.y + widthAtStart * normalizedLateralVector.y);
         trapezoidP3 = new Point(
-            endPoint.point.x + widthAtEnd * normalizedLateralVector.x,
-            endPoint.point.y + widthAtEnd * normalizedLateralVector.y);
+            endPoint.x + widthAtEnd * normalizedLateralVector.x,
+            endPoint.y + widthAtEnd * normalizedLateralVector.y);
 
         normalizedLateralVector = Vector.normalize(Vector.rotate(dirVector, angle));
         trapezoidP2 = new Point(
-            endPoint.point.x + widthAtEnd * normalizedLateralVector.x,
-            endPoint.point.y + widthAtEnd * normalizedLateralVector.y);
+            endPoint.x + widthAtEnd * normalizedLateralVector.x,
+            endPoint.y + widthAtEnd * normalizedLateralVector.y);
         trapezoidP1 = new Point(
-            startPoint.point.x + widthAtStart * normalizedLateralVector.x,
-            startPoint.point.y + widthAtStart * normalizedLateralVector.y);
+            startPoint.x + widthAtStart * normalizedLateralVector.x,
+            startPoint.y + widthAtStart * normalizedLateralVector.y);
     } else {
         normalizedLateralVector = new Vector(-dirVector.y / len, dirVector.x / len);
 
         trapezoidP0 = new Point(
-            startPoint.point.x + widthAtStart * normalizedLateralVector.x,
-            startPoint.point.y + widthAtStart * normalizedLateralVector.y);
+            startPoint.x + widthAtStart * normalizedLateralVector.x,
+            startPoint.y + widthAtStart * normalizedLateralVector.y);
         trapezoidP1 = new Point(
-            startPoint.point.x - widthAtStart * normalizedLateralVector.x,
-            startPoint.point.y - widthAtStart * normalizedLateralVector.y);
+            startPoint.x - widthAtStart * normalizedLateralVector.x,
+            startPoint.y - widthAtStart * normalizedLateralVector.y);
 
         trapezoidP2 = new Point(
-            endPoint.point.x - widthAtEnd * normalizedLateralVector.x,
-            endPoint.point.y - widthAtEnd * normalizedLateralVector.y);
+            endPoint.x - widthAtEnd * normalizedLateralVector.x,
+            endPoint.y - widthAtEnd * normalizedLateralVector.y);
         trapezoidP3 = new Point(
-            endPoint.point.x + widthAtEnd * normalizedLateralVector.x,
-            endPoint.point.y + widthAtEnd * normalizedLateralVector.y);
+            endPoint.x + widthAtEnd * normalizedLateralVector.x,
+            endPoint.y + widthAtEnd * normalizedLateralVector.y);
     }
 
     const polygon = new Polygon([trapezoidP0, trapezoidP3, trapezoidP2, trapezoidP1]);
@@ -94,14 +94,14 @@ export function getShapes(
         case SegmentCircleInclusive.None:
             break;
         case SegmentCircleInclusive.Both:
-            shapes.push(new Circle({ x: startPoint.point.x, y: startPoint.point.y }, widthAtStart));
-            shapes.push(new Circle({ x: endPoint.point.x, y: endPoint.point.y }, widthAtEnd));
+            shapes.push(new Circle({ x: startPoint.x, y: startPoint.y }, widthAtStart));
+            shapes.push(new Circle({ x: endPoint.x, y: endPoint.y }, widthAtEnd));
             break;
         case SegmentCircleInclusive.Start:
-            shapes.push(new Circle({ x: startPoint.point.x, y: startPoint.point.y }, widthAtStart));
+            shapes.push(new Circle({ x: startPoint.x, y: startPoint.y }, widthAtStart));
             break;
         case SegmentCircleInclusive.End:
-            shapes.push(new Circle({ x: endPoint.point.x, y: endPoint.point.y }, widthAtEnd));
+            shapes.push(new Circle({ x: endPoint.x, y: endPoint.y }, widthAtEnd));
             break;
         default:
             break;

--- a/packages/components/client-ui/src/controls/inkCanvas.ts
+++ b/packages/components/client-ui/src/controls/inkCanvas.ts
@@ -50,8 +50,8 @@ export class InkCanvas extends ui.Component {
             this.redraw();
         });
 
-        this.model.on("clear", this.executeClear.bind(this));
-        this.model.on("stylus", this.executeStylus.bind(this));
+        this.model.on("clear", this.handleClear.bind(this));
+        this.model.on("stylus", this.handleStylus.bind(this));
 
         // setup canvas
         this.canvasWrapper = document.createElement("div");
@@ -63,10 +63,9 @@ export class InkCanvas extends ui.Component {
         // get context
         this.context = this.canvas.getContext("2d");
 
-        const bb = false;
-        this.canvas.addEventListener("pointerdown", (evt) => this.handlePointerDown(evt), bb);
-        this.canvas.addEventListener("pointermove", (evt) => this.handlePointerMove(evt), bb);
-        this.canvas.addEventListener("pointerup", (evt) => this.handlePointerUp(evt), bb);
+        this.canvas.addEventListener("pointerdown", this.handlePointerDown.bind(this));
+        this.canvas.addEventListener("pointermove", this.handlePointerMove.bind(this));
+        this.canvas.addEventListener("pointerup", this.handlePointerUp.bind(this));
 
         this.currentPen = {
             color: { r: 0, g: 161 / 255, b: 241 / 255, a: 0 },
@@ -110,7 +109,6 @@ export class InkCanvas extends ui.Component {
 
     public clear() {
         this.model.clear();
-        this.executeClear();
     }
 
     /**
@@ -173,7 +171,6 @@ export class InkCanvas extends ui.Component {
             pressure: evt.pressure,
         };
         this.model.appendPointToStroke(inkPt, this.currentStrokeId);
-        this.executeStylus(inkPt, this.currentStrokeId);
     }
 
     private animateStroke(stroke: ink.IInkStroke, operationIndex: number, startTime: number) {
@@ -237,13 +234,14 @@ export class InkCanvas extends ui.Component {
         }
     }
 
-    private executeClear() {
+    private handleClear() {
         this.clearCanvas();
         this.lastStrokeRenderOp = {};
     }
 
-    private executeStylus(point: ink.IInkPoint, dirtyStrokeId: string) {
+    private handleStylus(operation: ink.IStylusOperation) {
         // Render the dirty stroke
+        const dirtyStrokeId = operation.id;
         let index = this.lastStrokeRenderOp[dirtyStrokeId] ? this.lastStrokeRenderOp[dirtyStrokeId] : 0;
 
         const stroke = this.model.getStroke(dirtyStrokeId);

--- a/packages/components/client-ui/src/controls/inkCanvas.ts
+++ b/packages/components/client-ui/src/controls/inkCanvas.ts
@@ -46,14 +46,12 @@ export class InkCanvas extends ui.Component {
     constructor(element: HTMLDivElement, private model: ink.IInk, private image?: CanvasImageSource) {
         super(element);
 
-        this.model.on("op", (op) => {
-            // Update the canvas
-            this.submitAndApplyOp(op.contents, false);
-        });
-
         this.model.on("load", () => {
             this.redraw();
         });
+
+        this.model.on("clear", this.executeClear.bind(this));
+        this.model.on("stylus", this.executeStylus.bind(this));
 
         // setup canvas
         this.canvasWrapper = document.createElement("div");
@@ -94,7 +92,7 @@ export class InkCanvas extends ui.Component {
         const strokes = this.model.getStrokes();
 
         // Time of the first operation in stroke 0 is our starting time
-        const startTime = strokes[0].operations[0].time;
+        const startTime = strokes[0].points[0].time;
         for (const stroke of strokes) {
             this.animateStroke(stroke, 0, startTime);
         }
@@ -111,8 +109,8 @@ export class InkCanvas extends ui.Component {
     }
 
     public clear() {
-        const operation = ink.Ink.makeClearOperation();
-        this.submitAndApplyOp(operation, true);
+        this.model.clear();
+        this.executeClear();
     }
 
     /**
@@ -131,17 +129,14 @@ export class InkCanvas extends ui.Component {
     private handlePointerDown(evt: PointerEvent) {
         if ((evt.pointerType === "pen") || ((evt.pointerType === "mouse") && (evt.button === 0))) {
             // Create a new stroke
-            const createOp = ink.Ink.makeCreateStrokeOperation(this.currentPen);
-            this.currentStrokeId = createOp.id;
-            this.submitAndApplyOp(createOp, true);
+            this.currentStrokeId = this.model.createStroke(this.currentPen).id;
 
             // Set pen state to be used during this active stroke
             this.penID = evt.pointerId;
-            this.currentStrokeId = createOp.id;
 
             this.appendPointerEventToCurrentStroke(evt);
 
-            evt.returnValue = false;
+            evt.preventDefault();
         }
     }
 
@@ -149,7 +144,7 @@ export class InkCanvas extends ui.Component {
         if (evt.pointerId === this.penID) {
             this.appendPointerEventToCurrentStroke(evt);
 
-            evt.returnValue = false;
+            evt.preventDefault();
         }
 
         return false;
@@ -163,7 +158,7 @@ export class InkCanvas extends ui.Component {
             this.penID = -1;
             this.currentStrokeId = undefined;
 
-            evt.returnValue = false;
+            evt.preventDefault();
         }
 
         return false;
@@ -171,22 +166,24 @@ export class InkCanvas extends ui.Component {
 
     private appendPointerEventToCurrentStroke(evt: PointerEvent) {
         const pt = new EventPoint(this.canvas, evt);
-        const operation = ink.Ink.makeStylusOperation(
-            pt.rawPosition,
-            evt.pressure,
-            this.currentStrokeId,
-        );
-        this.submitAndApplyOp(operation, true);
+        const inkPt = {
+            x: pt.rawPosition.x,
+            y: pt.rawPosition.y,
+            time: Date.now(),
+            pressure: evt.pressure,
+        };
+        this.model.appendPointToStroke(inkPt, this.currentStrokeId);
+        this.executeStylus(inkPt, this.currentStrokeId);
     }
 
     private animateStroke(stroke: ink.IInkStroke, operationIndex: number, startTime: number) {
-        if (operationIndex >= stroke.operations.length) {
+        if (operationIndex >= stroke.points.length) {
             return;
         }
 
         // Draw the requested stroke
-        const current = stroke.operations[operationIndex];
-        const previous = stroke.operations[Math.max(0, operationIndex - 1)];
+        const current = stroke.points[operationIndex];
+        const previous = stroke.points[Math.max(0, operationIndex - 1)];
         const time = operationIndex === 0
             ? current.time - startTime
             : current.time - previous.time;
@@ -212,8 +209,8 @@ export class InkCanvas extends ui.Component {
 
         const strokes = this.model.getStrokes();
         for (const stroke of strokes) {
-            let previous = stroke.operations[0];
-            for (const current of stroke.operations) {
+            let previous = stroke.points[0];
+            for (const current of stroke.points) {
                 // current === previous === stroke.operations[0] for the down
                 this.drawStroke(stroke, current, previous);
                 previous = current;
@@ -223,8 +220,8 @@ export class InkCanvas extends ui.Component {
 
     private drawStroke(
         stroke: ink.IInkStroke,
-        current: ink.IStylusOperation,
-        previous: ink.IStylusOperation,
+        current: ink.IInkPoint,
+        previous: ink.IInkPoint,
     ) {
         const pen = stroke.pen;
         const shapes = getShapes(previous, current, pen, SegmentCircleInclusive.End);
@@ -240,32 +237,19 @@ export class InkCanvas extends ui.Component {
         }
     }
 
-    private submitAndApplyOp(operation: ink.IInkOperation, submit: boolean) {
-        if (submit) {
-            this.model.submitOperation(operation);
-        }
-
-        if (operation.type === "clear") {
-            this.handleClearOp();
-        } else if (operation.type === "stylus") {
-            this.handleStylusOp(operation);
-        }
-    }
-
-    private handleClearOp() {
+    private executeClear() {
         this.clearCanvas();
         this.lastStrokeRenderOp = {};
     }
 
-    private handleStylusOp(operation: ink.IStylusOperation) {
+    private executeStylus(point: ink.IInkPoint, dirtyStrokeId: string) {
         // Render the dirty stroke
-        const dirtyStrokeId = operation.id;
         let index = this.lastStrokeRenderOp[dirtyStrokeId] ? this.lastStrokeRenderOp[dirtyStrokeId] : 0;
 
         const stroke = this.model.getStroke(dirtyStrokeId);
-        for (; index < stroke.operations.length; index++) {
+        for (; index < stroke.points.length; index++) {
             // render the stroke
-            this.drawStroke(stroke, stroke.operations[index], stroke.operations[Math.max(0, index - 1)]);
+            this.drawStroke(stroke, stroke.points[index], stroke.points[Math.max(0, index - 1)]);
         }
 
         this.lastStrokeRenderOp[dirtyStrokeId] = index;

--- a/packages/components/client-ui/src/controls/overlayCanvas.ts
+++ b/packages/components/client-ui/src/controls/overlayCanvas.ts
@@ -82,11 +82,11 @@ export class DrawingContext {
 
     // store instructions used to render itself? i.e. the total path? Or defer to someone else to actually
     // do the re-render with a context?
-    public drawStroke(current: ink.IInkPoint, stroke: ink.IInkStroke) {
+    public drawSegmentToNewPoint(endPoint: ink.IInkPoint) {
         assert(this.pen);
 
-        const previous = this.lastPoint || current;
-        const shapes = getShapes(previous, current, this.pen, SegmentCircleInclusive.End);
+        const previous = this.lastPoint || endPoint;
+        const shapes = getShapes(previous, endPoint, this.pen, SegmentCircleInclusive.End);
 
         if (shapes) {
             // Update canvas bounds
@@ -111,7 +111,7 @@ export class DrawingContext {
             }
         }
 
-        this.lastPoint = current;
+        this.lastPoint = endPoint;
     }
 
     /**
@@ -205,20 +205,16 @@ export class InkLayer extends Layer {
             throw new Error("Clear not supported in OverlayCanvas");
         });
 
-        this.model.on("createStroke", (op) => {
-            this.drawingContext.startNewStroke(op.pen);
-        });
-
         this.model.on("stylus", (op) => {
             const stroke = this.model.getStroke(op.id);
-            this.drawingContext.drawStroke(op, stroke);
+            this.drawingContext.drawSegmentToNewPoint(op.point);
         });
 
         const strokes = this.model.getStrokes();
         for (const stroke of strokes) {
             this.drawingContext.startNewStroke(stroke.pen);
             for (const point of stroke.points) {
-                this.drawingContext.drawStroke(point, stroke);
+                this.drawingContext.drawSegmentToNewPoint(point);
             }
         }
     }

--- a/packages/components/client-ui/src/controls/overlayCanvas.ts
+++ b/packages/components/client-ui/src/controls/overlayCanvas.ts
@@ -220,6 +220,7 @@ export class InkLayer extends Layer {
     }
 
     public createStroke(pen: ink.IPen) {
+        this.drawingContext.startNewStroke(pen);
         return this.model.createStroke(pen);
     }
 
@@ -267,9 +268,9 @@ export class OverlayCanvas extends ui.Component {
         this.trackInkEvents(eventTarget);
 
         // Ink handling messages
-        container.addEventListener("pointerdown", (evt) => this.handlePointerDown(evt));
-        container.addEventListener("pointermove", (evt) => this.handlePointerMove(evt));
-        container.addEventListener("pointerup", (evt) => this.handlePointerUp(evt));
+        container.addEventListener("pointerdown", this.handlePointerDown.bind(this));
+        container.addEventListener("pointermove", this.handlePointerMove.bind(this));
+        container.addEventListener("pointerup", this.handlePointerUp.bind(this));
     }
 
     public addLayer(layer: Layer) {

--- a/packages/components/client-ui/src/controls/overlayCanvas.ts
+++ b/packages/components/client-ui/src/controls/overlayCanvas.ts
@@ -54,7 +54,7 @@ function padRight(current: number, next: number, padding: number) {
 export class DrawingContext {
     public canvas = document.createElement("canvas");
     private context: CanvasRenderingContext2D;
-    private lastOperation: ink.IStylusOperation = null;
+    private lastPoint: ink.IInkPoint = null;
     private pen: ink.IPen;
     private canvasOffset: ui.IPoint = { x: 0, y: 0 };
 
@@ -71,21 +71,21 @@ export class DrawingContext {
     }
 
     public clear() {
-        this.lastOperation = null;
+        this.lastPoint = null;
         this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
     }
 
     public startNewStroke(pen: ink.IPen) {
         this.pen = pen;
-        this.lastOperation = null;
+        this.lastPoint = null;
     }
 
     // store instructions used to render itself? i.e. the total path? Or defer to someone else to actually
     // do the re-render with a context?
-    public drawStroke(current: ink.IStylusOperation, stroke: ink.IInkStroke) {
+    public drawStroke(current: ink.IInkPoint, stroke: ink.IInkStroke) {
         assert(this.pen);
 
-        const previous = this.lastOperation || current;
+        const previous = this.lastPoint || current;
         const shapes = getShapes(previous, current, this.pen, SegmentCircleInclusive.End);
 
         if (shapes) {
@@ -111,7 +111,7 @@ export class DrawingContext {
             }
         }
 
-        this.lastOperation = current;
+        this.lastPoint = current;
     }
 
     /**
@@ -201,42 +201,34 @@ export class InkLayer extends Layer {
     constructor(size: ui.ISize, private model: ink.IInk) {
         super(size);
 
-        // Listen for updates and re-render
-        this.model.on("op", (op, local) => {
-            if (local) {
-                return;
-            }
+        this.model.on("clear", (op) => {
+            throw new Error("Clear not supported in OverlayCanvas");
+        });
 
-            const operation = op.contents as ink.IInkOperation;
-            if (operation.type === "clear") {
-                throw new Error("Clear not supported in OverlayCanvas");
-            } else if (operation.type === "createStroke") {
-                this.drawingContext.startNewStroke(operation.pen);
-            } else if (operation.type === "stylus") {
-                const stroke = this.model.getStroke(operation.id);
-                this.drawingContext.drawStroke(operation, stroke);
-            }
+        this.model.on("createStroke", (op) => {
+            this.drawingContext.startNewStroke(op.pen);
+        });
+
+        this.model.on("stylus", (op) => {
+            const stroke = this.model.getStroke(op.id);
+            this.drawingContext.drawStroke(op, stroke);
         });
 
         const strokes = this.model.getStrokes();
         for (const stroke of strokes) {
             this.drawingContext.startNewStroke(stroke.pen);
-            for (const operation of stroke.operations) {
-                this.drawingContext.drawStroke(operation, stroke);
+            for (const point of stroke.points) {
+                this.drawingContext.drawStroke(point, stroke);
             }
         }
     }
 
-    public drawOperation(operation: ink.IInkOperation) {
-        this.model.submitOperation(operation);
-        if (operation.type === "clear") {
-            throw new Error("Clear not supported in OverlayCanvas");
-        } else if (operation.type === "createStroke") {
-            this.drawingContext.startNewStroke(operation.pen);
-        } else if (operation.type === "stylus") {
-            const stroke = this.model.getStroke(operation.id);
-            this.drawingContext.drawStroke(operation, stroke);
-        }
+    public createStroke(pen: ink.IPen) {
+        return this.model.createStroke(pen);
+    }
+
+    public updateStroke(point: ink.IInkPoint, strokeId: string) {
+        return this.model.appendPointToStroke(point, strokeId);
     }
 }
 
@@ -245,7 +237,7 @@ export class InkLayer extends Layer {
  */
 export class OverlayCanvas extends ui.Component {
     private layers: Layer[] = [];
-    private currentStylusActionId: string;
+    private currentStrokeId: string;
     private activePointerId: number;
     private inkEventsEnabled = false;
     private penHovering = false;
@@ -378,18 +370,17 @@ export class OverlayCanvas extends ui.Component {
             this.activePointerId = evt.pointerId;
             this.element.setPointerCapture(this.activePointerId);
 
-            const createOp = ink.Ink.makeCreateStrokeOperation(this.activePen);
-            this.currentStylusActionId = createOp.id;
-            this.activeLayer.drawOperation(createOp);
+            this.currentStrokeId = this.activeLayer.createStroke(this.activePen).id;
+            const layerTranslatedPoint = this.translateToLayer(translatedPoint, this.activeLayer);
+            const inkPoint: ink.IInkPoint = {
+                x: layerTranslatedPoint.x,
+                y: layerTranslatedPoint.y,
+                time: Date.now(),
+                pressure: evt.pressure,
+            };
+            this.activeLayer.updateStroke(inkPoint, this.currentStrokeId);
 
-            const operation = ink.Ink.makeStylusOperation(
-                this.translateToLayer(translatedPoint, this.activeLayer),
-                evt.pressure,
-                this.currentStylusActionId,
-            );
-            this.activeLayer.drawOperation(operation);
-
-            evt.returnValue = false;
+            evt.preventDefault();
         }
     }
 
@@ -397,40 +388,42 @@ export class OverlayCanvas extends ui.Component {
         if (evt.pointerId === this.activePointerId) {
             const translatedPoint = this.translatePoint(this.element, evt);
             this.pointsToRecognize.push(translatedPoint);
-            const operation = ink.Ink.makeStylusOperation(
-                this.translateToLayer(translatedPoint, this.activeLayer),
-                evt.pressure,
-                this.currentStylusActionId);
-            this.activeLayer.drawOperation(operation);
+            const layerTranslatedPoint = this.translateToLayer(translatedPoint, this.activeLayer);
+            const inkPoint: ink.IInkPoint = {
+                x: layerTranslatedPoint.x,
+                y: layerTranslatedPoint.y,
+                time: Date.now(),
+                pressure: evt.pressure,
+            };
+            this.activeLayer.updateStroke(inkPoint, this.currentStrokeId);
 
-            evt.returnValue = false;
+            evt.preventDefault();
         }
-
-        return false;
     }
 
     private handlePointerUp(evt: PointerEvent) {
         if (evt.pointerId === this.activePointerId) {
             const translatedPoint = this.translatePoint(this.element, evt);
             this.pointsToRecognize.push(translatedPoint);
-            evt.returnValue = false;
+            const layerTranslatedPoint = this.translateToLayer(translatedPoint, this.activeLayer);
+            const inkPoint: ink.IInkPoint = {
+                x: layerTranslatedPoint.x,
+                y: layerTranslatedPoint.y,
+                time: Date.now(),
+                pressure: evt.pressure,
+            };
+            this.activeLayer.updateStroke(inkPoint, this.currentStrokeId);
 
-            const operation = ink.Ink.makeStylusOperation(
-                this.translateToLayer(translatedPoint, this.activeLayer),
-                evt.pressure,
-                this.currentStylusActionId);
-            this.currentStylusActionId = undefined;
-
-            this.activeLayer.drawOperation(operation);
+            this.currentStrokeId = undefined;
 
             // Release the event
             this.element.releasePointerCapture(this.activePointerId);
             this.activePointerId = undefined;
 
             this.recognizeShape();
-        }
 
-        return false;
+            evt.preventDefault();
+        }
     }
 
     private recognizeShape() {

--- a/packages/runtime/ink/src/interfaces.ts
+++ b/packages/runtime/ink/src/interfaces.ts
@@ -6,17 +6,28 @@
 import { ISharedObject } from "@microsoft/fluid-shared-object-base";
 
 /**
- * X/Y point.
+ * Data about a single point in an ink stroke
  */
-export interface IPoint {
+export interface IInkPoint {
     /**
      * X coordinate
      */
     x: number;
+
     /**
      * Y coordinate
      */
     y: number;
+
+    /**
+     * Time, in milliseconds, that the point was generated on the originating device.
+     */
+    time: number;
+
+    /**
+     * The ink pressure applied (typically from PointerEvent.pressure).
+     */
+    pressure: number;
 }
 
 /**
@@ -49,6 +60,26 @@ export interface IColor {
  */
 export interface IInk extends ISharedObject {
     /**
+     * Create a stroke with the given pen information.
+     * @param pen - The pen information for this stroke
+     * @returns The stroke that was created
+     */
+    createStroke(pen: IPen): IInkStroke;
+
+    /**
+     * Append the given point to the indicated stroke.
+     * @param point - The point to append
+     * @param id - The ID for the stroke to append to
+     * @returns The stroke that was updated
+     */
+    appendPointToStroke(point: IInkPoint, id: string): IInkStroke;
+
+    /**
+     * Clear all strokes.
+     */
+    clear(): void;
+
+    /**
      * Get the collection of strokes stored in this Ink object.
      * @returns the array of strokes
      */
@@ -60,12 +91,6 @@ export interface IInk extends ISharedObject {
      * @returns the requested stroke, or undefined if it does not exist
      */
     getStroke(key: string): IInkStroke;
-
-    /**
-     * Send the op and apply it to the local Ink object as well.
-     * @param operation - op to submit and apply
-     */
-    submitOperation(operation: IInkOperation): void;
 }
 
 /**
@@ -134,19 +159,9 @@ export interface IStylusOperation {
     type: "stylus";
 
     /**
-     * Time, in milliseconds, that the operation occurred on the originating device.
+     * The ink point appended in this operation.
      */
-    time: number;
-
-    /**
-     * The location of the stylus.
-     */
-    point: IPoint;
-
-    /**
-     * The ink pressure applied (typically from PointerEvent.pressure).
-     */
-    pressure: number;
+    point: IInkPoint;
 
     /**
      * ID of the stroke this stylus operation is associated with.
@@ -172,9 +187,9 @@ export interface IInkStroke {
     id: string;
 
     /**
-     * The operations contained within the stroke.
+     * The points contained within the stroke.
      */
-    operations: IStylusOperation[];
+    points: IInkPoint[];
 
     /**
      * Description of the pen used to create the stroke.


### PR DESCRIPTION
This change follows up on two outstanding TODOs for Ink:

1. Changes `IInkStroke` to hold `IInkPoint`s rather than `IStylusOperation`s.  The operation holds no additional interesting information for long-term persistence as compared to the `IInkPoint`, so we can trim the data structure to only persist the interesting part.
2. Adds API surface and eventing to `Ink` to eliminate the need for customers to listen to `"op"` and manage ink operations outside of the DDS.  This makes the DDS easier to use correctly and protects our ability to add/modify op patterns in the future.