### PR TITLE
Skeleton for supporting read-only permissions

### DIFF
--- a/packages/loader/container-definitions/src/chaincode.ts
+++ b/packages/loader/container-definitions/src/chaincode.ts
@@ -114,6 +114,17 @@ export enum ConnectionState {
 }
 
 /**
+ * File / container permissions
+ */
+export interface IPermissions {
+    /**
+     * Tells if container is read-only.
+     * It it is, attempts to submit ops will result in error being raised on container
+     */
+    readonly readonly: boolean;
+}
+
+/**
  * Package manager configuration. Provides a key value mapping of config values
  */
 export interface IPackageConfig {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -13,6 +13,7 @@ import {
     IFluidCodeDetails,
     IFluidModule,
     IGenericBlob,
+    IPermissions,
     IProcessMessageResult,
     IQuorum,
     IRuntimeFactory,
@@ -175,6 +176,10 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
 
     private _closed = false;
 
+    public get permissions(): IPermissions {
+        return this._deltaManager!.permissions;
+    }
+
     public get closed(): boolean {
         return this._closed;
     }
@@ -315,6 +320,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         return this.protocolHandler!.quorum;
     }
 
+    public on(event: "permissionsChanged", listener: (permissions: Partial<IPermissions>) => void): void;
     public on(event: "connected" | "contextChanged", listener: (clientId: string) => void): this;
     public on(event: "disconnected" | "joining" | "closed", listener: () => void): this;
     public on(event: "error", listener: (error: any) => void): this;
@@ -892,6 +898,10 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
 
             this._deltaManager.on("processTime", (time) => {
                 this.emit("processTime", time);
+            });
+
+            this._deltaManager.on("permissionsChanged", (permissions) => {
+                this.emit("permissionsChanged", permissions);
             });
         }
     }


### PR DESCRIPTION
Auto-detection of permissions based on connection mode returned by server.

Couple questions to be answered:
1) Is this the right structure?
2) Should we hide it in the driver? If so, it's still exposed to runtime (i.e. runtime has to reason about state when it asks r/w but gets read).
3) Is this sufficient? We want permissions to be on getLatest as well, but I feel like we can start without it.
