### PR TITLE
Timer restart more efficiently

### DIFF
--- a/common/lib/common-utils/src/test/timer.spec.ts
+++ b/common/lib/common-utils/src/test/timer.spec.ts
@@ -1,0 +1,272 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { SinonFakeTimers, useFakeTimers } from "sinon";
+import { PromiseTimer, Timer, IPromiseTimerResult } from "../timer";
+
+const flushPromises = async () => new Promise((resolve) => process.nextTick(resolve));
+type PromiseTimerResultString = IPromiseTimerResult["timerResult"];
+
+describe("Timers", () => {
+    let clock: SinonFakeTimers;
+
+    before(() => {
+        clock = useFakeTimers();
+    });
+
+    afterEach(() => {
+        clock.reset();
+    });
+
+    after(() => {
+        clock.restore();
+    });
+
+    describe("Timer", () => {
+        let runCount = 0;
+        const defaultTimeout = 1000;
+        const defaultHandler = () => runCount++;
+        let timer: Timer;
+
+        beforeEach(() => {
+            runCount = 0;
+            timer = new Timer(defaultTimeout, defaultHandler);
+        });
+
+        afterEach(() => {
+            timer.clear();
+        });
+
+        const assertShouldNotRunYet = (initialRunCount = 0, getRunCount = () => runCount) => {
+            assert.strictEqual(getRunCount(), initialRunCount, "Should not run yet");
+        };
+
+        const assertShouldNotRunAgainAfterRestart = () => {
+            // Make sure only executes once
+            clock.tick(defaultTimeout + 1);
+            assert.strictEqual(runCount, 1, "Should not run additional times after restart");
+        };
+
+        const testExactTimeout = (time: number, getRunCount = () => runCount) => {
+            const initialRunCount = getRunCount();
+            clock.tick(time - 1);
+            assertShouldNotRunYet(initialRunCount, getRunCount);
+            clock.tick(1);
+            assert.strictEqual(getRunCount(), initialRunCount + 1, "Should run exactly once");
+        };
+
+        it("Should timeout at default time", () => {
+            timer.start();
+            testExactTimeout(defaultTimeout);
+        });
+
+        it("Should timeout at longer explicit time", () => {
+            const overrideTimeout = defaultTimeout * 2;
+            timer.start(overrideTimeout);
+            testExactTimeout(overrideTimeout);
+        });
+
+        it("Should timeout at shorter explicit time", () => {
+            const overrideTimeout = defaultTimeout - 10;
+            timer.start(overrideTimeout);
+            testExactTimeout(overrideTimeout);
+        });
+
+        it("Should be reusable multiple times", () => {
+            timer.start();
+            testExactTimeout(defaultTimeout);
+
+            const overrideTimeout = defaultTimeout + 10;
+            timer.start(overrideTimeout);
+            testExactTimeout(overrideTimeout);
+
+            timer.start();
+            testExactTimeout(defaultTimeout);
+        });
+
+        it("Should clear running timeout", () => {
+            timer.start();
+            clock.tick(defaultTimeout - 1);
+            assertShouldNotRunYet();
+            timer.clear();
+            clock.tick(1);
+            assert.strictEqual(runCount, 0, "Should not run after cleared");
+
+            // Make extra sure
+            clock.tick(defaultTimeout + 1);
+            assert.strictEqual(runCount, 0, "Should never run after cleared");
+        });
+
+        it("Should restart with defaults", () => {
+            // Elapse all but 10ms, then restart
+            timer.start();
+            clock.tick(defaultTimeout - 10);
+            assertShouldNotRunYet();
+
+            timer.restart();
+            testExactTimeout(defaultTimeout);
+
+            assertShouldNotRunAgainAfterRestart();
+        });
+
+        it("Should restart with previously overridden handler", () => {
+            let specialRunCount = 0;
+            timer.start(undefined, () => specialRunCount++);
+            clock.tick(defaultTimeout - 10);
+            assertShouldNotRunYet(0, () => specialRunCount);
+
+            timer.restart();
+            testExactTimeout(defaultTimeout, () => specialRunCount);
+            assert.strictEqual(runCount, 0, "Should not run default handler");
+        });
+
+        it("Should restart with explicit handler", () => {
+            let specialRunCount = 0;
+            timer.start();
+            clock.tick(defaultTimeout - 10);
+            assertShouldNotRunYet();
+
+            timer.restart(undefined, () => specialRunCount++);
+            testExactTimeout(defaultTimeout, () => specialRunCount);
+            assert.strictEqual(runCount, 0, "Should not run default handler");
+        });
+
+        it("Should restart with override time > remaining time", () => {
+            // Test: restart duration (15) > remaining time (10)
+            const restartTimeout = 15;
+            timer.start();
+            clock.tick(defaultTimeout - 10);
+            assertShouldNotRunYet();
+
+            timer.restart(restartTimeout);
+            testExactTimeout(restartTimeout);
+
+            assertShouldNotRunAgainAfterRestart();
+        });
+
+        it("Should restart with override time < remaining time", () => {
+            // Test: restart duration (5) < remaining time (10)
+            const restartTimeout = 5;
+            timer.start();
+            clock.tick(defaultTimeout - 10);
+            assertShouldNotRunYet();
+
+            timer.restart(restartTimeout);
+            testExactTimeout(restartTimeout);
+
+            assertShouldNotRunAgainAfterRestart();
+        });
+
+        it("Should handle consecutive restarts", () => {
+            timer.start();
+            clock.tick(defaultTimeout - 10);
+            assertShouldNotRunYet();
+
+            // 10 ms remaining
+            timer.restart();
+            clock.tick(defaultTimeout - 5);
+            assertShouldNotRunYet();
+
+            // 5 ms remaining
+            timer.restart();
+            clock.tick(defaultTimeout - 2);
+            assertShouldNotRunYet();
+
+            // 2 ms remaining
+            timer.restart();
+            clock.tick(defaultTimeout - 1);
+            assertShouldNotRunYet();
+
+            // 1 ms remaining
+            timer.restart();
+            testExactTimeout(defaultTimeout);
+
+            // 0 ms remaining; should behave as regular start now
+            timer.restart();
+            testExactTimeout(defaultTimeout);
+        });
+    });
+
+    describe("PromiseTimer", () => {
+        let runCount = 0;
+        let resolveResult: PromiseTimerResultString | undefined;
+        const defaultTimeout = 1000;
+        const defaultHandler = () => runCount++;
+        let timer: PromiseTimer;
+
+        beforeEach(() => {
+            runCount = 0;
+            resolveResult = undefined;
+            timer = new PromiseTimer(defaultTimeout, defaultHandler);
+        });
+
+        afterEach(() => {
+            timer.clear();
+        });
+
+        function startWithThen(ms?: number, handler?: () => void) {
+            timer.start(ms, handler).then(
+                (result) => resolveResult = result.timerResult,
+                (error) => assert.fail(error),
+            );
+        }
+
+        async function tickAndFlush(ms: number) {
+            clock.tick(ms);
+            await flushPromises();
+        }
+
+        const assertShouldNotRunYet = (initialRunCount = 0, getRunCount = () => runCount) => {
+            assert.strictEqual(getRunCount(), initialRunCount, "Should not run yet");
+            assert.strictEqual(resolveResult, undefined, "Run promise should not be resolved yet");
+        };
+
+        const testExactTimeout = async (time: number, getRunCount = () => runCount) => {
+            const initialRunCount = getRunCount();
+            await tickAndFlush(time - 1);
+            assertShouldNotRunYet(initialRunCount, getRunCount);
+            clock.tick(1);
+            assert.strictEqual(getRunCount(), initialRunCount + 1, "Should run exactly once");
+            assert(resolveResult === "timeout", "Run promise should be resolved");
+        };
+
+        it("Should timeout at default time and resolve", async () => {
+            startWithThen();
+            await testExactTimeout(defaultTimeout);
+        });
+
+        it("Should timeout at longer explicit timeout and resolve", async () => {
+            const overrideTimeout = defaultTimeout * 2;
+            startWithThen(overrideTimeout);
+
+            await testExactTimeout(overrideTimeout);
+        });
+
+        it("Should timeout at shorter explicit timeout and resolve", async () => {
+            const overrideTimeout = defaultTimeout - 10;
+            startWithThen(overrideTimeout);
+
+            await testExactTimeout(overrideTimeout);
+        });
+
+        it("Should clear running timeout and resolve as canceled", async () => {
+            startWithThen();
+            await tickAndFlush(defaultTimeout - 1);
+            assertShouldNotRunYet();
+
+            timer.clear();
+            await flushPromises();
+            assert(resolveResult === "cancel", "Run promise should be resolved as cancel");
+
+            await tickAndFlush(1);
+            assert.strictEqual(runCount, 0, "Should not run after cleared");
+
+            // Make extra sure
+            clock.tick(defaultTimeout + 1);
+            assert.strictEqual(runCount, 0, "Should never run after cleared");
+        });
+    });
+});


### PR DESCRIPTION
Add `restart` function to Timer which provides a potentially more efficient way to restart the timer.

Also added unit tests to Timer and PromiseTimer.

In order to avoid calls to clearTimeout and setTimeout, when `restart` is called with a duration > the remaining time of the currently running timeout, an optimization is made to store the data needed for the restart and then call setTimeout in the handler of the currently running timeout for the remaining restart duration.

Easier to understand with example:
- at 0ms start timer with duration 50 ms: call setTimeout with 50 ms
- at 5ms call restart: store the current tick as a pending restart
- at 10ms call restart: override the pending restart with the new current tick
- at 50ms: first timeout will expire, but handler will see pending restart and call setTimeout with 10ms (50 - (50 - (10 - 0))) instead of executing the handler
- at 60ms: new timeout will expire with no pending restart, and execute the handler

This is in response to issue #765 which pointed out excessive calls to clearTimeout/setTimeout.
For the summarizer heuristics, every inbound op restarts the "idle" timer.  This meant there was a call to clearTimeout + setTimeout on each op.  Now it will only need to incur the setTimeout call the first time and at less frequency afterwards (remainingTime).