### PR TITLE
Allow for redis connection to be made over SSL and with a password

### DIFF
--- a/packages/server/gateway/src/app.ts
+++ b/packages/server/gateway/src/app.ts
@@ -122,7 +122,7 @@ export function create(
         const redisHost = config.get("redis:host");
         const redisPort = config.get("redis:port");
         const redisPass = config.get("redis:pass");
-        const options: any = { auth_pass: redisPass };
+        const options: redis.ClientOpts = { password: redisPass, auth_pass: redisPass };
         if (config.get("redis:tls")) {
             options.tls = {
                 servername: redisHost,

--- a/packages/server/gateway/src/app.ts
+++ b/packages/server/gateway/src/app.ts
@@ -122,7 +122,7 @@ export function create(
         const redisHost = config.get("redis:host");
         const redisPort = config.get("redis:port");
         const redisPass = config.get("redis:pass");
-        const options: redis.ClientOpts = { password: redisPass, auth_pass: redisPass };
+        const options: redis.ClientOpts = { auth_pass: redisPass };
         if (config.get("redis:tls")) {
             options.tls = {
                 servername: redisHost,

--- a/packages/server/gateway/src/runnerFactory.ts
+++ b/packages/server/gateway/src/runnerFactory.ts
@@ -36,6 +36,12 @@ export class GatewayResourcesFactory implements utils.IResourcesFactory<GatewayR
     public async create(config: Provider): Promise<GatewayResources> {
         // Producer used to publish messages
         const redisConfig = config.get("redis");
+        const options: redis.ClientOpts = { auth_pass: redisConfig.pass };
+        if (redisConfig.tls) {
+            options.tls = {
+                servername: redisConfig.host,
+            };
+        }
 
         // Database connection
         const mongoUrl = config.get("mongo:endpoint") as string;
@@ -53,7 +59,7 @@ export class GatewayResourcesFactory implements utils.IResourcesFactory<GatewayR
             false);
 
         // Redis connection
-        const redisClient = redis.createClient(redisConfig.port, redisConfig.host);
+        const redisClient = redis.createClient(redisConfig.port, redisConfig.host, options);
         const redisCache = new services.RedisCache(redisClient);
 
         // Tenants attached to the apps this service exposes

--- a/server/admin/charts/admin/templates/configmap.yaml
+++ b/server/admin/charts/admin/templates/configmap.yaml
@@ -58,8 +58,10 @@ data:
             "endpoint" : "{{ .Values.error.endpoint }}"
         },
         "redis": {
-            "host": "{{ .Values.endpoints.redis }}",
-            "port": 6379
+            "host": "{{ .Values.endpoints.redis.url }}",
+            "port": "{{ .Values.endpoints.redis.port }}"",
+            "tls": {{ .Values.endpoints.redis.tls }},
+            "pass": "{{ .Values.endpoints.redis.password }}"
         },
         "keyValue": {
             "documentUrl": "{{ .Values.endpoints.keyValueUrl }}",

--- a/server/admin/charts/tools/generateChart.js
+++ b/server/admin/charts/tools/generateChart.js
@@ -61,7 +61,10 @@ ingress:
 endpoints:
   mongodb: mongodb://quieting-guppy-mongodb:27017
   kafka: left-numbat-zookeeper:2181
-  redis: winsome-wombat-redis
+  redis:
+    url: winsome-wombat-redis
+    port: 6379
+    tls: false
   tenantsUrl: https://admin.wu2.prague.office-int.com
   historianUrl: https://historian.wu2.prague.office-int.com
   riddlerUrl: http://pesky-platypus-riddler

--- a/server/admin/src/app.ts
+++ b/server/admin/src/app.ts
@@ -103,7 +103,7 @@ export function create(config: Provider, mongoManager: core.MongoManager) {
         const redisHost = config.get("redis:host");
         const redisPort = config.get("redis:port");
         const redisPass = config.get("redis:pass");
-        const options: any = { auth_pass: redisPass };
+        const options: redis.ClientOpts  = { auth_pass: redisPass };
         if (config.get("redis:tls")) {
             options.tls = {
                 servername: redisHost,

--- a/server/charts/historian/templates/historian-configmap.yaml
+++ b/server/charts/historian/templates/historian-configmap.yaml
@@ -21,7 +21,9 @@ data:
         "requestSizeLimit": "1gb",
         "riddler": "{{ .Values.historian.riddler }}",
         "redis": {
-            "host": "{{ .Values.historian.redis }}",
-            "port": 6379
+            "host": "{{ .Values.historian.redis.url }}",
+            "port": "{{ .Values.historian.redis.port }}"",
+            "tls": {{ .Values.historian.redis.tls }},
+            "pass": "{{ .Values.historian.redis.password }}"
         }
     }

--- a/server/charts/historian/values.yaml
+++ b/server/charts/historian/values.yaml
@@ -5,7 +5,10 @@ imagePullPolicy: IfNotPresent
 historian:
   name: historian
   image: prague.azurecr.io/historian:4049
-  redis: lumpy-condor-redis
+  redis:
+    url: lumpy-condor-redis
+    port: 6379
+    tls: false
   host: historian.wu2.prague.office-int.com
   cert: wu2-tls-certificate
   ingressClass: nginx-prod

--- a/server/headless-agent/charts/headless-agent/templates/configmap.yaml
+++ b/server/headless-agent/charts/headless-agent/templates/configmap.yaml
@@ -26,8 +26,10 @@ data:
             }
         },
         "redis": {
-            "host": "{{ .Values.endpoints.redis }}",
-            "port": 6379
+            "host": "{{ .Values.endpoints.redis.url }}",
+            "port": "{{ .Values.endpoints.redis.port }}"",
+            "tls": {{ .Values.endpoints.redis.tls }},
+            "pass": "{{ .Values.endpoints.redis.password }}"
         },
         "system": {
             "topics": {

--- a/server/headless-agent/charts/tools/generateChart.js
+++ b/server/headless-agent/charts/tools/generateChart.js
@@ -55,7 +55,10 @@ endpoints:
   packageUrl: https://pragueauspkn-3873244262.azureedge.net
   historianUrl: https://historian.wu2.prague.office-int.com
   rabbitmq: ""
-  redis: winsome-wombat-redis
+  redis:
+    url: winsome-wombat-redis
+    port: 6379
+    tls: false
 `;
 
 const writeFileAsync = util.promisify(fs.writeFile);

--- a/server/headless-agent/src/runnerFactory.ts
+++ b/server/headless-agent/src/runnerFactory.ts
@@ -29,10 +29,17 @@ export class HeadlessResourcesFactory implements utils.IResourcesFactory<Headles
     public async create(config: Provider): Promise<HeadlessResources> {
         const rabbitmqConfig = config.get("rabbitmq");
         const redisConfig = config.get("redis");
+        const redisOptions: redis.ClientOpts = { password: redisConfig.pass };
+        if (redisConfig.tls) {
+            redisOptions.tls = {
+                serverName: redisConfig.host,
+            };
+        }
+        
         const workerConfig = config.get("worker");
         const queueName = config.get("headless-agent:queue");
 
-        const redisClient = redis.createClient(redisConfig.port, redisConfig.host);
+        const redisClient = redis.createClient(redisConfig.port, redisConfig.host, redisOptions);
         const cache = new RedisCache(redisClient);
         const messageReceiver = services.createMessageReceiver(rabbitmqConfig, queueName);
 

--- a/server/historian/src/www.ts
+++ b/server/historian/src/www.ts
@@ -45,6 +45,13 @@ const riddlerEndpoint = provider.get("riddler");
 const riddler = new services.RiddlerService(riddlerEndpoint);
 
 const redisConfig = provider.get("redis");
+const redisOptions: redis.ClientOpts = { password: redisConfig.pass };
+if (redisConfig.tls) {
+    redisOptions.tls = {
+        serverName: redisConfig.host,
+    };
+}
+
 const redisClient = redis.createClient(redisConfig.port, redisConfig.host);
 const cache = new services.RedisCache(redisClient);
 

--- a/server/routerlicious/kubernetes/gateway/templates/configmap.yaml
+++ b/server/routerlicious/kubernetes/gateway/templates/configmap.yaml
@@ -64,7 +64,9 @@ data:
         },
         "redis": {
             "host": "{{ .Values.redis.url }}",
-            "port": 6379
+            "port": "{{ .Values.redis.port }}"",
+            "tls": {{ .Values.redis.tls }},
+            "pass": "{{ .Values.redis.password }}"
         },
         "error": {
             "track": {{ .Values.error.track }},

--- a/server/routerlicious/kubernetes/gateway/tools/generateChart.js
+++ b/server/routerlicious/kubernetes/gateway/tools/generateChart.js
@@ -73,6 +73,8 @@ mongodb:
 
 redis:
   url: winsome-wombat-redis
+  port: 6379
+  tls: false
 
 riddler:
   url: http://pesky-platypus-riddler

--- a/server/routerlicious/kubernetes/jarvis/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/jarvis/templates/fluid-configmap.yaml
@@ -119,7 +119,9 @@ data:
         },
         "redis": {
             "host": "{{ .Values.redis.url }}",
-            "port": 6379
+            "port": "{{ .Values.redis.port }}"",
+            "tls": {{ .Values.redis.tls }},
+            "pass": "{{ .Values.redis.password }}"
         },
         "error": {
             "track": true,

--- a/server/routerlicious/kubernetes/jarvis/values.yaml
+++ b/server/routerlicious/kubernetes/jarvis/values.yaml
@@ -52,6 +52,8 @@ mongodb:
 
 redis:
   url: punk-dachshund-redis
+  port: 6379
+  tls: false
 
 kafka:
   url: youngling-heron-kafka

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -167,7 +167,9 @@ data:
         },
         "redis": {
             "host": "{{ .Values.redis.url }}",
-            "port": 6379
+            "port": "{{ .Values.redis.port }}",
+            "pass": "{{ .Values.redis.password }}",
+            "tls": {{ .Values.redis.tls }}
         },
         "redis2": {
             "host": "{{ .Values.redis2.url }}",

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -172,7 +172,7 @@ data:
         "redis2": {
             "host": "{{ .Values.redis2.url }}",
             "port": "{{ .Values.redis2.port }}",
-            "pass": "{{ .Values.redis2.password }}"
+            "pass": "{{ .Values.redis2.password }}",
             "tls": {{ .Values.redis2.tls }}
         },
         "error": {

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -171,7 +171,8 @@ data:
         },
         "redis2": {
             "host": "{{ .Values.redis2.url }}",
-            "port": 6379
+            "port": "{{ .Values.redis2.port }}",
+            "pass": "{{ .Values.redis2.password }}"
         },
         "error": {
             "track": {{ .Values.error.track }},

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -173,6 +173,7 @@ data:
             "host": "{{ .Values.redis2.url }}",
             "port": "{{ .Values.redis2.port }}",
             "pass": "{{ .Values.redis2.password }}"
+            "tls": {{ .Values.redis2.tls }}
         },
         "error": {
             "track": {{ .Values.error.track }},

--- a/server/routerlicious/kubernetes/tools/generateChart.js
+++ b/server/routerlicious/kubernetes/tools/generateChart.js
@@ -135,6 +135,8 @@ redis:
 
 redis2:
   url: dining-maltese-redis
+  port: 6379
+  tls: false
 
 kafka:
   topics:

--- a/server/routerlicious/kubernetes/tools/generateChart.js
+++ b/server/routerlicious/kubernetes/tools/generateChart.js
@@ -130,6 +130,8 @@ mongodb:
 
 redis:
   url: winsome-wombat-redis
+  port: 6379
+  tls: false
 
 redis2:
   url: dining-maltese-redis

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -163,11 +163,13 @@
     },
     "redis": {
         "host": "redis",
-        "port": 6379
+        "port": 6379,
+        "tls": false
     },
     "redis2": {
         "host": "redis",
-        "port": 6379
+        "port": 6379,
+        "tls": false
     },
     "error": {
         "track": false,

--- a/server/routerlicious/packages/routerlicious/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious/src/alfred/runnerFactory.ts
@@ -116,9 +116,9 @@ export class AlfredResourcesFactory implements utils.IResourcesFactory<AlfredRes
         const webSocketLibrary = config.get("alfred:webSocketLib");
         const authEndpoint = config.get("auth:endpoint");
 
-        // Redis connection for client manaeger.
+        // Redis connection for client manager.
         const redisConfig2 = config.get("redis2");
-        const redisClient = redis.createClient(redisConfig2.port, redisConfig2.host);
+        const redisClient = redis.createClient(redisConfig2.port, redisConfig2.host, { auth_pass: redisConfig2.pass});
         const clientManager = new services.ClientManager(redisClient);
 
         // Database connection

--- a/server/routerlicious/packages/routerlicious/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious/src/alfred/runnerFactory.ts
@@ -118,7 +118,12 @@ export class AlfredResourcesFactory implements utils.IResourcesFactory<AlfredRes
 
         // Redis connection for client manager.
         const redisConfig2 = config.get("redis2");
-        const redisClient = redis.createClient(redisConfig2.port, redisConfig2.host, { auth_pass: redisConfig2.pass});
+        const redisClient = redis.createClient(
+            redisConfig2.port,
+            redisConfig2.host,
+            {
+                password: redisConfig2.pass
+            });
         const clientManager = new services.ClientManager(redisClient);
 
         // Database connection

--- a/server/routerlicious/packages/routerlicious/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious/src/alfred/runnerFactory.ts
@@ -118,12 +118,16 @@ export class AlfredResourcesFactory implements utils.IResourcesFactory<AlfredRes
 
         // Redis connection for client manager.
         const redisConfig2 = config.get("redis2");
+        const redisOptions2: redis.ClientOpts = { password: redisConfig2.pass };
+        if (redisConfig2.tls) {
+            redisOptions2.tls = {
+                serverName: redisConfig2.host,
+            };
+        }
         const redisClient = redis.createClient(
             redisConfig2.port,
             redisConfig2.host,
-            {
-                password: redisConfig2.pass
-            });
+            redisOptions2);
         const clientManager = new services.ClientManager(redisClient);
 
         // Database connection

--- a/server/routerlicious/packages/routerlicious/src/broadcaster/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/broadcaster/index.ts
@@ -10,7 +10,14 @@ import { Provider } from "nconf";
 
 export async function create(config: Provider): Promise<IPartitionLambdaFactory> {
     const redisConfig = config.get("redis");
-    const publisher = new services.SocketIoRedisPublisher(redisConfig.port, redisConfig.host);
+    const redisOptions: any = { password: redisConfig.pass };
+    if (redisConfig.tls) {
+        redisOptions.tls = {
+            serverName: redisConfig.host,
+        };
+    }
+
+    const publisher = new services.SocketIoRedisPublisher(redisConfig.port, redisConfig.host, redisOptions);
 
     return new BroadcasterLambdaFactory(publisher);
 }

--- a/server/routerlicious/packages/services/src/socketIoRedisPublisher.ts
+++ b/server/routerlicious/packages/services/src/socketIoRedisPublisher.ts
@@ -23,8 +23,8 @@ export class SocketIoRedisPublisher implements core.IPublisher {
     private io: any;
     private events = new EventEmitter();
 
-    constructor(port: number, host: string) {
-        this.redisClient = redis.createClient(port, host);
+    constructor(port: number, host: string, options: any) {
+        this.redisClient = redis.createClient(port, host, options);
         this.io = socketIoEmitter(this.redisClient);
 
         this.redisClient.on("error", (error) => {

--- a/server/service/src/bbc/index.ts
+++ b/server/service/src/bbc/index.ts
@@ -10,7 +10,14 @@ import { BBCLambdaFactory } from "./lambdaFactory";
 
 export async function create(config: Provider): Promise<IPartitionLambdaFactory> {
     const redisConfig = config.get("redis");
-    const publisher = redis.createClient(redisConfig.port, redisConfig.host);
+    const redisOptions: redis.ClientOpts = { password: redisConfig.pass };
+    if (redisConfig.tls) {
+        redisOptions.tls = {
+            serverName: redisConfig.host,
+        };
+    }
+
+    const publisher = redis.createClient(redisConfig.port, redisConfig.host, redisOptions);
 
     return new BBCLambdaFactory(publisher);
 }

--- a/server/service/src/jarvis/io.ts
+++ b/server/service/src/jarvis/io.ts
@@ -194,10 +194,10 @@ export function register(
     httpServer: http.Server,
     orderFactory: OrdererManager,
     tenantManager: core.ITenantManager,
-    redisConfig: { host: string, port: number }) {
+    redisConfig: { host: string, port: number, options: any }) {
 
     const webSocketServer = new ws.Server({ server: httpServer });
-    const subscriber = new RedisSubscriptionManager(redisConfig.host, redisConfig.port);
+    const subscriber = new RedisSubscriptionManager(redisConfig.host, redisConfig.port, redisConfig.options);
 
     webSocketServer.on("connection", (socket: ws) => {
         SocketConnection.attach(

--- a/server/service/src/jarvis/runner.ts
+++ b/server/service/src/jarvis/runner.ts
@@ -42,7 +42,14 @@ export class JarvisRunner implements utils.IRunner {
         alfred.set("port", this.port);
 
         this.server = http.createServer(alfred);
-        const redis = this.config.get("redis");
+        const redisConfig = this.config.get("redis");
+        const redisOptions: any = { password: redisConfig.pass };
+        if (redisConfig.tls) {
+            redisOptions.tls = {
+                serverName: redisConfig.host,
+            };
+        }
+        const redis = { host: redisConfig.host, port: redisConfig.port, options: redisOptions}
 
         // Register all the socket.io stuff
         io.register(

--- a/server/service/src/jarvis/subscriptions.ts
+++ b/server/service/src/jarvis/subscriptions.ts
@@ -16,8 +16,8 @@ export class RedisSubscriptionManager {
     private client: redis.RedisClient;
     private subscriptions = new Map<string, ISubscriptionDetails>();
 
-    constructor(host: string, port: number) {
-        this.client = redis.createClient(port, host);
+    constructor(host: string, port: number, options: any) {
+        this.client = redis.createClient(port, host, options);
 
         this.client.on("message", (topic, messageStr) => {
             const details = this.subscriptions.get(topic);


### PR DESCRIPTION
This allows TEO to switch from in-cluster Redis deployment to Azure Cache for Redis for our Teolicious deployment.

There might have to be some changes made in the build definitions to make this work.