### PR TITLE
add async dispose

### DIFF
--- a/common/lib/common-definitions/src/disposable.ts
+++ b/common/lib/common-definitions/src/disposable.ts
@@ -10,5 +10,5 @@ export interface IDisposable {
 
 export interface IAsyncDisposable {
     readonly disposed: boolean;
-    disposeAsync(): void;
+    async disposeAsync(): Promise<void>;
 }

--- a/common/lib/common-definitions/src/disposable.ts
+++ b/common/lib/common-definitions/src/disposable.ts
@@ -7,3 +7,8 @@ export interface IDisposable {
     readonly disposed: boolean;
     dispose(): void;
 }
+
+export interface IAsyncDisposable {
+    readonly disposed: boolean;
+    disposeAsync(): void;
+}

--- a/common/lib/common-definitions/src/disposable.ts
+++ b/common/lib/common-definitions/src/disposable.ts
@@ -10,5 +10,5 @@ export interface IDisposable {
 
 export interface IAsyncDisposable {
     readonly disposed: boolean;
-    async disposeAsync(): Promise<void>;
+    disposeAsync(): Promise<void>;
 }


### PR DESCRIPTION
Standardizing the lifecycle cleanup methods.  Dispose works for the sync ones, but some classes use an async stop() method currently.  DisposeAsync would help for that