### PR TITLE
Bugfix: Kafka host and docker-compose context.

### DIFF
--- a/server/routerlicious/docker-compose.yml
+++ b/server/routerlicious/docker-compose.yml
@@ -11,8 +11,9 @@ services:
         restart: always
     alfred:
         build:
-            context: .
-            dockerfile: ./r11s-Dockerfile
+            context: ../..
+            dockerfile: server/routerlicious/r11s-Dockerfile
+            target: runner
         ports:
             - "3003:3000"
         command: node dist/alfred/www.js
@@ -22,8 +23,9 @@ services:
         restart: always
     deli:
         build:
-            context: .
-            dockerfile: ./r11s-Dockerfile
+            context: ../..
+            dockerfile: server/routerlicious/r11s-Dockerfile
+            target: runner
         command: node dist/kafka-service/index.js deli /usr/src/server/server/routerlicious/packages/routerlicious/dist/deli/index.js
         environment:
             - DEBUG=fluid:*
@@ -31,8 +33,9 @@ services:
         restart: always
     scriptorium:
         build:
-            context: .
-            dockerfile: ./r11s-Dockerfile
+            context: ../..
+            dockerfile: server/routerlicious/r11s-Dockerfile
+            target: runner
         command: node dist/kafka-service/index.js scriptorium /usr/src/server/server/routerlicious/packages/routerlicious/dist/scriptorium/index.js
         environment:
             - DEBUG=fluid:*
@@ -40,8 +43,9 @@ services:
         restart: always
     copier:
         build:
-            context: .
-            dockerfile: ./r11s-Dockerfile
+            context: ../..
+            dockerfile: server/routerlicious/r11s-Dockerfile
+            target: runner
         command: node dist/kafka-service/index.js copier /usr/src/server/server/routerlicious/packages/routerlicious/dist/copier/index.js
         environment:
             - DEBUG=fluid:*
@@ -49,8 +53,9 @@ services:
         restart: always
     broadcaster:
         build:
-            context: .
-            dockerfile: ./r11s-Dockerfile
+            context: ../..
+            dockerfile: server/routerlicious/r11s-Dockerfile
+            target: runner
         command: node dist/kafka-service/index.js broadcaster /usr/src/server/server/routerlicious/packages/routerlicious/dist/broadcaster/index.js
         environment:
             - DEBUG=fluid:*
@@ -58,8 +63,9 @@ services:
         restart: always
     scribe:
         build:
-            context: .
-            dockerfile: ./r11s-Dockerfile
+            context: ../..
+            dockerfile: server/routerlicious/r11s-Dockerfile
+            target: runner
         command: node dist/kafka-service/index.js scribe /usr/src/server/server/routerlicious/packages/routerlicious/dist/scribe/index.js
         environment:
             - DEBUG=fluid:*
@@ -67,8 +73,9 @@ services:
         restart: always
     foreman:
         build:
-            context: .
-            dockerfile: ./r11s-Dockerfile
+            context: ../..
+            dockerfile: server/routerlicious/r11s-Dockerfile
+            target: runner
         command: node dist/kafka-service/index.js foreman /usr/src/server/server/routerlicious/packages/routerlicious/dist/foreman/index.js
         environment:
             - DEBUG=fluid:*
@@ -76,8 +83,9 @@ services:
         restart: always
     routemaster:
         build:
-            context: .
-            dockerfile: ./r11s-Dockerfile
+            context: ../..
+            dockerfile: server/routerlicious/r11s-Dockerfile
+            target: runner
         command: node dist/kafka-service/index.js routemaster /usr/src/server/server/routerlicious/packages/lambdas-driver/dist/document-router/index.js
         environment:
             - DEBUG=fluid:*
@@ -86,8 +94,9 @@ services:
         restart: always
     riddler:
         build:
-            context: .
-            dockerfile: ./r11s-Dockerfile
+            context: ../..
+            dockerfile: server/routerlicious/r11s-Dockerfile
+            target: runner
         ports:
             - "5000:5000"
         command: node dist/riddler/www.js

--- a/server/routerlicious/kubernetes/jarvis/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/jarvis/templates/fluid-configmap.yaml
@@ -34,7 +34,7 @@ data:
             "endpoint": "{{ .Values.kafka.url }}:9092",
             "lib": {
                 "name": "kafka-node",
-                "endpoint": "{{ .Values.zookeeper.url }}"
+                "endpoint": "{{ .Values.kafka.url }}"
             },
             "maxMessageSize": "1MB"
         },

--- a/server/routerlicious/kubernetes/jarvis/values.yaml
+++ b/server/routerlicious/kubernetes/jarvis/values.yaml
@@ -56,7 +56,7 @@ redis:
   tls: false
 
 kafka:
-  url: youngling-heron-kafka
+  url: youngling-heron-kafka:9092
   topics:
     rawdeltas: rawdeltas2
     deltas: deltas2

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -37,7 +37,7 @@ data:
         "kafka": {
             "lib": {
                 "name": "kafka-node",
-                "endpoint": "{{ .Values.zookeeper.url }}"
+                "endpoint": "{{ .Values.kafka.url }}"
             },
             "maxMessageSize": "1MB"
         },

--- a/server/routerlicious/kubernetes/tools/generateChart.js
+++ b/server/routerlicious/kubernetes/tools/generateChart.js
@@ -142,6 +142,7 @@ kafka:
   topics:
     rawdeltas: rawdeltas
     deltas: deltas
+  url: left-numbat-kafka:9092
 
 minio:
   externalUrl: https://minio.wu2.prague.office-int.com

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -26,7 +26,7 @@
     "kafka": {
         "lib": {
             "name": "kafka-node",
-            "endpoint": "zookeeper:2181"
+            "endpoint": "kafka:9092"
         },
         "maxMessageSize": "1MB"
     },

--- a/server/routerlicious/packages/services-utils/src/README.md
+++ b/server/routerlicious/packages/services-utils/src/README.md
@@ -8,7 +8,7 @@ We defined generic kafka interfaces (IProducer and IConsumer) that can be implem
 kafka": {
     "lib": {
         "name": "kafka-node",
-        "endpoint": "zookeeper:2181"
+        "endpoint": "kafka:9092"
     }
 }
 ```


### PR DESCRIPTION
1. PR #1255 updated kafka-node library version which now requires kafka broker address. But we were still using zookeeper.
2. Updated docker-compose file to fix the build