### PR TITLE
Address issue around isFirstContainerForService  / hashing blobs

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
@@ -132,7 +132,7 @@ export class OdspDocumentService implements IDocumentService {
             this.logger,
             true,
             this.odspCache,
-            this.isFirstTimeContainerOpened,
+            this.isFirstTimeDocumentOpened,
         );
 
         return new OdspDocumentStorageService(this.storageManager);

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
@@ -81,7 +81,7 @@ export class OdspDocumentService implements IDocumentService {
         private readonly deltasFetchWrapper: IFetchWrapper,
         private readonly socketIOClientP: Promise<SocketIOClientStatic>,
         private readonly odspCache: OdspCache,
-        private readonly isFirstTimeContainerOpened = true,
+        private readonly isFirstTimeDocumentOpened = true,
     ) {
 
         this.joinSessionKey = `${this.hashedDocumentId}/joinsession`;

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
@@ -49,10 +49,6 @@ export class OdspDocumentService implements IDocumentService {
 
     private readonly joinSessionKey: string;
 
-    // A hint for any document storage managers created if they are the first container
-    // being created by this service
-    private isFirstContainerForService: boolean = true;
-
     /**
      * @param appId - app id used for telemetry for network requests
      * @param hashedDocumentId - A unique identifer for the document. The "hashed" here implies that the contents of
@@ -133,11 +129,7 @@ export class OdspDocumentService implements IDocumentService {
             this.getStorageToken,
             this.logger,
             true,
-            this.odspCache,
-            this.isFirstContainerForService,
-        );
-
-        this.isFirstContainerForService = false;
+            this.odspCache);
 
         return new OdspDocumentStorageService(this.storageManager);
     }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
@@ -49,6 +49,10 @@ export class OdspDocumentService implements IDocumentService {
 
     private readonly joinSessionKey: string;
 
+    // A hint for any document storage managers created if they are the first container
+    // being created by this service
+    private isFirstContainerForService: boolean = true;
+
     /**
      * @param appId - app id used for telemetry for network requests
      * @param hashedDocumentId - A unique identifer for the document. The "hashed" here implies that the contents of
@@ -129,7 +133,11 @@ export class OdspDocumentService implements IDocumentService {
             this.getStorageToken,
             this.logger,
             true,
-            this.odspCache);
+            this.odspCache,
+            this.isFirstContainerForService,
+        );
+
+        this.isFirstContainerForService = false;
 
         return new OdspDocumentStorageService(this.storageManager);
     }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
@@ -81,7 +81,7 @@ export class OdspDocumentService implements IDocumentService {
         private readonly deltasFetchWrapper: IFetchWrapper,
         private readonly socketIOClientP: Promise<SocketIOClientStatic>,
         private readonly odspCache: OdspCache,
-        private readonly isFirstContainerForService = true,
+        private readonly isFirstTimeContainerOpened = true,
     ) {
 
         this.joinSessionKey = `${this.hashedDocumentId}/joinsession`;
@@ -132,7 +132,7 @@ export class OdspDocumentService implements IDocumentService {
             this.logger,
             true,
             this.odspCache,
-            this.isFirstContainerForService,
+            this.isFirstTimeContainerOpened,
         );
 
         return new OdspDocumentStorageService(this.storageManager);

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
@@ -49,9 +49,6 @@ export class OdspDocumentService implements IDocumentService {
 
     private readonly joinSessionKey: string;
 
-    // A hint for any document storage managers created if they are the first container
-    // being created by this service
-    private isFirstContainerForService: boolean = true;
 
     /**
      * @param appId - app id used for telemetry for network requests
@@ -84,6 +81,7 @@ export class OdspDocumentService implements IDocumentService {
         private readonly deltasFetchWrapper: IFetchWrapper,
         private readonly socketIOClientP: Promise<SocketIOClientStatic>,
         private readonly odspCache: OdspCache,
+        private readonly isFirstContainerForService = true,
     ) {
 
         this.joinSessionKey = `${this.hashedDocumentId}/joinsession`;
@@ -136,8 +134,6 @@ export class OdspDocumentService implements IDocumentService {
             this.odspCache,
             this.isFirstContainerForService,
         );
-
-        this.isFirstContainerForService = false;
 
         return new OdspDocumentStorageService(this.storageManager);
     }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactory.ts
@@ -21,6 +21,9 @@ import { OdspDocumentService } from "./odspDocumentService";
  */
 export class OdspDocumentServiceFactory implements IDocumentServiceFactory {
     public readonly protocolName = "fluid-odsp:";
+
+    private readonly documentsOpened = new Set<string>();
+
     /**
    * @param appId - app id used for telemetry for network requests.
    * @param getStorageToken - function that can provide the storage token for a given site. This is
@@ -43,9 +46,15 @@ export class OdspDocumentServiceFactory implements IDocumentServiceFactory {
 
     public async createDocumentService(resolvedUrl: IResolvedUrl): Promise<IDocumentService> {
         const odspResolvedUrl = resolvedUrl as IOdspResolvedUrl;
+
+        // A hint for driver if document was opened before by this factory
+        const docId = odspResolvedUrl.hashedDocumentId;
+        const isFirstContainerForService = this.documentsOpened.has(docId);
+        this.documentsOpened.add(docId);
+
         return new OdspDocumentService(
             this.appId,
-            odspResolvedUrl.hashedDocumentId,
+            docId,
             odspResolvedUrl.siteUrl,
             odspResolvedUrl.driveId,
             odspResolvedUrl.itemId,
@@ -57,6 +66,7 @@ export class OdspDocumentServiceFactory implements IDocumentServiceFactory {
             this.deltasFetchWrapper,
             Promise.resolve(getSocketIo()),
             this.odspCache,
+            isFirstContainerForService,
         );
     }
 }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactory.ts
@@ -66,7 +66,7 @@ export class OdspDocumentServiceFactory implements IDocumentServiceFactory {
             this.deltasFetchWrapper,
             Promise.resolve(getSocketIo()),
             this.odspCache,
-            isFirstTimeContainerOpened,
+            isFirstTimeDocumentOpened,
         );
     }
 }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactory.ts
@@ -49,7 +49,7 @@ export class OdspDocumentServiceFactory implements IDocumentServiceFactory {
 
         // A hint for driver if document was opened before by this factory
         const docId = odspResolvedUrl.hashedDocumentId;
-        const isFirstTimeDocumentOpened = this.documentsOpened.has(docId);
+        const isFirstTimeDocumentOpened = !this.documentsOpened.has(docId);
         this.documentsOpened.add(docId);
 
         return new OdspDocumentService(

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactory.ts
@@ -49,7 +49,7 @@ export class OdspDocumentServiceFactory implements IDocumentServiceFactory {
 
         // A hint for driver if document was opened before by this factory
         const docId = odspResolvedUrl.hashedDocumentId;
-        const isFirstTimeContainerOpened = this.documentsOpened.has(docId);
+        const isFirstTimeDocumentOpened = this.documentsOpened.has(docId);
         this.documentsOpened.add(docId);
 
         return new OdspDocumentService(

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactory.ts
@@ -49,7 +49,7 @@ export class OdspDocumentServiceFactory implements IDocumentServiceFactory {
 
         // A hint for driver if document was opened before by this factory
         const docId = odspResolvedUrl.hashedDocumentId;
-        const isFirstContainerForService = this.documentsOpened.has(docId);
+        const isFirstTimeContainerOpened = this.documentsOpened.has(docId);
         this.documentsOpened.add(docId);
 
         return new OdspDocumentService(
@@ -66,7 +66,7 @@ export class OdspDocumentServiceFactory implements IDocumentServiceFactory {
             this.deltasFetchWrapper,
             Promise.resolve(getSocketIo()),
             this.odspCache,
-            isFirstContainerForService,
+            isFirstTimeContainerOpened,
         );
     }
 }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryWithCodeSplit.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryWithCodeSplit.ts
@@ -50,7 +50,7 @@ export class OdspDocumentServiceFactoryWithCodeSplit implements IDocumentService
 
         // A hint for driver if document was opened before by this factory
         const docId = odspResolvedUrl.hashedDocumentId;
-        const isFirstTimeContainerOpened = this.documentsOpened.has(docId);
+        const isFirstTimeDocumentOpened = this.documentsOpened.has(docId);
         this.documentsOpened.add(docId);
 
         return new OdspDocumentService(

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryWithCodeSplit.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryWithCodeSplit.ts
@@ -67,7 +67,7 @@ export class OdspDocumentServiceFactoryWithCodeSplit implements IDocumentService
             this.deltasFetchWrapper,
             import("./getSocketIo").then((m) => m.getSocketIo()),
             this.odspCache,
-            isFirstTimeContainerOpened,
+            isFirstTimeDocumentOpened,
         );
     }
 }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryWithCodeSplit.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryWithCodeSplit.ts
@@ -50,7 +50,7 @@ export class OdspDocumentServiceFactoryWithCodeSplit implements IDocumentService
 
         // A hint for driver if document was opened before by this factory
         const docId = odspResolvedUrl.hashedDocumentId;
-        const isFirstContainerForService = this.documentsOpened.has(docId);
+        const isFirstTimeContainerOpened = this.documentsOpened.has(docId);
         this.documentsOpened.add(docId);
 
         return new OdspDocumentService(
@@ -67,7 +67,7 @@ export class OdspDocumentServiceFactoryWithCodeSplit implements IDocumentService
             this.deltasFetchWrapper,
             import("./getSocketIo").then((m) => m.getSocketIo()),
             this.odspCache,
-            isFirstContainerForService,
+            isFirstTimeContainerOpened,
         );
     }
 }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryWithCodeSplit.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryWithCodeSplit.ts
@@ -50,7 +50,7 @@ export class OdspDocumentServiceFactoryWithCodeSplit implements IDocumentService
 
         // A hint for driver if document was opened before by this factory
         const docId = odspResolvedUrl.hashedDocumentId;
-        const isFirstTimeDocumentOpened = this.documentsOpened.has(docId);
+        const isFirstTimeDocumentOpened = !this.documentsOpened.has(docId);
         this.documentsOpened.add(docId);
 
         return new OdspDocumentService(

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
@@ -315,7 +315,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
                         // If this is the first container that was created for the service, it cannot be
                         // the summarizing container (becauase the summarizing container is always created
                         // after the main container). In this case, we do not need to do any hashing
-                        if (!this.isFirstTimeContainerOpened && path) {
+                        if (!this.isFirstTimeDocumentOpened && path) {
                             // Schedule the hashes for later, but keep track of the tasks
                             // to ensure they finish before they might be used
                             const hashP = hashFile(Buffer.from(blob.content, blob.encoding)).then((hash: string) => {

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
@@ -77,7 +77,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
         private readonly logger: ITelemetryLogger,
         private readonly fetchFullSnapshot: boolean,
         private readonly odspCache: OdspCache,
-        private readonly isFirstTimeContainerOpened: boolean,
+        private readonly isFirstTimeDocumentOpened: boolean,
     ) {
         this.queryString = getQueryString(queryParams);
         this.appId = queryParams.app_id;

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
@@ -77,7 +77,6 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
         private readonly logger: ITelemetryLogger,
         private readonly fetchFullSnapshot: boolean,
         private readonly odspCache: OdspCache,
-        private readonly isFirstContainerForService: boolean,
     ) {
         this.queryString = getQueryString(queryParams);
         this.appId = queryParams.app_id;
@@ -254,7 +253,13 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
         if (this.firstVersionCall && count === 1 && (blobid === null || blobid === this.documentId)) {
             this.firstVersionCall = false;
 
+            const docLoadedBeforeKey = `${this.documentId}/loadedBefore`;
+            const docLoadedBefore = this.odspCache.get(docLoadedBeforeKey) === true;
+            this.odspCache.put(docLoadedBeforeKey, true);
+            assert(this.odspCache.get(docLoadedBeforeKey) === true);
+
             return getWithRetryForTokenRefresh(async (refresh) => {
+
                 const odspCacheKey: string = `${this.documentId}/getlatest`;
                 let odspSnapshot: IOdspSnapshot = this.odspCache.get(odspCacheKey);
                 if (!odspSnapshot) {
@@ -309,23 +314,26 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
 
                 if (blobs) {
                     this.initBlobsCache(blobs);
-                    // Populate the cache with paths from id-to-path mapping.
-                    for (const blob of this.blobCache.values()) {
-                        const path = blobsIdToPathMap.get(blob.sha);
-                        // If this is the first container that was created for the service, it cannot be
-                        // the summarizing container (becauase the summarizing container is always created
-                        // after the main container). In this case, we do not need to do any hashing
-                        if (!this.isFirstContainerForService && path) {
-                            // Schedule the hashes for later, but keep track of the tasks
-                            // to ensure they finish before they might be used
-                            const hashP = hashFile(Buffer.from(blob.content, blob.encoding)).then((hash: string) => {
-                                this.blobsShaToPathCache.set(hash, path);
-                            });
-                            this.blobsCachePendingHashes.add(hashP);
-                            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                            hashP.finally(() => {
-                                this.blobsCachePendingHashes.delete(hashP);
-                            });
+
+                    // If this is the first container that was created for the service, it cannot be
+                    // the summarizing container (becauase the summarizing container is always created
+                    // after the main container). In this case, we do not need to do any hashing
+                    if (docLoadedBefore) {
+                        // Populate the cache with paths from id-to-path mapping.
+                        for (const blob of this.blobCache.values()) {
+                            const path = blobsIdToPathMap.get(blob.sha);
+                            if (path) {
+                                // Schedule the hashes for later, but keep track of the tasks
+                                // to ensure they finish before they might be used
+                                const hashP = hashFile(Buffer.from(blob.content, blob.encoding)).then((hash: string) => {
+                                    this.blobsShaToPathCache.set(hash, path);
+                                });
+                                this.blobsCachePendingHashes.add(hashP);
+                                // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                                hashP.finally(() => {
+                                    this.blobsCachePendingHashes.delete(hashP);
+                                });
+                            }
                         }
                     }
                 }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
@@ -77,7 +77,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
         private readonly logger: ITelemetryLogger,
         private readonly fetchFullSnapshot: boolean,
         private readonly odspCache: OdspCache,
-        private readonly isFirstContainerForService: boolean,
+        private readonly isFirstTimeContainerOpened: boolean,
     ) {
         this.queryString = getQueryString(queryParams);
         this.appId = queryParams.app_id;
@@ -315,7 +315,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
                         // If this is the first container that was created for the service, it cannot be
                         // the summarizing container (becauase the summarizing container is always created
                         // after the main container). In this case, we do not need to do any hashing
-                        if (!this.isFirstContainerForService && path) {
+                        if (!this.isFirstTimeContainerOpened && path) {
                             // Schedule the hashes for later, but keep track of the tasks
                             // to ensure they finish before they might be used
                             const hashP = hashFile(Buffer.from(blob.content, blob.encoding)).then((hash: string) => {


### PR DESCRIPTION
Somehow I missed it in PR, but existing code around isFirstContainerForService does not look right - new instance of the driver is created per container, so both main & summarizer would not hash blobs

Fixing it by storing data in cache