### PR TITLE
Modify Base Telemetry definitions to be more generic and extendable

### DIFF
--- a/packages/loader/common-definitions/src/logger.ts
+++ b/packages/loader/common-definitions/src/logger.ts
@@ -4,7 +4,7 @@
  */
 
 // Examples of known categories, however category can be any string for extensibility
-export type TelemetryEventCategory = "generic" | "error" | "activity";
+export type TelemetryEventCategory = "generic" | "error" | "performance";
 
 // Logging entire objects is considered extremely dangerous from a telemetry point of view because people
 // can easily add fields to objects that shouldn't be logged and not realize it's going to be logged.

--- a/packages/loader/common-definitions/src/logger.ts
+++ b/packages/loader/common-definitions/src/logger.ts
@@ -3,8 +3,13 @@
  * Licensed under the MIT License.
  */
 
-export type TelemetryEventCategory = "generic" | "error" | "performance";
-export type TelemetryEventPropertyType = string | number | boolean | object | undefined;
+// Examples of known categories, however category can be any string for extensibility
+export type TelemetryEventCategory = "generic" | "error" | "activity";
+
+// Logging entire objects is considered extremely dangerous from a telemetry point of view because people
+// can easily add fields to objects that shouldn't be logged and not realize it's going to be logged.
+// General best practice is to explicitly log the fields you care about from objects
+export type TelemetryEventPropertyType = string | number | boolean | undefined;
 
 // Name of the error event property indicating if error was raised through Container.emit("error");
 // Presence of this property is a signal to the app not to raise this event to the user second time (if app chooses
@@ -22,7 +27,7 @@ export interface ITelemetryProperties {
  * @param eventName - name of the event.
  */
 export interface ITelemetryBaseEvent extends ITelemetryProperties {
-    category: TelemetryEventCategory;
+    category: string;
     eventName: string;
 }
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -672,7 +672,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         perfEvent.end({
             existing: this._existing,
             sequenceNumber: attributes.sequenceNumber,
-            version: maybeSnapshotTree ? maybeSnapshotTree.id : undefined,
+            version: maybeSnapshotTree && maybeSnapshotTree.id !== null ? maybeSnapshotTree.id : undefined,
         });
 
         if (!pause) {
@@ -739,7 +739,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
                 case MessageType.Summarize:
                     protocolLogger.sendTelemetryEvent({
                         eventName: "Summarize",
-                        message: message.contents as ISummaryContent,
+                        message: (message.contents as ISummaryContent).toString(),
                         summarySequenceNumber: message.sequenceNumber,
                         refSequenceNumber: message.referenceSequenceNumber,
                     });

--- a/packages/runtime/merge-tree/src/client.ts
+++ b/packages/runtime/merge-tree/src/client.ts
@@ -518,7 +518,7 @@ export class Client {
                     currentSeq: this.getCurrentSeq(),
                     end,
                     eventName: "InvalidOpRange",
-                    invalidPositions,
+                    invalidPositions: invalidPositions.toString(),
                     length,
                     opPos1: op.pos1,
                     opPos1Relative: op.relativePos1 !== undefined,


### PR DESCRIPTION
This is a very small subset of the previous telemetry changes, modifying only the Base Telemetry layer and leaving everything ITelemetryLogger and above alone. I will file an issue to stop exposing ITelemetryLogger as a public contract from the Fluid Runtime layer (containerContext) so that consumers can standardize on ITelemetryBaseLogger being passed into the runtime and nothing else.

https://github.com/microsoft/FluidFramework/issues/1051