### PR TITLE
Revive code coverage data collection

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,14 @@
   },
   "nyc": {
     "all": true,
+    "extension": [
+      ".ts",
+      ".tsx",
+      ".js",
+      ".jsx"
+    ],
     "exclude": [
+      "**/*.d.ts",
       "packages/**/src/test/**/*.ts",
       "packages/**/dist/test/**/*.js",
       "**/*.bundle.js",
@@ -77,6 +84,7 @@
     ],
     "temp-directory": "nyc/.nyc_output",
     "cache-dir": "nyc/.cache",
-    "report-dir": "nyc/report"
+    "report-dir": "nyc/report",
+    "exclude-after-remap": false
   }
 }

--- a/packages/components/client-ui/package.json
+++ b/packages/components/client-ui/package.json
@@ -77,6 +77,7 @@
     ],
     "temp-directory": "nyc/.nyc_output",
     "cache-dir": "nyc/.cache",
-    "report-dir": "nyc/report"
+    "report-dir": "nyc/report",
+    "exclude-after-remap": false
   }
 }

--- a/packages/components/flow-util/package.json
+++ b/packages/components/flow-util/package.json
@@ -49,5 +49,30 @@
     "ts-node": "^7.0.1",
     "tslint": "^5.20.0",
     "typescript": "~3.4.5"
+  },
+  "nyc": {
+    "all": true,
+    "extension": [
+      ".ts",
+      ".tsx",
+      ".js",
+      ".jsx"
+    ],
+    "exclude": [
+      "**/*.d.ts",
+      "src/test/**/*.ts",
+      "dist/test/**/*.js"
+    ],
+    "include": [
+      "src/**/*.ts",
+      "dist/**/*.js"
+    ],
+    "require" : [
+      "ts-node/register"
+    ],
+    "temp-directory": "nyc/.nyc_output",
+    "cache-dir": "nyc/.cache",
+    "report-dir": "nyc/report",
+    "exclude-after-remap": false
   }
 }

--- a/packages/components/source-document/package.json
+++ b/packages/components/source-document/package.json
@@ -20,7 +20,7 @@
     "dev": "npm run build:esnext -- --watch",
     "eslint": "eslint --ext=ts,tsx --format stylish src",
     "eslint:fix": "eslint --ext=ts,tsx --format stylish src --fix",
-    "test": "mocha -r ts-node/register -r ignore-styles --recursive test/**/*.spec.ts --exit",
+    "test": "mocha -r ts-node/register -r source-map-support/register -r ignore-styles --recursive test/**/*.spec.ts --exit",
     "test:coverage": "nyc npm test -- --reporter mocha-junit-reporter --reporter-options mochaFile=nyc/junit-report.xml --exit",
     "tsc": "tsc",
     "tslint": "npm run eslint"
@@ -50,6 +50,7 @@
     "mocha-junit-reporter": "^1.18.0",
     "nyc": "^14.1.1",
     "rimraf": "^2.6.2",
+    "source-map-support": "^0.5.16",
     "ts-node": "^7.0.1",
     "tslint": "^5.20.0",
     "typescript": "~3.4.5"
@@ -63,5 +64,30 @@
         "library": "main"
       }
     }
+  },
+  "nyc": {
+    "all": true,
+    "extension": [
+      ".ts",
+      ".tsx",
+      ".js",
+      ".jsx"
+    ],
+    "exclude": [
+      "**/*.d.ts",
+      "src/test/**/*.ts",
+      "dist/test/**/*.js"
+    ],
+    "include": [
+      "src/**/*.ts",
+      "dist/**/*.js"
+    ],
+    "require" : [
+      "ts-node/register"
+    ],
+    "temp-directory": "nyc/.nyc_output",
+    "cache-dir": "nyc/.cache",
+    "report-dir": "nyc/report",
+    "exclude-after-remap": false
   }
 }

--- a/packages/components/table-test/package.json
+++ b/packages/components/table-test/package.json
@@ -60,6 +60,7 @@
     ],
     "temp-directory": "nyc/.nyc_output",
     "cache-dir": "nyc/.cache",
-    "report-dir": "nyc/report"
+    "report-dir": "nyc/report",
+    "exclude-after-remap": false
   }
 }

--- a/packages/components/webflow/package.json
+++ b/packages/components/webflow/package.json
@@ -24,7 +24,7 @@
     "start": "webpack-dev-server --config webpack.config.js --package package.json",
     "start:live": "webpack-dev-server --config webpack.config.js --package package.json --env.mode live",
     "start:localhost": "webpack-dev-server --config webpack.config.js --package package.json --env.mode localhost",
-    "test": "mocha -r ts-node/register -r ignore-styles --recursive test/**/*.spec.ts --exit",
+    "test": "mocha -r ts-node/register -r source-map-support/register -r ignore-styles --recursive test/**/*.spec.ts --exit",
     "test:coverage": "nyc npm test -- --reporter mocha-junit-reporter --reporter-options mochaFile=nyc/junit-report.xml --exit",
     "tsc": "tsc",
     "tslint": "tslint --project tsconfig.json --format verbose",
@@ -65,6 +65,7 @@
     "nyc": "^14.1.1",
     "rimraf": "^2.6.2",
     "source-map-loader": "^0.2.4",
+    "source-map-support": "^0.5.16",
     "style-loader": "^1.0.0",
     "ts-loader": "^6.1.2",
     "ts-node": "^7.0.1",
@@ -87,5 +88,30 @@
         "library": "main"
       }
     }
+  },
+  "nyc": {
+    "all": true,
+    "extension": [
+      ".ts",
+      ".tsx",
+      ".js",
+      ".jsx"
+    ],
+    "exclude": [
+      "**/*.d.ts",
+      "src/test/**/*.ts",
+      "dist/test/**/*.js"
+    ],
+    "include": [
+      "src/**/*.ts",
+      "dist/**/*.js"
+    ],
+    "require" : [
+      "ts-node/register"
+    ],
+    "temp-directory": "nyc/.nyc_output",
+    "cache-dir": "nyc/.cache",
+    "report-dir": "nyc/report",
+    "exclude-after-remap": false
   }
 }

--- a/packages/drivers/odsp-socket-storage/package.json
+++ b/packages/drivers/odsp-socket-storage/package.json
@@ -78,6 +78,7 @@
     ],
     "temp-directory": "nyc/.nyc_output",
     "cache-dir": "nyc/.cache",
-    "report-dir": "nyc/report"
+    "report-dir": "nyc/report",
+    "exclude-after-remap": false
   }
 }

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -84,6 +84,7 @@
     ],
     "temp-directory": "nyc/.nyc_output",
     "cache-dir": "nyc/.cache",
-    "report-dir": "nyc/report"
+    "report-dir": "nyc/report",
+    "exclude-after-remap": false
   }
 }

--- a/packages/loader/utils/package.json
+++ b/packages/loader/utils/package.json
@@ -73,6 +73,7 @@
     ],
     "temp-directory": "nyc/.nyc_output",
     "cache-dir": "nyc/.cache",
-    "report-dir": "nyc/report"
+    "report-dir": "nyc/report",
+    "exclude-after-remap": false
   }
 }

--- a/packages/runtime/cell/package.json
+++ b/packages/runtime/cell/package.json
@@ -71,6 +71,7 @@
     ],
     "temp-directory": "nyc/.nyc_output",
     "cache-dir": "nyc/.cache",
-    "report-dir": "nyc/report"
+    "report-dir": "nyc/report",
+    "exclude-after-remap": false
   }
 }

--- a/packages/runtime/consensus-ordered-collection/package.json
+++ b/packages/runtime/consensus-ordered-collection/package.json
@@ -70,6 +70,7 @@
     ],
     "temp-directory": "nyc/.nyc_output",
     "cache-dir": "nyc/.cache",
-    "report-dir": "nyc/report"
+    "report-dir": "nyc/report",
+    "exclude-after-remap": false
   }
 }

--- a/packages/runtime/consensus-register-collection/package.json
+++ b/packages/runtime/consensus-register-collection/package.json
@@ -70,6 +70,7 @@
     ],
     "temp-directory": "nyc/.nyc_output",
     "cache-dir": "nyc/.cache",
-    "report-dir": "nyc/report"
+    "report-dir": "nyc/report",
+    "exclude-after-remap": false
   }
 }

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -64,5 +64,25 @@
     "sinon": "^7.4.2",
     "tslint": "^5.20.0",
     "typescript": "~3.4.5"
+  },
+  "nyc": {
+    "all": true,
+    "exclude": [
+      "src/test/**/*.ts",
+      "dist/test/**/*.js"
+    ],
+    "include": [
+      "src/**/*.ts",
+      "dist/**/*.js"
+    ],
+    "reporter": [
+      "cobertura",
+      "html",
+      "text"
+    ],
+    "temp-directory": "nyc/.nyc_output",
+    "cache-dir": "nyc/.cache",
+    "report-dir": "nyc/report",
+    "exclude-after-remap": false
   }
 }

--- a/packages/runtime/map/package.json
+++ b/packages/runtime/map/package.json
@@ -71,6 +71,7 @@
     ],
     "temp-directory": "nyc/.nyc_output",
     "cache-dir": "nyc/.cache",
-    "report-dir": "nyc/report"
+    "report-dir": "nyc/report",
+    "exclude-after-remap": false
   }
 }

--- a/packages/runtime/merge-tree/package.json
+++ b/packages/runtime/merge-tree/package.json
@@ -72,6 +72,7 @@
     ],
     "temp-directory": "nyc/.nyc_output",
     "cache-dir": "nyc/.cache",
-    "report-dir": "nyc/report"
+    "report-dir": "nyc/report",
+    "exclude-after-remap": false
   }
 }

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -73,6 +73,7 @@
     ],
     "temp-directory": "nyc/.nyc_output",
     "cache-dir": "nyc/.cache",
-    "report-dir": "nyc/report"
+    "report-dir": "nyc/report",
+    "exclude-after-remap": false
   }
 }

--- a/packages/runtime/sequence/package.json
+++ b/packages/runtime/sequence/package.json
@@ -83,6 +83,7 @@
     ],
     "temp-directory": "nyc/.nyc_output",
     "cache-dir": "nyc/.cache",
-    "report-dir": "nyc/report"
+    "report-dir": "nyc/report",
+    "exclude-after-remap": false
   }
 }

--- a/packages/server/gateway/package.json
+++ b/packages/server/gateway/package.json
@@ -170,6 +170,7 @@
     ],
     "temp-directory": "nyc/.nyc_output",
     "cache-dir": "nyc/.cache",
-    "report-dir": "nyc/report"
+    "report-dir": "nyc/report",
+    "exclude-after-remap": false
   }
 }

--- a/packages/server/local-test-server/package.json
+++ b/packages/server/local-test-server/package.json
@@ -89,6 +89,7 @@
     ],
     "temp-directory": "nyc/.nyc_output",
     "cache-dir": "nyc/.cache",
-    "report-dir": "nyc/report"
+    "report-dir": "nyc/report",
+    "exclude-after-remap": false
   }
 }

--- a/packages/test/end-to-end/package.json
+++ b/packages/test/end-to-end/package.json
@@ -80,6 +80,7 @@
     ],
     "temp-directory": "nyc/.nyc_output",
     "cache-dir": "nyc/.cache",
-    "report-dir": "nyc/report"
+    "report-dir": "nyc/report",
+    "exclude-after-remap": false
   }
 }

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -39,8 +39,30 @@
     "concurrently": "^4.1.0",
     "eslint": "^6.7.1",
     "mocha": "^5.2.0",
+    "mocha-junit-reporter": "^1.18.0",
+    "nyc": "^14.1.1",
     "rimraf": "^2.6.2",
     "tslint": "^5.20.0",
     "typescript": "~3.4.5"
+  },
+  "nyc": {
+    "all": true,
+    "exclude": [
+      "src/test/**/*.ts",
+      "dist/test/**/*.js"
+    ],
+    "include": [
+      "src/**/*.ts",
+      "dist/**/*.js"
+    ],
+    "reporter": [
+      "cobertura",
+      "html",
+      "text"
+    ],
+    "temp-directory": "nyc/.nyc_output",
+    "cache-dir": "nyc/.cache",
+    "report-dir": "nyc/report",
+    "exclude-after-remap": false
   }
 }

--- a/packages/tools/webpack-component-loader/package.json
+++ b/packages/tools/webpack-component-loader/package.json
@@ -85,6 +85,7 @@
     ],
     "temp-directory": "nyc/.nyc_output",
     "cache-dir": "nyc/.cache",
-    "report-dir": "nyc/report"
+    "report-dir": "nyc/report",
+    "exclude-after-remap": false
   }
 }

--- a/samples/chaincode/tourofheroes/package.json
+++ b/samples/chaincode/tourofheroes/package.json
@@ -36,6 +36,7 @@
     "@angular/platform-browser-dynamic": "^7.2.7",
     "@angular/router": "^7.2.7",
     "@microsoft/fluid-aqueduct": "^0.13.0",
+    "@microsoft/fluid-component-core-interfaces": "^0.13.0",
     "@microsoft/fluid-container-definitions": "^0.13.0",
     "@microsoft/fluid-container-runtime": "^0.13.0",
     "@microsoft/fluid-map": "^0.13.0",


### PR DESCRIPTION
exclude-after-remap needs to be set to false for nyc to collect data from ts file with source maps.