### PR TITLE
Augment connection telemetry to distinguish auto-reconnect from manual reconnect

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -980,7 +980,9 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         const duration = time - this.connectionTransitionTimes[oldState];
 
         let connectionStarter: string;
-        if (this.firstConnection) {
+        if (value === ConnectionState.Disconnected) {
+            connectionStarter = "Disconnect";
+        } else if (this.firstConnection) {
             connectionStarter = "InitialConnect";
         } else if (this.manualReconnectInProgress) {
             connectionStarter = "ManualReconnect";

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -980,15 +980,15 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         this.connectionTransitionTimes[value] = time;
         const duration = time - this.connectionTransitionTimes[oldState];
 
-        let connectionStarter: string;
+        let connectionInitiationReason: string;
         if (value === ConnectionState.Disconnected) {
-            connectionStarter = "Disconnect";
+            connectionInitiationReason = "Disconnect";
         } else if (this.firstConnection) {
-            connectionStarter = "InitialConnect";
+            connectionInitiationReason = "InitialConnect";
         } else if (this.manualReconnectInProgress) {
-            connectionStarter = "ManualReconnect";
+            connectionInitiationReason = "ManualReconnect";
         } else {
-            connectionStarter = "AutoReconnect";
+            connectionInitiationReason = "AutoReconnect";
         }
 
         this.logger.sendPerformanceEvent({
@@ -996,7 +996,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
             from: ConnectionState[oldState],
             duration,
             reason,
-            connectionStarter,
+            connectionInitiationReason,
             socketDocumentId: this._deltaManager ? this._deltaManager.socketDocumentId : undefined,
             pendingClientId: this.pendingClientId,
         });

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -932,6 +932,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         });
 
         this._deltaManager.on("disconnect", (reason: string) => {
+            this.manualReconnectInProgress = false;
             this.setConnectionState(ConnectionState.Disconnected, reason);
         });
 


### PR DESCRIPTION
Fixes #567 

With this change, the `connectionStarter` field will be added to all connection telemetry and can be used to distinguish whether the connection was kicked off as the initial connection vs. an automatic reconnection vs. a manual reconnection.

It removes the separate InitialConnect event since its functionality is mostly covered by this new field.  However, I didn't currently add the equivalent of its `duration` field (tracking disconnected->connected duration rather than just connecting->connected duration).  Since we'll be able to track both the disconnected->connecting and connecting->connected transitions for the initial connect, I think the combined duration is probably not needed but would love your thoughts on that.