### PR TITLE
adding assertion for slashes in doc id

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDriverUrlResolver.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import * as assert from "assert";
 import { IRequest } from "@microsoft/fluid-component-core-interfaces";
 import { IResolvedUrl, IUrlResolver } from "@microsoft/fluid-driver-definitions";
 import { IOdspResolvedUrl } from "./contracts";
@@ -44,6 +45,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
     public async resolve(request: IRequest): Promise<IResolvedUrl> {
         const { siteUrl, driveId, itemId, path } = this.decodeOdspUrl(request.url);
         const hashedDocumentId = getHashedDocumentId(driveId, itemId);
+        assert.ok(!hashedDocumentId.includes("/"), "Docid should not contain slashes!!");
 
         let documentUrl = `fluid-odsp://placeholder/placeholder/${hashedDocumentId}/${removeBeginningSlash(path)}`;
 


### PR DESCRIPTION
For issue: https://github.com/microsoft/FluidFramework/issues/580
1.) Docid should not contain slashes because it is used in loader resolve request where it is separated on basis of "/". So if the docid contain slashes it will create a problem. Now the hashed docid is encoded so it will not contian slashes. Adding assertion to check that and raise any error earlier.