### PR TITLE
Fluid-Build: fix execution path ordering

### DIFF
--- a/packages/utils/build-common/package-lock.json
+++ b/packages/utils/build-common/package-lock.json
@@ -29,12 +29,6 @@
 					}
 				}
 			}
-		},
-		"typescript": {
-			"version": "3.7.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
-			"integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==",
-			"dev": true
 		}
 	}
 }

--- a/tools/fluid-build/src/npmPackage.ts
+++ b/tools/fluid-build/src/npmPackage.ts
@@ -254,7 +254,7 @@ export class Package {
         let fixed = false;
         const buildScript = this.getScript("build");
         if (buildScript) {
-            if (buildScript.startsWith("echo ")) {
+            if (buildScript.startsWith("echo ") || buildScript === "npm run noop") {
                 return;
             }
             // These are script rules in the FluidFramework repo

--- a/tools/fluid-build/src/tasks/leaf/leafTask.ts
+++ b/tools/fluid-build/src/tasks/leaf/leafTask.ts
@@ -64,7 +64,7 @@ export abstract class LeafTask extends Task {
         }
         const ret = await execAsync(this.command, {
             cwd: this.node.pkg.directory,
-            env: { PATH: `${process.env["PATH"]}${path.delimiter}${path.join(this.node.pkg.directory, "node_modules", ".bin")}` }
+            env: { PATH: `${path.join(this.node.pkg.directory, "node_modules", ".bin")}${path.delimiter}${process.env["PATH"]}` }
         });
 
         if (ret.error) {


### PR DESCRIPTION
Installed version of the tools in node_modules should take priority over ones in the PATH