### PR TITLE
create summarizing container immediately after context reload

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -97,6 +97,7 @@ interface ISummaryTreeWithStats {
 
 export interface IPreviousState {
     summaryCollection?: SummaryCollection,
+    reload?: boolean,
 
     // only one (or zero) of these will be defined. the summarizing Summarizer will resolve the deferred promise, and
     // the SummaryManager that spawned it will have that deferred's promise
@@ -653,7 +654,8 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
             this.runtimeOptions.enableWorker,
             this.logger,
             (summarizer) => { this.nextSummarizerP = summarizer; },
-            this.previousState.nextSummarizerP);
+            this.previousState.nextSummarizerP,
+            !!this.previousState.reload);
 
         if (this.context.connectionState === ConnectionState.Connected) {
             this.summaryManager.setConnected(this.context.clientId);
@@ -731,6 +733,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         this.summarizer.dispose();
         this.closed = true;
         const state: IPreviousState = {
+            reload: true,
             summaryCollection: this.summarizer.summaryCollection,
             nextSummarizerP: this.nextSummarizerP,
             nextSummarizerD: this.nextSummarizerD,

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -62,7 +62,7 @@ export class SummaryManager extends EventEmitter implements IDisposable {
     private readonly logger: ITelemetryLogger;
     private readonly quorumHeap = new QuorumHeap();
     private readonly initialDelayP: Promise<void>;
-    private readonly initialDelayTimer: PromiseTimer;
+    private readonly initialDelayTimer?: PromiseTimer;
     private summarizerClientId?: string;
     private clientId?: string;
     private connected = false;
@@ -117,8 +117,9 @@ export class SummaryManager extends EventEmitter implements IDisposable {
             this.refreshSummarizer();
         });
 
-        this.initialDelayTimer = new PromiseTimer(immediateSummary ? 0 : initialDelayMs, () => {});
-        this.initialDelayP = this.initialDelayTimer.start().catch(() => {});
+        this.initialDelayTimer = immediateSummary ? undefined : new PromiseTimer(initialDelayMs, () => {});
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        this.initialDelayP = this.initialDelayTimer?.start().catch(() => {}) ?? Promise.resolve();
 
         this.refreshSummarizer();
     }
@@ -317,7 +318,8 @@ export class SummaryManager extends EventEmitter implements IDisposable {
     }
 
     public dispose() {
-        this.initialDelayTimer.clear();
+        // eslint-disable-next-line no-unused-expressions
+        this.initialDelayTimer?.clear();
         this._disposed = true;
     }
 }

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -89,6 +89,7 @@ export class SummaryManager extends EventEmitter implements IDisposable {
         parentLogger: ITelemetryLogger,
         private readonly setNextSummarizer: (summarizer: Promise<Summarizer>) => void,
         private readonly nextSummarizerP?: Promise<Summarizer>,
+        immediateSummary: boolean = false,
         private readonly maxRestarts: number = defaultMaxRestarts,
         initialDelayMs: number = defaultInitialDelayMs,
     ) {
@@ -116,7 +117,7 @@ export class SummaryManager extends EventEmitter implements IDisposable {
             this.refreshSummarizer();
         });
 
-        this.initialDelayTimer = new PromiseTimer(initialDelayMs, () => {});
+        this.initialDelayTimer = new PromiseTimer(immediateSummary ? 0 : initialDelayMs, () => {});
         this.initialDelayP = this.initialDelayTimer.start().catch(() => {});
 
         this.refreshSummarizer();


### PR DESCRIPTION
Previously, the `Summarizer` would summarize immediately after context reload, but if the summarizing container had not been created before the reload, there would be an initial delay before creation. This change removes the delay if we've gone through context reload.

Related: #1082