### PR TITLE
Fix for #754: Op processing blocks JS threads for long time.

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -13,6 +13,7 @@ import {
     IDeltaQueue,
 } from "@microsoft/fluid-container-definitions";
 import {
+    ChildLogger,
     Deferred,
     PerformanceEvent,
 } from "@microsoft/fluid-core-utils";
@@ -209,7 +210,9 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         this._inbound = new DeltaQueue<ISequencedDocumentMessage>(
             (op) => {
                 this.processInboundMessage(op);
-            });
+            },
+            ChildLogger.create(this.logger, "InboundDeltaQueue"),
+        );
 
         this._inbound.on("error", (error) => {
             this.emit("error", error);
@@ -221,6 +224,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
             (messages) => {
                 this.connection!.submit(messages);
             },
+            ChildLogger.create(this.logger, "OutboundDeltaQueue"),
         );
 
         this._outbound.on("error", (error) => {
@@ -233,7 +237,9 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
                 clientId: message.clientId,
                 content: JSON.parse(message.content as string),
             });
-        });
+        },
+        ChildLogger.create(this.logger, "InboundSignalDeltaQueue"),
+        );
 
         this._inboundSignal.on("error", (error) => {
             this.emit("error", error);

--- a/packages/loader/container-loader/src/deltaQueue.ts
+++ b/packages/loader/container-loader/src/deltaQueue.ts
@@ -234,7 +234,7 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
      * that all the ops process fairly quickly.
      */
     private processDeltasAsync(allowedProcessingTime = MaxAsyncProcessingTime) {
-        const startTime = performance.now();
+        const startTime = window.performance.now();
         let elaspedTime = 0;
         // Loop over the local messages until no messages to process, we have become paused, we hit an error
         // or the allowed time has elasped.
@@ -251,7 +251,7 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
                 this.emit("error", error);
             }
 
-            elaspedTime = performance.now() - startTime;
+            elaspedTime = window.performance.now() - startTime;
         }
 
         if (this.asyncProcessingLog) {

--- a/packages/loader/container-loader/src/deltaQueue.ts
+++ b/packages/loader/container-loader/src/deltaQueue.ts
@@ -10,6 +10,9 @@ import { IDeltaQueue } from "@microsoft/fluid-container-definitions";
 import { Deferred } from "@microsoft/fluid-core-utils";
 import * as Deque from "double-ended-queue";
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const performanceNow = require("performance-now") as (() => number);
+
 /**
  * The maximum time allowed for processing ops in a single iteration when processing ops
  * asynchronously.
@@ -234,7 +237,7 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
      * that all the ops process fairly quickly.
      */
     private processDeltasAsync(allowedProcessingTime = MaxAsyncProcessingTime) {
-        const startTime = window.performance.now();
+        const startTime = performanceNow();
         let elaspedTime = 0;
         // Loop over the local messages until no messages to process, we have become paused, we hit an error
         // or the allowed time has elasped.
@@ -251,7 +254,7 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
                 this.emit("error", error);
             }
 
-            elaspedTime = window.performance.now() - startTime;
+            elaspedTime = performanceNow() - startTime;
         }
 
         if (this.asyncProcessingLog) {

--- a/packages/loader/container-loader/src/deltaQueue.ts
+++ b/packages/loader/container-loader/src/deltaQueue.ts
@@ -5,9 +5,30 @@
 
 import * as assert from "assert";
 import { EventEmitter } from "events";
+import { ITelemetryLogger } from "@microsoft/fluid-common-definitions";
 import { IDeltaQueue } from "@microsoft/fluid-container-definitions";
 import { Deferred } from "@microsoft/fluid-core-utils";
 import * as Deque from "double-ended-queue";
+
+/**
+ * The maximum time allowed for processing ops in a single iteration when processing ops
+ * asynchronously.
+ */
+const MaxAsyncProcessingTime = 20;
+
+/**
+ * The increase in time allowed for processing ops after each iteration when processing ops
+ * asynchronously.
+ */
+const AsyncProcessingTimeIncrease = 10;
+
+/**
+ * The number of times ops have been processed asyncronously when there is more than one
+ * op in the queue. This is used to log the time taken to process large number of ops.
+ * For example, when catching up ops right after boot or catching up ops / delayed reaziling
+ * components by summarizer.
+ */
+let AsyncProcessingCount = -1;
 
 export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
     private isDisposed: boolean = false;
@@ -31,6 +52,18 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
      */
     private processingDeferred: Deferred<void> | undefined;
 
+    /**
+     * When async processing is ongoing, holds a deferred that will resolve once processing stops.
+     * Undefined when not processing.
+     */
+    private processingDeferredAsync: Deferred<void> | undefined;
+
+    private asyncProcessingLog: {
+        numberOfOps: number;
+        numberOfBatches: number;
+        totalProcessingTime: number;
+    } | undefined;
+
     public get disposed(): boolean {
         return this.isDisposed;
     }
@@ -49,14 +82,16 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
     }
 
     public get idle(): boolean {
-        return !this.processingDeferred && this.q.length === 0;
+        return !this.processingDeferred && !this.processingDeferredAsync && this.q.length === 0;
     }
 
     /**
      * @param worker - A callback to process a delta.
+     * @param logger - For logging telemetry.
      */
     constructor(
         private readonly worker: (delta: T) => void,
+        private readonly logger: ITelemetryLogger,
     ) {
         super();
     }
@@ -91,6 +126,9 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
         if (this.processingDeferred) {
             return this.processingDeferred.promise;
         }
+        if (this.processingDeferredAsync) {
+            return this.processingDeferredAsync.promise;
+        }
     }
 
     public resume(): void {
@@ -106,6 +144,9 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
         // that will resolve when processing has actually stopped.
         if (this.processingDeferred) {
             return this.processingDeferred.promise;
+        }
+        if (this.processingDeferredAsync) {
+            return this.processingDeferredAsync.promise;
         }
     }
 
@@ -124,19 +165,31 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
      * not become too large.
      */
     private ensureProcessing(processAsync = false) {
-        if (!this.processingDeferred) {
-            this.processingDeferred = new Deferred<void>();
-            if (processAsync) {
+        if (processAsync) {
+            if (!this.processingDeferred && !this.processingDeferredAsync) {
+                // Log telemetry for the time taken to process when there is more than one op in the queue.
+                // We want to catch any unexpected behavior when process large amount of ops such as when
+                // catching up ops right after boot.
+                if (this.q.length > 1) {
+                    AsyncProcessingCount++;
+                    this.asyncProcessingLog = {
+                        numberOfOps: this.q.length,
+                        numberOfBatches: 0,
+                        totalProcessingTime: 0,
+                    };
+                }
+                this.processingDeferredAsync = new Deferred<void>();
                 // Use a resolved promise to start the processing on a separate stack.
+                // processingDeferredAsync will be resolved in processDeltasAsync once we have asynchronously
+                // completed the processing.
                 // eslint-disable-next-line @typescript-eslint/no-floating-promises
                 Promise.resolve().then(() => {
-                    this.processDeltas();
-                    if (this.processingDeferred) {
-                        this.processingDeferred.resolve();
-                        this.processingDeferred = undefined;
-                    }
+                    this.processDeltasAsync();
                 });
-            } else {
+            }
+        } else {
+            if (!this.processingDeferred) {
+                this.processingDeferred = new Deferred<void>();
                 this.processDeltas();
                 this.processingDeferred.resolve();
                 this.processingDeferred = undefined;
@@ -162,6 +215,65 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
                 this.error = error;
                 this.emit("error", error);
             }
+        }
+    }
+
+    /**
+     * Executes the delta processing loop until a stop condition is reached. It processes
+     * ops for an allowed amount of time (20ms by default) and then schedules the rest of
+     * the ops to be processed aynschronously. This ensures that we don't block the JS
+     * threads for a long time (for example, when catching up ops right after boot or
+     * catching up ops / delayed reaziling components by summarizer).
+     *
+     * We increase the allowed processing time in each iteration until all the ops have been
+     * processed. This way we keep the responsiveness at the beginning while also making sure
+     * that all the ops process fairly quickly.
+     */
+    private processDeltasAsync(allowedProcessingTime = MaxAsyncProcessingTime) {
+        const startTime = new Date().getTime();
+        let elaspedTime = 0;
+        // Loop over the local messages until no messages to process, we have become paused, we hit an error
+        // or the allowed time has elasped.
+        while (!(this.q.length === 0 || this.paused || this.error || elaspedTime >= allowedProcessingTime)) {
+            // Get the next message in the queue
+            const next = this.q.shift();
+
+            // Process the message.
+            try {
+                this.worker(next!);
+                this.emit("op", next);
+            } catch (error) {
+                this.error = error;
+                this.emit("error", error);
+            }
+
+            elaspedTime = new Date().getTime() - startTime;
+        }
+
+        if (this.asyncProcessingLog) {
+            this.asyncProcessingLog.numberOfBatches++;
+            this.asyncProcessingLog.totalProcessingTime += elaspedTime;
+        }
+
+        if (this.q.length === 0 || this.paused || this.error) {
+            if (AsyncProcessingCount % 2000 === 0 && this.asyncProcessingLog) {
+                this.logger.sendTelemetryEvent({
+                    eventName: "AsyncDeltaProcessingComplete",
+                    numberOfOps: this.asyncProcessingLog.numberOfOps,
+                    numberOfBatches: this.asyncProcessingLog.numberOfBatches,
+                    processingTime: this.asyncProcessingLog.totalProcessingTime,
+                });
+                this.asyncProcessingLog = undefined;
+            }
+            if (this.processingDeferredAsync) {
+                this.processingDeferredAsync.resolve();
+                this.processingDeferredAsync = undefined;
+            }
+        } else {
+            // Increase the allowed processing time by asyncProcessingTimeIncrease for the next iteration.
+            setImmediate(() => {
+                this.processDeltasAsync(allowedProcessingTime + AsyncProcessingTimeIncrease);
+            });
         }
     }
 }


### PR DESCRIPTION
Fixes #754 

**Issue:** We block the JS thread for long periods of time when processing ops in two scenarios:
- Catching up ops right after boot.
- Catching up ops / delayed realizing components by summarizer (especially if it did not had a chance to run on idle trigger and runs due to other triggers).

**Fix:** In the above scenarios, process ops for a small amount of time and then schedule the remaining ops processing via setImmediate. We keep repeating this until we have processed all the ops or there is an error or the processing is paused.
For now, we start with 20ms as the base processing time. We gradually increase the processing time for each iteration by 10ms. This is done so that the service is more responsive towards the beginning of the processing and at the same time we do not take a long time to process the ops.

Also added telemetry to log the following: number of ops processed, number of iterations / batches taken to complete the operation and total processing time. We log every 2000th time we process more than one op (resume / systemResume is called a lot of times when we add a single op so we want to avoid logging those).