### PR TITLE
Add exception cases for string insertText ranges

### DIFF
--- a/packages/runtime/sequence/src/sequence.ts
+++ b/packages/runtime/sequence/src/sequence.ts
@@ -433,10 +433,13 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
     }
 
     protected replaceRange(start: number, end: number, segment: MergeTree.ISegment) {
-        // Insert first, so local references can slide to the inserted seg
-        // if any
+        if (start > end) {
+            return;
+        }
+
+        // Insert first, so local references can slide to the inserted seg if any
         const insert = this.client.insertSegmentLocal(end, segment);
-        if (insert) {
+        if (insert && (start < end)) {
             const remove = this.client.removeRangeLocal(start, end);
             this.submitSequenceMessage(MergeTree.createGroupOp(insert, remove));
         }

--- a/packages/runtime/sequence/src/sequence.ts
+++ b/packages/runtime/sequence/src/sequence.ts
@@ -437,7 +437,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
      * This is done by inserting the segment at the end of the range, followed
      * by removing the contents of the range
      * For a zero range (start == end), insert at end do not remove anything
-     * For a reverse range (start > end), insert the segment at the greater of
+     * For a reverse range (start \> end), insert the segment at the greater of
      * start/end and allow Client to attempt to remove the range
      *
      * @param start - The start of the range to replace

--- a/packages/runtime/sequence/src/test/sharedString.spec.ts
+++ b/packages/runtime/sequence/src/test/sharedString.spec.ts
@@ -80,5 +80,19 @@ describe("SharedString", () => {
 
             assert(sharedString.getText() === sharedString2.getText());
         }
+
+        it("replace zero range", async () => {
+            sharedString.insertText(0, "123");
+            sharedString.replaceText(1, 1, "\u00e4\u00c4");
+            assert.equal(sharedString.getText(), "1\u00e4\u00c423")
+        });
+
+        it("replace negative range", async () => {
+            sharedString.insertText(0, "123");
+            sharedString.replaceText(2, 1, "aaa");
+            // This assert relies on the behvaior that replacement for a reversed range
+            // will insert at the max end of the range but not delete the range
+            assert.equal(sharedString.getText(), "12aaa3")
+        })
     });
 });

--- a/packages/test/end-to-end/src/test/sharedInterval.spec.ts
+++ b/packages/test/end-to-end/src/test/sharedInterval.spec.ts
@@ -154,6 +154,22 @@ describe("SharedInterval", () => {
             assertIntervals([{ start: 0, end: 1 }]);
         });
 
+        it("replace empty range", async () => {
+            intervals.add(0, 2, IntervalType.SlideOnRemove);
+            assertIntervals([{ start: 0, end: 2}]);
+
+            sharedString.replaceText(1, 1, "\u00e4\u00c4");
+            assertIntervals([{ start: 0, end: 4}]);
+        });
+
+        it("replace negative range is excluded", async () => {
+            intervals.add(0, 2, IntervalType.SlideOnRemove);
+            assertIntervals([{ start: 0, end: 2}]);
+
+            sharedString.replaceText(2, 1, "aaa");
+            assertIntervals([{ start: 0, end: 2}]);
+        })
+
         // Uncomment below test to reproduce issue #2479:
         // https://github.com/microsoft/Prague/issues/2479
         //

--- a/packages/test/end-to-end/src/test/sharedInterval.spec.ts
+++ b/packages/test/end-to-end/src/test/sharedInterval.spec.ts
@@ -154,24 +154,6 @@ describe("SharedInterval", () => {
             assertIntervals([{ start: 0, end: 1 }]);
         });
 
-        it("replace empty range", async () => {
-            intervals.add(0, 2, IntervalType.SlideOnRemove);
-            assertIntervals([{ start: 0, end: 2}]);
-
-            sharedString.replaceText(1, 1, "\u00e4\u00c4");
-            assertIntervals([{ start: 0, end: 4}]);
-        });
-
-        it("replace negative range is excluded", async () => {
-            intervals.add(0, 2, IntervalType.SlideOnRemove);
-            assertIntervals([{ start: 0, end: 2}]);
-
-            sharedString.replaceText(2, 1, "aaa");
-            // This assert relies on the behvaior that replacement for a reversed range
-            // will insert at the max end of the range but not delete the range
-            assertIntervals([{ start: 0, end: 5}]);
-        })
-
         // Uncomment below test to reproduce issue #2479:
         // https://github.com/microsoft/Prague/issues/2479
         //

--- a/packages/test/end-to-end/src/test/sharedInterval.spec.ts
+++ b/packages/test/end-to-end/src/test/sharedInterval.spec.ts
@@ -167,7 +167,9 @@ describe("SharedInterval", () => {
             assertIntervals([{ start: 0, end: 2}]);
 
             sharedString.replaceText(2, 1, "aaa");
-            assertIntervals([{ start: 0, end: 2}]);
+            // This assert relies on the behvaior that replacement for a reversed range
+            // will insert at the max end of the range but not delete the range
+            assertIntervals([{ start: 0, end: 5}]);
         })
 
         // Uncomment below test to reproduce issue #2479:


### PR DESCRIPTION
Fixes #782 
Sequence's replaceRange doesn't handle cases where the start range is equal to or greater than the end range.  Update the behavior not to run removal when the ranges are the same, and to always insert at the greater end of the range (which handles the case where the start > end of the range).  Additionally for start > end, the removal step does not happen.