### PR TITLE
ESlint: disallow object literal type assertions

### DIFF
--- a/packages/components/blob-manager/src/index.ts
+++ b/packages/components/blob-manager/src/index.ts
@@ -88,8 +88,8 @@ export class BlobManager implements IBlobManager {
     public async createBlob(blob: IGenericBlob): Promise<IGenericBlob> {
         const response = await this.storage.createBlob(blob.content);
 
-        /* tslint:disable:no-object-literal-type-assertion */
         // Remove blobContent
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         const blobMetaData = {
             fileName: blob.fileName,
             id: response.id,

--- a/packages/components/search-menu/src/cursor.ts
+++ b/packages/components/search-menu/src/cursor.ts
@@ -63,12 +63,12 @@ export class Cursor {
         this.mark = Nope;
     }
 
-    public getSelection() {
+    public getSelection(): IRange | undefined {
         if (this.mark !== Nope) {
             return {
                 end: Math.max(this.mark, this.pos),
                 start: Math.min(this.mark, this.pos),
-            } as IRange;
+            };
         }
     }
 

--- a/packages/components/search-menu/src/searchMenu.ts
+++ b/packages/components/search-menu/src/searchMenu.ts
@@ -454,7 +454,7 @@ export function inputBoxCreate(
 
     const getText = () => span.innerText;
 
-    return {
+    const inputBox: IInputBox = {
         elm,
         getText,
         initCursor,
@@ -462,7 +462,9 @@ export function inputBoxCreate(
         keypress,
         setPrefixText,
         setText,
-    } as IInputBox;
+    };
+
+    return inputBox;
 }
 
 interface IParameterState {

--- a/packages/components/webflow/src/html/formatters.ts
+++ b/packages/components/webflow/src/html/formatters.ts
@@ -94,6 +94,7 @@ export class InclusionFormatter extends Formatter<IInclusionState> {
                 const visual = component.IComponentHTMLVisual;
                 const view: IComponentHTMLView = visual.addView
                     ? visual.addView(layout.scope)
+                    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                     : {
                         IComponentHTMLVisual: visual,
                         render: visual.render.bind(visual),

--- a/packages/loader/container-loader/src/blobManager.ts
+++ b/packages/loader/container-loader/src/blobManager.ts
@@ -46,6 +46,7 @@ export class BlobManager implements IBlobManager {
         const response = await this.storage.createBlob(blob.content);
 
         // Remove blobContent
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         const blobMetaData = {
             fileName: blob.fileName,
             id: response.id,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -631,6 +631,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
     public get IComponentTokenProvider() {
 
         if (this.options && this.options.intelligence) {
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             return {
                 intelligence: this.options.intelligence,
             } as IComponentTokenProvider;

--- a/packages/runtime/container-runtime/src/summaryTreeConverter.ts
+++ b/packages/runtime/container-runtime/src/summaryTreeConverter.ts
@@ -86,10 +86,11 @@ export class SummaryTreeConverter {
                             content = blob.contents;
                             summaryStats.totalBlobSize += Buffer.byteLength(content);
                         }
-                        value = {
+                        const summaryBlob: ISummaryBlob = {
                             content,
                             type: SummaryType.Blob,
-                        } as ISummaryBlob;
+                        };
+                        value = summaryBlob;
                         summaryStats.blobNodeCount++;
                         break;
 

--- a/packages/runtime/merge-tree/src/mergeTree.ts
+++ b/packages/runtime/merge-tree/src/mergeTree.ts
@@ -3049,7 +3049,6 @@ export class MergeTree {
         }
         if (this.collabWindow.collaborating) {
             strbuf += internedSpaces(indentCount);
-            // tslint:disable-next-line: prefer-template
             strbuf += `${block.partialLengths.toString((id) => glc(this, id), indentCount)}\n`;
         }
         const children = block.children;

--- a/packages/runtime/sequence/src/intervalCollection.ts
+++ b/packages/runtime/sequence/src/intervalCollection.ts
@@ -59,13 +59,12 @@ export class Interval implements ISerializableInterval {
             seq = client.getCurrentSeq();
         }
 
-        /* tslint:disable:no-object-literal-type-assertion */
-        const serializedInterval = {
+        const serializedInterval: ISerializedInterval = {
             end: this.end,
             intervalType: 0,
             sequenceNumber: seq,
             start: this.start,
-        } as ISerializedInterval;
+        };
         if (this.properties) {
             serializedInterval.properties = this.properties;
         }
@@ -122,12 +121,12 @@ export class SequenceInterval implements ISerializableInterval {
     public serialize(client: MergeTree.Client) {
         const startPosition = this.start.toPosition();
         const endPosition = this.end.toPosition();
-        const serializedInterval = {
+        const serializedInterval: ISerializedInterval = {
             end: endPosition,
             intervalType: this.intervalType,
             sequenceNumber: client.getCurrentSeq(),
             start: startPosition,
-        } as ISerializedInterval;
+        };
         if (this.properties) {
             serializedInterval.properties = this.properties;
         }

--- a/packages/utils/eslint-config-fluid/no-tslint.js
+++ b/packages/utils/eslint-config-fluid/no-tslint.js
@@ -61,7 +61,13 @@ module.exports = {
             }
         ],
         "@typescript-eslint/class-name-casing": "error",
-        "@typescript-eslint/consistent-type-assertions": "error",
+        "@typescript-eslint/consistent-type-assertions": [
+            "error",
+            {
+                "assertionStyle": "as",
+                "objectLiteralTypeAssertions": "never"
+            }
+        ],
         "@typescript-eslint/consistent-type-definitions": "error",
         "@typescript-eslint/explicit-function-return-type": "off",
         "@typescript-eslint/indent": [

--- a/samples/chaincode/musica/src/Player.tsx
+++ b/samples/chaincode/musica/src/Player.tsx
@@ -13,6 +13,7 @@ export class Player {
         const frequency = Math.pow(2, (note.midiNumber - 69) / 12) * 440;
         const instrument = note.instrument;
 
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         let waveProperties = {
             frequency,
         } as WaveProperties;

--- a/samples/chaincode/musica/src/Recorder.tsx
+++ b/samples/chaincode/musica/src/Recorder.tsx
@@ -67,7 +67,7 @@ export class Recorder {
         this.currentSongName = name;
         this.recordedSong = { noteSequence: [] };
 
-        const songProperties = { name: this.currentSongName, song: this.recordedSong } as SongProperties;
+        const songProperties: SongProperties = { name: this.currentSongName, song: this.recordedSong };
 
         const savedSongs = this.getSavedSongs();
         savedSongs.push(songProperties);

--- a/samples/chaincode/musica/src/daw.tsx
+++ b/samples/chaincode/musica/src/daw.tsx
@@ -216,7 +216,7 @@ export class DAW extends React.Component<DAWProps, DAWState> {
     public postPressKey(midiNumber: any) {
         this.recorder.postSaveNewNote(new Note(midiNumber, NoteType.quarter), this.state.tempo);
 
-        this.props.rootDir.set("playNote", {
+        this.props.rootDir.set<NoteProperties>("playNote", {
             length: 0.5,
             midiNumber,
             instrument: this.state.instrument,
@@ -226,7 +226,7 @@ export class DAW extends React.Component<DAWProps, DAWState> {
             overtone2: this.state.overtone2,
             overtone3: this.state.overtone3,
             overtone4: this.state.overtone4,
-        } as NoteProperties);
+        });
     }
 
     public postPlayNote(note: NoteProperties) {
@@ -235,7 +235,7 @@ export class DAW extends React.Component<DAWProps, DAWState> {
 
     public postSaveInstrument(event: any) {
         const savedInstruments = this.getSavedInstruments();
-        const waveProperties = {
+        const waveProperties: WaveProperties = {
             amplitude: 1,
             frequency: 0,
             modulation: this.state.customModulation,
@@ -244,8 +244,8 @@ export class DAW extends React.Component<DAWProps, DAWState> {
             overtone2: this.state.overtone2,
             overtone3: this.state.overtone3,
             overtone4: this.state.overtone4,
-        } as WaveProperties;
-        const instrumentProperty = { name: this.state.customInstrumentName, waveProperties } as InstrumentProperties;
+        };
+        const instrumentProperty: InstrumentProperties = { name: this.state.customInstrumentName, waveProperties };
 
         savedInstruments.push(instrumentProperty);
 

--- a/samples/chaincode/tourofheroes/src/app/heroes/heroes.component.ts
+++ b/samples/chaincode/tourofheroes/src/app/heroes/heroes.component.ts
@@ -31,6 +31,7 @@ export class HeroesComponent implements OnInit {
         // eslint-disable-next-line no-param-reassign
         name = name.trim();
         if (!name) { return; }
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         this.heroService.addHero({ name } as Hero)
             .subscribe((hero) => {
                 this.heroes.push(hero);


### PR DESCRIPTION
Tslint used to check this with rule no-object-literal-type-assertion.  
Enable eslint equivalent.