### PR TITLE
Fix core-utils dependency

### DIFF
--- a/packages/test/functional/package.json
+++ b/packages/test/functional/package.json
@@ -48,9 +48,11 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "devDependencies": {
+    "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-container-loader": "^0.14.0",
     "@microsoft/fluid-container-runtime": "^0.14.0",
-    "@microsoft/fluid-core-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/eslint-config-fluid": "^0.14.0",
     "@microsoft/fluid-protocol-definitions": "^0.1002.0",
     "@microsoft/fluid-test-loader-utils": "^0.14.0",
     "@microsoft/fluid-sequence": "^0.14.0",

--- a/packages/test/functional/src/test/containerRuntime.spec.ts
+++ b/packages/test/functional/src/test/containerRuntime.spec.ts
@@ -5,7 +5,7 @@
 
 import * as assert from "assert";
 import { EventEmitter } from "events";
-import { DebugLogger } from "@microsoft/fluid-core-utils";
+import { DebugLogger } from "@microsoft/fluid-common-utils";
 import {
     IClient,
     ISequencedDocumentMessage,

--- a/tools/fluid-build/src/fluidBuild.ts
+++ b/tools/fluid-build/src/fluidBuild.ts
@@ -57,17 +57,32 @@ async function main() {
     }
 
     try {
+        if (options.depcheck) {
+            repo.depcheck();
+            timer.time("Dependencies check completed", true)
+        }
+
         if (options.uninstall) {
             if (!await repo.uninstall()) {
                 console.error(`ERROR: uninstall failed`);
                 process.exit(-8);
             }
             timer.time("Uninstall completed", true);
-        }
 
-        if (options.depcheck) {
-            repo.depcheck();
-            timer.time("Dependencies check completed", true)
+            if (!options.install) {
+                let errorStep: string | undefined = undefined;
+                if (options.symlink) {
+                    errorStep = "symlink";
+                } else if (options.clean) {
+                    errorStep = "clean";
+                } else if (options.build) {
+                    errorStep = "build";
+                }
+                if (!errorStep) {
+                    console.warn(`WARNING: Skipping ${errorStep} after uninstall`);
+                }
+                process.exit(0);
+            }
         }
 
         if (options.install) {

--- a/tools/fluid-build/src/fluidBuild/options.ts
+++ b/tools/fluid-build/src/fluidBuild/options.ts
@@ -151,7 +151,7 @@ export function parseOptions(argv: string[]) {
             options.force = true;
             continue;
         }
-        
+
         if (arg === "--nosamples") {
             options.samples = false;
             continue;


### PR DESCRIPTION
- core-utils was renamed common-utils.   This new dependency that comes in afterward needs to change too.
- fluid-build --uninstall will not continue onto build/clean/symlink since they will surely fail.
- add missing dependencies in functional-tests package.
