### PR TITLE
Jsonable: Replace interfaces w/recursive type decls

### DIFF
--- a/packages/runtime/runtime-definitions/src/jsonable.ts
+++ b/packages/runtime/runtime-definitions/src/jsonable.ts
@@ -3,15 +3,15 @@
  * Licensed under the MIT License.
  */
 
-// Do not use capital 'I' for JsonObject<T> and JsonArray<T> as the use of interfaces is
-// a workaround for lack of type recursion.
-// tslint:disable:interface-name
-
 export type JsonablePrimitive = undefined | null | boolean | number | string;
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface JsonableObject<T> extends Record<string, Jsonable<T>> { }
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface JsonableArray<T> extends Array<Jsonable<T>> { }
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type JsonableObject<T> = {
+    [key: string]: Jsonable<T>
+    [key: number]: Jsonable<T>
+};
+
+export type JsonableArray<T> = Jsonable<T>[];
 
 /**
  * Used to constrain a value to types that are serializable as JSON.  The `T` type parameter may be used to


### PR DESCRIPTION
Tidy `Jsonable` decl now that we're on TypeScript 3.7.