### PR TITLE
Telemetry improvements:

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentStorageManager.ts
@@ -10,6 +10,7 @@ import {
     fromUtf8ToBase64,
     gitHashFile,
     PerformanceEvent,
+    TelemetryLogger,
 } from "@microsoft/fluid-core-utils";
 import * as resources from "@microsoft/fluid-gitresources";
 import * as api from "@microsoft/fluid-protocol-definitions";
@@ -257,8 +258,8 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
                             blobs: odspSnapshot.blobs ? odspSnapshot.blobs.length : 0,
                             ops: odspSnapshot.ops.length,
                             sprequestguid: response.headers.get("sprequestguid"),
-                            sprequestduration: response.headers.get("sprequestduration"),
-                            contentsize: response.headers.get("content-length"),
+                            sprequestduration: TelemetryLogger.numberFromString(response.headers.get("sprequestduration")),
+                            contentsize: TelemetryLogger.numberFromString(response.headers.get("content-length")),
                         };
                         event.end(props);
                     } catch (error) {

--- a/packages/drivers/odsp-socket-storage/src/OdspUtils.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspUtils.ts
@@ -27,7 +27,7 @@ export function throwOdspNetworkError(
         statusCode,
         canRetry,
         undefined,
-        response && response.headers ? `${response.headers.get("sprequestguid")}` : undefined,
+        response && response.headers && response.headers.get("sprequestguid"),
         online,
     );
 }
@@ -38,7 +38,7 @@ export class OdspNetworkError extends NetworkError {
         readonly statusCode: number | undefined,
         readonly canRetry: boolean,
         readonly retryAfterSeconds?: number,
-        readonly sprequestguid?: string,
+        readonly sprequestguid?: string | null,
         readonly online = OnlineStatus[isOnline()]) {
         super(errorMessage, statusCode, canRetry, retryAfterSeconds, online);
     }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -170,6 +170,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
     private connectionDetailsP: Promise<IConnectionDetails> | undefined;
 
     private firstConnection = true;
+    private manualReconnectInProgress = false;
     private readonly connectionTransitionTimes: number[] = [];
     private messageCountAfterDisconnection: number = 0;
 
@@ -295,9 +296,6 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
                 clientType: this.client.type, // differentiating summarizer container from main container
                 packageName: TelemetryLogger.sanitizePkgName(pkgName),
                 packageVersion: pkgVersion,
-            },
-            {
-                clientId: () => this.clientId,
             });
 
         // Prefix all events in this file with container-loader
@@ -421,6 +419,10 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
      * Connect the deltaManager.  Useful when the autoConnect flag is set to false.
      */
     public async reconnect() {
+        // Only track this as a manual reconnection if we are truly the ones kicking it off.
+        if (this._connectionState === ConnectionState.Disconnected) {
+            this.manualReconnectInProgress = true;
+        }
         return this._deltaManager!.connect();
     }
 
@@ -879,6 +881,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
             });
 
             this._deltaManager.on("disconnect", (reason: string) => {
+                this.manualReconnectInProgress = false;
                 this.setConnectionState(ConnectionState.Disconnected, reason);
             });
 
@@ -942,27 +945,44 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         this.connectionTransitionTimes[value] = time;
         const duration = time - this.connectionTransitionTimes[oldState];
 
+        let durationFromDisconnected: number | undefined;
+        let connectionMode: string | undefined;
+        let connectionInitiationReason: string | undefined;
+        let autoReconnect: boolean | undefined;
+        if (value === ConnectionState.Disconnected) {
+            autoReconnect = this._deltaManager!.autoReconnect;
+        } else {
+            connectionMode = this._deltaManager!.connectionMode;
+            if (value === ConnectionState.Connected) {
+                durationFromDisconnected = time - this.connectionTransitionTimes[ConnectionState.Disconnected];
+                this.firstConnection = false;
+            }
+            if (this.firstConnection) {
+                connectionInitiationReason = "InitialConnect";
+            } else if (this.manualReconnectInProgress) {
+                connectionInitiationReason = "ManualReconnect";
+            } else {
+                connectionInitiationReason = "AutoReconnect";
+            }
+        }
+
         this.logger.sendPerformanceEvent({
             eventName: `ConnectionStateChange_${ConnectionState[value]}`,
             from: ConnectionState[oldState],
             duration,
+            durationFromDisconnected,
             reason,
+            connectionInitiationReason,
             socketDocumentId: this._deltaManager ? this._deltaManager.socketDocumentId : undefined,
             pendingClientId: this.pendingClientId,
+            clientId: this.clientId,
+            connectionMode,
+            autoReconnect,
         });
 
-        if (value === ConnectionState.Connected && this.firstConnection) {
-            // We just logged event with disconnected/connecting -> connected time
-            // Log extra event recording disconnected -> connected time, as well as provide some extra info.
-            // We can group that info in previous event, but it's easier to analyze telemetry if these are
-            // two separate events (actually - three!).
-            this.logger.sendPerformanceEvent({
-                eventName: "ConnectionStateChange_InitialConnect",
-                duration: time - this.connectionTransitionTimes[ConnectionState.Disconnected],
-                durationCatchUp: time - this.connectionTransitionTimes[ConnectionState.Connecting],
-                reason,
-            });
+        if (value === ConnectionState.Connected) {
             this.firstConnection = false;
+            this.manualReconnectInProgress = false;
         }
     }
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -694,7 +694,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
 
         // Always connect in write mode after getting nacked.
         connection.on("nack", (target: number) => {
-            const nackReason = target === -1 ? "Reconnecting to start writing" : "Reconnecting on nack";
+            const nackReason = target === -1 ? "Nack: Start writing" : "Nack";
             if (!this.autoReconnect) {
                 // Not clear if reconnecting is the right thing in such state.
                 // Let's get telemetry to learn more...
@@ -710,7 +710,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
             // ("server_disconnect", ODSP-specific) is mapped to "disconnect"
             // tslint:disable-next-line:no-floating-promises
             this.reconnectOnError(
-                `Got disconnect: ${disconnectReason}, autoReconnect: ${this.autoReconnect}`,
+                `Disconnect: ${disconnectReason}`,
                 connection,
                 this.systemConnectionMode,
                 disconnectReason,
@@ -725,7 +725,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
             logNetworkFailure(this.logger, {eventName: "DeltaConnectionError"}, error);
             // tslint:disable-next-line:no-floating-promises
             this.reconnectOnError(
-                `Reconnecting on error: ${error}`,
+                `Error: ${error}`,
                 connection,
                 this.systemConnectionMode,
                 error);

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -941,7 +941,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         if (message.sequenceNumber % 2000 === 0) {
             this.logger.sendTelemetryEvent({
                 eventName: "OpStats",
-                seqNumber: message.sequenceNumber,
+                sequenceNumber: message.sequenceNumber,
                 value: msnDistance,
                 timeDelta: this.lastMessageTimeForTelemetry ?
                     message.timestamp - this.lastMessageTimeForTelemetry : undefined,

--- a/packages/loader/utils/src/logger.ts
+++ b/packages/loader/utils/src/logger.ts
@@ -49,6 +49,20 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
         return Math.floor(tick);
     }
 
+    /**
+     * Attempts to parse number from string.
+     * If fails,returns original string.
+     * Used to make telemetry data typed (and support math operations, like comparison),
+     * in places where we do expect numbers (like contentsize/duration property in http header)
+     */
+    public static numberFromString(str: string | null | undefined): string | number | undefined {
+        if (str === undefined || str === null) {
+            return undefined;
+        }
+        const num = Number(str);
+        return Number.isNaN(num) ? str : num;
+    }
+
     public static sanitizePkgName(name: string) {
         return name.replace("@", "").replace("/", "-");
     }
@@ -476,7 +490,7 @@ export class PerformanceEvent {
     protected constructor(
             private readonly logger: ITelemetryLogger,
             event: ITelemetryGenericEvent) {
-        this.event = {...event, tick: this.startTime};
+        this.event = {...event};
         this.reportEvent("start");
 
         if (typeof window === "object" && window != null && window.performance) {
@@ -517,11 +531,10 @@ export class PerformanceEvent {
             return;
         }
 
-        const tick = performanceNow();
-        const event: ITelemetryPerformanceEvent = {...this.event, ...props, tick};
+        const event: ITelemetryPerformanceEvent = {...this.event, ...props};
         event.eventName = `${event.eventName}_${eventNameSuffix}`;
         if (eventNameSuffix !== "start") {
-            event.duration = tick - this.startTime;
+            event.duration = performanceNow() - this.startTime;
         }
 
         this.logger.sendPerformanceEvent(event, error);


### PR DESCRIPTION
Telemetry improvements:

1) Record certain fields as numbers, not strings, for better analyzes in Kusto.
2) Remove clientId from all events and leave only on connection events (COGS). If we learn that creates a lot of inconveniences, we might reconsider.
3) Port Matt's change from master to track reconnect times.
4) Add more state tracking for autoReconnect, full Disconnected -> Connected duration, connection mode.
5) Removed tick property from perf events - can use Event_Time for that.