### PR TITLE
Update Gateway JWT to include subset of session claims

### DIFF
--- a/packages/server/gateway/src/app.ts
+++ b/packages/server/gateway/src/app.ts
@@ -22,6 +22,7 @@ import * as path from "path";
 import * as redis from "redis";
 import * as favicon from "serve-favicon";
 import * as expiry from "static-expiry";
+import { v4 } from "uuid";
 import * as winston from "winston";
 import { AccountManager } from "./accounts";
 import { saveSpoTokens } from "./gateway-odsp-utils";
@@ -211,7 +212,14 @@ export function create(
             for (const localAccount of localAccounts) {
                 // tslint:disable-next-line:possible-timing-attack
                 if (localAccount.username === username && localAccount.password === password) {
-                    return done(null, localAccount.username);
+                    const name = getRandomName(" ", true);
+                    return done(
+                        null,
+                        {
+                            displayName: name,
+                            name,
+                            sub: localAccount.username,
+                        });
                 }
             }
 
@@ -291,7 +299,12 @@ export function create(
 
     app.use((request, response, next) => {
         if (!request.session.guest) {
-            request.session.guest = { name: getRandomName(" ", true) };
+            const name = getRandomName(" ", true);
+            request.session.guest = {
+                displayName: name,
+                sub: `guest-${v4()}`,
+                name,
+            };
         }
 
         next();

--- a/packages/server/gateway/src/routes/api/api.ts
+++ b/packages/server/gateway/src/routes/api/api.ts
@@ -12,10 +12,11 @@ import { Request, Router } from "express";
 import * as safeStringify from "json-stringify-safe";
 import * as moniker from "moniker";
 import { Provider } from "nconf";
+import * as passport from "passport";
 import { parse, UrlWithStringQuery } from "url";
 import * as winston from "winston";
+import { IJWTClaims } from "../../utils";
 
-import passport = require("passport");
 // Although probably the case we want a default behavior here. Maybe just the URL?
 async function getWebComponent(url: UrlWithStringQuery): Promise<IWebResolvedUrl> {
     const result = await Axios.get(url.href);
@@ -70,11 +71,7 @@ async function getInternalComponent(
 
     const orderer = config.get("worker:serverUrl");
 
-    const user: IAlfredUser = (request.user) ? {
-        displayName: request.user.name,
-        id: request.user.oid,
-        name: request.user.name,
-    } : undefined;
+    const user: IAlfredUser = (request.user as IJWTClaims).user;
 
     const token = getR11sToken(tenantId, documentId, appTenants, scopes, user);
     const fluidUrl = `fluid://${url.host}/${tenantId}/${documentId}${path}${url.hash ? url.hash : ""}`;

--- a/packages/server/gateway/src/routes/loader.ts
+++ b/packages/server/gateway/src/routes/loader.ts
@@ -18,7 +18,7 @@ import * as winston from "winston";
 import { spoEnsureLoggedIn } from "../gateway-odsp-utils";
 import { resolveUrl } from "../gateway-urlresolver";
 import { IAlfred, IKeyValueWrapper } from "../interfaces";
-import { getConfig, getParam, getUserDetails } from "../utils";
+import { getConfig, getJWTClaims, getParam, getUserDetails } from "../utils";
 import { defaultPartials } from "./partials";
 
 export function create(
@@ -62,11 +62,8 @@ export function create(
                 winston.info(`Redirecting to ${redirectUrl}`);
                 response.redirect(redirectUrl);
             } else {
-                const jwtToken = jwt.sign(
-                    {
-                        user: request.user,
-                    },
-                    jwtKey);
+                const claims = getJWTClaims(request);
+                const jwtToken = jwt.sign(claims, jwtKey);
 
                 const rawPath = request.params[0] as string;
                 const slash = rawPath.indexOf("/");

--- a/packages/server/gateway/src/utils.ts
+++ b/packages/server/gateway/src/utils.ts
@@ -15,6 +15,14 @@ export interface ICachedPackage {
     scripts: { id: string, url: string }[];
 }
 
+export interface IJWTClaims {
+    user: {
+        displayName: string;
+        id: string;
+        name: string;
+    };
+}
+
 /**
  * Helper function to return tenant specific configuration
  */
@@ -52,6 +60,22 @@ export function getVersion() {
     return `${version.endsWith(".0") ? "^" : ""}${version}`;
 }
 
+function getUser(request: Request) {
+    return request.user ? request.user : request.session.guest;
+}
+
+export function getJWTClaims(request: Request): IJWTClaims {
+    const user = getUser(request);
+
+    return {
+        user: {
+            displayName: user.name,
+            id: user.sub,
+            name: user.name,
+        },
+    };
+}
+
 export function getUserDetails(request: Request): string {
-    return JSON.stringify(request.user ? request.user : request.session.guest);
+    return JSON.stringify(getUser(request));
 }


### PR DESCRIPTION
Using the entire user session object leads to a very large bearer token which overflows the nginx defaults for HTTP headers. Passing the entire user object was done for simplicity but the vast majority of fields are unnecessary. Instead restricts the JWT claims to only the required values.