### PR TITLE
Fix docker build with local build artifact

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,4 @@
 **/dist
 **/lib
 **/nyc
+**/*.tsbuildinfo


### PR DESCRIPTION
If a build was done locally, doing client or server Docker build (via the Dockerfile/r11s-Dockerfil) or docker-compose will cause type script compiler error (unable to fine module even if the module is there.

I believe the root cause of that the *.tsbuildinfo interfered with the module resolution.  With the new typescript compiler upgrade recently, we pick up the change where typescript compiler start emitting relative paths in the *.tsbuildinfo.   I speculate that is the problem.

The solution is add *.tsbuildinfo to .dockerignore so that it doesn't copy over.