### PR TITLE
Scribe component and standalone docker compose fix

### DIFF
--- a/packages/components/scribe/src/scribe.ts
+++ b/packages/components/scribe/src/scribe.ts
@@ -219,7 +219,7 @@ function initialize(
 
         const details: IFluidCodeDetails = {
             config: {
-                "@chaincode:cdn": "https://pragueauspkn-3873244262.azureedge.net",
+                "@fluid-example:cdn": "https://pragueauspkn-3873244262.azureedge.net",
             },
             package: `@fluid-example/shared-text@${version}`,
         };
@@ -332,7 +332,7 @@ const html =
     </div>
 
     <div class="typing-details hidden">
-        <img src="https://www.wu2.prague.office-int.com/public/images/corgi-typing.gif" />
+        <img src="https://praguenpm.blob.core.windows.net/images/corgi-typing.gif" />
 
         <!-- Progress of the scribe writing the document -->
         <h3>

--- a/server/routerlicious/docker-compose.standalone.yml
+++ b/server/routerlicious/docker-compose.standalone.yml
@@ -10,7 +10,7 @@ services:
             - NODE_ENV=development
         restart: always
     alfred:
-        image: prague.azurecr.io/prague:latest
+        image: prague.azurecr.io/prague-server:latest
         ports:
             - "3003:3000"
         command: node dist/alfred/www.js
@@ -19,43 +19,43 @@ services:
             - NODE_ENV=development
         restart: always
     deli:
-        image: prague.azurecr.io/prague:latest
+        image: prague.azurecr.io/prague-server:latest
         command: node dist/kafka-service/index.js deli /usr/src/server/server/routerlicious/packages/routerlicious/dist/deli/index.js
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
         restart: always
     scriptorium:
-        image: prague.azurecr.io/prague:latest
+        image: prague.azurecr.io/prague-server:latest
         command: node dist/kafka-service/index.js scriptorium /usr/src/server/server/routerlicious/packages/routerlicious/dist/scriptorium/index.js
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
         restart: always
     broadcaster:
-        image: prague.azurecr.io/prague:latest
+        image: prague.azurecr.io/prague-server:latest
         command: node dist/kafka-service/index.js broadcaster /usr/src/server/server/routerlicious/packages/routerlicious/dist/broadcaster/index.js
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
         restart: always
     scribe:
-        image: prague.azurecr.io/prague:latest
+        image: prague.azurecr.io/prague-server:latest
         command: node dist/kafka-service/index.js scribe /usr/src/server/server/routerlicious/packages/routerlicious/dist/scribe/index.js
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
         restart: always
     foreman:
-        image: prague.azurecr.io/prague:latest
+        image: prague.azurecr.io/prague-server:latest
         command: node dist/kafka-service/index.js foreman /usr/src/server/server/routerlicious/packages/routerlicious/dist/foreman/index.js
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
         restart: always
     routemaster:
-        image: prague.azurecr.io/prague:latest
-        command: node dist/kafka-service/index.js routemaster /usr/src/server/server/routerlicious/packages/routerlicious/dist/document-router/index.js
+        image: prague.azurecr.io/prague-server:latest
+        command: node dist/kafka-service/index.js routemaster /usr/src/server/server/routerlicious/packages/lambdas-driver/dist/document-router/index.js
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
@@ -70,7 +70,7 @@ services:
             - NODE_ENV=development
         restart: always
     riddler:
-        image: prague.azurecr.io/prague:latest
+        image: prague.azurecr.io/prague-server:latest
         ports:
             - "5000:5000"
         command: node dist/riddler/www.js


### PR DESCRIPTION
Fixes a small bug in the scribe component due to the npm scope rename from chaincode to fluid-example.

Also updates the standalone docker-compose file based on the recent server package move.