### PR TITLE
Remove clientId from reason to close

### DIFF
--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -134,7 +134,7 @@ export class SummaryManager extends EventEmitter {
         if (!this.connected) {
             return "parentNotConnected";
         } else if (this.clientId !== this.summarizer) {
-            return `parentShouldNotSummarize:${this.summarizer}`;
+            return "parentShouldNotSummarize";
         } else {
             return undefined;
         }


### PR DESCRIPTION
Fixes #866.  This information probably hasn't been useful so far anyway.