### PR TITLE
Fix fluid fetch

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/odspUtils.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspUtils.ts
@@ -132,7 +132,7 @@ export function fetchHelper(
     requestInfo: RequestInfo,
     requestInit: RequestInit | undefined,
     retryFilter: RetryFilter = defaultRetryFilter,
-): Promise<any> {
+): Promise<IOdspResponse<any>> {
     // Node-fetch and dom have conflicting typing, force them to work by casting for now
     return fetch(requestInfo as FetchRequestInfo, requestInit as FetchRequestInit).then(async (fetchResponse) => {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
@@ -152,13 +152,14 @@ export function fetchHelper(
         // succeeds on retry.
         try {
             const text = await response.text();
+            response.headers.set("body-size", text.length.toString());
             const res = {
-                headers: new Headers({ ...response.headers, "body-size": text.length }),
+                headers: response.headers,
                 content: JSON.parse(text),
             };
             return res;
         } catch (e) {
-            throwOdspNetworkError(`Error while parsing fetch response`, 400, true, response);
+            throwOdspNetworkError(`Error while parsing fetch response: ${e}`, 400, true, response);
         }
     }, (error) => {
         // While we do not know for sure whether computer is offline, this error is not actionable and


### PR DESCRIPTION
Fluid fetch fails because there is no "new Headers()" construct available in node.js environment.

Also error messages are not descriptive, so hard to figure out what went wrong - fixing this.
Also add type info and cleanup a bit join session code to pass around only resulting object, not whole response