### PR TITLE
Minor build fixes

### DIFF
--- a/samples/chaincode/sudoku/.eslintrc.json
+++ b/samples/chaincode/sudoku/.eslintrc.json
@@ -18,6 +18,7 @@
     },
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
+
         "ecmaFeatures": {
             "jsx": true
         },
@@ -30,6 +31,11 @@
         "@typescript-eslint/tslint",
         "@typescript-eslint"
     ],
+    "settings": {
+        "react": {
+            "version": "detect"
+        }
+    },
     "rules": {
         "@typescript-eslint/interface-name-prefix": "off",
         "@typescript-eslint/explicit-function-return-type": "off",

--- a/samples/chaincode/sudoku/.eslintrc.json
+++ b/samples/chaincode/sudoku/.eslintrc.json
@@ -18,7 +18,6 @@
     },
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
-
         "ecmaFeatures": {
             "jsx": true
         },

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -5,7 +5,7 @@
   "author": "Microsoft",
   "scripts": {
     "build": "npm run policy-check && npm run build:genver && npm run build:compile && npm run tslint && npm run build:docs",
-    "build:ci": "npm run build:genver && lerna run build:full:compile --stream",
+    "build:ci": "npm run build:genver && lerna run build:compile:min --stream",
     "build:compile": "lerna run build:compile --stream",
     "build:docs": "npm run clean:docs && lerna run build:docs --stream --parallel && npm run build:gendocs",
     "build:fast": "node ../../tools/fluid-build/dist/fluidBuild.js --root .",
@@ -49,7 +49,7 @@
     "watch:esnext": "lerna run --parallel build:esnext -- -- --watch",
     "watch:tsc": "lerna run --parallel tsc -- -- --watch",
     "watch:webpack": "lerna run --parallel webpack -- -- --watch",
-    "webpack": "lerna run --parallel webpack --stream"
+    "webpack": "lerna run --no-sort webpack --stream"
   },
   "dependencies": {},
   "devDependencies": {

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "concurrently npm:build:compile npm:tslint",
     "build:compile": "npm run tsc",
+    "build:compile:min": "npm run build:compile",
     "build:full": "npm run build",
     "build:full:compile": "npm run build:compile",
     "clean": "rimraf dist *.tsbuildinfo *.build.log",

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "concurrently npm:build:compile npm:tslint",
     "build:compile": "npm run tsc",
+    "build:compile:min": "npm run build:compile",
     "build:full": "npm run build",
     "build:full:compile": "npm run build:compile",
     "clean": "rimraf dist lib *.tsbuildinfo *.build.log",

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build": "concurrently npm:build:compile npm:tslint",
     "build:compile": "npm run tsc",
+    "build:compile:min": "npm run build:compile",
     "build:full": "npm run build",
     "build:full:compile": "npm run build:compile",
     "clean": "rimraf dist lib *.tsbuildinfo *.build.log",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "concurrently npm:build:compile npm:tslint",
     "build:compile": "npm run tsc",
+    "build:compile:min": "npm run build:compile",
     "build:full": "npm run build",
     "build:full:compile": "npm run build:compile",
     "clean": "rimraf dist lib *.tsbuildinfo *.build.log",
@@ -37,7 +38,7 @@
     "winston": "^3.1.0"
   },
   "devDependencies": {
-    "@microsoft/fluid-build-common":"^0.12.0",
+    "@microsoft/fluid-build-common": "^0.12.0",
     "@microsoft/fluid-server-test-utils": "^0.12.0",
     "@types/async": "^2.0.50",
     "@types/lodash": "^4.14.118",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "npm run build:genver && concurrently npm:build:compile npm:tslint",
     "build:compile": "npm run tsc",
+    "build:compile:min": "npm run build:compile",
     "build:full": "npm run build",
     "build:full:compile": "npm run build:compile",
     "build:genver": "node node_modules/@microsoft/fluid-build-common/gen_version.js",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "npm run build:genver && concurrently npm:build:compile npm:tslint",
     "build:compile": "concurrently npm:tsc npm:build:esnext",
+    "build:compile:min": "npm run build:compile",
     "build:docs": "api-extractor run --local",
     "build:esnext": "tsc --project ./tsconfig.esnext.json",
     "build:full": "npm run build",

--- a/server/routerlicious/packages/protocol-definitions/package.json
+++ b/server/routerlicious/packages/protocol-definitions/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "concurrently npm:build:compile npm:tslint",
     "build:compile": "concurrently npm:tsc npm:build:esnext",
+    "build:compile:min": "npm run build:compile",
     "build:docs": "api-extractor run --local",
     "build:esnext": "tsc --project ./tsconfig.esnext.json",
     "build:full": "npm run build",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -17,6 +17,7 @@
     "beast": "npm test -- --beast --grep beastTest",
     "build": "concurrently npm:build:compile npm:tslint",
     "build:compile": "npm run tsc",
+    "build:compile:min": "npm run build:compile",
     "build:full": "npm run build",
     "build:full:compile": "npm run build:compile",
     "clean": "rimraf dist *.tsbuildinfo *.build.log",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "npm run build:genver && concurrently npm:build:compile npm:tslint",
     "build:compile": "concurrently npm:tsc npm:build:esnext",
+    "build:compile:min": "npm run build:compile",
     "build:esnext": "tsc --project ./tsconfig.esnext.json",
     "build:full": "npm run build",
     "build:full:compile": "npm run build:compile",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "npm run build:genver && concurrently npm:build:compile npm:tslint",
     "build:compile": "npm run tsc",
+    "build:compile:min": "npm run build:compile",
     "build:full": "npm run build",
     "build:full:compile": "npm run build:compile",
     "build:genver": "node node_modules/@microsoft/fluid-build-common/gen_version.js",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build": "npm run build:genver && concurrently npm:build:compile npm:tslint",
     "build:compile": "npm run tsc",
+    "build:compile:min": "npm run build:compile",
     "build:full": "npm run build",
     "build:full:compile": "npm run build:compile",
     "build:genver": "node node_modules/@microsoft/fluid-build-common/gen_version.js",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "npm run build:genver && concurrently npm:build:compile npm:tslint",
     "build:compile": "npm run tsc",
+    "build:compile:min": "npm run build:compile",
     "build:full": "npm run build",
     "build:full:compile": "npm run build:compile",
     "build:genver": "node node_modules/@microsoft/fluid-build-common/gen_version.js",
@@ -37,8 +38,8 @@
     "socket.io": "^2.2.0",
     "socket.io-emitter": "^3.1.1",
     "socket.io-redis": "^5.2.0",
-    "winston": "^3.1.0",
-    "telegrafjs": "^0.1.3"
+    "telegrafjs": "^0.1.3",
+    "winston": "^3.1.0"
   },
   "devDependencies": {
     "@microsoft/fluid-build-common": "^0.12.0",

--- a/tools/fluid-build/src/fluidBuild.ts
+++ b/tools/fluid-build/src/fluidBuild.ts
@@ -92,9 +92,11 @@ async function main() {
         return;
     }
 
+    // TODO: Should read lerna.json to determine
     const baseDirectories = [ path.join(resolvedRoot, "packages")];
-    if (options.samples) {
-        baseDirectories.push(path.join(resolvedRoot, "samples/chaincode"));
+    const samplesDirectory = path.join(resolvedRoot, "samples/chaincode");
+    if (options.samples && existsSync(samplesDirectory)) {
+        baseDirectories.push(samplesDirectory);
     }
 
     // Load the package


### PR DESCRIPTION
Fluid-Build: Add proper tsBuildInfo path detection so that samples/chaincode/containers/monoco-container use the right tsBuildInfo to detect if it needs to be rebuilt

Fix eslint warning about missing react version in samples/chaincode/sudoku

Fluid-Build: Fix server build using fluid-build (without the sample directory)

Server/Routerlicious: Make the build look the same as the packages build.  