### PR TITLE
Fix ES-Lint VsCode Extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "typescript.tsdk": "node_modules/typescript/lib"
+    "typescript.tsdk": "node_modules/typescript/lib",
+    "eslint.workingDirectories": [{ "mode": "auto" }],
 }


### PR DESCRIPTION
The eslint extentsion assumes the workspace root is the build root, so it expects a tsconfig.json, which fails in our repo. This setting change makes it look for eslint config per package.