### PR TITLE
Batch Processing: Remove DeltaQueue pause / unpause and move batch logic from ContainerRuntime to DeltaManager

### DIFF
--- a/packages/components/clicker/src/index.tsx
+++ b/packages/components/clicker/src/index.tsx
@@ -5,8 +5,8 @@
 
 import { PrimedComponent, PrimedComponentFactory } from "@microsoft/fluid-aqueduct";
 import { IComponentHTMLVisual } from "@microsoft/fluid-component-core-interfaces";
-import { Counter, CounterValueType, ISharedDirectory } from "@microsoft/fluid-map";
-import { ITask, IHostRuntime } from "@microsoft/fluid-runtime-definitions";
+import { Counter, CounterValueType } from "@microsoft/fluid-map";
+import { ITask } from "@microsoft/fluid-runtime-definitions";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { ClickerAgent } from "./agent";
@@ -14,9 +14,6 @@ import { ClickerAgent } from "./agent";
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 const pkg = require("../package.json");
 export const ClickerName = pkg.name as string;
-
-let batchCount = 0;
-let opsCount = 0;
 
 /**
  * Basic Clicker example using new interfaces and stock component classes.
@@ -49,7 +46,7 @@ export class Clicker extends PrimedComponent implements IComponentHTMLVisual {
     // Get our counter object that we set in initialize and pass it in to the view.
         const counter = this.root.get("clicks");
         ReactDOM.render(
-            <CounterReactView counter={counter} sharedDirectory={this.root} runtime={this.context.hostRuntime}/>,
+            <CounterReactView counter={counter} />,
             div,
         );
         return div;
@@ -76,8 +73,6 @@ export class Clicker extends PrimedComponent implements IComponentHTMLVisual {
 
 interface CounterProps {
     counter: Counter;
-    sharedDirectory: ISharedDirectory;
-    runtime: IHostRuntime;
 }
 
 interface CounterState {
@@ -105,31 +100,7 @@ class CounterReactView extends React.Component<CounterProps, CounterState> {
                 <span className="clicker-value-class" id={`clicker-value-${Date.now().toString()}`}>
                     {this.state.value}
                 </span>
-                <br />
-                <button onClick={
-                    () => {
-                        this.props.runtime.orderSequentially(() => {
-                            batchCount++;
-                            for (let i = 0; i < 100; i++) {
-                                this.props.sharedDirectory.set(`batch-${batchCount}`, i);
-                            }
-                        });
-                    }
-                }>
-                    + (Batches)
-                </button>
-                <br />
-                <button onClick={
-                    () => {
-                        this.props.counter.increment(1);
-                        opsCount++;
-                        for (let i = 0; i < 10; i++) {
-                            this.props.sharedDirectory.set(`ops-${opsCount}`, i);
-                        }
-                    }
-                }>
-                    + (Ops)
-                </button>
+                <button onClick={() => { this.props.counter.increment(1); }}>+</button>
             </div>
         );
     }

--- a/packages/components/clicker/src/index.tsx
+++ b/packages/components/clicker/src/index.tsx
@@ -110,7 +110,7 @@ class CounterReactView extends React.Component<CounterProps, CounterState> {
                     () => {
                         this.props.runtime.orderSequentially(() => {
                             batchCount++;
-                            for (let i = 0; i < 500; i++) {
+                            for (let i = 0; i < 100; i++) {
                                 this.props.sharedDirectory.set(`batch-${batchCount}`, i);
                             }
                         });
@@ -123,7 +123,7 @@ class CounterReactView extends React.Component<CounterProps, CounterState> {
                     () => {
                         this.props.counter.increment(1);
                         opsCount++;
-                        for (let i = 0; i < 500; i++) {
+                        for (let i = 0; i < 10; i++) {
                             this.props.sharedDirectory.set(`ops-${opsCount}`, i);
                         }
                     }

--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -73,7 +73,7 @@ export interface IDeltaSender extends IProvideDeltaSender {
 
 export interface IDeltaManager<T, U> extends EventEmitter, IDeltaSender, IDisposable {
     // The queue of inbound delta messages
-    inbound: IDeltaQueue<T>;
+    inbound: IDeltaQueue<T[]>;
 
     // The queue of outbound delta messages
     outbound: IDeltaQueue<U[]>;
@@ -121,6 +121,8 @@ export interface IDeltaManager<T, U> extends EventEmitter, IDeltaSender, IDispos
         resume: boolean);
 
     submitSignal(content: any): void;
+
+    setInboundMessageBufferReady(ready: boolean): void;
 }
 
 export interface IDeltaQueue<T> extends EventEmitter, IDisposable {

--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -121,10 +121,6 @@ export interface IDeltaManager<T, U> extends EventEmitter, IDeltaSender, IDispos
         resume: boolean);
 
     submitSignal(content: any): void;
-
-    setInboundMessageBufferReady(ready: boolean): void;
-
-    pushToInboundQueue(): void;
 }
 
 export interface IDeltaQueue<T> extends EventEmitter, IDisposable {

--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -123,6 +123,8 @@ export interface IDeltaManager<T, U> extends EventEmitter, IDeltaSender, IDispos
     submitSignal(content: any): void;
 
     setInboundMessageBufferReady(ready: boolean): void;
+
+    pushToInboundQueue(): void;
 }
 
 export interface IDeltaQueue<T> extends EventEmitter, IDisposable {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1074,14 +1074,14 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         }
     }
 
-    private submitMessage(type: MessageType, contents: any, batch?: boolean, metadata?: any): number {
+    private submitMessage(type: MessageType, contents: any, batch?: boolean): number {
         if (this.connectionState !== ConnectionState.Connected) {
             this.logger.sendErrorEvent({ eventName: "SubmitMessageWithNoConnection", type });
             return -1;
         }
 
         this.messageCountAfterDisconnection += 1;
-        return this._deltaManager.submit(type, contents, batch, metadata);
+        return this._deltaManager.submit(type, contents, batch);
     }
 
     private processRemoteMessage(message: ISequencedDocumentMessage): IProcessMessageResult {
@@ -1169,7 +1169,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
             loader,
             storage,
             (err) => this.raiseCriticalError(err),
-            (type, contents, batch, metadata) => this.submitMessage(type, contents, batch, metadata),
+            (type, contents, batch?) => this.submitMessage(type, contents, batch),
             (message) => this.submitSignal(message),
             async (message) => this.snapshot(message),
             (reason?: string) => this.close(reason),

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -260,6 +260,13 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         }
     }
 
+    public pushToInboundQueue() {
+        if (this.inboundMessageBuffer) {
+            this._inbound.push(this.inboundMessageBuffer.messages);
+            this.inboundMessageBuffer.messages = [];
+        }
+    }
+
     public dispose() {
         assert.fail("Not implemented.");
         this.isDisposed = true;
@@ -942,11 +949,10 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
                 if (this.inboundMessageBuffer === undefined) {
                     this.inboundMessageBuffer = { messages: [], ready: true };
                 }
-                this.inboundMessageBuffer.messages.push(message);
-                this.inboundMessageBuffer.ready = true;
 
                 this.emit("preparePush", message);
 
+                this.inboundMessageBuffer.messages.push(message);
                 if (this.inboundMessageBuffer.ready) {
                     this._inbound.push(this.inboundMessageBuffer.messages);
                     this.inboundMessageBuffer = undefined;

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -77,7 +77,6 @@ interface IRuntimeMessageMetadata {
  * Adds all messages in a batch to a buffer before pushing it to the respective queue.
  * For outgoing messages, adds the being and end metadata to the batch before sending it out.
  */
-
 class MessageProcessingDelegate {
     private readonly deltaManager: EventEmitter;
     private readonly logger: ITelemetryLogger;

--- a/packages/loader/container-loader/src/deltaManagerProxy.ts
+++ b/packages/loader/container-loader/src/deltaManagerProxy.ts
@@ -146,6 +146,10 @@ export class DeltaManagerProxy
         this.deltaManager.setInboundMessageBufferReady(ready);
     }
 
+    public pushToInboundQueue() {
+        this.deltaManager.pushToInboundQueue();
+    }
+
     public dispose(): void {
         this.inbound.dispose();
         this.outbound.dispose();

--- a/packages/loader/container-loader/src/deltaManagerProxy.ts
+++ b/packages/loader/container-loader/src/deltaManagerProxy.ts
@@ -86,7 +86,7 @@ export class DeltaManagerProxy
     extends EventForwarder
     implements IDeltaManager<ISequencedDocumentMessage, IDocumentMessage> {
 
-    public readonly inbound: IDeltaQueue<ISequencedDocumentMessage>;
+    public readonly inbound: IDeltaQueue<ISequencedDocumentMessage[]>;
     public readonly outbound: IDeltaQueue<IDocumentMessage[]>;
     public readonly inboundSignal: IDeltaQueue<ISignalMessage>;
 
@@ -140,6 +140,10 @@ export class DeltaManagerProxy
         this.inbound = new DeltaQueueProxy(deltaManager.inbound);
         this.outbound = new DeltaQueueProxy(deltaManager.outbound);
         this.inboundSignal = new DeltaQueueProxy(deltaManager.inboundSignal);
+    }
+
+    public setInboundMessageBufferReady(ready: boolean) {
+        this.deltaManager.setInboundMessageBufferReady(ready);
     }
 
     public dispose(): void {

--- a/packages/loader/container-loader/src/deltaManagerProxy.ts
+++ b/packages/loader/container-loader/src/deltaManagerProxy.ts
@@ -142,14 +142,6 @@ export class DeltaManagerProxy
         this.inboundSignal = new DeltaQueueProxy(deltaManager.inboundSignal);
     }
 
-    public setInboundMessageBufferReady(ready: boolean) {
-        this.deltaManager.setInboundMessageBufferReady(ready);
-    }
-
-    public pushToInboundQueue() {
-        this.deltaManager.pushToInboundQueue();
-    }
-
     public dispose(): void {
         this.inbound.dispose();
         this.outbound.dispose();

--- a/packages/loader/container-loader/src/deltaQueue.ts
+++ b/packages/loader/container-loader/src/deltaQueue.ts
@@ -118,7 +118,6 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
 
     public push(task: T) {
         this.q.push(task);
-        this.emit("push", task);
         this.ensureProcessing();
     }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -375,7 +375,6 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
     private version: string;
 
     private _flushMode = FlushMode.Automatic;
-    private needsFlush = false;
 
     private _leader = false;
 
@@ -726,13 +725,6 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
             debug("DeltaManager does not yet support flush modes");
             return;
         }
-
-        // If flush has already been called then exit early
-        if (!this.needsFlush) {
-            return;
-        }
-
-        this.needsFlush = false;
         return this.deltaSender.flush();
     }
 


### PR DESCRIPTION
- Currently, ContainerRuntime looks into inbound/outbound messages for batch information and sends the information to DeltaManager.
- This change moves the batching logic into DeltaManager.
- When a batch is received, ContainerRuntime pauses the inbound DeltaQueue until the entire batch is processed.
- This change removes that. Instead, it adds all the incoming batch messages into a buffer and pushes it to the DeltaQueue once the entire batch is received. DeltaQueue will process the entire batch buffer as a single task which ensures that batch messages are processed together.

With #834 , the processing of DeltaQueue was made async. So if receive a batch which takes a long time to process, we would have yielded the JS thread in between the processing of a batch. This changes fixes that too since the entire batch is pushed as a single task into the queue so its guaranteed to be processed together.