### PR TITLE
Remove protocol summary events

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -59,9 +59,6 @@ import {
     ISignalClient,
     ISignalMessage,
     ISnapshotTree,
-    ISummaryAck,
-    ISummaryContent,
-    ISummaryNack,
     ITokenClaims,
     ITree,
     ITreeEntry,
@@ -735,38 +732,6 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
             (sequenceNumber) => this.submitMessage(MessageType.Reject, sequenceNumber));
 
         const protocolLogger = ChildLogger.create(this.subLogger, "ProtocolHandler");
-
-        protocol.on("Summary", (message) => {
-            switch (message.type) {
-                case MessageType.Summarize:
-                    protocolLogger.sendTelemetryEvent({
-                        eventName: "Summarize",
-                        message: (message.contents as ISummaryContent).toString(),
-                        summarySequenceNumber: message.sequenceNumber,
-                        refSequenceNumber: message.referenceSequenceNumber,
-                    });
-                    break;
-                case MessageType.SummaryAck:
-                    const ack = message.contents as ISummaryAck;
-                    protocolLogger.sendTelemetryEvent({
-                        eventName: "SummaryAck",
-                        handle: ack.handle,
-                        sequenceNumber: message.sequenceNumber,
-                        summarySequenceNumber: ack.summaryProposal.summarySequenceNumber,
-                    });
-                    break;
-                case MessageType.SummaryNack:
-                    const nack = message.contents as ISummaryNack;
-                    protocolLogger.sendTelemetryEvent({
-                        eventName: "SummaryNack",
-                        error: nack.errorMessage,
-                        sequenceNumber: message.sequenceNumber,
-                        summarySequenceNumber: nack.summaryProposal.summarySequenceNumber,
-                    });
-                    break;
-                default:
-            }
-        });
 
         protocol.quorum.on("error", (error) => {
             protocolLogger.sendErrorEvent(error);

--- a/server/routerlicious/packages/protocol-base/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-base/src/protocol.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { EventEmitter } from "events";
 import {
     IClientJoin,
     ICommittedProposal,
@@ -47,7 +46,7 @@ export function isSystemMessage(message: ISequencedDocumentMessage) {
 /**
  * Handles protocol specific ops.
  */
-export class ProtocolOpHandler extends EventEmitter {
+export class ProtocolOpHandler {
     public readonly quorum: Quorum;
 
     constructor(
@@ -59,7 +58,6 @@ export class ProtocolOpHandler extends EventEmitter {
         values: [string, ICommittedProposal][],
         sendProposal: (key: string, value: any) => number,
         sendReject: (sequenceNumber: number) => void) {
-        super();
         this.quorum = new Quorum(
             minimumSequenceNumber,
             members,
@@ -110,18 +108,6 @@ export class ProtocolOpHandler extends EventEmitter {
             case MessageType.Reject:
                 const sequenceNumber = message.contents as number;
                 this.quorum.rejectProposal(message.clientId, sequenceNumber);
-                break;
-
-            case MessageType.Summarize:
-                this.emit("Summary", message);
-                break;
-
-            case MessageType.SummaryAck:
-                this.emit("Summary", message);
-                break;
-
-            case MessageType.SummaryNack:
-                this.emit("Summary", message);
                 break;
 
             default:
@@ -184,11 +170,5 @@ export class ProtocolOpHandler extends EventEmitter {
         };
 
         return summary;
-    }
-
-    public on(event: "Summary", listener: (message: ISequencedDocumentMessage) => void): this;
-
-    public on(event: string | symbol, listener: (...args: any[]) => void): this {
-        return super.on(event, listener);
     }
 }


### PR DESCRIPTION
Fixes #775 

Removes telemetry events being logged on every playthrough of Summarize, SummaryAck, and SummaryNack op by every client (at protocol-level).  This generates a lot of events, and the Summarizer should already be logging events for these.

ProtocolOpHandler was made into an EventEmitter for this reason, so this has been reverted as well.