### PR TITLE
Handle undefined summaryData; make event category error

### DIFF
--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -387,7 +387,7 @@ export class RunningSummarizer implements IDisposable {
     private async summarize(reason: string) {
         // wait to generate and send summary
         const summaryData = await this.generateSummaryWithLogging(reason);
-        if (!summaryData.submitted) {
+        if (!summaryData || !summaryData.submitted) {
             // did not send the summary op
             return;
         }
@@ -448,7 +448,7 @@ export class RunningSummarizer implements IDisposable {
         try {
             summaryData = await this.generateSummary();
         } catch (error) {
-            summarizingEvent.cancel({}, error);
+            summarizingEvent.cancel({ category: "error" }, error);
             return;
         }
 

--- a/packages/runtime/container-runtime/src/test/summarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizer.spec.ts
@@ -124,9 +124,9 @@ describe("Runtime", () => {
                 }
 
                 async function flushPromises(count: number = 1) {
-                    for (let i = 0; i < count; i++) {
-                        await Promise.resolve();
-                    }
+                    const p = new Promise((resolve) => setTimeout(() => { resolve(); }, 0));
+                    clock.tick(0);
+                    return p;
                 }
 
                 it("Should summarize after configured number of ops when not pending", async () => {


### PR DESCRIPTION
When generateSummary fails, summaryData comes back undefined, changed the check to handle this.  This was causing a floating promise to reject.  Changed category of failure to error.

Also backport change from master to fix summarizer unit tests.

Will do a follow-up change in master to back-off and restart on consecutive summarize errors.