### PR TITLE
make FailedNonAfdUrl-NoAfdFallback a generic event

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
@@ -395,7 +395,7 @@ export class OdspDocumentService implements IDocumentService {
                     throw retryError;
                 });
             } else {
-                logger.sendErrorEvent({
+                logger.sendPerformanceEvent({
                     eventName: "FailedNonAfdUrl-NoAfdFallback",
                 }, connectionError);
             }


### PR DESCRIPTION
Fix #928
Make `FailedNonAfdUrl-NoAfdFallback` a performance event, same as `FailedAfdUrl-NoNonAfdFallback`