### PR TITLE
Process inbound ops in chunks to avoid blocking JS thread for long time and preserve batching

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -12,10 +12,7 @@ import {
     IDeltaManager,
     IDeltaQueue,
 } from "@microsoft/fluid-container-definitions";
-import {
-    ChildLogger,
-    PerformanceEvent,
-} from "@microsoft/fluid-core-utils";
+import { PerformanceEvent } from "@microsoft/fluid-core-utils";
 import {
     IDocumentDeltaStorageService,
     IDocumentService,
@@ -212,9 +209,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         this._inbound = new DeltaQueue<ISequencedDocumentMessage>(
             (op) => {
                 this.processInboundMessage(op);
-            },
-            ChildLogger.create(this.logger, "InboundDeltaQueue"),
-        );
+            });
 
         this._inbound.on("error", (error) => {
             this.emit("error", createIError(error));
@@ -225,9 +220,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         this._outbound = new DeltaQueue<IDocumentMessage[]>(
             (messages) => {
                 this.connection!.submit(messages);
-            },
-            ChildLogger.create(this.logger, "OutboundDeltaQueue"),
-        );
+            });
 
         this._outbound.on("error", (error) => {
             this.emit("error", createIError(error));
@@ -239,9 +232,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
                 clientId: message.clientId,
                 content: JSON.parse(message.content as string),
             });
-        },
-        ChildLogger.create(this.logger, "InboundSignalDeltaQueue"),
-        );
+        });
 
         this._inboundSignal.on("error", (error) => {
             this.emit("error", createIError(error));

--- a/packages/loader/container-loader/src/deltaQueue.ts
+++ b/packages/loader/container-loader/src/deltaQueue.ts
@@ -5,32 +5,9 @@
 
 import * as assert from "assert";
 import { EventEmitter } from "events";
-import { ITelemetryLogger } from "@microsoft/fluid-common-definitions";
 import { IDeltaQueue } from "@microsoft/fluid-container-definitions";
 import { Deferred } from "@microsoft/fluid-core-utils";
 import * as Deque from "double-ended-queue";
-
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const performanceNow = require("performance-now") as (() => number);
-
-/**
- * The initial time for processing ops in a single iteration.
- */
-const asyncProcessingStartTime = 20;
-
-/**
- * The increase in time allowed for processing ops after each iteration when processing ops
- * asynchronously.
- */
-const asyncProcessingTimeIncrease = 10;
-
-/**
- * The number of times ops have been processed asyncronously when there is more than one
- * op in the queue. This is used to log the time taken to process large number of ops.
- * For example, when catching up ops right after boot or catching up ops / delayed reaziling
- * components by summarizer.
- */
-let asyncProcessingCount = -1;
 
 export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
     private isDisposed: boolean = false;
@@ -54,18 +31,6 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
      */
     private processingDeferred: Deferred<void> | undefined;
 
-    /**
-     * When async processing is ongoing, holds a deferred that will resolve once processing stops.
-     * Undefined when not processing.
-     */
-    private processingDeferredAsync: Deferred<void> | undefined;
-
-    private asyncProcessingLog: {
-        numberOfOps: number;
-        numberOfBatches: number;
-        totalProcessingTime: number;
-    } | undefined;
-
     public get disposed(): boolean {
         return this.isDisposed;
     }
@@ -84,7 +49,7 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
     }
 
     public get idle(): boolean {
-        return !this.processingDeferred && !this.processingDeferredAsync && this.q.length === 0;
+        return !this.processingDeferred && this.q.length === 0;
     }
 
     /**
@@ -93,7 +58,6 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
      */
     constructor(
         private readonly worker: (delta: T) => void,
-        private readonly logger: ITelemetryLogger,
     ) {
         super();
     }
@@ -125,20 +89,15 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
         this.userPause = true;
         // If called from within the processing loop, we are in the middle of processing an op. Return a promise
         // that will resolve when processing has actually stopped.
-        const processingPromise: Promise<void>[] = [];
         if (this.processingDeferred) {
-            processingPromise.push(this.processingDeferred.promise);
+            return this.processingDeferred.promise;
         }
-        if (this.processingDeferredAsync) {
-            processingPromise.push(this.processingDeferredAsync.promise);
-        }
-        await Promise.all(processingPromise);
     }
 
     public resume(): void {
         this.userPause = false;
         if (!this.paused) {
-            this.ensureProcessing(true);
+            this.ensureProcessing();
         }
     }
 
@@ -146,20 +105,15 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
         this.sysPause = true;
         // If called from within the processing loop, we are in the middle of processing an op. Return a promise
         // that will resolve when processing has actually stopped.
-        const processingPromise: Promise<void>[] = [];
         if (this.processingDeferred) {
-            processingPromise.push(this.processingDeferred.promise);
+            return this.processingDeferred.promise;
         }
-        if (this.processingDeferredAsync) {
-            processingPromise.push(this.processingDeferredAsync.promise);
-        }
-        await Promise.all(processingPromise);
     }
 
     public systemResume(): void {
         this.sysPause = false;
         if (!this.paused) {
-            this.ensureProcessing(true);
+            this.ensureProcessing();
         }
     }
 
@@ -167,39 +121,19 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
      * There are several actions that may need to kick off delta processing, so we want to guard against
      * accidental reentrancy. ensureProcessing can be called safely to start the processing loop if it is
      * not already started.
-     * If processAsync is true, delta processing is done on a separate stack so that the user stack does
-     * not become too large.
      */
-    private ensureProcessing(processAsync = false) {
-        if (processAsync) {
-            if (!this.processingDeferred && !this.processingDeferredAsync) {
-                // Log telemetry for the time taken to process when there is more than one op in the queue.
-                // We want to catch any unexpected behavior when process large amount of ops such as when
-                // catching up ops right after boot.
-                if (this.q.length > 1) {
-                    asyncProcessingCount++;
-                    this.asyncProcessingLog = {
-                        numberOfOps: this.q.length,
-                        numberOfBatches: 0,
-                        totalProcessingTime: 0,
-                    };
-                }
-                this.processingDeferredAsync = new Deferred<void>();
-                // Use a resolved promise to start the processing on a separate stack.
-                // processingDeferredAsync will be resolved in processDeltasAsync once we have asynchronously
-                // completed the processing.
-                // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                Promise.resolve().then(() => {
-                    this.processDeltasAsync();
-                });
-            }
-        } else {
-            if (!this.processingDeferred) {
-                this.processingDeferred = new Deferred<void>();
+    private ensureProcessing() {
+        if (!this.processingDeferred) {
+            this.processingDeferred = new Deferred<void>();
+            // Use a resolved promise to start the processing on a separate stack.
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            Promise.resolve().then(() => {
                 this.processDeltas();
-                this.processingDeferred.resolve();
-                this.processingDeferred = undefined;
-            }
+                if (this.processingDeferred) {
+                    this.processingDeferred.resolve();
+                    this.processingDeferred = undefined;
+                }
+            });
         }
     }
 
@@ -222,64 +156,9 @@ export class DeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
                 this.emit("error", error);
             }
         }
-    }
 
-    /**
-     * Executes the delta processing loop until a stop condition is reached. It processes
-     * ops for an allowed amount of time (asyncProcessingStartTime by default) and then
-     * schedules the rest of the ops to be processed aynschronously. This ensures that we
-     * don't block the JS threads for a long time (for example, when catching up ops right
-     * after boot or catching up ops / delayed reaziling components by summarizer).
-     *
-     * We increase the allowed processing time in each iteration until all the ops have been
-     * processed. This way we keep the responsiveness at the beginning while also making sure
-     * that all the ops process fairly quickly.
-     */
-    private processDeltasAsync(processingTime = asyncProcessingStartTime) {
-        const startTime = performanceNow();
-        let elaspedTime = 0;
-        // Loop over the local messages until no messages to process, we have become paused, we hit an error
-        // or the processing time has elasped.
-        while (!(this.q.length === 0 || this.paused || this.error || elaspedTime >= processingTime)) {
-            // Get the next message in the queue
-            const next = this.q.shift();
-
-            // Process the message.
-            try {
-                this.worker(next!);
-                this.emit("op", next);
-            } catch (error) {
-                this.error = error;
-                this.emit("error", error);
-            }
-
-            elaspedTime = performanceNow() - startTime;
-        }
-
-        if (this.asyncProcessingLog) {
-            this.asyncProcessingLog.numberOfBatches++;
-            this.asyncProcessingLog.totalProcessingTime += elaspedTime;
-        }
-
-        if (this.q.length === 0 || this.paused || this.error) {
-            if (asyncProcessingCount % 2000 === 0 && this.asyncProcessingLog) {
-                this.logger.sendTelemetryEvent({
-                    eventName: "AsyncDeltaProcessingComplete",
-                    numberOfOps: this.asyncProcessingLog.numberOfOps,
-                    numberOfBatches: this.asyncProcessingLog.numberOfBatches,
-                    processingTime: this.asyncProcessingLog.totalProcessingTime,
-                });
-                this.asyncProcessingLog = undefined;
-            }
-            if (this.processingDeferredAsync) {
-                this.processingDeferredAsync.resolve();
-                this.processingDeferredAsync = undefined;
-            }
-        } else {
-            // Increase the allowed processing time by asyncProcessingTimeIncrease for the next iteration.
-            setTimeout(() => {
-                this.processDeltasAsync(processingTime + asyncProcessingTimeIncrease);
-            });
+        if (this.q.length === 0) {
+            this.emit("idle");
         }
     }
 }

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -65,6 +65,7 @@
     "@types/node": "^10.14.6",
     "@types/uuid": "^3.4.4",
     "debug": "^4.1.1",
+    "performance-now": "^2.1.0",
     "uuid": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/runtime/container-runtime/src/deltaScheduler.ts
+++ b/packages/runtime/container-runtime/src/deltaScheduler.ts
@@ -1,0 +1,120 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ITelemetryLogger } from "@microsoft/fluid-common-definitions";
+import { IDeltaManager } from "@microsoft/fluid-container-definitions";
+import {
+    IDocumentMessage,
+    ISequencedDocumentMessage,
+} from "@microsoft/fluid-protocol-definitions";
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const performanceNow = require("performance-now") as (() => number);
+
+/**
+ * The number of times inbound queue has been processed when there is more than one op in the
+ * queue. This is used to log the time taken to process large number of ops.
+ * For example, when catching up ops right after boot or catching up ops / delayed reaziling
+ * components by summarizer.
+ */
+let inboundQueueProcessingCount = -1;
+
+export class DeltaScheduler {
+    private readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
+    // The time for processing ops in a single turn.
+    private readonly processingTime = 20;
+
+    // The increase in time for processing ops after each turn.
+    private readonly processingTimeIncrement = 10;
+
+    private processingStartTime: number | undefined;
+    private totalProcessingTime: number = this.processingTime;
+
+    private opProcessingLog: {
+        numberOfOps: number;
+        numberOfBatches: number;
+        totalProcessingTime: number;
+    } | undefined;
+
+    constructor(
+        deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
+        private readonly logger: ITelemetryLogger,
+    ) {
+        this.deltaManager = deltaManager;
+
+        this.deltaManager.inbound.on("idle", () => { this.inboundQueueIdle(); });
+    }
+
+    public batchBegin(message: ISequencedDocumentMessage) {
+        if (this.deltaManager.inbound.length > 0 && !this.processingStartTime) {
+            // Start the timer that keeps track of how long we have processed ops in the delta queue
+            // in this call.
+            this.processingStartTime = performanceNow();
+
+            // Initialize the object that will be used to log the time taken to process the ops.
+            if (this.opProcessingLog === undefined) {
+                inboundQueueProcessingCount++;
+                this.opProcessingLog = {
+                    numberOfOps: this.deltaManager.inbound.length,
+                    numberOfBatches: 1,
+                    totalProcessingTime: 0,
+                };
+            }
+        }
+    }
+
+    public batchEnd(message: ISequencedDocumentMessage) {
+        // If we have processed ops for more than the total processing time, we pause the
+        // queue, yield the thread and schedule a resume. This ensures that we don't block
+        // the JS threads for a long time (for example, when catching up ops right after
+        // boot or catching up ops / delayed reaziling components by summarizer).
+        //
+        // We keep increasing the total processing time after each turn until all the ops have been
+        // processed. This way we keep the responsiveness at the beginning while also making sure
+        // that all the ops process fairly quickly.
+        if (this.processingStartTime && this.deltaManager.inbound.length > 0) {
+            const elaspedTime = performanceNow() - this.processingStartTime;
+            if (elaspedTime > this.totalProcessingTime) {
+                // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                this.deltaManager.inbound.systemPause();
+
+                setTimeout(() => {
+                    this.deltaManager.inbound.systemResume();
+                });
+
+                this.processingStartTime = undefined;
+                this.totalProcessingTime += this.processingTimeIncrement;
+
+                // Update the telemetry log object since.
+                this.opProcessingLog.numberOfBatches++;
+                this.opProcessingLog.totalProcessingTime += elaspedTime;
+            }
+        }
+    }
+
+    private inboundQueueIdle() {
+        if (this.processingStartTime) {
+            // Log telemetry for the time taken to process ops in the inbound queue every 2000th time
+            // we process more than one op.
+            if (inboundQueueProcessingCount % 2000 === 0) {
+                // Add the time taken for processing the final ops to the total processing time in the
+                // telemetry log object.
+                this.opProcessingLog.totalProcessingTime += performanceNow() - this.processingStartTime;
+
+                this.logger.sendTelemetryEvent({
+                    eventName: "InboundOpsProcessingTime",
+                    numberOfOps: this.opProcessingLog.numberOfOps,
+                    numberOfBatches: this.opProcessingLog.numberOfBatches,
+                    processingTime: this.opProcessingLog.totalProcessingTime,
+                });
+
+                this.opProcessingLog = undefined;
+            }
+
+            this.processingStartTime = undefined;
+            this.totalProcessingTime = this.processingTime;
+        }
+    }
+}

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -5,6 +5,7 @@
 
 import * as assert from "assert";
 import { EventEmitter } from "events";
+import { DebugLogger } from "@microsoft/fluid-core-utils";
 import { BlobTreeEntry, TreeTreeEntry } from "@microsoft/fluid-protocol-base";
 import {
     ISummaryBlob,
@@ -122,12 +123,17 @@ describe("Runtime", () => {
                     emitter = new EventEmitter();
                     deltaManager = new MockDeltaManager();
                     messageScheduler = new MockMessageScheduler(deltaManager);
-                    scheduleManager = new ScheduleManager(messageScheduler, emitter, deltaManager);
+                    scheduleManager = new ScheduleManager(
+                        messageScheduler,
+                        emitter,
+                        deltaManager,
+                        DebugLogger.create("fluid:testScheduleManager"),
+                    );
 
                     emitter.on("batchBegin", () => {
                         // When we receive a "batchBegin" event, we should not have any outstanding
                         // events, i.e., batchBegin and batchEnd should be equal.
-                        assert.strictEqual(batchBegin, batchEnd, "Received batchBegin before batchEnd for previous batch");
+                        assert.strictEqual(batchBegin, batchEnd, "Received batchBegin before previous batchEnd");
                         batchBegin++;
                     });
 
@@ -142,7 +148,7 @@ describe("Runtime", () => {
                 afterEach(() => {
                     batchBegin = 0;
                     batchEnd = 0;
-                })
+                });
 
                 it("Single non-batch message", () => {
                     const clientId: string = "test-client";

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -127,7 +127,7 @@ describe("Runtime", () => {
                     emitter.on("batchBegin", () => {
                         // When we receive a "batchBegin" event, we should not have any outstanding
                         // events, i.e., batchBegin and batchEnd should be equal.
-                        assert.strictEqual(batchBegin, batchEnd);
+                        assert.strictEqual(batchBegin, batchEnd, "Received batchBegin before batchEnd for previous batch");
                         batchBegin++;
                     });
 
@@ -135,14 +135,14 @@ describe("Runtime", () => {
                         batchEnd++;
                         // Every "batchEnd" event should correspond to a "batchBegin" event, i.e.,
                         // batchBegin and batchEnd should be equal.
-                        assert.strictEqual(batchBegin, batchEnd);
+                        assert.strictEqual(batchBegin, batchEnd, "Received batcEnd without corresponding batchBegin");
                     });
                 });
 
                 afterEach(() => {
                     batchBegin = 0;
                     batchEnd = 0;
-                });
+                })
 
                 it("Single non-batch message", () => {
                     const clientId: string = "test-client";
@@ -156,8 +156,8 @@ describe("Runtime", () => {
                     scheduleManager.beginOperation(message as ISequencedDocumentMessage);
                     scheduleManager.endOperation(undefined, message as ISequencedDocumentMessage);
 
-                    assert.strictEqual(1, batchBegin);
-                    assert.strictEqual(1, batchEnd);
+                    assert.strictEqual(1, batchBegin, "Did not receive correct batchBegin events");
+                    assert.strictEqual(1, batchEnd, "Did not receive correct batchEnd events");
                 });
 
                 it("Multiple non-batch messages", () => {
@@ -184,8 +184,8 @@ describe("Runtime", () => {
                     scheduleManager.beginOperation(message as ISequencedDocumentMessage);
                     scheduleManager.endOperation(undefined, message as ISequencedDocumentMessage);
 
-                    assert.strictEqual(5, batchBegin);
-                    assert.strictEqual(5, batchEnd);
+                    assert.strictEqual(5, batchBegin, "Did not receive correct batchBegin events");
+                    assert.strictEqual(5, batchEnd, "Did not receive correct batchEnd events");
                 });
 
                 it("Messages in a single batch", () => {
@@ -224,8 +224,8 @@ describe("Runtime", () => {
                     scheduleManager.endOperation(undefined, batchEndMessage as ISequencedDocumentMessage);
 
                     // We should have only received one "batchBegin" and one "batchEnd" for the batch.
-                    assert.strictEqual(1, batchBegin);
-                    assert.strictEqual(1, batchEnd);
+                    assert.strictEqual(1, batchBegin, "Did not receive correct batchBegin event for the batch");
+                    assert.strictEqual(1, batchEnd, "Did not receive correct batchEnd event for the batch");
                 });
             });
         });

--- a/packages/runtime/runtime-test-utils/src/index.ts
+++ b/packages/runtime/runtime-test-utils/src/index.ts
@@ -4,4 +4,5 @@
  */
 
 export * from "./mocks";
+export * from "./mockDeltas";
 export * from "./mockStorage";

--- a/packages/runtime/runtime-test-utils/src/mockDeltas.ts
+++ b/packages/runtime/runtime-test-utils/src/mockDeltas.ts
@@ -1,0 +1,160 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { EventEmitter } from "events";
+import {
+    IClientDetails,
+    IDocumentMessage,
+    ISequencedDocumentMessage,
+    IServiceConfiguration,
+    ISignalMessage,
+    ConnectionMode,
+    MessageType,
+} from "@microsoft/fluid-protocol-definitions";
+
+import {
+    IConnectionDetails,
+    IDeltaHandlerStrategy,
+    IDeltaManager,
+    IDeltaQueue,
+} from "@microsoft/fluid-container-definitions";
+
+/**
+ * Mock implementation of IDeltaQueue for testing that does nothing
+ */
+class MockDeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
+    public get disposed() { return undefined; }
+
+    public get paused(): boolean {
+        return false;
+    }
+
+    public get length(): number {
+        return 0;
+    }
+
+    public get idle(): boolean {
+        return false;
+    }
+
+    public async pause(): Promise<void> {
+        return;
+    }
+
+    public resume(): void {}
+
+    public peek(): T | undefined {
+        return undefined;
+    }
+
+    public toArray(): T[] {
+        return [];
+    }
+
+    public async systemPause(): Promise<void> {
+        return;
+    }
+
+    public systemResume(): void {
+        return undefined;
+    }
+
+    public dispose() {}
+
+    constructor() {
+        super();
+    }
+}
+
+/**
+ * Mock implementation of IDeltaManager for testing that creates mock DeltaQueues for testing
+ */
+export class MockDeltaManager extends EventEmitter
+    implements IDeltaManager<ISequencedDocumentMessage, IDocumentMessage> {
+    public get disposed() { return undefined; }
+
+    public readonly clientType: string;
+    public readonly clientDetails: IClientDetails;
+    public get IDeltaSender() { return this; }
+
+    private readonly _inbound: MockDeltaQueue<ISequencedDocumentMessage>;
+    private readonly _inboundSignal: MockDeltaQueue<ISignalMessage>;
+    private readonly _outbound: MockDeltaQueue<IDocumentMessage[]>;
+
+    public get inbound(): IDeltaQueue<ISequencedDocumentMessage> {
+        return this._inbound;
+    }
+
+    public get outbound(): IDeltaQueue<IDocumentMessage[]> {
+        return this._outbound;
+    }
+
+    public get inboundSignal(): IDeltaQueue<ISignalMessage> {
+        return this._inboundSignal;
+    }
+
+    public get minimumSequenceNumber(): number {
+        return 0;
+    }
+
+    public get referenceSequenceNumber(): number {
+        return 0;
+    }
+
+    public get initialSequenceNumber(): number {
+        return 0;
+    }
+
+    public get version(): string {
+        return undefined;
+    }
+
+    public get maxMessageSize(): number {
+        return 0;
+    }
+
+    public get serviceConfiguration(): IServiceConfiguration {
+        return undefined;
+    }
+
+    public get active(): boolean {
+        return false;
+    }
+
+    public close(): void {}
+
+    public async connect(requestedMode?: ConnectionMode): Promise<IConnectionDetails> {
+        return;
+    }
+
+    public async getDeltas(
+        reason: string, from: number, to?: number): Promise<ISequencedDocumentMessage[]> {
+        return [];
+    }
+
+    public attachOpHandler(
+        minSequenceNumber: number,
+        sequenceNumber: number,
+        handler: IDeltaHandlerStrategy,
+        resume: boolean) {}
+
+    public submitSignal(content: any): void {}
+
+    public flush() {}
+
+    public submit(type: MessageType, contents: any, batch = false, metadata?: any): number {
+        return 0;
+    }
+
+    public dispose() {}
+
+    constructor() {
+        super();
+
+        this._inbound = new MockDeltaQueue<ISequencedDocumentMessage>();
+        this._outbound = new MockDeltaQueue<IDocumentMessage[]>();
+        this._inboundSignal = new MockDeltaQueue<ISignalMessage>();
+    }
+}

--- a/packages/runtime/runtime-test-utils/src/mocks.ts
+++ b/packages/runtime/runtime-test-utils/src/mocks.ts
@@ -17,6 +17,7 @@ import {
     IDeltaManager,
     IGenericBlob,
     ILoader,
+    IMessageScheduler,
 } from "@microsoft/fluid-container-definitions";
 import {
     DebugLogger,
@@ -492,5 +493,15 @@ export class MockSharedObjectServices implements ISharedObjectServices {
 
     public constructor(contents: { [key: string]: string }) {
         this.objectStorage = new MockObjectStorageService(contents);
+    }
+}
+
+/**
+ * Mock implementation of IMessageScheduler for testing that does nothing
+ */
+export class MockMessageScheduler implements IMessageScheduler {
+    readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
+    constructor(manager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>) {
+        this.deltaManager = manager;
     }
 }

--- a/packages/test/end-to-end/src/test/localTestSignals.spec.ts
+++ b/packages/test/end-to-end/src/test/localTestSignals.spec.ts
@@ -54,10 +54,12 @@ describe("TestSignals", () => {
             });
 
             user1Document.runtime.submitSignal("TestSignal", true);
+            await documentDeltaEventManager.process();
             assert.equal(user1SignalReceivedCount, 1, "client 1 did not received signal");
             assert.equal(user2SignalReceivedCount, 1, "client 2 did not received signal");
 
             user2Document.runtime.submitSignal("TestSignal", true);
+            await documentDeltaEventManager.process();
             assert.equal(user1SignalReceivedCount, 2, "client 1 did not received signal");
             assert.equal(user2SignalReceivedCount, 2, "client 2 did not received signal");
 

--- a/packages/test/end-to-end/src/test/localTestSignals.spec.ts
+++ b/packages/test/end-to-end/src/test/localTestSignals.spec.ts
@@ -84,10 +84,12 @@ describe("TestSignals", () => {
             });
 
             user1HostRuntime.submitSignal("TestSignal", true);
+            await documentDeltaEventManager.process();
             assert.equal(user1SignalReceivedCount, 1, "client 1 did not receive signal");
             assert.equal(user2SignalReceivedCount, 1, "client 2 did not receive signal");
 
             user2HostRuntime.submitSignal("TestSignal", true);
+            await documentDeltaEventManager.process();
             assert.equal(user1SignalReceivedCount, 2, "client 1 did not receive signal");
             assert.equal(user2SignalReceivedCount, 2, "client 2 did not receive signal");
         });
@@ -128,12 +130,14 @@ describe("TestSignals", () => {
         });
 
         user1HostRuntime.submitSignal("TestSignal", true);
+        await documentDeltaEventManager.process();
         assert.equal(user1HostSignalReceivedCount, 1, "client 1 did not receive signal on host runtime");
         assert.equal(user2HostSignalReceivedCount, 1, "client 2 did not receive signal on host runtime");
         assert.equal(user1CompSignalReceivedCount, 0, "client 1 should not receive signal on component runtime");
         assert.equal(user2CompSignalReceivedCount, 0, "client 2 should not receive signal on component runtime");
 
         user2ComponentRuntime.submitSignal("TestSignal", true);
+        await documentDeltaEventManager.process();
         assert.equal(user1HostSignalReceivedCount, 1, "client 1 should not receive signal on host runtime");
         assert.equal(user2HostSignalReceivedCount, 1, "client 2 should not receive signal on host runtime");
         assert.equal(user1CompSignalReceivedCount, 1, "client 1 did not receive signal on component runtime");


### PR DESCRIPTION
Fixes #1047 .

#834 addressed this by breaking op processing in the deltaQueue. But it turns out, we do not want to handle it at the loader but rather at the runtime. Also, that change did not preserve batching.

The original issue was that we don't want to block the JS thread for long time in scenarios such as the following because we want to keep the app responsive:
- Catching up ops right after boot.
- Catching up ops / delayed realizing components by summarizer (especially if it did not had a chance to run on idle trigger and runs due to other triggers).

This change puts ContainerRuntime in charge of doing this. It does the following:
- It keeps a timer to keep track for how long we have processed op in this particular turn. When we are processing an op (in beginOperation), it starts the timer.
- Every time a batch ends, it checks if the time spend exceeds a specified value (totalProcessingTime - currently we start that at 20ms). If the time exceeded, it increases totalProcessingTime by a specificed value (opProcessingTimeIncrement - currently 10ms), pauses the inbound queue and schedules a resume via setTimeout.
- We keep repeating the above step until the queue is empty. At that point, deltaQueue emits an "idle" event which is an indication for us to reset the timers.
- Batching is preserved because we yield the thread only at batch boundaries.

Added ScheduleManager tests that verify "batchBegin" and "batchEnd" events are properly received for batches and for non-batch messages.