### PR TITLE
add getWebsocketToken perf event

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
@@ -183,7 +183,7 @@ export class OdspDocumentService implements IDocumentService {
             event.end();
 
             return token;
-        }
+        };
 
         this.localStorageAvailable = isLocalStorageAvailable();
     }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
@@ -102,6 +102,7 @@ export class OdspDocumentService implements IDocumentService {
     private readonly logger: TelemetryLogger;
 
     private readonly getStorageToken: (refresh: boolean) => Promise<string | null>;
+    private readonly getWebsocketToken: (refresh) => Promise<string | null>;
 
     private readonly localStorageAvailable: boolean;
 
@@ -133,7 +134,7 @@ export class OdspDocumentService implements IDocumentService {
         private readonly itemId: string,
         private readonly snapshotStorageUrl: string,
         getStorageToken: (siteUrl: string, refresh: boolean) => Promise<string | null>,
-        readonly getWebsocketToken: (refresh) => Promise<string | null>,
+        getWebsocketToken: (refresh) => Promise<string | null>,
         logger: ITelemetryBaseLogger,
         private readonly storageFetchWrapper: IFetchWrapper,
         private readonly deltasFetchWrapper: IFetchWrapper,
@@ -169,6 +170,20 @@ export class OdspDocumentService implements IDocumentService {
 
             return token;
         };
+
+        this.getWebsocketToken = async (refresh) => {
+            const event = PerformanceEvent.start(this.logger, { eventName: "GetWebsocketToken" });
+            let token: string | null;
+            try {
+                token = await getWebsocketToken(refresh);
+            } catch (error) {
+                event.cancel({}, error);
+                throw error;
+            }
+            event.end();
+
+            return token;
+        }
 
         this.localStorageAvailable = isLocalStorageAvailable();
     }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
@@ -269,7 +269,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
                 const odspCacheKey: string = `${this.documentId}/getlatest`;
                 let odspSnapshot: IOdspSnapshot = this.odspCache.get(odspCacheKey);
                 if (!odspSnapshot) {
-                    const storageToken = await this.getStorageToken(refresh, "GetVersions");
+                    const storageToken = await this.getStorageToken(refresh, "TreesLatest");
 
                     // TODO: This snapshot will return deltas, which we currently aren't using. We need to enable this flag to go down the "optimized"
                     // snapshot code path. We should leverage the fact that these deltas are returned to speed up the deltas fetch.


### PR DESCRIPTION
Add `getWebsocketToken()` performance event similar to the `getStorageToken()` performance event.

Also, rename one of the `getStorageToken()` prefixes in `getVersions()` to more easily discern between the two.