### PR TITLE
Remove back-compat support to loader <= 0.8

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -14,7 +14,7 @@ The `type` field on `IClient` has been removed.
 ## Remove back-compat support for loader <= 0.8
 
 Back-compat support code in ScheduleManager is removed for loader <= 0.8, which doesn't support group ops.
-Any component based on runtime >= 0.14 will no longer with with loader <= 0.8
+Any component based on runtime >= 0.14 will no longer work with loader <= 0.8
 
 # 0.13 Breaking Changes
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,6 +1,7 @@
 # 0.14 Breaking Changes
 - [Samples and chaincode have been renamed to examples and components respectively](##Samples-and-chaincode-have-been-renamed-to-examples-and-components-respectively)
 - [Top-level `type` on `IClient` removed](#Top-level-type-on-IClient-removed)
+- [Remove back-compat support for loader <= 0.8](#remove-back-compat-support-for-loader-0.8)
 
 ## Samples and chaincode have been renamed to examples and components respectively
 The directories themselves have been renamed.
@@ -9,6 +10,11 @@ All path references in the dockerfile and json manifests have been updated along
 ## Top-level `type` on `IClient` removed
 
 The `type` field on `IClient` has been removed.
+
+## Remove back-compat support for loader <= 0.8
+
+Back-compat support code in ScheduleManager is removed for loader <= 0.8, which doesn't support group ops.
+Any component based on runtime >= 0.14 will no longer with with loader <= 0.8
 
 # 0.13 Breaking Changes
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -148,7 +148,6 @@ interface IRuntimeMessageMetadata {
 }
 
 export class ScheduleManager {
-    private readonly messageScheduler: IMessageScheduler | undefined;
     private readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     private readonly deltaScheduler: DeltaScheduler;
     private pauseSequenceNumber: number | undefined;
@@ -159,16 +158,10 @@ export class ScheduleManager {
     private batchClientId: string;
 
     constructor(
-        messageScheduler: IMessageScheduler | undefined,
+        private readonly messageScheduler: IMessageScheduler,
         private readonly emitter: EventEmitter,
-        legacyDeltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
         private readonly logger: ITelemetryLogger,
     ) {
-        if (!messageScheduler || !("toArray" in messageScheduler.deltaManager.inbound as any)) {
-            this.deltaManager = legacyDeltaManager;
-            return;
-        }
-
         this.messageScheduler = messageScheduler;
         this.deltaManager = this.messageScheduler.deltaManager;
         this.deltaScheduler = new DeltaScheduler(
@@ -590,7 +583,6 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         this.scheduleManager = new ScheduleManager(
             context.IMessageScheduler,
             this,
-            context.deltaManager,
             ChildLogger.create(this.logger, "ScheduleManager"),
         );
 

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -126,7 +126,6 @@ describe("Runtime", () => {
                     scheduleManager = new ScheduleManager(
                         messageScheduler,
                         emitter,
-                        deltaManager,
                         DebugLogger.create("fluid:testScheduleManager"),
                     );
 

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -18,8 +18,8 @@ import {
     ISequencedDocumentMessage,
     MessageType,
 } from "@microsoft/fluid-protocol-definitions";
-import { IDeltaManager, IMessageScheduler } from "@microsoft/fluid-container-definitions";
-import { MockDeltaManager, MockMessageScheduler } from "@microsoft/fluid-test-runtime-utils";
+import { IDeltaManager } from "@microsoft/fluid-container-definitions";
+import { MockDeltaManager } from "@microsoft/fluid-test-runtime-utils";
 import { IConvertedSummaryResults, SummaryTreeConverter } from "../summaryTreeConverter";
 import { ScheduleManager } from "../containerRuntime";
 
@@ -116,15 +116,13 @@ describe("Runtime", () => {
                 let batchEnd: number = 0;
                 let emitter: EventEmitter;
                 let deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
-                let messageScheduler: IMessageScheduler;
                 let scheduleManager: ScheduleManager;
 
                 beforeEach(() => {
                     emitter = new EventEmitter();
                     deltaManager = new MockDeltaManager();
-                    messageScheduler = new MockMessageScheduler(deltaManager);
                     scheduleManager = new ScheduleManager(
-                        messageScheduler,
+                        deltaManager,
                         emitter,
                         DebugLogger.create("fluid:testScheduleManager"),
                     );


### PR DESCRIPTION
ScheduleManager has back-compat code for loader that doesn't have batch op support.
Cleaning up that code (which mean any component written with runtime >= 0.14 would not work on loader <= 0.8)