### PR TITLE
Make scope a class property of testhost and use it in clone method

### DIFF
--- a/packages/server/local-test-server/src/testHost.ts
+++ b/packages/server/local-test-server/src/testHost.ts
@@ -159,7 +159,7 @@ export class TestHost {
         private readonly componentRegistry: NamedComponentRegistryEntries,
         private readonly sharedObjectFactories: readonly ISharedObjectFactory[] = [],
         deltaConnectionServer?: ITestDeltaConnectionServer,
-        scope?: IComponent,
+        private readonly scope: IComponent = {},
     ) {
         this.deltaConnectionServer = deltaConnectionServer || TestDeltaConnectionServer.create();
 
@@ -195,7 +195,8 @@ export class TestHost {
         return new TestHost(
             this.componentRegistry,
             this.sharedObjectFactories,
-            this.deltaConnectionServer);
+            this.deltaConnectionServer,
+            this.scope);
     }
 
     /**


### PR DESCRIPTION
Right now, when we clone a test host, we lose the scope the previous test host had. With this change, we are making scope a readonly class property that is used also when we clone the testhost.