### PR TITLE
Fix r11s linting/building issues

### DIFF
--- a/server/routerlicious/docker-compose.dev.yml
+++ b/server/routerlicious/docker-compose.dev.yml
@@ -1,8 +1,5 @@
 version: '3.4'
 services:
-    gateway:
-        volumes:
-            - ../gateway:/usr/src/server
     alfred:
         volumes:
             - .:/usr/src/server/server/routerlicious

--- a/server/routerlicious/lerna-docker.json
+++ b/server/routerlicious/lerna-docker.json
@@ -1,7 +1,0 @@
-{
-    "packages": [
-      "packages/**"
-    ],
-    "version": "0.1001.0"
-}
-  

--- a/server/routerlicious/lerna.json
+++ b/server/routerlicious/lerna.json
@@ -1,7 +1,6 @@
 {
   "packages": [
     "../../packages/utils/build-common/**",
-    "../../packages/utils/eslint-config-fluid/**",
     "packages/**"
   ],
   "version": "0.1001.0"

--- a/server/routerlicious/r11s-Dockerfile
+++ b/server/routerlicious/r11s-Dockerfile
@@ -22,7 +22,9 @@ WORKDIR /usr/src/server
 # Copy over the package and package-lock and install prior to the other code to optimize Docker's file system cache on rebuilds
 COPY LICENSE.txt .
 COPY server/routerlicious/package*.json server/routerlicious/
-COPY server/routerlicious/lerna-docker.json server/routerlicious/lerna.json
+
+# Why don't we use the same lerna file?
+COPY server/routerlicious/lerna.json server/routerlicious/lerna.json
 COPY server/routerlicious/.npmrc server/routerlicious/
 COPY tools/build-server-resources/build-version.js server/routerlicious/tools/build-server-resources/
 

--- a/server/routerlicious/r11s-Dockerfile
+++ b/server/routerlicious/r11s-Dockerfile
@@ -22,8 +22,6 @@ WORKDIR /usr/src/server
 # Copy over the package and package-lock and install prior to the other code to optimize Docker's file system cache on rebuilds
 COPY LICENSE.txt .
 COPY server/routerlicious/package*.json server/routerlicious/
-
-# Why don't we use the same lerna file?
 COPY server/routerlicious/lerna.json server/routerlicious/lerna.json
 COPY server/routerlicious/.npmrc server/routerlicious/
 COPY tools/build-server-resources/build-version.js server/routerlicious/tools/build-server-resources/


### PR DESCRIPTION
npm run build:ci was failing within the docker container due to the lerna-docker.json file. This removes the need for lerna-docker.json.

@tylerbutler, let me know if you think this will let the eslint commands fall out of sync.

I also removed gateway from the docker-compose.dev.yml file