### PR TITLE
[0.11] Revert baseSnapshot to be separate from summaryTracker.baseTree

### DIFF
--- a/packages/runtime/component-runtime/src/remoteChannelContext.ts
+++ b/packages/runtime/component-runtime/src/remoteChannelContext.ts
@@ -40,7 +40,7 @@ export class RemoteChannelContext implements IChannelContext {
         private readonly storageService: IDocumentStorageService,
         private readonly submitFn: (type: MessageType, content: any) => number,
         private readonly id: string,
-        baseSnapshot: ISnapshotTree,
+        private readonly baseSnapshot: ISnapshotTree,
         private readonly registry: ISharedObjectRegistry,
         private readonly extraBlobs: Map<string, string>,
         private readonly branch: string,
@@ -100,14 +100,9 @@ export class RemoteChannelContext implements IChannelContext {
     }
 
     private getAttributesFromBaseTree(): Promise<RequiredIChannelAttributes> {
-        const baseTree = this.summaryTracker.baseTree;
-        if (baseTree) {
-            return readAndParse<RequiredIChannelAttributes>(
-                this.storageService,
-                baseTree.blobs[".attributes"]);
-        } else {
-            throw new Error("Null base summary tree should not be possible for remote channel.");
-        }
+        return readAndParse<RequiredIChannelAttributes>(
+            this.storageService,
+            this.baseSnapshot.blobs[".attributes"]);
     }
 
     private async loadChannel(): Promise<IChannel> {
@@ -138,7 +133,7 @@ export class RemoteChannelContext implements IChannelContext {
             this.componentContext.connectionState,
             this.submitFn,
             this.storageService,
-            this.summaryTracker.baseTree === null ? undefined : this.summaryTracker.baseTree,
+            this.baseSnapshot,
             this.extraBlobs);
         this.channel = await factory.load(
             this.runtime,

--- a/packages/runtime/component-runtime/src/remoteChannelContext.ts
+++ b/packages/runtime/component-runtime/src/remoteChannelContext.ts
@@ -45,9 +45,7 @@ export class RemoteChannelContext implements IChannelContext {
         private readonly extraBlobs: Map<string, string>,
         private readonly branch: string,
         private readonly attributes: RequiredIChannelAttributes | undefined,
-    ) {
-        this.summaryTracker.setBaseTree(baseSnapshot);
-    }
+    ) {}
 
     public getChannel(): Promise<IChannel> {
         if (!this.channelP) {

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -181,6 +181,9 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
         if (!this.componentRuntimeDeferred) {
             this.componentRuntimeDeferred = new Deferred<IComponentRuntime>();
             const details = await this.getInitialSnapshotDetails();
+            // Base snapshot is the baseline where pending ops are applied to.
+            // It is important that this be in sync with the pending ops, and also
+            // that it is set here, before bindRuntime is called.
             this._baseSnapshot = details.snapshot;
             const packages = details.pkg;
             let entry: ComponentRegistryEntry;

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -136,7 +136,7 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
     }
 
     public get baseSnapshot(): ISnapshotTree {
-        return this.summaryTracker.baseTree;
+        return this._baseSnapshot;
     }
 
     protected componentRuntime: IComponentRuntime;
@@ -145,6 +145,7 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
     private loaded = false;
     private pending: ISequencedDocumentMessage[] = [];
     private componentRuntimeDeferred: Deferred<IComponentRuntime>;
+    private _baseSnapshot: ISnapshotTree;
 
     constructor(
         private readonly _hostRuntime: ContainerRuntime,
@@ -180,14 +181,7 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
         if (!this.componentRuntimeDeferred) {
             this.componentRuntimeDeferred = new Deferred<IComponentRuntime>();
             const details = await this.getInitialSnapshotDetails();
-            if (details.snapshot && !this.summaryTracker.baseTree) {
-                // do not overwrite if refreshed!
-                // local - will always give undefined tree, so never enter here
-                // remote - will give the tree at the time of construction (initial),
-                // which may be older than the refreshed one, but never newer than
-                // the refreshed or one set at constructor (in case of summarizer)
-                this.summaryTracker.setBaseTree(details.snapshot);
-            }
+            this._baseSnapshot = details.snapshot;
             const packages = details.pkg;
             let entry: ComponentRegistryEntry;
             let registry = this._hostRuntime.IComponentRegistry;
@@ -432,20 +426,12 @@ export class RemotedComponentContext extends ComponentContext {
             () => {
                 throw new Error("Already attached");
             });
-
-        if (initSnapshotValue && typeof initSnapshotValue !== "string") {
-            // This will allow the summarizer to avoid calling realize if there
-            // are no changes to the component.  If the initSnapshotValue is a
-            // string, the summarizer cannot avoid calling realize.
-            this.summaryTracker.setBaseTree(initSnapshotValue);
-        }
     }
 
     public generateAttachMessage(): IAttachMessage {
         throw new Error("Cannot attach remote component");
     }
 
-    // Only refers to the initial snapshot value, not necessarily the baseSnapshot.
     // This should only be called during realize to get the baseSnapshot,
     // or it can be called at any time to get the pkg, but that assumes the
     // pkg can never change for a component.


### PR DESCRIPTION
This assumption was too fragile anyway, but when violated, the base snapshot used to restore the component/DDS might be different than the pending op queue expected.  So while summarizing, the pending ops might include ops older than the snapshot used for refresh.  The baseSnapshot and summaryTracker (previously baseId) were conflated, and have been split back out.

This fixes #790 and #791

The assumption was only violated in somewhat uncommon cases: when the user passed an older specifiedVersion to the container load, or when a previous summary got acked after the next summarizer loaded, but before it summarized.

There is a more optimal fix, to remove ops with seq < base snapshot seq from pending, but it requires more safety around the base snapshot to prevent race conditions (i.e. make sure that pending is in sync with refreshed baseTree before allowing access to pending in realize/load calls).  This is something we can implement in the future if we want to, but too complicated for a hotfix.