### PR TITLE
Allow to submit signal and emit signal event on container level

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -966,6 +966,17 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         return this.dirtyDocument;
     }
 
+    /**
+     * Submits the signal to be sent to other clients.
+     * @param type - Type of the signal.
+     * @param content - Content of the signal.
+     */
+    public submitSignal(type: string, content: any) {
+        this.verifyNotClosed();
+        const envelope: IEnvelope = { address: undefined, contents: {type, content} };
+        return this.context.submitSignalFn(envelope);
+    }
+
     private refreshBaseSummary(snapshot: ISnapshotTree) {
         // Currently only is called from summaries
         this.loadedFromSummary = true;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -797,6 +797,19 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
 
     public processSignal(message: ISignalMessage, local: boolean) {
         const envelope = message.content as IEnvelope;
+        const innerContent = envelope.contents as { content: any; type: string };
+        const transformed: IInboundSignalMessage = {
+            clientId: message.clientId,
+            content: innerContent.content,
+            type: innerContent.type,
+        };
+
+        if (envelope.address === undefined) {
+            // No address indicates a container signal message.
+            this.emit("signal", transformed, local);
+            return;
+        }
+
         const context = this.contexts.get(envelope.address);
         if (!context) {
             // Attach message may not have been processed yet
@@ -804,13 +817,6 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
             this.logger.sendTelemetryEvent({ eventName: "SignalComponentNotFound", componentId: envelope.address });
             return;
         }
-
-        const innerContent = envelope.contents as { content: any; type: string };
-        const transformed: IInboundSignalMessage = {
-            clientId: message.clientId,
-            content: innerContent.content,
-            type: innerContent.type,
-        };
 
         context.processSignal(transformed, local);
     }

--- a/packages/runtime/runtime-definitions/src/components.ts
+++ b/packages/runtime/runtime-definitions/src/components.ts
@@ -417,4 +417,11 @@ export interface IHostRuntime extends
      * Executes a request against the runtime
      */
     request(request: IRequest): Promise<IResponse>;
+
+    /**
+     * Submits the signal to be sent to other clients.
+     * @param type - Type of the signal.
+     * @param content - Content of the signal.
+     */
+    submitSignal(type: string, content: any): void;
 }


### PR DESCRIPTION
This PR adds a submitSignal function to IHostRuntime interface, and implemented it in ContainerRuntime. Container level signal's address is set to undefined, which can be used to distinguish it from signals sent by components.

Also, processSignal() in ContainerRuntime is updated to emit signal event when the signal was sent on container level.