### PR TITLE
Eslint: clean up tslint-disable

### DIFF
--- a/packages/components/client-ui/src/controls/flowContainer.ts
+++ b/packages/components/client-ui/src/controls/flowContainer.ts
@@ -259,6 +259,7 @@ export class FlowContainer extends ui.Component {
         for (const layerId in this.activeLayers) {
             if (!this.activeLayers[layerId].active) {
                 const layer = this.activeLayers[layerId];
+                // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
                 delete this.activeLayers[layerId];
                 this.overlayCanvas.removeLayer(layer.layer);
             }

--- a/packages/components/flow-scroll/src/host/host.ts
+++ b/packages/components/flow-scroll/src/host/host.ts
@@ -60,7 +60,6 @@ export class HostView implements IComponentHTMLView, SearchMenu.ISearchMenuHost 
         }
     }
 
-    // tslint:disable-next-line:max-func-body-length
     public render(elm: HTMLElement): void {
         const flowDiv = document.createElement("div");
         const insightsDiv = document.createElement("div");

--- a/packages/components/flow-util/src/resizeobserver/index.ts
+++ b/packages/components/flow-util/src/resizeobserver/index.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-// tslint:disable:import-name
 import { isBrowser } from "../isbrowser";
 import { Template } from "../template";
 import { View } from "../view";

--- a/packages/components/markflow/test/layout.spec.ts
+++ b/packages/components/markflow/test/layout.spec.ts
@@ -42,7 +42,6 @@ function expectTree(actual: Node, expected: ISnapshotNode) {
     assert.strictEqual(i, children.length);
 }
 
-// tslint:disable:max-func-body-length
 describe("Layout", () => {
     let host: TestHost;
     let doc: FlowDocument;

--- a/packages/components/markflow/test/markdown.editing.spec.ts
+++ b/packages/components/markflow/test/markdown.editing.spec.ts
@@ -81,7 +81,6 @@ describe("Markdown", () => {
         layout.invalidatedCallback = (start, end) => {
             oldInvalidatedCallback(start, end);
             if (!renderResolver) {
-                // tslint:disable-next-line:promise-must-complete
                 rendered = new Promise((accept) => {
                     console.log("Render pending");
                     renderResolver = accept;

--- a/packages/components/markflow/test/markdown.editing.spec.ts
+++ b/packages/components/markflow/test/markdown.editing.spec.ts
@@ -49,7 +49,6 @@ import { Layout } from "../src/view/layout";
 //     assert.strictEqual(i, children.length);
 // }
 
-// tslint:disable:max-func-body-length
 describe("Markdown", () => {
     let host: TestHost;
     let doc: FlowDocument;

--- a/packages/components/markflow/test/markdown.spec.ts
+++ b/packages/components/markflow/test/markdown.spec.ts
@@ -96,7 +96,6 @@ describe("Markdown", () => {
         let renderResolver: () => void;
         layout.invalidatedCallback = () => {
             if (!renderResolver) {
-                // tslint:disable-next-line:promise-must-complete
                 rendered = new Promise((accept) => {
                     console.log("Render pending");
                     renderResolver = accept;

--- a/packages/components/markflow/test/markdown.spec.ts
+++ b/packages/components/markflow/test/markdown.spec.ts
@@ -68,7 +68,6 @@ function processTests(tests: { markdown: string, html: string, section: string }
 //     assert.strictEqual(i, children.length);
 // }
 
-// tslint:disable:max-func-body-length
 describe("Markdown", () => {
     let host: TestHost;
     let doc: FlowDocument;

--- a/packages/drivers/iframe-socket-storage/src/innerDocumentDeltaConnection.ts
+++ b/packages/drivers/iframe-socket-storage/src/innerDocumentDeltaConnection.ts
@@ -39,7 +39,6 @@ export class InnerDocumentDeltaConnection extends EventEmitter implements IDocum
         connection: IConnected,
         outerProxy: IOuterDocumentDeltaConnectionProxy): Promise<IDocumentDeltaConnection> {
 
-        // tslint:disable-next-line: no-unsafe-any
         const deltaConnection = new InnerDocumentDeltaConnection(connection, outerProxy);
 
         return deltaConnection;

--- a/packages/drivers/iframe-socket-storage/src/outerDocumentServiceFactory.ts
+++ b/packages/drivers/iframe-socket-storage/src/outerDocumentServiceFactory.ts
@@ -154,7 +154,6 @@ export class DocumentServiceFactoryProxy implements IDocumentServiceFactoryProxy
         const connectedDocumentService: IDocumentService =
             await this.documentServiceFactory.createDocumentService(resolvedUrl);
 
-        // tslint:disable-next-line: no-unsafe-any
         const clientDetails = this.options ? (this.options.client as IClient) : null;
         const mode: ConnectionMode = "write";
 

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
@@ -262,7 +262,6 @@ export class OdspDocumentService implements IDocumentService {
      * @param url - websocket URL
      * @param url2 - alternate websocket URL
      */
-    // tslint:disable-next-line: max-func-body-length
     private async connectToDeltaStreamWithRetry(
         tenantId: string,
         websocketId: string,

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
@@ -192,7 +192,6 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
         return hierarchicalTree;
     }
 
-    // tslint:disable-next-line: max-func-body-length
     public async getVersions(blobid: string | null, count: number): Promise<api.IVersion[]> {
         // Regular load workflow uses blobId === documentID to indicate "latest".
         if (blobid === this.documentId) {

--- a/packages/drivers/odsp-socket-storage/src/test/odspError.spec.ts
+++ b/packages/drivers/odsp-socket-storage/src/test/odspError.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-// tslint:disable: no-string-literal
+
 import * as assert from "assert";
 import { OdspNetworkError } from "../odspUtils";
 

--- a/packages/drivers/replay-socket-storage/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-socket-storage/src/replayDocumentDeltaConnection.ts
@@ -122,7 +122,6 @@ export class ReplayControllerStatic extends ReplayController {
         fetchedOps: ISequencedDocumentMessage[]): Promise<void> {
         let current = this.skipToIndex(fetchedOps);
 
-        // tslint:disable-next-line:promise-must-complete
         return new Promise((resolve, reject) => {
             const replayNextOps = () => {
                 // Emit the ops from replay to the end every "deltainterval" milliseconds

--- a/packages/drivers/replay-socket-storage/src/storageImplementations.ts
+++ b/packages/drivers/replay-socket-storage/src/storageImplementations.ts
@@ -149,7 +149,6 @@ export class StaticStorageDocumentService implements IDocumentService {
 
     public async connectToDeltaStream(client: IClient, mode: ConnectionMode): Promise<IDocumentDeltaConnection> {
         // We have no delta stream, so make it not return forever...
-        // tslint:disable-next-line:promise-must-complete
         return new Promise(() => { });
     }
 

--- a/packages/drivers/routerlicious-socket-storage/src/registration.ts
+++ b/packages/drivers/routerlicious-socket-storage/src/registration.ts
@@ -29,7 +29,6 @@ export function createDocumentService(
     credentials?,
     seedData?: IGitCache): IDocumentService {
 
-    /* tslint:disable:no-unsafe-any */
     const service = new DocumentService(
         ordererUrl,
         deltaStorageUrl,

--- a/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
+++ b/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
@@ -66,7 +66,6 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
      * @param url - websocket URL
      * @param timeoutMs - timeout for socket connection attempt in milliseconds (default: 20000)
      */
-    // tslint:disable-next-line: max-func-body-length
     public static async create(
         tenantId: string,
         id: string,

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -859,7 +859,6 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
     }
 
     private getRetryDelayFromError(error): number | undefined {
-        // tslint:disable-next-line: no-unsafe-any
         return error !== null && typeof error === "object" && error.retryAfterSeconds ? error.retryAfterSeconds
             : undefined;
     }
@@ -1114,7 +1113,6 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
 
     private stopSequenceNumberUpdate(): void {
         if (this.updateSequenceNumberTimer) {
-            // tslint:disable-next-line: no-unsafe-any
             clearTimeout(this.updateSequenceNumberTimer);
         }
         this.updateSequenceNumberTimer = undefined;

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -345,7 +345,6 @@ export class Loader extends EventEmitter implements ILoader {
 
         const headerSeqNum = request.headers[LoaderHeader.sequenceNumber];
         if (headerSeqNum) {
-            // tslint:disable-next-line no-unsafe-any
             fromSequenceNumber = headerSeqNum;
         }
 

--- a/packages/loader/execution-context-loader/src/webWorkerLoader.ts
+++ b/packages/loader/execution-context-loader/src/webWorkerLoader.ts
@@ -15,7 +15,6 @@ import * as Comlink from "comlink";
 
 // Proxy loader that proxies request to web worker.
 interface IProxyLoader extends ILoader, IComponentRunnable {
-    // tslint:disable no-misused-new
     // eslint-disable-next-line @typescript-eslint/no-misused-new
     new(id: string,
         options: any,

--- a/packages/loader/loader-web/src/webLoader.ts
+++ b/packages/loader/loader-web/src/webLoader.ts
@@ -105,7 +105,6 @@ class ScriptManager {
                     script.async = false;
 
                     // Call signatures don't match and so need to wrap the method
-                    // tslint:disable-next-line:no-unnecessary-callback-wrapper
                     script.onload = () => resolve();
                     script.onerror = () =>
                         reject(new Error(`Failed to download the script at url: ${scriptUrl}`));
@@ -255,7 +254,6 @@ class FluidPackage {
 
         await Promise.all(this.scriptManager.loadScripts(umdDetails, this.details.packageUrl));
 
-        // tslint:disable-next-line:no-unsafe-any
         return this.scriptManager.isBrowser ? window[umdDetails.library] : self[umdDetails.library];
     }
 }

--- a/packages/runtime/consensus-ordered-collection/src/consensusOrderedCollection.ts
+++ b/packages/runtime/consensus-ordered-collection/src/consensusOrderedCollection.ts
@@ -91,7 +91,6 @@ export class ConsensusOrderedCollection<T = any> extends SharedObject implements
         }
 
         let operationValue: IConsensusOrderedCollectionValue;
-        /* tslint:disable:no-unsafe-any */
 
         // TODO: Not all shared object will be derived from SharedObject
         if (SharedObject.is(value)) {

--- a/packages/runtime/consensus-register-collection/src/consensusRegisterCollection.ts
+++ b/packages/runtime/consensus-register-collection/src/consensusRegisterCollection.ts
@@ -177,7 +177,6 @@ export class ConsensusRegisterCollection<T> extends SharedObject implements ICon
             // We don't support deletion. So there should be at least one value.
             assert(versions.length > 0, "Value should be undefined or non empty");
 
-            /* tslint:disable:no-unsafe-any */
             return versions[versions.length - 1];
         }
     }
@@ -343,8 +342,6 @@ export class ConsensusRegisterCollection<T> extends SharedObject implements ICon
 
     private async submit(message: IRegisterOperation): Promise<void> {
         const clientSequenceNumber = this.submitLocalMessage(message);
-        // False positive - tslint couldn't track that the promise is stored in promiseResolveQueue and resolved later
-        // tslint:disable:promise-must-complete
         return new Promise((resolve, reject) => {
             // Note that clientSequenceNumber and key is only used for asserts and isn't strictly necessary.
             this.promiseResolveQueue.push({ resolve, reject, clientSequenceNumber, key: message.key });

--- a/packages/runtime/container-runtime/src/test/requestParser.spec.ts
+++ b/packages/runtime/container-runtime/src/test/requestParser.spec.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-// tslint:disable: prefer-const
+
 import * as assert from "assert";
 import { RequestParser } from "../requestParser";
 

--- a/packages/runtime/map/src/test/counter.spec.ts
+++ b/packages/runtime/map/src/test/counter.spec.ts
@@ -38,7 +38,6 @@ describe("Routerlicious", () => {
                         get("defaultCounter");
                     assert.ok(counterWithValue);
 
-                    /* tslint:disable:no-unsafe-any */
                     assert.equal(counterWithValue.value, 50);
                 });
             });

--- a/packages/runtime/map/src/test/counter.spec.ts
+++ b/packages/runtime/map/src/test/counter.spec.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-// tslint:disable: newline-per-chained-call
-// tslint:disable: no-backbone-get-set-outside-model
 import * as assert from "assert";
 import { MockRuntime } from "@microsoft/fluid-test-runtime-utils";
 import * as map from "../";

--- a/packages/runtime/map/src/test/directory.spec.ts
+++ b/packages/runtime/map/src/test/directory.spec.ts
@@ -258,7 +258,6 @@ describe("Routerlicious", () => {
             });
 
             it("Should populate the directory with undefined values", async () => {
-                // tslint:disable-next-line:max-line-length
                 await populate(testDirectory, {
                     storage: {
                         testKey: {

--- a/packages/runtime/map/src/test/map.spec.ts
+++ b/packages/runtime/map/src/test/map.spec.ts
@@ -35,8 +35,6 @@ describe("Routerlicious", () => {
             });
 
             it("Can set and get map data", async () => {
-                // tslint:disable:no-backbone-get-set-outside-model
-                /* tslint:disable:no-unsafe-any */
                 testMap.set("testKey", "testValue");
                 testMap.set("testKey2", "testValue2");
                 assert.equal(testMap.get("testKey"), "testValue");

--- a/packages/runtime/merge-tree/.eslintrc.js
+++ b/packages/runtime/merge-tree/.eslintrc.js
@@ -8,7 +8,6 @@ module.exports = {
         "@microsoft/eslint-config-fluid"
     ],
     "rules": {
-        "@typescript-eslint/consistent-type-assertions": "off",
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/strict-boolean-expressions": "off",
         "no-case-declarations": "off",

--- a/packages/runtime/merge-tree/.eslintrc.js
+++ b/packages/runtime/merge-tree/.eslintrc.js
@@ -13,7 +13,6 @@ module.exports = {
         "@typescript-eslint/strict-boolean-expressions": "off",
         "no-case-declarations": "off",
         "no-null/no-null": "off",
-        "max-len": "off",
         "prefer-arrow/prefer-arrow-functions": "off"
     }
 }

--- a/packages/runtime/merge-tree/.eslintrc.js
+++ b/packages/runtime/merge-tree/.eslintrc.js
@@ -14,7 +14,6 @@ module.exports = {
         "no-bitwise": "off",
         "no-case-declarations": "off",
         "no-null/no-null": "off",
-        "no-param-reassign": "off",
         "no-shadow": "off",
         "max-len": "off",
         "prefer-arrow/prefer-arrow-functions": "off"

--- a/packages/runtime/merge-tree/.eslintrc.js
+++ b/packages/runtime/merge-tree/.eslintrc.js
@@ -11,10 +11,8 @@ module.exports = {
         "@typescript-eslint/consistent-type-assertions": "off",
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/strict-boolean-expressions": "off",
-        "no-bitwise": "off",
         "no-case-declarations": "off",
         "no-null/no-null": "off",
-        "no-shadow": "off",
         "max-len": "off",
         "prefer-arrow/prefer-arrow-functions": "off"
     }

--- a/packages/runtime/merge-tree/src/client.ts
+++ b/packages/runtime/merge-tree/src/client.ts
@@ -664,10 +664,10 @@ export class Client {
     }
     cloneFromSegments() {
         const clone = new Client(this.specToSegment, this.logger, this.mergeTree.options);
-        const segments = <ISegment[]>[];
+        const segments: ISegment[] = [];
         const newRoot = this.mergeTree.blockClone(this.mergeTree.root, segments);
         clone.mergeTree.root = newRoot;
-        let undoSeg = <IUndoInfo[]>[];
+        let undoSeg: IUndoInfo[] = [];
         for (const segment of segments) {
             if (segment.seq !== 0) {
                 undoSeg.push({

--- a/packages/runtime/merge-tree/src/client.ts
+++ b/packages/runtime/merge-tree/src/client.ts
@@ -227,7 +227,11 @@ export class Client {
             segment,
             opArgs);
 
-        this.completeAndLogOp(opArgs, this.getClientSequenceArgs(opArgs), { start: op.pos1, end: undefined }, clockStart);
+        this.completeAndLogOp(
+            opArgs,
+            this.getClientSequenceArgs(opArgs),
+            { start: op.pos1, end: undefined },
+            clockStart);
 
         return op;
     }
@@ -996,6 +1000,7 @@ export class Client {
     getPropertiesAtPosition(pos: number) {
         const segWindow = this.getCollabWindow();
         if (this.verboseOps) {
+            // eslint-disable-next-line max-len
             console.log(`getPropertiesAtPosition cli ${this.getLongClientId(segWindow.clientId)} ref seq ${segWindow.currentSeq}`);
         }
 
@@ -1010,6 +1015,7 @@ export class Client {
     getRangeExtentsOfPosition(pos: number) {
         const segWindow = this.getCollabWindow();
         if (this.verboseOps) {
+            // eslint-disable-next-line max-len
             console.log(`getRangeExtentsOfPosition cli ${this.getLongClientId(segWindow.clientId)} ref seq ${segWindow.currentSeq}`);
         }
 

--- a/packages/runtime/merge-tree/src/collections.ts
+++ b/packages/runtime/merge-tree/src/collections.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable eqeqeq, object-shorthand, no-param-reassign */
+/* eslint-disable eqeqeq, object-shorthand, no-bitwise, no-param-reassign, no-shadow */
 
 import * as Base from "./base";
 import * as MergeTree from "./mergeTree";

--- a/packages/runtime/merge-tree/src/collections.ts
+++ b/packages/runtime/merge-tree/src/collections.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable eqeqeq, object-shorthand, no-bitwise, no-param-reassign, no-shadow */
+/* eslint-disable @typescript-eslint/consistent-type-assertions, eqeqeq, object-shorthand */
+/* eslint-disable no-bitwise, no-param-reassign, no-shadow */
 
 import * as Base from "./base";
 import * as MergeTree from "./mergeTree";

--- a/packages/runtime/merge-tree/src/collections.ts
+++ b/packages/runtime/merge-tree/src/collections.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable eqeqeq, object-shorthand */
+/* eslint-disable eqeqeq, object-shorthand, no-param-reassign */
 
 import * as Base from "./base";
 import * as MergeTree from "./mergeTree";

--- a/packages/runtime/merge-tree/src/collections.ts
+++ b/packages/runtime/merge-tree/src/collections.ts
@@ -950,6 +950,7 @@ export class IntegerRangeTree implements IRBAugmentation<Base.IIntegerRange, Aug
                     red = "R ";
                 }
                 buf += MergeTree.internedSpaces(indentAmt);
+                // eslint-disable-next-line max-len
                 buf += `${red}key: ${integerRangeToString(node.key)} minmax: ${integerRangeToString(node.data.minmax)}\n`;
                 indentAmt += 2;
                 return true;

--- a/packages/runtime/merge-tree/src/localReference.ts
+++ b/packages/runtime/merge-tree/src/localReference.ts
@@ -310,7 +310,7 @@ export class LocalReferenceCollection {
 
         for (const iterable of refs) {
             for (const lref of iterable) {
-                // tslint:disable-next-line: no-bitwise
+                // eslint-disable-next-line no-bitwise
                 if (lref.refType & ReferenceType.SlideOnRemove) {
                     beforeRefs.push(lref);
                     lref.segment = this.segment;
@@ -341,7 +341,7 @@ export class LocalReferenceCollection {
 
         for (const iterable of refs) {
             for (const lref of iterable) {
-                // tslint:disable-next-line: no-bitwise
+                // eslint-disable-next-line no-bitwise
                 if (lref.refType & ReferenceType.SlideOnRemove) {
                     afterRefs.push(lref);
                     lref.segment = this.segment;

--- a/packages/runtime/merge-tree/src/mergeTree.ts
+++ b/packages/runtime/merge-tree/src/mergeTree.ts
@@ -40,7 +40,6 @@ import { SegmentPropertiesManager } from "./segmentPropertiesManager";
 // tslint:disable:member-access
 // tslint:disable:no-parameter-reassignment
 // tslint:disable:no-shadowed-variable
-// tslint:disable:no-unsafe-any
 // tslint:disable:whitespace
 // tslint:disable:align
 // tslint:disable:no-string-literal

--- a/packages/runtime/merge-tree/src/mergeTree.ts
+++ b/packages/runtime/merge-tree/src/mergeTree.ts
@@ -39,7 +39,6 @@ import { SegmentPropertiesManager } from "./segmentPropertiesManager";
 // tslint:disable:member-access
 // tslint:disable:whitespace
 // tslint:disable:align
-// tslint:disable:no-string-literal
 // tslint:disable:no-object-literal-type-assertion
 
 export interface ReferencePosition {

--- a/packages/runtime/merge-tree/src/mergeTree.ts
+++ b/packages/runtime/merge-tree/src/mergeTree.ts
@@ -31,8 +31,6 @@ import { SegmentGroupCollection } from "./segmentGroupCollection";
 import { SegmentPropertiesManager } from "./segmentPropertiesManager";
 
 // tslint:disable:interface-name
-// tslint:disable:member-ordering
-// tslint:disable:callable-types
 // tslint:disable:no-suspicious-comment
 // tslint:disable:no-angle-bracket-type-assertion
 // tslint:disable:member-access

--- a/packages/runtime/merge-tree/src/mergeTree.ts
+++ b/packages/runtime/merge-tree/src/mergeTree.ts
@@ -34,7 +34,6 @@ import { SegmentPropertiesManager } from "./segmentPropertiesManager";
 // tslint:disable:no-suspicious-comment
 // tslint:disable:no-angle-bracket-type-assertion
 // tslint:disable:member-access
-// tslint:disable:align
 // tslint:disable:no-object-literal-type-assertion
 
 export interface ReferencePosition {

--- a/packages/runtime/merge-tree/src/mergeTree.ts
+++ b/packages/runtime/merge-tree/src/mergeTree.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable no-param-reassign */
+
 import * as assert from "assert";
 import * as Base from "./base";
 import * as Collections from "./collections";
@@ -38,7 +40,6 @@ import { SegmentPropertiesManager } from "./segmentPropertiesManager";
 // tslint:disable:no-suspicious-comment
 // tslint:disable:no-angle-bracket-type-assertion
 // tslint:disable:member-access
-// tslint:disable:no-parameter-reassignment
 // tslint:disable:no-shadowed-variable
 // tslint:disable:whitespace
 // tslint:disable:align

--- a/packages/runtime/merge-tree/src/mergeTree.ts
+++ b/packages/runtime/merge-tree/src/mergeTree.ts
@@ -34,8 +34,6 @@ import { SegmentPropertiesManager } from "./segmentPropertiesManager";
 // tslint:disable:member-ordering
 // tslint:disable:max-line-length
 // tslint:disable:callable-types
-// tslint:disable:no-for-in
-// tslint:disable:forin
 // tslint:disable:no-suspicious-comment
 // tslint:disable:no-angle-bracket-type-assertion
 // tslint:disable:member-access

--- a/packages/runtime/merge-tree/src/mergeTree.ts
+++ b/packages/runtime/merge-tree/src/mergeTree.ts
@@ -2069,7 +2069,6 @@ export class MergeTree {
         }
     }
 
-    // tslint:disable-next-line: max-func-body-length
     public insertAtReferencePosition(referencePosition: ReferencePosition, insertSegment: ISegment, opArgs: IMergeTreeDeltaOpArgs): void {
 
         if (insertSegment.cachedLength === 0) {
@@ -2410,7 +2409,6 @@ export class MergeTree {
         }
     }
 
-    // tslint:disable-next-line: max-func-body-length
     private insertingWalk(
         block: IMergeBlock, pos: number, refSeq: number, clientId: number, seq: number,
         context: InsertContext) {
@@ -2674,7 +2672,6 @@ export class MergeTree {
         }
     }
 
-    // tslint:disable-next-line: max-func-body-length
     markRangeRemoved(start: number, end: number, refSeq: number, clientId: number, seq: number, overwrite = false, opArgs: IMergeTreeDeltaOpArgs) {
         this.ensureIntervalBoundary(start, refSeq, clientId);
         this.ensureIntervalBoundary(end, refSeq, clientId);
@@ -2742,15 +2739,15 @@ export class MergeTree {
                 const afterSegOff = this.getContainingSegment(start, refSeq, clientId);
                 refSegment = afterSegOff.segment;
                 assert(refSegment);
-                if(!refSegment.localRefs){
+                if (!refSegment.localRefs) {
                     refSegment.localRefs = new LocalReferenceCollection(refSegment);
                 }
                 refSegment.localRefs.addBeforeTombstones(...savedLocalRefs);
-            } else if(length > 0) {
+            } else if (length > 0) {
                 const beforeSegOff = this.getContainingSegment(length - 1, refSeq, clientId);
                 refSegment = beforeSegOff.segment;
                 assert(refSegment);
-                if(!refSegment.localRefs){
+                if (!refSegment.localRefs) {
                     refSegment.localRefs = new LocalReferenceCollection(refSegment);
                 }
                 refSegment.localRefs.addAfterTombstones(...savedLocalRefs);
@@ -2864,7 +2861,7 @@ export class MergeTree {
     }
 
     removeLocalReference(segment: ISegment, lref: LocalReference) {
-        if(segment.localRefs){
+        if (segment.localRefs) {
             const removedRef = segment.localRefs.removeLocalRef(lref);
             if (removedRef) {
                 this.blockUpdatePathLengths(segment.parent, TreeMaintenanceSequenceNumber,
@@ -2875,7 +2872,7 @@ export class MergeTree {
 
     addLocalReference(lref: LocalReference) {
         const segment = lref.segment;
-        if(!segment.localRefs){
+        if (!segment.localRefs) {
             segment.localRefs = new LocalReferenceCollection(segment);
         }
         segment.localRefs.addLocalRef(lref);

--- a/packages/runtime/merge-tree/src/mergeTree.ts
+++ b/packages/runtime/merge-tree/src/mergeTree.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable no-bitwise, no-param-reassign, no-shadow */
+/* eslint-disable max-len, no-bitwise, no-param-reassign, no-shadow */
 
 import * as assert from "assert";
 import * as Base from "./base";
@@ -32,12 +32,10 @@ import { SegmentPropertiesManager } from "./segmentPropertiesManager";
 
 // tslint:disable:interface-name
 // tslint:disable:member-ordering
-// tslint:disable:max-line-length
 // tslint:disable:callable-types
 // tslint:disable:no-suspicious-comment
 // tslint:disable:no-angle-bracket-type-assertion
 // tslint:disable:member-access
-// tslint:disable:whitespace
 // tslint:disable:align
 // tslint:disable:no-object-literal-type-assertion
 

--- a/packages/runtime/merge-tree/src/mergeTree.ts
+++ b/packages/runtime/merge-tree/src/mergeTree.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable max-len, no-bitwise, no-param-reassign, no-shadow */
+/* eslint-disable @typescript-eslint/consistent-type-assertions, max-len, no-bitwise, no-param-reassign, no-shadow */
 
 import * as assert from "assert";
 import * as Base from "./base";
@@ -32,9 +32,6 @@ import { SegmentPropertiesManager } from "./segmentPropertiesManager";
 
 // tslint:disable:interface-name
 // tslint:disable:no-suspicious-comment
-// tslint:disable:no-angle-bracket-type-assertion
-// tslint:disable:member-access
-// tslint:disable:no-object-literal-type-assertion
 
 export interface ReferencePosition {
     properties: Properties.PropertySet;

--- a/packages/runtime/merge-tree/src/mergeTree.ts
+++ b/packages/runtime/merge-tree/src/mergeTree.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable no-param-reassign */
+/* eslint-disable no-bitwise, no-param-reassign, no-shadow */
 
 import * as assert from "assert";
 import * as Base from "./base";
@@ -34,13 +34,11 @@ import { SegmentPropertiesManager } from "./segmentPropertiesManager";
 // tslint:disable:member-ordering
 // tslint:disable:max-line-length
 // tslint:disable:callable-types
-// tslint:disable:no-bitwise
 // tslint:disable:no-for-in
 // tslint:disable:forin
 // tslint:disable:no-suspicious-comment
 // tslint:disable:no-angle-bracket-type-assertion
 // tslint:disable:member-access
-// tslint:disable:no-shadowed-variable
 // tslint:disable:whitespace
 // tslint:disable:align
 // tslint:disable:no-string-literal

--- a/packages/runtime/merge-tree/src/mergeTreeDeltaCallback.ts
+++ b/packages/runtime/merge-tree/src/mergeTreeDeltaCallback.ts
@@ -13,12 +13,13 @@ export type MergeTreeDeltaOperationType =
 
 // Note: Assigned negative integers to avoid clashing with MergeTreeDeltaType
 export const enum MergeTreeMaintenanceType {
-    APPEND  = -1,
-    SPLIT   = -2,
+    APPEND = -1,
+    SPLIT = -2,
 }
 
 export type MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationType | MergeTreeMaintenanceType;
 
+// eslint-disable-next-line max-len
 export interface IMergeTreeDeltaCallbackArgs<TOperationType extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationType> {
     readonly operation: TOperationType;
     readonly deltaSegments: IMergeTreeSegmentDelta[];

--- a/packages/runtime/merge-tree/src/overlayTree.ts
+++ b/packages/runtime/merge-tree/src/overlayTree.ts
@@ -30,6 +30,7 @@ function createTreeMarkerOps(
     endMarkerProps[onodeTypeKey] = nodeType;
 
     if (!beginMarkerProps) {
+        // eslint-disable-next-line no-param-reassign
         beginMarkerProps = MergeLib.createMap<any>();
     }
     beginMarkerProps[MergeLib.reservedMarkerIdKey] = id;

--- a/packages/runtime/merge-tree/src/partialLengths.ts
+++ b/packages/runtime/merge-tree/src/partialLengths.ts
@@ -232,6 +232,7 @@ export class PartialSequenceLengths {
                 // Leaf segment
                 const segment = child;
                 const segBranchId = mergeTree.getBranchId(segment.clientId);
+                // eslint-disable-next-line max-len
                 // console.log(`seg br ${segBranchId} cli ${glc(mergeTree, segment.clientId)} me ${glc(mergeTree, mergeTree.collabWindow.clientId)}`);
                 if (segBranchId <= branchId) {
                     if (seqLTE(segment.seq, collabWindow.minSeq)) {
@@ -409,6 +410,7 @@ export class PartialSequenceLengths {
         clientId: number,
         collabWindow: CollaborationWindow) {
         const segBranchId = mergeTree.getBranchId(clientId);
+        // eslint-disable-next-line max-len
         // console.log(`seg br ${segBranchId} cli ${glc(mergeTree, segment.clientId)} me ${glc(mergeTree, mergeTree.collabWindow.clientId)}`);
         if (segBranchId === 0) {
             this.updateBranch(mergeTree, 0, block, seq, clientId, collabWindow);

--- a/packages/runtime/merge-tree/src/partialLengths.ts
+++ b/packages/runtime/merge-tree/src/partialLengths.ts
@@ -84,7 +84,6 @@ export class PartialSequenceLengths {
      * has its partials up to date
      * @param collabWindow - segment window of the segment tree containing textSegmentBlock
      */
-    // tslint:disable-next-line: max-func-body-length
     private static combineBranch(
         mergeTree: MergeTree,
         block: IMergeBlock,

--- a/packages/runtime/merge-tree/src/partialLengths.ts
+++ b/packages/runtime/merge-tree/src/partialLengths.ts
@@ -376,7 +376,7 @@ export class PartialSequenceLengths {
             }
         }
         if (seqPartialLen === undefined) {
-            // tslint:disable-next-line: no-object-literal-type-assertion
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             seqPartialLen = {
                 clientId,
                 seglen: seqSeglen,

--- a/packages/runtime/merge-tree/src/properties.ts
+++ b/packages/runtime/merge-tree/src/properties.ts
@@ -8,7 +8,6 @@
 import * as ops from "./ops";
 
 // tslint:disable:interface-name
-// tslint:disable:switch-final-break
 
 export interface MapLike<T> {
     [index: string]: T;

--- a/packages/runtime/merge-tree/src/properties.ts
+++ b/packages/runtime/merge-tree/src/properties.ts
@@ -8,7 +8,6 @@
 import * as ops from "./ops";
 
 // tslint:disable:interface-name
-// tslint:disable:switch-default
 // tslint:disable:switch-final-break
 
 export interface MapLike<T> {

--- a/packages/runtime/merge-tree/src/properties.ts
+++ b/packages/runtime/merge-tree/src/properties.ts
@@ -102,6 +102,7 @@ export function extend<T>(base: MapLike<T>, extension: MapLike<T>, combiningOp?:
         for (const key in extension) {
             const v = extension[key];
             if (v === null) {
+                // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
                 delete base[key];
             } else {
                 if (combiningOp && (combiningOp.name !== "rewrite")) {
@@ -162,7 +163,7 @@ export function createMap<T>(): MapLike<T> {
     // constantly changing shape.
     // eslint-disable-next-line dot-notation
     map["__"] = undefined;
-    // eslint-disable-next-line dot-notation
+    // eslint-disable-next-line dot-notation, @typescript-eslint/no-dynamic-delete
     delete map["__"];
 
     return map;

--- a/packages/runtime/merge-tree/src/properties.ts
+++ b/packages/runtime/merge-tree/src/properties.ts
@@ -8,8 +8,6 @@
 import * as ops from "./ops";
 
 // tslint:disable:interface-name
-// tslint:disable:no-for-in
-// tslint:disable:forin
 // tslint:disable:switch-default
 // tslint:disable:switch-final-break
 

--- a/packages/runtime/merge-tree/src/properties.ts
+++ b/packages/runtime/merge-tree/src/properties.ts
@@ -11,7 +11,6 @@ import * as ops from "./ops";
 // tslint:disable:switch-default
 // tslint:disable:no-parameter-reassignment
 // tslint:disable:switch-final-break
-// tslint:disable:no-unsafe-any
 
 export interface MapLike<T> {
     [index: string]: T;
@@ -165,6 +164,5 @@ export function createMap<T>(): MapLike<T> {
     // eslint-disable-next-line dot-notation
     delete map["__"];
 
-    // tslint:disable-next-line: no-unsafe-any
     return map;
 }

--- a/packages/runtime/merge-tree/src/properties.ts
+++ b/packages/runtime/merge-tree/src/properties.ts
@@ -3,13 +3,14 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable no-param-reassign */
+
 import * as ops from "./ops";
 
 // tslint:disable:interface-name
 // tslint:disable:no-for-in
 // tslint:disable:forin
 // tslint:disable:switch-default
-// tslint:disable:no-parameter-reassignment
 // tslint:disable:switch-final-break
 
 export interface MapLike<T> {

--- a/packages/runtime/merge-tree/src/segmentGroupCollection.ts
+++ b/packages/runtime/merge-tree/src/segmentGroupCollection.ts
@@ -27,7 +27,6 @@ export class SegmentGroupCollection {
     }
 
     public dequeue(): SegmentGroup {
-        // tslint:disable-next-line:no-unsafe-any
         return this.segmentGroups.dequeue();
     }
 

--- a/packages/runtime/merge-tree/src/segmentPropertiesManager.ts
+++ b/packages/runtime/merge-tree/src/segmentPropertiesManager.ts
@@ -26,7 +26,7 @@ export class SegmentPropertiesManager {
                 assert(this.pendingKeyUpdateCount[key] > 0);
                 this.pendingKeyUpdateCount[key]--;
                 if (this.pendingKeyUpdateCount[key] === 0) {
-                    // tslint:disable-next-line: no-dynamic-delete
+                    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
                     delete this.pendingKeyUpdateCount[key];
                 }
             }
@@ -74,7 +74,7 @@ export class SegmentPropertiesManager {
             for (const key of  Object.keys(this.segment.properties)) {
                 if (!newProps[key] && shouldModifyKey(key)) {
                     deltas[key] = this.segment.properties[key];
-                    // tslint:disable-next-line: no-dynamic-delete
+                    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
                     delete this.segment.properties[key];
                 }
             }
@@ -102,7 +102,7 @@ export class SegmentPropertiesManager {
                 newValue = newProps[key];
             }
             if (newValue === null) {
-                // tslint:disable-next-line: no-dynamic-delete
+                // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
                 delete this.segment.properties[key];
 
             } else {

--- a/packages/runtime/merge-tree/src/snapshot.ts
+++ b/packages/runtime/merge-tree/src/snapshot.ts
@@ -41,8 +41,8 @@ export class Snapshot {
     // Please note that this number has no direct relationship to anything other than size of raw text (characters).
     // As we produce json for the blob (and then encode into base64 and send over the wire compressed), this number
     // is really hard to correlate with any actual metric that matters (like bytes over the wire).
-    // For test with small number of chunks it would be closer to blob size (before base64 encoding), for very chunky text
-    // blob size can easily be 4x-8x of that number.
+    // For test with small number of chunks it would be closer to blob size (before base64 encoding),
+    // for very chunky text, blob size can easily be 4x-8x of that number.
     public static readonly sizeOfFirstChunk: number = 10000;
 
     private header: SnapshotHeader;
@@ -124,7 +124,8 @@ export class Snapshot {
             };
 
             if (chunk1.chunkSegmentCount < chunk1.totalSegmentCount) {
-                const chunk2 = this.getSeqLengthSegs(this.segments, this.segmentLengths, this.header.segmentsTotalLength, chunk1.chunkSegmentCount);
+                const chunk2 = this.getSeqLengthSegs(this.segments, this.segmentLengths,
+                    this.header.segmentsTotalLength, chunk1.chunkSegmentCount);
                 length += chunk2.chunkLengthChars;
                 segments += chunk2.chunkSegmentCount;
                 tree.entries.push({
@@ -203,9 +204,9 @@ export class Snapshot {
             // Next determine if the snapshot needs to preserve information required for merging the segment
             // (seq, client, etc.)  This information is only needed if the segment is above the MSN (and doesn't
             // have a pending remove.)
-            if ((segment.seq <= minSeq)                                     // Segment is below the MSN, and...
-                && (segment.removedSeq === undefined                        // .. Segment has not been removed, or...
-                    || segment.removedSeq === UnassignedSequenceNumber)     // .. Removal op to be delivered on reconnect
+            if ((segment.seq <= minSeq)                                   // Segment is below the MSN, and...
+                && (segment.removedSeq === undefined                      // .. Segment has not been removed, or...
+                    || segment.removedSeq === UnassignedSequenceNumber)   // .. Removal op to be delivered on reconnect
             ) {
                 // This segment is below the MSN, which means that future ops will not reference it.  Attempt to
                 // coalesce the new segment with the previous (if any).

--- a/packages/runtime/merge-tree/src/snapshotLoader.ts
+++ b/packages/runtime/merge-tree/src/snapshotLoader.ts
@@ -35,7 +35,6 @@ export class SnapshotLoader {
         // Override branch by default which is derived from document id,
         // as document id isn't stable for spo
         // which leads to branch id being in correct
-        // tslint:disable-next-line: no-unsafe-any
         const branch = this.runtime.options && this.runtime.options.enableBranching
             ? branchId : this.runtime.documentId;
 

--- a/packages/runtime/merge-tree/src/snapshotlegacy.ts
+++ b/packages/runtime/merge-tree/src/snapshotlegacy.ts
@@ -64,7 +64,7 @@ export class SnapshotLegacy {
         approxSequenceLength: number,
         startIndex = 0): ops.MergeTreeChunk {
 
-        const segs = <ops.IJSONSegment[]>[];
+        const segs: ops.IJSONSegment[] = [];
         let sequenceLength = 0;
         let segCount = 0;
         while ((sequenceLength < approxSequenceLength) && ((startIndex + segCount) < allSegments.length)) {
@@ -158,7 +158,7 @@ export class SnapshotLegacy {
             seq: this.mergeTree.collabWindow.minSeq,
         };
 
-        const segs = <MergeTree.ISegment[]>[];
+        const segs: MergeTree.ISegment[] = [];
         let prev: MergeTree.ISegment | undefined;
         const extractSegment =
             // eslint-disable-next-line max-len

--- a/packages/runtime/merge-tree/src/snapshotlegacy.ts
+++ b/packages/runtime/merge-tree/src/snapshotlegacy.ts
@@ -40,8 +40,8 @@ export class SnapshotLegacy {
     // Please note that this number has no direct relationship to anything other than size of raw text (characters).
     // As we produce json for the blob (and then encode into base64 and send over the wire compressed), this number
     // is really hard to correlate with any actual metric that matters (like bytes over the wire).
-    // For test with small number of chunks it would be closer to blob size (before base64 encoding), for very chunky text
-    // blob size can easily be 4x-8x of that number.
+    // For test with small number of chunks it would be closer to blob size (before base64 encoding),
+    // for very chunky text, blob size can easily be 4x-8x of that number.
     public static readonly sizeOfFirstChunk: number = 10000;
 
     header: SnapshotHeader;
@@ -113,7 +113,8 @@ export class SnapshotLegacy {
         };
 
         if (chunk1.chunkSegmentCount < chunk1.totalSegmentCount) {
-            const chunk2 = this.getSeqLengthSegs(this.segments, this.segmentLengths, this.header.segmentsTotalLength, chunk1.chunkSegmentCount);
+            const chunk2 = this.getSeqLengthSegs(this.segments, this.segmentLengths,
+                this.header.segmentsTotalLength, chunk1.chunkSegmentCount);
             length += chunk2.chunkLengthChars;
             segments += chunk2.chunkSegmentCount;
             tree.entries.push({
@@ -160,13 +161,16 @@ export class SnapshotLegacy {
         const segs = <MergeTree.ISegment[]>[];
         let prev: MergeTree.ISegment | undefined;
         const extractSegment =
+            // eslint-disable-next-line max-len
             (segment: MergeTree.ISegment, pos: number, refSeq: number, clientId: number, start: number, end: number) => {
                 // eslint-disable-next-line eqeqeq
                 if ((segment.seq != UnassignedSequenceNumber) && (segment.seq <= this.seq) &&
                     // eslint-disable-next-line eqeqeq
                     ((segment.removedSeq === undefined) || (segment.removedSeq == UnassignedSequenceNumber) ||
                         (segment.removedSeq > this.seq))) {
-                    if (prev && prev.canAppend(segment) && Properties.matchProperties(prev.properties, segment.properties)) {
+                    if (prev && prev.canAppend(segment)
+                        && Properties.matchProperties(prev.properties, segment.properties)
+                    ) {
                         prev = prev.clone();
                         prev.append(segment.clone());
                     } else {
@@ -194,12 +198,16 @@ export class SnapshotLegacy {
         });
 
         // We observed this.header.segmentsTotalLength < totalLength to happen in some cases
-        // When this condition happens, we might not write out all segments in getSeqLengthSegs() when writing out "body"
-        // Issue #1995 tracks following up on the core of the problem.
+        // When this condition happens, we might not write out all segments in getSeqLengthSegs()
+        // when writing out "body". Issue #1995 tracks following up on the core of the problem.
         // In the meantime, this code makes sure we will write out all segments properly
         // eslint-disable-next-line eqeqeq
         if (this.header.segmentsTotalLength != totalLength) {
-            this.logger.sendErrorEvent({ eventName: "SegmentsTotalLengthMismatch", totalLength, segmentsTotalLength: this.header.segmentsTotalLength });
+            this.logger.sendErrorEvent({
+                eventName: "SegmentsTotalLengthMismatch",
+                totalLength,
+                segmentsTotalLength: this.header.segmentsTotalLength,
+            });
             this.header.segmentsTotalLength = totalLength;
         }
 

--- a/packages/runtime/merge-tree/src/test/beastTest.ts
+++ b/packages/runtime/merge-tree/src/test/beastTest.ts
@@ -1635,8 +1635,10 @@ export class DocumentTree {
                 const pg = DocumentTree.generateParagraph();
                 items.push(pg);
             } else {
+                // eslint-disable-next-line no-param-reassign
                 rowProbability /= 2;
                 if (rowProbability < 0.08) {
+                    // eslint-disable-next-line no-param-reassign
                     rowProbability = 0;
                 }
                 const row = DocumentTree.generateRow(rowProbability);

--- a/packages/runtime/merge-tree/src/test/beastTest.ts
+++ b/packages/runtime/merge-tree/src/test/beastTest.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable eqeqeq, no-bitwise, no-shadow */
+/* eslint-disable eqeqeq, max-len, no-bitwise, no-shadow */
 
 import * as assert from "assert";
 import * as fs from "fs";

--- a/packages/runtime/merge-tree/src/test/beastTest.ts
+++ b/packages/runtime/merge-tree/src/test/beastTest.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable eqeqeq */
+/* eslint-disable eqeqeq, no-bitwise, no-shadow */
 
 import * as assert from "assert";
 import * as fs from "fs";

--- a/packages/runtime/merge-tree/src/test/beastTest.ts
+++ b/packages/runtime/merge-tree/src/test/beastTest.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable eqeqeq, max-len, no-bitwise, no-shadow */
+/* eslint-disable @typescript-eslint/consistent-type-assertions, eqeqeq, max-len, no-bitwise, no-shadow */
 
 import * as assert from "assert";
 import * as fs from "fs";

--- a/packages/runtime/merge-tree/src/test/client.conflictFarm.spec.ts
+++ b/packages/runtime/merge-tree/src/test/client.conflictFarm.spec.ts
@@ -114,7 +114,7 @@ describe("MergeTree.Client", () => {
 
                 doOverRange(opts.opsPerRound, opts.growthFunc, (opsPerRound) => {
                     if (opts.incrementalLog) {
-                        // tslint:disable-next-line: max-line-length
+                        // eslint-disable-next-line max-len
                         console.log(`MinLength: ${minLength} Clients: ${clients.length} Ops: ${opsPerRound} Seq: ${seq}`);
                     }
                     for (let round = 0; round < opts.rounds; round++) {

--- a/packages/runtime/merge-tree/src/test/mergeTree.annotate.spec.ts
+++ b/packages/runtime/merge-tree/src/test/mergeTree.annotate.spec.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-// tslint:disable: no-object-literal-type-assertion
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+
 import * as assert from "assert";
 import { ISequencedDocumentMessage } from "@microsoft/fluid-protocol-definitions";
 import { TextSegment } from "../";

--- a/packages/runtime/merge-tree/src/test/mergeTree.annotate.spec.ts
+++ b/packages/runtime/merge-tree/src/test/mergeTree.annotate.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-// tslint:disable: no-object-literal-type-assertion max-func-body-length
+// tslint:disable: no-object-literal-type-assertion
 import * as assert from "assert";
 import { ISequencedDocumentMessage } from "@microsoft/fluid-protocol-definitions";
 import { TextSegment } from "../";

--- a/packages/runtime/merge-tree/src/test/testClient.ts
+++ b/packages/runtime/merge-tree/src/test/testClient.ts
@@ -63,7 +63,7 @@ export class TestClient extends Client {
 
         const client2 = new TestClient(undefined, specToSeg);
         await client2.load(
-            // tslint:disable-next-line: no-object-literal-type-assertion
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             {
                 logger: client2.logger,
                 clientId: newLongClientId,

--- a/packages/runtime/merge-tree/src/test/testClient.ts
+++ b/packages/runtime/merge-tree/src/test/testClient.ts
@@ -75,6 +75,7 @@ export class TestClient extends Client {
     public mergeTree: MergeTree;
 
     public readonly checkQ: Collections.List<string> = Collections.ListMakeHead<string>();
+    // eslint-disable-next-line max-len
     protected readonly q: Collections.List<ISequencedDocumentMessage> = Collections.ListMakeHead<ISequencedDocumentMessage>();
 
     private readonly textHelper: MergeTreeTextHelper;

--- a/packages/runtime/merge-tree/src/test/testClientLogger.ts
+++ b/packages/runtime/merge-tree/src/test/testClientLogger.ts
@@ -34,7 +34,7 @@ export class TestClientLogger {
         const client = msg ? msg.clientId : "";
         const op = msg ? msg.contents as IMergeTreeOp : undefined;
         const opType = op ? op.type.toString() : "";
-        // eslint-disable-next-line dot-notation
+        // eslint-disable-next-line dot-notation, max-len
         const opPos = op && op["pos1"] !== undefined ? `@${op["pos1"]}${op["pos2"] !== undefined ? `,${op["pos2"]}` : ""}` : "";
         const clientOp = ` ${client}${opType}${opPos}`;
         const ackedLine: string[] = [
@@ -81,6 +81,7 @@ export class TestClientLogger {
                     assert.equal(
                         c.getText(),
                         baseText,
+                        // eslint-disable-next-line max-len
                         `${this.toString()}\nClient ${c.longClientId} does not match client ${this.clients[0].longClientId}`);
                 }
             });

--- a/packages/runtime/merge-tree/src/test/testClientLogger.ts
+++ b/packages/runtime/merge-tree/src/test/testClientLogger.ts
@@ -51,7 +51,6 @@ export class TestClientLogger {
                 try {
                     preAction(c);
                 } catch (e) {
-                    // tslint:disable-next-line: no-unsafe-any
                     e.message += this.toString();
                     throw e;
                 }

--- a/packages/runtime/merge-tree/src/test/testServer.ts
+++ b/packages/runtime/merge-tree/src/test/testServer.ts
@@ -131,6 +131,7 @@ export class TestServer extends TestClient {
             else {
                 break;
             }
+            // eslint-disable-next-line no-param-reassign
             msgCount--;
         }
         return false;

--- a/packages/runtime/merge-tree/src/test/testServer.ts
+++ b/packages/runtime/merge-tree/src/test/testServer.ts
@@ -78,7 +78,8 @@ export class TestServer extends TestClient {
         msg.sequenceNumber = -1;
     }
     copyMsg(msg: ISequencedDocumentMessage) {
-        return <ISequencedDocumentMessage>{
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        return {
             clientId: msg.clientId,
             clientSequenceNumber: msg.clientSequenceNumber,
             contents: msg.contents,
@@ -86,7 +87,7 @@ export class TestServer extends TestClient {
             referenceSequenceNumber: msg.referenceSequenceNumber,
             sequenceNumber: msg.sequenceNumber,
             type: msg.type,
-        };
+        } as ISequencedDocumentMessage;
     }
 
     private minSeq = 0;

--- a/packages/runtime/merge-tree/src/test/testUtils.ts
+++ b/packages/runtime/merge-tree/src/test/testUtils.ts
@@ -82,12 +82,10 @@ export function countOperations(mergeTree: MergeTree) {
     assert.strictEqual(mergeTree.mergeTreeMaintenanceCallback, undefined);
 
     const fn = (deltaArgs) => {
-        // tslint:disable:no-unsafe-any
         const previous = counts[deltaArgs.operation] as undefined | number;
         counts[deltaArgs.operation] = (previous === undefined
             ? 1
             : previous + 1);
-        // tslint:enable:no-unsafe-any
     };
 
     mergeTree.mergeTreeDeltaCallback = (opArgs, deltaArgs) => { fn(deltaArgs); };

--- a/packages/runtime/merge-tree/src/test/wordUnitTests.ts
+++ b/packages/runtime/merge-tree/src/test/wordUnitTests.ts
@@ -26,8 +26,8 @@ export function propertyCopy() {
     const propCount = 2000;
     const iterCount = 1000;
     const map = new Map<string, number>();
-    const a = <string[]>[];
-    const v = <number[]>[];
+    const a: string[] = [];
+    const v: number[] = [];
     for (let i = 0; i < propCount; i++) {
         a[i] = `prop${i}`;
         v[i] = i;
@@ -113,7 +113,7 @@ export function propertyCopy() {
 function makeBookmarks(client: TestClient, bookmarkCount: number) {
     const mt = random.engines.mt19937();
     mt.seedWithArray([0xdeadbeef, 0xfeedbed]);
-    const bookmarks = <LocalReference[]>[];
+    const bookmarks: LocalReference[] = [];
     const len = client.getLength();
     for (let i = 0; i < bookmarkCount; i++) {
         const pos = random.integer(0, len - 1)(mt);

--- a/packages/runtime/merge-tree/src/test/wordUnitTests.ts
+++ b/packages/runtime/merge-tree/src/test/wordUnitTests.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable no-bitwise, no-shadow */
+
 import * as path from "path";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import * as random from "random-js";

--- a/packages/runtime/merge-tree/src/test/wordUnitTests.ts
+++ b/packages/runtime/merge-tree/src/test/wordUnitTests.ts
@@ -85,7 +85,8 @@ export function propertyCopy() {
     et = elapsedMicroseconds(clockStart);
     perIter = (et / iterCount).toFixed(3);
     perProp = (et / (iterCount * propCount)).toFixed(2);
-    console.log(`map to map foreach prop init time ${perIter} us per ${propCount} properties; ${perProp} us per property`);
+    console.log(
+        `map to map foreach prop init time ${perIter} us per ${propCount} properties; ${perProp} us per property`);
     const diffMap = new Map<string, number>();
     map.forEach((v, k) => {
         if (Math.random() < 0.5) {
@@ -160,6 +161,7 @@ function measureFetch(startFile: string, withBookmarks = false) {
         }
     }
     let et = elapsedMicroseconds(clockStart);
+    // eslint-disable-next-line max-len
     console.log(`fetch of ${count / reps} runs over ${client.getLength()} total chars took ${(et / count).toFixed(1)} microseconds per run`);
     // Bonus: measure clone
     clockStart = clock();

--- a/packages/runtime/merge-tree/src/text.ts
+++ b/packages/runtime/merge-tree/src/text.ts
@@ -8,7 +8,7 @@ import * as ops from "./ops";
 import { TextSegment } from "./textSegment";
 
 export function loadSegments(content: string, segLimit: number, markers: boolean = false, withProps: boolean = true) {
-    // tslint:disable-next-line:no-parameter-reassignment
+    // eslint-disable-next-line no-param-reassign
     content = content.replace(/^\uFEFF/, "");
 
     const paragraphs = content.split(/\r?\n/);

--- a/packages/runtime/merge-tree/src/text.ts
+++ b/packages/runtime/merge-tree/src/text.ts
@@ -41,7 +41,7 @@ export function loadSegments(content: string, segLimit: number, markers: boolean
             } else {
                 const emphStrings = paragraph.split("_");
                 for (let i = 0, len = emphStrings.length; i < len; i++) {
-                    // tslint:disable-next-line:no-bitwise
+                    // eslint-disable-next-line no-bitwise
                     if (i & 1) {
                         if (emphStrings[i].length > 0) {
                             segments.push(

--- a/packages/runtime/merge-tree/src/textSegment.ts
+++ b/packages/runtime/merge-tree/src/textSegment.ts
@@ -31,7 +31,6 @@ export class TextSegment extends BaseSegment {
     public static fromJSONObject(spec: any) {
         if (typeof spec === "string") {
             return new TextSegment(spec);
-        // tslint:disable-next-line: no-unsafe-any
         } else if (spec && typeof spec === "object" && "text" in spec) {
             const textSpec = spec as IJSONTextSegment;
             return TextSegment.make(textSpec.text, textSpec.props as Properties.PropertySet);

--- a/packages/runtime/merge-tree/src/textSegment.ts
+++ b/packages/runtime/merge-tree/src/textSegment.ts
@@ -245,7 +245,7 @@ export class MergeTreeTextHelper {
                 accumText.textSegment.text += segment.text;
             } else {
                 if (start < 0) {
-                    // tslint:disable-next-line: no-parameter-reassignment
+                    // eslint-disable-next-line no-param-reassign
                     start = 0;
                 }
                 if (end >= segment.text.length) {

--- a/packages/runtime/runtime-utils/src/test/serializer.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/serializer.spec.ts
@@ -4,7 +4,6 @@
  */
 
 // tslint:disable:completed-docs
-// tslint:disable:no-unsafe-any
 // tslint:disable:mocha-no-side-effect-code
 
 import { strict as assert } from "assert";

--- a/packages/runtime/sequence/src/intervalCollection.ts
+++ b/packages/runtime/sequence/src/intervalCollection.ts
@@ -560,7 +560,6 @@ export class IntervalCollectionView<TInterval extends ISerializableInterval> ext
         return this.localCollection.nextInterval(pos);
     }
 
-    /* tslint:disable:no-unnecessary-override */
     public on(
         event: "addInterval" | "deleteInterval",
         listener: (interval: ISerializedInterval, local: boolean, op: ISequencedDocumentMessage) => void): this {

--- a/packages/runtime/sequence/src/sequence.ts
+++ b/packages/runtime/sequence/src/sequence.ts
@@ -110,7 +110,6 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
     ) {
         super(id, document, attributes);
 
-        /* tslint:disable:no-unsafe-any */
         this.client = new MergeTree.Client(
             segmentFromSpec,
             ChildLogger.create(this.logger, "SharedSegmentSequence.MergeTreeClient"),

--- a/packages/runtime/shared-object-common/src/sharedObject.ts
+++ b/packages/runtime/shared-object-common/src/sharedObject.ts
@@ -196,7 +196,6 @@ export abstract class SharedObject extends EventEmitterWithErrorHandling impleme
     public on(event: "error", listener: (error: any) => void): this;
     public on(event: string | symbol, listener: (...args: any[]) => void): this;
 
-    /* tslint:disable:no-unnecessary-override */
     public on(event: string | symbol, listener: (...args: any[]) => void): this {
         return super.on(event, listener);
     }

--- a/packages/test/end-to-end/src/test/directoryEndToEndTests.spec.ts
+++ b/packages/test/end-to-end/src/test/directoryEndToEndTests.spec.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-/* tslint:disable:no-unsafe-any */
-/* tslint:disable:no-backbone-get-set-outside-model  */
 import * as assert from "assert";
 import * as api from "@fluid-internal/client-api";
 import { IComponentHandle } from "@microsoft/fluid-component-core-interfaces";

--- a/packages/test/end-to-end/src/test/mapEndToEndTests.spec.ts
+++ b/packages/test/end-to-end/src/test/mapEndToEndTests.spec.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-/* tslint:disable:no-unsafe-any */
-/* tslint:disable:no-backbone-get-set-outside-model  */
 import * as assert from "assert";
 import * as api from "@fluid-internal/client-api";
 import {

--- a/packages/test/end-to-end/src/test/sharedInterval.spec.ts
+++ b/packages/test/end-to-end/src/test/sharedInterval.spec.ts
@@ -295,7 +295,6 @@ describe("SharedInterval", () => {
             const parsedSnapshot = JSON.parse(snapshotBlob.contents);
             // LocalIntervalCollection serializes as an array of ISerializedInterval, let's get the first comment
             const serializedInterval1FromSnapshot =
-                // tslint:disable-next-line: no-unsafe-any
                 (parsedSnapshot["intervalCollections/comments"].value as ISerializedInterval[])[0];
             // The "story" is the ILocalValue of the handle pointing to the SharedString
             const handleLocalValueFromSnapshot = serializedInterval1FromSnapshot.properties.story as { type: string };

--- a/packages/utils/eslint-config-fluid/no-tslint.js
+++ b/packages/utils/eslint-config-fluid/no-tslint.js
@@ -85,6 +85,7 @@ module.exports = {
         ],
         "@typescript-eslint/interface-name-prefix": "off",
         "@typescript-eslint/member-delimiter-style": "off",
+        "@typescript-eslint/no-dynamic-delete": "error",
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-empty-interface": "error",
         "@typescript-eslint/no-explicit-any": "off",

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -306,7 +306,6 @@ export class LocalOrderer implements IOrderer {
         this.deltasKafka = new LocalKafka();
     }
 
-    // tslint:disable-next-line: max-func-body-length
     private setupLambdas() {
         this.scriptoriumLambda = new LocalLambdaController(
             this.deltasKafka,

--- a/server/routerlicious/packages/services-client/src/dockerNames.ts
+++ b/server/routerlicious/packages/services-client/src/dockerNames.ts
@@ -623,7 +623,8 @@ const right = [
     // Nikolay Yegorovich Zhukovsky (Russian: Никола́й Его́рович Жуко́вский, January 17 1847 – March 17, 1921) was a Russian scientist, mathematician and engineer, and a founding father of modern aero- and hydrodynamics. Whereas contemporary scientists scoffed at the idea of human flight, Zhukovsky was the first to undertake the study of airflow. He is often called the Father of Russian Aviation. https://en.wikipedia.org/wiki/Nikolay_Yegorovich_Zhukovsky
     "zhukovsky",
 ];
-// tslint:enable:max-line-length
+
+/* eslint-enable max-len */
 
 const fluidNames = [
     "lucco",

--- a/server/routerlicious/packages/services-client/src/test/restwrapper.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/restwrapper.spec.ts
@@ -112,9 +112,7 @@ describe("RestWrapper", () => {
             // assert
             // tslint:disable-next-line:max-line-length
             assert.equal(outputUrl, requestOptions.url.substring(0, outputUrl.length), "requestUrl should be the same");
-            // tslint:disable-next-line:no-unsafe-any
             assert.equal(defaultHeaders.h1, requestOptions.headers.h1 as string, "Header1 value should be correct");
-            // tslint:disable-next-line:no-unsafe-any
             assert.equal(defaultHeaders.h2, requestOptions.headers.h2 as string, "Header2 value should be correct");
         });
 
@@ -139,11 +137,8 @@ describe("RestWrapper", () => {
 
             // assert
             assert.equal(outputUrl, requestOptions.url.substring(0, outputUrl.length), "requestUrl should be the same");
-            // tslint:disable-next-line:no-unsafe-any
             assert.equal(requestHeaders.h1, requestOptions.headers.h1 as string, "Header1 value should be updated");
-            // tslint:disable-next-line:no-unsafe-any
             assert.equal(defaultHeaders.h2, requestOptions.headers.h2 as string, "Header2 value should be correct");
-            // tslint:disable-next-line:no-unsafe-any
             assert.equal(requestHeaders.h3, requestOptions.headers.h3 as string, "Header2 value should be added");
         });
     });
@@ -194,9 +189,7 @@ describe("RestWrapper", () => {
 
             // assert
             assert.equal(`${requestUrl}?q1=valueq1&q2=valueq2`, requestOptions.url, "requestUrl should be the same");
-            // tslint:disable-next-line:no-unsafe-any
             assert.equal(defaultHeaders.h1, requestOptions.headers.h1 as string, "Header1 value should be correct");
-            // tslint:disable-next-line:no-unsafe-any
             assert.equal(defaultHeaders.h2, requestOptions.headers.h2 as string, "Header2 value should be correct");
         });
 
@@ -224,11 +217,8 @@ describe("RestWrapper", () => {
                 requestOptions.url,
                 "requestUrl should be the same",
             );
-            // tslint:disable-next-line:no-unsafe-any
             assert.equal(requestHeaders.h1, requestOptions.headers.h1 as string, "Header1 value should be updated");
-            // tslint:disable-next-line:no-unsafe-any
             assert.equal(defaultHeaders.h2, requestOptions.headers.h2 as string, "Header2 value should be correct");
-            // tslint:disable-next-line:no-unsafe-any
             assert.equal(requestHeaders.h3, requestOptions.headers.h3 as string, "Header2 value should be added");
         });
     });
@@ -279,9 +269,7 @@ describe("RestWrapper", () => {
 
             // assert
             assert.equal(`${requestUrl}?q1=valueq1&q2=valueq2`, requestOptions.url, "requestUrl should be the same");
-            // tslint:disable-next-line:no-unsafe-any
             assert.equal(defaultHeaders.h1, requestOptions.headers.h1 as string, "Header1 value should be correct");
-            // tslint:disable-next-line:no-unsafe-any
             assert.equal(defaultHeaders.h2, requestOptions.headers.h2 as string, "Header2 value should be correct");
         });
 
@@ -309,11 +297,8 @@ describe("RestWrapper", () => {
                 requestOptions.url,
                 "requestUrl should be the same",
             );
-            // tslint:disable-next-line:no-unsafe-any
             assert.equal(requestHeaders.h1, requestOptions.headers.h1 as string, "Header1 value should be updated");
-            // tslint:disable-next-line:no-unsafe-any
             assert.equal(defaultHeaders.h2, requestOptions.headers.h2 as string, "Header2 value should be correct");
-            // tslint:disable-next-line:no-unsafe-any
             assert.equal(requestHeaders.h3, requestOptions.headers.h3 as string, "Header2 value should be added");
         });
     });
@@ -364,9 +349,7 @@ describe("RestWrapper", () => {
 
             // assert
             assert.equal(`${requestUrl}?q1=valueq1&q2=valueq2`, requestOptions.url, "requestUrl should be the same");
-            // tslint:disable-next-line:no-unsafe-any
             assert.equal(defaultHeaders.h1, requestOptions.headers.h1 as string, "Header1 value should be correct");
-            // tslint:disable-next-line:no-unsafe-any
             assert.equal(defaultHeaders.h2, requestOptions.headers.h2 as string, "Header2 value should be correct");
         });
 
@@ -394,11 +377,8 @@ describe("RestWrapper", () => {
                 requestOptions.url,
                 "requestUrl should be the same",
             );
-            // tslint:disable-next-line:no-unsafe-any
             assert.equal(requestHeaders.h1, requestOptions.headers.h1 as string, "Header1 value should be updated");
-            // tslint:disable-next-line:no-unsafe-any
             assert.equal(defaultHeaders.h2, requestOptions.headers.h2 as string, "Header2 value should be correct");
-            // tslint:disable-next-line:no-unsafe-any
             assert.equal(requestHeaders.h3, requestOptions.headers.h3 as string, "Header2 value should be added");
         });
     });

--- a/server/routerlicious/packages/services-client/src/test/restwrapper.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/restwrapper.spec.ts
@@ -35,7 +35,6 @@ describe("RestWrapper", () => {
         };
 
         axiosErrorMock = {
-            // tslint:disable-next-line:promise-must-complete
             request: async (options?) => new Promise<AxiosResponse>(
                 (resolve, reject) => {
                     requestOptions = options;


### PR DESCRIPTION
1. Clean up tslint:disable rules that doesn't have eslint equivalent
    - `import-name`
    - `no-unsafe-any`
    - `no-unnecesssary-callback-wrapper`
    - `promise-must-complete`
    - `no-backbone-get-set-outside-model`
    - `no-unnecessary-override`
    - `switch-final-break`
    - `align`
2. Clean up tslint:disable that is fixed/not needed any more: 
    - `odspError.spec.ts`, 'mergeTree.ts`, `counter.spec.ts`: `no-string-literal` , `member-ordering`, `callable-types`
    - `requestParser.spect.ts`: `prefer-const`
3. Clean up tslint:disable that has duplicate eslint-disabled already: 
    - `webWorkerLoader.ts`: `no-misused-new`
    - `mergeTree.ts`, `properties.ts`: `no-for-in`, `for-in`, `switch-default`
4. Reenable rules in package `merge-tree` and disable individual violation or in the file level
    - `no-param-reassign` (Filed issue #990)
    - `no-bitwise`
    - `no-shadow` (Filed issue #991)
    - `max-len`
    - `consistant-type-assertions` (Filed Issue #992)
5. Enable Eslint rules that has tslint equivalent:
    - `no-dynamic-delete`
6. Clean up tslint:disable that hasn't enable for eslint yet
    - `max-func-body-length`
7. Clean up eslint-disable that is fixed/not needed any more:
    - `merge-tree-client-replay/src/clientReplayTool.ts`, `tourofheroes/src/index.ts`: `@typescript-eslint/unbound-method`
