### PR TITLE
Retry summarize in safe mode on failure

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1393,11 +1393,12 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
     private async refreshLatestSummaryAck(handle: string, referenceSequenceNumber: number) {
         if (referenceSequenceNumber < this.latestSummaryAck.referenceSequenceNumber) {
             return;
-        } else if (referenceSequenceNumber === this.latestSummaryAck.referenceSequenceNumber) {
-            if (!this.latestSummaryAck.handle) {
-                // When first loading we may not have the ack handle (version)
-                this.latestSummaryAck.handle = handle;
-            }
+        } else if (
+            referenceSequenceNumber === this.latestSummaryAck.referenceSequenceNumber
+            && !this.latestSummaryAck.handle
+        ) {
+            // When first loading we may not have the ack handle (version)
+            this.latestSummaryAck.handle = handle;
             return;
         }
 


### PR DESCRIPTION
Fixes #799.

When an error occurs while summarizing, the summarizer will retry in "safe" mode.  This will refresh the latest summary ack handle from the server and summarize the full tree without optimizations.