### PR TITLE
Change hostRuntime in ComponentContext from ContainerRuntime to IHostRuntime

### DIFF
--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -39,7 +39,6 @@ import {
 import { SummaryTracker } from "@microsoft/fluid-runtime-utils";
 // eslint-disable-next-line import/no-internal-modules
 import * as uuid from "uuid/v4";
-import { ContainerRuntime } from "./containerRuntime";
 
 // Snapshot Format Version to be used in component attributes.
 const currentSnapshotFormatVersion = "0.1";
@@ -146,7 +145,7 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
     private _baseSnapshot: ISnapshotTree;
 
     constructor(
-        private readonly _hostRuntime: ContainerRuntime,
+        private readonly _hostRuntime: IHostRuntime,
         public readonly id: string,
         public readonly existing: boolean,
         public readonly storage: IDocumentStorageService,
@@ -434,7 +433,7 @@ export class RemotedComponentContext extends ComponentContext {
     constructor(
         id: string,
         private readonly initSnapshotValue: ISnapshotTree | string,
-        runtime: ContainerRuntime,
+        runtime: IHostRuntime,
         storage: IDocumentStorageService,
         scope: IComponent,
         pkg?: string[],
@@ -512,7 +511,7 @@ export class LocalComponentContext extends ComponentContext {
     constructor(
         id: string,
         pkg: string[],
-        runtime: ContainerRuntime,
+        runtime: IHostRuntime,
         storage: IDocumentStorageService,
         scope: IComponent,
         attachCb: (componentRuntime: IComponentRuntime) => void,


### PR DESCRIPTION
Fixes #1202 .

ComponentContext has a member of type ContainerRuntime. However, it does not need the entire object so it is changed to IHostRuntime.