### PR TITLE
Producer and consumer improvements for Kafka and Event Hubs

### DIFF
--- a/server/routerlicious/packages/kafka-orderer/src/kafkaOrderer.ts
+++ b/server/routerlicious/packages/kafka-orderer/src/kafkaOrderer.ts
@@ -124,7 +124,7 @@ export class KafkaOrdererConnection implements core.IOrdererConnection {
         this.submitRawOperation([message]);
     }
 
-    public once(event: "producerError", listener: (...args: any[]) => void) {
+    public once(event: "error", listener: (...args: any[]) => void) {
         this.producer.once(event, listener);
     }
 

--- a/server/routerlicious/packages/lambdas-driver/src/event-hub-service/resourcesFactory.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/event-hub-service/resourcesFactory.ts
@@ -51,7 +51,6 @@ export class EventHubResourcesFactory implements IResourcesFactory<EventHubResou
             clientId,
             groupId,
             receiveTopic,
-            true,
             storageEndpoint,
             storageContainer);
 

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/index.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/index.ts
@@ -5,3 +5,4 @@
 
 export * from "./resourcesFactory";
 export * from "./runnerFactory";
+export * from "./partitionManager";

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/resourcesFactory.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/resourcesFactory.ts
@@ -50,7 +50,7 @@ export class KafkaResourcesFactory implements IResourcesFactory<KafkaResources> 
         const receiveTopic = streamConfig.topic;
 
         const clientId = moniker.choose();
-        const consumer = createConsumer(kafkaLibrary, kafkaEndpoint, clientId, groupId, receiveTopic, false);
+        const consumer = createConsumer(kafkaLibrary, kafkaEndpoint, clientId, groupId, receiveTopic);
 
         return new KafkaResources(
             lambdaFactory,

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -210,7 +210,7 @@ export function configureWebSocketServices(
                 connectionsMap.set(clientId, connection);
 
                 // Eventually we will send disconnect reason as headers to client.
-                connection.once("producerError", (error) => {
+                connection.once("error", (error) => {
                     winston.info(`Disconnecting socket on connection error`, error);
                     socket.disconnect(true);
                 });

--- a/server/routerlicious/packages/memory-orderer/src/localKafka.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localKafka.ts
@@ -85,7 +85,11 @@ export class LocalKafka implements IProducer {
         this.subscriptions.length = 0;
     }
 
-    public once(event: "producerError", listener: (...args: any[]) => void): this {
+    public on(event: "connected" | "produced" | "error", listener: (...args: any[]) => void): this {
+        return this;
+    }
+
+    public once(event: "connected" | "produced" | "error", listener: (...args: any[]) => void): this {
         return this;
     }
 

--- a/server/routerlicious/packages/memory-orderer/src/localOrdererConnection.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrdererConnection.ts
@@ -117,7 +117,7 @@ export class LocalOrdererConnection implements IOrdererConnection {
         this.pubsub.unsubscribe(`client#${this.clientId}`, this.socket);
     }
 
-    public once(event: "producerError", listener: (...args: any[]) => void) {
+    public once(event: "error", listener: (...args: any[]) => void) {
         this.producer.once(event, listener);
     }
 

--- a/server/routerlicious/packages/memory-orderer/src/remoteNode.ts
+++ b/server/routerlicious/packages/memory-orderer/src/remoteNode.ts
@@ -55,7 +55,7 @@ class ProxySocketConnection implements IOrdererConnection {
         this.socket.emit(op, id, ...data);
     }
 
-    public once(event: "producerError", listener: (...args: any[]) => void) {
+    public once(event: "error", listener: (...args: any[]) => void) {
         return;
     }
 }

--- a/server/routerlicious/packages/protocol-definitions/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/protocol.ts
@@ -175,7 +175,7 @@ export interface ISequencedDocumentMessage {
     traces: ITrace[];
 
     // Timestamp when the server ticketed the message
-    timestamp?: number;
+    timestamp: number;
 }
 
 export interface ISequencedDocumentSystemMessage extends ISequencedDocumentMessage {

--- a/server/routerlicious/packages/protocol-definitions/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/protocol.ts
@@ -175,7 +175,7 @@ export interface ISequencedDocumentMessage {
     traces: ITrace[];
 
     // Timestamp when the server ticketed the message
-    timestamp: number;
+    timestamp?: number;
 }
 
 export interface ISequencedDocumentSystemMessage extends ISequencedDocumentMessage {

--- a/server/routerlicious/packages/services-core/src/orderer.ts
+++ b/server/routerlicious/packages/services-core/src/orderer.ts
@@ -51,7 +51,7 @@ export interface IOrdererConnection {
     /**
      * Error event Handler.
      */
-    once(event: "producerError", listener: (...args: any[]) => void): void;
+    once(event: "error", listener: (...args: any[]) => void): void;
 
     disconnect(): void;
 }

--- a/server/routerlicious/packages/services-core/src/queue.ts
+++ b/server/routerlicious/packages/services-core/src/queue.ts
@@ -19,9 +19,9 @@ export interface IPartition {
 }
 
 export interface IConsumer {
-    groupId: string;
+    readonly groupId: string;
 
-    topic: string;
+    readonly topic: string;
 
     /**
      * Commits consumer checkpoint offset.
@@ -31,6 +31,7 @@ export interface IConsumer {
     /**
      * Event Handler.
      */
+    on(event: "connected", listener: () => void): this;
     on(event: "data", listener: (message: IQueuedMessage) => void): this;
     on(event: "rebalancing" | "rebalanced", listener: (partitions: IPartition[]) => void): this;
     on(event: string, listener: (...args: any[]) => void): this;
@@ -74,9 +75,10 @@ export interface IProducer {
     close(): Promise<void>;
 
     /**
-     * Error event Handler.
+     * Event handlers
      */
-    once(event: "producerError", listener: (...args: any[]) => void): this;
+    on(event: "connected" | "produced" | "error", listener: (...args: any[]) => void): this;
+    once(event: "connected" | "produced" | "error", listener: (...args: any[]) => void): this;
 }
 
 export interface IPendingBoxcar {

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -32,7 +32,7 @@
     "amqplib": "^0.5.5",
     "axios": "^0.18.0",
     "debug": "^4.1.1",
-    "kafka-node": "^3.0.1",
+    "kafka-node": "^5.0.0",
     "lodash": "^4.17.11",
     "minio": "^7.0.2",
     "mongodb": "3.1.10",

--- a/server/routerlicious/packages/services/src/eventHubConsumer.ts
+++ b/server/routerlicious/packages/services/src/eventHubConsumer.ts
@@ -27,9 +27,8 @@ export class EventHubConsumer implements IConsumer {
     constructor(
         endpoint: string,
         clientId: string,
-        public groupId: string,
-        public topic: string,
-        autoCommit: boolean,
+        public readonly groupId: string,
+        public readonly topic: string,
         storageEndpoint: string,
         storageContainerName: string,
         additionalOptions?: FromTokenProviderOptions,

--- a/server/routerlicious/packages/services/src/eventHubConsumer.ts
+++ b/server/routerlicious/packages/services/src/eventHubConsumer.ts
@@ -46,15 +46,11 @@ export class EventHubConsumer implements IConsumer {
                 ...additionalOptions,
             });
 
-        const startP = this.eventHost.start(
+        this.eventHost.start(
             (context, data) => this.handleMessage(context, data),
-            (error) => this.error(error));
-
-        startP.catch((error) => {
-            debug("Error starting event hub");
-            debug(JSON.stringify(error));
-            this.error(error);
-        });
+            (error) => this.handleError(error))
+            .then(() => this.events.emit("connected"),
+                (error) => this.handleError(error));
     }
 
     public async commitCheckpoint(partitionId: number, queuedMessage: IQueuedMessage): Promise<void> {
@@ -147,7 +143,7 @@ export class EventHubConsumer implements IConsumer {
         this.events.emit("data", eventHubMessage);
     }
 
-    private error(error) {
+    private handleError(error) {
         this.events.emit("error", error);
     }
 }

--- a/server/routerlicious/packages/services/src/kafkaFactory.ts
+++ b/server/routerlicious/packages/services/src/kafkaFactory.ts
@@ -12,12 +12,13 @@ export const createConsumer = (
     endPoint: string,
     clientId: string,
     groupId: string,
-    topic: string,
-    autoCommit: boolean): IConsumer => new KafkaNodeConsumer(endPoint, clientId, groupId, topic, autoCommit);
+    topic: string): IConsumer =>
+    new KafkaNodeConsumer({ kafkaHost: endPoint }, clientId, groupId, topic);
 
 export const createProducer = (
     type: string,
     endPoint: string,
     clientId: string,
     topic: string,
-    maxKafkaMessageSize: number): IProducer => new KafkaNodeProducer(endPoint, clientId, topic);
+    maxKafkaMessageSize: number): IProducer =>
+    new KafkaNodeProducer({ kafkaHost: endPoint }, clientId, topic);

--- a/server/routerlicious/packages/services/src/kafkaNodeConsumer.ts
+++ b/server/routerlicious/packages/services/src/kafkaNodeConsumer.ts
@@ -93,21 +93,13 @@ export class KafkaNodeConsumer implements IConsumer {
             });
 
             this.consumerGroup.on("rebalancing", () => {
-                try {
-                    const payloads = (this.consumerGroup as any).topicPayloads;
-                    this.events.emit("rebalancing", this.getPartitions(payloads));
-                } catch (ex) {
-                    this.events.emit("error", ex);
-                }
+                const payloads = (this.consumerGroup as any).topicPayloads;
+                this.events.emit("rebalancing", this.getPartitions(payloads));
             });
 
             this.consumerGroup.on("rebalanced", () => {
-                try {
-                    const payloads = (this.consumerGroup as any).topicPayloads;
-                    this.events.emit("rebalanced", this.getPartitions(payloads));
-                } catch (ex) {
-                    this.events.emit("error", ex);
-                }
+                const payloads = (this.consumerGroup as any).topicPayloads;
+                this.events.emit("rebalanced", this.getPartitions(payloads));
             });
 
             this.consumerGroup.on("message", (message: any) => {

--- a/server/routerlicious/packages/services/src/kafkaNodeConsumer.ts
+++ b/server/routerlicious/packages/services/src/kafkaNodeConsumer.ts
@@ -6,45 +6,48 @@
 import { EventEmitter } from "events";
 import * as util from "util";
 import { IConsumer, IPartition, IQueuedMessage } from "@microsoft/fluid-server-services-core";
-import * as kafkaNode from "kafka-node";
+import * as kafka from "kafka-node";
 import { debug } from "./debug";
+import { ensureTopics } from "./kafkaTopics";
 
 export class KafkaNodeConsumer implements IConsumer {
-    private client: kafkaNode.Client;
-    private offset: kafkaNode.Offset;
-    private instance: kafkaNode.HighLevelConsumer;
+    private client: kafka.KafkaClient;
+    private offset: kafka.Offset;
+    private consumerGroup: kafka.ConsumerGroup;
     private readonly events = new EventEmitter();
 
     constructor(
-        private readonly endpoint: string,
-        private readonly clientId: string,
-        public groupId: string,
-        public topic: string,
-        private readonly autoCommit: boolean) {
+        private readonly clientOptions: kafka.KafkaClientOptions,
+        clientId: string,
+        public readonly groupId: string,
+        public readonly topic: string,
+        private readonly topicPartitions?: number,
+        private readonly topicReplicationFactor?: number) {
+        clientOptions.clientId = clientId;
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.connect();
     }
 
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    public commitCheckpoint(partitionId: number, queuedMessage: IQueuedMessage): Promise<void> {
+    public async commitCheckpoint(partitionId: number, queuedMessage: IQueuedMessage): Promise<void> {
         const commitRequest = [{
             offset: queuedMessage.offset + 1,
             partition: partitionId,
             topic: this.topic,
         }];
-        return new Promise<any>((resolve, reject) => {
+
+        return new Promise<void>((resolve, reject) => {
             this.offset.commit(this.groupId, commitRequest, (err, data) => {
                 if (err) {
                     reject(err);
                 } else {
-                    resolve(JSON.stringify(data));
+                    resolve();
                 }
             });
         });
     }
 
     public async close(): Promise<void> {
-        await util.promisify(((callback) => this.instance.close(false, callback)) as any)();
+        await util.promisify(((callback) => this.consumerGroup.close(false, callback)) as any)();
         await util.promisify(((callback) => this.client.close(callback)) as any)();
     }
 
@@ -54,60 +57,88 @@ export class KafkaNodeConsumer implements IConsumer {
     }
 
     public async pause() {
-        this.instance.pause();
+        this.consumerGroup.pause();
     }
 
     public async resume() {
-        this.instance.resume();
+        this.consumerGroup.resume();
     }
 
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    private connect() {
-        this.client = new kafkaNode.Client(this.endpoint, this.clientId);
-        this.offset = new kafkaNode.Offset(this.client);
+    private async connect() {
+        this.client = new kafka.KafkaClient(this.clientOptions);
+        this.offset = new kafka.Offset(this.client);
+
         const groupId = this.groupId;
-        return new Promise<any>((resolve, reject) => {
-            this.ensureTopics(this.client, [this.topic]).then(
-                () => {
-                    this.instance = new kafkaNode.HighLevelConsumer(
-                        this.client,
-                        [{ topic: this.topic }],
-                        {
-                            autoCommit: this.autoCommit,
-                            fetchMaxBytes: 1024 * 1024,
-                            fetchMinBytes: 1,
-                            fromOffset: true,
-                            groupId,
-                            maxTickMessages: 100000,
-                        });
 
-                    this.instance.on("rebalancing", () => {
-                        const payloads = (this.instance as any).getTopicPayloads();
-                        this.events.emit("rebalancing", this.getPartitions(payloads));
-                    });
+        try {
+            await ensureTopics(this.client, [this.topic], this.topicPartitions, this.topicReplicationFactor);
 
-                    this.instance.on("rebalanced", () => {
-                        const payloads = (this.instance as any).getTopicPayloads();
-                        this.events.emit("rebalanced", this.getPartitions(payloads));
-                    });
+            this.consumerGroup = new kafka.ConsumerGroup(
+                {
+                    kafkaHost: this.clientOptions.kafkaHost,
+                    ssl: this.clientOptions.sslOptions,
+                    sslOptions: this.clientOptions.sslOptions,
+                    id: this.clientOptions.clientId,
+                    autoCommit: false,
+                    fetchMaxBytes: 1024 * 1024,
+                    fetchMinBytes: 1,
+                    fromOffset: "latest",
+                    groupId,
+                    maxTickMessages: 100000,
+                },
+                [this.topic]);
 
-                    this.instance.on("message", (message: any) => {
-                        this.events.emit("data", message);
-                    });
+            this.consumerGroup.on("connect", () => {
+                this.events.emit("connected");
+            });
 
-                    this.instance.on("error", (error) => {
-                        // Workaround to resolve rebalance partition error.
-                        // https://github.com/SOHU-Co/kafka-node/issues/90
-                        debug(`Error in kafka consumer: ${error}. Wait for 30 seconds and return error...`);
-                        setTimeout(() => {
-                            this.events.emit("error", error);
-                        }, 30000);
-                    });
+            this.consumerGroup.on("rebalancing", () => {
+                try {
+                    const payloads = (this.consumerGroup as any).topicPayloads;
+                    this.events.emit("rebalancing", this.getPartitions(payloads));
+                } catch (ex) {
+                    this.events.emit("error", ex);
+                }
+            });
 
-                }, (error) => {
-                    this.handleError(error);
-                });
-        });
+            this.consumerGroup.on("rebalanced", () => {
+                try {
+                    const payloads = (this.consumerGroup as any).topicPayloads;
+                    this.events.emit("rebalanced", this.getPartitions(payloads));
+                } catch (ex) {
+                    this.events.emit("error", ex);
+                }
+            });
+
+            this.consumerGroup.on("message", (message: any) => {
+                this.events.emit("data", message);
+            });
+
+            this.consumerGroup.on("error", (error) => {
+                this.events.emit("error", error);
+            });
+
+            this.consumerGroup.on("offsetOutOfRange", (error) => {
+                this.events.emit("error", error);
+            });
+
+        } catch (error) {
+            // Close the client if it exists
+            if (this.client) {
+                this.client.close();
+                this.client = undefined;
+            }
+
+            debug("Kafka error - attempting reconnect", error);
+
+            this.events.emit("error", error);
+
+            // reconnect in 5 seconds
+            setTimeout(() => {
+                // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                this.connect();
+            }, 5000);
+        }
     }
 
     private getPartitions(rawPartitions: any[]): IPartition[] {
@@ -116,35 +147,5 @@ export class KafkaNodeConsumer implements IConsumer {
             partition: parseInt(partition.partition, 10),
             topic: partition.topic,
         }));
-    }
-
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    private ensureTopics(client: kafkaNode.Client, topics: string[]): Promise<void> {
-        return new Promise<void>((resolve, reject) => {
-            // We make use of a refreshMetadata call to validate the given topics exist
-            client.refreshMetadata(
-                topics,
-                (error) => {
-                    if (error) {
-                        return reject(error);
-                    }
-                    return resolve();
-                });
-        });
-    }
-
-    /**
-     * Handles an error that requires a reconnect to Kafka
-     */
-    private handleError(error: any) {
-        // Close the client if it exists
-        if (this.client) {
-            this.client.close();
-            this.client = undefined;
-        }
-
-        debug("Kafka error - attempting reconnect", error);
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.connect();
     }
 }

--- a/server/routerlicious/packages/services/src/kafkaNodeProducer.ts
+++ b/server/routerlicious/packages/services/src/kafkaNodeProducer.ts
@@ -7,8 +7,9 @@ import { EventEmitter } from "events";
 import * as util from "util";
 import { Deferred } from "@microsoft/fluid-core-utils";
 import { BoxcarType, IBoxcarMessage, IPendingBoxcar, IProducer } from "@microsoft/fluid-server-services-core";
-import * as kafkaNode from "kafka-node";
+import * as kafka from "kafka-node";
 import { debug } from "./debug";
+import { ensureTopics } from "./kafkaTopics";
 
 // 1MB batch size / (16KB max message size + overhead)
 const MaxBatchSize = 32;
@@ -26,17 +27,20 @@ class PendingBoxcar implements IPendingBoxcar {
  */
 export class KafkaNodeProducer implements IProducer {
     private readonly messages = new Map<string, IPendingBoxcar[]>();
-    private client: any;
-    private producer: any;
+    private client: kafka.KafkaClient;
+    private producer: kafka.Producer;
     private sendPending: NodeJS.Immediate;
     private readonly events = new EventEmitter();
     private connecting = false;
     private connected = false;
 
     constructor(
-        private readonly endpoint: string,
-        private readonly clientId: string,
-        private readonly topic: string) {
+        private readonly clientOptions: kafka.KafkaClientOptions,
+        clientId: string,
+        private readonly topic: string,
+        private readonly topicPartitions?: number,
+        private readonly topicReplicationFactor?: number) {
+        clientOptions.clientId = clientId;
         this.connect();
     }
 
@@ -77,14 +81,16 @@ export class KafkaNodeProducer implements IProducer {
     }
 
     public async close(): Promise<void> {
-        const producer = this.producer as kafkaNode.Producer;
-        const client = this.client as kafkaNode.Client;
-
-        await util.promisify(((callback) => producer.close(callback)) as any)();
-        await util.promisify(((callback) => client.close(callback)) as any)();
+        await util.promisify(((callback) => this.producer.close(callback)) as any)();
+        await util.promisify(((callback) => this.client.close(callback)) as any)();
     }
 
-    public once(event: "producerError", listener: (...args: any[]) => void): this {
+    public on(event: "connected" | "produced" | "error", listener: (...args: any[]) => void): this {
+        this.events.on(event, listener);
+        return this;
+    }
+
+    public once(event: "connected" | "produced" | "error", listener: (...args: any[]) => void): this {
         this.events.once(event, listener);
         return this;
     }
@@ -139,6 +145,7 @@ export class KafkaNodeProducer implements IProducer {
                         this.handleError(error);
                         boxcar.deferred.reject(error);
                     } else {
+                        this.events.emit("produced");
                         boxcar.deferred.resolve();
                     }
                 });
@@ -155,23 +162,28 @@ export class KafkaNodeProducer implements IProducer {
         }
 
         this.connecting = true;
-        this.client = new kafkaNode.Client(this.endpoint, this.clientId);
-        this.producer = new kafkaNode.Producer(this.client, { partitionerType: 3 });
 
-        (this.client).on("error", (error) => {
+        this.client = new kafka.KafkaClient(this.clientOptions);
+        this.producer = new kafka.Producer(this.client, { partitionerType: 3 });
+
+        this.client.on("error", (error) => {
             this.handleError(error);
         });
 
-        this.producer.on("ready", () => {
-            this.ensureTopics(this.client, [this.topic]).then(
-                () => {
-                    this.connected = true;
-                    this.connecting = false;
-                    this.sendPendingMessages();
-                },
-                (error) => {
-                    this.handleError(error);
-                });
+        this.producer.on("ready", async () => {
+            try {
+                await ensureTopics(this.client, [this.topic], this.topicPartitions, this.topicReplicationFactor);
+
+                this.connected = true;
+                this.connecting = false;
+
+                this.events.emit("connected");
+
+                this.sendPendingMessages();
+
+            } catch (error) {
+                this.handleError(error);
+            }
         });
 
         this.producer.on("error", (error) => {
@@ -185,35 +197,14 @@ export class KafkaNodeProducer implements IProducer {
     private handleError(error: any) {
         // Close the client if it exists
         if (this.client) {
-            this.client.close((closeError) => {
-                if (closeError) {
-                    debug(closeError);
-                }
-            });
+            this.client.close();
             this.client = undefined;
         }
 
         this.connecting = this.connected = false;
         debug("Kafka error - closing", error);
-        this.events.emit("producerError", error);
+        this.events.emit("error", error);
         this.connect();
     }
-    /**
-     * Ensures that the provided topics are ready
-     */
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    private ensureTopics(client: kafkaNode.Client, topics: string[]): Promise<void> {
-        return new Promise<void>((resolve, reject) => {
-            // We make use of a refreshMetadata call to validate the given topics exist
-            client.refreshMetadata(
-                topics,
-                (error) => {
-                    if (error) {
-                        return reject(error);
-                    }
 
-                    return resolve();
-                });
-        });
-    }
 }

--- a/server/routerlicious/packages/services/src/kafkaTopics.ts
+++ b/server/routerlicious/packages/services/src/kafkaTopics.ts
@@ -1,0 +1,61 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as kafka from "kafka-node";
+
+export const defaultPartitionCount = 32;
+
+export const defaultReplicationFactor = 3;
+
+/**
+ * Ensures that the provided topics exist
+ * The topics will be created if they do not exist
+ */
+export async function ensureTopics(
+    client: kafka.KafkaClient,
+    topics: string[],
+    partitions: number = defaultPartitionCount,
+    replicationFactor: number = defaultReplicationFactor): Promise<void> {
+
+    const topicExistsError = await new Promise<kafka.TopicsNotExistError | any | undefined>((resolve) =>
+        client.topicExists(topics, (error) => error ? resolve(error) : resolve(undefined)));
+    if (!topicExistsError) {
+        // no error - the topics exist
+        return;
+    }
+
+    const topicsNotExistError = topicExistsError as kafka.TopicsNotExistError;
+    if (typeof (topicsNotExistError) !== "object" || typeof (topicsNotExistError.topics) !== "object") {
+        throw new Error(`Failed to ensure topics. ${topicExistsError}`);
+    }
+
+    // create the missing topics
+    return new Promise<void>((resolve, reject) => {
+        const newTopics = Array.isArray(topicsNotExistError.topics) ?
+            topicsNotExistError.topics :
+            [topicsNotExistError.topics];
+
+        client.createTopics(newTopics.map((topic) => {
+            return {
+                topic,
+                partitions,
+                replicationFactor,
+            };
+
+        }), (createTopicError, result) => {
+            if (createTopicError) {
+                reject(createTopicError);
+
+            } else {
+                const topicError = result.find((value) => value.error);
+                if (topicError) {
+                    reject(`Failed to create topic "${topicError.topic}". Error: ${topicError.error}`);
+                } else {
+                    resolve();
+                }
+            }
+        });
+    });
+}

--- a/server/routerlicious/packages/test-utils/src/testKafka.ts
+++ b/server/routerlicious/packages/test-utils/src/testKafka.ts
@@ -110,7 +110,11 @@ export class TestProducer implements core.IProducer {
         return Promise.resolve();
     }
 
-    public once(event: "producerError", listener: (...args: any[]) => void): this {
+    public on(event: "connected" | "produced" | "error", listener: (...args: any[]) => void): this {
+        return this;
+    }
+
+    public once(event: "connected" | "produced" | "error", listener: (...args: any[]) => void): this {
         return this;
     }
 }


### PR DESCRIPTION
- Add `connected` & `produced` events to producers - Useful for telemetry purposes.
- Rename `producerError` event to just `error`.
- Allow `ensureTopics` method to create topics.
- Update node-kafka to latest version. The current version was over a year old.
- Add error handling to event hub producer batch sending.
- Remove autoCommit arg from the consumers. It's always set to `false` so we don't need it.