### PR TITLE
Properly propagate socket disconnection reason

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentDeltaConnection.ts
@@ -11,9 +11,10 @@ import {
     IClient,
     IDocumentDeltaConnection,
 } from "@microsoft/fluid-protocol-definitions";
+import * as assert from "assert";
 import { IOdspSocketError } from "./contracts";
 import { debug } from "./debug";
-import { errorObjectFromOdspError } from "./OdspUtils";
+import { errorObjectFromOdspError, OdspNetworkError } from "./OdspUtils";
 
 const protocolVersions = ["^0.3.0", "^0.2.0", "^0.1.0"];
 
@@ -21,11 +22,28 @@ const protocolVersions = ["^0.3.0", "^0.2.0", "^0.1.0"];
 // this allows reconnection after receiving a nack to be smooth
 const socketReferenceBufferTime = 2000;
 
-interface ISocketReference {
-    socket: SocketIOClient.Socket | undefined;
-    references: number;
-    delayDeleteTimeout?: NodeJS.Timeout;
-    delayDeleteTimeoutSetTime?: number;
+class SocketReference {
+    public references: number = 1;
+    public delayDeleteTimeout?: NodeJS.Timeout;
+    public delayDeleteTimeoutSetTime?: number;
+
+    public constructor(public socket: SocketIOClient.Socket | undefined) {
+    }
+
+    public clearTimer() {
+        if (this.delayDeleteTimeout !== undefined) {
+            clearTimeout(this.delayDeleteTimeout);
+            this.delayDeleteTimeout = undefined;
+            this.delayDeleteTimeoutSetTime = undefined;
+        }
+    }
+
+    public closeSocket() {
+        if (this.socket) {
+            this.socket.disconnect();
+            this.socket = undefined;
+        }
+    }
 }
 
 /**
@@ -96,7 +114,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
     }
 
     // Map of all existing socket io sockets. [url, tenantId, documentId] -> socket
-    private static readonly socketIoSockets: Map<string, ISocketReference> = new Map();
+    private static readonly socketIoSockets: Map<string, SocketReference> = new Map();
 
     /**
      * Gets or create a socket io connection for the given key
@@ -108,14 +126,17 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
         url: string,
         tenantId: string,
         documentId: string,
-        telemetryLogger: ITelemetryLogger): ISocketReference {
+        telemetryLogger: ITelemetryLogger): SocketReference {
         let socketReference = OdspDocumentDeltaConnection.socketIoSockets.get(key);
 
         // verify the socket is healthy before reusing it
         if (socketReference && (!socketReference.socket || !socketReference.socket.connected)) {
+            // We should not get here with active users.
+            assert(socketReference.references === 0);
             // the socket is in a bad state. fully remove the reference
+            OdspDocumentDeltaConnection.removeSocketIoReference(key, true, "socket is closed");
+
             socketReference = undefined;
-            OdspDocumentDeltaConnection.removeSocketIoReference(key, true);
         }
 
         if (socketReference) {
@@ -129,11 +150,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
             socketReference.references++;
 
             // clear the pending deletion if there is one
-            if (socketReference.delayDeleteTimeout !== undefined) {
-                clearTimeout(socketReference.delayDeleteTimeout);
-                socketReference.delayDeleteTimeout = undefined;
-                socketReference.delayDeleteTimeoutSetTime = undefined;
-            }
+            socketReference.clearTimer();
 
             debug(`Using existing socketio reference for ${key} (${socketReference.references})`);
 
@@ -152,19 +169,13 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
                 });
 
             socket.on("server_disconnect", (socketError: IOdspSocketError) => {
-                // the server always closes the socket after sending this message
+                // The server always closes the socket after sending this message
                 // fully remove the socket reference now
-                OdspDocumentDeltaConnection.removeSocketIoReference(key, true);
-
-                // Raise it as disconnect.
-                // That produces cleaner telemetry (no errors) and keeps protocol simpler (and not driver-specific).
-                socket.emit("disconnect", errorObjectFromOdspError(socketError));
+                // This raises "disconnect" event with proper error object.
+                OdspDocumentDeltaConnection.removeSocketIoReference(key, true /*socketProtocolError*/, errorObjectFromOdspError(socketError));
             });
 
-            socketReference = {
-                socket,
-                references: 1,
-            };
+            socketReference = new SocketReference(socket);
 
             OdspDocumentDeltaConnection.socketIoSockets.set(key, socketReference);
             debug(`Created new socketio reference for ${key}`);
@@ -179,7 +190,10 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
      * @param key - socket reference key
      * @param isFatalError - true if the socket reference should be removed immediately due to a fatal error
      */
-    private static removeSocketIoReference(key: string, isFatalError?: boolean) {
+    private static removeSocketIoReference(
+            key: string,
+            isFatalError: boolean,
+            reason: string | OdspNetworkError) {
         const socketReference = OdspDocumentDeltaConnection.socketIoSockets.get(key);
         if (!socketReference) {
             // this is expected to happen if we removed the reference due the socket not being connected
@@ -191,32 +205,28 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
         debug(`Removed socketio reference for ${key}. Remaining references: ${socketReference.references}.`);
 
         if (isFatalError || (socketReference.socket && !socketReference.socket.connected)) {
-            // delete the reference if a fatal error occurred or if the socket is not connected
-            if (socketReference.socket) {
-                socketReference.socket.disconnect();
-                socketReference.socket = undefined;
-            }
-
             // clear the pending deletion if there is one
-            if (socketReference.delayDeleteTimeout !== undefined) {
-                clearTimeout(socketReference.delayDeleteTimeout);
-                socketReference.delayDeleteTimeout = undefined;
-                socketReference.delayDeleteTimeoutSetTime = undefined;
-            }
+            socketReference.clearTimer();
 
             OdspDocumentDeltaConnection.socketIoSockets.delete(key);
             debug(`Deleted socketio reference for ${key}. Is fatal error: ${isFatalError}.`);
+
+            // Raise "disconnect" event before closing.
+            // That produces cleaner telemetry with reason behind closure
+            if (socketReference.socket) {
+                socketReference.socket.emit("disconnect", reason);
+            }
+            socketReference.closeSocket();
             return;
         }
 
         if (socketReference.references === 0 && socketReference.delayDeleteTimeout === undefined) {
             socketReference.delayDeleteTimeout = setTimeout(() => {
-                OdspDocumentDeltaConnection.socketIoSockets.delete(key);
+                // We should not get here with active users.
+                assert(socketReference.references === 0);
 
-                if (socketReference.socket) {
-                    socketReference.socket.disconnect();
-                    socketReference.socket = undefined;
-                }
+                OdspDocumentDeltaConnection.socketIoSockets.delete(key);
+                socketReference.closeSocket();
 
                 debug(`Deleted socketio reference for ${key}.`);
             }, socketReferenceBufferTime);
@@ -242,10 +252,15 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
      */
     public disconnect(socketProtocolError: boolean = false) {
         if (this.socketReferenceKey !== undefined) {
-            OdspDocumentDeltaConnection.removeSocketIoReference(this.socketReferenceKey, socketProtocolError);
+            const key = this.socketReferenceKey;
             this.socketReferenceKey = undefined;
 
-            this.emit("disconnect", "client closing connection");
+            const reason = "client closing connection";
+            OdspDocumentDeltaConnection.removeSocketIoReference(key, socketProtocolError, reason);
+
+            // removeSocketIoReference() above raises "disconnect" event on socket for socketProtocolError === true
+            // If it's not critical error, we want to raise event on this object only.
+            this.emit("disconnect", reason);
         }
     }
 }

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -577,11 +577,13 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
 
         this.stopSequenceNumberUpdate();
 
+        const errorToReport = error !== undefined ? error : new Error("Container closed");
+
         // This raises "disconnect" event
-        this.disconnectFromDeltaStream("Disconnect on close");
+        this.disconnectFromDeltaStream(`${error}`);
 
         if (this.connecting) {
-            this.connecting.reject(error !== undefined ? error : new Error("Container closed"));
+            this.connecting.reject(errorToReport);
             this.connecting = undefined;
         }
 


### PR DESCRIPTION
We are not receiving clear disconnect reasons in telemetry.
Most of the reasons are either "io client disconnect" or "transport close"
Looking through the code, I believe we are not propagating disconnect reasons soon enough (in case of "error" or "server_disconnect" messages), and instead initiate disconnect from client side first (before raising "disconnect" event with right reason).
This results in "disconnect" event being raised with "io client disconnect" message (and real disconnect message with right reason coming next and being ignored).
