### PR TITLE
Delay spawn summarizer

### DIFF
--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -55,10 +55,12 @@ enum SummaryManagerState {
 }
 
 const defaultMaxRestarts = 5;
+const defaultInitialDelayMs = 5000;
 
 export class SummaryManager extends EventEmitter {
     private readonly logger: ITelemetryLogger;
     private readonly quorumHeap = new QuorumHeap();
+    private readonly initialDelayP: Promise<void>;
     private summarizerClientId?: string;
     private clientId?: string;
     private connected = false;
@@ -79,6 +81,7 @@ export class SummaryManager extends EventEmitter {
         private readonly enableWorker: boolean,
         parentLogger: ITelemetryLogger,
         private readonly maxRestarts: number = defaultMaxRestarts,
+        initialDelayMs: number = defaultInitialDelayMs,
     ) {
         super();
 
@@ -103,6 +106,8 @@ export class SummaryManager extends EventEmitter {
             this.quorumHeap.removeClient(clientId);
             this.refreshSummarizer();
         });
+
+        this.initialDelayP = new Promise((resolve) => setTimeout(resolve, initialDelayMs));
 
         this.refreshSummarizer();
     }
@@ -201,8 +206,15 @@ export class SummaryManager extends EventEmitter {
             return;
         }
 
-        this.createSummarizer().then((summarizer) => {
-            if (this.shouldSummarize) {
+        const delayMs = (attempt - 1) * 20; // delay by 20ms, 40ms, 60ms etc.
+        this.createSummarizer(delayMs).then((summarizer) => {
+            if (summarizer === undefined) {
+                if (this.shouldSummarize) {
+                    this.start(attempt + 1);
+                } else {
+                    this.state = SummaryManagerState.Off;
+                }
+            } else if (this.shouldSummarize) {
                 this.run(summarizer);
             } else {
                 summarizer.stop(this.getStopReason());
@@ -238,7 +250,16 @@ export class SummaryManager extends EventEmitter {
         });
     }
 
-    private async createSummarizer(): Promise<IComponentRunnable> {
+    private async createSummarizer(delayMs: number): Promise<IComponentRunnable | undefined> {
+        await Promise.all([
+            this.initialDelayP,
+            delayMs > 0 ? new Promise((resolve) => setTimeout(resolve, delayMs)) : Promise.resolve(),
+        ]);
+
+        if (!this.shouldSummarize) {
+            return undefined;
+        }
+
         // We have been elected the summarizer. Some day we may be able to summarize with a live document but for
         // now we play it safe and launch a second copy.
         this.logger.sendTelemetryEvent({ eventName: "CreatingSummarizer" });

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -206,7 +206,9 @@ export class SummaryManager extends EventEmitter {
             return;
         }
 
-        const delayMs = (attempt - 1) * 20; // delay by 20ms, 40ms, 60ms etc.
+        // Back-off delay for subsequent retry starting.  The delay increase is linear,
+        // increasing by 20ms each time: 0ms, 20ms, 40ms, 60ms, etc.
+        const delayMs = (attempt - 1) * 20;
         this.createSummarizer(delayMs).then((summarizer) => {
             if (summarizer === undefined) {
                 if (this.shouldSummarize) {


### PR DESCRIPTION
Fixes #1088 

First commit just allows initial delay of 5 seconds (configurable) before spawning the first summarizer.  This timer starts from the creation of the SummaryManager.  This is a simple approach, we could improve on it later.

Second commit allows for an approximation (open to ideas) of the delay before spawning the first summarizer.  This timer starts the first time `refreshSummarizer` is called _and_ the client is connected, which is basically immediately after the client is connected and the runtime is aware of it.  The number used to approximate performance is the number of milliseconds between the SummaryManager being created and the first connected call to `refreshSummarizer`.  This is a very rough approximation of the time it took to "catch up" to the MSN (note that things may still not be rendered, etc.).  The calculated delay ranges from 2 seconds to 10 seconds, with any input duration under 500ms treated as the minimum (2 sec).  The increase is concave (rapid at first, then diminishes).

Additionally, this PR adds a simple timer to repeatedly failing summarizer creation restarts.  This is a simple 20ms, 40ms, 60ms linear increase.