### PR TITLE
Ignore remote signals addressed to components not found

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -783,6 +783,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         if (!context) {
             // attach message may not have been processed yet
             assert(!local);
+            this.logger.sendTelemetryEvent({ eventName: "SignalComponentNotFound", componentId: envelope.address });
             return;
         }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -780,7 +780,11 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
     public processSignal(message: ISignalMessage, local: boolean) {
         const envelope = message.content as IEnvelope;
         const context = this.contexts.get(envelope.address);
-        assert(context);
+        if (!context) {
+            // attach message may not have been processed yet
+            assert(!local);
+            return;
+        }
 
         const innerContent = envelope.contents as { content: any, type: string };
         const transformed: IInboundSignalMessage = {


### PR DESCRIPTION
Fixes issue #663.
It seems possible for a signal for a (remote) component to come in before the attach message is processed.  In this case, I believe the signal can be ignored.

I don't think we need to try to flush the ops first or make a pending queue for signals assuming the addressed components will eventually load, but let me know if there are any guarantees around signals we are trying to make.