### PR TITLE
Exposed package "path" on IComponentContext.

### DIFF
--- a/packages/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
+++ b/packages/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
@@ -124,7 +124,7 @@ export class ExternalComponentLoader extends PrimedComponent
                             componentRuntime = await this.context.hostRuntime.createComponent(
                                 uuid(),
                                 [
-                                    ...this.context.path,
+                                    ...this.context.packagePath,
                                     "url",
                                     url,
                                     pkgReg.IComponentDefaultFactoryName.getDefaultFactoryName(),
@@ -133,7 +133,7 @@ export class ExternalComponentLoader extends PrimedComponent
                             componentRuntime = await this.context.hostRuntime.createComponent(
                                 uuid(),
                                 [
-                                    ...this.context.path,
+                                    ...this.context.packagePath,
                                     "url",
                                     url,
                                 ]);

--- a/packages/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
+++ b/packages/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
@@ -124,7 +124,7 @@ export class ExternalComponentLoader extends PrimedComponent
                             componentRuntime = await this.context.hostRuntime.createComponent(
                                 uuid(),
                                 [
-                                    WaterParkLoaderName,
+                                    ...this.context.path,
                                     "url",
                                     url,
                                     pkgReg.IComponentDefaultFactoryName.getDefaultFactoryName(),
@@ -133,7 +133,7 @@ export class ExternalComponentLoader extends PrimedComponent
                             componentRuntime = await this.context.hostRuntime.createComponent(
                                 uuid(),
                                 [
-                                    WaterParkLoaderName,
+                                    ...this.context.path,
                                     "url",
                                     url,
                                 ]);

--- a/packages/runtime/runtime-definitions/src/components.ts
+++ b/packages/runtime/runtime-definitions/src/components.ts
@@ -200,6 +200,14 @@ export interface IComponentRuntime extends EventEmitter, IComponentRouter, Parti
 export interface IComponentContext extends EventEmitter {
     readonly documentId: string;
     readonly id: string;
+    /**
+     * The pacakge type for the component as specified in the factory.
+     */
+    readonly type: string;
+    /**
+     * The path for the component in the component tree.
+     */
+    readonly path: string[];
     readonly existing: boolean;
     readonly options: any;
     readonly clientId: string;

--- a/packages/runtime/runtime-definitions/src/components.ts
+++ b/packages/runtime/runtime-definitions/src/components.ts
@@ -201,13 +201,9 @@ export interface IComponentContext extends EventEmitter {
     readonly documentId: string;
     readonly id: string;
     /**
-     * The pacakge type for the component as specified in the factory.
+     * The package path of the component as per the package factory.
      */
-    readonly type: string;
-    /**
-     * The path for the component in the component tree.
-     */
-    readonly path: string[];
+    readonly packagePath: readonly string[];
     readonly existing: boolean;
     readonly options: any;
     readonly clientId: string;


### PR DESCRIPTION
Fixes #1123 and #1208 .

- This change adds the package "path" to IComponentContext. This will let the component know the context it was in when it is created. Currently only the container runtime knows this. Initially this will be used just for telemetry.
- There is is a small window where a remoted component context is created but is not set until getInitialSnapshotDetails is called. We want to at least log an error in this case.
- Also fixes #1208 by updating createComponent to use the "path" in IComponentContext instead of hardcoded WaterParkLoaderName as the path.