### PR TITLE
ODSP driver should emit ES2017 code

### DIFF
--- a/packages/drivers/odsp-socket-storage/tsconfig.json
+++ b/packages/drivers/odsp-socket-storage/tsconfig.json
@@ -5,7 +5,6 @@
         "node_modules"
     ],
     "compilerOptions": {
-        "target": "es2016",
         "strict": true,
         "rootDir": "./src",
         "outDir": "./dist",


### PR DESCRIPTION
We want the code that runs in the browser to be in ES2017 format so that async/await code is not transpiled and easier to debug in the dev tools. This change was made a few months ago, but the odsp driver package overrides the base tsconfig here. Removing that override.