### PR TITLE
Make clientType back-compat

### DIFF
--- a/packages/drivers/odsp-socket-storage/package.json
+++ b/packages/drivers/odsp-socket-storage/package.json
@@ -27,12 +27,12 @@
     "tslint": "tslint --project tsconfig.json --format verbose"
   },
   "dependencies": {
-    "@microsoft/fluid-component-core-interfaces": "^0.12.0",
     "@microsoft/fluid-common-definitions": "^0.12.0",
+    "@microsoft/fluid-component-core-interfaces": "^0.12.0",
     "@microsoft/fluid-core-utils": "^0.12.0",
     "@microsoft/fluid-driver-base": "^0.12.0",
-    "@microsoft/fluid-driver-utils": "^0.12.0",
     "@microsoft/fluid-driver-definitions": "^0.12.0",
+    "@microsoft/fluid-driver-utils": "^0.12.0",
     "@microsoft/fluid-gitresources": "^0.12.0",
     "@microsoft/fluid-protocol-definitions": "^0.12.0",
     "debug": "^4.1.1",

--- a/packages/loader/common-definitions/package.json
+++ b/packages/loader/common-definitions/package.json
@@ -24,8 +24,7 @@
     "tsc:watch": "tsc --watch",
     "tslint": "tslint --project tsconfig.json --format verbose"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "@microsoft/api-extractor": "^7.4.4",
     "@microsoft/eslint-config-fluid": "^0.12.0",

--- a/packages/loader/container-definitions/src/chaincode.ts
+++ b/packages/loader/container-definitions/src/chaincode.ts
@@ -178,7 +178,8 @@ export interface IContainerContext extends EventEmitter, IMessageScheduler, IPro
     readonly options: any;
     readonly configuration: IComponentConfiguration;
     readonly clientId: string | undefined;
-    readonly clientType: string | undefined;
+    // DEPRECATED: use clientDetails.type instead
+    readonly clientType: string; // back-compat: 0.11 clientType
     readonly clientDetails: IClientDetails;
     readonly parentBranch: string | undefined | null;
     readonly blobManager: IBlobManager | undefined;

--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -89,8 +89,8 @@ export interface IDeltaManager<T, U> extends EventEmitter, IDeltaSender, IDispos
     // The initial sequence number set when attaching the op handler
     initialSequenceNumber: number;
 
-    // Type of client
-    clientType: string | undefined;
+    // DEPRECATED: use clientDetails.type instead
+    clientType: string; // back-compat: 0.11 clientType
 
     // Details of client
     clientDetails: IClientDetails;

--- a/packages/loader/container-definitions/src/loader.ts
+++ b/packages/loader/container-definitions/src/loader.ts
@@ -69,7 +69,13 @@ export enum LoaderHeader {
      * true) if the reconnect header is false or the pause header is true, since these containers should not be cached.
      */
     cache = "fluid-cache",
-    clientDetails = "fluid-client-type",
+
+    /**
+     * DEPRECATED use clientDetails instead
+     * back-compat: 0.11 clientType
+     */
+    clientType = "fluid-client-type",
+    clientDetails = "fluid-client-details",
     executionContext = "execution-context",
 
     /**
@@ -89,6 +95,12 @@ export enum LoaderHeader {
 }
 export interface ILoaderHeader {
     [LoaderHeader.cache]: boolean;
+
+    /**
+     * DEPRECATED use clientDetails instead
+     * back-compat: 0.11 clientType
+     */
+    [LoaderHeader.clientType]: string;
     [LoaderHeader.clientDetails]: IClientDetails;
     [LoaderHeader.pause]: boolean;
     [LoaderHeader.executionContext]: string;

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -91,7 +91,11 @@ export class ContainerContext extends EventEmitter implements IContainerContext 
         return this.container.clientId;
     }
 
-    public get clientType(): string | undefined {
+    /**
+     * DEPRECATED use clientDetails.type
+     * back-compat: 0.11 clientType
+     */
+    public get clientType(): string {
         return this.container.clientType;
     }
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -75,7 +75,7 @@ enum retryFor {
 export class DeltaManager extends EventEmitter implements IDeltaManager<ISequencedDocumentMessage, IDocumentMessage> {
     public get disposed() { return this.isDisposed; }
 
-    public readonly clientType: string | undefined;
+    public readonly clientType: string;
     public readonly clientDetails: IClientDetails;
     public get IDeltaSender() { return this; }
 
@@ -202,7 +202,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         private readonly reconnect: boolean) {
         super();
 
-        this.clientType = this.client.type;
+        this.clientType = this.client.type!; // back-compat: 0.11 clientType
         this.clientDetails = this.client.details;
         this.systemConnectionMode = this.client.mode === "write" ? "write" : "read";
 
@@ -396,10 +396,12 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         // const maxOpSize = this.context.deltaManager.maxMessageSize;
 
         // Start adding trace for the op.
+        // back-compat: 0.11 clientType
+        const clientType = this.clientDetails ? this.clientDetails.type : this.clientType;
         const traces: ITrace[] = [
             {
                 action: "start",
-                service: this.clientDetails.type || "unknown",
+                service: clientType || "unknown",
                 timestamp: Date.now(),
             }];
 
@@ -944,9 +946,11 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
 
         // Add final ack trace.
         if (message.traces && message.traces.length > 0) {
+            // back-compat: 0.11 clientType
+            const clientType = this.clientDetails ? this.clientDetails.type : this.clientType;
             message.traces.push({
                 action: "end",
-                service: this.clientDetails.type || "unknown",
+                service: clientType || "unknown",
                 timestamp: Date.now(),
             });
         }

--- a/packages/loader/container-loader/src/deltaManagerProxy.ts
+++ b/packages/loader/container-loader/src/deltaManagerProxy.ts
@@ -106,7 +106,11 @@ export class DeltaManagerProxy
         return this.deltaManager.initialSequenceNumber;
     }
 
-    public get clientType(): string | undefined {
+    /**
+     * DEPRECATED use clientDetails.type
+     * back-compat: 0.11 clientType
+     */
+    public get clientType(): string {
         return this.deltaManager.clientType;
     }
 

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "@microsoft/fluid-common-definitions": "^0.12.0",
     "@microsoft/fluid-component-core-interfaces": "^0.12.0",
-    "@microsoft/fluid-core-utils": "^0.12.0",
     "@microsoft/fluid-container-definitions": "^0.12.0",
+    "@microsoft/fluid-core-utils": "^0.12.0",
     "@microsoft/fluid-driver-definitions": "^0.12.0",
     "@microsoft/fluid-gitresources": "^0.12.0",
     "@microsoft/fluid-protocol-definitions": "^0.12.0",

--- a/packages/runtime/component-runtime/src/componentRuntime.ts
+++ b/packages/runtime/component-runtime/src/componentRuntime.ts
@@ -27,6 +27,7 @@ import {
 } from "@microsoft/fluid-core-utils";
 import {
     ConnectionState,
+    IClientDetails,
     IDocumentMessage,
     IQuorum,
     ISequencedDocumentMessage,
@@ -116,8 +117,16 @@ export class ComponentRuntime extends EventEmitter implements IComponentRuntime,
         return this.componentContext.clientId;
     }
 
-    public get clientType(): string | undefined {
+    /**
+     * DEPRECATED use clientDetails.type instead
+     * back-compat: 0.11 clientType
+     */
+    public get clientType(): string {
         return this.componentContext.clientType;
+    }
+
+    public get clientDetails(): IClientDetails {
+        return this.componentContext.hostRuntime.clientDetails;
     }
 
     public get loader(): ILoader {

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -83,7 +83,11 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
         return this._hostRuntime.clientId;
     }
 
-    public get clientType(): string | undefined {
+    /**
+     * DEPRECATED use hostRuntime.clientDetails.type instead
+     * back-compat: 0.11 clientType
+     */
+    public get clientType(): string {
         return this._hostRuntime.clientType;
     }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -39,6 +39,7 @@ import { readAndParse } from "@microsoft/fluid-driver-utils";
 import {
     ConnectionState,
     IChunkedOp,
+    IClientDetails,
     IDocumentMessage,
     IHelpMessage,
     IQuorum,
@@ -421,8 +422,16 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         return this.context.clientId;
     }
 
-    public get clientType(): string | undefined {
+    /**
+     * DEPRECATED use clientDetails.type instead
+     * back-compat: 0.11 clientType
+     */
+    public get clientType(): string {
         return this.context.clientType;
+    }
+
+    public get clientDetails(): IClientDetails {
+        return this.context.clientDetails;
     }
 
     public get blobManager(): IBlobManager {
@@ -1289,7 +1298,11 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
     }
 
     private subscribeToLeadership() {
-        if (this.context.clientDetails.capabilities.interactive) {
+        // back-compat: 0.11 clientType
+        const interactive = this.context.clientType === "browser"
+            || (this.context.clientDetails && this.context.clientDetails.capabilities.interactive);
+
+        if (interactive) {
             this.getScheduler().then((scheduler) => {
                 if (scheduler.leader) {
                     this.updateLeader(true);

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -195,7 +195,9 @@ export class SummaryManager extends EventEmitter {
             return;
         }
 
-        if (this.context.clientDetails.type === "summarizer") {
+        // back-compat: 0.11 clientType
+        const clientType = this.context.clientDetails ? this.context.clientDetails.type : this.context.clientType;
+        if (clientType === "summarizer") {
             // Make sure that the summarizer client does not load another summarizer.
             return;
         }
@@ -248,6 +250,7 @@ export class SummaryManager extends EventEmitter {
         const request: IRequest = {
             headers: {
                 [LoaderHeader.cache]: false,
+                [LoaderHeader.clientType]: "summarizer", // back-compat: 0.11 clientType
                 [LoaderHeader.clientDetails]: {
                     capabilities: { interactive: false },
                     type: "summarizer",

--- a/packages/runtime/container-runtime/src/taskAnalyzer.ts
+++ b/packages/runtime/container-runtime/src/taskAnalyzer.ts
@@ -42,5 +42,15 @@ export function analyzeTasks(
 }
 
 function isRobot(client: ISequencedClient): boolean {
-    return client.client && client.client.details.capabilities && !client.client.details.capabilities.interactive;
+    return client.client && (
+        (
+            // back-compat: 0.11 clientType
+            !client.client.details
+            && client.client.type !== "browser"
+        ) || (
+            client.client.details
+            && client.client.details.capabilities
+            && !client.client.details.capabilities.interactive
+        )
+    );
 }

--- a/packages/runtime/runtime-definitions/src/components.ts
+++ b/packages/runtime/runtime-definitions/src/components.ts
@@ -24,6 +24,7 @@ import {
 import { IDocumentStorageService } from "@microsoft/fluid-driver-definitions";
 import {
     ConnectionState,
+    IClientDetails,
     IDocumentMessage,
     IQuorum,
     ISequencedDocumentMessage,
@@ -202,7 +203,11 @@ export interface IComponentContext extends EventEmitter {
     readonly existing: boolean;
     readonly options: any;
     readonly clientId: string;
-    readonly clientType: string | undefined;
+    /**
+     * DEPRECATED use hostRuntime.clientDetails.type instead
+     * back-compat: 0.11 clientType
+     */
+    readonly clientType: string;
     readonly parentBranch: string;
     readonly connected: boolean;
     readonly leader: boolean;
@@ -316,7 +321,12 @@ export interface IHostRuntime extends
     readonly existing: boolean;
     readonly options: any;
     readonly clientId: string;
-    readonly clientType: string | undefined;
+    /**
+     * DEPRECATED use clientDetails.type instead
+     * back-compat: 0.11 clientType
+     */
+    readonly clientType: string;
+    readonly clientDetails: IClientDetails;
     readonly parentBranch: string;
     readonly connected: boolean;
     readonly leader: boolean;

--- a/packages/runtime/runtime-test-utils/src/mocks.ts
+++ b/packages/runtime/runtime-test-utils/src/mocks.ts
@@ -186,7 +186,7 @@ export class MockRuntime extends EventEmitter
     public readonly existing: boolean;
     public readonly options: any = {};
     public clientId: string = uuid();
-    public readonly clientType: string = "";
+    public readonly clientType: string = "browser"; // back-compat: 0.11 clientType
     public readonly parentBranch: string;
     public readonly path = "";
     public readonly connected: boolean;

--- a/packages/server/agent/src/agent/baseWork.ts
+++ b/packages/server/agent/src/agent/baseWork.ts
@@ -121,7 +121,18 @@ export class BaseWork extends EventEmitter {
     // A leader is any interactive client connected to the document.
     private noLeader(): boolean {
         for (const client of this.document.getClients()) {
-            if (!client[1].client || !client[1].client.details.capabilities.interactive) {
+            if (
+                !client[1].client || (
+                    // back-compat: 0.11 clientType
+                    !client[1].client.details && (
+                        !client[1].client.type
+                        || client[1].client.type === "browser"
+                    )
+                ) || (
+                    client[1].client.details
+                    && client[1].client.details.capabilities.interactive
+                )
+            ) {
                 return false;
             }
         }

--- a/packages/server/agent/src/agent/chaincodes/chaincodeWork.ts
+++ b/packages/server/agent/src/agent/chaincodes/chaincodeWork.ts
@@ -113,7 +113,18 @@ export class ChaincodeWork extends EventEmitter {
     // a browser client connected.
     private noLeader(): boolean {
         for (const client of this.document.getQuorum().getMembers()) {
-            if (!client[1].client || !client[1].client.details.capabilities.interactive) {
+            if (
+                !client[1].client || (
+                    // back-compat: 0.11 clientType
+                    !client[1].client.details && (
+                        !client[1].client.type
+                        || client[1].client.type === "browser"
+                    )
+                ) || (
+                    client[1].client.details
+                    && client[1].client.details.capabilities.interactive
+                )
+            ) {
                 return false;
             }
         }

--- a/packages/server/gateway/src/utils.ts
+++ b/packages/server/gateway/src/utils.ts
@@ -36,6 +36,7 @@ export function getConfig(
     updatedConfig.tenantId = tenantId;
     updatedConfig.trackError = trackError;
     const client: IClient = {
+        type: "browser", // back-compat: 0.11 clientType
         details: { capabilities: { interactive: true } },
         permission: [],
         scopes: [],

--- a/packages/server/paparazzi/src/test/agent/testDocument.ts
+++ b/packages/server/paparazzi/src/test/agent/testDocument.ts
@@ -94,7 +94,7 @@ export class TestDeltaManager
 
     public inboundSignal = new TestDeltaQueue<ISignalMessage>();
 
-    public clientType = "";
+    public clientType = "browser"; // back-compat: 0.11 clientType
     public clientDetails: IClientDetails = { capabilities: { interactive: true} };
 
     public version = "^0.1.0";

--- a/packages/server/test-utils/src/messageFactory.ts
+++ b/packages/server/test-utils/src/messageFactory.ts
@@ -99,6 +99,7 @@ export class MessageFactory {
             detail: {
                 permission: [],
                 scopes: [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite],
+                type: "browser", // back-compat: 0.11 clientType
                 details: {
                     capabilities: { interactive: true },
                 },

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -17,10 +17,10 @@
     "clean": "rimraf dist lib *.tsbuildinfo *.build.log",
     "eslint": "eslint --ext=ts,tsx --format stylish src",
     "eslint:fix": "eslint --ext=ts,tsx --format stylish src --fix",
-    "test_disabled": "node --experimental-worker ../../../node_modules/mocha/bin/_mocha --recursive dist/test",
     "test:coverage": "nyc npm test -- --reporter mocha-junit-reporter --reporter-options mochaFile=nyc/junit-report.xml",
     "test:generate": "node --experimental-worker dist/generateSnapshotFiles.js",
     "test:sequential": "node ../../../node_modules/mocha/bin/_mocha --recursive dist/test",
+    "test_disabled": "node --experimental-worker ../../../node_modules/mocha/bin/_mocha --recursive dist/test",
     "tsc": "tsc",
     "tslint": "tslint --project tsconfig.json --format verbose"
   },

--- a/packages/tools/fluid-fetch/src/fluidFetchMessages.ts
+++ b/packages/tools/fluid-fetch/src/fluidFetchMessages.ts
@@ -101,6 +101,7 @@ async function *loadAllSequencedMessages(
         const client: IClient = {
             permission: [],
             scopes: [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite],
+            type: "browser", // back-compat: 0.11 clientType
             details: {
                 capabilities: { interactive: true },
             },

--- a/server/headless-agent/client-src/fluid-loader/index.ts
+++ b/server/headless-agent/client-src/fluid-loader/index.ts
@@ -95,7 +95,14 @@ function checkContainerActivity(container: Container) {
             (window as IWindow).closeContainer();
         } else {
             for (const client of quorum.getMembers()) {
-                if (!client[1].client || !client[1].client.details.capabilities.interactive) {
+                // back-compat: 0.11 clientType
+                if (client[1].client.type === "browser") {
+                    return;
+                }
+                if (!client[1].client || (
+                    client[1].client.details // back-compat: 0.11 clientType
+                    && !client[1].client.details.capabilities.interactive
+                )) {
                     return;
                 }
             }

--- a/server/routerlicious/packages/routerlicious/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious/src/alfred/routes/api/api.ts
@@ -85,6 +85,7 @@ function sendJoin(tenantId: string, documentId: string, clientId: string, produc
     const detail: IClient = {
         permission: [],
         scopes: [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite],
+        type: "robot", // back-compat: 0.11 clientType
         details: {
             capabilities: { interactive: false },
         },


### PR DESCRIPTION
Fixes issue #707.
Support 0.11 top-level clientType backwards compatibility along with new clientDetails approach.

Created new issue to track removing this deprecated code and back-compat in later version: #713.
