### PR TITLE
Reenabling snapshot tests

### DIFF
--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -20,7 +20,7 @@
     "test:coverage": "nyc npm test -- --reporter mocha-junit-reporter --reporter-options mochaFile=nyc/junit-report.xml",
     "test:generate": "node --experimental-worker dist/generateSnapshotFiles.js",
     "test:sequential": "node ../../../node_modules/mocha/bin/_mocha --recursive dist/test",
-    "test_disabled": "node --experimental-worker ../../../node_modules/mocha/bin/_mocha --recursive dist/test",
+    "test": "node --experimental-worker ../../../node_modules/mocha/bin/_mocha --recursive dist/test",
     "tsc": "tsc",
     "tslint": "npm run eslint"
   },

--- a/packages/tools/replay-tool/src/replayMessages.ts
+++ b/packages/tools/replay-tool/src/replayMessages.ts
@@ -47,6 +47,8 @@ try {
 } catch (error) { }
 
 import { ReplayArgs } from "./replayArgs";
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const packageJson = require("../package.json");
 
 function expandTreeForReadability(tree: ITree): ITree {
     const newTree: ITree = { entries: [], id: undefined };
@@ -718,7 +720,8 @@ export class ReplayTool {
         const snapshotAsString = fs.readFileSync(
             `${filename}.json`,
             { encoding: "utf-8" });
-        if (snapshotAsString !== content.snapshotAsString) {
+        if (snapshotAsString.replace(new RegExp("0.12.0" , "g"), `${packageJson.version}`)
+            !== content.snapshotAsString.replace(new RegExp("0.12.0" , "g"), `${packageJson.version}`)) {
             this.reportError(`Mismatch in snapshot ${filename}.json`);
         }
     }


### PR DESCRIPTION
1.) Snapshot comparison tests were failing due to  package version ".attributes" which will keep changing. So while comparing we replaced test collateral package version with current version.