### PR TITLE
enable back compat test

### DIFF
--- a/packages/test/snapshots/src/test/replay.spec.ts
+++ b/packages/test/snapshots/src/test/replay.spec.ts
@@ -14,7 +14,7 @@ describe("Snapshots", function() {
         return processContent(Mode.Stress);
     });
 
-    // it("Backward Compat", async () => {
-    //     return processContent(Mode.Compare);
-    // });
+    it("Backward Compat", async () => {
+        return processContent(Mode.Compare);
+    });
 });

--- a/packages/tools/replay-tool/src/replayMessages.ts
+++ b/packages/tools/replay-tool/src/replayMessages.ts
@@ -273,8 +273,18 @@ class Document {
         const resolver = new ContainerUrlResolver(
             new Map<string, IResolvedUrl>([[resolved.url, resolved]]));
         const host = { resolver };
-
-        const codeLoader = new API.CodeLoader({ generateSummaries: false });
+        const chaincode = new API.Chaincode();
+        const codeLoader = new API.CodeLoader({ generateSummaries: false },
+            [
+                ["@ms/atmentions", Promise.resolve(chaincode)],
+                ["@ms/augloop", Promise.resolve(chaincode)],
+                ["@ms/catalog", Promise.resolve(chaincode)],
+                ["@ms/scriptor", Promise.resolve(chaincode)],
+                ["@ms/discover", Promise.resolve(chaincode)],
+                ["@ms/registro", Promise.resolve(chaincode)],
+                ["@ms/formula", Promise.resolve(chaincode)],
+                ["@ms/application-services", Promise.resolve(chaincode)],
+            ]);
         const options = {};
 
         // Load the Fluid document


### PR DESCRIPTION
1.) Already pushed the newer snapshots in collateral repo.
2.) In 0.11, due to newer component registry pattern, Tony deleted the back compat loader in codeLoader.ts which used to supply the same chaincode for any component asked. So due to that,
I supplied the all the other registries which are required in current snapshots.