### PR TITLE
Add historian.internalUrl config value

### DIFF
--- a/server/routerlicious/kubernetes/gateway/templates/configmap.yaml
+++ b/server/routerlicious/kubernetes/gateway/templates/configmap.yaml
@@ -83,6 +83,7 @@ data:
             "gatewayUrl": "http://{{ template "fullname" . }}",
             "serverUrl": "{{ .Values.alfred.externalUrl }}",
             "blobStorageUrl": "{{ .Values.historian.externalUrl }}",
+            "internalBlobStorageUrl": "{{ .Values.historian.internalUrl }}",
             "repository": "FluidFramework",
             "clusterNpm": "{{ .Values.worker.clusterNpm }}",
             "npm": "{{ .Values.worker.npm }}",

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -189,6 +189,7 @@ data:
             "alfredUrl": "http://{{ template "alfred.fullname" . }}",
             "serverUrl": "{{ .Values.alfred.externalUrl }}",
             "blobStorageUrl": "{{ .Values.historian.externalUrl }}",
+            "internalBlobStorageUrl": "{{ .Values.historian.internalUrl }}",
             "repository": "FluidFramework",
             "clusterNpm": "{{ .Values.worker.clusterNpm }}",
             "npm": "{{ .Values.worker.npm }}",

--- a/server/routerlicious/kubernetes/tools/generateChart.js
+++ b/server/routerlicious/kubernetes/tools/generateChart.js
@@ -110,6 +110,7 @@ packageManager:
 
 historian:
   externalUrl: https://historian.wu2.prague.office-int.com
+  internalUrl: http://smelly-wolf-historian
 
 gitrest:
   url: http://smelly-wolf-gitrest

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -20,7 +20,8 @@ export async function scribeCreate(config: Provider): Promise<IPartitionLambdaFa
     const mongoUrl = config.get("mongo:endpoint") as string;
     const documentsCollectionName = config.get("mongo:collectionNames:documents");
     const messagesCollectionName = config.get("mongo:collectionNames:scribeDeltas");
-    const historianUrl = config.get("worker:internalBlobStorageUrl") as string || config.get("worker:blobStorageUrl") as string;
+    const internalHistorianUrl = config.get("worker:internalBlobStorageUrl") as string;
+    const historianUrl = internalHistorianUrl || config.get("worker:blobStorageUrl") as string;
     const kafkaEndpoint = config.get("kafka:lib:endpoint");
     const kafkaLibrary = config.get("kafka:lib:name");
     const maxMessageSize = bytes.parse(config.get("kafka:maxMessageSize"));

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -20,7 +20,7 @@ export async function scribeCreate(config: Provider): Promise<IPartitionLambdaFa
     const mongoUrl = config.get("mongo:endpoint") as string;
     const documentsCollectionName = config.get("mongo:collectionNames:documents");
     const messagesCollectionName = config.get("mongo:collectionNames:scribeDeltas");
-    const historianUrl = config.get("worker:blobStorageUrl") as string;
+    const historianUrl = config.get("worker:internalBlobStorageUrl") as string || config.get("worker:blobStorageUrl") as string;
     const kafkaEndpoint = config.get("kafka:lib:endpoint");
     const kafkaLibrary = config.get("kafka:lib:name");
     const maxMessageSize = bytes.parse(config.get("kafka:maxMessageSize"));


### PR DESCRIPTION
When deploying a routerlicious cluster for TEO I run into some certificate validation issues when Scribe is trying to talk to Historian. To work around that in a same-cluster configuration (which is how we're running it) this PR is adding the ability to use internal historian URL instead of an external one.