### PR TITLE
Add Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Describe the bug
+<!-- A clear and concise description of what the bug is. -->
+<!-- If applicable, add screenshots or screen recordings to help explain your problem. -->
+
+### To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+### Expected behavior
+<!--A clear and concise description of what you expected to happen.-->
+
+### Logs
+<!-- If applicable, please share logs or Session IDs -->
+
+
+
+<!-- By filing an Issue, you are expected to comply with the Code of Conduct: https://github.com/microsoft/FluidFramework/blob/master/CODE_OF_CONDUCT.md -->
+
+<!-- Lastly, be sure to preview your issue before saving. Thanks! -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Feature
+**Is your feature request related to a problem? Please describe.**
+<!--A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]-->
+
+<!--If applicable, add screenshots, logs, or screen recordings to help explain your problem.-->
+
+**Describe the solution you'd like**
+<!--A clear and concise description of what you want to happen. -->
+
+**Existing work**
+<!--Does this feature exist elsewhere? Please share as much info as possible about that approach. -->
+
+**Describe alternatives you've considered**
+<!--A clear and concise description of any alternative solutions or features you've considered. -->
+
+**Additional context**
+<!--Add any other context about the feature request here. -->
+
+
+<!-- By filing an Issue, you are expected to comply with the Code of Conduct: https://github.com/microsoft/FluidFramework/blob/master/CODE_OF_CONDUCT.md -->
+
+<!-- Lastly, be sure to preview your issue before saving. Thanks! -->


### PR DESCRIPTION
Added Issue Templates to help people file issues on the repo. 

---------------------

Submitting your first issue is always a daunting task. You don't always know what is expected on a project, or what info you should write down. In this PR I've added two issue templates (Bug Report and Feature Request) with the hope that it will help us be more descriptive with our Issues :) 

The templates I added are more "generic OSS" templates, but let me know if I can change anything if we like to make it more "Fluid" specific 

This is how the templates will look when you press the Create New Issue button

![image](https://user-images.githubusercontent.com/10786508/75297579-16363500-57e5-11ea-850b-e04dde07d42a.png)
