### PR TITLE
Prevent reusing the socket after receiving a server_disconnect

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentDeltaConnection.ts
@@ -11,7 +11,6 @@ import {
     IClient,
     IDocumentDeltaConnection,
 } from "@microsoft/fluid-protocol-definitions";
-import * as assert from "assert";
 import { IOdspSocketError } from "./contracts";
 import { debug } from "./debug";
 import { errorObjectFromOdspError } from "./OdspUtils";
@@ -210,9 +209,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
             return;
         }
 
-        assert(socketReference.delayDeleteTimeout === undefined);
-
-        if (socketReference.references === 0) {
+        if (socketReference.references === 0 && socketReference.delayDeleteTimeout === undefined) {
             socketReference.delayDeleteTimeout = setTimeout(() => {
                 OdspDocumentDeltaConnection.socketIoSockets.delete(key);
 

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentDeltaConnection.ts
@@ -145,7 +145,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
                     timeout: timeoutMs,
                 });
 
-            socketReference = {
+            const newSocketReference: ISocketReference = {
                 socket,
                 references: 1,
             };
@@ -153,9 +153,11 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
             socket.on("server_disconnect", (socketError: IOdspSocketError) => {
                 // Raise it as disconnect.
                 // That produces cleaner telemetry (no errors) and keeps protocol simpler (and not driver-specific).
-                socketReference!.socketClosing = true;
+                newSocketReference.socketClosing = true;
                 socket.emit("disconnect", errorObjectFromOdspError(socketError));
             });
+
+            socketReference = newSocketReference;
 
             OdspDocumentDeltaConnection.socketIoSockets.set(key, socketReference);
             debug(`Created new socketio reference for ${key}`);

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentDeltaConnection.ts
@@ -152,11 +152,6 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
                     timeout: timeoutMs,
                 });
 
-            socketReference = {
-                socket,
-                references: 1,
-            };
-
             socket.on("server_disconnect", (socketError: IOdspSocketError) => {
                 // the server always closes the socket after sending this message
                 // fully remove the socket reference now
@@ -166,6 +161,11 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
                 // That produces cleaner telemetry (no errors) and keeps protocol simpler (and not driver-specific).
                 socket.emit("disconnect", errorObjectFromOdspError(socketError));
             });
+
+            socketReference = {
+                socket,
+                references: 1,
+            };
 
             OdspDocumentDeltaConnection.socketIoSockets.set(key, socketReference);
             debug(`Created new socketio reference for ${key}`);

--- a/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
+++ b/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
@@ -382,6 +382,12 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
                 reject(createErrorObject("connect_timeout", "Socket connection timed out"));
             });
 
+            // Listen for disconnects
+            this.addConnectionListener("disconnect", () => {
+                this.disconnect(true);
+                reject(createErrorObject("disconnect", "Socket disconnectd"));
+            });
+
             this.addConnectionListener("connect_document_success", (response: IConnected) => {
                 this.removeTrackedListeners(true);
                 resolve(response);


### PR DESCRIPTION
The client gets a "server_disconnect" message from the server for "IdleTime" and emits a "disconnect" for the socket. That "disconnect" doesn't close the socket until 2 seconds later. The client then decides to reconnect, and it ends up using that same socket (this a problem). It sends a "connect_document" message, but then the socket is closed by the server and the client waits forever.
 
When the client gets a "server_disconnect", mark the socket reference as closing. When deltaConnection.disconnect is called, the reference will be removed.