### PR TITLE
Remove DeltaQueue pause/resume when processing inbound batch messages

### DIFF
--- a/packages/components/clicker/src/index.tsx
+++ b/packages/components/clicker/src/index.tsx
@@ -110,7 +110,7 @@ class CounterReactView extends React.Component<CounterProps, CounterState> {
                     () => {
                         this.props.runtime.orderSequentially(() => {
                             batchCount++;
-                            for (let i = 0; i < 100; i++) {
+                            for (let i = 0; i < 200; i++) {
                                 this.props.sharedDirectory.set(`batch-${batchCount}`, i);
                             }
                         });

--- a/packages/components/clicker/src/index.tsx
+++ b/packages/components/clicker/src/index.tsx
@@ -5,8 +5,8 @@
 
 import { PrimedComponent, PrimedComponentFactory } from "@microsoft/fluid-aqueduct";
 import { IComponentHTMLVisual } from "@microsoft/fluid-component-core-interfaces";
-import { Counter, CounterValueType, ISharedDirectory } from "@microsoft/fluid-map";
-import { ITask, IHostRuntime } from "@microsoft/fluid-runtime-definitions";
+import { Counter, CounterValueType } from "@microsoft/fluid-map";
+import { ITask } from "@microsoft/fluid-runtime-definitions";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { ClickerAgent } from "./agent";
@@ -14,9 +14,6 @@ import { ClickerAgent } from "./agent";
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 const pkg = require("../package.json");
 export const ClickerName = pkg.name as string;
-
-let batchCount = 0;
-let opsCount = 0;
 
 /**
  * Basic Clicker example using new interfaces and stock component classes.
@@ -49,7 +46,7 @@ export class Clicker extends PrimedComponent implements IComponentHTMLVisual {
     // Get our counter object that we set in initialize and pass it in to the view.
         const counter = this.root.get("clicks");
         ReactDOM.render(
-            <CounterReactView counter={counter} sharedDirectory={this.root} runtime={this.context.hostRuntime}/>,
+            <CounterReactView counter={counter} />,
             div,
         );
         return div;
@@ -76,8 +73,6 @@ export class Clicker extends PrimedComponent implements IComponentHTMLVisual {
 
 interface CounterProps {
     counter: Counter;
-    sharedDirectory: ISharedDirectory;
-    runtime: IHostRuntime;
 }
 
 interface CounterState {
@@ -105,31 +100,7 @@ class CounterReactView extends React.Component<CounterProps, CounterState> {
                 <span className="clicker-value-class" id={`clicker-value-${Date.now().toString()}`}>
                     {this.state.value}
                 </span>
-                <br />
-                <button onClick={
-                    () => {
-                        this.props.runtime.orderSequentially(() => {
-                            batchCount++;
-                            for (let i = 0; i < 200; i++) {
-                                this.props.sharedDirectory.set(`batch-${batchCount}`, i);
-                            }
-                        });
-                    }
-                }>
-                    + (Batches)
-                </button>
-                <br />
-                <button onClick={
-                    () => {
-                        this.props.counter.increment(1);
-                        opsCount++;
-                        for (let i = 0; i < 10; i++) {
-                            this.props.sharedDirectory.set(`ops-${opsCount}`, i);
-                        }
-                    }
-                }>
-                    + (Ops)
-                </button>
+                <button onClick={() => { this.props.counter.increment(1); }}>+</button>
             </div>
         );
     }

--- a/packages/components/clicker/src/index.tsx
+++ b/packages/components/clicker/src/index.tsx
@@ -110,7 +110,7 @@ class CounterReactView extends React.Component<CounterProps, CounterState> {
                     () => {
                         this.props.runtime.orderSequentially(() => {
                             batchCount++;
-                            for (let i = 0; i < 500; i++) {
+                            for (let i = 0; i < 100; i++) {
                                 this.props.sharedDirectory.set(`batch-${batchCount}`, i);
                             }
                         });
@@ -123,7 +123,7 @@ class CounterReactView extends React.Component<CounterProps, CounterState> {
                     () => {
                         this.props.counter.increment(1);
                         opsCount++;
-                        for (let i = 0; i < 500; i++) {
+                        for (let i = 0; i < 10; i++) {
                             this.props.sharedDirectory.set(`ops-${opsCount}`, i);
                         }
                     }

--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -73,7 +73,7 @@ export interface IDeltaSender extends IProvideDeltaSender {
 
 export interface IDeltaManager<T, U> extends EventEmitter, IDeltaSender, IDisposable {
     // The queue of inbound delta messages
-    inbound: IDeltaQueue<T>;
+    inbound: IDeltaQueue<T[]>;
 
     // The queue of outbound delta messages
     outbound: IDeltaQueue<U[]>;
@@ -121,6 +121,8 @@ export interface IDeltaManager<T, U> extends EventEmitter, IDeltaSender, IDispos
         resume: boolean);
 
     submitSignal(content: any): void;
+
+    setInboundMessageBufferReady(ready: boolean): void;
 }
 
 export interface IDeltaQueue<T> extends EventEmitter, IDisposable {

--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -122,7 +122,7 @@ export interface IDeltaManager<T, U> extends EventEmitter, IDeltaSender, IDispos
 
     submitSignal(content: any): void;
 
-    setInboundMessageBufferReady(ready: boolean): void;
+    attachBatchHandler(handler: (message: ISequencedDocumentMessage) => boolean);
 
     pushToInboundQueue(): void;
 }

--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -123,6 +123,8 @@ export interface IDeltaManager<T, U> extends EventEmitter, IDeltaSender, IDispos
     submitSignal(content: any): void;
 
     setInboundMessageBufferReady(ready: boolean): void;
+
+    pushToInboundQueue(): void;
 }
 
 export interface IDeltaQueue<T> extends EventEmitter, IDisposable {

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -256,19 +256,6 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         this._inboundSignal.pause();
     }
 
-    public setInboundMessageBufferReady(ready: boolean) {
-        if (this.inboundMessageBuffer) {
-            this.inboundMessageBuffer.ready = ready;
-        }
-    }
-
-    public pushToInboundQueue() {
-        if (this.inboundMessageBuffer) {
-            this._inbound.push(this.inboundMessageBuffer.messages);
-            this.inboundMessageBuffer.messages = [];
-        }
-    }
-
     public dispose() {
         assert.fail("Not implemented.");
         this.isDisposed = true;
@@ -314,6 +301,13 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
 
     public attachBatchHandler(handler: (message: ISequencedDocumentMessage) => boolean) {
         this.batchHandler = handler;
+    }
+
+    public pushToInboundQueue() {
+        if (this.inboundMessageBuffer) {
+            this._inbound.push(this.inboundMessageBuffer.messages);
+            this.inboundMessageBuffer.messages = [];
+        }
     }
 
     public updateQuorumJoin() {

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -260,6 +260,13 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         }
     }
 
+    public pushToInboundQueue() {
+        if (this.inboundMessageBuffer) {
+            this._inbound.push(this.inboundMessageBuffer.messages);
+            this.inboundMessageBuffer.messages = [];
+        }
+    }
+
     public dispose() {
         assert.fail("Not implemented.");
         this.isDisposed = true;
@@ -942,11 +949,10 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
                 if (this.inboundMessageBuffer === undefined) {
                     this.inboundMessageBuffer = { messages: [], ready: true };
                 }
-                this.inboundMessageBuffer.messages.push(message);
-                this.inboundMessageBuffer.ready = true;
 
                 this.emit("preparePush", message);
 
+                this.inboundMessageBuffer.messages.push(message);
                 if (this.inboundMessageBuffer.ready) {
                     this._inbound.push(this.inboundMessageBuffer.messages);
                     this.inboundMessageBuffer = undefined;

--- a/packages/loader/container-loader/src/deltaManagerProxy.ts
+++ b/packages/loader/container-loader/src/deltaManagerProxy.ts
@@ -146,6 +146,10 @@ export class DeltaManagerProxy
         this.deltaManager.setInboundMessageBufferReady(ready);
     }
 
+    public pushToInboundQueue() {
+        this.deltaManager.pushToInboundQueue();
+    }
+
     public dispose(): void {
         this.inbound.dispose();
         this.outbound.dispose();

--- a/packages/loader/container-loader/src/deltaManagerProxy.ts
+++ b/packages/loader/container-loader/src/deltaManagerProxy.ts
@@ -86,7 +86,7 @@ export class DeltaManagerProxy
     extends EventForwarder
     implements IDeltaManager<ISequencedDocumentMessage, IDocumentMessage> {
 
-    public readonly inbound: IDeltaQueue<ISequencedDocumentMessage>;
+    public readonly inbound: IDeltaQueue<ISequencedDocumentMessage[]>;
     public readonly outbound: IDeltaQueue<IDocumentMessage[]>;
     public readonly inboundSignal: IDeltaQueue<ISignalMessage>;
 
@@ -140,6 +140,10 @@ export class DeltaManagerProxy
         this.inbound = new DeltaQueueProxy(deltaManager.inbound);
         this.outbound = new DeltaQueueProxy(deltaManager.outbound);
         this.inboundSignal = new DeltaQueueProxy(deltaManager.inboundSignal);
+    }
+
+    public setInboundMessageBufferReady(ready: boolean) {
+        this.deltaManager.setInboundMessageBufferReady(ready);
     }
 
     public dispose(): void {

--- a/packages/loader/container-loader/src/deltaManagerProxy.ts
+++ b/packages/loader/container-loader/src/deltaManagerProxy.ts
@@ -142,8 +142,8 @@ export class DeltaManagerProxy
         this.inboundSignal = new DeltaQueueProxy(deltaManager.inboundSignal);
     }
 
-    public setInboundMessageBufferReady(ready: boolean) {
-        this.deltaManager.setInboundMessageBufferReady(ready);
+    public attachBatchHandler(handler: (message: ISequencedDocumentMessage) => boolean) {
+        this.deltaManager.attachBatchHandler(handler);
     }
 
     public pushToInboundQueue() {

--- a/packages/loader/container-loader/src/deltaQueue.ts
+++ b/packages/loader/container-loader/src/deltaQueue.ts
@@ -118,7 +118,6 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
 
     public push(task: T) {
         this.q.push(task);
-        this.emit("push", task);
         this.ensureProcessing();
     }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -164,6 +164,10 @@ class ScheduleManager {
         this.messageScheduler = messageScheduler;
         this.deltaManager = this.messageScheduler.deltaManager;
 
+        this.deltaManager.attachBatchHandler((message: ISequencedDocumentMessage) => {
+            return this.processBatch(message);
+        });
+
         // Listen for delta manager sends and add batch metadata to messages
         this.deltaManager.on("prepareSend", (messages: IDocumentMessage[]) => {
             if (messages.length === 0) {
@@ -185,10 +189,6 @@ class ScheduleManager {
             // Set the batch flag to false on the last message to indicate the end of the send batch
             const lastMessage = messages[messages.length - 1];
             lastMessage.metadata = { ...lastMessage.metadata, ...{ batch: false } };
-        });
-
-        this.deltaManager.on("preparePush", (message: ISequencedDocumentMessage) => {
-            this.trackPending(message);
         });
     }
 
@@ -254,46 +254,51 @@ class ScheduleManager {
         this.deltaManager.inbound.systemResume();
     }
 
-    private trackPending(message: ISequencedDocumentMessage) {
+    private processBatch(message: ISequencedDocumentMessage): boolean {
         const metadata = message.metadata as IRuntimeMessageMetadata | undefined;
 
         let ready: boolean = false;
 
         // Protocol messages are never part of a runtime batch of messages
         if (!isRuntimeMessage(message)) {
-            this.pauseClientId = undefined;
-            ready = true;
-            return;
-        }
-
-        const batchMetadata = metadata ? metadata.batch : undefined;
-
-        // If the client ID changes then we can move the pause point. If it stayed the same then we need to check.
-        if (this.pauseClientId === message.clientId) {
-            if (batchMetadata !== undefined) {
-                // If batchMetadata is false we've ended the current batch.
-                // If batchMetadata is true, we've started a new batch while receiving the current batch which should
-                // not happen. We treat this as part of the ongoing batch and log a telemetry event.
-                if (batchMetadata === false) {
-                    this.pauseClientId = undefined;
-                    ready = true;
-                } else {
-                    // Log error.
-                }
-            }
-        } else {
-            // If pauseClientId is not undefined, we were in the middle of receiving a batch and we started receiving
-            // messages from another client. Push the current batch into the queue (indicating that the batch is over)
+            // If pauseClientId is not undefined, we were in the middle of receiving a batch and we received
+            // a non runtime message. Push the current batch into the queue (indicating that the batch is over)
             // and log a telemetry event.
             if (this.pauseClientId) {
                 this.deltaManager.pushToInboundQueue();
-                // Log error.
+                // Log telemetry.
             }
-            this.pauseClientId = batchMetadata ? message.clientId : undefined;
-            ready = batchMetadata ? false : true;
-        }
+            this.pauseClientId = undefined;
+            ready = true;
+        } else {
+            const batchMetadata = metadata ? metadata.batch : undefined;
 
-        this.deltaManager.setInboundMessageBufferReady(ready);
+            // If the client ID changes then we can move the pause point. If it stayed the same then we need to check.
+            if (this.pauseClientId === message.clientId) {
+                if (batchMetadata !== undefined) {
+                    // If batchMetadata is false we've ended the current batch.
+                    // If batchMetadata is true, we've started a new batch while receiving the current batch which
+                    // should not happen. We treat this as part of the ongoing batch and log a telemetry event.
+                    if (batchMetadata === false) {
+                        this.pauseClientId = undefined;
+                        ready = true;
+                    } else {
+                        // Log telemetry.
+                    }
+                }
+            } else {
+                // If pauseClientId is not undefined, we were in the middle of receiving a batch and we started
+                // receiving messages from another client. Push the current batch into the queue (indicating that
+                // the batch is over) and log a telemetry event.
+                if (this.pauseClientId) {
+                    this.deltaManager.pushToInboundQueue();
+                    // Log telemetry.
+                }
+                this.pauseClientId = batchMetadata ? message.clientId : undefined;
+                ready = batchMetadata ? false : true;
+            }
+        }
+        return ready;
     }
 }
 


### PR DESCRIPTION
Currently, when a batch is received, ContainerRuntime pauses the inbound DeltaQueue until the entire batch is processed.

This change removes that. Instead, it adds all the incoming batch messages into a buffer and pushes it to the DeltaQueue once the entire batch is received. DeltaQueue will process the entire batch buffer as a single task which ensures that batch messages are processed together.

With #834 , the processing of DeltaQueue was made async. So if receive a batch which takes a long time to process, we would have yielded the JS thread in between the processing of a batch. This changes fixes that too since the entire batch is pushed as a single task into the queue so its guaranteed to be processed together.