### PR TITLE
performance event in OdspDocumentService.getStorageToken()

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/OdspDeltaStorageService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDeltaStorageService.ts
@@ -23,7 +23,7 @@ export class OdspDeltaStorageService implements api.IDocumentDeltaStorageService
         private readonly deltaFeedUrlProvider: () => Promise<string>,
         private readonly fetchWrapper: IFetchWrapper,
         private ops: ISequencedDeltaOpMessage[] | undefined,
-        private readonly getStorageToken: (refresh: boolean) => Promise<string | null>,
+        private readonly getStorageToken: (refresh: boolean, name?: string) => Promise<string | null>,
         private readonly logger?: ITelemetryLogger,
     ) {
         this.queryString = getQueryString(queryParams);
@@ -45,7 +45,7 @@ export class OdspDeltaStorageService implements api.IDocumentDeltaStorageService
             // Thus it needs to be done before we call getStorageToken() to reduce extra calls
             const baseUrl = await this.buildUrl(from, to);
 
-            const storageToken = await this.getStorageToken(refresh);
+            const storageToken = await this.getStorageToken(refresh, "DeltaStorage");
 
             const { url, headers } = getUrlAndHeadersWithAuth(baseUrl, storageToken);
 

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
@@ -4,7 +4,7 @@
  */
 
 import { ITelemetryBaseLogger } from "@microsoft/fluid-common-definitions";
-import { DebugLogger, TelemetryLogger, TelemetryNullLogger } from "@microsoft/fluid-core-utils";
+import { DebugLogger, PerformanceEvent, TelemetryLogger, TelemetryNullLogger } from "@microsoft/fluid-core-utils";
 import {
     IDocumentDeltaConnection,
     IDocumentDeltaStorageService,
@@ -89,14 +89,24 @@ export class OdspDocumentService implements IDocumentService {
             logger,
             { docId: hashedDocumentId });
 
-        this.getStorageToken = (refresh: boolean) => {
+        this.getStorageToken = (refresh: boolean, name?: string) => {
             if (refresh) {
                 // Potential perf issue:
                 // Host should optimize and provide non-expired tokens on all critical paths.
                 // Exceptions: race conditions around expiration, revoked tokens, host that does not care (fluid-fetcher)
                 this.logger.sendTelemetryEvent({ eventName: "StorageTokenRefresh" });
             }
-            return getStorageToken(this.siteUrl, refresh);
+            const event = PerformanceEvent.start(this.logger, { eventName: `${name || "OdspDocumentService"}GetToken` });
+            let token: Promise<string | null>;
+            try {
+                token = getStorageToken(this.siteUrl, refresh);
+            } catch (error) {
+                event.cancel({}, error);
+                throw error;
+            }
+            event.end();
+
+            return token;
         };
 
         this.localStorageAvailable = isLocalStorageAvailable();

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentService.ts
@@ -96,7 +96,7 @@ export class OdspDocumentService implements IDocumentService {
                 // Exceptions: race conditions around expiration, revoked tokens, host that does not care (fluid-fetcher)
                 this.logger.sendTelemetryEvent({ eventName: "StorageTokenRefresh" });
             }
-            const event = PerformanceEvent.start(this.logger, { eventName: `${name || "OdspDocumentService"}GetToken` });
+            const event = PerformanceEvent.start(this.logger, { eventName: `${name || "OdspDocumentService"}_GetToken` });
             let token: Promise<string | null>;
             try {
                 token = getStorageToken(this.siteUrl, refresh);

--- a/packages/drivers/odsp-socket-storage/src/OdspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/OdspDocumentStorageManager.ts
@@ -69,7 +69,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
         private readonly snapshotUrl: string | undefined,
         private latestSha: string | null | undefined,
         private readonly fetchWrapper: IFetchWrapper,
-        private readonly getStorageToken: (refresh: boolean) => Promise<string | null>,
+        private readonly getStorageToken: (refresh: boolean, name?: string) => Promise<string | null>,
         private readonly logger: ITelemetryLogger,
         private readonly fetchFullSnapshot: boolean,
         private readonly odspCache: OdspCache,
@@ -91,7 +91,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
             this.checkSnapshotUrl();
 
             const response = await getWithRetryForTokenRefresh(async (refresh: boolean) => {
-                const storageToken = await this.getStorageToken(refresh);
+                const storageToken = await this.getStorageToken(refresh, "GetBlob");
 
                 const { url, headers } = getUrlAndHeadersWithAuth(`${this.snapshotUrl}/blobs/${blobid}${this.queryString}`, storageToken);
 
@@ -117,7 +117,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
         this.checkSnapshotUrl();
 
         return getWithRetryForTokenRefresh(async (refresh: boolean) => {
-            const storageToken = await this.getStorageToken(refresh);
+            const storageToken = await this.getStorageToken(refresh, "GetContent");
 
             const { url, headers } = getUrlAndHeadersWithAuth(`${this.snapshotUrl}/contents${getQueryString({ ref: version.id, path })}`, storageToken);
 
@@ -240,7 +240,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
                 const odspCacheKey: string = `${this.documentId}/getlatest`;
                 let odspSnapshot: IOdspSnapshot = this.odspCache.get(odspCacheKey);
                 if (!odspSnapshot) {
-                    const storageToken = await this.getStorageToken(refresh);
+                    const storageToken = await this.getStorageToken(refresh, "GetVersions");
 
                     // TODO: This snapshot will return deltas, which we currently aren't using. We need to enable this flag to go down the "optimized"
                     // snapshot code path. We should leverage the fact that these deltas are returned to speed up the deltas fetch.
@@ -306,7 +306,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
         }
 
         return getWithRetryForTokenRefresh(async (refresh) => {
-            const storageToken = await this.getStorageToken(refresh);
+            const storageToken = await this.getStorageToken(refresh, "GetVersions");
             const { url, headers } = getUrlAndHeadersWithAuth(`${this.snapshotUrl}/versions?count=${count}`, storageToken);
 
             // fetch the latest snapshot versions for the document
@@ -399,7 +399,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
         let tree = this.treesCache.get(id);
         if (!tree) {
             tree = await getWithRetryForTokenRefresh(async (refresh: boolean) => {
-                const storageToken = await this.getStorageToken(refresh);
+                const storageToken = await this.getStorageToken(refresh, "ReadTree");
 
                 const response = await fetchSnapshot(this.snapshotUrl!, storageToken, this.appId, this.fetchWrapper, id, this.fetchFullSnapshot);
                 const odspSnapshot: IOdspSnapshot = response.content;
@@ -507,7 +507,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
         };
 
         return getWithRetryForTokenRefresh(async (refresh: boolean) => {
-            const storageToken = await this.getStorageToken(refresh);
+            const storageToken = await this.getStorageToken(refresh, "WriteSummaryTree");
 
             const { url, headers } = getUrlAndHeadersWithAuth(`${this.snapshotUrl}/snapshot${this.queryString}`, storageToken);
             headers["Content-Type"] = "application/json";

--- a/packages/drivers/odsp-socket-storage/src/Vroom.ts
+++ b/packages/drivers/odsp-socket-storage/src/Vroom.ts
@@ -40,10 +40,15 @@ export async function fetchJoinSession(
 ): Promise<IOdspResponse<ISocketStorageDiscovery>> {
     return getWithRetryForTokenRefresh(async (refresh: boolean) => {
         const tokenEvent = PerformanceEvent.start(logger, { eventName: "JoinSessionToken" });
-        const token = await getVroomToken(refresh);
-        if (!token) {
-            tokenEvent.cancel();
-            throwOdspNetworkError("Failed to acquire Vroom token", 400, true);
+        let token: string | undefined | null;
+        try {
+            token = await getVroomToken(refresh);
+            if (!token) {
+                throwOdspNetworkError("Failed to acquire Vroom token", 400, true);
+            }
+        } catch (error) {
+            tokenEvent.cancel({}, error);
+            throw error;
         }
         tokenEvent.end();
 

--- a/packages/drivers/odsp-socket-storage/src/Vroom.ts
+++ b/packages/drivers/odsp-socket-storage/src/Vroom.ts
@@ -39,8 +39,7 @@ export async function fetchJoinSession(
     getVroomToken: (refresh: boolean, name?: string) => Promise<string | undefined | null>,
 ): Promise<IOdspResponse<ISocketStorageDiscovery>> {
     return getWithRetryForTokenRefresh(async (refresh: boolean) => {
-        let token: string | undefined | null;
-        token = await getVroomToken(refresh, "JoinSession");
+        const token = await getVroomToken(refresh, "JoinSession");
         if (!token) {
             throwOdspNetworkError("Failed to acquire Vroom token", 400, true);
         }

--- a/packages/drivers/odsp-socket-storage/src/Vroom.ts
+++ b/packages/drivers/odsp-socket-storage/src/Vroom.ts
@@ -36,21 +36,14 @@ export async function fetchJoinSession(
     additionalParams: string,
     method: string,
     logger: ITelemetryLogger,
-    getVroomToken: (refresh: boolean) => Promise<string | undefined | null>,
+    getVroomToken: (refresh: boolean, name?: string) => Promise<string | undefined | null>,
 ): Promise<IOdspResponse<ISocketStorageDiscovery>> {
     return getWithRetryForTokenRefresh(async (refresh: boolean) => {
-        const tokenEvent = PerformanceEvent.start(logger, { eventName: "JoinSessionToken" });
         let token: string | undefined | null;
-        try {
-            token = await getVroomToken(refresh);
-            if (!token) {
-                throwOdspNetworkError("Failed to acquire Vroom token", 400, true);
-            }
-        } catch (error) {
-            tokenEvent.cancel({}, error);
-            throw error;
+        token = await getVroomToken(refresh, "JoinSession");
+        if (!token) {
+            throwOdspNetworkError("Failed to acquire Vroom token", 400, true);
         }
-        tokenEvent.end();
 
         const joinSessionEvent = PerformanceEvent.start(logger, { eventName: "JoinSession" });
         let response: IOdspResponse<ISocketStorageDiscovery>;
@@ -96,7 +89,7 @@ export async function getSocketStorageDiscovery(
     itemId: string,
     siteUrl: string,
     logger: ITelemetryLogger,
-    getVroomToken: (refresh: boolean) => Promise<string | undefined | null>,
+    getVroomToken: (refresh: boolean, name?: string) => Promise<string | undefined | null>,
     odspCache: OdspCache,
     joinSessionKey: string,
 ): Promise<ISocketStorageDiscovery> {


### PR DESCRIPTION
Add performance event in OdspDocumentService.getStorageToken() to track token fetch. This will help differentiate between exception and timing out.