### PR TITLE
Fluid-Build: Fix incremental detection from upgrading to typescript v3.7.4

### DIFF
--- a/tools/fluid-build/package-lock.json
+++ b/tools/fluid-build/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fluid-build",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -253,9 +253,9 @@
       }
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g=="
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
+      "integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw=="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/tools/fluid-build/package.json
+++ b/tools/fluid-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluid-build",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "description": "Fluid Build tool",
   "license": "MIT",
@@ -22,7 +22,7 @@
     "lodash.isequal": "^4.5.0",
     "rimraf": "^2.6.2",
     "sort-package-json": "1.31.0",
-    "typescript": "^3.5.3"
+    "typescript": "^3.7.4"
   },
   "devDependencies": {
     "@types/async": "^2.4.1",

--- a/tools/fluid-build/src/fluidBuild.ts
+++ b/tools/fluid-build/src/fluidBuild.ts
@@ -16,7 +16,7 @@ import chalk from "chalk";
 
 function versionCheck() {
     const pkg = require(path.join(__dirname, "..", "package.json"));
-    const builtVersion = "0.0.3";
+    const builtVersion = "0.0.4";
     if (pkg.version > builtVersion) {
         console.warn(`WARNING: fluid-build is out of date, please rebuild (built: ${builtVersion}, package: ${pkg.version})\n`);
     }

--- a/tools/fluid-build/src/layerCheck/layerCheck.ts
+++ b/tools/fluid-build/src/layerCheck/layerCheck.ts
@@ -65,9 +65,9 @@ function parseOptions(argv: string[]) {
 
 function versionCheck() {
     const pkg = require(path.join(__dirname, "..", "..", "package.json"));
-    const builtVersion = "0.0.3";
+    const builtVersion = "0.0.4";
     if (pkg.version > builtVersion) {
-        console.warn(`WARNING: fluid-build is out of date, please rebuild (built: ${builtVersion}, package: ${pkg.version})\n`);
+        console.warn(`WARNING: layer-check is out of date, please rebuild (built: ${builtVersion}, package: ${pkg.version})\n`);
     }
 }
 

--- a/tools/fluid-build/src/npmPackage.ts
+++ b/tools/fluid-build/src/npmPackage.ts
@@ -380,7 +380,7 @@ export class Package {
                     if (existsSync(symlinkPath)) {
                         const stat = await lstatAsync(symlinkPath);
                         if (!stat.isSymbolicLink || await realpathAsync(symlinkPath) !== depBuildPackage.directory) {
-                            if (stat.isDirectory) {
+                            if (stat.isDirectory()) {
                                 await rimrafWithErrorAsync(symlinkPath, this.nameColored);
                             } else {
                                 await unlinkAsync(symlinkPath);


### PR DESCRIPTION
v3.7's buildInfo use relative path instead of absolute path.  Make sure fluid-build will resolve the relative path.

Also update fluid-build to use v3.7 as well so that option parsing matches the build.