### PR TITLE
Fix Dockerfile to point to existing folder

### DIFF
--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -180,8 +180,8 @@ FROM base AS runner
 # Don't run as root user
 USER node
 
-# Switch to the routerlicious folder
-WORKDIR /usr/src/server/packages/server/routerlicious
+# Switch to the gateway folder
+WORKDIR /usr/src/server/packages/server/gateway
 
 # Node wasn't designed to be run as PID 1. Tini is a tiny init wrapper. You can also set --init on docker later than
 # 1.13 but Kubernetes is at 1.12 so we prefer tini for now.


### PR DESCRIPTION
The Dockerfile for services in packages (gateway, paparazzi) was still trying to go to a directory that no longer exists (packages/server/routerlicious).  Changed it to go to gateway (packages/server/gateway) and navigate from there.