### PR TITLE
Make PrimedComponent and SharedComponent api more restrictive

### DIFF
--- a/examples/components/tourofheroes/src/index.ts
+++ b/examples/components/tourofheroes/src/index.ts
@@ -10,6 +10,7 @@ import { PrimedComponent, PrimedComponentFactory } from "@microsoft/fluid-aquedu
 import { IContainerContext, IRuntime, IRuntimeFactory } from "@microsoft/fluid-container-definitions";
 import { IComponentHTMLVisual, IRequest } from "@microsoft/fluid-component-core-interfaces";
 import { ContainerRuntime } from "@microsoft/fluid-container-runtime";
+import { ISharedDirectory } from "@microsoft/fluid-map";
 import {
     IComponentContext,
     IComponentFactory,
@@ -26,6 +27,10 @@ import { GraphQLService } from "./app/hero.service";
 export class TourOfHeroes extends PrimedComponent implements IComponentHTMLVisual {
 
     public get IComponentHTMLVisual() { return this; }
+
+    public get root(): ISharedDirectory {
+        return super.root;
+    }
 
     // Create the component's schema and perform other initialization tasks
     // (only called when document is initially created).

--- a/packages/framework/aqueduct/src/components/primedComponent.ts
+++ b/packages/framework/aqueduct/src/components/primedComponent.ts
@@ -44,7 +44,7 @@ export abstract class PrimedComponent extends SharedComponent {
      * The root directory will either be ready or will return an error. If an error is thrown
      * the root has not been correctly created/set.
      */
-    public get root(): ISharedDirectory {
+    protected get root(): ISharedDirectory {
         if (!this.internalRoot) {
             throw new Error(this.getUninitializedErrorString(`root`));
         }
@@ -55,7 +55,7 @@ export abstract class PrimedComponent extends SharedComponent {
     /**
      * Returns the built-in task manager responsible for scheduling tasks.
      */
-    public get taskManager(): ITaskManager {
+    protected get taskManager(): ITaskManager {
         if (!this.internalTaskManager) {
             throw new Error(this.getUninitializedErrorString(`taskManager`));
         }
@@ -69,7 +69,7 @@ export abstract class PrimedComponent extends SharedComponent {
      * on map doing proper snapshot blob partitioning to reuse non-changing big properties.
      * In future blobs would be implemented as first class citizen, using blob storage APIs
      */
-    public async writeBlob(blob: string): Promise<IComponentHandle> {
+    protected async writeBlob(blob: string): Promise<IComponentHandle> {
         const path = `${this.bigBlobs}${uuid()}`;
         this.root.set(path, blob);
         return new BlobHandle(path, this.root, this.runtime.IComponentHandleContext);

--- a/packages/framework/aqueduct/src/components/sharedComponent.ts
+++ b/packages/framework/aqueduct/src/components/sharedComponent.ts
@@ -93,7 +93,7 @@ export abstract class SharedComponent extends EventEmitter implements IComponent
     /**
      * Given a request response will return a component if a component was in the response.
      */
-    public async asComponent<T>(response: Promise<IResponse>): Promise<T> {
+    protected async asComponent<T>(response: Promise<IResponse>): Promise<T> {
         const result = await response;
 
         if (result.status === 200 && result.mimeType === "fluid/component") {

--- a/packages/test/end-to-end/src/test/primedComponent.spec.ts
+++ b/packages/test/end-to-end/src/test/primedComponent.spec.ts
@@ -7,6 +7,7 @@ import * as assert from "assert";
 import { PrimedComponent, PrimedComponentFactory } from "@microsoft/fluid-aqueduct";
 import { IComponentHandle } from "@microsoft/fluid-component-core-interfaces";
 import { TestHost } from "@microsoft/fluid-local-test-server";
+import { ISharedDirectory } from "@microsoft/fluid-map";
 
 const PrimedType = "@microsoft/fluid-primedComponent";
 
@@ -14,6 +15,12 @@ const PrimedType = "@microsoft/fluid-primedComponent";
  * My sample component
  */
 class Component extends PrimedComponent {
+    public get root(): ISharedDirectory {
+        return super.root;
+    }
+    public async writeBlob(blob: string): Promise<IComponentHandle> {
+        return super.writeBlob(blob);
+    }
 }
 
 describe("PrimedComponent", () => {


### PR DESCRIPTION
Made the following class variables from public -> protected

PrimedComponent:
root
taskManager
writeBlob

SharedComponent:
asComponent