### PR TITLE
Fix build break: Fix fluid-component-core-interfaces version

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -21,7 +21,9 @@
     "tslint": "tslint --project tsconfig.json --format verbose"
   },
   "dependencies": {
+    "@microsoft/fluid-component-core-interfaces": "0.12.17216",
     "@microsoft/fluid-core-utils": "0.12.17216",
+    
     "@microsoft/fluid-server-services": "^0.12.0",
     "@microsoft/fluid-server-services-core": "^0.12.0",
     "@microsoft/fluid-server-services-utils": "^0.12.0",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -24,6 +24,7 @@
     "tslint": "tslint --project tsconfig.json --format verbose"
   },
   "dependencies": {
+    "@microsoft/fluid-component-core-interfaces": "0.12.17216",
     "@microsoft/fluid-core-utils": "0.12.17216",
     "@microsoft/fluid-gitresources": "^0.12.0",
     "@microsoft/fluid-protocol-base": "^0.12.0",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@azure/event-hubs": "^1.0.8",
     "@azure/event-processor-host": "^1.0.6",
+    "@microsoft/fluid-component-core-interfaces": "0.12.17216",
     "@microsoft/fluid-core-utils": "0.12.17216",
     "@microsoft/fluid-gitresources": "^0.12.0",
     "@microsoft/fluid-protocol-definitions": "^0.12.0",


### PR DESCRIPTION
The package version of fluid-core-utils and fluid-component-core-interfaces needs to be in sync.