### PR TITLE
Remove winston from server lambdas, and replace with logging abstraction

### DIFF
--- a/packages/server/local-test-utils/package.json
+++ b/packages/server/local-test-utils/package.json
@@ -22,8 +22,6 @@
     "eslint:fix": "eslint --ext=ts,tsx --format stylish src --fix",
     "lint": "npm run eslint",
     "lint:fix": "npm run eslint:fix",
-    "test": "echo Tests reside in the `local-test-server-test` package.",
-    "test:coverage": "nyc npm test -- --reporter mocha-junit-reporter --reporter-options mochaFile=nyc/junit-report.xml",
     "tsc": "tsc",
     "webpack": "webpack --config webpack.config.js"
   },

--- a/packages/server/local-test-utils/webpack.config.js
+++ b/packages/server/local-test-utils/webpack.config.js
@@ -34,7 +34,4 @@ module.exports = {
     devServer: {
         publicPath: '/dist'
     },
-    node: {
-      fs: "empty",
-    },
 };

--- a/packages/server/local-test-utils/webpack.config.js
+++ b/packages/server/local-test-utils/webpack.config.js
@@ -34,4 +34,7 @@ module.exports = {
     devServer: {
         publicPath: '/dist'
     },
+    node: {
+      fs: "empty",
+    },
 };

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -5,7 +5,8 @@
 
 import * as assert from "assert";
 import { EventEmitter } from "events";
-import { IContext, IQueuedMessage } from "@microsoft/fluid-server-services-core";
+import { IContext, IQueuedMessage, ILogger } from "@microsoft/fluid-server-services-core";
+import * as winston from "winston";
 
 export class DocumentContext extends EventEmitter implements IContext {
     // We track two offsets - head and tail. Head represents the largest offset related to this document we
@@ -73,6 +74,10 @@ export class DocumentContext extends EventEmitter implements IContext {
 
     public error(error: any, restart: boolean) {
         this.emit("error", error, restart);
+    }
+
+    public get log(): ILogger {
+        return winston;
     }
 
     public close() {

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts
@@ -4,7 +4,8 @@
  */
 
 import { EventEmitter } from "events";
-import { IContext, IQueuedMessage } from "@microsoft/fluid-server-services-core";
+import { IContext, IQueuedMessage, ILogger } from "@microsoft/fluid-server-services-core";
+import * as winston from "winston";
 import { CheckpointManager } from "./checkpointManager";
 
 export class Context extends EventEmitter implements IContext {
@@ -35,6 +36,10 @@ export class Context extends EventEmitter implements IContext {
      */
     public error(error: any, restart: boolean) {
         this.emit("error", error, restart);
+    }
+
+    public get log(): ILogger {
+        return winston;
     }
 
     /**

--- a/server/routerlicious/packages/lambdas-driver/src/test/document-router/contextManager.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/document-router/contextManager.spec.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { IContext, IQueuedMessage } from "@microsoft/fluid-server-services-core";
-import { TestKafka } from "@microsoft/fluid-server-test-utils";
+import { IContext, IQueuedMessage, ILogger } from "@microsoft/fluid-server-services-core";
+import { TestKafka, DebugLogger } from "@microsoft/fluid-server-test-utils";
 import * as assert from "assert";
 import { DocumentContextManager } from "../../document-router/contextManager";
 
@@ -19,6 +19,8 @@ class TestContext implements IContext {
     public error(error: any, restart: boolean) {
         throw new Error("Method not implemented.");
     }
+
+    public readonly log: ILogger = DebugLogger.create("fluid-server:TestContextManager");
 }
 
 describe("document-router", () => {

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -62,8 +62,7 @@
     "moniker": "^0.1.2",
     "nconf": "^0.10.0",
     "semver": "^6.3.0",
-    "uuid": "^3.3.2",
-    "winston": "^3.1.0"
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "@microsoft/eslint-config-fluid": "^0.14.0",

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -22,7 +22,6 @@ import { canSummarize, canWrite } from "@microsoft/fluid-server-services-client"
 
 import * as jwt from "jsonwebtoken";
 import * as semver from "semver";
-import * as winston from "winston";
 import * as core from "@microsoft/fluid-server-services-core";
 import {
     createRoomJoinMessage,
@@ -115,7 +114,8 @@ export function configureWebSocketServices(
     storage: core.IDocumentStorage,
     contentCollection: core.ICollection<any>,
     clientManager: core.IClientManager,
-    metricLogger: core.IMetricClient) {
+    metricLogger: core.IMetricClient,
+    logger: core.ILogger) {
 
 
     webSocketServer.on("connection", (socket: core.IWebSocket) => {
@@ -211,7 +211,7 @@ export function configureWebSocketServices(
 
                 // Eventually we will send disconnect reason as headers to client.
                 connection.once("error", (error) => {
-                    winston.info(`Disconnecting socket on connection error`, error);
+                    logger.error(`Disconnecting socket on connection error: ${JSON.stringify(error)}`);
                     socket.disconnect(true);
                 });
 
@@ -265,7 +265,7 @@ export function configureWebSocketServices(
                     }
                 },
                 (error) => {
-                    winston.info(`connectDocument error`, error);
+                    logger.error(`Connect Document error: ${JSON.stringify(error)}`);
                     socket.emit("connect_document_error", error);
                 });
         });
@@ -288,7 +288,7 @@ export function configureWebSocketServices(
                                     // End of tracking. Write traces.
                                     metricLogger.writeLatencyMetric("latency", message.traces).catch(
                                         (error) => {
-                                            winston.error(error.stack);
+                                            logger.error(error.stack);
                                         });
                                     return false;
                                 } else {
@@ -377,13 +377,13 @@ export function configureWebSocketServices(
         socket.on("disconnect", async () => {
             // Send notification messages for all client IDs in the connection map
             for (const [clientId, connection] of connectionsMap) {
-                winston.info(`Disconnect of ${clientId}`);
+                logger.info(`Disconnect of ${clientId}`);
                 connection.disconnect();
             }
             // Send notification messages for all client IDs in the room map
             const removeP = [];
             for (const [clientId, room] of roomMap) {
-                winston.info(`Disconnect of ${clientId} from room`);
+                logger.info(`Disconnect of ${clientId} from room`);
                 removeP.push(clientManager.removeClient(room.tenantId, room.documentId, clientId));
                 // Back-compat check for older clients.
                 if (versionMap.has(clientId)) {

--- a/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
@@ -7,7 +7,6 @@
 
 import { IRangeTrackerSnapshot } from "@microsoft/fluid-core-utils";
 import { ICollection, IContext, IDocument, IQueuedMessage } from "@microsoft/fluid-server-services-core";
-import * as winston from "winston";
 
 export interface IClientSequenceNumber {
     // Whether or not the object can expire
@@ -69,7 +68,7 @@ export class CheckpointContext {
             },
             (error) => {
                 // TODO flag context as error
-                winston.error("Error writing checkpoint to MongoDB", error);
+                this.context.log.error(`Error writing checkpoint to MongoDB: ${JSON.stringify(error)}`);
             });
     }
 
@@ -95,7 +94,7 @@ export class CheckpointContext {
         // Retry the checkpoint on error
         // eslint-disable-next-line @typescript-eslint/promise-function-async
         return updateP.catch((error) => {
-            winston.error("Error writing checkpoint to MongoDB", error);
+            this.context.log.error(`Error writing checkpoint to MongoDB: ${JSON.stringify(error)}`);
             return new Promise<void>((resolve, reject) => {
                 resolve(this.checkpointCore(checkpoint));
             });

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -36,7 +36,6 @@ import {
     SequencedOperationType,
     IQueuedMessage,
 } from "@microsoft/fluid-server-services-core";
-import * as winston from "winston";
 import { CheckpointContext, ICheckpoint, IClientSequenceNumber } from "./checkpointContext";
 import { ClientSequenceNumberManager } from "./clientSeqManager";
 
@@ -197,7 +196,7 @@ export class DeliLambda implements IPartitionLambda {
                 this.checkpointContext.checkpoint(checkpoint);
             },
             (error) => {
-                winston.error("Could not send message to scriptorium", error);
+                this.context.log.error(`Could not send message to scriptorium: ${JSON.stringify(error)}`);
                 this.context.error(error, true);
             });
 
@@ -248,7 +247,7 @@ export class DeliLambda implements IPartitionLambda {
                         clientJoinMessage.detail.scopes);
                     this.canClose = false;
                 } else if (message.operation.type === MessageType.Fork) {
-                    winston.info(`Fork ${message.documentId} -> ${systemContent.name}`);
+                    this.context.log.info(`Fork ${message.documentId} -> ${systemContent.name}`);
                 }
             } else {
                 // Nack inexistent client.
@@ -506,7 +505,8 @@ export class DeliLambda implements IPartitionLambda {
         // Perform duplicate detection on client IDs - Check that we have an increasing CID
         // For back compat ignore the 0/undefined message
         if (clientSequenceNumber && (client.clientSequenceNumber + 1 !== clientSequenceNumber)) {
-            winston.info(`Duplicate ${client.clientId}:${client.clientSequenceNumber + 1} !== ${clientSequenceNumber}`);
+            this.context.log.info(
+                `Duplicate ${client.clientId}:${client.clientSequenceNumber + 1} !== ${clientSequenceNumber}`);
             return true;
         }
 
@@ -520,7 +520,7 @@ export class DeliLambda implements IPartitionLambda {
 
     private sendToAlfred(message: IRawOperationMessage) {
         this.reverseProducer.send([message], message.tenantId, message.documentId).catch((error) => {
-            winston.error("Could not send message to alfred", error);
+            this.context.log.error(`Could not send message to alfred: ${JSON.stringify(error)}`);
             this.context.error(error, true);
         });
     }

--- a/server/routerlicious/packages/lambdas/src/foreman/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/foreman/lambda.ts
@@ -12,7 +12,6 @@ import {
     ScopeType,
 } from "@microsoft/fluid-protocol-definitions";
 import * as core from "@microsoft/fluid-server-services-core";
-import * as winston from "winston";
 import { generateToken } from "@microsoft/fluid-server-services-client";
 import { SequencedLambda } from "../sequencedLambda";
 
@@ -105,7 +104,8 @@ export class ForemanLambda extends SequencedLambda {
                         type: "tasks:start",
                     },
                 );
-                winston.info(`Request to ${queueName}: ${tenantId}/${docId}/${clientId}:${JSON.stringify(tasks)}`);
+                this.context.log.info(
+                    `Request to ${queueName}: ${tenantId}/${docId}/${clientId}:${JSON.stringify(tasks)}`);
             }
         }
     }

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -109,6 +109,7 @@ export class ScribeLambda extends SequencedLambda {
                 this.minSequenceNumber = value.operation.minimumSequenceNumber;
 
                 if (msnChanged) {
+                    // When the MSN changes we can process up to it to save space
                     this.processFromPending(this.minSequenceNumber);
                 }
 
@@ -418,7 +419,6 @@ export class ScribeLambda extends SequencedLambda {
         };
 
         await this.sendToDeli(operation);
-        this.context.log.info(`Sent summaryAck for sequenceNumber: ${summarySequenceNumber}`);
     }
 
     private async sendSummaryNack(summarySequenceNumber: number, errorMessage: string) {
@@ -436,7 +436,6 @@ export class ScribeLambda extends SequencedLambda {
         };
 
         await this.sendToDeli(operation);
-        this.context.log.info(`Sent summaryNack for sequenceNumber: ${summarySequenceNumber}`);
     }
 
     // eslint-disable-next-line @typescript-eslint/promise-function-async

--- a/server/routerlicious/packages/lambdas/src/test/webpack.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/webpack.spec.ts
@@ -36,9 +36,6 @@ const options: webpack.Configuration = {
         library: 'FluidLambdasTest',
         libraryTarget: 'umd',
     },
-    node: {
-        fs: "empty",
-    },
 };
 
 

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -49,8 +49,7 @@
     "@microsoft/fluid-server-lambdas": "^0.1002.0",
     "@microsoft/fluid-server-memory-orderer": "^0.1002.0",
     "@microsoft/fluid-server-services-core": "^0.1002.0",
-    "@microsoft/fluid-server-test-utils": "^0.1002.0",
-    "winston": "^3.1.0"
+    "@microsoft/fluid-server-test-utils": "^0.1002.0"
   },
   "devDependencies": {
     "@types/debug": "^0.0.31",

--- a/server/routerlicious/packages/local-server/src/testDeltaConnectionServer.ts
+++ b/server/routerlicious/packages/local-server/src/testDeltaConnectionServer.ts
@@ -25,16 +25,10 @@ import {
     TestTenantManager,
     TestWebSocketServer,
     TestClientManager,
+    DebugLogger,
 } from "@microsoft/fluid-server-test-utils";
 import { configureWebSocketServices} from "@microsoft/fluid-server-lambdas";
-import * as winston from "winston";
 import { TestReservationManager } from "./testReservationManager";
-
-winston.configure({
-    transports: [
-        new winston.transports.Console(),
-    ],
-});
 
 /**
  * Items needed for handling deltas.
@@ -143,7 +137,8 @@ export class TestDeltaConnectionServer implements ITestDeltaConnectionServer {
             testStorage,
             testDbFactory.testDatabase.collection("ops"),
             new TestClientManager(),
-            new DefaultMetricClient());
+            new DefaultMetricClient(),
+            DebugLogger.create("fluid-server:TestDeltaConnectionServer"));
 
         return new TestDeltaConnectionServer(webSocketServer, databaseManager, testOrderer, testDbFactory);
     }

--- a/server/routerlicious/packages/local-server/src/testDeltaConnectionServer.ts
+++ b/server/routerlicious/packages/local-server/src/testDeltaConnectionServer.ts
@@ -110,6 +110,8 @@ export class TestDeltaConnectionServer implements ITestDeltaConnectionServer {
             databaseManager,
             testTenantManager);
 
+        const logger = DebugLogger.create("fluid-server:TestDeltaConnectionServer");
+
         const nodeFactory = new LocalNodeFactory(
             "os",
             "http://localhost:4000", // Unused placeholder url
@@ -120,7 +122,8 @@ export class TestDeltaConnectionServer implements ITestDeltaConnectionServer {
             new TestTaskMessageSender(),
             testTenantManager,
             {},
-            16 * 1024);
+            16 * 1024,
+            logger);
 
         const reservationManager = new TestReservationManager(
             nodeFactory,
@@ -138,7 +141,7 @@ export class TestDeltaConnectionServer implements ITestDeltaConnectionServer {
             testDbFactory.testDatabase.collection("ops"),
             new TestClientManager(),
             new DefaultMetricClient(),
-            DebugLogger.create("fluid-server:TestDeltaConnectionServer"));
+            logger);
 
         return new TestDeltaConnectionServer(webSocketServer, databaseManager, testOrderer, testDbFactory);
     }

--- a/server/routerlicious/packages/local-server/webpack.config.js
+++ b/server/routerlicious/packages/local-server/webpack.config.js
@@ -34,7 +34,4 @@ module.exports = {
     devServer: {
         publicPath: '/dist'
     },
-    node: {
-      fs: "empty",
-    },
 };

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -31,6 +31,7 @@
     "@microsoft/fluid-server-lambdas": "^0.1002.0",
     "@microsoft/fluid-server-services-client": "^0.1002.0",
     "@microsoft/fluid-server-services-core": "^0.1002.0",
+    "@microsoft/fluid-server-test-utils": "^0.1002.0",
     "@types/debug": "^0.0.31",
     "@types/double-ended-queue": "^2.1.0",
     "@types/lodash": "^4.14.118",

--- a/server/routerlicious/packages/memory-orderer/src/localNode.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localNode.ts
@@ -15,6 +15,7 @@ import {
     ITaskMessageSender,
     ITenantManager,
     IWebSocketServer,
+    ILogger,
 } from "@microsoft/fluid-server-services-core";
 import * as _ from "lodash";
 import * as moniker from "moniker";
@@ -75,7 +76,8 @@ export class LocalNode extends EventEmitter implements IConcreteNode {
         taskMessageSender: ITaskMessageSender,
         tenantManager: ITenantManager,
         permission: any,
-        maxMessageSize: number) {
+        maxMessageSize: number,
+        logger: ILogger) {
 
         // Look up any existing information for the node or create a new one
         const node = await LocalNode.create(
@@ -93,7 +95,8 @@ export class LocalNode extends EventEmitter implements IConcreteNode {
             taskMessageSender,
             tenantManager,
             permission,
-            maxMessageSize);
+            maxMessageSize,
+            logger);
     }
 
     private static async create(
@@ -160,7 +163,8 @@ export class LocalNode extends EventEmitter implements IConcreteNode {
         private readonly taskMessageSender: ITaskMessageSender,
         private readonly tenantManager: ITenantManager,
         private readonly permission: any,
-        private readonly maxMessageSize: number) {
+        private readonly maxMessageSize: number,
+        private readonly logger: ILogger) {
         super();
 
         // Schedule the first heartbeat to update the reservation
@@ -247,7 +251,8 @@ export class LocalNode extends EventEmitter implements IConcreteNode {
             this.taskMessageSender,
             this.tenantManager,
             this.permission,
-            this.maxMessageSize);
+            this.maxMessageSize,
+            this.logger);
         assert(!this.orderMap.has(fullId));
         this.orderMap.set(fullId, orderer);
 

--- a/server/routerlicious/packages/memory-orderer/src/localNodeFactory.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localNodeFactory.ts
@@ -9,6 +9,7 @@ import {
     ITaskMessageSender,
     ITenantManager,
     IWebSocketServer,
+    ILogger,
 } from "@microsoft/fluid-server-services-core";
 // eslint-disable-next-line import/no-internal-modules
 import * as uuid from "uuid/v4";
@@ -26,7 +27,8 @@ export class LocalNodeFactory implements IConcreteNodeFactory {
         private readonly taskMessageSender: ITaskMessageSender,
         private readonly tenantManager: ITenantManager,
         private readonly permission: any,
-        private readonly maxMessageSize: number) {
+        private readonly maxMessageSize: number,
+        private readonly logger: ILogger) {
     }
 
     public async create(): Promise<LocalNode> {
@@ -40,7 +42,8 @@ export class LocalNodeFactory implements IConcreteNodeFactory {
             this.taskMessageSender,
             this.tenantManager,
             this.permission,
-            this.maxMessageSize);
+            this.maxMessageSize,
+            this.logger);
 
         return node;
     }

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -34,7 +34,6 @@ import {
     IQueuedMessage,
     ILogger,
 } from "@microsoft/fluid-server-services-core";
-import { DebugLogger } from "@microsoft/fluid-server-test-utils";
 import { ILocalOrdererSetup } from "./interfaces";
 import { LocalKafka } from "./localKafka";
 import { LocalLambdaController } from "./localLambdaController";
@@ -142,6 +141,8 @@ class LocalSocketPublisher implements IPublisher {
 
 // Want a pure local orderer that can do all kinds of stuff
 class LocalContext implements IContext {
+    constructor(public readonly log: ILogger) {}
+
     public checkpoint(queuedMessage: IQueuedMessage) {
         return;
     }
@@ -149,8 +150,6 @@ class LocalContext implements IContext {
     public error(error: any, restart: boolean) {
         return;
     }
-
-    public readonly log: ILogger = DebugLogger.create("fluid-server:LocalContext");
 }
 
 /**
@@ -166,6 +165,7 @@ export class LocalOrderer implements IOrderer {
         tenantManager: ITenantManager,
         permission: any,
         maxMessageSize: number,
+        logger: ILogger,
         gitManager?: IGitManager,
         setup: ILocalOrdererSetup = new LocalOrdererSetup(
             tenantId,
@@ -174,11 +174,11 @@ export class LocalOrderer implements IOrderer {
             databaseManager,
             gitManager),
         pubSub: IPubSub = new PubSub(),
-        broadcasterContext: IContext = new LocalContext(),
-        scriptoriumContext: IContext = new LocalContext(),
-        foremanContext: IContext = new LocalContext(),
-        scribeContext: IContext = new LocalContext(),
-        deliContext: IContext = new LocalContext(),
+        broadcasterContext: IContext = new LocalContext(logger),
+        scriptoriumContext: IContext = new LocalContext(logger),
+        foremanContext: IContext = new LocalContext(logger),
+        scribeContext: IContext = new LocalContext(logger),
+        deliContext: IContext = new LocalContext(logger),
         clientTimeout: number = ClientSequenceTimeout,
         serviceConfiguration = DefaultServiceConfiguration,
         scribeNackOnSummarizeException = false,

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -32,7 +32,9 @@ import {
     ITopic,
     IWebSocket,
     IQueuedMessage,
+    ILogger,
 } from "@microsoft/fluid-server-services-core";
+import { DebugLogger } from "@microsoft/fluid-server-test-utils";
 import { ILocalOrdererSetup } from "./interfaces";
 import { LocalKafka } from "./localKafka";
 import { LocalLambdaController } from "./localLambdaController";
@@ -147,6 +149,8 @@ class LocalContext implements IContext {
     public error(error: any, restart: boolean) {
         return;
     }
+
+    public readonly log: ILogger = DebugLogger.create("fluid-server:LocalContext");
 }
 
 /**

--- a/server/routerlicious/packages/routerlicious/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious/src/alfred/runner.ts
@@ -68,7 +68,8 @@ export class AlfredRunner implements utils.IRunner {
             this.storage,
             this.contentCollection,
             this.clientManager,
-            createMetricClient(this.metricClientConfig));
+            createMetricClient(this.metricClientConfig),
+            winston);
 
         // Listen on provided port, on all network interfaces.
         httpServer.listen(this.port);

--- a/server/routerlicious/packages/routerlicious/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious/src/alfred/runnerFactory.ts
@@ -197,7 +197,8 @@ export class AlfredResourcesFactory implements utils.IResourcesFactory<AlfredRes
             taskMessageSender,
             tenantManager,
             foremanConfig.permissions,
-            maxSendMessageSize);
+            maxSendMessageSize,
+            winston);
         const localOrderManager = new LocalOrderManager(nodeFactory, reservationManager);
         const kafkaOrdererFactory = new KafkaOrdererFactory(
             producer,

--- a/server/routerlicious/packages/routerlicious/src/test/alfred/io.spec.ts
+++ b/server/routerlicious/packages/routerlicious/src/test/alfred/io.spec.ts
@@ -86,7 +86,7 @@ describe("Routerlicious", () => {
                         contentCollection,
                         testClientManager,
                         new DefaultMetricClient(),
-                        DebugLogger.create("fluid-test:TestAlfredIO"));
+                        DebugLogger.create("fluid-server:TestAlfredIO"));
                 });
 
                 function connectToServer(

--- a/server/routerlicious/packages/routerlicious/src/test/alfred/io.spec.ts
+++ b/server/routerlicious/packages/routerlicious/src/test/alfred/io.spec.ts
@@ -25,6 +25,7 @@ import {
     TestTenantManager,
     TestWebSocket,
     TestWebSocketServer,
+    DebugLogger,
 } from "@microsoft/fluid-server-test-utils";
 import * as assert from "assert";
 import { OrdererManager } from "../../alfred/runnerFactory";
@@ -84,7 +85,8 @@ describe("Routerlicious", () => {
                         testStorage,
                         contentCollection,
                         testClientManager,
-                        new DefaultMetricClient());
+                        new DefaultMetricClient(),
+                        DebugLogger.create("fluid-test:TestAlfredIO"));
                 });
 
                 function connectToServer(

--- a/server/routerlicious/packages/services-core/src/lambdas.ts
+++ b/server/routerlicious/packages/services-core/src/lambdas.ts
@@ -9,6 +9,12 @@ import * as nconf from "nconf";
 import { BoxcarType, IBoxcarMessage, IMessage } from "./messages";
 import { IQueuedMessage } from "./queue";
 
+export interface ILogger {
+    info(message: string): void;
+    warn(message: string): void;
+    error(message: string): void;
+}
+
 export interface IContext {
     /**
      * Updates the checkpoint
@@ -20,6 +26,11 @@ export interface IContext {
      * should be restarted.
      */
     error(error: any, restart: boolean): void;
+
+    /**
+     * Used to log events / errors.
+     */
+    readonly log: ILogger;
 }
 
 export interface IPartitionLambda {

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -29,6 +29,7 @@
     "@microsoft/fluid-protocol-definitions": "^0.1002.0",
     "@microsoft/fluid-server-services-client": "^0.1002.0",
     "@microsoft/fluid-server-services-core": "^0.1002.0",
+    "debug": "^4.1.1",
     "lodash": "^4.17.11",
     "moniker": "^0.1.2",
     "string-hash": "^1.1.3",

--- a/server/routerlicious/packages/test-utils/src/index.ts
+++ b/server/routerlicious/packages/test-utils/src/index.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+export * from "./logger";
 export * from "./messageFactory";
 export * from "./testClientManager";
 export * from "./testCollection";

--- a/server/routerlicious/packages/test-utils/src/logger.ts
+++ b/server/routerlicious/packages/test-utils/src/logger.ts
@@ -1,0 +1,48 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as registerDebug from "debug";
+import { ILogger } from "@microsoft/fluid-server-services-core";
+
+/**
+ * Implementation of debug logger
+ */
+export class DebugLogger implements ILogger {
+    /**
+     * Create logger - all events are output to debug npm library
+     * @param namespace - Telemetry event name prefix to add to all events
+     */
+    public static create(namespace: string): ILogger {
+        const debugInfo = registerDebug(namespace);
+
+        const debugWarn = registerDebug(namespace);
+        debugWarn.log = console.warn.bind(console);
+        debugWarn.enabled = true;
+
+        const debugErr = registerDebug(namespace);
+        debugErr.log = console.error.bind(console);
+        debugErr.enabled = true;
+
+        return new DebugLogger(debugInfo, debugErr, debugWarn);
+    }
+
+    constructor(
+        private readonly debugInfo: registerDebug.IDebugger,
+        private readonly debugErr: registerDebug.IDebugger,
+        private readonly debugWarn: registerDebug.IDebugger) {
+    }
+
+    public info(message: string) {
+        this.debugInfo(message);
+    }
+
+    public warn(message: string) {
+        this.debugWarn(message);
+    }
+
+    public error(message: string) {
+        this.debugErr(message);
+    }
+}

--- a/server/routerlicious/packages/test-utils/src/testContext.ts
+++ b/server/routerlicious/packages/test-utils/src/testContext.ts
@@ -37,7 +37,7 @@ export class TestContext extends EventEmitter implements IContext {
         this.emit("error", error, restart);
     }
 
-    public readonly log: ILogger = DebugLogger.create("fluid-test:TestContext");
+    public readonly log: ILogger = DebugLogger.create("fluid-server:TestContext");
 
     // eslint-disable-next-line @typescript-eslint/promise-function-async
     public waitForOffset(value: number): Promise<void> {

--- a/server/routerlicious/packages/test-utils/src/testContext.ts
+++ b/server/routerlicious/packages/test-utils/src/testContext.ts
@@ -6,7 +6,8 @@
 import * as assert from "assert";
 import { EventEmitter } from "events";
 import { Deferred } from "@microsoft/fluid-core-utils";
-import { IContext, IQueuedMessage } from "@microsoft/fluid-server-services-core";
+import { IContext, IQueuedMessage, ILogger } from "@microsoft/fluid-server-services-core";
+import { DebugLogger } from "./logger";
 
 interface IWaitOffset {
     deferred: Deferred<void>;
@@ -35,6 +36,8 @@ export class TestContext extends EventEmitter implements IContext {
     public error(error: any, restart: boolean) {
         this.emit("error", error, restart);
     }
+
+    public readonly log: ILogger = DebugLogger.create("fluid-test:TestContext");
 
     // eslint-disable-next-line @typescript-eslint/promise-function-async
     public waitForOffset(value: number): Promise<void> {

--- a/server/routerlicious/packages/test-utils/src/testContext.ts
+++ b/server/routerlicious/packages/test-utils/src/testContext.ts
@@ -18,6 +18,10 @@ export class TestContext extends EventEmitter implements IContext {
     public offset: number = Number.NEGATIVE_INFINITY;
     private waits: IWaitOffset[] = [];
 
+    constructor(public readonly log: ILogger = DebugLogger.create("fluid-server:TestContext")) {
+        super();
+    }
+
     public checkpoint(queuedMessage: IQueuedMessage) {
         assert(queuedMessage.offset > this.offset, `${queuedMessage.offset} > ${this.offset}`);
         this.offset = queuedMessage.offset;
@@ -36,8 +40,6 @@ export class TestContext extends EventEmitter implements IContext {
     public error(error: any, restart: boolean) {
         this.emit("error", error, restart);
     }
-
-    public readonly log: ILogger = DebugLogger.create("fluid-server:TestContext");
 
     // eslint-disable-next-line @typescript-eslint/promise-function-async
     public waitForOffset(value: number): Promise<void> {


### PR DESCRIPTION
Fixes #1210 

- Removed winston from server lambdas and replaced with a logging abstraction in IContext. To log, we can now use context.log.info, context.log.warn or context.log.error. Each of these methods accept a string as param.
- Removed winston dependency from local-server.
- Removed empty fs from local-server consumers.