### PR TITLE
Upload summary with context made backwards compatible

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -6,6 +6,7 @@
 - [New Error types](#new-error-types)
 - [`IComponentContext` - `createSubComponent` removed, `createComponent` signature updated](#icomponentcontext-createsubcomponent-removed-createcomponent-signature-updated)
 - [Changes to the render interfaces](#changes-to-the-render-interfaces)
+- [Old runtime container cannot load new components](#old-runtime-container-cannot-load-new-components)
 
 ## Packages move and renamed
 
@@ -78,6 +79,10 @@ The rendering interfaces have undergone several changes:
 - Since `IComponentHTMLVisual` now only has the member `addView()`, it is mandatory.  If your component does not already implement `addView`, it should not be an `IComponentHTMLVisual`.
 - On `IComponentHTMLView`, `remove()` is now optional.  If your view component needs to perform cleanup when removed from the DOM, do it in `remove()` - otherwise there is no need to implement it.
 - `IComponentHTMLView` now extends the new `IProvideComponentHTMLView`, so you can query for whether a component is a view.  You must implement the `IComponentHTMLView` member if you implement the interface.
+
+## Old runtime container cannot load new components
+
+The way that summaries are generated has changed in such a way that the runtime container is backwards compatible with 0.13 components, but 0.13 runtime container cannot load 0.14 or later components.
 
 # 0.13 Breaking Changes
 

--- a/packages/components/external-component-loader/src/waterParkView/externalComponentView.ts
+++ b/packages/components/external-component-loader/src/waterParkView/externalComponentView.ts
@@ -96,9 +96,11 @@ export class ExternalComponentView extends PrimedComponent implements
                 this.sequence.getItems(0).forEach((url) => {
                     const component = this.urlToComponent.get(url);
                     if (component) {
-                        const renderable = component.IComponentHTMLView;
+                        const renderable = component.IComponentHTMLView
+                            // back-compat: 0.14 htmlView
+                            ?? component.IComponentHTMLVisual as any as IComponentHTMLView;
 
-                        if (renderable) {
+                        if (renderable && renderable.render !== undefined) {
                             const containerDiv = document.createElement("div");
                             mainDiv.appendChild(containerDiv);
                             const style = containerDiv.style;

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -35,8 +35,8 @@ import {
     IEnvelope,
     IHostRuntime,
     IInboundSignalMessage,
-    ISummaryTracker,
 } from "@microsoft/fluid-runtime-definitions";
+import { SummaryTracker } from "@microsoft/fluid-runtime-utils";
 // eslint-disable-next-line import/no-internal-modules
 import * as uuid from "uuid/v4";
 
@@ -149,11 +149,26 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
         public readonly existing: boolean,
         public readonly storage: IDocumentStorageService,
         public readonly scope: IComponent,
-        public readonly summaryTracker: ISummaryTracker,
+        public readonly summaryTracker: SummaryTracker,
         public readonly attach: (componentRuntime: IComponentRuntime) => void,
         protected pkg?: readonly string[],
     ) {
         super();
+
+        // back-compat: 0.14 uploadSummary
+        this.summaryTracker.addRefreshHandler(async () => {
+            // We do not want to get the snapshot unless we have to.
+            // If the component runtime is listening on refreshBaseSummary
+            // event, then that means it is older version and requires the
+            // component context to emit this event.
+            if (this.listeners("refreshBaseSummary")?.length > 0) {
+                const subtree = await this.summaryTracker.getSnapshotTree();
+                if (subtree) {
+                    // This subtree may not yet exist in acked summary, so only emit if found.
+                    this.emit("refreshBaseSummary", subtree);
+                }
+            }
+        });
     }
 
     public async createComponent(pkgOrId: string | undefined, pkg?: string, props?: any): Promise<IComponentRuntime> {
@@ -426,7 +441,7 @@ export class RemotedComponentContext extends ComponentContext {
         runtime: IHostRuntime,
         storage: IDocumentStorageService,
         scope: IComponent,
-        summaryTracker: ISummaryTracker,
+        summaryTracker: SummaryTracker,
         pkg?: string[],
     ) {
         super(
@@ -499,7 +514,7 @@ export class LocalComponentContext extends ComponentContext {
         runtime: IHostRuntime,
         storage: IDocumentStorageService,
         scope: IComponent,
-        summaryTracker: ISummaryTracker,
+        summaryTracker: SummaryTracker,
         attachCb: (componentRuntime: IComponentRuntime) => void,
         public readonly createProps?: any,
     ) {

--- a/packages/runtime/container-runtime/src/test/componentCreation.spec.ts
+++ b/packages/runtime/container-runtime/src/test/componentCreation.spec.ts
@@ -10,7 +10,6 @@ import {
     IComponentRuntime,
     ComponentRegistryEntry,
     NamedComponentRegistryEntries,
-    ISummaryTracker,
 } from "@microsoft/fluid-runtime-definitions";
 import { IComponent } from "@microsoft/fluid-component-core-interfaces";
 import { IDocumentStorageService } from "@microsoft/fluid-driver-definitions";
@@ -42,7 +41,7 @@ describe("Component Creation Tests", () => {
         const componentAName = "componentA";
         const componentBName = "componentB";
         const componentCName = "componentC";
-        let summaryTracker: ISummaryTracker;
+        let summaryTracker: SummaryTracker;
 
         // Helper function that creates a ComponentRegistryEntry with the registry entries
         // provided to it.


### PR DESCRIPTION
The changes from PR #1027 were only made backwards and forwards compatible between [driver <-> runtime] and [loader <-> runtime], but not between [(runtime container) <-> (runtime components)].

This change should allow old components (component runtime and below) to work with new runtime containers (`ContainerRuntime` and `ComponentContext`).  These were changes to runtime-definitions.  It does not work the other way; container is not forwards compatible to load new components.

Changes include:
- Convert handle id to path (when driver supports upload summary with context/path) during the ITree to ISummaryTree conversion which happens in `ContainerRuntime`.  Each component/dds will return the path making this redundant, but old code will not, so this ensures that even old components will have path as id in their summary handles.
- `ComponentContext` will still emit the "refreshBaseSummary" event if there are any registered listeners.  Old `ComponentRuntime` relies on this event and the entire previous snapshot tree to be fetched, so we will only do this if we detect an old component via checking the event listeners.
- Update BREAKING.md to inform that 0.13 runtime container cannot load 0.14 or later components.

Additionally changed external component loader to still be able to render old components.