### PR TITLE
Revert incorrectly merged code in commit 93c183f in release/0.13 branch

### DIFF
--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -36,7 +36,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -71,7 +71,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/agents/flow-intel-viewer/package.json
+++ b/packages/agents/flow-intel-viewer/package.json
@@ -38,7 +38,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/agents/flow-intel/package.json
+++ b/packages/agents/flow-intel/package.json
@@ -37,7 +37,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/agents/intelligence-runner/package.json
+++ b/packages/agents/intelligence-runner/package.json
@@ -38,7 +38,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/agents/snapshotter/package.json
+++ b/packages/agents/snapshotter/package.json
@@ -34,7 +34,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/agents/spellchecker/package.json
+++ b/packages/agents/spellchecker/package.json
@@ -38,7 +38,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/agents/translator/package.json
+++ b/packages/agents/translator/package.json
@@ -39,7 +39,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/agent-scheduler/package.json
+++ b/packages/components/agent-scheduler/package.json
@@ -69,7 +69,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/blob-manager/package.json
+++ b/packages/components/blob-manager/package.json
@@ -42,7 +42,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/canvas/package.json
+++ b/packages/components/canvas/package.json
@@ -52,7 +52,7 @@
     "css-loader": "^1.0.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/clicker/package.json
+++ b/packages/components/clicker/package.json
@@ -54,7 +54,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/client-ui/package.json
+++ b/packages/components/client-ui/package.json
@@ -75,7 +75,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/dice-roller/package.json
+++ b/packages/components/dice-roller/package.json
@@ -51,7 +51,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/external-component-loader/package.json
+++ b/packages/components/external-component-loader/package.json
@@ -56,7 +56,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/flow-scroll/package.json
+++ b/packages/components/flow-scroll/package.json
@@ -65,7 +65,7 @@
     "css-loader": "^1.0.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/flow-util/package.json
+++ b/packages/components/flow-util/package.json
@@ -65,7 +65,7 @@
     "copyfiles": "^2.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/image-collection/package.json
+++ b/packages/components/image-collection/package.json
@@ -43,7 +43,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/markflow/package.json
+++ b/packages/components/markflow/package.json
@@ -57,7 +57,7 @@
     "css-loader": "^1.0.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/math/package.json
+++ b/packages/components/math/package.json
@@ -54,7 +54,7 @@
     "css-loader": "^1.0.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/monaco/package.json
+++ b/packages/components/monaco/package.json
@@ -50,7 +50,7 @@
     "css-loader": "^1.0.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/owned-map/package.json
+++ b/packages/components/owned-map/package.json
@@ -51,7 +51,7 @@
     "@typescript-eslint/parser": "~2.17.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/pond/package.json
+++ b/packages/components/pond/package.json
@@ -48,7 +48,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/progress-bars/package.json
+++ b/packages/components/progress-bars/package.json
@@ -44,7 +44,7 @@
     "css-loader": "^1.0.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/scoreboard/package.json
+++ b/packages/components/scoreboard/package.json
@@ -48,7 +48,7 @@
     "css-loader": "^1.0.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/scribe/package.json
+++ b/packages/components/scribe/package.json
@@ -50,7 +50,7 @@
     "@typescript-eslint/parser": "~2.17.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/search-menu/package.json
+++ b/packages/components/search-menu/package.json
@@ -35,7 +35,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/shared-map-visualizer/package.json
+++ b/packages/components/shared-map-visualizer/package.json
@@ -49,7 +49,7 @@
     "@typescript-eslint/parser": "~2.17.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/shared-text/package.json
+++ b/packages/components/shared-text/package.json
@@ -74,7 +74,7 @@
     "css-loader": "^1.0.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/source-document/package.json
+++ b/packages/components/source-document/package.json
@@ -73,7 +73,7 @@
     "copyfiles": "^2.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/table-document/package.json
+++ b/packages/components/table-document/package.json
@@ -63,7 +63,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/table-view/package.json
+++ b/packages/components/table-view/package.json
@@ -50,7 +50,7 @@
     "copyfiles": "^2.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/todo/package.json
+++ b/packages/components/todo/package.json
@@ -52,7 +52,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/video-players/package.json
+++ b/packages/components/video-players/package.json
@@ -43,7 +43,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/components/webflow/package.json
+++ b/packages/components/webflow/package.json
@@ -82,7 +82,7 @@
     "css-loader": "^1.0.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/drivers/create-new-driver/package.json
+++ b/packages/drivers/create-new-driver/package.json
@@ -64,7 +64,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/drivers/file-socket-storage/package.json
+++ b/packages/drivers/file-socket-storage/package.json
@@ -43,7 +43,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/drivers/fluid-debugger/package.json
+++ b/packages/drivers/fluid-debugger/package.json
@@ -42,7 +42,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -41,7 +41,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/drivers/iframe-socket-storage/package.json
+++ b/packages/drivers/iframe-socket-storage/package.json
@@ -47,7 +47,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/drivers/odsp-socket-storage/package.json
+++ b/packages/drivers/odsp-socket-storage/package.json
@@ -76,7 +76,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -40,7 +40,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/drivers/replay-socket-storage/package.json
+++ b/packages/drivers/replay-socket-storage/package.json
@@ -44,7 +44,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -40,7 +40,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/drivers/routerlicious-socket-storage/package.json
+++ b/packages/drivers/routerlicious-socket-storage/package.json
@@ -55,7 +55,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -43,7 +43,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/drivers/socket-storage-shared/package.json
+++ b/packages/drivers/socket-storage-shared/package.json
@@ -44,7 +44,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/drivers/test-driver/package.json
+++ b/packages/drivers/test-driver/package.json
@@ -42,7 +42,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/framework/aqueduct-react/package.json
+++ b/packages/framework/aqueduct-react/package.json
@@ -41,7 +41,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -69,7 +69,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/framework/experimental/package.json
+++ b/packages/framework/experimental/package.json
@@ -37,7 +37,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/framework/framework-definitions/package.json
+++ b/packages/framework/framework-definitions/package.json
@@ -37,7 +37,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -68,7 +68,7 @@
     "diff": "^3.5.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/hosts/base-host/package.json
+++ b/packages/hosts/base-host/package.json
@@ -41,7 +41,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/hosts/host-service-interfaces/package.json
+++ b/packages/hosts/host-service-interfaces/package.json
@@ -39,7 +39,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/hosts/react-web-host/package.json
+++ b/packages/hosts/react-web-host/package.json
@@ -38,7 +38,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/hosts/tiny-web-host/package.json
+++ b/packages/hosts/tiny-web-host/package.json
@@ -57,7 +57,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/loader/component-core-interfaces/package.json
+++ b/packages/loader/component-core-interfaces/package.json
@@ -35,7 +35,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/loader/container-definitions/package.json
+++ b/packages/loader/container-definitions/package.json
@@ -41,7 +41,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -81,7 +81,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/loader/driver-definitions/package.json
+++ b/packages/loader/driver-definitions/package.json
@@ -39,7 +39,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -59,7 +59,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/loader/execution-context-loader/package.json
+++ b/packages/loader/execution-context-loader/package.json
@@ -42,7 +42,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/loader/loader-web/package.json
+++ b/packages/loader/loader-web/package.json
@@ -39,7 +39,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -34,7 +34,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/runtime/cell/package.json
+++ b/packages/runtime/cell/package.json
@@ -69,7 +69,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/runtime/client-api/package.json
+++ b/packages/runtime/client-api/package.json
@@ -77,7 +77,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/runtime/component-runtime/package.json
+++ b/packages/runtime/component-runtime/package.json
@@ -54,7 +54,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/runtime/consensus-ordered-collection/package.json
+++ b/packages/runtime/consensus-ordered-collection/package.json
@@ -68,7 +68,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/runtime/consensus-register-collection/package.json
+++ b/packages/runtime/consensus-register-collection/package.json
@@ -68,7 +68,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -79,7 +79,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/runtime/ink/package.json
+++ b/packages/runtime/ink/package.json
@@ -44,7 +44,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/runtime/map/package.json
+++ b/packages/runtime/map/package.json
@@ -70,7 +70,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/runtime/merge-tree/package.json
+++ b/packages/runtime/merge-tree/package.json
@@ -69,7 +69,7 @@
     "diff": "^3.5.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -39,7 +39,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/runtime/runtime-test-utils/package.json
+++ b/packages/runtime/runtime-test-utils/package.json
@@ -44,7 +44,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -66,7 +66,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/runtime/sequence/package.json
+++ b/packages/runtime/sequence/package.json
@@ -79,7 +79,7 @@
     "diff": "^3.5.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/runtime/shared-object-common/package.json
+++ b/packages/runtime/shared-object-common/package.json
@@ -47,7 +47,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/server/local-test-server/package.json
+++ b/packages/server/local-test-server/package.json
@@ -78,7 +78,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/server/tools-core/package.json
+++ b/packages/server/tools-core/package.json
@@ -47,7 +47,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/test/end-to-end/package.json
+++ b/packages/test/end-to-end/package.json
@@ -78,7 +78,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -59,7 +59,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/tools/fluid-fetch/package.json
+++ b/packages/tools/fluid-fetch/package.json
@@ -43,7 +43,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/tools/merge-tree-client-replay/package.json
+++ b/packages/tools/merge-tree-client-replay/package.json
@@ -43,7 +43,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -47,7 +47,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/tools/webpack-component-loader/package.json
+++ b/packages/tools/webpack-component-loader/package.json
@@ -80,7 +80,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/utils/build-common/package.json
+++ b/packages/utils/build-common/package.json
@@ -18,7 +18,7 @@
     "@typescript-eslint/parser": "~2.17.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/utils/eslint-config-fluid/package.json
+++ b/packages/utils/eslint-config-fluid/package.json
@@ -15,7 +15,7 @@
     "@typescript-eslint/parser": "~2.17.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/packages/utils/odsp-utils/package.json
+++ b/packages/utils/odsp-utils/package.json
@@ -35,7 +35,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/samples/chaincode/badge/package.json
+++ b/samples/chaincode/badge/package.json
@@ -51,7 +51,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/samples/chaincode/chat/package.json
+++ b/samples/chaincode/chat/package.json
@@ -45,7 +45,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/samples/chaincode/codemirror/package.json
+++ b/samples/chaincode/codemirror/package.json
@@ -53,7 +53,7 @@
     "css-loader": "^1.0.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/samples/chaincode/containers/monaco/package.json
+++ b/samples/chaincode/containers/monaco/package.json
@@ -45,7 +45,7 @@
     "css-loader": "^1.0.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/samples/chaincode/draft-js/package.json
+++ b/samples/chaincode/draft-js/package.json
@@ -55,7 +55,7 @@
     "css-loader": "^1.0.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/samples/chaincode/drawer/package.json
+++ b/samples/chaincode/drawer/package.json
@@ -57,7 +57,7 @@
     "css-loader": "^1.0.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/samples/chaincode/github-comment/package.json
+++ b/samples/chaincode/github-comment/package.json
@@ -48,7 +48,7 @@
     "css-loader": "^1.0.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/samples/chaincode/image-gallery/package.json
+++ b/samples/chaincode/image-gallery/package.json
@@ -46,7 +46,7 @@
     "css-loader": "^1.0.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/samples/chaincode/key-value-cache/package.json
+++ b/samples/chaincode/key-value-cache/package.json
@@ -48,7 +48,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/samples/chaincode/musica/package.json
+++ b/samples/chaincode/musica/package.json
@@ -51,7 +51,7 @@
     "css-loader": "^1.0.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/samples/chaincode/persona/package.json
+++ b/samples/chaincode/persona/package.json
@@ -56,7 +56,7 @@
     "css-loader": "^1.0.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/samples/chaincode/pollster/package.json
+++ b/samples/chaincode/pollster/package.json
@@ -45,7 +45,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/samples/chaincode/prosemirror/package.json
+++ b/samples/chaincode/prosemirror/package.json
@@ -66,7 +66,7 @@
     "css-loader": "^1.0.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/samples/chaincode/simple-component-embed/package.json
+++ b/samples/chaincode/simple-component-embed/package.json
@@ -40,7 +40,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/samples/chaincode/simple-data-share/package.json
+++ b/samples/chaincode/simple-data-share/package.json
@@ -43,7 +43,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/samples/chaincode/smde/package.json
+++ b/samples/chaincode/smde/package.json
@@ -54,7 +54,7 @@
     "css-loader": "^1.0.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/samples/chaincode/spaces/package.json
+++ b/samples/chaincode/spaces/package.json
@@ -67,7 +67,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/samples/chaincode/sudoku/package.json
+++ b/samples/chaincode/sudoku/package.json
@@ -58,7 +58,7 @@
     "eslint": "~6.8.0",
     "eslint-config-prettier": "^6.4.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/samples/chaincode/textarea-noreact/package.json
+++ b/samples/chaincode/textarea-noreact/package.json
@@ -45,7 +45,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/samples/chaincode/tourofheroes/package.json
+++ b/samples/chaincode/tourofheroes/package.json
@@ -66,7 +66,7 @@
     "css-loader": "^1.0.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/samples/chaincode/type-race/package.json
+++ b/samples/chaincode/type-race/package.json
@@ -46,7 +46,7 @@
     "css-loader": "^1.0.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/samples/chaincode/vltava/package.json
+++ b/samples/chaincode/vltava/package.json
@@ -71,7 +71,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -27,7 +27,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -34,7 +34,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -68,7 +68,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -80,7 +80,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -53,7 +53,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -66,7 +66,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/server/routerlicious/packages/protocol-definitions/package.json
+++ b/server/routerlicious/packages/protocol-definitions/package.json
@@ -38,7 +38,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -127,7 +127,7 @@
     "diff": "^3.5.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -68,7 +68,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -39,7 +39,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -40,7 +40,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -61,7 +61,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -45,7 +45,7 @@
     "concurrently": "^4.1.0",
     "eslint": "~6.8.0",
     "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "~2.20.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-optimize-regex": "~1.1.7",
     "eslint-plugin-prefer-arrow": "~1.1.7",


### PR DESCRIPTION
Also pin eslint-plugin-import to v2.20.0

This is a workaround to a regression introduced in v2.20.1:

https://github.com/benmosher/eslint-plugin-import/issues/1643
