### PR TITLE
Fix server break from version bump

### DIFF
--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -17,7 +17,7 @@
     "tslint": "tslint --project tsconfig.json --format verbose"
   },
   "devDependencies": {
-    "@microsoft/fluid-build-common": "^0.12.0",
+    "@microsoft/fluid-build-common": "^0.13.0",
     "concurrently": "^4.1.0",
     "rimraf": "^2.6.2",
     "tslint": "^5.20.0",

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -25,7 +25,7 @@
     "lodash": "^4.17.11"
   },
   "devDependencies": {
-    "@microsoft/fluid-build-common": "^0.12.0",
+    "@microsoft/fluid-build-common": "^0.13.0",
     "concurrently": "^4.1.0",
     "rimraf": "^2.6.2",
     "tslint": "^5.20.0",

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -33,7 +33,7 @@
     "winston": "^3.1.0"
   },
   "devDependencies": {
-    "@microsoft/fluid-build-common": "^0.12.0",
+    "@microsoft/fluid-build-common": "^0.13.0",
     "@microsoft/fluid-server-test-utils": "^0.12.0",
     "@types/async": "^2.0.50",
     "@types/lodash": "^4.14.118",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -39,7 +39,7 @@
     "winston": "^3.1.0"
   },
   "devDependencies": {
-    "@microsoft/fluid-build-common": "^0.12.0",
+    "@microsoft/fluid-build-common": "^0.13.0",
     "@microsoft/fluid-server-test-utils": "^0.12.0",
     "@types/async": "^2.0.50",
     "@types/lodash": "^4.14.118",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -43,7 +43,7 @@
     "ws": "^6.1.2"
   },
   "devDependencies": {
-    "@microsoft/fluid-build-common": "^0.12.0",
+    "@microsoft/fluid-build-common": "^0.13.0",
     "@types/uuid": "^3.4.4",
     "concurrently": "^4.1.0",
     "rimraf": "^2.6.2",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.4.4",
-    "@microsoft/fluid-build-common": "^0.12.0",
+    "@microsoft/fluid-build-common": "^0.13.0",
     "@types/lodash": "^4.14.118",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.14.6",

--- a/server/routerlicious/packages/protocol-definitions/package.json
+++ b/server/routerlicious/packages/protocol-definitions/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.4.4",
-    "@microsoft/fluid-build-common": "^0.12.0",
+    "@microsoft/fluid-build-common": "^0.13.0",
     "@types/node": "^10.14.6",
     "concurrently": "^4.1.0",
     "rimraf": "^2.6.2",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -75,7 +75,7 @@
     "ws": "^6.1.2"
   },
   "devDependencies": {
-    "@microsoft/fluid-build-common": "^0.12.0",
+    "@microsoft/fluid-build-common": "^0.13.0",
     "@microsoft/fluid-server-test-utils": "^0.12.0",
     "@types/bytes": "^3.0.0",
     "@types/compression": "0.0.33",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -33,7 +33,7 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@microsoft/fluid-build-common": "^0.12.0",
+    "@microsoft/fluid-build-common": "^0.13.0",
     "@types/debug": "^0.0.31",
     "@types/mocha": "^5.2.5",
     "concurrently": "^4.1.0",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -31,7 +31,7 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "@microsoft/fluid-build-common": "^0.12.0",
+    "@microsoft/fluid-build-common": "^0.13.0",
     "@types/jsonwebtoken": "^8.3.0",
     "concurrently": "^4.1.0",
     "rimraf": "^2.6.2",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -28,7 +28,7 @@
     "winston": "^3.1.0"
   },
   "devDependencies": {
-    "@microsoft/fluid-build-common": "^0.12.0",
+    "@microsoft/fluid-build-common": "^0.13.0",
     "@types/debug": "^0.0.31",
     "@types/nconf": "^0.0.37",
     "@types/node": "^10.14.6",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -43,7 +43,7 @@
     "winston": "^3.1.0"
   },
   "devDependencies": {
-    "@microsoft/fluid-build-common": "^0.12.0",
+    "@microsoft/fluid-build-common": "^0.13.0",
     "@types/amqplib": "^0.5.9",
     "@types/debug": "^0.0.31",
     "@types/lodash": "^4.14.118",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -35,8 +35,8 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.12.0",
-    "@microsoft/fluid-build-common": "^0.12.0",
+    "@microsoft/eslint-config-fluid": "^0.13.0",
+    "@microsoft/fluid-build-common": "^0.13.0",
     "@types/lodash": "^4.14.118",
     "@types/node": "^10.14.6",
     "@types/string-hash": "^1.1.1",


### PR DESCRIPTION
Since we specify to lerna that we will always use the live version of fluid-build-common, we need to bump the version referenced as well.