### PR TITLE
Remove cobalt from docker-compose files

### DIFF
--- a/server/routerlicious/docker-compose.standalone-slim.yml
+++ b/server/routerlicious/docker-compose.standalone-slim.yml
@@ -56,9 +56,6 @@ services:
             - DEBUG=fluid:*
             - NODE_ENV=development
         restart: always
-    cobalt:
-        image: prague.azurecr.io/cobalt:1544
-        restart: always
     gitrest:
         image: prague.azurecr.io/gitrest:4048
         environment:

--- a/server/routerlicious/docker-compose.standalone.yml
+++ b/server/routerlicious/docker-compose.standalone.yml
@@ -86,9 +86,6 @@ services:
             - DEBUG=fluid:*
             - NODE_ENV=development
         restart: always
-    cobalt:
-        image: prague.azurecr.io/cobalt:1544
-        restart: always
     gitrest:
         image: prague.azurecr.io/gitrest:4048
         environment:

--- a/server/routerlicious/docker-compose.yml
+++ b/server/routerlicious/docker-compose.yml
@@ -130,9 +130,6 @@ services:
             - DEBUG=fluid:*
             - NODE_ENV=development
         restart: always
-    cobalt:
-        image: prague.azurecr.io/cobalt:1544
-        restart: always
     gitrest:
         image: prague.azurecr.io/gitrest:4048
         environment:

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -47,10 +47,6 @@
                 "key": "0bea3f87c186991a69245a29dc3f61d2"
             },
             {
-                "id": "cobalt",
-                "key": "0e3c439e9ba63d85936c7e7e9c79478c"
-            },
-            {
                 "id": "local",
                 "key": "43cfc3fbf04a97c0921fd23ff10f9e4b"
             }
@@ -214,15 +210,6 @@
                     "user": "praguegit",
                     "password": "8d043006d0a2704d4dd9972f848f1982026672a1"
                 }
-            }
-        },
-        {
-            "_id": "cobalt",
-            "key": "0e3c439e9ba63d85936c7e7e9c79478c",
-            "storage": {
-                "url": "http://cobalt",
-                "owner": "prague",
-                "repository": "cobalt"
             }
         },
         {


### PR DESCRIPTION
The cobalt container was a valuable prototype/experiment during the early days of SPO integration. But now doesn't serve much use given there are better storage options available. So removing to have one less Docker container run on boot.