### PR TITLE
Enable new map/directory serialization formats & blob summary dedupping

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentStorageManager.ts
@@ -34,8 +34,6 @@ import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth";
 import { OdspCache } from "./odspCache";
 import { getWithRetryForTokenRefresh, throwOdspNetworkError } from "./OdspUtils";
 
-const blobReuseFeatureDisabled = true;
-
 export class OdspDocumentStorageManager implements IDocumentStorageManager {
     // This cache is associated with mapping sha to path for previous summary which belongs to last summary handle.
     private blobsShaToPathCache: Map<string, string> = new Map();
@@ -546,7 +544,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
                     let completePath = this.blobsShaToPathCache.get(hash);
                     // If the cache has the hash of the blob and handle of last summary is also present, then use that to generate complete path for
                     // the given blob.
-                    if (blobReuseFeatureDisabled || !completePath || !this.lastSummaryHandle) {
+                    if (!completePath || !this.lastSummaryHandle) {
                         value = {
                             content,
                             encoding,

--- a/packages/runtime/map/src/directory.ts
+++ b/packages/runtime/map/src/directory.ts
@@ -218,7 +218,7 @@ type IDirectoryOperation = IDirectoryStorageOperation | IDirectorySubDirectoryOp
  * @privateRemarks
  * Directly used in JSON.stringify, direct result from JSON.parse.
  */
-interface IDirectoryDataObject {
+export interface IDirectoryDataObject {
     storage?: { [key: string]: ISerializableValue };
     subdirectories?: { [subdirName: string]: IDirectoryDataObject };
 }

--- a/packages/runtime/map/src/directory.ts
+++ b/packages/runtime/map/src/directory.ts
@@ -224,15 +224,12 @@ export interface IDirectoryDataObject {
     subdirectories?: { [subdirName: string]: IDirectoryDataObject };
 }
 
-interface IDirectoryNewStorageFormat {
+export interface IDirectoryNewStorageFormat {
     blobs: string[];
     content: IDirectoryDataObject;
 }
 
 function serializeDirectory(root: SubDirectory): ITree {
-    // Splitting of big properties is currently disabled (via this big number)
-    // Once build with support for reading new snapshot format propagates, we can enable it.
-    const writeNewFormat = false;
     const MinValueSizeSeparateSnapshotBlob = 8 * 1024;
 
     const tree: ITree = { entries: [], id: null };
@@ -253,7 +250,7 @@ function serializeDirectory(root: SubDirectory): ITree {
                 type: value.type,
                 value: value.value && JSON.parse(value.value) as object,
             };
-            if (writeNewFormat && value.value && value.value.length >= MinValueSizeSeparateSnapshotBlob) {
+            if (value.value && value.value.length >= MinValueSizeSeparateSnapshotBlob) {
                 const extraContent: IDirectoryDataObject = {};
                 let largeContent = extraContent;
                 if (currentSubDir.absolutePath !== posix.sep) {
@@ -283,15 +280,11 @@ function serializeDirectory(root: SubDirectory): ITree {
         }
     }
 
-    if (writeNewFormat) {
-        const newFormat: IDirectoryNewStorageFormat = {
-            blobs,
-            content,
-        };
-        addBlobToTree(tree, snapshotFileName, newFormat);
-    } else {
-        addBlobToTree(tree, snapshotFileName, content);
-    }
+    const newFormat: IDirectoryNewStorageFormat = {
+        blobs,
+        content,
+    };
+    addBlobToTree(tree, snapshotFileName, newFormat);
 
     return tree;
 }

--- a/packages/runtime/map/src/directory.ts
+++ b/packages/runtime/map/src/directory.ts
@@ -217,9 +217,8 @@ type IDirectoryOperation = IDirectoryStorageOperation | IDirectorySubDirectoryOp
  * Defines the in-memory object structure to be used for the conversion to/from serialized.
  * @privateRemarks
  * Directly used in JSON.stringify, direct result from JSON.parse.
- * @internal
  */
-export interface IDirectoryDataObject {
+interface IDirectoryDataObject {
     storage?: { [key: string]: ISerializableValue };
     subdirectories?: { [subdirName: string]: IDirectoryDataObject };
 }

--- a/packages/runtime/map/src/map.ts
+++ b/packages/runtime/map/src/map.ts
@@ -19,7 +19,6 @@ import {
     ISharedObjectFactory,
     SharedObject,
 } from "@microsoft/fluid-shared-object-base";
-import * as assert from "assert";
 import { debug } from "./debug";
 import {
     ISharedMap,
@@ -278,18 +277,12 @@ export class SharedMap extends SharedObject implements ISharedMap {
 
         const data = this.kernel.getSerializedStorage();
 
-        // Remove it (make it true) to enable new format
-        const enableNewFormat = false;
-
-        // Remove this (make it 1) to enable formatting
-        const disableMultiplier = enableNewFormat ? 1 : 1024 * 1024;
-
         // If single property exceeds this size, it goes into its own blob
-        const MinValueSizeSeparateSnapshotBlob = 8 * 1024 * disableMultiplier;
+        const MinValueSizeSeparateSnapshotBlob = 8 * 1024;
 
         // Maximum blob size for multiple map properties
         // Should be bigger than MinValueSizeSeparateSnapshotBlob
-        const MaxSnapshotBlobSize = 16 * 1024 * disableMultiplier;
+        const MaxSnapshotBlobSize = 16 * 1024;
 
         // Partitioning algorithm:
         // 1) Split large (over MinValueSizeSeparateSnapshotBlob = 8K) properties into their own blobs.
@@ -336,18 +329,11 @@ export class SharedMap extends SharedObject implements ISharedMap {
             }
         }
 
-        if (enableNewFormat) {
-            const header: IMapSerializationFormat = {
-                blobs,
-                content: headerBlob,
-            };
-            addBlobToTree(tree, snapshotFileName, header);
-        } else {
-            // For now, new code is disabled. Once ability to load snapshots in new format is deployed
-            // and build is propagated to all users, we can enable new format.
-            assert(counter === 0);
-            addBlobToTree(tree, snapshotFileName, headerBlob);
-        }
+        const header: IMapSerializationFormat = {
+            blobs,
+            content: headerBlob,
+        };
+        addBlobToTree(tree, snapshotFileName, header);
 
         return tree;
     }

--- a/packages/runtime/map/src/test/directory.spec.ts
+++ b/packages/runtime/map/src/test/directory.spec.ts
@@ -31,8 +31,7 @@ function serialize(directory: map.ISharedDirectory): string {
     assert(tree.entries[0].path === "header");
     assert(tree.entries[0].type === TreeEntry[TreeEntry.Blob]);
     const contents = (tree.entries[0].value as IBlob).contents;
-    // return JSON.stringify((JSON.parse(contents) as IDirectoryNewStorageFormat).content);
-    return contents;
+    return JSON.stringify((JSON.parse(contents) as map.IDirectoryNewStorageFormat).content);
 }
 
 describe("Routerlicious", () => {
@@ -193,7 +192,7 @@ describe("Routerlicious", () => {
         });
 
         describe(".populate", () => {
-            it("Should populate the directory from an empty JSON object", async () => {
+            it("Should populate the directory from an empty JSON object (old format)", async () => {
                 await populate(testDirectory, {});
                 assert.equal(testDirectory.size, 0, "Failed to initialize to empty directory storage");
                 testDirectory.set("testKey", "testValue");
@@ -206,7 +205,7 @@ describe("Routerlicious", () => {
                 );
             });
 
-            it("Should populate the directory from a basic JSON object", async () => {
+            it("Should populate the directory from a basic JSON object (old format)", async () => {
                 await populate(testDirectory, {
                     storage: {
                         testKey: {
@@ -257,7 +256,7 @@ describe("Routerlicious", () => {
                 );
             });
 
-            it("Should populate the directory with undefined values", async () => {
+            it("Should populate the directory with undefined values (old format)", async () => {
                 // tslint:disable-next-line:max-line-length
                 await populate(testDirectory, {
                     storage: {
@@ -309,7 +308,7 @@ describe("Routerlicious", () => {
                 );
             });
 
-            it.skip("Should populate, serialize and de-serialize directory with long property values", async () => {
+            it("Should populate, serialize and de-serialize directory with long property values", async () => {
                 // 40K word
                 let longWord = "0123456789";
                 for (let i = 0; i < 12; i++) {

--- a/packages/runtime/map/src/test/map.spec.ts
+++ b/packages/runtime/map/src/test/map.spec.ts
@@ -209,26 +209,22 @@ describe("Routerlicious", () => {
                     assert.equal(serialized, `{"object":{"type":"Plain","value":{"subMapHandle":{"type":"__fluid_handle__","url":"subMap"},"nestedObj":{"subMap2Handle":{"type":"__fluid_handle__","url":"subMap2"}}}}}`);
                 });
 
-                it("old serialization format", async () => {
+                it("can load old serialization format", async () => {
                     sharedMap.set("key", "value");
 
-                    const tree = sharedMap.snapshot();
-                    assert(tree.entries.length === 1);
                     const content = JSON.stringify({
                         key: {
                             type: "Plain",
                             value: "value",
                         },
                     });
-                    assert(tree.entries.length === 1);
-                    assert((tree.entries[0].value as IBlob).contents === content);
 
                     const services = new MockSharedObjectServices({header: content});
                     const map2 = await factory.load(runtime, "mapId", services, "branchId");
                     assert(map2.get("key") === "value");
                 });
 
-                it.skip("new serialization format for small maps", async () => {
+                it("new serialization format for small maps", async () => {
                     sharedMap.set("key", "value");
 
                     const tree = sharedMap.snapshot();
@@ -250,7 +246,7 @@ describe("Routerlicious", () => {
                     assert(map2.get("key") === "value");
                 });
 
-                it.skip("new serialization format for big maps", async () => {
+                it("new serialization format for big maps", async () => {
                     sharedMap.set("key", "value");
 
                     // 40K char string


### PR DESCRIPTION
Required for image support (Ignite+30 blocking).
Can be submitted only after any new version of Bohemia released to prod (ability to load snapshots in new format).
Will do end-to-end integration test pass before submitting.