### PR TITLE
Add an activity timeout to document partitions

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentLambda.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentLambda.ts
@@ -14,7 +14,7 @@ import { Provider } from "nconf";
 import { DocumentContextManager } from "./contextManager";
 import { DocumentPartition } from "./documentPartition";
 
-// expire document partitions after 10 minutes of no activity
+// Expire document partitions after 10 minutes of no activity
 const ActivityTimeout = 10 * 60 * 1000;
 
 export class DocumentLambda implements IPartitionLambda {
@@ -74,7 +74,7 @@ export class DocumentLambda implements IPartitionLambda {
                 documentContext,
                 this.activityTimeout);
             document.on("inactive", () => {
-                // close and remove the inactive document
+                // Close and remove the inactive document
                 document.close();
                 this.documents.delete(routingKey);
             });

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { EventEmitter } from "events";
 import { IKafkaMessage, IPartitionLambda, IPartitionLambdaFactory } from "@microsoft/fluid-server-services-core";
 import { AsyncQueue, queue } from "async";
 import * as _ from "lodash";
@@ -10,18 +11,21 @@ import { Provider } from "nconf";
 import * as winston from "winston";
 import { DocumentContext } from "./documentContext";
 
-export class DocumentPartition {
+export class DocumentPartition extends EventEmitter {
     private readonly q: AsyncQueue<IKafkaMessage>;
     private readonly lambdaP: Promise<IPartitionLambda>;
     private lambda: IPartitionLambda;
     private corrupt = false;
+    private activityTimer: NodeJS.Timeout | undefined;
 
     constructor(
         factory: IPartitionLambdaFactory,
         config: Provider,
         tenantId: string,
         documentId: string,
-        public context: DocumentContext) {
+        public readonly context: DocumentContext,
+        private readonly activityTimeout: number) {
+        super();
 
         // Default to the git tenant if not specified
         const clonedConfig = _.cloneDeep((config as any).get());
@@ -67,9 +71,14 @@ export class DocumentPartition {
 
     public process(message: IKafkaMessage) {
         this.q.push(message);
+        this.updateActivityTimer();
     }
 
     public close() {
+        this.clearActivityTimer();
+
+        this.removeAllListeners();
+
         // Stop any future processing
         this.q.kill();
 
@@ -80,5 +89,20 @@ export class DocumentPartition {
             (error) => {
                 // Lambda was never created - ignoring
             });
+    }
+
+    private updateActivityTimer() {
+        this.clearActivityTimer();
+
+        this.activityTimer = setTimeout(() => {
+            this.emit("inactive");
+        }, this.activityTimeout);
+    }
+
+    private clearActivityTimer() {
+        if (this.activityTimer !== undefined) {
+            clearTimeout(this.activityTimer);
+            this.activityTimer = undefined;
+        }
     }
 }

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/lambdaFactory.ts
@@ -11,7 +11,8 @@ import { DocumentLambda } from "./documentLambda";
 export class DocumentLambdaFactory extends EventEmitter implements IPartitionLambdaFactory {
     constructor(
         private readonly documentLambdaFactory: IPartitionLambdaFactory,
-        private readonly activityTimeout?: number) {
+        private readonly activityTimeout?: number
+    ) {
         super();
 
         // Forward on any factory errors

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/lambdaFactory.ts
@@ -11,7 +11,7 @@ import { DocumentLambda } from "./documentLambda";
 export class DocumentLambdaFactory extends EventEmitter implements IPartitionLambdaFactory {
     constructor(
         private readonly documentLambdaFactory: IPartitionLambdaFactory,
-        private readonly activityTimeout?: number
+        private readonly activityTimeout?: number,
     ) {
         super();
 

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/lambdaFactory.ts
@@ -9,7 +9,9 @@ import { Provider } from "nconf";
 import { DocumentLambda } from "./documentLambda";
 
 export class DocumentLambdaFactory extends EventEmitter implements IPartitionLambdaFactory {
-    constructor(private readonly documentLambdaFactory: IPartitionLambdaFactory) {
+    constructor(
+        private readonly documentLambdaFactory: IPartitionLambdaFactory,
+        private readonly activityTimeout?: number) {
         super();
 
         // Forward on any factory errors
@@ -19,7 +21,7 @@ export class DocumentLambdaFactory extends EventEmitter implements IPartitionLam
     }
 
     public async create(config: Provider, context: IContext): Promise<IPartitionLambda> {
-        const lambda = new DocumentLambda(this.documentLambdaFactory, config, context);
+        const lambda = new DocumentLambda(this.documentLambdaFactory, config, context, this.activityTimeout);
         return lambda;
     }
 


### PR DESCRIPTION
Over time the `documents` map in `DocumentLambda` will continue to grow as messages for new documents are processed by the system.
This change adds an activity timeout to close `DocumentPartition`'s when they do not receive messages after 10 minutes.