### PR TITLE
Eslint: disable arrow-body-style rule

### DIFF
--- a/packages/components/markflow/.eslintrc.json
+++ b/packages/components/markflow/.eslintrc.json
@@ -5,7 +5,6 @@
     "rules": {
         "@typescript-eslint/array-type": "off",
         "@typescript-eslint/strict-boolean-expressions": "off",
-        "arrow-body-style": "off",
         "import/no-internal-modules": "off",
         "max-len": "off",
         "no-bitwise": "off",

--- a/packages/components/math/src/mathComponent.ts
+++ b/packages/components/math/src/mathComponent.ts
@@ -408,7 +408,6 @@ class MathView implements IComponentHTMLView, IComponentCursor, IComponentLayout
     }
 
     private noteCursorExit(direction: ComponentCursorDirection) {
-        // eslint-disable-next-line arrow-body-style
         const cursorElement = ClientUI.controls.findFirstMatch(this.containerElement, (cursor: HTMLElement) => {
             return cursor.style && (cursor.style.color === MathExpr.cursorColor);
         }) || this.containerElement;

--- a/packages/drivers/iframe-socket-storage/.eslintrc.json
+++ b/packages/drivers/iframe-socket-storage/.eslintrc.json
@@ -4,7 +4,6 @@
     ],
     "rules": {
         "@typescript-eslint/strict-boolean-expressions": "off",
-        "arrow-body-style": "off",
         "no-null/no-null": "off"
     }
 }

--- a/packages/runtime/runtime-utils/src/test/serializer.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/serializer.spec.ts
@@ -22,7 +22,6 @@ const serHandle = {
 
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 function printHandle(target: any) {
-    // eslint-disable-next-line arrow-body-style
     return JSON.stringify(target, (key, value) => {
         return value && value.IComponentHandle
             ? "#HANDLE"

--- a/packages/utils/eslint-config-fluid/no-tslint.js
+++ b/packages/utils/eslint-config-fluid/no-tslint.js
@@ -195,7 +195,7 @@ module.exports = {
         "unicorn/no-new-buffer": "error",
 
         // eslint
-        "arrow-body-style": "error",
+        "arrow-body-style": "off",
         "arrow-parens": [
             "error",
             "always"

--- a/packages/utils/odsp-utils/.eslintrc.json
+++ b/packages/utils/odsp-utils/.eslintrc.json
@@ -5,7 +5,6 @@
     "rules": {
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/strict-boolean-expressions": "off",
-        "arrow-body-style": "off",
         "no-case-declarations": "off",
         "prefer-arrow/prefer-arrow-functions": "off"
     }

--- a/server/routerlicious/lerna.json
+++ b/server/routerlicious/lerna.json
@@ -1,6 +1,7 @@
 {
   "packages": [
     "../../packages/utils/build-common/**",
+    "../../packages/utils/eslint-config-fluid/**",
     "packages/**"
   ],
   "version": "0.1001.0"

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -26,6 +26,7 @@
     "@types/node": "^10.14.6"
   },
   "devDependencies": {
+    "@microsoft/eslint-config-fluid": "^0.13.0",
     "@microsoft/fluid-build-common": "^0.13.0",
     "@typescript-eslint/eslint-plugin": "^2.9.0",
     "@typescript-eslint/parser": "^2.9.0",

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -86,7 +86,6 @@ export class ScribeLambdaFactory extends EventEmitter implements IPartitionLambd
             scribe.protocolState.proposals,
             scribe.protocolState.values,
             () => -1,
-            // eslint-disable-next-line arrow-body-style
             () => { return; },
         );
 

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -395,7 +395,6 @@ export class LocalOrderer implements IOrderer {
             lastState.proposals,
             lastState.values,
             () => -1,
-            // eslint-disable-next-line arrow-body-style
             () => { return; });
 
         return new ScribeLambda(

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -89,7 +89,6 @@ export class Quorum extends EventEmitter implements IQuorum {
 
         this.members = new Map(members);
         this.proposals = new Map(
-            // eslint-disable-next-line arrow-body-style
             proposals.map(([, proposal, rejections]) => {
                 return [
                     proposal.sequenceNumber,

--- a/server/routerlicious/packages/protocol-definitions/package.json
+++ b/server/routerlicious/packages/protocol-definitions/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
     "@microsoft/fluid-build-common": "^0.13.0",
+    "@microsoft/eslint-config-fluid": "^0.13.0",
     "@types/node": "^10.14.6",
     "@typescript-eslint/eslint-plugin": "^2.9.0",
     "@typescript-eslint/parser": "^2.9.0",

--- a/server/routerlicious/r11s-Dockerfile
+++ b/server/routerlicious/r11s-Dockerfile
@@ -40,6 +40,7 @@ COPY server/routerlicious/packages/services-utils/package*.json server/routerlic
 COPY server/routerlicious/packages/test-utils/package*.json server/routerlicious/packages/test-utils/
 COPY server/routerlicious/packages/protocol-base/package*.json server/routerlicious/packages/protocol-base/
 COPY packages/utils/build-common/package*.json server/routerlicious/packages/utils/build-common/
+COPY packages/utils/eslint-config-fluid/package*.json server/routerlicious/packages/utils/eslint-config-fluid/
 
 # Copy over chaincode npmrc and package.json to dynamically install packages.
 COPY server/routerlicious/chaincode/* /tmp/chaincode/
@@ -68,6 +69,7 @@ RUN npm install --unsafe-perm
 WORKDIR /usr/src/server
 COPY server/routerlicious/packages/ server/routerlicious/packages/
 COPY packages/utils/build-common/ server/routerlicious/packages/utils/build-common/
+COPY packages/utils/eslint-config-fluid/ server/routerlicious/packages/utils/eslint-config-fluid/
 
 # Switch to the server folder and build
 WORKDIR /usr/src/server/server/routerlicious

--- a/server/tinylicious/src/routes/storage/repository/commits.ts
+++ b/server/tinylicious/src/routes/storage/repository/commits.ts
@@ -24,7 +24,6 @@ export function create(store: nconf.Provider): Router {
             ref: sha,
         });
 
-        // eslint-disable-next-line arrow-body-style
         return descriptions.map((description) => {
             return {
                 url: "",


### PR DESCRIPTION
For returning a more complex expression, a brace around it would make it clearer.