### PR TITLE
Add container service support in test host

### DIFF
--- a/packages/server/local-test-server/src/testHost.ts
+++ b/packages/server/local-test-server/src/testHost.ts
@@ -3,7 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { PrimedComponent, PrimedComponentFactory, SimpleContainerRuntimeFactory } from "@microsoft/fluid-aqueduct";
+import {
+    PrimedComponent,
+    PrimedComponentFactory,
+    SimpleContainerRuntimeFactory,
+    ContainerServiceRegistryEntries,
+} from "@microsoft/fluid-aqueduct";
 import {
     IComponent,
     IComponentHandle,
@@ -158,6 +163,7 @@ export class TestHost {
         private readonly sharedObjectFactories: readonly ISharedObjectFactory[] = [],
         deltaConnectionServer?: ITestDeltaConnectionServer,
         private readonly scope: IComponent = {},
+        private readonly containerServiceRegistry: ContainerServiceRegistryEntries = [],
     ) {
         this.deltaConnectionServer = deltaConnectionServer || TestDeltaConnectionServer.create();
 
@@ -176,7 +182,8 @@ export class TestHost {
                                 [TestRootComponent.type, Promise.resolve(
                                     new PrimedComponentFactory(TestRootComponent, sharedObjectFactories),
                                 )],
-                            ]),
+                            ],
+                            this.containerServiceRegistry),
                     },
                 ],
             ]),
@@ -197,7 +204,8 @@ export class TestHost {
             this.componentRegistry,
             this.sharedObjectFactories,
             this.deltaConnectionServer,
-            this.scope);
+            this.scope,
+            this.containerServiceRegistry);
     }
 
     /**


### PR DESCRIPTION
This is a very simple change but I wasn't able to test the change though, since the change requires the new SimpleContainerRuntimeFactory.instantiateRuntime API (v0.13 which takes the container services as a parameter), and right now Bohemia is still on v0.12.

Please help take a look whether the change looks correct, and I think I'll have to wait for the next major version bump to test it out.