### PR TITLE
Don't export Alfred lambda by default

### DIFF
--- a/server/routerlicious/packages/lambdas/src/index.ts
+++ b/server/routerlicious/packages/lambdas/src/index.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export * from "./alfred";
 export * from "./broadcaster";
 export * from "./deli";
 export * from "./scribe";

--- a/server/routerlicious/packages/routerlicious/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious/src/alfred/runner.ts
@@ -20,7 +20,8 @@ import { Provider } from "nconf";
 import * as winston from "winston";
 import { createMetricClient } from "@microsoft/fluid-server-services";
 import { IAlfredTenant } from "@microsoft/fluid-server-services-client";
-import { configureWebSocketServices } from "@microsoft/fluid-server-lambdas";
+// eslint-disable-next-line import/no-internal-modules
+import { configureWebSocketServices } from "@microsoft/fluid-server-lambdas/dist/alfred";
 import * as app from "./app";
 
 export class AlfredRunner implements utils.IRunner {

--- a/server/routerlicious/packages/routerlicious/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious/src/alfred/runnerFactory.ts
@@ -20,7 +20,8 @@ import * as redis from "redis";
 import * as winston from "winston";
 import * as ws from "ws";
 import { IAlfredTenant } from "@microsoft/fluid-server-services-client";
-import { DefaultServiceConfiguration } from "@microsoft/fluid-server-lambdas";
+// eslint-disable-next-line import/no-internal-modules
+import { DefaultServiceConfiguration } from "@microsoft/fluid-server-lambdas/dist/alfred";
 import { AlfredRunner } from "./runner";
 
 class NodeWebSocketServer implements core.IWebSocketServer {

--- a/server/routerlicious/packages/routerlicious/src/test/alfred/io.spec.ts
+++ b/server/routerlicious/packages/routerlicious/src/test/alfred/io.spec.ts
@@ -30,7 +30,7 @@ import * as assert from "assert";
 import { OrdererManager } from "../../alfred/runnerFactory";
 import { DefaultMetricClient } from "@microsoft/fluid-server-services-core";
 import { generateToken } from "@microsoft/fluid-server-services-client";
-import { configureWebSocketServices, DefaultServiceConfiguration } from "@microsoft/fluid-server-lambdas";
+import { configureWebSocketServices, DefaultServiceConfiguration } from "@microsoft/fluid-server-lambdas/dist/alfred";
 
 describe("Routerlicious", () => {
     describe("Alfred", () => {


### PR DESCRIPTION
This is a temporary work around to unblock client builds until #948 is complete