### PR TITLE
add scope to IHostRuntime interface

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -491,6 +491,10 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         return this._flushMode;
     }
 
+    public get scope(): IComponent {
+        return this.context.scope;
+    }
+
     public get IComponentRegistry(): IComponentRegistry {
         return this.registry;
     }

--- a/packages/runtime/runtime-definitions/src/components.ts
+++ b/packages/runtime/runtime-definitions/src/components.ts
@@ -342,6 +342,7 @@ export interface IHostRuntime extends
     readonly submitSignalFn: (contents: any) => void;
     readonly snapshotFn: (message: string) => Promise<void>;
     readonly closeFn: () => void;
+    readonly scope: IComponent;
 
     /**
      * Returns the runtime of the component.


### PR DESCRIPTION
- Allow scope from container context to be returned from the IHostRuntime interface
- Added function to containerRuntime to return the scope from context

#1143 