### PR TITLE
fix 0.12 lint build break

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "clean:docs": "rimraf packages/_api-extractor-temp docs/api/*/**",
     "clean:nyc": "rimraf nyc/**",
     "clean:r11s": "cd server/routerlicious && npm run clean",
+    "lint": "npm run tslint",
     "postinstall": "npm run postinstall:lerna && (npm run postinstall:fluid-build || true)",
     "policy-check": "cd tools/repo-policy-check && npm run policy-check",
     "policy-check:full": "cd tools/repo-policy-check && npm install && npm run policy-check",


### PR DESCRIPTION
Fix 0.12 CI build break caused by no `lint` script.

This should not be merged into master