### PR TITLE
container-runtime: Friendly error msg on missing pkg registration

### DIFF
--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -182,7 +182,7 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
         }
 
         if (!entry) {
-            throw new Error("Registry does not contain entry for the package");
+            throw new Error(`Registry does not contain entry for package '${pkgName}'`);
         }
 
         return this.hostRuntime._createComponentWithProps(packagePath, props, id);
@@ -207,7 +207,7 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
                 }
                 entry = await registry.get(pkg);
                 if (!entry) {
-                    this.componentRuntimeDeferred.reject("Registry does not contain an entry for the package");
+                    this.componentRuntimeDeferred.reject(`Registry does not contain entry for package '${pkg}'`);
                     return this.componentRuntimeDeferred.promise;
                 }
                 factory = entry.IComponentFactory;


### PR DESCRIPTION
Forgetting to register packages is a common mistake.

Putting the package name in the error message saves some time in the debugger.