### PR TITLE
TestHost: Add scope option to testHost

### DIFF
--- a/packages/server/local-test-server/src/testDataStore.ts
+++ b/packages/server/local-test-server/src/testDataStore.ts
@@ -31,7 +31,7 @@ export class TestDataStore {
         componentId: string,
         chaincodePackage: IFluidCodeDetails,
         path: string,
-        scope: IComponent,
+        scope?: IComponent,
     ): Promise<T> {
         debug(`TestDataStore.open("${componentId}", "${chaincodePackage.package}")`);
 
@@ -41,7 +41,7 @@ export class TestDataStore {
             this.documentServiceFactory,
             this.codeLoader,
             { blockUpdateMarkers: true },
-            scope,
+            scope || {},
             new Map<string, IProxyLoaderFactory>());
         const baseUrl = `https://test.com/tenantId/documentId/${encodeURIComponent(componentId)}`;
         const url = `${baseUrl}${

--- a/packages/server/local-test-server/src/testDataStore.ts
+++ b/packages/server/local-test-server/src/testDataStore.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { IComponent} from '@microsoft/fluid-component-core-interfaces';
 import { ICodeLoader, IFluidCodeDetails, IProxyLoaderFactory } from "@microsoft/fluid-container-definitions";
 import { Container, Loader } from "@microsoft/fluid-container-loader";
 import { IDocumentServiceFactory, IUrlResolver } from "@microsoft/fluid-protocol-definitions";
@@ -30,6 +31,7 @@ export class TestDataStore {
         componentId: string,
         chaincodePackage: IFluidCodeDetails,
         path: string,
+        scope: IComponent,
     ): Promise<T> {
         debug(`TestDataStore.open("${componentId}", "${chaincodePackage.package}")`);
 
@@ -39,7 +41,7 @@ export class TestDataStore {
             this.documentServiceFactory,
             this.codeLoader,
             { blockUpdateMarkers: true },
-            {},
+            scope,
             new Map<string, IProxyLoaderFactory>());
         const baseUrl = `https://test.com/tenantId/documentId/${encodeURIComponent(componentId)}`;
         const url = `${baseUrl}${

--- a/packages/server/local-test-server/src/testDataStore.ts
+++ b/packages/server/local-test-server/src/testDataStore.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IComponent} from '@microsoft/fluid-component-core-interfaces';
+import { IComponent} from "@microsoft/fluid-component-core-interfaces";
 import { ICodeLoader, IFluidCodeDetails, IProxyLoaderFactory } from "@microsoft/fluid-container-definitions";
 import { Container, Loader } from "@microsoft/fluid-container-loader";
 import { IDocumentServiceFactory, IUrlResolver } from "@microsoft/fluid-protocol-definitions";

--- a/packages/server/local-test-server/src/testHost.ts
+++ b/packages/server/local-test-server/src/testHost.ts
@@ -4,7 +4,7 @@
  */
 
 import { PrimedComponent, PrimedComponentFactory, SimpleContainerRuntimeFactory } from "@microsoft/fluid-aqueduct";
-import { IComponentHandle, IComponentLoadable, IComponentRunnable } from "@microsoft/fluid-component-core-interfaces";
+import { IComponent, IComponentHandle, IComponentLoadable, IComponentRunnable } from "@microsoft/fluid-component-core-interfaces";
 import { IFluidCodeDetails } from "@microsoft/fluid-container-definitions";
 import {
     IComponentContext,
@@ -161,6 +161,7 @@ export class TestHost {
     constructor(
         private readonly componentRegistry: NamedComponentRegistryEntries,
         deltaConnectionServer?: ITestDeltaConnectionServer,
+        scope?: IComponent
     ) {
         this.deltaConnectionServer = deltaConnectionServer || TestDeltaConnectionServer.create();
 
@@ -181,7 +182,7 @@ export class TestHost {
             new TestDocumentServiceFactory(this.deltaConnectionServer),
             new TestResolver());
 
-        store.open<TestRootComponent>("test-root-component", TestRootComponent.codeProposal, "")
+        store.open<TestRootComponent>("test-root-component", TestRootComponent.codeProposal, "", scope)
             .then(this.rootResolver)
             .catch((reason) => { throw new Error(`${reason}`); });
     }

--- a/packages/server/local-test-server/src/testHost.ts
+++ b/packages/server/local-test-server/src/testHost.ts
@@ -4,7 +4,12 @@
  */
 
 import { PrimedComponent, PrimedComponentFactory, SimpleContainerRuntimeFactory } from "@microsoft/fluid-aqueduct";
-import { IComponent, IComponentHandle, IComponentLoadable, IComponentRunnable } from "@microsoft/fluid-component-core-interfaces";
+import {
+    IComponent,
+    IComponentHandle,
+    IComponentLoadable,
+    IComponentRunnable ,
+} from "@microsoft/fluid-component-core-interfaces";
 import { IFluidCodeDetails } from "@microsoft/fluid-container-definitions";
 import {
     IComponentContext,
@@ -161,7 +166,7 @@ export class TestHost {
     constructor(
         private readonly componentRegistry: NamedComponentRegistryEntries,
         deltaConnectionServer?: ITestDeltaConnectionServer,
-        scope?: IComponent
+        scope?: IComponent,
     ) {
         this.deltaConnectionServer = deltaConnectionServer || TestDeltaConnectionServer.create();
 


### PR DESCRIPTION
Right now there is no way to manipulate the scope from an app using the testhost. This pr adds scope as a parameter of the constructor of testHost and passes it to the testDataStore via the open method.

This PR will enable us to pass in test app services for verification purposes.