### PR TITLE
Add try-catch around change connection state calls

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -743,14 +743,14 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
             }
         }
 
-        for (const [key, componentContext] of this.contexts) {
+        for (const [component, componentContext] of this.contexts) {
             try {
                 componentContext.changeConnectionState(value, clientId);
             } catch (error) {
                 this.logger.sendErrorEvent({
                     eventName: "ChangeConnectionStateError",
                     clientId,
-                    component: key,
+                    component,
                 }, error);
             }
         }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -741,14 +741,25 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
             for (const [, message] of this.pendingAttach) {
                 this.submit(MessageType.Attach, message);
             }
-
         }
 
-        for (const [, componentContext] of this.contexts) {
-            componentContext.changeConnectionState(value, clientId);
+        for (const [key, componentContext] of this.contexts) {
+            try {
+                componentContext.changeConnectionState(value, clientId);
+            } catch (error) {
+                this.logger.sendErrorEvent({
+                    eventName: "ChangeConnectionStateError",
+                    clientId,
+                    component: key,
+                }, error);
+            }
         }
 
-        raiseConnectedEvent(this, value, clientId);
+        try {
+            raiseConnectedEvent(this, value, clientId);
+        } catch (error) {
+            this.logger.sendErrorEvent({ eventName: "RaiseConnectedEventError", clientId }, error);
+        }
 
         if (value === ConnectionState.Connected) {
             this.summaryManager.setConnected(clientId);


### PR DESCRIPTION
In response to issue #954.  I think this is a possible cause: that an unhandled error prevents SummaryManager from realizing it is disconnected.