### PR TITLE
Server: bump dependency fluid-core-utils version to reduce client monorepo dependencies

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -21,8 +21,7 @@
     "tslint": "tslint --project tsconfig.json --format verbose"
   },
   "dependencies": {
-    "@microsoft/fluid-component-core-interfaces": "0.12.17216",
-    "@microsoft/fluid-core-utils": "0.12.17216",
+    "@microsoft/fluid-core-utils": "0.13.17538",
     "@microsoft/fluid-server-services": "^0.12.0",
     "@microsoft/fluid-server-services-core": "^0.12.0",
     "@microsoft/fluid-server-services-utils": "^0.12.0",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -24,8 +24,7 @@
     "tslint": "tslint --project tsconfig.json --format verbose"
   },
   "dependencies": {
-    "@microsoft/fluid-component-core-interfaces": "0.12.17216",
-    "@microsoft/fluid-core-utils": "0.12.17216",
+    "@microsoft/fluid-core-utils": "0.13.17538",
     "@microsoft/fluid-gitresources": "^0.12.0",
     "@microsoft/fluid-protocol-base": "^0.12.0",
     "@microsoft/fluid-protocol-definitions": "^0.12.0",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -22,8 +22,7 @@
     "tslint": "tslint --project tsconfig.json --format verbose"
   },
   "dependencies": {
-    "@microsoft/fluid-component-core-interfaces": "0.12.17216",
-    "@microsoft/fluid-core-utils": "0.12.17216",
+    "@microsoft/fluid-core-utils": "0.13.17538",
     "@microsoft/fluid-protocol-base": "^0.12.0",
     "@microsoft/fluid-protocol-definitions": "^0.12.0",
     "@microsoft/fluid-server-lambdas": "^0.12.0",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -26,8 +26,7 @@
     "tslint": "tslint --project tsconfig.json --format verbose"
   },
   "dependencies": {
-    "@microsoft/fluid-component-core-interfaces": "0.12.17216",
-    "@microsoft/fluid-core-utils": "0.12.17216",
+    "@microsoft/fluid-core-utils": "0.13.17538",
     "@microsoft/fluid-gitresources": "^0.12.0",
     "@microsoft/fluid-protocol-definitions": "^0.12.0",
     "lodash": "^4.17.11"

--- a/server/routerlicious/packages/protocol-definitions/package.json
+++ b/server/routerlicious/packages/protocol-definitions/package.json
@@ -23,7 +23,7 @@
     "tslint": "tslint --project tsconfig.json --format verbose"
   },
   "dependencies": {
-    "@microsoft/fluid-common-definitions": "0.12.17216"
+    "@microsoft/fluid-common-definitions": "0.13.17538"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.4.4",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -36,8 +36,7 @@
     "tslint": "tslint --project tsconfig.json --format verbose"
   },
   "dependencies": {
-    "@microsoft/fluid-component-core-interfaces": "0.12.17216",
-    "@microsoft/fluid-core-utils": "0.12.17216",
+    "@microsoft/fluid-core-utils": "0.13.17538",
     "@microsoft/fluid-gitresources": "^0.12.0",
     "@microsoft/fluid-protocol-base": "^0.12.0",
     "@microsoft/fluid-protocol-definitions": "^0.12.0",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -24,8 +24,7 @@
     "tslint": "tslint --project tsconfig.json --format verbose"
   },
   "dependencies": {
-    "@microsoft/fluid-component-core-interfaces": "0.12.17216",
-    "@microsoft/fluid-core-utils": "0.12.17216",
+    "@microsoft/fluid-core-utils": "0.13.17538",
     "@microsoft/fluid-gitresources": "^0.12.0",
     "@microsoft/fluid-protocol-base": "^0.12.0",
     "@microsoft/fluid-protocol-definitions": "^0.12.0",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -19,8 +19,7 @@
     "tslint": "tslint --project tsconfig.json --format verbose"
   },
   "dependencies": {
-    "@microsoft/fluid-component-core-interfaces": "0.12.17216",
-    "@microsoft/fluid-core-utils": "0.12.17216",
+    "@microsoft/fluid-core-utils": "0.13.17538",
     "@microsoft/fluid-gitresources": "^0.12.0",
     "@microsoft/fluid-protocol-definitions": "^0.12.0",
     "@microsoft/fluid-server-services-client": "^0.12.0",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -21,8 +21,7 @@
   "dependencies": {
     "@azure/event-hubs": "^1.0.8",
     "@azure/event-processor-host": "^1.0.6",
-    "@microsoft/fluid-component-core-interfaces": "0.12.17216",
-    "@microsoft/fluid-core-utils": "0.12.17216",
+    "@microsoft/fluid-core-utils": "0.13.17538",
     "@microsoft/fluid-gitresources": "^0.12.0",
     "@microsoft/fluid-protocol-definitions": "^0.12.0",
     "@microsoft/fluid-server-services-client": "^0.12.0",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -23,8 +23,7 @@
     "tslint": "npm run eslint"
   },
   "dependencies": {
-    "@microsoft/fluid-component-core-interfaces": "0.12.17216",
-    "@microsoft/fluid-core-utils": "0.12.17216",
+    "@microsoft/fluid-core-utils": "0.13.17538",
     "@microsoft/fluid-gitresources": "^0.12.0",
     "@microsoft/fluid-protocol-definitions": "^0.12.0",
     "@microsoft/fluid-server-services-client": "^0.12.0",


### PR DESCRIPTION
Server packages should only depend on `fluid-core-utils` and indirectly `fluid-common-definitions`