### PR TITLE
error in DeltaManager.connect() instead of assert

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -404,9 +404,6 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
     }
 
     public resume() {
-        if (this.closed) {
-            return;
-        }
         assert(this.loaded);
         // Resume processing ops
         this._deltaManager.inbound.resume();

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -404,6 +404,9 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
     }
 
     public resume() {
+        if (this.closed) {
+            return;
+        }
         assert(this.loaded);
         // Resume processing ops
         this._deltaManager.inbound.resume();

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -298,7 +298,9 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
     }
 
     public async connect(requestedMode: ConnectionMode = "write"): Promise<IConnectionDetails> {
-        assert(!this.closed);
+        if (this.closed) {
+            throw new Error("Attempting to connect a closed DeltaManager");
+        }
 
         if (this.connection) {
             return this.connection.details;


### PR DESCRIPTION
Calling `resume()` on a closed container seems to account for a significant proportion of assertion failures reported. If a container is closed when `resume()` is called, it calls `connectToDeltaStream()` which in turn calls `deltaManager.connect()`, causing an immediate assertion failure since the deltaManager is closed when the container is closed.