### PR TITLE
update BREAKING.md for new tsc version

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,10 +1,12 @@
 # 0.13 Breaking Changes
 
-- [Fluid Packages Require Consumers on Typescript ^3.6.0](##Fluid-Packages-Require-Consumers-on-Typescript-^3.4.0)
+- [Fluid Packages Require Consumers on TypeScript `>=3.6`](##Fluid-Packages-Require-Consumers-on-TypeScript->=3.6)
 
-## Fluid Packages Require Consumers on Typescript ^3.6.0
+## Fluid Packages Require Consumers on TypeScript `>=3.6`
 
-Fluid now requires consumers on a Typescript version higher than `3.6`. The Fluid `./packages` repo has upgraded to Typescript `3.7.4`. Typescript 3.7 has a breaking change to the d.ts format having to do with getters and setters and is part of an effort to do [Class Field Mitigations](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#class-field-mitigations). Typescript made version `3.6` forwards compatible but users on Typescript version `3.5` and older will receive the following error when building against fluid:
+Fluid now requires consumers of our packages to use a TypeScript compiler version `>=3.6`. The Fluid `./packages` repo has upgraded to TypeScript `3.7.4`. TypeScript 3.7 has a breaking change to the `.d.ts` format having to do with getters and setters and is part of an effort to do [Class Field Mitigations](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#class-field-mitigations).
+
+TypeScript now emits `get/set` accessors in `.d.ts` files. TypeScript versions `3.5` and prior do not know how to read these and throw the below error when compiling. TypeScript version `3.6` is forwards compatible but does not emit the accessors.
 
 ```text
 "error TS1086: An accessor cannot be declared in an ambient context."
@@ -13,7 +15,7 @@ Fluid now requires consumers on a Typescript version higher than `3.6`. The Flui
 Links about the changes:
 
 - [Class Field Mitigations](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#class-field-mitigations)  
-- [Full list of Typescript changes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html)
+- [Full list of TypeScript changes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html)
 
 # 0.12 Breaking Changes
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -12,7 +12,7 @@ TypeScript now emits `get/set` accessors in `.d.ts` files. TypeScript versions `
 "error TS1086: An accessor cannot be declared in an ambient context."
 ```
 
-Links about the changes:
+More about the changes:
 
 - [Class Field Mitigations](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#class-field-mitigations)  
 - [Full list of TypeScript changes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,3 +1,20 @@
+# 0.13 Breaking Changes
+
+- [Fluid Packages Require Consumers on Typescript ^3.6.0](##Fluid-Packages-Require-Consumers-on-Typescript-^3.4.0)
+
+## Fluid Packages Require Consumers on Typescript ^3.6.0
+
+Fluid now requires consumers on a Typescript version higher than `3.6`. The Fluid `./packages` repo has upgraded to Typescript `3.7.4`. Typescript 3.7 has a breaking change to the d.ts format having to do with getters and setters and is part of an effort to do [Class Field Mitigations](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#class-field-mitigations). Typescript made version `3.6` forwards compatible but users on Typescript version `3.5` and older will receive the following error when building against fluid:
+
+```text
+"error TS1086: An accessor cannot be declared in an ambient context."
+```
+
+Links about the changes:
+
+- [Class Field Mitigations](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#class-field-mitigations)  
+- [Full list of Typescript changes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html)
+
 # 0.12 Breaking Changes
 
 - [Packages moved from packages to server](#Packages-moved-from-packages-to-server)


### PR DESCRIPTION
We have a new version of typescript and it's only compatible with 3.6 and higher. 