### PR TITLE
remove gateway volume mount

### DIFF
--- a/server/routerlicious/docker-compose.dev.yml
+++ b/server/routerlicious/docker-compose.dev.yml
@@ -1,8 +1,5 @@
 version: '3.4'
 services:
-    gateway:
-        volumes:
-            - ../gateway:/usr/src/server
     alfred:
         volumes:
             - .:/usr/src/server/server/routerlicious


### PR DESCRIPTION
It can corrupt the www.js file of Gateway now that we're using the Gateway docker image directly.

