### PR TITLE
Make Replay Tool closer to reality

### DIFF
--- a/packages/drivers/file-socket-storage/src/fileDocumentDeltaConnection.ts
+++ b/packages/drivers/file-socket-storage/src/fileDocumentDeltaConnection.ts
@@ -26,8 +26,10 @@ const ReplayMaxMessageSize = 16 * 1024;
 
 const fileProtocolVersion = "^0.1.0";
 
+const replayDocumentId = "replayDocId";
+
 const Claims: ITokenClaims = {
-    documentId: "",
+    documentId: replayDocumentId,
     scopes: [],
     tenantId: "",
     user: {
@@ -91,7 +93,7 @@ export class Replayer {
         // If Replay Tool fails due to one container patching message in-place,
         // then same thing can happen in shipping product due to
         // socket reuse in ODSP between main and summarizer containers.
-        this.deltaConnection.emit("op", "docId", ops);
+        this.deltaConnection.emit("op", replayDocumentId, ops);
     }
 }
 

--- a/packages/drivers/file-socket-storage/src/fileDocumentDeltaConnection.ts
+++ b/packages/drivers/file-socket-storage/src/fileDocumentDeltaConnection.ts
@@ -91,7 +91,7 @@ export class Replayer {
         // If Replay Tool fails due to one container patching message in-place,
         // then same thing can happen in shipping product due to
         // socket reuse in ODSP between main and summarizer containers.
-        ops.map((op) => this.deltaConnection.emit("op", "docId", op));
+        this.deltaConnection.emit("op", "docId", ops);
     }
 }
 

--- a/packages/drivers/fluid-debugger/src/fluidDebuggerController.ts
+++ b/packages/drivers/fluid-debugger/src/fluidDebuggerController.ts
@@ -274,7 +274,7 @@ export class DebugReplayController extends ReplayController implements IDebugger
     }
 
     public async replay(
-            emitter: (op: ISequencedDocumentMessage) => void,
+            emitter: (op: ISequencedDocumentMessage[]) => void,
             fetchedOps: ISequencedDocumentMessage[]): Promise<void> {
         // eslint-disable-next-line no-constant-condition
         while (true) {
@@ -305,7 +305,7 @@ export class DebugReplayController extends ReplayController implements IDebugger
                 playOps = fetchedOps.splice(0, this.stepsToPlay);
                 this.stepsToPlay = 0;
             }
-            playOps.map(emitter);
+            emitter(playOps);
         }
     }
 

--- a/packages/drivers/replay-socket-storage/src/replayController.ts
+++ b/packages/drivers/replay-socket-storage/src/replayController.ts
@@ -87,6 +87,6 @@ export abstract class ReplayController extends ReadDocumentStorageServiceBase {
      * @param fetchedOps - ops to process
      */
     public abstract replay(
-        emitter: (op: api.ISequencedDocumentMessage) => void,
+        emitter: (op: api.ISequencedDocumentMessage[]) => void,
         fetchedOps: api.ISequencedDocumentMessage[]): Promise<void>;
 }

--- a/packages/drivers/replay-socket-storage/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-socket-storage/src/replayDocumentDeltaConnection.ts
@@ -114,7 +114,7 @@ export class ReplayControllerStatic extends ReplayController {
     }
 
     public replay(
-            emitter: (op: ISequencedDocumentMessage) => void,
+            emitter: (op: ISequencedDocumentMessage[]) => void,
             fetchedOps: ISequencedDocumentMessage[]): Promise<void> {
         let current = this.skipToIndex(fetchedOps);
 
@@ -165,7 +165,7 @@ export class ReplayControllerStatic extends ReplayController {
                     }
                 }
                 scheduleNext(nextInterval);
-                playbackOps.map(emitter);
+                emitter(playbackOps);
             };
             const scheduleNext = (nextInterval: number) => {
                 if (nextInterval >= 0 && current < fetchedOps.length) {
@@ -329,7 +329,7 @@ export class ReplayDocumentDeltaConnection extends EventEmitter implements IDocu
                 continue;
             }
 
-            replayP = replayP.then(() => controller.replay((op) => this.emit("op", op.clientId, op), fetchedOps));
+            replayP = replayP.then(() => controller.replay((ops) => this.emit("op", "docId", ops), fetchedOps));
 
             currentOp += fetchedOps.length;
             done = controller.isDoneFetch(currentOp, fetchedOps[fetchedOps.length - 1].timestamp);

--- a/packages/drivers/replay-socket-storage/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-socket-storage/src/replayDocumentDeltaConnection.ts
@@ -331,7 +331,9 @@ export class ReplayDocumentDeltaConnection extends EventEmitter implements IDocu
                 continue;
             }
 
-            replayP = replayP.then(() => controller.replay((ops) => this.emit("op", ReplayDocumentId, ops), fetchedOps));
+            replayP = replayP.then(() => {
+                return controller.replay((ops) => this.emit("op", ReplayDocumentId, ops), fetchedOps);
+            });
 
             currentOp += fetchedOps.length;
             done = controller.isDoneFetch(currentOp, fetchedOps[fetchedOps.length - 1].timestamp);

--- a/packages/drivers/replay-socket-storage/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-socket-storage/src/replayDocumentDeltaConnection.ts
@@ -26,6 +26,8 @@ import { ReplayController } from "./replayController";
 
 const MaxBatchDeltas = 2000;
 
+const ReplayDocumentId = "documentId";
+
 export class ReplayControllerStatic extends ReplayController {
     private static readonly DelayInterval = 50;
     private static readonly ReplayResolution = 15;
@@ -227,7 +229,7 @@ export class ReplayDocumentDeltaConnection extends EventEmitter implements IDocu
     private static readonly ReplayMaxMessageSize = 16 * 1024;
 
     private static readonly claims: ITokenClaims = {
-        documentId: "",
+        documentId: ReplayDocumentId,
         scopes: [],
         tenantId: "",
         user: {
@@ -329,7 +331,7 @@ export class ReplayDocumentDeltaConnection extends EventEmitter implements IDocu
                 continue;
             }
 
-            replayP = replayP.then(() => controller.replay((ops) => this.emit("op", "docId", ops), fetchedOps));
+            replayP = replayP.then(() => controller.replay((ops) => this.emit("op", ReplayDocumentId, ops), fetchedOps));
 
             currentOp += fetchedOps.length;
             done = controller.isDoneFetch(currentOp, fetchedOps[fetchedOps.length - 1].timestamp);


### PR DESCRIPTION
1) Close containers before exiting
2) Deliver / process ops in batches, not one by one.
3) Do not clone messages before delivering to all containers, catch issues where containers do modify messages and screw other containers (which happens in real life with ODSP driver & summarizing container)