### PR TITLE
Refactor flatten+buildHierarchy to buildSnapshotTree

### DIFF
--- a/packages/drivers/file-socket-storage/src/fileDocumentStorageService.ts
+++ b/packages/drivers/file-socket-storage/src/fileDocumentStorageService.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { buildHierarchy, flatten, fromBase64ToUtf8 } from "@microsoft/fluid-core-utils";
+import { buildSnapshotTree, fromBase64ToUtf8 } from "@microsoft/fluid-core-utils";
 import { IDocumentStorageService } from "@microsoft/fluid-driver-definitions";
 import * as api from "@microsoft/fluid-protocol-definitions";
 import { IFileSnapshot, ReadDocumentStorageServiceBase } from "@microsoft/fluid-replay-driver";
@@ -169,8 +169,7 @@ export function FileSnapshotWriterClassFactory<TBase extends ReaderConstructor>(
                 return this.latestWriterTree;
             }
             if (version && this.commitsWriter[version.id] !== undefined) {
-                const flattened = flatten(this.commitsWriter[version.id].entries, this.blobsWriter);
-                return buildHierarchy(flattened);
+                return buildSnapshotTree(this.commitsWriter[version.id].entries, this.blobsWriter);
             }
             return super.getSnapshotTree(version);
         }
@@ -212,8 +211,7 @@ export function FileSnapshotWriterClassFactory<TBase extends ReaderConstructor>(
 
                 // Prep for the future - refresh latest tree, as it's requests on next snapshot generation.
                 // Do not care about blobs (at least for now), as blobs are not written out (need follow up)
-                const flattened = flatten(tree.entries, this.blobsWriter);
-                this.latestWriterTree = buildHierarchy(flattened);
+                this.latestWriterTree = buildSnapshotTree(tree.entries, this.blobsWriter);
 
                 // Do not reset this.commitsWriter - runtime will reference same commits in future snapshots
                 // if component did not change in between two snapshots.

--- a/packages/drivers/replay-socket-storage/src/storageImplementations.ts
+++ b/packages/drivers/replay-socket-storage/src/storageImplementations.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { buildHierarchy, flatten } from "@microsoft/fluid-core-utils";
+import { buildSnapshotTree } from "@microsoft/fluid-core-utils";
 import {
     IDocumentDeltaConnection,
     IDocumentDeltaStorageService,
@@ -44,8 +44,7 @@ export class FileSnapshotReader extends ReadDocumentStorageServiceBase implement
     public constructor(json: IFileSnapshot) {
         super();
         this.commits = json.commits;
-        const flattened = flatten(json.tree.entries, this.blobs);
-        this.docTree = buildHierarchy(flattened);
+        this.docTree = buildSnapshotTree(json.tree.entries, this.blobs);
     }
 
     public async getVersions(
@@ -77,8 +76,7 @@ export class FileSnapshotReader extends ReadDocumentStorageServiceBase implement
                 throw new Error(`Can't find version ${versionRequested.id}`);
             }
 
-            const flattened = flatten(tree.entries, this.blobs);
-            this.trees[versionRequested.id] = snapshotTree = buildHierarchy(flattened);
+            this.trees[versionRequested.id] = snapshotTree = buildSnapshotTree(tree.entries, this.blobs);
         }
         return snapshotTree;
     }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -21,11 +21,10 @@ import {
     LoaderHeader,
 } from "@microsoft/fluid-container-definitions";
 import {
-    buildHierarchy,
+    buildSnapshotTree,
     ChildLogger,
     DebugLogger,
     EventEmitterWithErrorHandling,
-    flatten,
     PerformanceEvent,
     raiseConnectedEvent,
     TelemetryLogger,
@@ -468,8 +467,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         let snapshot: ISnapshotTree | undefined;
         const blobs = new Map();
         if (previousContextState) {
-            const flattened = flatten(previousContextState.entries, blobs);
-            snapshot = buildHierarchy(flattened);
+            snapshot = buildSnapshotTree(previousContextState.entries, blobs);
         }
 
         const storage = blobs.size > 0

--- a/packages/loader/utils/src/blobs.ts
+++ b/packages/loader/utils/src/blobs.ts
@@ -39,7 +39,7 @@ export function gitHashFile(file: Buffer): string {
  * @param blobMap - a map of blob's sha1 to content
  * @returns A flatten with of the ITreeEntry
  */
-export function flatten(tree: ITreeEntry[], blobMap: Map<string, string>): git.ITree {
+function flatten(tree: ITreeEntry[], blobMap: Map<string, string>): git.ITree {
     const entries = flattenCore("", tree, blobMap);
     return {
         sha: "",
@@ -97,6 +97,18 @@ function flattenCore(path: string, treeEntries: ITreeEntry[], blobMap: Map<strin
     }
 
     return entries;
+}
+
+/**
+ * Build a tree hierarchy base on an array of ITreeEntry
+ *
+ * @param entries - an array of ITreeEntry to flatten
+ * @param blobMap - a map of blob's sha1 to content
+ * @returns the hierarchical tree
+ */
+export function buildSnapshotTree(entries: ITreeEntry[], blobMap: Map<string, string>): ISnapshotTree {
+    const flattened = flatten(entries, blobMap);
+    return buildHierarchy(flattened);
 }
 
 /**
@@ -169,7 +181,7 @@ export class CommitTreeEntry implements ITreeEntry {
      * @param path - path of entry
      * @param value - commit value
      */
-    constructor(public readonly path: string, public readonly value: string) {}
+    constructor(public readonly path: string, public readonly value: string) { }
 }
 
 /**
@@ -184,7 +196,7 @@ export class TreeTreeEntry implements ITreeEntry {
      * @param path - path of entry
      * @param value - subtree
      */
-    constructor(public readonly path: string, public readonly value: ITree) {}
+    constructor(public readonly path: string, public readonly value: ITree) { }
 }
 
 export function addBlobToTree(tree: ITree, blobName: string, content: object) {

--- a/packages/runtime/component-runtime/src/componentRuntime.ts
+++ b/packages/runtime/component-runtime/src/componentRuntime.ts
@@ -18,10 +18,9 @@ import {
     ILoader,
 } from "@microsoft/fluid-container-definitions";
 import {
-    buildHierarchy,
+    buildSnapshotTree,
     ChildLogger,
     Deferred,
-    flatten,
     raiseConnectedEvent,
     TreeTreeEntry,
 } from "@microsoft/fluid-core-utils";
@@ -443,8 +442,7 @@ export class ComponentRuntime extends EventEmitter implements IComponentRuntime,
                     const origin = message.origin ? message.origin.id : this.documentId;
 
                     const flatBlobs = new Map<string, string>();
-                    const flattened = flatten(attachMessage.snapshot.entries, flatBlobs);
-                    const snapshotTree = buildHierarchy(flattened);
+                    const snapshotTree = buildSnapshotTree(attachMessage.snapshot.entries, flatBlobs);
 
                     const remoteChannelContext = new RemoteChannelContext(
                         this,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -25,11 +25,10 @@ import {
 } from "@microsoft/fluid-container-definitions";
 import {
     BlobTreeEntry,
-    buildHierarchy,
+    buildSnapshotTree,
     CommitTreeEntry,
     ComponentSerializer,
     Deferred,
-    flatten,
     isSystemType,
     raiseConnectedEvent,
     Trace,
@@ -1017,8 +1016,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
                 const flatBlobs = new Map<string, string>();
                 let snapshotTree: ISnapshotTree = null;
                 if (attachMessage.snapshot) {
-                    const flattened = flatten(attachMessage.snapshot.entries, flatBlobs);
-                    snapshotTree = buildHierarchy(flattened);
+                    snapshotTree = buildSnapshotTree(attachMessage.snapshot.entries, flatBlobs);
                 }
 
                 // Include the type of attach message which is the pkg of the component to be


### PR DESCRIPTION
The flatten function converts an array of ITreeEntry to git.ITreeEntry, and the output is always used with buildHierarchy to convert it to ISnapshotTree.  Refactor it so that we have a function to convert
directly to ITreeEntry to ISnapshotTree and avoid exposing git concepts to the runtime.