### PR TITLE
iframe-driver shouldn't depend on IHost from container-definitions

### DIFF
--- a/packages/drivers/iframe-socket-storage/package.json
+++ b/packages/drivers/iframe-socket-storage/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "@microsoft/fluid-component-core-interfaces": "^0.13.0",
-    "@microsoft/fluid-container-definitions": "^0.13.0",
     "@microsoft/fluid-core-utils": "^0.13.0",
     "@microsoft/fluid-driver-definitions": "^0.13.0",
     "@microsoft/fluid-driver-utils": "^0.13.0",

--- a/packages/drivers/replay-socket-storage/package.json
+++ b/packages/drivers/replay-socket-storage/package.json
@@ -25,7 +25,6 @@
     "tslint": "tslint --project tsconfig.json --format verbose"
   },
   "dependencies": {
-    "@microsoft/fluid-core-utils": "^0.13.0",
     "@microsoft/fluid-driver-definitions": "^0.13.0",
     "@microsoft/fluid-protocol-base": "^0.12.0",
     "@microsoft/fluid-protocol-definitions": "^0.12.0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -28,18 +28,14 @@
     "tslint": "npm run eslint"
   },
   "dependencies": {
-    "@microsoft/fluid-common-definitions": "^0.13.0",
     "@microsoft/fluid-component-core-interfaces": "^0.13.0",
-    "@microsoft/fluid-gitresources": "^0.12.0",
-    "@microsoft/fluid-protocol-definitions": "^0.12.0",
-    "debug": "^4.1.1"
+    "@microsoft/fluid-protocol-definitions": "^0.12.0"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.4.4",
     "@microsoft/eslint-config-fluid": "^0.13.0",
     "@microsoft/fluid-build-common": "^0.13.0",
     "@types/benchmark": "^1.0.31",
-    "@types/debug": "^0.0.31",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.14.6",
     "@typescript-eslint/eslint-plugin": "^2.9.0",

--- a/packages/server/gateway/src/controllers/loaderHost.ts
+++ b/packages/server/gateway/src/controllers/loaderHost.ts
@@ -73,6 +73,6 @@ export async function initialize(
         document.getElementById("ifr") as HTMLIFrameElement,
         // privateSession.frame,
         options,
-        { resolver },
+        resolver,
     )).createDocumentServiceFromRequest({ url });
 }

--- a/tools/fluid-build/src/npmDepChecker.ts
+++ b/tools/fluid-build/src/npmDepChecker.ts
@@ -5,6 +5,7 @@
 
 import { readFileAsync } from "./common/utils";
 import { Package } from "./npmPackage";
+import { logVerbose } from "./common/logging";
 
 interface DepCheckRecord {
     name: string,
@@ -65,6 +66,7 @@ export class NpmDepChecker {
                     continue;
                 }
                 if (!record.import.test(content) && !record.declare.test(content)) {
+                    logVerbose(`${this.pkg.nameColored}: ${record.name} found in ${tsFile}`);
                     continue;
                 }
                 record.found = true;


### PR DESCRIPTION
It only need the url resolver in it, so we should just pass it in directly.