### PR TITLE
Aqueduct: Typing fixes.

### DIFF
--- a/examples/components/vltava/src/components/anchor/anchor.ts
+++ b/examples/components/vltava/src/components/anchor/anchor.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-    IComponent,
     IComponentHandle,
     IComponentHTMLVisual,
     IProvideComponentHTMLVisual,
@@ -37,8 +36,8 @@ export class Anchor extends PrimedComponent implements IProvideComponentHTMLVisu
     public get IComponentHTMLVisual() { return this.defaultComponent; }
 
     protected async componentInitializingFirstTime(props: any) {
-        const defaultComponent = await this.createAndAttachComponent<IComponent>(uuid(), "vltava");
-        this.root.set(this.defaultComponentId, defaultComponent.IComponentHandle);
+        const defaultComponent = await this.createAndAttachComponent(uuid(), "vltava");
+        this.root.set(this.defaultComponentId, defaultComponent.handle);
     }
 
     protected async componentHasInitialized() {

--- a/examples/components/vltava/src/components/vltava/vltava.tsx
+++ b/examples/components/vltava/src/components/vltava/vltava.tsx
@@ -4,7 +4,7 @@
  */
 
 import { PrimedComponent, PrimedComponentFactory } from "@microsoft/fluid-aqueduct";
-import { IComponent, IComponentHTMLView } from "@microsoft/fluid-component-core-interfaces";
+import { IComponentHTMLView } from "@microsoft/fluid-component-core-interfaces";
 
 import * as React from "react";
 import * as ReactDOM from "react-dom";
@@ -36,8 +36,8 @@ export class Vltava extends PrimedComponent implements IComponentHTMLView {
     public get IComponentHTMLView() { return this; }
 
     protected async componentInitializingFirstTime(props: any) {
-        const tabsComponent = await this.createAndAttachComponent<IComponent>(uuid(), "tabs");
-        this.root.set("tabs-component-id", tabsComponent.IComponentHandle);
+        const tabsComponent = await this.createAndAttachComponent(uuid(), "tabs");
+        this.root.set("tabs-component-id", tabsComponent.handle);
     }
 
     protected async componentHasInitialized() {

--- a/packages/components/webflow/src/document/index.ts
+++ b/packages/components/webflow/src/document/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import { randomId, TokenList, TagName } from "@fluid-example/flow-util-lib";
 import { PrimedComponent, PrimedComponentFactory } from "@microsoft/fluid-aqueduct";
 import { IComponent, IComponentHandle, IComponentHTMLOptions } from "@microsoft/fluid-component-core-interfaces";
@@ -84,7 +84,7 @@ export const getDocSegmentKind = (segment: ISegment): DocSegmentKind => {
 
                 // Ensure that 'nestEnd' range label matches the 'beginTags' range label (otherwise it
                 // will not close the range.)
-                assert.strictEqual(segment.getRangeLabels()[0], DocSegmentKind.beginTags, `Unknown refType '${markerType}'.`);
+                assert.equal(segment.getRangeLabels()[0], DocSegmentKind.beginTags, `Unknown refType '${markerType}'.`);
                 return DocSegmentKind.endTags;
         }
     }

--- a/packages/framework/aqueduct/src/components/sharedComponent.ts
+++ b/packages/framework/aqueduct/src/components/sharedComponent.ts
@@ -93,7 +93,7 @@ export abstract class SharedComponent extends EventEmitter implements IComponent
     /**
      * Given a request response will return a component if a component was in the response.
      */
-    protected async asComponent<T>(response: Promise<IResponse>): Promise<T> {
+    protected async asComponent<T extends IComponent>(response: Promise<IResponse>): Promise<T> {
         const result = await response;
 
         if (result.status === 200 && result.mimeType === "fluid/component") {
@@ -131,37 +131,38 @@ export abstract class SharedComponent extends EventEmitter implements IComponent
      * @param pkg - package name for the new component
      * @param props - optional props to be passed in
      */
-    protected async createAndAttachComponent<T>(id: string, pkg: string, props?: any): Promise<T> {
+    protected async createAndAttachComponent<T extends IComponentLoadable>(
+        id: string, pkg: string, props?: any,
+    ): Promise<T> {
         const componentRuntime = await this.context.hostRuntime._createComponentWithProps(pkg, props, id);
-        const component = await this.asComponent<IComponent>(componentRuntime.request({ url: "/" }));
+        const component = await this.asComponent<T>(componentRuntime.request({ url: "/" }));
         componentRuntime.attach();
-
-        return component as T;
+        return component;
     }
 
     /**
      * Gets the component of a given id. Will follow the pattern of the container for waiting.
      * @param id - component id
      */
-    protected async getComponent<T>(id: string, wait: boolean = true): Promise<T> {
+    protected async getComponent<T extends IComponent>(id: string, wait: boolean = true): Promise<T> {
         const request = {
             headers: [[wait]],
             url: `/${id}`,
         };
 
-        return this.asComponent(this.context.hostRuntime.request(request));
+        return this.asComponent<T>(this.context.hostRuntime.request(request));
     }
 
     /**
      * Gets the service at a given id.
      * @param id - service id
      */
-    protected async getService<T>(id: string): Promise<T> {
+    protected async getService<T extends IComponent>(id: string): Promise<T> {
         const request = {
             url:`/${serviceRoutePathRoot}/${id}`,
         };
 
-        return this.asComponent(this.context.hostRuntime.request(request));
+        return this.asComponent<T>(this.context.hostRuntime.request(request));
     }
 
     /**

--- a/packages/framework/aqueduct/src/components/sharedComponent.ts
+++ b/packages/framework/aqueduct/src/components/sharedComponent.ts
@@ -131,7 +131,7 @@ export abstract class SharedComponent extends EventEmitter implements IComponent
      * @param pkg - package name for the new component
      * @param props - optional props to be passed in
      */
-    protected async createAndAttachComponent<T extends IComponentLoadable>(
+    protected async createAndAttachComponent<T extends IComponent & IComponentLoadable>(
         id: string, pkg: string, props?: any,
     ): Promise<T> {
         const componentRuntime = await this.context.hostRuntime._createComponentWithProps(pkg, props, id);

--- a/packages/server/local-test-utils/src/sessionStorageTestDb.ts
+++ b/packages/server/local-test-utils/src/sessionStorageTestDb.ts
@@ -204,7 +204,6 @@ class SessionStorageCollection<T> implements ICollection<T> {
                 return value;
             }
         }
-        // eslint-disable-next-line no-null/no-null
         return null;
     }
 }

--- a/packages/server/local-test-utils/src/testHost.ts
+++ b/packages/server/local-test-utils/src/testHost.ts
@@ -55,7 +55,9 @@ class TestRootComponent extends PrimedComponent implements IComponentRunnable {
     public run = () => Promise.resolve();
 
     // Make this function public so TestHost can use them
-    public async createAndAttachComponent<T>(id: string, type: string, props?: any): Promise<T> {
+    public async createAndAttachComponent<T extends IComponentLoadable>(
+        id: string, type: string, props?: any,
+    ): Promise<T> {
         return super.createAndAttachComponent<T>(id, type, props);
     }
 


### PR DESCRIPTION
Narrows the return type of `asComponent`, `getComponent`, `getService` -> IComponent
Narrows the return type of `createAndAttachComponent` -> IComponentLoadable