### PR TITLE
Move LoaderHeader to container-definitions so that runtime doesn't depend on the loader directly

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,5 +1,17 @@
 # 0.12 Breaking Changes
 
+- [LoaderHeader enum moved from @microsoft/fluid-container-loader to @microsoft/fluid-container-definitions](#LoaderHeader moved to fluid-container-definitions)
+- [Driver interface moved from @microsoft/fluid-protocol-defintions to @microsoft/fluid-driver-definitions](#driver-interfaces-moved-to-fluid-driver-definitions)
+- [Top-level `type` on `IClient` deprecated](#Top-level-type-on-IClient-deprecated)
+- [Support for `IFluidResolvedUrl.type` === "prague" removed](#support-for-ifluidresolvedurltype--prague-removed)
+- [`connect` header replaced with `pause` header; ability to load closed containers removed](#connect-header-replaced-with-pause-header-ability-to-load-closed-containers-removed)
+
+## LoaderHeader moved to fluid-container-definitions
+
+`LoaderHeader` enum is a shared definitions between the runtime and the loader and is moved to fluid-container-definitions from fluid-container-loader
+
+## Driver interfaces moved to fluid-driver-definitions
+
 The following interfaces/types have been moved to `@microsoft/fluid-protocol-definitions`:
 ```
 ConnectionState
@@ -34,11 +46,6 @@ IWebResolvedUrl
 IFluidResolvedUrl
 IUrlResolver
 ```
-
-- [Top-level `type` on `IClient` deprecated](#Top-level-type-on-IClient-deprecated)
-- [Support for `IFluidResolvedUrl.type` === "prague" removed](#support-for-ifluidresolvedurltype--prague-removed)
-- [`connect` header replaced with `pause` header; ability to load closed containers removed](#connect-header-replaced-with-pause-header-ability-to-load-closed-containers-removed)
-
 ## Top-level `type` on `IClient` deprecated
 The `type` field on `IClient` has been deprecated and will be removed in the future. There is now an optional type in the new `details` member of `IClient`. Some of the functionality of the top-level `type` field has been replaced by the `capabilities` member in `IClient.details`, specifically the `interactive` boolean is used to distinguish between human and non-human clients.
 

--- a/packages/components/agent-scheduler/package.json
+++ b/packages/components/agent-scheduler/package.json
@@ -27,8 +27,8 @@
   },
   "dependencies": {
     "@microsoft/fluid-component-core-interfaces": "^0.12.0",
+    "@microsoft/fluid-container-definitions": "^0.12.0",
     "@microsoft/fluid-component-runtime": "^0.12.0",
-    "@microsoft/fluid-container-loader": "^0.12.0",
     "@microsoft/fluid-map": "^0.12.0",
     "@microsoft/fluid-protocol-definitions": "^0.12.0",
     "@microsoft/fluid-register-collection": "^0.12.0",

--- a/packages/components/agent-scheduler/src/scheduler.ts
+++ b/packages/components/agent-scheduler/src/scheduler.ts
@@ -12,7 +12,7 @@ import {
     IResponse,
 } from "@microsoft/fluid-component-core-interfaces";
 import { ComponentRuntime } from "@microsoft/fluid-component-runtime";
-import { LoaderHeader } from "@microsoft/fluid-container-loader";
+import { LoaderHeader } from "@microsoft/fluid-container-definitions";
 import { ISharedMap, SharedMap } from "@microsoft/fluid-map";
 import { ConnectionState } from "@microsoft/fluid-protocol-definitions";
 import { ConsensusRegisterCollection } from "@microsoft/fluid-register-collection";

--- a/packages/loader/container-definitions/src/loader.ts
+++ b/packages/loader/container-definitions/src/loader.ts
@@ -6,6 +6,7 @@
 import { IRequest, IResponse } from "@microsoft/fluid-component-core-interfaces";
 import { IUrlResolver } from "@microsoft/fluid-driver-definitions";
 import {
+    IClientDetails,
     IDocumentMessage,
     IQuorum,
     ISequencedDocumentMessage,
@@ -58,4 +59,45 @@ export interface ILoader {
      * a request against the server found from the resolve step.
      */
     resolve(request: IRequest): Promise<IContainer>;
+}
+
+export enum LoaderHeader {
+    /**
+     * Use cache for this container. If true, we will load a container from cache if one with the same id/version exists
+     * or create a new container and cache it if it does not. If false, always load a new container and don't cache it.
+     * Currently only used to opt-out of caching, as it will default to true but will be false (even if specified as
+     * true) if the reconnect header is false or the pause header is true, since these containers should not be cached.
+     */
+    cache = "fluid-cache",
+    clientDetails = "fluid-client-type",
+    executionContext = "execution-context",
+
+    /**
+     * Start the container in a paused, unconnected state. Defaults to false
+     */
+    pause = "pause",
+    reconnect = "fluid-reconnect",
+    sequenceNumber = "fluid-sequence-number",
+
+    /**
+     * One of the following:
+     * null or "null": use ops, no snapshots
+     * undefined: fetch latest snapshot
+     * otherwise, version sha to load snapshot
+     */
+    version = "version",
+}
+export interface ILoaderHeader {
+    [LoaderHeader.cache]: boolean;
+    [LoaderHeader.clientDetails]: IClientDetails;
+    [LoaderHeader.pause]: boolean;
+    [LoaderHeader.executionContext]: string;
+    [LoaderHeader.sequenceNumber]: number;
+    [LoaderHeader.reconnect]: boolean;
+    [LoaderHeader.version]: string | undefined | null;
+}
+
+declare module "@microsoft/fluid-component-core-interfaces" {
+    export interface IRequestHeader extends Partial<ILoaderHeader> {
+    }
 }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -14,6 +14,7 @@ import {
     IRuntimeFactory,
     ITelemetryBaseLogger,
     ITelemetryLogger,
+    LoaderHeader,
     TelemetryEventRaisedOnContainer,
 } from "@microsoft/fluid-container-definitions";
 import {
@@ -68,7 +69,7 @@ import { ContainerContext } from "./containerContext";
 import { debug } from "./debug";
 import { DeltaManager } from "./deltaManager";
 import { DeltaManagerProxy } from "./deltaManagerProxy";
-import { Loader, LoaderHeader, RelativeLoader } from "./loader";
+import { Loader, RelativeLoader } from "./loader";
 import { NullChaincode } from "./nullRuntime";
 import { pkgName, pkgVersion } from "./packageVersion";
 import { PrefetchDocumentStorageService } from "./prefetchDocumentStorageService";

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -14,6 +14,7 @@ import {
     ILoader,
     IProxyLoaderFactory,
     ITelemetryBaseLogger,
+    LoaderHeader,
 } from "@microsoft/fluid-container-definitions";
 import { configurableUrlResolver, Deferred } from "@microsoft/fluid-core-utils";
 import {
@@ -22,10 +23,7 @@ import {
     IFluidResolvedUrl,
     IResolvedUrl,
 } from "@microsoft/fluid-driver-definitions";
-import {
-    IClientDetails,
-    ISequencedDocumentMessage,
-} from "@microsoft/fluid-protocol-definitions";
+import { ISequencedDocumentMessage } from "@microsoft/fluid-protocol-definitions";
 import { EventEmitter } from "events";
 // tslint:disable-next-line:no-var-requires
 const now = require("performance-now") as () => number;
@@ -42,47 +40,6 @@ interface IParsedUrl {
      * If needed, can add undefined which is treated by Container.load() as load latest snapshot.
      */
     version: string | null | undefined;
-}
-
-export enum LoaderHeader {
-    /**
-     * Use cache for this container. If true, we will load a container from cache if one with the same id/version exists
-     * or create a new container and cache it if it does not. If false, always load a new container and don't cache it.
-     * Currently only used to opt-out of caching, as it will default to true but will be false (even if specified as
-     * true) if the reconnect header is false or the pause header is true, since these containers should not be cached.
-     */
-    cache = "fluid-cache",
-    clientDetails = "fluid-client-type",
-    executionContext = "execution-context",
-
-    /**
-     * Start the container in a paused, unconnected state. Defaults to false
-     */
-    pause = "pause",
-    reconnect = "fluid-reconnect",
-    sequenceNumber = "fluid-sequence-number",
-
-    /**
-     * One of the following:
-     * null or "null": use ops, no snapshots
-     * undefined: fetch latest snapshot
-     * otherwise, version sha to load snapshot
-     */
-    version = "version",
-}
-export interface ILoaderHeader {
-    [LoaderHeader.cache]: boolean;
-    [LoaderHeader.clientDetails]: IClientDetails;
-    [LoaderHeader.pause]: boolean;
-    [LoaderHeader.executionContext]: string;
-    [LoaderHeader.sequenceNumber]: number;
-    [LoaderHeader.reconnect]: boolean;
-    [LoaderHeader.version]: string | undefined | null;
-}
-
-declare module "@microsoft/fluid-component-core-interfaces" {
-    export interface IRequestHeader extends Partial<ILoaderHeader> {
-    }
 }
 
 export class RelativeLoader extends EventEmitter implements ILoader {

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -29,7 +29,6 @@
     "@microsoft/fluid-agent-scheduler": "^0.12.0",
     "@microsoft/fluid-component-core-interfaces": "^0.12.0",
     "@microsoft/fluid-container-definitions": "^0.12.0",
-    "@microsoft/fluid-container-loader": "^0.12.0",
     "@microsoft/fluid-core-utils": "^0.12.0",
     "@microsoft/fluid-driver-definitions": "^0.12.0",
     "@microsoft/fluid-protocol-definitions": "^0.12.0",

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -4,8 +4,7 @@
  */
 
 import { IComponent, IComponentRunnable, IRequest } from "@microsoft/fluid-component-core-interfaces";
-import { IContainerContext, ITelemetryLogger } from "@microsoft/fluid-container-definitions";
-import { LoaderHeader } from "@microsoft/fluid-container-loader";
+import { IContainerContext, ITelemetryLogger, LoaderHeader } from "@microsoft/fluid-container-definitions";
 import { ChildLogger, Heap, IComparer, IHeapNode, PerformanceEvent } from "@microsoft/fluid-core-utils";
 import { ISequencedClient } from "@microsoft/fluid-protocol-definitions";
 import { EventEmitter } from "events";

--- a/tools/fluid-build/data/layerInfo.json
+++ b/tools/fluid-build/data/layerInfo.json
@@ -1,0 +1,97 @@
+{
+    "Base-Definitions": {
+        "packages": [
+            "@microsoft/fluid-component-core-interfaces",
+            "@microsoft/fluid-protocol-definitions"
+        ]
+    },
+
+    "Driver-Definitions": {
+        "packages": [
+            "@microsoft/fluid-driver-definitions"
+        ],
+        "deps": [
+            "@microsoft/fluid-protocol-definitions"
+        ]
+    },
+    "Container-Definitions": {
+        "packages": [
+            "@microsoft/fluid-container-definitions"
+        ],
+        "deps": [
+            "Driver-Definitions",
+            "@microsoft/fluid-component-core-interfaces"
+        ]
+    },
+    "Common-Utils": {
+        "dirs": [
+            "packages/utils"
+        ]
+    },
+    "Driver": {
+        "dirs": [
+            "packages/drivers/"
+        ],
+        "deps": [
+            "Common-Utils",
+            "Driver-Definitions",
+            "@microsoft/fluid-component-core-interfaces"
+        ]
+    },
+    "Container-Utils": {
+        "packages": [
+            "@microsoft/fluid-core-utils"
+        ],
+        "deps": [
+            "Container-Definitions",
+            "@microsoft/fluid-component-core-interfaces"
+        ]
+    },
+    "Loader": {
+        "dirs": [
+            "packages/loader/"
+        ],
+        "deps": [
+            "Container-Utils"
+        ]
+    },
+    "Hosts": {
+        "dirs": [
+            "packages/hosts/"
+        ],
+        "deps": [
+            "Loader",
+            "Driver"
+        ]
+    },
+    "Runtime": {
+        "dirs": [
+            "packages/runtime/"
+        ],
+        "deps": [
+            "Container-Utils"
+        ]
+    },
+    "Framework": {
+        "dirs": [
+            "packages/framework/"
+        ],
+        "deps": [
+            "Hosts",
+            "Runtime"
+        ]
+    },
+    "Component": {
+        "dirs": [
+            "packages/component/",
+            "samples/chaincode/",
+            "packages/agent/",
+            "packages/server/",
+            "packages/tools/",
+            "packages/test/"
+        ],
+        "deps": [
+            "Framework"
+        ]
+    }
+}

--- a/tools/fluid-build/src/buildGraph.ts
+++ b/tools/fluid-build/src/buildGraph.ts
@@ -185,7 +185,7 @@ export class BuildGraph {
         const needPropagate: BuildPackage[] = [];
         this.buildPackages.forEach((node) => {
             if (node.pkg.markForBuild) { needPropagate.push(node); }
-            for (const key of node.pkg.dependencies) {
+            for (const key of node.pkg.combinedDependencies) {
                 const child = this.buildPackages.get(key);
                 if (child) {
                     logVerbose(`Package dependency: ${node.pkg.nameColored} => ${child.pkg.nameColored}`);

--- a/tools/fluid-build/src/fluidBuild.ts
+++ b/tools/fluid-build/src/fluidBuild.ts
@@ -6,6 +6,7 @@
 import { Packages } from "./npmPackage";
 import { parseOptions, options } from "./options";
 import { BuildGraph, BuildResult } from "./buildGraph";
+import { LayerGraph } from "./LayerGraph";
 import { Timer } from "./common/timer";
 import { logStatus } from "./common/logging";
 import { existsSync, readFileAsync, rimrafWithErrorAsync, execWithErrorAsync } from "./common/utils";
@@ -103,6 +104,10 @@ async function main() {
     const packages = Packages.load(baseDirectories);
     timer.time("Package scan completed");
 
+    if (options.layerCheck) {
+        LayerGraph.check(resolvedRoot, packages);
+        timer.time("Layer check completed");
+    }
     // Check scripts
     await packages.checkScripts();
     timer.time("Check scripts completed");

--- a/tools/fluid-build/src/layerGraph.ts
+++ b/tools/fluid-build/src/layerGraph.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import { Packages } from "./npmPackage";
 import * as path from "path";
 

--- a/tools/fluid-build/src/layerGraph.ts
+++ b/tools/fluid-build/src/layerGraph.ts
@@ -1,0 +1,171 @@
+import { Packages } from "./npmPackage";
+import * as path from "path";
+
+interface ILayerInfo {
+    deps?: string[];
+    packages?: string[];
+    dirs?: string[];
+};
+
+interface ILayerInfoFile {
+    [key: string]: ILayerInfo;
+};
+
+class BaseLayerNode {
+    private dependentSet = new Set<BaseLayerNode>();
+    constructor(public readonly name: string) { }
+
+    public addDependent(dep: BaseLayerNode) {
+        this.dependentSet.add(dep);
+    }
+
+    public get dependents() {
+        return this.dependentSet.values();
+    }
+
+    public verifyDependent(dep: PackageLayerNode) {
+        //console.log(`${this.name} -> ${dep.name}`);
+        if (this.dependentSet.has(dep)) {
+            return true;
+        }
+
+        for (const node of this.dependents) {
+            if (node.verifyDependent(dep)) {
+                return true;
+            }
+        }
+        return false;
+    }
+};
+
+class TopLayerNode extends BaseLayerNode {
+};
+
+class LayerItemNode extends BaseLayerNode {
+    constructor(name: string, public readonly topLayerNode: TopLayerNode) {
+        super(name);
+    }
+
+    public get topLayerName() {
+        return this.topLayerNode.name;
+    }
+};
+
+class PackageLayerNode extends LayerItemNode {
+    constructor(name: string, layerNode: TopLayerNode) {
+        super(name, layerNode);
+    }
+};
+
+class DirLayerNode extends LayerItemNode {
+    private packages = new Set<PackageLayerNode>();
+    public addPackage(pkg: PackageLayerNode) {
+        this.packages.add(pkg);
+    }
+
+    public verifyDependent(dep: PackageLayerNode) {
+        if (this.packages.has(dep)) { return true; }
+        return super.verifyDependent(dep);
+    }
+}
+
+
+export class LayerGraph {
+    private layers = new Map<string, TopLayerNode>();
+    private packageLayer = new Map<string, PackageLayerNode>();
+    private dirLayers: { [key: string]: DirLayerNode } = {};
+
+    private createPackage(name: string, layer: TopLayerNode) {
+        if (this.packageLayer.get(name)) {
+            throw new Error(`Duplicate package layer entry ${name}`);
+        }
+        const packageLayerNode = new PackageLayerNode(name, layer);
+        this.packageLayer.set(name, packageLayerNode);
+        return packageLayerNode;
+    }
+    private constructor(root: string, layerInfo: ILayerInfoFile) {
+        const pendingDeps: { node: BaseLayerNode, deps: string[] | undefined }[] = [];
+
+        // First pass get the layer nodes
+        for (const layer of Object.keys(layerInfo)) {
+            const layerNode = new TopLayerNode(layer)
+            this.layers.set(layer, layerNode);
+            const info = layerInfo[layer];
+            if (info.dirs) {
+                for (const dir of info.dirs) {
+                    const fullDir = path.resolve(root, dir);
+                    const dirLayerNode = new DirLayerNode(fullDir, layerNode);
+                    this.dirLayers[fullDir] = dirLayerNode;
+                    layerNode.addDependent(dirLayerNode);
+                    pendingDeps.push({ node: dirLayerNode, deps: info.deps });
+                }
+            }
+            if (info.packages) {
+                for (const pkg of info.packages) {
+                    const packageLayerNode = this.createPackage(pkg, layerNode);
+                    layerNode.addDependent(packageLayerNode);
+                    pendingDeps.push({ node: packageLayerNode, deps: info.deps });
+                }
+            }
+        }
+
+        // Wire up the dependents
+        for (const { node, deps } of pendingDeps) {
+            if (!deps) { continue; }
+            for (const dep of deps) {
+                const depLayer = this.layers.get(dep);
+                if (depLayer) {
+                    node.addDependent(depLayer);
+                } else {
+                    const depPackage = this.packageLayer.get(dep);
+                    if (depPackage === undefined) {
+                        throw new Error(`Missing package entry for dependency ${dep} in ${node.name}`);
+                    }
+                    node.addDependent(depPackage);
+                }
+            }
+        }
+    }
+
+    private verify(packages: Packages) {
+        for (const pkg of packages.packages) {
+            if (this.packageLayer.get(pkg.name)) { continue; }
+            for (const dir of Object.keys(this.dirLayers)) {
+                if (pkg.directory.startsWith(dir)) {
+                    //console.log(`${pkg.nameColored}: ${dir}`);
+                    const dirLayerNode = this.dirLayers[dir];
+                    const packageLayerNode = this.createPackage(pkg.name, dirLayerNode.topLayerNode);
+                    dirLayerNode.addPackage(packageLayerNode);
+                    for (const dep of dirLayerNode.dependents) {
+                        packageLayerNode.addDependent(dep);
+                    }
+                    break;
+                }
+            }
+        }
+
+        for (const pkg of packages.packages) {
+            const packageLayerNode = this.packageLayer.get(pkg.name);
+            if (!packageLayerNode) {
+                console.warn(`${pkg.nameColored}: warning: Package doesn't match any directories. Unable to do dependency check`);
+                continue;
+            }
+            for (const dep of pkg.dependencies) {
+                const depLayerNode = this.packageLayer.get(dep);
+                if (!depLayerNode) { continue; }
+                // Package can depend on each other if they are in the same layer
+                if (packageLayerNode.topLayerNode === depLayerNode.topLayerNode) { continue; }
+                //console.log(`${pkg.nameColored}: checking ${dep}`);
+                if (!packageLayerNode.verifyDependent(depLayerNode)) {
+                    console.warn(`${pkg.nameColored}: warning: Dependency layer violation ${dep}, "${packageLayerNode.topLayerName}" -> "${depLayerNode.topLayerName}"`);
+                }
+            }
+        }
+    }
+
+    public static check(root: string, packages: Packages) {
+        const layerInfoFile = require("../data/layerInfo.json");
+        const layerGraph = new LayerGraph(root, layerInfoFile);
+        layerGraph.verify(packages);
+    }
+};

--- a/tools/fluid-build/src/npmPackage.ts
+++ b/tools/fluid-build/src/npmPackage.ts
@@ -107,6 +107,10 @@ export class Package {
     }
 
     public get dependencies() {
+        return this.packageJson.dependencies? Object.keys(this.packageJson.dependencies) : [];
+    }
+
+    public get combinedDependencies() {
         const it = function* (packageJson: IPackage) {
             for (const item in packageJson.dependencies) {
                 yield (item);
@@ -258,7 +262,7 @@ export class Package {
     }
 
     public async symlink(buildPackages: Map<string, Package>) {
-        for (const dep of this.dependencies) {
+        for (const dep of this.combinedDependencies) {
             const depBuildPackage = buildPackages.get(dep);
             if (depBuildPackage) {
                 const symlinkPath = path.join(this.directory, "node_modules", dep);

--- a/tools/fluid-build/src/options.ts
+++ b/tools/fluid-build/src/options.ts
@@ -28,6 +28,7 @@ interface FastBuildOptions {
     concurrency: number;
     samples: boolean;
     fixScripts: boolean;
+    layerCheck: boolean;
 }
 
 // defaults
@@ -53,7 +54,7 @@ export const options: FastBuildOptions = {
     concurrency: os.cpus().length, // TODO: argument?
     samples: true,
     fixScripts: false,
-
+    layerCheck: false,
 };
 
 function printUsage() {
@@ -149,6 +150,13 @@ export function parseOptions(argv: string[]) {
 
         if (arg === "--fixscripts") {
             options.fixScripts = true;
+            setBuild(false);
+            continue;
+        }
+
+        if (arg === "--layercheck") {
+            options.layerCheck = true;
+            setBuild(false);
             continue;
         }
 


### PR DESCRIPTION
Also add --layercheck to FluidBuild to check layering violations.   
Not all the violations are fixed yet.  Most are from driver -> loader because of the telemetry interface.  Will fix in the future PR.