### PR TITLE
Remove references to pinpoint-editor

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -53,7 +53,3 @@ in a different canvas.
 ## Pond
 
 [Source code](https://github.com/Microsoft/FluidFramework/tree/release/0.6/packages/components/pond)
-
-## Pinpoint editor
-
-[Source code](https://github.com/Microsoft/FluidFramework/tree/release/0.6/packages/components/pinpoint-editor)

--- a/packages/components/client-ui/src/controls/flowView.ts
+++ b/packages/components/client-ui/src/controls/flowView.ts
@@ -485,12 +485,6 @@ const commands: IFlowViewCmd[] = [
     },
     {
         exec: (c, p, f) => {
-            f.insertComponentNew("map", "@fluid-example/pinpoint-editor");
-        },
-        key: "insert new map",
-    },
-    {
-        exec: (c, p, f) => {
             f.insertComponentNew("code", "@fluid-example/monaco");
         },
         key: "insert new monaco",

--- a/packages/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
+++ b/packages/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
@@ -25,7 +25,6 @@ export class ExternalComponentLoader extends PrimedComponent
     implements IComponentHTMLVisual {
 
     private static readonly defaultComponents = [
-        "@fluid-example/pinpoint-editor",
         "@fluid-example/todo",
         "@fluid-example/math",
         "@fluid-example/monaco",

--- a/packages/components/flow-scroll/package.json
+++ b/packages/components/flow-scroll/package.json
@@ -33,7 +33,6 @@
     "@fluid-example/flow-util-lib": "^0.12.0",
     "@fluid-example/image-collection": "^0.12.0",
     "@fluid-example/math": "^0.12.0",
-    "@fluid-example/pinpoint-editor": "^0.12.0",
     "@fluid-example/progress-bars": "^0.12.0",
     "@fluid-example/search-menu": "^0.12.0",
     "@fluid-example/table-document": "^0.12.0",

--- a/packages/components/flow-scroll/src/runtime.ts
+++ b/packages/components/flow-scroll/src/runtime.ts
@@ -10,19 +10,5 @@ export const fluidExport = new SimpleModuleInstantiationFactory(
     WebFlowHost.type,
     new Map([
         [WebFlowHost.type, Promise.resolve(webFlowHostFactory)],
-
-        // Demo components
-        // Bootstrap CSS definitions conflict with flow-scroll
-        // ["@fluid-example/progress-bars", import("@fluid-example/progress-bars")],
-        // pinpoint editor's SASS loading of resources causes trouble
-        // If I can change webpack to do this then things are ok
-        // {
-        //     test: /\.css$/,
-        //     use: [
-        //         "style-loader", // creates style nodes from JS strings
-        //         "css-loader", // translates CSS into CommonJS
-        //     ]
-        // },
-        // ["@fluid-example/pinpoint-editor", import(/* webpackChunkName: "video-players", webpackPrefetch: true */ "@fluid-example/pinpoint-editor")],
     ]),
 );

--- a/packages/components/shared-text/package.json
+++ b/packages/components/shared-text/package.json
@@ -33,7 +33,6 @@
     "@fluid-example/intelligence-runner-agent": "^0.12.0",
     "@fluid-example/math": "^0.12.0",
     "@fluid-example/monaco": "^0.12.0",
-    "@fluid-example/pinpoint-editor": "^0.12.0",
     "@fluid-example/progress-bars": "^0.12.0",
     "@fluid-example/video-players": "^0.12.0",
     "@fluid-internal/client-api": "^0.12.0",

--- a/packages/components/shared-text/src/index.ts
+++ b/packages/components/shared-text/src/index.ts
@@ -21,7 +21,6 @@ import * as sharedTextComponent from "./component";
 
 const math = import(/* webpackChunkName: "math", webpackPrefetch: true */ "@fluid-example/math");
 // const monaco = import(/* webpackChunkName: "monaco", webpackPrefetch: true */ "@fluid-example/monaco");
-const pinpoint = import(/* webpackChunkName: "pinpoint", webpackPrefetch: true */ "@fluid-example/pinpoint-editor");
 const progressBars = import(
     /* webpackChunkName: "collections", webpackPrefetch: true */ "@fluid-example/progress-bars");
 const videoPlayers = import(
@@ -52,7 +51,6 @@ const defaultRegistryEntries: NamedComponentRegistryEntries = [
     ["@fluid-example/progress-bars", progressBars.then((m) => m.fluidExport)],
     ["@fluid-example/video-players", videoPlayers.then((m) => m.fluidExport)],
     ["@fluid-example/image-collection", images.then((m) => m.fluidExport)],
-    ["@fluid-example/pinpoint-editor", pinpoint.then((m) => m.fluidExport)],
 ];
 
 class MyRegistry implements IComponentRegistry {

--- a/packages/server/gateway/config.json
+++ b/packages/server/gateway/config.json
@@ -74,9 +74,6 @@
             },
             "translation": {
                 "key": ""
-            },
-            "pinpointEditor": {
-                "key": ""
             }
         },
         "alfredUrl": "http://alfred:3000",

--- a/packages/server/paparazzi/config.json
+++ b/packages/server/paparazzi/config.json
@@ -180,9 +180,6 @@
             },
             "translation": {
                 "key": ""
-            },
-            "pinpointEditor": {
-                "key": ""
             }
         },
         "alfredUrl": "http://alfred:3000",

--- a/samples/chaincode/containers/monaco/package.json
+++ b/samples/chaincode/containers/monaco/package.json
@@ -30,7 +30,8 @@
     "@fluid-example/monaco": "^0.12.0",
     "@microsoft/fluid-component-core-interfaces": "^0.12.0",
     "@microsoft/fluid-container-definitions": "^0.12.0",
-    "@microsoft/fluid-container-runtime": "^0.12.0"
+    "@microsoft/fluid-container-runtime": "^0.12.0",
+    "@microsoft/fluid-runtime-definitions": "^0.12.0"
   },
   "devDependencies": {
     "@microsoft/fluid-webpack-component-loader": "^0.12.0",

--- a/samples/chaincode/prosemirror/package.json
+++ b/samples/chaincode/prosemirror/package.json
@@ -49,7 +49,7 @@
     "prosemirror-view": "^1.10.3"
   },
   "devDependencies": {
-    "@microsoft/fluid-webpack-component-loader": "^0.11.0",
+    "@microsoft/fluid-webpack-component-loader": "^0.12.0",
     "@types/node": "^10.14.6",
     "concurrently": "^4.1.0",
     "css-loader": "^1.0.0",

--- a/samples/chaincode/sudoku/package.json
+++ b/samples/chaincode/sudoku/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@microsoft/fluid-build-common": "^0.12.0",
-    "@microsoft/fluid-webpack-component-loader": "^0.11.0",
+    "@microsoft/fluid-webpack-component-loader": "^0.12.0",
     "@prague/url-generator": "^1.0.4",
     "@types/node": "^10.14.6",
     "@types/react-dom": "^16.9.0",

--- a/samples/chaincode/tourofheroes/package.json
+++ b/samples/chaincode/tourofheroes/package.json
@@ -38,6 +38,7 @@
     "@microsoft/fluid-container-runtime": "^0.12.0",
     "@microsoft/fluid-map": "^0.12.0",
     "@microsoft/fluid-protocol-definitions": "^0.12.0",
+    "@microsoft/fluid-runtime-definitions": "^0.12.0",
     "@types/double-ended-queue": "^2.1.0",
     "@types/react": "^16.9.2",
     "angular-in-memory-web-api": "^0.8.0",

--- a/server/routerlicious/kubernetes/gateway/templates/configmap.yaml
+++ b/server/routerlicious/kubernetes/gateway/templates/configmap.yaml
@@ -77,9 +77,6 @@ data:
                 },
                 "translation": {
                     "key": "{{ .Values.worker.intelligence.translation.key }}"
-                },
-                "pinpointEditor": {
-                    "key": "{{ .Values.worker.intelligence.pinpointEditor.key }}"
                 }
             },
             "alfredUrl": "{{ .Values.alfred.url }}",

--- a/server/routerlicious/kubernetes/gateway/tools/generateChart.js
+++ b/server/routerlicious/kubernetes/gateway/tools/generateChart.js
@@ -90,8 +90,6 @@ worker:
       key: ""
     translation:
       key: ""
-    pinpointEditor:
-      key: ""
   clusterNpm: ""
   npm: ""
 `;

--- a/server/routerlicious/kubernetes/jarvis/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/jarvis/templates/fluid-configmap.yaml
@@ -132,9 +132,6 @@ data:
                 },
                 "translation": {
                     "key": ""
-                },
-                "pinpointEditor": {
-                    "key": ""
                 }
             },
             "alfredUrl": "http://{{ template "jarvis.fullname" . }}",

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -184,9 +184,6 @@ data:
                 },
                 "translation": {
                     "key": "{{ .Values.worker.intelligence.translation.key }}"
-                },
-                "pinpointEditor": {
-                    "key": "{{ .Values.worker.intelligence.pinpointEditor.key }}"
                 }
             },
             "alfredUrl": "http://{{ template "alfred.fullname" . }}",

--- a/server/routerlicious/kubernetes/tools/generateChart.js
+++ b/server/routerlicious/kubernetes/tools/generateChart.js
@@ -157,8 +157,6 @@ worker:
       key: ""
     translation:
       key: ""
-    pinpointEditor:
-      key: ""
   clusterNpm: ""
   npm: ""
 `;

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -180,9 +180,6 @@
             },
             "translation": {
                 "key": ""
-            },
-            "pinpointEditor": {
-                "key": ""
             }
         },
         "alfredUrl": "http://alfred:3000",


### PR DESCRIPTION
Remove pinpoint from SharedText, FlowView, and External Component Loader.
Also remove from examples README and few other places.

Also fix references to fluid-webpack-component-loader 0.11 where it should be 0.12 in prosemirror and sudoku, which hid the issue of missing dependencies to fluid-runtime-definitions in monaco and tourofheroes.