### PR TITLE
Removed catch on Container.reconnect() so that the error propagates in case of a reconnect when container is closed

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -448,7 +448,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         if (this._connectionState === ConnectionState.Disconnected) {
             this.manualReconnectInProgress = true;
         }
-        return this._deltaManager.connect().catch(() => { });
+        return this._deltaManager.connect();
     }
 
     private async reloadContextCore(): Promise<void> {


### PR DESCRIPTION
Fixes #768 

The bug in #768 should already be fixed with the op processing in deltaQueue being async. This change removes the catch in Container.reconnect() so that if we try to connect to a closed DeltaManager, the error propagates to the app.