### PR TITLE
Add IProvideComponentHTMLView interface as partial to IComponent

### DIFF
--- a/packages/loader/component-core-interfaces/src/componentRender.ts
+++ b/packages/loader/component-core-interfaces/src/componentRender.ts
@@ -26,6 +26,10 @@ export interface IComponentHTMLView extends IComponentHTMLRender {
     remove(): void;
 }
 
+export interface IProvideComponentHTMLView {
+    readonly IComponentHTMLView: IComponentHTMLView
+}
+
 export interface IProvideComponentHTMLVisual {
     readonly IComponentHTMLVisual: IComponentHTMLVisual;
 }

--- a/packages/loader/component-core-interfaces/src/components.ts
+++ b/packages/loader/component-core-interfaces/src/components.ts
@@ -8,7 +8,7 @@ import {
     IProvideComponentLoadable,
     IProvideComponentRunnable,
 } from "./componentLoadable";
-import { IProvideComponentHTMLVisual } from "./componentRender";
+import { IProvideComponentHTMLVisual, IProvideComponentHTMLView } from "./componentRender";
 import { IProvideComponentRouter } from "./componentRouter";
 import { IProvideComponentHandle, IProvideComponentHandleContext } from "./handles";
 import { IProvideComponentSerializer } from "./serializer";
@@ -16,6 +16,7 @@ import { IProvideComponentSerializer } from "./serializer";
 export interface IComponent extends
     Readonly<Partial<
         IProvideComponentHTMLVisual
+        & IProvideComponentHTMLView
         & IProvideComponentLoadable
         & IProvideComponentRunnable
         & IProvideComponentRouter


### PR DESCRIPTION
Enable query and access of `IComponentHTMLView` interface  on `IComponent`.

# Use Case
`IComponentHTMLView` avails `remove()` utility called by component hosts to trigger proper disposal of  nested component views