### PR TITLE
Hotfix summary to not do full summary on first open [0.13]

### DIFF
--- a/packages/runtime/component-runtime/src/remoteChannelContext.ts
+++ b/packages/runtime/component-runtime/src/remoteChannelContext.ts
@@ -46,7 +46,9 @@ export class RemoteChannelContext implements IChannelContext {
         private readonly extraBlobs: Map<string, string>,
         private readonly branch: string,
         private readonly attributes: RequiredIChannelAttributes | undefined,
-    ) {}
+    ) {
+        this.summaryTracker.setBaseTree(baseSnapshot);
+    }
 
     // eslint-disable-next-line @typescript-eslint/promise-function-async
     public getChannel(): Promise<IChannel> {

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -431,6 +431,13 @@ export class RemotedComponentContext extends ComponentContext {
             () => {
                 throw new Error("Already attached");
             });
+
+        if (initSnapshotValue && typeof initSnapshotValue !== "string") {
+            // This will allow the summarizer to avoid calling realize if there
+            // are no changes to the component.  If the initSnapshotValue is a
+            // string, the summarizer cannot avoid calling realize.
+            this.summaryTracker.setBaseTree(initSnapshotValue);
+        }
     }
 
     public generateAttachMessage(): IAttachMessage {


### PR DESCRIPTION
There was a regression causing summarizer to do full summary on first sumamrize attempt (until successful).