### PR TITLE
Consolidate defaultserviceconfig usage to only consume the one exported from fluid-server-lambdas package

### DIFF
--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -10,6 +10,7 @@ import {
     ActivityCheckingTimeout,
     BroadcasterLambda,
     ClientSequenceTimeout,
+    DefaultServiceConfiguration,
     DeliLambda,
     ForemanLambda,
     NoopConsolidationTimeout,
@@ -49,17 +50,6 @@ const DefaultScribe: IScribe = {
     minimumSequenceNumber: -1,
     protocolState: undefined,
     sequenceNumber: -1,
-};
-
-const DefaultServiceConfiguration: IServiceConfiguration = {
-    blockSize: 64436,
-    maxMessageSize: 16 * 1024,
-    summary: {
-        idleTime: 5000,
-        maxOps: 1000,
-        maxTime: 5000 * 12,
-        maxAckWaitTime: 600000,
-    },
 };
 
 class WebSocketSubscriber implements ISubscriber {

--- a/server/tinylicious/src/utils.ts
+++ b/server/tinylicious/src/utils.ts
@@ -4,7 +4,7 @@
  */
 
 import { ITenantManager } from "@microsoft/fluid-server-services-core";
-import { IServiceConfiguration, IUser, ScopeType } from "@microsoft/fluid-protocol-definitions";
+import { IUser, ScopeType } from "@microsoft/fluid-protocol-definitions";
 // In this case we want @types/express-serve-static-core, not express-serve-static-core, and so disable the lint rule
 // eslint-disable-next-line import/no-unresolved
 import { Params } from "express-serve-static-core";
@@ -56,17 +56,6 @@ export interface IAlfredUser extends IUser {
     displayName: string;
     name: string;
 }
-
-export const DefaultServiceConfiguration: IServiceConfiguration = {
-    blockSize: 64436,
-    maxMessageSize:  16 * 1024,
-    summary: {
-        idleTime: 5000,
-        maxOps: 1000,
-        maxTime: 5000 * 12,
-        maxAckWaitTime: 600000,
-    },
-};
 
 export function getParam(params: Params, key: string) {
     return Array.isArray(params) ? undefined : params[key];


### PR DESCRIPTION
 - Routerlicious now consumes the config from fluid-server-lambdas packages instead of using its own
- Removed the config set up in tinylicious as it is not consumed anywhere

fixes #937 