### PR TITLE
Fix Sequence Delta Event Operation Typing

### DIFF
--- a/packages/framework/undo-redo/src/sequenceHandler.ts
+++ b/packages/framework/undo-redo/src/sequenceHandler.ts
@@ -83,7 +83,7 @@ export class SharedSegmentSequenceRevertable implements IRevertable {
                     current = {
                         trackingGroup: tg,
                         propertyDelta: range.propertyDeltas,
-                        operation: event.deltaOperation as MergeTreeDeltaOperationType,
+                        operation: event.deltaOperation,
                     };
                     this.tracking.push(current);
                 }

--- a/packages/runtime/merge-tree/src/mergeTreeDeltaCallback.ts
+++ b/packages/runtime/merge-tree/src/mergeTreeDeltaCallback.ts
@@ -11,8 +11,16 @@ import { IMergeTreeOp, ISegment, MergeTreeDeltaType } from "./";
 export type MergeTreeDeltaOperationType =
     MergeTreeDeltaType.ANNOTATE | MergeTreeDeltaType.INSERT | MergeTreeDeltaType.REMOVE;
 
-export interface IMergeTreeDeltaCallbackArgs {
-    readonly operation: MergeTreeDeltaOperationType;
+// Note: Assigned negative integers to avoid clashing with MergeTreeDeltaType
+export const enum MergeTreeMaintenanceType {
+    APPEND  = -1,
+    SPLIT   = -2,
+}
+
+export type MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationType | MergeTreeMaintenanceType;
+
+export interface IMergeTreeDeltaCallbackArgs<TOperationType extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationType> {
+    readonly operation: TOperationType;
     readonly deltaSegments: IMergeTreeSegmentDelta[];
 }
 
@@ -47,16 +55,8 @@ export interface IMergeTreeClientSequenceArgs {
 export type MergeTreeDeltaCallback =
     (opArgs: IMergeTreeDeltaOpArgs, deltaArgs: IMergeTreeDeltaCallbackArgs) => void;
 
-// Note: Assigned negative integers to avoid clashing with MergeTreeDeltaType
-export const enum MergeTreeMaintenanceType {
-    APPEND  = -1,
-    SPLIT   = -2,
-}
-
-export interface IMergeTreeMaintenanceCallbackArgs {
-    readonly operation: MergeTreeMaintenanceType;
-    readonly deltaSegments: IMergeTreeSegmentDelta[];
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface IMergeTreeMaintenanceCallbackArgs extends IMergeTreeDeltaCallbackArgs<MergeTreeMaintenanceType> { }
 
 export type MergeTreeMaintenanceCallback =
     (MaintenanceArgs: IMergeTreeMaintenanceCallbackArgs) => void;


### PR DESCRIPTION
make SequenceEvent, IMergeTreeDeltaCallbackArgs, and ISequenceDeltaRange generic so the operation can be strongly typed, rather than using a union type with necessitates casting.