### PR TITLE
Remove empty fs from local-server consumers.

### DIFF
--- a/packages/hosts/local-web-host/webpack.config.js
+++ b/packages/hosts/local-web-host/webpack.config.js
@@ -35,7 +35,6 @@ module.exports = env => {
         devtool: "source-map",
         watch: env != "build",
         node: {
-            fs: "empty",
             dgram: "empty",
             net: "empty",
             tls: "empty"

--- a/packages/server/local-test-utils/webpack.config.js
+++ b/packages/server/local-test-utils/webpack.config.js
@@ -34,7 +34,4 @@ module.exports = {
     devServer: {
         publicPath: '/dist'
     },
-    node: {
-      fs: "empty",
-    },
 };

--- a/packages/tools/webpack-component-loader/webpack.config.js
+++ b/packages/tools/webpack-component-loader/webpack.config.js
@@ -34,7 +34,4 @@ module.exports = {
     library: 'FluidLoader',
     libraryTarget: 'umd',
   },
-  node: {
-    fs: "empty",
-  },
 };


### PR DESCRIPTION
Fixes #1210 
Follow up to #1265 that removed winston dependency from local-server. This change removes empty fs (which was needed for winston) from the consumers of local-server.