### PR TITLE
Fix for batchBegin and batchEnd events not firing correctly in certain scenarios.

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -220,17 +220,16 @@ export class ScheduleManager {
         // If in legacy mode every operation is a batch
         if (!this.messageScheduler) {
             this.emitter.emit("batchBegin", message);
-            this.deltaScheduler.batchBegin(message);
+            this.deltaScheduler.batchBegin();
             return;
         }
 
-        const batch = (message?.metadata as IRuntimeMessageMetadata)?.batch;
         if (this.batchClientId !== message.clientId) {
             // As a back stop for any bugs marking the end of a batch - if the client ID flipped, we
             // consider the previous batch over.
             if (this.batchClientId) {
                 this.emitter.emit("batchEnd", undefined, undefined);
-                this.deltaScheduler.batchEnd(message);
+                this.deltaScheduler.batchEnd();
 
                 this.logger.sendTelemetryEvent({
                     eventName: "BatchEndNotReceived",
@@ -241,7 +240,9 @@ export class ScheduleManager {
 
             // This could be the beginning of a new batch or an invidual message.
             this.emitter.emit("batchBegin", message);
-            this.deltaScheduler.batchBegin(message);
+            this.deltaScheduler.batchBegin();
+
+            const batch = (message?.metadata as IRuntimeMessageMetadata)?.batch;
             if (batch) {
                 this.batchClientId = message.clientId;
             } else {
@@ -254,7 +255,7 @@ export class ScheduleManager {
         if (!this.messageScheduler || error) {
             this.batchClientId = undefined;
             this.emitter.emit("batchEnd", error, message);
-            this.deltaScheduler.batchEnd(message);
+            this.deltaScheduler.batchEnd();
             return;
         }
 
@@ -266,7 +267,7 @@ export class ScheduleManager {
         if (!this.batchClientId || batch === false) {
             this.batchClientId = undefined;
             this.emitter.emit("batchEnd", undefined, message);
-            this.deltaScheduler.batchEnd(message);
+            this.deltaScheduler.batchEnd();
             return;
         }
     }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -228,7 +228,7 @@ export class ScheduleManager {
             // As a back stop for any bugs marking the end of a batch - if the client ID flipped, we
             // consider the previous batch over.
             if (this.batchClientId) {
-                this.emitter.emit("batchEnd", undefined, undefined);
+                this.emitter.emit("batchEnd", "Did not receive real batchEnd message", undefined);
                 this.deltaScheduler.batchEnd();
 
                 this.logger.sendTelemetryEvent({

--- a/packages/runtime/container-runtime/src/deltaScheduler.ts
+++ b/packages/runtime/container-runtime/src/deltaScheduler.ts
@@ -47,7 +47,7 @@ export class DeltaScheduler {
         this.deltaManager.inbound.on("idle", () => { this.inboundQueueIdle(); });
     }
 
-    public batchBegin(message: ISequencedDocumentMessage) {
+    public batchBegin() {
         if (this.deltaManager.inbound.length > 0 && !this.processingStartTime) {
             // Start the timer that keeps track of how long we have processed ops in the delta queue
             // in this call.
@@ -65,7 +65,7 @@ export class DeltaScheduler {
         }
     }
 
-    public batchEnd(message: ISequencedDocumentMessage) {
+    public batchEnd() {
         // If we have processed ops for more than the total processing time, we pause the
         // queue, yield the thread and schedule a resume. This ensures that we don't block
         // the JS threads for a long time (for example, when catching up ops right after

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -141,7 +141,7 @@ describe("Runtime", () => {
                         batchEnd++;
                         // Every "batchEnd" event should correspond to a "batchBegin" event, i.e.,
                         // batchBegin and batchEnd should be equal.
-                        assert.strictEqual(batchBegin, batchEnd, "Received batcEnd without corresponding batchBegin");
+                        assert.strictEqual(batchBegin, batchEnd, "Received batchEnd without corresponding batchBegin");
                     });
                 });
 
@@ -194,6 +194,23 @@ describe("Runtime", () => {
                     assert.strictEqual(5, batchEnd, "Did not receive correct batchEnd events");
                 });
 
+                it("Message with non batch-related metdata", () => {
+                    const clientId: string = "test-client";
+                    const message: Partial<ISequencedDocumentMessage> = {
+                        clientId,
+                        sequenceNumber: 0,
+                        type: MessageType.Operation,
+                        metadata: { foo: 1 },
+                    };
+
+                    scheduleManager.beginOperation(message as ISequencedDocumentMessage);
+                    scheduleManager.endOperation(undefined, message as ISequencedDocumentMessage);
+
+                    // We should have a "batchBegin" and a "batchEnd" event for the batch.
+                    assert.strictEqual(1, batchBegin, "Did not receive correct batchBegin event for the batch");
+                    assert.strictEqual(1, batchEnd, "Did not receive correct batchEnd event for the batch");
+                });
+
                 it("Messages in a single batch", () => {
                     const clientId: string = "test-client";
                     const batchBeginMessage: Partial<ISequencedDocumentMessage> = {
@@ -225,6 +242,200 @@ describe("Runtime", () => {
 
                     scheduleManager.beginOperation(batchMessage as ISequencedDocumentMessage);
                     scheduleManager.endOperation(undefined, batchMessage as ISequencedDocumentMessage);
+
+                    scheduleManager.beginOperation(batchEndMessage as ISequencedDocumentMessage);
+                    scheduleManager.endOperation(undefined, batchEndMessage as ISequencedDocumentMessage);
+
+                    // We should have only received one "batchBegin" and one "batchEnd" event for the batch.
+                    assert.strictEqual(1, batchBegin, "Did not receive correct batchBegin event for the batch");
+                    assert.strictEqual(1, batchEnd, "Did not receive correct batchEnd event for the batch");
+                });
+
+                it("Partial batch messages followed by a non-batch message from another client", () => {
+                    const clientId1: string = "test-client-1";
+                    const clientId2: string = "test-client-2";
+                    const batchBeginMessage: Partial<ISequencedDocumentMessage> = {
+                        clientId: clientId1,
+                        sequenceNumber: 0,
+                        type: MessageType.Operation,
+                        metadata: { batch: true },
+                    };
+
+                    const batchMessage: Partial<ISequencedDocumentMessage> = {
+                        clientId: clientId1,
+                        sequenceNumber: 0,
+                        type: MessageType.Operation,
+                    };
+
+                    // Send a batch with 3 messages from first client but don't send batch end message.
+                    scheduleManager.beginOperation(batchBeginMessage as ISequencedDocumentMessage);
+                    scheduleManager.endOperation(undefined, batchBeginMessage as ISequencedDocumentMessage);
+
+                    scheduleManager.beginOperation(batchMessage as ISequencedDocumentMessage);
+                    scheduleManager.endOperation(undefined, batchMessage as ISequencedDocumentMessage);
+
+                    scheduleManager.beginOperation(batchMessage as ISequencedDocumentMessage);
+                    scheduleManager.endOperation(undefined, batchMessage as ISequencedDocumentMessage);
+
+                    // Send a message from another client. This should result in a "batchEnd" event for the
+                    // previous batch since the client id changes. Also, we should get a "batchBegin" and
+                    // a "batchEnd" event for the new client.
+                    const client2Message: Partial<ISequencedDocumentMessage> = {
+                        clientId: clientId2,
+                        sequenceNumber: 0,
+                        type: MessageType.Operation,
+                    };
+
+                    scheduleManager.beginOperation(client2Message as ISequencedDocumentMessage);
+                    scheduleManager.endOperation(undefined, client2Message as ISequencedDocumentMessage);
+
+                    // We should have received two sets of "batchBegin" and "batchEnd" events.
+                    assert.strictEqual(2, batchBegin, "Did not receive correct batchBegin event for the batch");
+                    assert.strictEqual(2, batchEnd, "Did not receive correct batchBegin event for the batch");
+                });
+
+                it("Partial batch messages followed by non batch-related metdata message from another client", () => {
+                    const clientId1: string = "test-client-1";
+                    const clientId2: string = "test-client-2";
+                    const batchBeginMessage: Partial<ISequencedDocumentMessage> = {
+                        clientId: clientId1,
+                        sequenceNumber: 0,
+                        type: MessageType.Operation,
+                        metadata: { batch: true },
+                    };
+
+                    const batchMessage: Partial<ISequencedDocumentMessage> = {
+                        clientId: clientId1,
+                        sequenceNumber: 0,
+                        type: MessageType.Operation,
+                    };
+
+                    // Send a batch with 3 messages from first client but don't send batch end message.
+                    scheduleManager.beginOperation(batchBeginMessage as ISequencedDocumentMessage);
+                    scheduleManager.endOperation(undefined, batchBeginMessage as ISequencedDocumentMessage);
+
+                    scheduleManager.beginOperation(batchMessage as ISequencedDocumentMessage);
+                    scheduleManager.endOperation(undefined, batchMessage as ISequencedDocumentMessage);
+
+                    scheduleManager.beginOperation(batchMessage as ISequencedDocumentMessage);
+                    scheduleManager.endOperation(undefined, batchMessage as ISequencedDocumentMessage);
+
+                    // Send a message from another client with non batch-related metadata. This should result
+                    // in a "batchEnd" event for the previous batch since the client id changes. Also, we
+                    // should get a "batchBegin" and a "batchEnd" event for the new client.
+                    const client2Message: Partial<ISequencedDocumentMessage> = {
+                        clientId: clientId2,
+                        sequenceNumber: 0,
+                        type: MessageType.Operation,
+                        metadata: { foo: 1},
+                    };
+
+                    scheduleManager.beginOperation(client2Message as ISequencedDocumentMessage);
+                    scheduleManager.endOperation(undefined, client2Message as ISequencedDocumentMessage);
+
+                    // We should have received two sets of "batchBegin" and "batchEnd" events.
+                    assert.strictEqual(2, batchBegin, "Did not receive correct batchBegin event for the batch");
+                    assert.strictEqual(2, batchEnd, "Did not receive correct batchBegin event for the batch");
+                });
+
+                it("Partial batch messages followed by batch messages from another client", () => {
+                    const clientId1: string = "test-client-1";
+                    const clientId2: string = "test-client-2";
+                    const client1batchBeginMessage: Partial<ISequencedDocumentMessage> = {
+                        clientId: clientId1,
+                        sequenceNumber: 0,
+                        type: MessageType.Operation,
+                        metadata: { batch: true },
+                    };
+
+                    const client1batchMessage: Partial<ISequencedDocumentMessage> = {
+                        clientId: clientId1,
+                        sequenceNumber: 0,
+                        type: MessageType.Operation,
+                    };
+
+                    // Send a batch with 3 messages from first client but don't send batch end message.
+                    scheduleManager.beginOperation(client1batchBeginMessage as ISequencedDocumentMessage);
+                    scheduleManager.endOperation(undefined, client1batchBeginMessage as ISequencedDocumentMessage);
+
+                    scheduleManager.beginOperation(client1batchMessage as ISequencedDocumentMessage);
+                    scheduleManager.endOperation(undefined, client1batchMessage as ISequencedDocumentMessage);
+
+                    scheduleManager.beginOperation(client1batchMessage as ISequencedDocumentMessage);
+                    scheduleManager.endOperation(undefined, client1batchMessage as ISequencedDocumentMessage);
+
+                    // Send a batch from another client. This should result in a "batchEnd" event for the
+                    // previous batch since the client id changes. Also, we should get one "batchBegin" and
+                    // one "batchEnd" event for the batch from the new client.
+                    const client2batchBeginMessage: Partial<ISequencedDocumentMessage> = {
+                        clientId: clientId2,
+                        sequenceNumber: 0,
+                        type: MessageType.Operation,
+                        metadata: { batch: true },
+                    };
+
+                    const client2batchMessage: Partial<ISequencedDocumentMessage> = {
+                        clientId: clientId2,
+                        sequenceNumber: 0,
+                        type: MessageType.Operation,
+                    };
+
+                    const client2batchEndMessage: Partial<ISequencedDocumentMessage> = {
+                        clientId: clientId2,
+                        sequenceNumber: 0,
+                        type: MessageType.Operation,
+                        metadata: { batch: false },
+                    };
+
+                    scheduleManager.beginOperation(client2batchBeginMessage as ISequencedDocumentMessage);
+                    scheduleManager.endOperation(undefined, client2batchBeginMessage as ISequencedDocumentMessage);
+
+                    scheduleManager.beginOperation(client2batchMessage as ISequencedDocumentMessage);
+                    scheduleManager.endOperation(undefined, client2batchMessage as ISequencedDocumentMessage);
+
+                    scheduleManager.beginOperation(client2batchEndMessage as ISequencedDocumentMessage);
+                    scheduleManager.endOperation(undefined, client2batchEndMessage as ISequencedDocumentMessage);
+
+                    // We should have received two sets of "batchBegin" and one "batchEnd" events.
+                    assert.strictEqual(2, batchBegin, "Did not receive correct batchBegin event for the batches");
+                    assert.strictEqual(2, batchEnd, "Did not receive correct batchBegin event for the batches");
+                });
+
+                it("Batch messages interleaved with a batch begin message from same client", () => {
+                    const clientId: string = "test-client";
+                    const batchBeginMessage: Partial<ISequencedDocumentMessage> = {
+                        clientId,
+                        sequenceNumber: 0,
+                        type: MessageType.Operation,
+                        metadata: { batch: true },
+                    };
+
+                    const batchMessage: Partial<ISequencedDocumentMessage> = {
+                        clientId,
+                        sequenceNumber: 0,
+                        type: MessageType.Operation,
+                    };
+
+                    const batchEndMessage: Partial<ISequencedDocumentMessage> = {
+                        clientId,
+                        sequenceNumber: 0,
+                        type: MessageType.Operation,
+                        metadata: { batch: false },
+                    };
+
+                    // Send a batch with an interleaved batch begin message.
+                    scheduleManager.beginOperation(batchBeginMessage as ISequencedDocumentMessage);
+                    scheduleManager.endOperation(undefined, batchBeginMessage as ISequencedDocumentMessage);
+
+                    scheduleManager.beginOperation(batchMessage as ISequencedDocumentMessage);
+                    scheduleManager.endOperation(undefined, batchMessage as ISequencedDocumentMessage);
+
+                    scheduleManager.beginOperation(batchMessage as ISequencedDocumentMessage);
+                    scheduleManager.endOperation(undefined, batchMessage as ISequencedDocumentMessage);
+
+                    // The interleaved batch begin message. We should not get a "batchBegin" event for this.
+                    scheduleManager.beginOperation(batchBeginMessage as ISequencedDocumentMessage);
+                    scheduleManager.endOperation(undefined, batchBeginMessage as ISequencedDocumentMessage);
 
                     scheduleManager.beginOperation(batchEndMessage as ISequencedDocumentMessage);
                     scheduleManager.endOperation(undefined, batchEndMessage as ISequencedDocumentMessage);


### PR DESCRIPTION
Fixes #1054 .

Fixed the following cases where "batchBegin" and "batchEnd" events emitted by ScheduleManager are not correct:
- We are receiving a batch from a client and before we receive a batch end, we receive a non-batch message from another client. In this scenario, we emit only one pair of "batchBegin" and "batchEnd" events whereas we should should have emitted two pairs.
- We are receiving a batch from a client and before we receive a batch end, we receive a batch start message from another client. We do not emit a "batchEnd" for the previous client but emit a "batchBegin" for the new client.
- We are receiving a batch for a client and in between we receive another batch begin message. We emit another "batchBegin".
- If we receive a message with metadata other than batch related ones, we do not correctly emit "batchBegin" event for it since batchBegin depends on metadata being undefined for non-batch messages which might not always be true.

Also added unit tests for all the above cases.