### PR TITLE
Replace container resumer with container reconnect

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -15,12 +15,15 @@ TypeScript now emits `get/set` accessors in `.d.ts` files. TypeScript versions `
 
 More about the changes:
 
-- [Class Field Mitigations](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#class-field-mitigations)  
+- [Class Field Mitigations](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#class-field-mitigations)
 - [Full list of TypeScript changes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html)
 
 ## IHost interface removed, Loader constructor signature updated
 
 The IHost interface has been removed.  This primarily impacts the signature of the `Loader` constructor, which now just takes the `IUrlResolver` directly in its place.
+
+## Replace Container.resume with Container.reconnect
+`container.resume();` becomes `container.reconnect();`
 
 # 0.12 Breaking Changes
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -675,7 +675,8 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         });
 
         if (!pause) {
-            await this.resume();
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            this.resume();
         }
     }
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -415,7 +415,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         }
     }
 
-    public resume() {
+    private async resume() {
         assert(this.loaded);
         // Resume processing ops
         this._deltaManager.inbound.resume();
@@ -423,8 +423,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         this._deltaManager.inboundSignal.resume();
 
         // Ensure connection to web socket
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.connectToDeltaStream();
+        return this.connectToDeltaStream();
     }
 
     public raiseCriticalError(error: any) {
@@ -446,7 +445,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         if (this._connectionState === ConnectionState.Disconnected) {
             this.manualReconnectInProgress = true;
         }
-        return this._deltaManager.connect().catch(() => { });
+        return this.resume().catch(() => { });
     }
 
     private async reloadContextCore(): Promise<void> {
@@ -676,7 +675,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         });
 
         if (!pause) {
-            this.resume();
+            await this.resume();
         }
     }
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -415,17 +415,6 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         }
     }
 
-    private async resume() {
-        assert(this.loaded);
-        // Resume processing ops
-        this._deltaManager.inbound.resume();
-        this._deltaManager.outbound.resume();
-        this._deltaManager.inboundSignal.resume();
-
-        // Ensure connection to web socket
-        return this.connectToDeltaStream();
-    }
-
     public raiseCriticalError(error: any) {
         this.emit("error", error);
     }
@@ -445,7 +434,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         if (this._connectionState === ConnectionState.Disconnected) {
             this.manualReconnectInProgress = true;
         }
-        return this.resume().catch(() => { });
+        return this.connectToDeltaStream().catch(() => { });
     }
 
     private async reloadContextCore(): Promise<void> {
@@ -676,7 +665,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
 
         if (!pause) {
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            this.resume();
+            this.connectToDeltaStream();
         }
     }
 


### PR DESCRIPTION
These methods do essentially the same thing so I don't think having both is necessary