### PR TITLE
CI: Add 'ts-node/register' to NYC config

### DIFF
--- a/packages/runtime/matrix/package.json
+++ b/packages/runtime/matrix/package.json
@@ -48,6 +48,9 @@
       "html",
       "text"
     ],
+    "require": [
+      "ts-node/register"
+    ],
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {


### PR DESCRIPTION
I suspect this will fix CI.  (Still testing locally.)