### PR TITLE
Rename TestDeltaConnectionServer to LocalDeltaConnectionServer in local-server - part 1

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -15,7 +15,7 @@ The package name is changed to `fluid-common-utils` to make it parallel to `flui
 
 ### `fluid-local-test-server` package move and rename
 
-The following classes / interfaces in have moved from `@microsoft/fluid-local-test-server` to `@microsoft/fluid-test-driver` in `./packages`:
+The following classes / interfaces have moved from `@microsoft/fluid-local-test-server` to `@microsoft/fluid-test-driver` in `./packages`:
 
 ```text
 DocumentDeltaEventManager
@@ -25,12 +25,11 @@ TestDocumentServiceFactory
 TestResolver
 ```
 
-The following classes / interfaces have moved from `@microsoft/fluid-local-test-server` in `./packages` to `@microsoft/fluid-server-local-server` in `./server`:
-
+The following classes / interfaces have been renamed and have moved from `@microsoft/fluid-local-test-server` in `./packages` to `@microsoft/fluid-server-local-server` in `./server`:
 ```text
-ITestDeltaConnectionServer
-TestDeltaConnectionServer
-TestReservationManager
+ITestDeltaConnectionServer -> ILocalDeltaConnectionServer
+TestDeltaConnectionServer -> LocalDeltaConnectionServer
+TestReservationManager -> LocalReservationManager
 ```
 
 The following packages have been renamed in `./packages`:

--- a/server/routerlicious/packages/local-server/src/index.ts
+++ b/server/routerlicious/packages/local-server/src/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export * from "./testDeltaConnectionServer";
-export * from "./testReservationManager";
+export * from "./localDeltaConnectionServer";
+export * from "./localReservationManager";

--- a/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
+++ b/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
@@ -28,12 +28,12 @@ import {
     DebugLogger,
 } from "@microsoft/fluid-server-test-utils";
 import { configureWebSocketServices} from "@microsoft/fluid-server-lambdas";
-import { TestReservationManager } from "./testReservationManager";
+import { LocalReservationManager } from "./localReservationManager";
 
 /**
  * Items needed for handling deltas.
  */
-export interface ITestDeltaConnectionServer {
+export interface ILocalDeltaConnectionServer {
     webSocketServer: IWebSocketServer;
     databaseManager: IDatabaseManager;
     testDbFactory: ITestDbFactory;
@@ -41,7 +41,7 @@ export interface ITestDeltaConnectionServer {
 }
 
 /**
- * Implementation of order manager for testing.
+ * Implementation of order manager.
  */
 class TestOrderManager implements IOrdererManager {
     private readonly orderersP: Promise<IOrderer>[] = [];
@@ -82,13 +82,13 @@ class TestOrderManager implements IOrdererManager {
 }
 
 /**
- * Implementation of delta connection server for testing.
+ * Implementation of local delta connection server.
  */
-export class TestDeltaConnectionServer implements ITestDeltaConnectionServer {
+export class LocalDeltaConnectionServer implements ILocalDeltaConnectionServer {
     /**
-     * Creates and returns a delta connection server for testing.
+     * Creates and returns a local delta connection server.
      */
-    public static create(testDbFactory: ITestDbFactory = new TestDbFactory({})): ITestDeltaConnectionServer {
+    public static create(testDbFactory: ITestDbFactory = new TestDbFactory({})): ILocalDeltaConnectionServer {
         const nodesCollectionName = "nodes";
         const documentsCollectionName = "documents";
         const deltasCollectionName = "deltas";
@@ -110,7 +110,7 @@ export class TestDeltaConnectionServer implements ITestDeltaConnectionServer {
             databaseManager,
             testTenantManager);
 
-        const logger = DebugLogger.create("fluid-server:TestDeltaConnectionServer");
+        const logger = DebugLogger.create("fluid-server:LocalDeltaConnectionServer");
 
         const nodeFactory = new LocalNodeFactory(
             "os",
@@ -125,7 +125,7 @@ export class TestDeltaConnectionServer implements ITestDeltaConnectionServer {
             16 * 1024,
             logger);
 
-        const reservationManager = new TestReservationManager(
+        const reservationManager = new LocalReservationManager(
             nodeFactory,
             mongoManager,
             reservationsCollectionName);
@@ -143,7 +143,7 @@ export class TestDeltaConnectionServer implements ITestDeltaConnectionServer {
             new DefaultMetricClient(),
             logger);
 
-        return new TestDeltaConnectionServer(webSocketServer, databaseManager, testOrderer, testDbFactory);
+        return new LocalDeltaConnectionServer(webSocketServer, databaseManager, testOrderer, testDbFactory);
     }
 
     private constructor(

--- a/server/routerlicious/packages/local-server/src/localReservationManager.ts
+++ b/server/routerlicious/packages/local-server/src/localReservationManager.ts
@@ -12,7 +12,7 @@ import {
 } from "@microsoft/fluid-server-memory-orderer";
 import { ICollection, MongoManager } from "@microsoft/fluid-server-services-core";
 
-export class TestReservationManager extends EventEmitter implements IReservationManager {
+export class LocalReservationManager extends EventEmitter implements IReservationManager {
     constructor(
         private readonly nodeFactory: IConcreteNodeFactory,
         private readonly mongoManager: MongoManager,


### PR DESCRIPTION
Fixes #1338 

Renamed TestDeltaConnectionServer and other related classes in local-server with local prefix instead of test since these are used in scenarios other than testing.
A follow up change will update the consumers to use the new name.