### PR TITLE
remove 0.12 lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "clean:docs": "rimraf packages/_api-extractor-temp docs/api/*/**",
     "clean:nyc": "rimraf nyc/**",
     "clean:r11s": "cd server/routerlicious && npm run clean",
-    "lint": "npm run tslint",
     "postinstall": "npm run postinstall:lerna && (npm run postinstall:fluid-build || true)",
     "layer-check": "cd tools/fluid-build && npm run layer-check",
     "layer-check:full": "cd tools/fluid-build && npm install && npm run build && npm run layer-check",


### PR DESCRIPTION
This line was added in 0.12 after the CI build was changed so that 0.12 builds would still work.

This got added somehow in https://github.com/microsoft/FluidFramework/commit/94d744364fb8ee26243558922e3481d558e3777f