### PR TITLE
Enable base-host usage without rendering

### DIFF
--- a/packages/hosts/base-host/src/host.ts
+++ b/packages/hosts/base-host/src/host.ts
@@ -131,7 +131,7 @@ export class BaseHost {
                 response.mimeType === "fluid/component" ||
                 response.mimeType === "prague/component"
             )) {
-            throw new Error("Failed to getComponent");
+            return undefined;
         }
 
         return response.value as IComponent;
@@ -139,6 +139,10 @@ export class BaseHost {
 
     private async getComponentAndRender(url: string, div: HTMLDivElement) {
         const component = await this.getComponent(url);
+        if (component === undefined) {
+            return;
+        }
+
         // First try to get it as a view
         let renderable = component.IComponentHTMLView;
         if (!renderable) {

--- a/packages/hosts/base-host/src/host.ts
+++ b/packages/hosts/base-host/src/host.ts
@@ -14,21 +14,6 @@ import { IResolvedPackage, WebCodeLoader } from "@microsoft/fluid-web-code-loade
 import { IBaseHostConfig } from "./hostConfig";
 import { initializeContainerCode } from "./initializeContainerCode";
 
-function renderComponent(component: IComponent, div: HTMLDivElement) {
-    // First try to get it as a view
-    let renderable = component.IComponentHTMLView;
-    if (!renderable) {
-        // Otherwise get the visual, which is a view factory
-        const visual = component.IComponentHTMLVisual;
-        if (visual) {
-            renderable = visual.addView();
-        }
-    }
-    if (renderable) {
-        renderable.render(div, { display: "block" });
-    }
-}
-
 /**
  * Create a loader and return it.
  * @param hostConfig - Config specifying the resolver/factory to be used.
@@ -152,9 +137,20 @@ export class BaseHost {
         return response.value as IComponent;
     }
 
-    private async getComponentAndRender(url, div) {
+    private async getComponentAndRender(url: string, div: HTMLDivElement) {
         const component = await this.getComponent(url);
-        renderComponent(component, div);
+        // First try to get it as a view
+        let renderable = component.IComponentHTMLView;
+        if (!renderable) {
+            // Otherwise get the visual, which is a view factory
+            const visual = component.IComponentHTMLVisual;
+            if (visual) {
+                renderable = visual.addView();
+            }
+        }
+        if (renderable) {
+            renderable.render(div, { display: "block" });
+        }
     }
 
     public async loadAndRender(url: string, div: HTMLDivElement, pkg?: IFluidCodeDetails) {

--- a/packages/hosts/tiny-web-host/src/host.ts
+++ b/packages/hosts/tiny-web-host/src/host.ts
@@ -179,14 +179,39 @@ async function loadContainer(
         documentServiceFactory,
         urlResolver: resolver,
     };
-    return BaseHost.start(
+
+    const baseHost = new BaseHost(
         hostConf,
-        href,
-        resolved, // resolved, IResolvedUrl,
-        pkg, // pkg, IResolvedPackage, (gateway/routes/loader has an example (pkgP))
-        scriptIds, // scriptIds, string[], defines the id of the script tag added to the page
-        div,
+        resolved,
+        pkg,
+        scriptIds,
     );
+    const container = await baseHost.initializeContainer(
+        href,
+        pkg ? pkg.details : undefined,
+    );
+    container.on("contextChanged", (value) => {
+        getComponentAndRender(baseHost, href, div).catch(() => { });
+    });
+    await getComponentAndRender(baseHost, href, div);
+
+    return container;
+}
+
+async function getComponentAndRender(baseHost: BaseHost, url: string, div: HTMLDivElement) {
+    const component = await baseHost.getComponent(url);
+    // First try to get it as a view
+    let renderable = component.IComponentHTMLView;
+    if (!renderable) {
+        // Otherwise get the visual, which is a view factory
+        const visual = component.IComponentHTMLVisual;
+        if (visual) {
+            renderable = visual.addView();
+        }
+    }
+    if (renderable) {
+        renderable.render(div, { display: "block" });
+    }
 }
 
 const routerliciousRegex = /^(http(s)?:\/\/)?www\..{3,9}\.prague\.office-int\.com\/loader\/.*/;

--- a/packages/hosts/tiny-web-host/src/host.ts
+++ b/packages/hosts/tiny-web-host/src/host.ts
@@ -200,6 +200,10 @@ async function loadContainer(
 
 async function getComponentAndRender(baseHost: BaseHost, url: string, div: HTMLDivElement) {
     const component = await baseHost.getComponent(url);
+    if (component === undefined) {
+        return;
+    }
+
     // First try to get it as a view
     let renderable = component.IComponentHTMLView;
     if (!renderable) {

--- a/packages/tools/webpack-component-loader/package.json
+++ b/packages/tools/webpack-component-loader/package.json
@@ -53,6 +53,7 @@
     "@microsoft/fluid-base-host": "^0.14.0",
     "@microsoft/fluid-component-core-interfaces": "^0.14.0",
     "@microsoft/fluid-container-definitions": "^0.14.0",
+    "@microsoft/fluid-container-loader": "^0.14.0",
     "@microsoft/fluid-driver-definitions": "^0.14.0",
     "@microsoft/fluid-local-driver": "^0.14.0",
     "@microsoft/fluid-local-test-utils": "^0.14.0",

--- a/packages/tools/webpack-component-loader/src/loader.ts
+++ b/packages/tools/webpack-component-loader/src/loader.ts
@@ -314,7 +314,7 @@ export async function start(
 
         await Promise.all([
             container1Promise.then(async (container) => {
-                await startRendering(container, baseHost1, url, leftDiv);
+                await startRendering(container, baseHost2, url, leftDiv);
             }),
             container2Promise.then(async (container) => {
                 await startRendering(container, baseHost1, url, rightDiv);
@@ -335,6 +335,10 @@ async function startRendering(container: Container, baseHost: BaseHost, url: str
 
 async function getComponentAndRender(baseHost: BaseHost, url: string, div: HTMLDivElement) {
     const component = await baseHost.getComponent(url);
+    if (component === undefined) {
+        return;
+    }
+
     // First try to get it as a view
     let renderable = component.IComponentHTMLView;
     if (!renderable) {

--- a/packages/tools/webpack-component-loader/src/loader.ts
+++ b/packages/tools/webpack-component-loader/src/loader.ts
@@ -314,10 +314,10 @@ export async function start(
 
         await Promise.all([
             container1Promise.then(async (container) => {
-                await startRendering(container, baseHost2, url, leftDiv);
+                await startRendering(container, baseHost1, url, leftDiv);
             }),
             container2Promise.then(async (container) => {
-                await startRendering(container, baseHost1, url, rightDiv);
+                await startRendering(container, baseHost2, url, rightDiv);
             }),
         ]);
     } else {

--- a/packages/tools/webpack-component-loader/src/loader.ts
+++ b/packages/tools/webpack-component-loader/src/loader.ts
@@ -12,6 +12,7 @@ import {
     IPackage,
     isFluidPackage,
 } from "@microsoft/fluid-container-definitions";
+import { Container } from "@microsoft/fluid-container-loader";
 import { IDocumentServiceFactory, IUrlResolver } from "@microsoft/fluid-driver-definitions";
 import { TestDocumentServiceFactory, TestResolver } from "@microsoft/fluid-local-driver";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
@@ -232,19 +233,6 @@ export async function start(
     options: RouteOptions,
     div: HTMLDivElement,
 ): Promise<void> {
-    const url = window.location.href;
-
-    // Create Package
-    const scriptIds: string[] = [];
-    const pkg = await getResolvedPackage(packageJson, scriptIds);
-
-    // Construct a request
-    const req: IRequest = {
-        url,
-    };
-
-    const urlResolver = getUrlResolver(documentId, options);
-
     let documentServiceFactory: IDocumentServiceFactory;
     let deltaConn: ILocalDeltaConnectionServer;
 
@@ -276,44 +264,89 @@ export async function start(
         }
     }
 
-    const hostConf: IBaseHostConfig = { documentServiceFactory, urlResolver };
+    const urlResolver = getUrlResolver(documentId, options);
 
-    const double = (options.mode === "local") && !options.single;
-    let leftDiv: HTMLDivElement;
-    let rightDiv: HTMLDivElement;
-    if (double) {
-        leftDiv = makeSideBySideDiv("sbs-left");
-        rightDiv = makeSideBySideDiv("sbs-right");
-        div.append(leftDiv, rightDiv);
-    }
-
-    const start1Promise = BaseHost.start(
-        hostConf,
+    // Construct a request
+    const url = window.location.href;
+    const req: IRequest = {
         url,
+    };
+
+    // Create Package
+    const scriptIds: string[] = [];
+    const pkg = await getResolvedPackage(packageJson, scriptIds);
+    const codeDetails = pkg ? pkg.details : undefined;
+
+    const host1Conf: IBaseHostConfig = { documentServiceFactory, urlResolver };
+    const baseHost1 = new BaseHost(
+        host1Conf,
         await urlResolver.resolve(req),
         pkg,
         scriptIds,
-        double ? leftDiv : div,
+    );
+    const container1Promise = baseHost1.initializeContainer(
+        url,
+        codeDetails,
     );
 
-    let start2Promise: Promise<any> = Promise.resolve();
-    if (double) {
+    // Side-by-side mode
+    if (options.mode === "local" && !options.single) {
         // New documentServiceFactory for right div, same everything else
         const docServFac2: IDocumentServiceFactory = new TestDocumentServiceFactory(deltaConn);
         const hostConf2 = { documentServiceFactory: docServFac2, urlResolver };
 
-        // BaseHost.start will create a new Loader/Container/Component from the startCore above. This is
+        // This will create a new Loader/Container/Component from the BaseHost above. This is
         // intentional because we want to emulate two clients collaborating with each other.
-        start2Promise = BaseHost.start(
+        const baseHost2 = new BaseHost(
             hostConf2,
-            url,
             await urlResolver.resolve(req),
             pkg,
             scriptIds,
-            rightDiv,
         );
+        const container2Promise = baseHost2.initializeContainer(
+            url,
+            codeDetails,
+        );
+
+        const leftDiv = makeSideBySideDiv("sbs-left");
+        const rightDiv = makeSideBySideDiv("sbs-right");
+        div.append(leftDiv, rightDiv);
+
+        await Promise.all([
+            container1Promise.then(async (container) => {
+                await startRendering(container, baseHost1, url, leftDiv);
+            }),
+            container2Promise.then(async (container) => {
+                await startRendering(container, baseHost1, url, rightDiv);
+            }),
+        ]);
+    } else {
+        const container = await container1Promise;
+        await startRendering(container, baseHost1, url, div);
     }
-    await Promise.all([start1Promise, start2Promise]);
+}
+
+async function startRendering(container: Container, baseHost: BaseHost, url: string, div: HTMLDivElement) {
+    container.on("contextChanged", (value) => {
+        getComponentAndRender(baseHost, url, div).catch(() => { });
+    });
+    await getComponentAndRender(baseHost, url, div);
+}
+
+async function getComponentAndRender(baseHost: BaseHost, url: string, div: HTMLDivElement) {
+    const component = await baseHost.getComponent(url);
+    // First try to get it as a view
+    let renderable = component.IComponentHTMLView;
+    if (!renderable) {
+        // Otherwise get the visual, which is a view factory
+        const visual = component.IComponentHTMLVisual;
+        if (visual) {
+            renderable = visual.addView();
+        }
+    }
+    if (renderable) {
+        renderable.render(div, { display: "block" });
+    }
 }
 
 export function getUserToken(bearerSecret: string) {


### PR DESCRIPTION
This change adds methods to `BaseHost` to enable its consumers to load a container and get components without rendering.  It also updates webpack-component-loader and tiny-web-host to do so.

The purpose is to remove all rendering and DOM references from base-host.  Externalizing rendering will address the bundle size concerns raised in #1308, and will also help with isomorphism of base-host.  It also aligns with goal 1 from #1044.

Since there are still consumers of `loadAndRender` in gateway, the server updates and removal of `loadAndRender` will have to be done in a second change.