### PR TITLE
Remove error from unsubmitted summary cancels

### DIFF
--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -502,7 +502,7 @@ export class RunningSummarizer implements IDisposable {
         if (summaryData.submitted) {
             summarizingEvent.end(telemetryProps);
         } else {
-            summarizingEvent.cancel({ ...telemetryProps, category: "error" });
+            summarizingEvent.cancel(telemetryProps);
         }
 
         return summaryData;


### PR DESCRIPTION
Previously unnecessarily logging this case of canceled summary as error.  When `submitted` is false on returned object, it means that summarizer container disconnected during generate summary.  This is not necessarily an error case.  If the container closing itself is an error, that should be logged separately.

Unexpected errors during generate summary will still log as error category.