### PR TITLE
Update consumers of local-server to use the new names - ILocalDeltaConnectionServer and LocalDeltaConnectionServer

### DIFF
--- a/packages/drivers/local-driver/src/documentEventManager.ts
+++ b/packages/drivers/local-driver/src/documentEventManager.ts
@@ -5,7 +5,7 @@
 
 import { IDeltaManager } from "@microsoft/fluid-container-definitions";
 import { IDocumentMessage, ISequencedDocumentMessage } from "@microsoft/fluid-protocol-definitions";
-import { ITestDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
+import { ILocalDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
 
 /**
  * Document delta event which must at least provide access
@@ -40,9 +40,9 @@ export class DocumentDeltaEventManager {
     }
 
     /**
-     * @param testDeltaConnectionServer - instance of delta connection server
+     * @param localDeltaConnectionServer - instance of delta connection server
      */
-    public constructor(private readonly testDeltaConnectionServer: ITestDeltaConnectionServer) { }
+    public constructor(private readonly localDeltaConnectionServer: ILocalDeltaConnectionServer) { }
 
     /**
      * Registers a collection of document delta events by adding them to
@@ -146,7 +146,7 @@ export class DocumentDeltaEventManager {
         let working: boolean;
         do {
             await DocumentDeltaEventManager.yieldEventLoop();
-            working = await this.testDeltaConnectionServer.hasPendingWork();
+            working = await this.localDeltaConnectionServer.hasPendingWork();
             if (!working) {
                 for (const doc of docs) {
                     if (hasWork(doc)) {

--- a/packages/drivers/local-driver/src/testDocumentService.ts
+++ b/packages/drivers/local-driver/src/testDocumentService.ts
@@ -8,7 +8,7 @@ import { ConnectionMode, IClient } from "@microsoft/fluid-protocol-definitions";
 import * as socketStorage from "@microsoft/fluid-routerlicious-driver";
 import { GitManager } from "@microsoft/fluid-server-services-client";
 import { TestHistorian } from "@microsoft/fluid-server-test-utils";
-import { ITestDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
+import { ILocalDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
 import { TestDeltaStorageService, TestDocumentDeltaConnection } from "./";
 
 /**
@@ -16,13 +16,13 @@ import { TestDeltaStorageService, TestDocumentDeltaConnection } from "./";
  */
 export class TestDocumentService implements api.IDocumentService {
     /**
-     * @param testDeltaConnectionServer - delta connection server for ops
+     * @param localDeltaConnectionServer - delta connection server for ops
      * @param tokenProvider - token provider with a single token
      * @param tenantId - ID of tenant
      * @param documentId - ID of document
      */
     constructor(
-        private readonly testDeltaConnectionServer: ITestDeltaConnectionServer,
+        private readonly localDeltaConnectionServer: ILocalDeltaConnectionServer,
         private readonly tokenProvider: socketStorage.TokenProvider,
         private readonly tenantId: string,
         private readonly documentId: string,
@@ -33,7 +33,7 @@ export class TestDocumentService implements api.IDocumentService {
      */
     public async connectToStorage(): Promise<api.IDocumentStorageService> {
         return new socketStorage.DocumentStorageService(this.documentId,
-            new GitManager(new TestHistorian(this.testDeltaConnectionServer.testDbFactory.testDatabase)));
+            new GitManager(new TestHistorian(this.localDeltaConnectionServer.testDbFactory.testDatabase)));
     }
 
     /**
@@ -43,7 +43,7 @@ export class TestDocumentService implements api.IDocumentService {
         return new TestDeltaStorageService(
             this.tenantId,
             this.documentId,
-            this.testDeltaConnectionServer.databaseManager);
+            this.localDeltaConnectionServer.databaseManager);
     }
 
     /**
@@ -59,7 +59,7 @@ export class TestDocumentService implements api.IDocumentService {
             this.documentId,
             this.tokenProvider.token,
             client,
-            this.testDeltaConnectionServer.webSocketServer,
+            this.localDeltaConnectionServer.webSocketServer,
             mode);
     }
 
@@ -82,16 +82,16 @@ export class TestDocumentService implements api.IDocumentService {
 
 /**
  * Creates and returns a document service for testing.
- * @param testDeltaConnectionServer - delta connection server for ops
+ * @param localDeltaConnectionServer - delta connection server for ops
  * @param tokenProvider - token provider with a single token
  * @param tenantId - ID of tenant
  * @param documentId - ID of document
  */
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export function createTestDocumentService(
-    testDeltaConnectionServer: ITestDeltaConnectionServer,
+    localDeltaConnectionServer: ILocalDeltaConnectionServer,
     tokenProvider: socketStorage.TokenProvider,
     tenantId: string,
     documentId: string): api.IDocumentService {
-    return new TestDocumentService(testDeltaConnectionServer, tokenProvider, tenantId, documentId);
+    return new TestDocumentService(localDeltaConnectionServer, tokenProvider, tenantId, documentId);
 }

--- a/packages/drivers/local-driver/src/testDocumentServiceFactory.ts
+++ b/packages/drivers/local-driver/src/testDocumentServiceFactory.ts
@@ -10,7 +10,7 @@ import {
     IResolvedUrl,
 } from "@microsoft/fluid-driver-definitions";
 import { TokenProvider } from "@microsoft/fluid-routerlicious-driver";
-import { ITestDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
+import { ILocalDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
 import { createTestDocumentService } from "./testDocumentService";
 
 /**
@@ -20,9 +20,9 @@ export class TestDocumentServiceFactory implements IDocumentServiceFactory {
 
     public readonly protocolName = "fluid-test:";
     /**
-     * @param testDeltaConnectionServer - delta connection server for ops
+     * @param localDeltaConnectionServer - delta connection server for ops
      */
-    constructor(private readonly testDeltaConnectionServer: ITestDeltaConnectionServer) { }
+    constructor(private readonly localDeltaConnectionServer: ILocalDeltaConnectionServer) { }
 
     /**
      * Creates and returns a document service for testing using the given resolved
@@ -52,6 +52,6 @@ export class TestDocumentServiceFactory implements IDocumentServiceFactory {
         const tokenProvider = new TokenProvider(jwtToken);
 
         return Promise.resolve(
-            createTestDocumentService(this.testDeltaConnectionServer, tokenProvider, tenantId, documentId));
+            createTestDocumentService(this.localDeltaConnectionServer, tokenProvider, tenantId, documentId));
     }
 }

--- a/packages/hosts/local-web-host/src/index.ts
+++ b/packages/hosts/local-web-host/src/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { TestDocumentServiceFactory, TestResolver } from "@microsoft/fluid-local-driver";
-import { TestDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
+import { LocalDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
 // eslint-disable-next-line import/no-internal-modules
 import * as uuid from "uuid/v4";
 import {
@@ -28,7 +28,7 @@ export async function createLocalContainerFactory(
 
     const urlResolver = new TestResolver(documentId);
 
-    const deltaConn = TestDeltaConnectionServer.create();
+    const deltaConn = LocalDeltaConnectionServer.create();
     const documentServiceFactory = new TestDocumentServiceFactory(deltaConn);
 
 

--- a/packages/server/local-test-utils/src/testHost.ts
+++ b/packages/server/local-test-utils/src/testHost.ts
@@ -22,7 +22,7 @@ import {
     NamedComponentRegistryEntries,
 } from "@microsoft/fluid-runtime-definitions";
 import { ISharedObject, ISharedObjectFactory } from "@microsoft/fluid-shared-object-base";
-import { ITestDeltaConnectionServer, TestDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
+import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
 import {
     IDocumentDeltaEvent,
     TestDocumentServiceFactory,
@@ -147,7 +147,7 @@ export class TestHost {
         }
     }
 
-    public readonly deltaConnectionServer: ITestDeltaConnectionServer;
+    public readonly deltaConnectionServer: ILocalDeltaConnectionServer;
     private rootResolver: (accept: TestRootComponent) => void;
 
     private readonly root = new Promise<TestRootComponent>((accept) => { this.rootResolver = accept; });
@@ -160,11 +160,11 @@ export class TestHost {
     constructor(
         private readonly componentRegistry: NamedComponentRegistryEntries,
         private readonly sharedObjectFactories: readonly ISharedObjectFactory[] = [],
-        deltaConnectionServer?: ITestDeltaConnectionServer,
+        deltaConnectionServer?: ILocalDeltaConnectionServer,
         private readonly scope: IComponent = {},
         private readonly containerServiceRegistry: ContainerServiceRegistryEntries = [],
     ) {
-        this.deltaConnectionServer = deltaConnectionServer || TestDeltaConnectionServer.create();
+        this.deltaConnectionServer = deltaConnectionServer || LocalDeltaConnectionServer.create();
 
         const runtimeFactory = {
             IRuntimeFactory: undefined,

--- a/packages/test/end-to-end/src/test/cellEndToEndTests.spec.ts
+++ b/packages/test/end-to-end/src/test/cellEndToEndTests.spec.ts
@@ -12,7 +12,7 @@ import {
     TestDocumentServiceFactory,
     TestResolver,
 } from "@microsoft/fluid-local-driver";
-import { ITestDeltaConnectionServer, TestDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
+import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
 import { ISharedMap } from "@microsoft/fluid-map";
 
 describe("Cell", () => {
@@ -21,7 +21,7 @@ describe("Cell", () => {
     const initialCellValue = "Initial cell value";
     const newCellValue = "A new cell value";
 
-    let testDeltaConnectionServer: ITestDeltaConnectionServer;
+    let testDeltaConnectionServer: ILocalDeltaConnectionServer;
     let documentDeltaEventManager: DocumentDeltaEventManager;
     let user1Document: api.Document;
     let user2Document: api.Document;
@@ -34,7 +34,7 @@ describe("Cell", () => {
     let root3Cell: ISharedCell;
 
     beforeEach(async () => {
-        testDeltaConnectionServer = TestDeltaConnectionServer.create();
+        testDeltaConnectionServer = LocalDeltaConnectionServer.create();
         documentDeltaEventManager = new DocumentDeltaEventManager(testDeltaConnectionServer);
         const serviceFactory = new TestDocumentServiceFactory(testDeltaConnectionServer);
         const resolver = new TestResolver();

--- a/packages/test/end-to-end/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
+++ b/packages/test/end-to-end/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
@@ -11,7 +11,7 @@ import {
     TestDocumentServiceFactory,
     TestResolver,
 } from "@microsoft/fluid-local-driver";
-import { ITestDeltaConnectionServer, TestDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
+import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
 import { ISharedMap } from "@microsoft/fluid-map";
 import { ConsensusQueue, IConsensusOrderedCollection } from "@microsoft/fluid-ordered-collection";
 import { IComponentRuntime } from "@microsoft/fluid-runtime-definitions";
@@ -27,7 +27,7 @@ function generate(
     describe(name, () => {
         const id = "fluid://test.com/test/test";
 
-        let testDeltaConnectionServer: ITestDeltaConnectionServer;
+        let testDeltaConnectionServer: ILocalDeltaConnectionServer;
         let documentDeltaEventManager: DocumentDeltaEventManager;
         let user1Document: api.Document;
         let user2Document: api.Document;
@@ -37,7 +37,7 @@ function generate(
         let root3: ISharedMap;
 
         beforeEach(async () => {
-            testDeltaConnectionServer = TestDeltaConnectionServer.create();
+            testDeltaConnectionServer = LocalDeltaConnectionServer.create();
             documentDeltaEventManager = new DocumentDeltaEventManager(testDeltaConnectionServer);
             const documentService = new TestDocumentServiceFactory(testDeltaConnectionServer);
             const resolver = new TestResolver();

--- a/packages/test/end-to-end/src/test/consensusRegisterCollectionEndToEndTests.spec.ts
+++ b/packages/test/end-to-end/src/test/consensusRegisterCollectionEndToEndTests.spec.ts
@@ -11,7 +11,7 @@ import {
     TestDocumentServiceFactory,
     TestResolver,
 } from "@microsoft/fluid-local-driver";
-import { ITestDeltaConnectionServer, TestDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
+import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
 import { ISharedMap } from "@microsoft/fluid-map";
 import {
     ConsensusRegisterCollection,
@@ -28,7 +28,7 @@ function generate(name: string, ctor: ISharedObjectConstructor<IConsensusRegiste
     describe(name, () => {
         const id = "fluid://test.com/test/test";
 
-        let testDeltaConnectionServer: ITestDeltaConnectionServer;
+        let testDeltaConnectionServer: ILocalDeltaConnectionServer;
         let documentDeltaEventManager: DocumentDeltaEventManager;
         let user1Document: api.Document;
         let user2Document: api.Document;
@@ -38,7 +38,7 @@ function generate(name: string, ctor: ISharedObjectConstructor<IConsensusRegiste
         let root3: ISharedMap;
 
         beforeEach(async () => {
-            testDeltaConnectionServer = TestDeltaConnectionServer.create();
+            testDeltaConnectionServer = LocalDeltaConnectionServer.create();
             documentDeltaEventManager = new DocumentDeltaEventManager(testDeltaConnectionServer);
             const documentService = new TestDocumentServiceFactory(testDeltaConnectionServer);
             const resolver = new TestResolver();

--- a/packages/test/end-to-end/src/test/container.spec.ts
+++ b/packages/test/end-to-end/src/test/container.spec.ts
@@ -18,12 +18,12 @@ import {
     ErrorType,
 } from "@microsoft/fluid-driver-definitions";
 import { TestDocumentServiceFactory, TestResolver } from "@microsoft/fluid-local-driver";
-import { ITestDeltaConnectionServer, TestDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
+import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
 import { MockDocumentDeltaConnection } from "@microsoft/fluid-test-loader-utils";
 import { ConnectionState } from "@microsoft/fluid-protocol-definitions";
 
 describe("Container", () => {
-    let testDeltaConnectionServer: ITestDeltaConnectionServer;
+    let testDeltaConnectionServer: ILocalDeltaConnectionServer;
     let testResolver: TestResolver;
     let testResolved: IFluidResolvedUrl;
     let deltaConnection: MockDocumentDeltaConnection;
@@ -33,7 +33,7 @@ describe("Container", () => {
     let loader: Loader;
 
     beforeEach(async () => {
-        testDeltaConnectionServer = TestDeltaConnectionServer.create();
+        testDeltaConnectionServer = LocalDeltaConnectionServer.create();
         testResolver = new TestResolver();
         testResolved = await testResolver.resolve(testRequest) as IFluidResolvedUrl;
         const serviceFactory = new TestDocumentServiceFactory(testDeltaConnectionServer);

--- a/packages/test/end-to-end/src/test/directoryEndToEndTests.spec.ts
+++ b/packages/test/end-to-end/src/test/directoryEndToEndTests.spec.ts
@@ -11,7 +11,7 @@ import {
     TestDocumentServiceFactory,
     TestResolver,
 } from "@microsoft/fluid-local-driver";
-import { ITestDeltaConnectionServer, TestDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
+import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
 import { ISharedDirectory, ISharedMap, SharedDirectory, SharedMap } from "@microsoft/fluid-map";
 import { MessageType } from "@microsoft/fluid-protocol-definitions";
 
@@ -19,7 +19,7 @@ describe("Directory", () => {
     const id = "fluid://test.com/test/test";
     const directoryId = "testDirectory";
 
-    let testDeltaConnectionServer: ITestDeltaConnectionServer;
+    let testDeltaConnectionServer: ILocalDeltaConnectionServer;
     let documentDeltaEventManager: DocumentDeltaEventManager;
     let user1Document: api.Document;
     let user2Document: api.Document;
@@ -29,7 +29,7 @@ describe("Directory", () => {
     let root3Directory: ISharedDirectory;
 
     beforeEach(async () => {
-        testDeltaConnectionServer = TestDeltaConnectionServer.create();
+        testDeltaConnectionServer = LocalDeltaConnectionServer.create();
         documentDeltaEventManager = new DocumentDeltaEventManager(testDeltaConnectionServer);
         const serviceFactory = new TestDocumentServiceFactory(testDeltaConnectionServer);
         const resolver = new TestResolver();

--- a/packages/test/end-to-end/src/test/error.spec.ts
+++ b/packages/test/end-to-end/src/test/error.spec.ts
@@ -15,13 +15,13 @@ import {
     ErrorType,
 } from "@microsoft/fluid-driver-definitions";
 import { TestDocumentServiceFactory, TestResolver } from "@microsoft/fluid-local-driver";
-import { ITestDeltaConnectionServer, TestDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
+import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
 import { createErrorObject } from "@microsoft/fluid-driver-base";
 import { errorObjectFromOdspError } from "@microsoft/fluid-odsp-driver";
 import { createIError } from "@microsoft/fluid-driver-utils";
 
 describe("Errors Types", () => {
-    let testDeltaConnectionServer: ITestDeltaConnectionServer;
+    let testDeltaConnectionServer: ILocalDeltaConnectionServer;
     let testResolver: TestResolver;
     let testResolved: IFluidResolvedUrl;
     const testRequest: IRequest = { url: "" };
@@ -30,7 +30,7 @@ describe("Errors Types", () => {
     let loader: Loader;
 
     beforeEach(async () => {
-        testDeltaConnectionServer = TestDeltaConnectionServer.create();
+        testDeltaConnectionServer = LocalDeltaConnectionServer.create();
         testResolver = new TestResolver();
         testResolved = await testResolver.resolve(testRequest) as IFluidResolvedUrl;
         const serviceFactory = new TestDocumentServiceFactory(testDeltaConnectionServer);

--- a/packages/test/end-to-end/src/test/localTestServer.spec.ts
+++ b/packages/test/end-to-end/src/test/localTestServer.spec.ts
@@ -11,14 +11,14 @@ import {
     TestDocumentServiceFactory,
     TestResolver,
 } from "@microsoft/fluid-local-driver";
-import { ITestDeltaConnectionServer, TestDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
+import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
 import { MessageType } from "@microsoft/fluid-protocol-definitions";
 import { SharedString } from "@microsoft/fluid-sequence";
 
 describe("LocalTestServer", () => {
     const id = "fluid://test.com/test/test";
 
-    let testDeltaConnectionServer: ITestDeltaConnectionServer;
+    let testDeltaConnectionServer: ILocalDeltaConnectionServer;
     let documentDeltaEventManager: DocumentDeltaEventManager;
     let user1Document: api.Document;
     let user2Document: api.Document;
@@ -26,7 +26,7 @@ describe("LocalTestServer", () => {
     let user2SharedString: SharedString;
 
     beforeEach(async () => {
-        testDeltaConnectionServer = TestDeltaConnectionServer.create();
+        testDeltaConnectionServer = LocalDeltaConnectionServer.create();
         documentDeltaEventManager = new DocumentDeltaEventManager(testDeltaConnectionServer);
 
         const resolver = new TestResolver();

--- a/packages/test/end-to-end/src/test/localTestSignals.spec.ts
+++ b/packages/test/end-to-end/src/test/localTestSignals.spec.ts
@@ -10,19 +10,19 @@ import {
     TestDocumentServiceFactory,
     TestResolver,
 } from "@microsoft/fluid-local-driver";
-import { ITestDeltaConnectionServer, TestDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
+import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
 import { IInboundSignalMessage } from "@microsoft/fluid-runtime-definitions";
 
 describe("TestSignals", () => {
     const id = "fluid-test://test.com/test/test";
 
-    let testDeltaConnectionServer: ITestDeltaConnectionServer;
+    let testDeltaConnectionServer: ILocalDeltaConnectionServer;
     let documentDeltaEventManager: DocumentDeltaEventManager;
     let user1Document: Document;
     let user2Document: Document;
 
     beforeEach(async () => {
-        testDeltaConnectionServer = TestDeltaConnectionServer.create();
+        testDeltaConnectionServer = LocalDeltaConnectionServer.create();
         documentDeltaEventManager = new DocumentDeltaEventManager(testDeltaConnectionServer);
 
         const resolver = new TestResolver();

--- a/packages/test/end-to-end/src/test/mapEndToEndTests.spec.ts
+++ b/packages/test/end-to-end/src/test/mapEndToEndTests.spec.ts
@@ -10,14 +10,14 @@ import {
     TestDocumentServiceFactory,
     TestResolver,
 } from "@microsoft/fluid-local-driver";
-import { ITestDeltaConnectionServer, TestDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
+import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
 import { ISharedMap } from "@microsoft/fluid-map";
 import { MessageType } from "@microsoft/fluid-protocol-definitions";
 
 describe("Map", () => {
     const id = "fluid://test.com/test/test";
 
-    let testDeltaConnectionServer: ITestDeltaConnectionServer;
+    let testDeltaConnectionServer: ILocalDeltaConnectionServer;
     let documentDeltaEventManager: DocumentDeltaEventManager;
     let user1Document: api.Document;
     let user2Document: api.Document;
@@ -27,7 +27,7 @@ describe("Map", () => {
     let root3: ISharedMap;
 
     beforeEach(async () => {
-        testDeltaConnectionServer = TestDeltaConnectionServer.create();
+        testDeltaConnectionServer = LocalDeltaConnectionServer.create();
         documentDeltaEventManager = new DocumentDeltaEventManager(testDeltaConnectionServer);
         const serviceFactory = new TestDocumentServiceFactory(testDeltaConnectionServer);
         const resolver = new TestResolver();

--- a/packages/test/end-to-end/src/test/sharedInterval.spec.ts
+++ b/packages/test/end-to-end/src/test/sharedInterval.spec.ts
@@ -12,7 +12,7 @@ import {
     TestResolver,
 } from "@microsoft/fluid-local-driver";
 import { TestHost } from "@microsoft/fluid-local-test-utils";
-import { ITestDeltaConnectionServer, TestDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
+import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
 import { ISharedMap, SharedMap } from "@microsoft/fluid-map";
 import { IntervalType, LocalReference } from "@microsoft/fluid-merge-tree";
 import { IBlob } from "@microsoft/fluid-protocol-definitions";
@@ -208,7 +208,7 @@ describe("SharedInterval", () => {
     describe("Handles in value types", () => {
         const id = "fluid://test.com/test/test";
 
-        let testDeltaConnectionServer: ITestDeltaConnectionServer;
+        let testDeltaConnectionServer: ILocalDeltaConnectionServer;
         let documentDeltaEventManager: DocumentDeltaEventManager;
         let user1Document: api.Document;
         let user2Document: api.Document;
@@ -218,7 +218,7 @@ describe("SharedInterval", () => {
         let root3: ISharedMap;
 
         beforeEach(async () => {
-            testDeltaConnectionServer = TestDeltaConnectionServer.create();
+            testDeltaConnectionServer = LocalDeltaConnectionServer.create();
             documentDeltaEventManager = new DocumentDeltaEventManager(testDeltaConnectionServer);
             const serviceFactory = new TestDocumentServiceFactory(testDeltaConnectionServer);
             const resolver = new TestResolver();

--- a/packages/tools/webpack-component-loader/src/loader.ts
+++ b/packages/tools/webpack-component-loader/src/loader.ts
@@ -14,7 +14,7 @@ import {
 } from "@microsoft/fluid-container-definitions";
 import { IDocumentServiceFactory, IUrlResolver } from "@microsoft/fluid-driver-definitions";
 import { TestDocumentServiceFactory, TestResolver } from "@microsoft/fluid-local-driver";
-import { ITestDeltaConnectionServer, TestDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
+import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
 import { SessionStorageDbFactory } from "@microsoft/fluid-local-test-utils";
 import { IUser } from "@microsoft/fluid-protocol-definitions";
 import { DefaultErrorTracking, RouterliciousDocumentServiceFactory } from "@microsoft/fluid-routerlicious-driver";
@@ -246,11 +246,11 @@ export async function start(
     const urlResolver = getUrlResolver(documentId, options);
 
     let documentServiceFactory: IDocumentServiceFactory;
-    let deltaConn: ITestDeltaConnectionServer;
+    let deltaConn: ILocalDeltaConnectionServer;
 
     switch (options.mode) {
         case "local": {
-            deltaConn = TestDeltaConnectionServer.create(new SessionStorageDbFactory(documentId));
+            deltaConn = LocalDeltaConnectionServer.create(new SessionStorageDbFactory(documentId));
             documentServiceFactory = new TestDocumentServiceFactory(deltaConn);
             break;
         }


### PR DESCRIPTION
Fixes #1338 

Follow-up change to #1339 . Updates the consumers of local-server to use the renamed LocalDeltaConnectionServer and ILocalDeltaConnectionServer.