### PR TITLE
blob deduping for odsp driver

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentStorageManager.ts
@@ -35,8 +35,8 @@ import { OdspCache } from "./odspCache";
 import { getWithRetryForTokenRefresh, throwOdspNetworkError } from "./OdspUtils";
 
 export class OdspDocumentStorageManager implements IDocumentStorageManager {
-    private readonly blobsShaToPathMap: Map<string, string> = new Map<string, string>();
-    private readonly blobsShaCache: Map<string, string> = new Map();
+    private readonly blobsIdToPathMap: Map<string, string> = new Map<string, string>();
+    private readonly blobsShaToPathCache: Map<string, string> = new Map();
     private readonly blobCache: Map<string, resources.IBlob> = new Map();
     private readonly treesCache: Map<string, resources.ITree> = new Map();
 
@@ -109,8 +109,8 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
 
         // Populate the cache with paths from sha-to-path mapping.
         const hash = gitHashFile(Buffer.from(blob.content, blob.encoding));
-        if (this.blobsShaToPathMap.has(blob.sha)) {
-            this.blobsShaCache.set(hash, this.blobsShaToPathMap.get(blob.sha)!);
+        if (this.blobsIdToPathMap.has(blob.sha)) {
+            this.blobsShaToPathCache.set(hash, this.blobsIdToPathMap.get(blob.sha)!);
         }
         return blob;
     }
@@ -163,7 +163,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
             return null;
         }
 
-        const hierarchicalTree = buildHierarchy(tree, this.blobsShaToPathMap);
+        const hierarchicalTree = buildHierarchy(tree, this.blobsIdToPathMap);
 
         // decode commit paths
         const commits = {};
@@ -433,7 +433,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
 
             appTree = trees[1];
 
-            hierarchicalProtocolTree = buildHierarchy(protocolTree, this.blobsShaToPathMap);
+            hierarchicalProtocolTree = buildHierarchy(protocolTree, this.blobsIdToPathMap);
 
         } else {
             appTree = await this.readTree(appTreeId);
@@ -445,7 +445,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
             throw new Error("Invalid app tree");
         }
 
-        const hierarchicalAppTree = buildHierarchy(appTree, this.blobsShaToPathMap);
+        const hierarchicalAppTree = buildHierarchy(appTree, this.blobsIdToPathMap);
 
         if (hierarchicalProtocolTree.blobs) {
             const attributesBlob = hierarchicalProtocolTree.blobs.attributes;
@@ -528,14 +528,14 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
                     const hash = gitHashFile(Buffer.from(content, encoding));
                     // If the cache has the hash of the blob and handle of last summary is also present, then use that to generate complete path for
                     // the given blob.
-                    if (!this.blobsShaCache.has(hash) || !this.lastSummaryHandle) {
+                    if (!this.blobsShaToPathCache.has(hash) || !this.lastSummaryHandle) {
                         value = {
                             content,
                             encoding,
                         };
-                        this.blobsShaCache.set(hash, `${path}/${key}`);
+                        this.blobsShaToPathCache.set(hash, `${path}/${key}`);
                     } else {
-                        id = `${this.lastSummaryHandle}${this.blobsShaCache.get(hash)}`;
+                        id = `${this.lastSummaryHandle}${this.blobsShaToPathCache.get(hash)}`;
                     }
                     break;
 

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentStorageManager.ts
@@ -290,7 +290,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
 
                 if (blobs) {
                     this.initBlobsCache(blobs);
-                    // Populate the cache with paths from sha-to-path mapping.
+                    // Populate the cache with paths from id-to-path mapping.
                     for (const blob of this.blobCache.values()) {
                         const path = this.blobsIdToPathMap.get(blob.sha);
                         if (path) {

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentStorageManager.ts
@@ -110,12 +110,6 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
             blob.content = fromUtf8ToBase64(JSON.stringify(documentAttributes));
         }
 
-        // Populate the cache with paths from sha-to-path mapping.
-        const path = this.blobsIdToPathMap.get(blob.sha);
-        if (path) {
-            const hash = gitHashFile(Buffer.from(blob.content, blob.encoding));
-            this.blobsShaToPathCache.set(hash, path);
-        }
         return blob;
     }
 
@@ -296,6 +290,14 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
 
                 if (blobs) {
                     this.initBlobsCache(blobs);
+                    // Populate the cache with paths from sha-to-path mapping.
+                    for (const blob of this.blobCache.values()) {
+                        const path = this.blobsIdToPathMap.get(blob.sha);
+                        if (path) {
+                            const hash = gitHashFile(Buffer.from(blob.content, blob.encoding));
+                            this.blobsShaToPathCache.set(hash, path);
+                        }
+                    }
                 }
 
                 this.ops = ops;

--- a/packages/drivers/routerlicious-socket-storage/src/documentStorageService.ts
+++ b/packages/drivers/routerlicious-socket-storage/src/documentStorageService.ts
@@ -25,7 +25,7 @@ import * as assert from "assert";
  */
 export class DocumentStorageService implements IDocumentStorageService  {
 
-    private readonly blobsShaCache = new Set<string>();
+    private readonly blobsShaCache = new Map<string, string>();
     public get repositoryUrl(): string {
         return "";
     }
@@ -59,7 +59,7 @@ export class DocumentStorageService implements IDocumentStorageService  {
 
     public async read(blobId: string): Promise<string> {
         const value = await this.manager.getBlob(blobId);
-        this.blobsShaCache.add(value.sha);
+        this.blobsShaCache.set(value.sha, value.sha);
         return value.content;
     }
 
@@ -110,7 +110,7 @@ export class DocumentStorageService implements IDocumentStorageService  {
                 if (!this.blobsShaCache.has(hash)) {
                     const blob = await this.manager.createBlob(content, encoding);
                     assert.strictEqual(hash, blob.sha, "Blob.sha and hash do not match!!");
-                    this.blobsShaCache.add(blob.sha);
+                    this.blobsShaCache.set(blob.sha, blob.sha);
                 }
                 return hash;
             case SummaryType.Commit:

--- a/packages/drivers/routerlicious-socket-storage/src/documentStorageService.ts
+++ b/packages/drivers/routerlicious-socket-storage/src/documentStorageService.ts
@@ -25,6 +25,8 @@ import * as assert from "assert";
  */
 export class DocumentStorageService implements IDocumentStorageService  {
 
+    // The values of this cache is useless. We only need the keys. So we are always putting
+    // empty strings as values.
     private readonly blobsShaCache = new Map<string, string>();
     public get repositoryUrl(): string {
         return "";
@@ -59,7 +61,7 @@ export class DocumentStorageService implements IDocumentStorageService  {
 
     public async read(blobId: string): Promise<string> {
         const value = await this.manager.getBlob(blobId);
-        this.blobsShaCache.set(value.sha, value.sha);
+        this.blobsShaCache.set(value.sha, "");
         return value.content;
     }
 
@@ -110,7 +112,7 @@ export class DocumentStorageService implements IDocumentStorageService  {
                 if (!this.blobsShaCache.has(hash)) {
                     const blob = await this.manager.createBlob(content, encoding);
                     assert.strictEqual(hash, blob.sha, "Blob.sha and hash do not match!!");
-                    this.blobsShaCache.set(blob.sha, blob.sha);
+                    this.blobsShaCache.set(blob.sha, "");
                 }
                 return hash;
             case SummaryType.Commit:

--- a/packages/loader/utils/src/blobs.ts
+++ b/packages/loader/utils/src/blobs.ts
@@ -121,7 +121,10 @@ function flattenCore(path: string, treeEntries: ITreeEntry[], blobMap: Map<strin
  * @param flatTree - a flat tree
  * @returns the hierarchical tree
  */
-export function buildHierarchy(flatTree: git.ITree, blobsShaCache: Set<string> = new Set<string>()): ISnapshotTree {
+export function buildHierarchy(
+    flatTree: git.ITree,
+    blobsShaCache: Map<string, string> = new Map<string, string>()): ISnapshotTree {
+
     const lookup: { [path: string]: ISnapshotTree } = {};
     const root: ISnapshotTree = { id: flatTree.sha, blobs: {}, commits: {}, trees: {} };
     lookup[""] = root;
@@ -141,7 +144,7 @@ export function buildHierarchy(flatTree: git.ITree, blobsShaCache: Set<string> =
             lookup[entry.path] = newTree;
         } else if (entry.type === "blob") {
             node.blobs[decodeURIComponent(entryPathBase)] = entry.sha;
-            blobsShaCache.add(entry.sha);
+            blobsShaCache.set(entry.sha, `/${entry.path}`);
         } else if (entry.type === "commit") {
             node.commits[decodeURIComponent(entryPathBase)] = entry.sha;
         }

--- a/packages/loader/utils/src/blobs.ts
+++ b/packages/loader/utils/src/blobs.ts
@@ -119,8 +119,7 @@ function flattenCore(path: string, treeEntries: ITreeEntry[], blobMap: Map<strin
  * Build a tree hierarchy base on a flat tree
  *
  * @param flatTree - a flat tree
- * @param blobsShaToPathCache - Map with blobs sha as keys for routerlicious driver or blobs id as keys for
- *  odsp driver and values as path of the blob.
+ * @param blobsShaToPathCache - Map with blobs sha as keys and values as path of the blob.
  * @returns the hierarchical tree
  */
 export function buildHierarchy(

--- a/packages/loader/utils/src/blobs.ts
+++ b/packages/loader/utils/src/blobs.ts
@@ -119,11 +119,13 @@ function flattenCore(path: string, treeEntries: ITreeEntry[], blobMap: Map<strin
  * Build a tree hierarchy base on a flat tree
  *
  * @param flatTree - a flat tree
+ * @param blobsShaToPathCache - Map with blobs sha as keys for routerlicious driver or blobs id as keys for
+ *  odsp driver and values as path of the blob.
  * @returns the hierarchical tree
  */
 export function buildHierarchy(
     flatTree: git.ITree,
-    blobsShaCache: Map<string, string> = new Map<string, string>()): ISnapshotTree {
+    blobsShaToPathCache: Map<string, string> = new Map<string, string>()): ISnapshotTree {
 
     const lookup: { [path: string]: ISnapshotTree } = {};
     const root: ISnapshotTree = { id: flatTree.sha, blobs: {}, commits: {}, trees: {} };
@@ -144,7 +146,7 @@ export function buildHierarchy(
             lookup[entry.path] = newTree;
         } else if (entry.type === "blob") {
             node.blobs[decodeURIComponent(entryPathBase)] = entry.sha;
-            blobsShaCache.set(entry.sha, `/${entry.path}`);
+            blobsShaToPathCache.set(entry.sha, `/${entry.path}`);
         } else if (entry.type === "commit") {
             node.commits[decodeURIComponent(entryPathBase)] = entry.sha;
         }

--- a/packages/utils/odsp-utils/src/odsp-utils.ts
+++ b/packages/utils/odsp-utils/src/odsp-utils.ts
@@ -298,7 +298,7 @@ async function getDriveItem(
             return Promise.reject(createRequestError("Unable to get drive/item id from path", getDriveItemResult));
         }
         // try createing the file
-        const contentUri = `${getDriveItemUrl}:/content`;
+        const contentUri = `${getDriveItemUrl}/content`;
         const createResult = await putAsync(server, clientConfig, tokens, contentUri);
         if (createResult.status !== 201) {
             return Promise.reject(createRequestError("Failed to create file", createResult));


### PR DESCRIPTION
1.) Use id+path method for specifying the path of the blob in previous summary so as to reuse it.
2.) id is the unacked handle of the previous summary.
3.) So lets say we posted a summary and got back handle x. While specifying path next time for a given blob we will use X/path1/path2 and lets say we get handle Y back. So then next time we will use Y/path1/path2 for the same blob.
4.) Populate the cache on blob reading in get latest.
5.) Update id to path map to get latest so that we does not depend on getTree as we are not sure there that the requested tree is latest or not.