### PR TITLE
Single url resolver for a host

### DIFF
--- a/packages/drivers/iframe-socket-storage/src/outerDocumentServiceFactory.ts
+++ b/packages/drivers/iframe-socket-storage/src/outerDocumentServiceFactory.ts
@@ -15,7 +15,6 @@ import {
     IResolvedUrl,
     IUrlResolver,
 } from "@microsoft/fluid-driver-definitions";
-import { configurableUrlResolver } from "@microsoft/fluid-driver-utils";
 import {
     ConnectionMode,
     IClient,
@@ -62,7 +61,7 @@ export class IFrameDocumentServiceProxyFactory {
         documentServiceFactory: IDocumentServiceFactory,
         frame: HTMLIFrameElement,
         options: any,
-        urlResolver: IUrlResolver | IUrlResolver[],
+        urlResolver: IUrlResolver,
     ) {
         return new IFrameDocumentServiceProxyFactory(documentServiceFactory, frame, options, urlResolver);
     }
@@ -74,7 +73,7 @@ export class IFrameDocumentServiceProxyFactory {
         private readonly documentServiceFactory: IDocumentServiceFactory,
         private readonly frame: HTMLIFrameElement,
         private readonly options: any,
-        private readonly urlResolver: IUrlResolver | IUrlResolver[],
+        private readonly urlResolver: IUrlResolver,
     ) {
 
     }
@@ -92,16 +91,7 @@ export class IFrameDocumentServiceProxyFactory {
     }
 
     public async createDocumentServiceFromRequest(request: IRequest): Promise<void> {
-        // Simplify this with either https://github.com/microsoft/FluidFramework/pull/448
-        // or https://github.com/microsoft/FluidFramework/issues/447
-        const resolvers: IUrlResolver[] = [];
-        if (!(Array.isArray(this.urlResolver))) {
-            resolvers.push(this.urlResolver);
-        } else {
-            resolvers.push(... this.urlResolver);
-        }
-
-        const resolvedUrl = await configurableUrlResolver(resolvers, request);
+        const resolvedUrl = await this.urlResolver.resolve(request);
         if (!resolvedUrl) {
             return Promise.reject("No Resolver for request");
         }

--- a/packages/hosts/base-host/src/hostConfig.ts
+++ b/packages/hosts/base-host/src/hostConfig.ts
@@ -14,7 +14,7 @@ import { IDocumentServiceFactory, IUrlResolver } from "@microsoft/fluid-driver-d
  */
 export interface IBaseHostConfig {
     documentServiceFactory: IDocumentServiceFactory | IDocumentServiceFactory[];
-    urlResolver: IUrlResolver | IUrlResolver[];
+    urlResolver: IUrlResolver;
 
     // Any config to be provided to loader.
     config?: any;

--- a/packages/loader/container-definitions/src/loader.ts
+++ b/packages/loader/container-definitions/src/loader.ts
@@ -36,7 +36,7 @@ export interface ICodeWhiteList {
  * Host provider interfaces
  */
 export interface IHost {
-    resolver: IUrlResolver | IUrlResolver[];
+    resolver: IUrlResolver;
 }
 
 export interface IContainer extends EventEmitter {

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -25,7 +25,6 @@ import {
     IFluidResolvedUrl,
     IResolvedUrl,
 } from "@microsoft/fluid-driver-definitions";
-import { configurableUrlResolver } from "@microsoft/fluid-driver-utils";
 import { ISequencedDocumentMessage } from "@microsoft/fluid-protocol-definitions";
 import { Container } from "./container";
 import { debug } from "./debug";
@@ -242,12 +241,7 @@ export class Loader extends EventEmitter implements ILoader {
             return maybeResolvedUrl;
         }
 
-        let toCache: IResolvedUrl | undefined;
-        if (Array.isArray(this.containerHost.resolver)) {
-            toCache = await configurableUrlResolver(this.containerHost.resolver, request);
-        } else {
-            toCache = await this.containerHost.resolver.resolve(request);
-        }
+        const toCache = await this.containerHost.resolver.resolve(request);
         if (!toCache) {
             return Promise.reject(`Invalid URL ${request.url}`);
         }


### PR DESCRIPTION
Simplify host config to only take a single `IUrlResolver`.  We don't appear to currently have any cases using the array functionality, and if any come up they could be satisfied by creating a multi-url-resolver that does something similar to `configurableUrlResolver` (or whatever other resolver mediation policy they may want).