### PR TITLE
Fix math routing

### DIFF
--- a/packages/components/math/src/mathComponent.ts
+++ b/packages/components/math/src/mathComponent.ts
@@ -602,10 +602,14 @@ export class MathCollection implements IComponentLoadable, IComponentCollection,
     }
 
     public async request(request: IRequest): Promise<IResponse> {
-        const instanceId = request.url
-            .substr(1)
-            .substr(0, !request.url.includes("/", 1) ? request.url.length : request.url.indexOf("/"));
+        // Trim leading slash, if it exists
+        const trimmedUrl = request.url.startsWith("/") ? request.url.substr(1) : request.url;
 
+        // Next segment is math instance id, if it exists
+        const instanceId = trimmedUrl
+            .substr(0, !trimmedUrl.includes("/", 1) ? trimmedUrl.length : trimmedUrl.indexOf("/"));
+
+        // If no instance is requested, then the collection itself is being requested
         if (!instanceId) {
             return {
                 mimeType: "fluid/component",


### PR DESCRIPTION
When a math instance is requested, there is no leading slash, causing the request to fail after the instance id gets trimmed.  Conditionally trim the leading slash only if it exists.