### PR TITLE
Fix: getItems on SharedSequence doesn't respect range

### DIFF
--- a/packages/runtime/sequence/src/sharedSequence.ts
+++ b/packages/runtime/sequence/src/sharedSequence.ts
@@ -150,10 +150,19 @@ export class SharedSequence<T> extends SharedSegmentSequence<SubSequence<T>> {
      */
     public getItems(start: number, end?: number): T[] {
         const items: T[] = [];
+        let firstSegment: ISegment;
+
+        // Return if the range is incorrect.
+        if (end !== undefined && end <= start) {
+            return items;
+        }
 
         this.walkSegments(
             (segment: ISegment) => {
                 if (SubSequence.is(segment)) {
+                    if (firstSegment === undefined) {
+                        firstSegment = segment;
+                    }
                     items.push(...segment.items);
                 }
                 return true;
@@ -161,6 +170,17 @@ export class SharedSequence<T> extends SharedSegmentSequence<SubSequence<T>> {
             start,
             end);
 
+        // The above call to walkSegments adds all the items in the walked
+        // segments. However, we only want items beginning at |start| in
+        // the first segment. Similarly, if |end| is passed in, we only
+        // want items until |end| in the last segment. Remove the rest of
+        // the items.
+        if (firstSegment !== undefined) {
+            items.splice(0, start - this.getPosition(firstSegment));
+        }
+        if (end !== undefined) {
+            items.splice(end - start);
+        }
         return items;
     }
 }

--- a/packages/runtime/sequence/src/test/sharedNumberSequence.spec.ts
+++ b/packages/runtime/sequence/src/test/sharedNumberSequence.spec.ts
@@ -1,0 +1,60 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { MockDeltaConnectionFactory, MockRuntime, MockStorage } from "@microsoft/fluid-test-runtime-utils";
+import * as assert from "assert";
+import { SharedNumberSequence } from "../sharedNumberSequence";
+
+describe("SharedNumberSequence", () => {
+    const documentId = "fakeId";
+    let deltaConnectionFactory: MockDeltaConnectionFactory;
+    let sharedNumberSequence: SharedNumberSequence;
+    beforeEach(() => {
+        const runtime = new MockRuntime();
+        deltaConnectionFactory = new MockDeltaConnectionFactory();
+        sharedNumberSequence = new SharedNumberSequence(runtime, documentId);
+        runtime.services = {
+            deltaConnection: deltaConnectionFactory.createDeltaConnection(runtime),
+            objectStorage: new MockStorage(undefined),
+        };
+        runtime.attach();
+    });
+
+    describe("getItems", () => {
+        it("insert and get items", async () => {
+            sharedNumberSequence.insert(0, [2, 11], undefined);
+            sharedNumberSequence.insert(0, [4, 5, 6], undefined);
+            sharedNumberSequence.insert(5, [1, 5, 6, 2, 3], undefined);
+            sharedNumberSequence.insert(0, [9, 12], undefined);
+
+            let items = sharedNumberSequence.getItems(1, 6);
+            console.log(items);
+            assert(verifyItems(items, [12, 4, 5, 6, 2]));
+
+            items = sharedNumberSequence.getItems(4, 10);
+            console.log(items);
+            assert(verifyItems(items, [6, 2, 11, 1, 5, 6]));
+
+            items = sharedNumberSequence.getItems(0);
+            console.log(items);
+            assert(verifyItems(items, [9, 12, 4, 5, 6, 2, 11, 1, 5, 6, 2, 3]));
+
+            items = sharedNumberSequence.getItems(1, 1);
+            console.log(items);
+            assert(verifyItems(items, []));
+        });
+
+        function verifyItems(actual: Number[], expected: Number[]) : boolean {
+            if (actual.length !== expected.length) {
+                return false;
+            }
+            for (let i = 0; i < expected.length; i++) {
+                if (actual[i] != expected[i]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    });
+});

--- a/packages/runtime/sequence/src/test/sharedNumberSequence.spec.ts
+++ b/packages/runtime/sequence/src/test/sharedNumberSequence.spec.ts
@@ -45,12 +45,12 @@ describe("SharedNumberSequence", () => {
             assert(verifyItems(items, []));
         });
 
-        function verifyItems(actual: Number[], expected: Number[]) : boolean {
+        function verifyItems(actual: number[], expected: number[]): boolean {
             if (actual.length !== expected.length) {
                 return false;
             }
             for (let i = 0; i < expected.length; i++) {
-                if (actual[i] != expected[i]) {
+                if (actual[i] !== expected[i]) {
                     return false;
                 }
             }


### PR DESCRIPTION
Fixes #688 
In getItems, trimmed the items returned by walkSegments as per the passed range. Added test for verifying the same.