### PR TITLE
Eslint/Tslint cleanup: object-literal-sort-keys

### DIFF
--- a/packages/components/flow-util/src/resizeobserver/index.ts
+++ b/packages/components/flow-util/src/resizeobserver/index.ts
@@ -9,7 +9,6 @@ import { Template } from "../template";
 import { View } from "../view";
 import * as style from "./index.css";
 
-// tslint:disable:object-literal-sort-keys
 const template = isBrowser && new Template(
     { tag: "div", ref: "root", props: { className: style.root }, children: [
         { tag: "div", ref: "observer", props: { className: style.observer }, children: [

--- a/packages/components/flow-util/test/template.spec.ts
+++ b/packages/components/flow-util/test/template.spec.ts
@@ -5,7 +5,6 @@
 
 // tslint:disable:no-import-side-effect
 // tslint:disable:no-submodule-imports
-// tslint:disable:object-literal-sort-keys
 import "jsdom-global/register";
 import "mocha";
 import { Template } from "../src/template";

--- a/packages/components/flow-util/test/tokenlist.spec.ts
+++ b/packages/components/flow-util/test/tokenlist.spec.ts
@@ -4,7 +4,6 @@
  */
 
 // tslint:disable:no-import-side-effect
-// tslint:disable:object-literal-sort-keys
 import * as assert from "assert";
 import "mocha";
 import { findToken, TokenList } from "../src/tokenlist";

--- a/packages/runtime/merge-tree/src/mergeTree.ts
+++ b/packages/runtime/merge-tree/src/mergeTree.ts
@@ -37,7 +37,6 @@ import { SegmentPropertiesManager } from "./segmentPropertiesManager";
 // tslint:disable:forin
 // tslint:disable:no-suspicious-comment
 // tslint:disable:no-angle-bracket-type-assertion
-// tslint:disable:object-literal-sort-keys
 // tslint:disable:member-access
 // tslint:disable:no-parameter-reassignment
 // tslint:disable:no-shadowed-variable

--- a/packages/runtime/merge-tree/src/properties.ts
+++ b/packages/runtime/merge-tree/src/properties.ts
@@ -11,7 +11,6 @@ import * as ops from "./ops";
 // tslint:disable:switch-default
 // tslint:disable:no-parameter-reassignment
 // tslint:disable:switch-final-break
-// tslint:disable:object-literal-sort-keys
 // tslint:disable:no-unsafe-any
 
 export interface MapLike<T> {


### PR DESCRIPTION
Remove all mention of tslint:disable:object-literal-sort-keys
It was disabled globally before and we are not going to enable the eslint equivalent sort-keys.