### PR TITLE
Handle all summary acks - remove getVersions call in generateSummary

### DIFF
--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -172,11 +172,12 @@ export class Summarizer implements IComponentRouter, IComponentRunnable, ICompon
         let refSequenceNumber = this.summaryCollection.initialSequenceNumber;
         while (this.runningSummarizer) {
             try {
-                const ack = await this.summaryCollection.waitSummaryAck(refSequenceNumber + 1);
+                const ack = await this.summaryCollection.waitSummaryAck(refSequenceNumber);
                 refSequenceNumber = ack.summaryOp.referenceSequenceNumber;
                 const handle = ack.summaryAckNack.contents.handle;
 
                 await this.refreshLatestAck(handle, refSequenceNumber);
+                refSequenceNumber++;
             } catch (error) {
                 this.logger.sendErrorEvent({ eventName: "HandleSummaryAckError", refSequenceNumber }, error);
             }

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -14,13 +14,12 @@ import { ChildLogger, PerformanceEvent, PromiseTimer, Timer } from "@microsoft/f
 import {
     ISequencedDocumentMessage,
     ISequencedDocumentSystemMessage,
-    ISnapshotTree,
     ISummaryConfiguration,
     MessageType,
 } from "@microsoft/fluid-protocol-definitions";
 import { ContainerRuntime, GenerateSummaryData } from "./containerRuntime";
 import { RunWhileConnectedCoordinator } from "./runWhileConnectedCoordinator";
-import { IClientSummaryWatcher, ISummaryAckMessage, SummaryCollection } from "./summaryCollection";
+import { IClientSummaryWatcher, SummaryCollection } from "./summaryCollection";
 
 // send some telemetry if generate summary takes too long
 const maxSummarizeTimeoutTime = 20000; // 20 sec
@@ -46,7 +45,7 @@ export class Summarizer implements IComponentRouter, IComponentRunnable, ICompon
         private readonly runtime: ContainerRuntime,
         private readonly configurationGetter: () => ISummaryConfiguration,
         private readonly generateSummaryCore: () => Promise<GenerateSummaryData>,
-        private readonly refreshBaseSummary: (snapshot: ISnapshotTree) => void,
+        private readonly refreshLatestAck: (handle: string, referenceSequenceNumber: number) => Promise<void>,
     ) {
         this.logger = ChildLogger.create(this.runtime.logger, "Summarizer");
         this.runCoordinator = new RunWhileConnectedCoordinator(runtime);
@@ -98,10 +97,15 @@ export class Summarizer implements IComponentRouter, IComponentRunnable, ICompon
             this.summaryCollection.createWatcher(this.runtime.clientId),
             this.configurationGetter(),
             () => this.generateSummary(),
-            (ack) => this.handleSuccessfulSummary(ack),
             this.runtime.deltaManager.referenceSequenceNumber,
             initialAttempt,
         );
+
+        // handle summary acks
+        this.handleSummaryAcks().catch((error) => {
+            this.logger.sendErrorEvent({ eventName: "HandleSummaryAckFatalError" }, error);
+            this.stop("handleAckError");
+        });
 
         // listen for ops
         const systemOpHandler = (op: ISequencedDocumentMessage) => this.runningSummarizer.handleSystemOp(op);
@@ -164,47 +168,19 @@ export class Summarizer implements IComponentRouter, IComponentRunnable, ICompon
         return this.generateSummaryCore();
     }
 
-    private async handleSuccessfulSummary(ack: ISummaryAckMessage): Promise<void> {
-        // we have to call get version to get the treeId for r11s; this isnt needed
-        // for odsp currently, since their treeId is undefined
-        const versionsResult = await this.setOrLogError("SummarizerFailedToGetVersion",
-            () => this.runtime.storage.getVersions(ack.contents.handle, 1),
-            (versions) => !!(versions && versions.length));
+    private async handleSummaryAcks() {
+        let refSequenceNumber = this.summaryCollection.initialSequenceNumber;
+        while (this.runningSummarizer) {
+            try {
+                const ack = await this.summaryCollection.waitSummaryAck(refSequenceNumber + 1);
+                refSequenceNumber = ack.summaryOp.referenceSequenceNumber;
+                const handle = ack.summaryAckNack.contents.handle;
 
-        if (versionsResult.success) {
-            const snapshotResult = await this.setOrLogError("SummarizerFailedToGetSnapshot",
-                () => this.runtime.storage.getSnapshotTree(versionsResult.result[0]),
-                (snapshot) => !!snapshot);
-
-            if (snapshotResult.success) {
-                // refresh base summary
-                // it might be nice to do this in the container in the future, and maybe for all
-                // clients, not just the summarizer
-                this.refreshBaseSummary(snapshotResult.result);
+                await this.refreshLatestAck(handle, refSequenceNumber);
+            } catch (error) {
+                this.logger.sendErrorEvent({ eventName: "HandleSummaryAckError", refSequenceNumber }, error);
             }
         }
-    }
-
-    private async setOrLogError<T>(
-        eventName: string,
-        setter: () => Promise<T>,
-        validator: (result: T) => boolean,
-    ): Promise<{ result: T, success: boolean }> {
-        let result: T;
-        let success = true;
-        try {
-            result = await setter();
-        } catch (error) {
-            // send error event for exceptions
-            this.logger.sendErrorEvent({ eventName }, error);
-            success = false;
-        }
-        if (success && !validator(result)) {
-            // send error event when result is invalid
-            this.logger.sendErrorEvent({ eventName });
-            success = false;
-        }
-        return { result, success };
     }
 }
 
@@ -242,7 +218,6 @@ export class RunningSummarizer implements IDisposable {
         summaryWatcher: IClientSummaryWatcher,
         configuration: ISummaryConfiguration,
         generateSummary: () => Promise<GenerateSummaryData | undefined>,
-        handleSuccessfulSummary: (ack: ISummaryAckMessage) => Promise<void>,
         lastOpSeqNumber: number,
         firstAck: ISummaryAttempt,
     ): Promise<RunningSummarizer> {
@@ -253,7 +228,6 @@ export class RunningSummarizer implements IDisposable {
             summaryWatcher,
             configuration,
             generateSummary,
-            handleSuccessfulSummary,
             lastOpSeqNumber,
             firstAck);
 
@@ -278,7 +252,6 @@ export class RunningSummarizer implements IDisposable {
         private readonly summaryWatcher: IClientSummaryWatcher,
         private readonly configuration: ISummaryConfiguration,
         private readonly generateSummary: () => Promise<GenerateSummaryData | undefined>,
-        private readonly handleSuccessfulSummary: (ack: ISummaryAckMessage) => Promise<void>,
         lastOpSeqNumber: number,
         firstAck: ISummaryAttempt,
     ) {
@@ -443,7 +416,6 @@ export class RunningSummarizer implements IDisposable {
         // update for success
         if (ackNack.type === MessageType.SummaryAck) {
             this.heuristics.ackLastSent();
-            await this.handleSuccessfulSummary(ackNack);
         }
     }
 

--- a/packages/runtime/container-runtime/src/summaryCollection.ts
+++ b/packages/runtime/container-runtime/src/summaryCollection.ts
@@ -201,6 +201,8 @@ export class SummaryCollection {
 
     private lastAck?: IAckedSummary;
 
+    public get latestAck() { return this.lastAck; }
+
     public constructor(public readonly initialSequenceNumber: number) {}
 
     /**

--- a/packages/runtime/container-runtime/src/test/summarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizer.spec.ts
@@ -35,7 +35,6 @@ describe("Runtime", () => {
                     maxOps: 1000, // 1k ops (active)
                     maxAckWaitTime: 600000, // 10 min
                 };
-                let refreshBaseSummaryDeferred: Deferred<void>;
                 let shouldDeferGenerateSummary: boolean = false;
                 let deferGenerateSummary: Deferred<void>;
 
@@ -48,7 +47,6 @@ describe("Runtime", () => {
                     clock.reset();
                     runCount = 0;
                     lastRefSeq = 0;
-                    refreshBaseSummaryDeferred = new Deferred();
                     summaryCollection = new SummaryCollection(0);
                     summarizer = await RunningSummarizer.start(
                         summarizerClientId,
@@ -79,7 +77,6 @@ describe("Runtime", () => {
                                 clientSequenceNumber: lastClientSeq,
                             };
                         },
-                        async () => { refreshBaseSummaryDeferred.resolve(); },
                         0,
                         { refSequenceNumber: 0, summaryTime: Date.now() },
                     );
@@ -123,11 +120,7 @@ describe("Runtime", () => {
                     };
                     summaryCollection.handleOp({ contents, type } as ISequencedDocumentMessage);
 
-                    // wait for refresh base summary to complete
-                    await refreshBaseSummaryDeferred.promise;
-                    refreshBaseSummaryDeferred = new Deferred();
-
-                    await flushPromises(); // let finally of summarize run
+                    await flushPromises(); // let summarize run
                 }
 
                 async function flushPromises(count: number = 1) {


### PR DESCRIPTION
This PR leverages the SummaryCollection to listen for any incoming summary ack, and then tracks the latest handle in the ContainerRuntime.  It moves the logic for reacting to the latest handle out of Summarizer and into ContainerRuntime (so that in future it can be further extracted/removed).

Now that we are tracking the latest summary ack from any source (not just our own generated ones), we can be sure that we always have the parent handle cached.  So generateSummary no longer calls getVersions when generating a summary to build the summary op.

Broke this out into a separate PR, so that later changes can be simpler to understand.