### PR TITLE
Fix container-runtime tests

### DIFF
--- a/packages/runtime/container-runtime/src/test/componentContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/componentContext.spec.ts
@@ -29,12 +29,15 @@ describe("Component Context Tests", () => {
         beforeEach(async () => {
             let registry: IComponentRegistry;
             let factory: IComponentFactory;
-            factory = { IComponentFactory: factory,  instantiateComponent: (context: IComponentContext) => { } };
+            factory = {
+                get IComponentFactory() { return factory; },
+                instantiateComponent: (context: IComponentContext) => { },
+            };
             registry = {
                 IComponentRegistry: registry,
                 get: (pkg) => Promise.resolve(factory),
             };
-            containerRuntime = { IComponentRegistry: registry} as ContainerRuntime;
+            containerRuntime = { IComponentRegistry: registry } as ContainerRuntime;
         });
 
         it("Check LocalComponent Attributes", () => {

--- a/packages/runtime/container-runtime/src/test/summarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizer.spec.ts
@@ -123,10 +123,14 @@ describe("Runtime", () => {
                     await flushPromises(); // let summarize run
                 }
 
-                async function flushPromises(count: number = 1) {
-                    for (let i = 0; i < count; i++) {
-                        await Promise.resolve();
-                    }
+                // tslint:disable-next-line: mocha-no-side-effect-code
+                const flush = typeof setImmediate === "function"
+                    ? (fn: (...args: any[]) => void) => { setImmediate(fn); }
+                    : (fn: (...args: any[]) => void) => { setTimeout(fn, 0); };
+                async function flushPromises() {
+                    const p = new Promise((resolve) => { flush(resolve); });
+                    clock.tick(0);
+                    return p;
                 }
 
                 it("Should summarize after configured number of ops when not pending", async () => {

--- a/packages/runtime/container-runtime/src/test/summarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizer.spec.ts
@@ -123,12 +123,8 @@ describe("Runtime", () => {
                     await flushPromises(); // let summarize run
                 }
 
-                // tslint:disable-next-line: mocha-no-side-effect-code
-                const flush = typeof setImmediate === "function"
-                    ? (fn: (...args: any[]) => void) => { setImmediate(fn); }
-                    : (fn: (...args: any[]) => void) => { setTimeout(fn, 0); };
                 async function flushPromises() {
-                    const p = new Promise((resolve) => { flush(resolve); });
+                    const p = new Promise((resolve) => setTimeout(() => { resolve(); }, 0));
                     clock.tick(0);
                     return p;
                 }


### PR DESCRIPTION
Summarizer test was failing, changed implementation of flushPromises to fix it.
Component Context test had an unhandle promise rejection, changed IComponentFactory to getter to fix.