### PR TITLE
Fix summarizer bug when no ack/nack

### DIFF
--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -233,6 +233,9 @@ export class RunningSummarizer implements IDisposable {
             firstAck);
 
         await summarizer.waitStart();
+
+        // run the heuristics after starting
+        summarizer.heuristics.run();
         return summarizer;
     }
 
@@ -277,9 +280,6 @@ export class RunningSummarizer implements IDisposable {
                     timePending: Date.now() - this.heuristics.lastSent.summaryTime,
                 });
             });
-
-        // run the heuristics after starting
-        this.heuristics.run();
     }
 
     public dispose(): void {


### PR DESCRIPTION
There was a bug where the first heuristics were running _before_ starting rather than after.  This caused some weird behavior when the start takes too long or fails.

Fix is to move the first heuristics run to after the start.
Also fixed so that the summarizer client will make sure its container closes as the run promise is settled (either resolve or rejects).