### PR TITLE
Convert connecting Deferred to a promise

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -587,8 +587,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         this._deltaManager.connect().catch(() => { });
     }
 
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    private connectToDeltaStream() {
+    private async connectToDeltaStream() {
         this.recordConnectStartTime();
         return this._deltaManager.connect();
     }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -576,21 +576,19 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         return versions[0];
     }
 
-    private async recordConnectStartTime() {
+    private recordConnectStartTime() {
         if (this.connectionTransitionTimes[ConnectionState.Disconnected] === undefined) {
             this.connectionTransitionTimes[ConnectionState.Disconnected] = performanceNow();
         }
     }
 
     private startConnectingToDeltaStream() {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.recordConnectStartTime();
         this._deltaManager.connect().catch(() => { });
     }
 
     // eslint-disable-next-line @typescript-eslint/promise-function-async
     private connectToDeltaStream() {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.recordConnectStartTime();
         return this._deltaManager.connect();
     }

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -622,9 +622,9 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         // Drop pending messages - this will ensure catchUp() does not go into infinite loop
         this.pending = [];
 
-        this.removeAllListeners();
-
         this.emit("closed");
+
+        this.removeAllListeners();
     }
 
     private recordPingTime(latency: number) {


### PR DESCRIPTION
Currently, a connection attempt in progress is tracked via the connecting Deferred.  It can be rejected in two ways:

1. An error occurs in the connection attempt, which calls `close()`, which rejects the Deferred.
2. `close()` is called before the connection attempt completes, which rejects the Deferred immediately (even if the connection attempt is still pending).

This change consolidates the rejection logic into the connect method via the "closed" event.  This then allows the Deferred to be made into a Promise, and resolve the floating promise exception.  This change also ensures we fire the event before clearing the listeners, and cleans up a couple other eslint exceptions.