### PR TITLE
OdspDriver in charge of creating new files

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
@@ -50,15 +50,9 @@ export class OdspDocumentService implements IDocumentService {
 
     private odspResolvedUrl: Promise<IOdspResolvedUrl> | undefined;
 
-    // TODO: fix jsdoc
     /**
      * @param appId - app id used for telemetry for network requests
-     * @param hashedDocumentId - A unique identifer for the document. The "hashed" here implies that the contents of this string
-     * contains no end user identifiable information.
-     * @param siteUrl - the url of the site that hosts this container
-     * @param driveId - the id of the drive that hosts this container
-     * @param itemId - the id of the container within the drive
-     * @param snapshotStorageUrl - the URL where snapshots should be obtained from
+     * @param resolvedUrl - resolved URL containing all the pieces required to connect to Odsp
      * @param getStorageToken - function that can provide the storage token for a given site. This is
      * is also referred to as the "VROOM" token in SPO.
      * @param getWebsocketToken - function that can provide a token for accessing the web socket. This is also
@@ -67,6 +61,8 @@ export class OdspDocumentService implements IDocumentService {
      * @param storageFetchWrapper - if not provided FetchWrapper will be used
      * @param deltasFetchWrapper - if not provided FetchWrapper will be used
      * @param socketIOClientP - promise to the socket io library required by the driver
+     * @param newFileInfoPromise - Promise with information necessary to create a new file.
+     *                             a new file is not created until this promise resolves
      */
     constructor(
         private readonly appId: string,

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
@@ -227,7 +227,7 @@ export class OdspDocumentService implements IDocumentService {
             const storageToken = await this.getStorageToken(newFileInfo.siteUrl, false);
             const file = await createNewFluidFile(newFileInfo, storageToken);
             if (newFileInfo.callback) {
-                newFileInfo.callback(file.itemId);
+                newFileInfo.callback(file.itemId, file.filename);
             }
             const url = createOdspUrl(file.siteUrl, file.driveId, file.itemId, "/");
             const resolver = new OdspDriverUrlResolver();

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentServiceFactory.ts
@@ -9,7 +9,7 @@ import {
   IDocumentServiceFactory,
   IResolvedUrl,
 } from "@microsoft/fluid-driver-definitions";
-import { IOdspResolvedUrl } from "./contracts";
+import { INewFileInfo } from "./createFile";
 import { FetchWrapper, IFetchWrapper } from "./fetchWrapper";
 import { getSocketIo } from "./getSocketIo";
 import { OdspCache } from "./odspCache";
@@ -36,20 +36,16 @@ export class OdspDocumentServiceFactory implements IDocumentServiceFactory {
     private readonly getStorageToken: (siteUrl: string, refresh: boolean) => Promise<string | null>,
     private readonly getWebsocketToken: (refresh: boolean) => Promise<string | null>,
     private readonly logger: ITelemetryBaseLogger,
+    private readonly newFileInfoPromise?: Promise<INewFileInfo> | undefined,
     private readonly storageFetchWrapper: IFetchWrapper = new FetchWrapper(),
     private readonly deltasFetchWrapper: IFetchWrapper = new FetchWrapper(),
     private readonly odspCache: OdspCache = new OdspCache(),
   ) { }
 
   public async createDocumentService(resolvedUrl: IResolvedUrl): Promise<IDocumentService> {
-    const odspResolvedUrl = resolvedUrl as IOdspResolvedUrl;
     return new OdspDocumentService(
       this.appId,
-      odspResolvedUrl.hashedDocumentId,
-      odspResolvedUrl.siteUrl,
-      odspResolvedUrl.driveId,
-      odspResolvedUrl.itemId,
-      odspResolvedUrl.endpoints.snapshotStorageUrl,
+      resolvedUrl,
       this.getStorageToken,
       this.getWebsocketToken,
       this.logger,
@@ -57,6 +53,7 @@ export class OdspDocumentServiceFactory implements IDocumentServiceFactory {
       this.deltasFetchWrapper,
       Promise.resolve(getSocketIo()),
       this.odspCache,
+      this.newFileInfoPromise,
     );
   }
 }

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentServiceFactoryWithCodeSplit.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentServiceFactoryWithCodeSplit.ts
@@ -8,20 +8,12 @@ import {
   IDocumentServiceFactory,
   IResolvedUrl,
 } from "@microsoft/fluid-driver-definitions";
-import { IOdspResolvedUrl } from "./contracts";
-import { createNewFluidFile } from "./createFile";
+import { INewFileInfo } from "./createFile";
 import { FetchWrapper, IFetchWrapper } from "./fetchWrapper";
 import { OdspCache } from "./odspCache";
 import { OdspDocumentService } from "./OdspDocumentService";
-import { createOdspUrl, OdspDriverUrlResolver } from "./OdspDriverUrlResolver";
 
-export interface INewFileInfo {
-  siteUrl: string;
-  driveId: string;
-  filename: string;
-  filePath: string;
-  callback?(itemId: string): void;
-}
+// TODO: port the changes here to OdspDocumentServiceFactory
 
 /**
  * Factory for creating the sharepoint document service. Use this if you want to
@@ -39,6 +31,7 @@ export class OdspDocumentServiceFactoryWithCodeSplit implements IDocumentService
    * @param getWebsocketToken - function that can provide a token for accessing the web socket. This is also
    * referred to as the "Push" token in SPO.
    * @param logger - a logger that can capture performance and diagnostic information
+   * @param newFileInfoPromise - promise to supply info needed to create a new file. New file is not created until this promise resolves.
    * @param storageFetchWrapper - if not provided FetchWrapper will be used
    * @param deltasFetchWrapper - if not provided FetchWrapper will be used
    */
@@ -47,22 +40,16 @@ export class OdspDocumentServiceFactoryWithCodeSplit implements IDocumentService
     private readonly getStorageToken: (siteUrl: string, refresh: boolean) => Promise<string | null>,
     private readonly getWebsocketToken: (refresh: boolean) => Promise<string | null>,
     private readonly logger: ITelemetryBaseLogger,
-    private readonly newFileInfo?: INewFileInfo | undefined,
+    private readonly newFileInfoPromise?: Promise<INewFileInfo> | undefined,
     private readonly storageFetchWrapper: IFetchWrapper = new FetchWrapper(),
     private readonly deltasFetchWrapper: IFetchWrapper = new FetchWrapper(),
     private readonly odspCache: OdspCache = new OdspCache(),
   ) {}
 
   public async createDocumentService(resolvedUrl: IResolvedUrl): Promise<IDocumentService> {
-    const odspResolvedUrl = await this.createFileIfNeeded(resolvedUrl) as IOdspResolvedUrl;
-
     return new OdspDocumentService(
         this.appId,
-        odspResolvedUrl.hashedDocumentId,
-        odspResolvedUrl.siteUrl,
-        odspResolvedUrl.driveId,
-        odspResolvedUrl.itemId,
-        odspResolvedUrl.endpoints.snapshotStorageUrl,
+        resolvedUrl,
         this.getStorageToken,
         this.getWebsocketToken,
         this.logger,
@@ -70,35 +57,7 @@ export class OdspDocumentServiceFactoryWithCodeSplit implements IDocumentService
         this.deltasFetchWrapper,
         import("./getSocketIo").then((m) => m.getSocketIo()),
         this.odspCache,
+        this.newFileInfoPromise,
     );
-  }
-
-  // TODO: For now we assume that the file will be created before we create the document service. This will be changed
-  // when we have the ability to boot without a file
-  // TODO: The host will need to provide a notification when it wants the file to be created. This could be through calling
-  // a function on the OdspDocumentServiceFactory instance
-  /**
-   * Checks if the resolveUrl we are getting is fluid-new and creates a new file before returning a real resolved url
-   */
-  private async createFileIfNeeded(resolvedUrl: IResolvedUrl): Promise<IResolvedUrl> {
-    if (resolvedUrl.type === "fluid-new") {
-      if (!this.newFileInfo) {
-        throw new Error ("Odsp driver needs to create a new file but no newFileInfo supplied");
-      }
-      // We don't have an itemId, which means the file was not created yet.
-      const storageToken = await this.getStorageToken(this.newFileInfo.siteUrl, true);
-      if (!storageToken) {
-          throw new Error("Failed to aqcuire storage token to create a new file");
-      }
-      const file = await createNewFluidFile(this.newFileInfo, storageToken);
-      if (this.newFileInfo.callback) {
-        this.newFileInfo.callback(file.itemId);
-      }
-      const url = createOdspUrl(file.siteUrl, file.driveId, file.itemId, "/");
-      const resolver = new OdspDriverUrlResolver();
-      return resolver.resolve({url});
-      // TODO: Notify host
-    }
-    return resolvedUrl as IOdspResolvedUrl;
   }
 }

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentServiceFactoryWithCodeSplit.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentServiceFactoryWithCodeSplit.ts
@@ -13,8 +13,6 @@ import { FetchWrapper, IFetchWrapper } from "./fetchWrapper";
 import { OdspCache } from "./odspCache";
 import { OdspDocumentService } from "./OdspDocumentService";
 
-// TODO: port the changes here to OdspDocumentServiceFactory
-
 /**
  * Factory for creating the sharepoint document service. Use this if you want to
  * use the sharepoint implementation.

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentServiceFactoryWithCodeSplit.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentServiceFactoryWithCodeSplit.ts
@@ -9,9 +9,19 @@ import {
   IResolvedUrl,
 } from "@microsoft/fluid-driver-definitions";
 import { IOdspResolvedUrl } from "./contracts";
+import { createNewFluidFile } from "./createFile";
 import { FetchWrapper, IFetchWrapper } from "./fetchWrapper";
 import { OdspCache } from "./odspCache";
 import { OdspDocumentService } from "./OdspDocumentService";
+import { createOdspUrl, OdspDriverUrlResolver } from "./OdspDriverUrlResolver";
+
+export interface INewFileInfo {
+  siteUrl: string;
+  driveId: string;
+  filename: string;
+  filePath: string;
+  callback?(itemId: string): void;
+}
 
 /**
  * Factory for creating the sharepoint document service. Use this if you want to
@@ -37,27 +47,58 @@ export class OdspDocumentServiceFactoryWithCodeSplit implements IDocumentService
     private readonly getStorageToken: (siteUrl: string, refresh: boolean) => Promise<string | null>,
     private readonly getWebsocketToken: (refresh: boolean) => Promise<string | null>,
     private readonly logger: ITelemetryBaseLogger,
+    private readonly newFileInfo?: INewFileInfo | undefined,
     private readonly storageFetchWrapper: IFetchWrapper = new FetchWrapper(),
     private readonly deltasFetchWrapper: IFetchWrapper = new FetchWrapper(),
     private readonly odspCache: OdspCache = new OdspCache(),
   ) {}
 
   public async createDocumentService(resolvedUrl: IResolvedUrl): Promise<IDocumentService> {
-    const odspResolvedUrl = resolvedUrl as IOdspResolvedUrl;
+    const odspResolvedUrl = await this.createFileIfNeeded(resolvedUrl) as IOdspResolvedUrl;
+
     return new OdspDocumentService(
-      this.appId,
-      odspResolvedUrl.hashedDocumentId,
-      odspResolvedUrl.siteUrl,
-      odspResolvedUrl.driveId,
-      odspResolvedUrl.itemId,
-      odspResolvedUrl.endpoints.snapshotStorageUrl,
-      this.getStorageToken,
-      this.getWebsocketToken,
-      this.logger,
-      this.storageFetchWrapper,
-      this.deltasFetchWrapper,
-      import("./getSocketIo").then((m) => m.getSocketIo()),
-      this.odspCache,
+        this.appId,
+        odspResolvedUrl.hashedDocumentId,
+        odspResolvedUrl.siteUrl,
+        odspResolvedUrl.driveId,
+        odspResolvedUrl.itemId,
+        odspResolvedUrl.endpoints.snapshotStorageUrl,
+        this.getStorageToken,
+        this.getWebsocketToken,
+        this.logger,
+        this.storageFetchWrapper,
+        this.deltasFetchWrapper,
+        import("./getSocketIo").then((m) => m.getSocketIo()),
+        this.odspCache,
     );
+  }
+
+  // TODO: For now we assume that the file will be created before we create the document service. This will be changed
+  // when we have the ability to boot without a file
+  // TODO: The host will need to provide a notification when it wants the file to be created. This could be through calling
+  // a function on the OdspDocumentServiceFactory instance
+  /**
+   * Checks if the resolveUrl we are getting is fluid-new and creates a new file before returning a real resolved url
+   */
+  private async createFileIfNeeded(resolvedUrl: IResolvedUrl): Promise<IResolvedUrl> {
+    if (resolvedUrl.type === "fluid-new") {
+      if (!this.newFileInfo) {
+        throw new Error ("Odsp driver needs to create a new file but no newFileInfo supplied");
+      }
+      // We don't have an itemId, which means the file was not created yet.
+      const storageToken = await this.getStorageToken(this.newFileInfo.siteUrl, true);
+      if (!storageToken) {
+          throw new Error("Failed to aqcuire storage token to create a new file");
+      }
+      const file = await createNewFluidFile(this.newFileInfo, storageToken);
+      if (this.newFileInfo.callback) {
+        this.newFileInfo.callback(file.itemId);
+      }
+      const url = createOdspUrl(file.siteUrl, file.driveId, file.itemId, "/");
+      const resolver = new OdspDriverUrlResolver();
+      return resolver.resolve({url});
+      // TODO: Notify host
+    }
+    return resolvedUrl as IOdspResolvedUrl;
   }
 }

--- a/packages/drivers/odsp-socket-storage/src/OdspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDriverUrlResolver.ts
@@ -43,7 +43,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
 
   public async resolve(request: IRequest): Promise<IOdspResolvedUrl | IFluidNewResolvedUrl> {
     if (request.url === "NEW") {
-      return {type: "fluid-new"};
+      return {type: "fluid-new", url: "fluid-odsp://NEW"};
     }
     const { siteUrl, driveId, itemId, path } = this.decodeOdspUrl(request.url);
     const hashedDocumentId = getHashedDocumentId(driveId, itemId);

--- a/packages/drivers/odsp-socket-storage/src/createFile.ts
+++ b/packages/drivers/odsp-socket-storage/src/createFile.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { throwOdspNetworkError } from "./OdspUtils";
+
 export interface INewFileInfo {
     siteUrl: string;
     driveId: string;
@@ -43,15 +45,15 @@ export async function createNewFluidFile(
     if (fetchResponse.status !== 201) {
         // We encounter status=-1 if url path including filename length exceeds 400 characters.
         if (fetchResponse.status === -1) {
-            throw new Error("File path length exceeds 400 characters. Please use shorter filename.");
+            throwOdspNetworkError("Unknown Error. File path length exceeding 400 characters could cause this error", fetchResponse.status, false);
         }
 
-        throw new Error(`${fetchResponse.status} Failed to create file`);
+        throwOdspNetworkError("Failed to create file", fetchResponse.status, true);
     }
 
     const item = await fetchResponse.json();
     if (!item || !item.id) {
-        throw new Error("Could not parse drive item from Vroom response");
+        throwOdspNetworkError("Could not parse drive item from Vroom response", fetchResponse.status, false);
     }
 
     return {itemId: item.id, siteUrl: newFileInfo.siteUrl, driveId: newFileInfo.driveId, filename: item.name};

--- a/packages/drivers/odsp-socket-storage/src/createFile.ts
+++ b/packages/drivers/odsp-socket-storage/src/createFile.ts
@@ -8,7 +8,6 @@ export interface INewFileInfo {
     driveId: string;
     filename: string;
     filePath: string;
-    // TODO: this callback should probably take a full 'file' representation not jus the itemid
     callback?(itemId: string, filename: string): void;
 }
 

--- a/packages/drivers/odsp-socket-storage/src/createFile.ts
+++ b/packages/drivers/odsp-socket-storage/src/createFile.ts
@@ -1,0 +1,56 @@
+
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { INewFileInfo } from "./OdspDocumentServiceFactoryWithCodeSplit";
+
+const isInvalidFileName = (fileName: string): boolean => {
+    const invalidCharsRegex = /["*/:<>?\\|]+/g;
+    return !!fileName.match(invalidCharsRegex);
+};
+
+/**
+ * Creates a new fluid file. '.fluid' is appended to the filename
+ */
+export async function createNewFluidFile(
+    newFileInfo: INewFileInfo,
+    storageToken: string,
+): Promise<{driveId: string, itemId: string, siteUrl: string}> {
+    // Check for valid filename
+    // Adding invalid filename check here for another sanity pass before the request to create file is actually made
+    if (isInvalidFileName(newFileInfo.filename)) {
+        throw new Error("Invalid filename. Please try again.");
+    }
+
+    const token = storageToken;
+    if (!token) {
+        throw new Error("Failed to acquire Storage token");
+    }
+    const encodedFilename = encodeURIComponent(`${newFileInfo.filename}.fluid`);
+
+    const url = `${newFileInfo.siteUrl}/_api/v2.1/drives/${newFileInfo.driveId}/items/root:/${encodeURIComponent(
+        newFileInfo.filePath,
+    )}/${encodedFilename}:/content?@name.conflictBehavior=rename&select=id,name,parentReference`;
+    const fetchResponse = await fetch(url, {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${token}` },
+    });
+
+    if (fetchResponse.status !== 201) {
+        // We encounter status=-1 if url path including filename length exceeds 400 characters.
+        if (fetchResponse.status === -1) {
+            throw new Error("File path length exceeds 400 characters. Please use shorter filename.");
+        }
+
+        throw new Error(`${fetchResponse.status} Failed to create file`);
+    }
+
+    const item = await fetchResponse.json();
+    if (!item || !item.id) {
+        throw new Error("Could not parse drive item from Vroom response");
+    }
+
+    return {itemId: item.id, siteUrl: newFileInfo.siteUrl, driveId: newFileInfo.driveId};
+}

--- a/packages/drivers/odsp-socket-storage/src/createFile.ts
+++ b/packages/drivers/odsp-socket-storage/src/createFile.ts
@@ -1,4 +1,3 @@
-
 /*!
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
@@ -10,7 +9,7 @@ export interface INewFileInfo {
     filename: string;
     filePath: string;
     // TODO: this callback should probably take a full 'file' representation not jus the itemid
-    callback?(itemId: string): void;
+    callback?(itemId: string, filename: string): void;
 }
 
 const isInvalidFileName = (fileName: string): boolean => {
@@ -24,7 +23,7 @@ const isInvalidFileName = (fileName: string): boolean => {
 export async function createNewFluidFile(
     newFileInfo: INewFileInfo,
     storageToken: string | null,
-): Promise<{driveId: string, itemId: string, siteUrl: string}> {
+): Promise<{driveId: string, itemId: string, siteUrl: string, filename: string}> {
     // Check for valid filename
     // Adding invalid filename check here for another sanity pass before the request to create file is actually made
     if (isInvalidFileName(newFileInfo.filename)) {
@@ -56,5 +55,5 @@ export async function createNewFluidFile(
         throw new Error("Could not parse drive item from Vroom response");
     }
 
-    return {itemId: item.id, siteUrl: newFileInfo.siteUrl, driveId: newFileInfo.driveId};
+    return {itemId: item.id, siteUrl: newFileInfo.siteUrl, driveId: newFileInfo.driveId, filename: item.name};
 }

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -223,6 +223,11 @@ export class Loader extends EventEmitter implements ILoader {
     }
 
     private parseUrl(url: string): IParsedUrl | null {
+        // tslint:disable-next-line: max-line-length
+        // TODO: We have to figure out a way to replace those IDs with something that makes sense even if we don't have a file
+        if (url.endsWith("NEW")) {
+            return {id: "NEW", path: "/", version: null};
+        }
         const parsed = parse(url, true);
 
         const regex = /^\/([^/]*\/[^/]*)(\/?.*)$/;
@@ -249,6 +254,10 @@ export class Loader extends EventEmitter implements ILoader {
         }
         if (!toCache) {
             return Promise.reject(`Invalid URL ${request.url}`);
+        }
+        // don't cache new and just return it
+        if (toCache.type === "fluid-new") {
+            return toCache;
         }
         if (toCache.type !== "fluid") {
             return Promise.reject("Only Fluid components currently supported");
@@ -279,6 +288,8 @@ export class Loader extends EventEmitter implements ILoader {
         const factory: IDocumentServiceFactory =
             selectDocumentServiceFactoryForProtocol(resolvedAsFluid, this.protocolToDocumentFactoryMap);
 
+        // TODO: we need to figure out summaries since it does call another resolve, which creates a new file
+        // if we are using the delayed createNew path
         let container: Container;
         if (canCache) {
             const versionedId = request.headers[LoaderHeader.version]

--- a/packages/loader/driver-definitions/src/urlResolver.ts
+++ b/packages/loader/driver-definitions/src/urlResolver.ts
@@ -5,7 +5,7 @@
 
 import { IRequest } from "@microsoft/fluid-component-core-interfaces";
 
-export type IResolvedUrl = IWebResolvedUrl | IFluidResolvedUrl;
+export type IResolvedUrl = IWebResolvedUrl | IFluidResolvedUrl | IFluidNewResolvedUrl;
 
 export interface IResolvedUrlBase {
     type: string;
@@ -21,6 +21,10 @@ export interface IFluidResolvedUrl extends IResolvedUrlBase {
     url: string;
     tokens: { [name: string]: string };
     endpoints: { [name: string]: string };
+}
+
+export interface IFluidNewResolvedUrl extends IResolvedUrlBase {
+    type: "fluid-new";
 }
 
 export interface IUrlResolver {

--- a/packages/loader/driver-definitions/src/urlResolver.ts
+++ b/packages/loader/driver-definitions/src/urlResolver.ts
@@ -25,6 +25,7 @@ export interface IFluidResolvedUrl extends IResolvedUrlBase {
 
 export interface IFluidNewResolvedUrl extends IResolvedUrlBase {
     type: "fluid-new";
+    url: string;
 }
 
 export interface IUrlResolver {


### PR DESCRIPTION
This PR is a first stab at the interface changes required to allow the driver to take charge of creating new files.
This is in prep for an in-memory driver that will allow booting a new container without a file attached then having it attach to a file later when the new file is created.