### PR TITLE
fix spaces lint

### DIFF
--- a/examples/components/spaces/src/components/componentToolbar.tsx
+++ b/examples/components/spaces/src/components/componentToolbar.tsx
@@ -75,7 +75,7 @@ class ComponentToolbarView extends React.Component<IComponentToolbarViewProps, I
         };
         props.root.on("valueChanged", (change, local) => {
             if (change.key === "isEditable") {
-                this.setState({isEditable: props.root.get("isEditable")})
+                this.setState({isEditable: props.root.get("isEditable")});
             }
         });
     }


### PR DESCRIPTION
For some reason examples/ is linted as part of build, but changes in examples/ don't trigger a CI build

Edit: nevermind, apparently Tony already fixed this, now it should trigger a build