### PR TITLE
add @microsoft/fluid-component-core-interfaces to tour of heros

### DIFF
--- a/samples/chaincode/tourofheroes/package.json
+++ b/samples/chaincode/tourofheroes/package.json
@@ -40,6 +40,7 @@
     "@microsoft/fluid-container-runtime": "^0.12.0",
     "@microsoft/fluid-map": "^0.12.0",
     "@microsoft/fluid-runtime-definitions": "^0.12.0",
+    "@microsoft/fluid-component-core-interfaces": "^0.12.0",
     "@types/react": "^16.9.2",
     "angular-in-memory-web-api": "^0.8.0",
     "core-js": "^2.6.5",


### PR DESCRIPTION
There's a build break sometimes because `tourofheros` can't find `@microsoft/fluid-component-core-interfaces`.

Because of caching this can sometimes pass because it exists even though it's not referenced correctly.