### PR TITLE
Jest / Puppeteer tests for @fluid-example/shared-text.

### DIFF
--- a/packages/agents/flow-intel/src/index.ts
+++ b/packages/agents/flow-intel/src/index.ts
@@ -20,7 +20,7 @@ export class TextAnalyzer implements IComponentRouter, IComponentRunnable {
 
     public async run() {
         if (this.config === undefined || this.config.key === undefined || this.config.key.length === 0) {
-            return Promise.reject("No intel key provided.");
+            throw new Error("No intel key provided.");
         }
         const intelRunner = new IntelRunner(this.document, this.insightsMap, this.config);
         return intelRunner.start();

--- a/packages/agents/intelligence-runner/src/index.ts
+++ b/packages/agents/intelligence-runner/src/index.ts
@@ -20,7 +20,7 @@ export class TextAnalyzer implements IComponentRouter, IComponentRunnable {
 
     public async run() {
         if (this.config === undefined || this.config.key === undefined || this.config.key.length === 0) {
-            return Promise.reject("No intel key provided.");
+            throw new Error("No intel key provided.");
         }
         const intelRunner = new IntelRunner(this.sharedString, this.insightsMap, this.config);
         return intelRunner.start();

--- a/packages/components/agent-scheduler/src/scheduler.ts
+++ b/packages/components/agent-scheduler/src/scheduler.ts
@@ -262,7 +262,11 @@ class AgentScheduler extends EventEmitter implements IAgentScheduler, IComponent
                     }
 
                     this.emit("picked", key);
-                    await worker();
+                    try {
+                        await worker();
+                    } catch (error) {
+                        debug(error as string);
+                    }
                 } else {
                     if (this.runningTasks.has(key)) {
                         this.runningTasks.delete(key);

--- a/packages/components/agent-scheduler/src/scheduler.ts
+++ b/packages/components/agent-scheduler/src/scheduler.ts
@@ -262,11 +262,9 @@ class AgentScheduler extends EventEmitter implements IAgentScheduler, IComponent
                     }
 
                     this.emit("picked", key);
-                    try {
-                        await worker();
-                    } catch (error) {
+                    await worker().catch((error) => {
                         debug(error as string);
-                    }
+                    });
                 } else {
                     if (this.runningTasks.has(key)) {
                         this.runningTasks.delete(key);

--- a/packages/components/flow-scroll/src/host/index.ts
+++ b/packages/components/flow-scroll/src/host/index.ts
@@ -168,7 +168,7 @@ class TaskScheduler {
         this.taskManager.pick(this.componentUrl, "intel").then(() => {
             console.log(`Picked text analyzer`);
         }, (err) => {
-            console.log(err);
+            console.log(JSON.stringify(err));
         });
     }
 }

--- a/packages/components/shared-text/jest-puppeteer.config.js
+++ b/packages/components/shared-text/jest-puppeteer.config.js
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+module.exports = {
+  server: {
+    command: "npm run start -- --port 8086",
+    port: 8086,
+    launchTimeout: 10000,
+    usedPortAction: 'error'
+  },
+  launch: {
+    args: ['--no-sandbox', '--disable-setuid-sandbox'], // https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#setting-up-chrome-linux-sandbox
+    dumpio: true, // output browser console to cmd line
+    // slowMo: 500, // slows down process for easier viewing
+    // headless: false, // run in the browser
+  },
+};

--- a/packages/components/shared-text/jest-puppeteer.config.js
+++ b/packages/components/shared-text/jest-puppeteer.config.js
@@ -5,8 +5,8 @@
 
 module.exports = {
   server: {
-    command: "npm run start -- --port 8086",
-    port: 8086,
+    command: "npm run start -- --port 8087",
+    port: 8087,
     launchTimeout: 10000,
     usedPortAction: 'error'
   },

--- a/packages/components/shared-text/jest.config.js
+++ b/packages/components/shared-text/jest.config.js
@@ -1,0 +1,16 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+module.exports = {
+  preset: "jest-puppeteer",
+  globals: {
+    PATH: "http://localhost:8086"
+  },
+  testMatch: ["**/?(*.)+(spec|test).[t]s"],
+  testPathIgnorePatterns: ['/node_modules/', 'dist'],
+  transform: {
+    "^.+\\.ts?$": "ts-jest"
+  },
+};

--- a/packages/components/shared-text/jest.config.js
+++ b/packages/components/shared-text/jest.config.js
@@ -6,7 +6,7 @@
 module.exports = {
   preset: "jest-puppeteer",
   globals: {
-    PATH: "http://localhost:8086"
+    PATH: "http://localhost:8087"
   },
   testMatch: ["**/?(*.)+(spec|test).[t]s"],
   testPathIgnorePatterns: ['/node_modules/', 'dist'],

--- a/packages/components/shared-text/package.json
+++ b/packages/components/shared-text/package.json
@@ -28,6 +28,7 @@
     "start:r11s": "webpack-dev-server --config webpack.config.js --package package.json --env.mode r11s",
     "start:spo": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo",
     "start:spo-df": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo-df",
+    "test:jest": "jest",
     "tsc": "tsc",
     "webpack": "webpack --env.production",
     "webpack:dev": "webpack --env.development"
@@ -66,40 +67,24 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.14.0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.14.0",
-    "@types/debug": "^0.0.31",
-    "@typescript-eslint/eslint-plugin": "~2.17.0",
-    "@typescript-eslint/parser": "~2.17.0",
+    "@types/expect-puppeteer": "2.2.1",
+    "@types/jest": "22.2.3",
+    "@types/jest-environment-puppeteer": "2.2.0",
+    "@types/node": "^10.14.6",
+    "@types/puppeteer": "1.3.0",
     "concurrently": "^4.1.0",
-    "css-loader": "^1.0.0",
-    "eslint": "~6.8.0",
-    "eslint-plugin-eslint-comments": "~3.1.2",
-    "eslint-plugin-import": "2.20.0",
-    "eslint-plugin-no-null": "~1.0.2",
-    "eslint-plugin-optimize-regex": "~1.1.7",
-    "eslint-plugin-prefer-arrow": "~1.1.7",
-    "eslint-plugin-react": "~7.18.0",
-    "eslint-plugin-unicorn": "~15.0.1",
-    "file-loader": "^3.0.1",
-    "html-loader": "^0.5.5",
-    "loader-utils": "^1.1.0",
-    "monaco-editor-webpack-plugin": "^1.5.4",
-    "node-sass": "^4.9.3",
-    "rimraf": "^2.6.2",
-    "sass-loader": "^7.1.0",
-    "source-map-loader": "^0.2.4",
-    "style-loader": "^1.0.0",
+    "jest": "^24.9.0",
+    "jest-junit": "^10.0.0",
+    "jest-puppeteer": "^4.3.0",
+    "puppeteer": "^1.20.0",
     "ts-loader": "^6.1.2",
     "typescript": "~3.7.4",
-    "url-loader": "^2.1.0",
     "webpack": "^4.16.5",
-    "webpack-bundle-analyzer": "^2.13.1",
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.8.0",
-    "webpack-merge": "^4.1.4",
-    "webpack-visualizer-plugin": "^0.1.11"
+    "webpack-merge": "^4.1.4"
   },
   "fluid": {
     "browser": {
@@ -110,5 +95,9 @@
         "library": "main"
       }
     }
+  },
+  "jest-junit": {
+    "outputDirectory": "nyc",
+    "outputName": "jest-junit-report.xml"
   }
 }

--- a/packages/components/shared-text/src/component.ts
+++ b/packages/components/shared-text/src/component.ts
@@ -281,7 +281,7 @@ class TaskScheduler {
         this.taskManager.pick(this.componentUrl, "intel").then(() => {
             console.log(`Picked text analyzer`);
         }, (err) => {
-            console.log(err);
+            console.log(JSON.stringify(err));
         });
     }
 }

--- a/packages/components/shared-text/src/index.ts
+++ b/packages/components/shared-text/src/index.ts
@@ -109,7 +109,7 @@ class SharedTextFactoryComponent implements IComponentFactory, IRuntimeFactory {
         return component.request(
             {
                 headers: request.headers,
-                url: trailingSlash === -1 ? "" : requestUrl.substr(trailingSlash),
+                url: trailingSlash === -1 ? "" : requestUrl.substr(trailingSlash + 1),
             });
     }
 

--- a/packages/components/shared-text/tests/sharedText.test.ts
+++ b/packages/components/shared-text/tests/sharedText.test.ts
@@ -1,0 +1,71 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { globals } from "../jest.config";
+
+describe("sharedText", () => {
+  jest.setTimeout(30000);
+
+  beforeEach(async () => {
+    await page.goto(globals.PATH, { waitUntil: "load" });
+  });
+
+  it ("Title of the document is same for both the users", async() => {
+    const getTitles = async (index: number) => {
+      return page.evaluate((i: number) => {
+        const titleElements = document.getElementsByClassName("title-bar");
+            const title = titleElements[i] as HTMLDivElement;
+            if (title) {
+                return title.innerText;
+            }
+
+            return "";
+      }, index);
+    }
+
+    // Get the titles of the two documents and verify they are the same.
+    const titleLeft = await getTitles(0);
+    expect(titleLeft).not.toEqual("");
+
+    const titleRight = await getTitles(1);
+    expect(titleRight).not.toEqual("");
+
+    expect(titleLeft).toEqual(titleRight);
+  });
+
+  it ("Typing text for one user updates both the users", async() => {
+    const getText = async (index: number) => {
+      return page.evaluate((i: number) => {
+        const titleElements = document.getElementsByClassName("flow-view");
+            const title = titleElements[i] as HTMLDivElement;
+            if (title) {
+                return title.innerText;
+            }
+
+            return "";
+      }, index);
+    }
+
+    const word: string = "sharedTestText";
+    // Type a word in one of the documents. There are two classes with name "flow-view",
+    // one for each user. This will pick the first class it finds and type in that.
+    await page.type('[class=flow-view]', word, {delay: 10});
+
+    // The text returned has extra spaces and some characters showing the other user's cursor.
+    // Remove the extra spaces and get the characters for the word we typed.
+    let textLeft = await getText(0);
+    expect(textLeft).not.toEqual("");
+    textLeft = textLeft.replace(/\s/g,'');
+    textLeft = textLeft.substring(0, word.length - 1);
+
+    let textRight = await getText(1);
+    expect(textRight).not.toEqual("");
+    textRight = textRight.replace(/\s/g,'');
+    textRight = textRight.substring(0, word.length - 1);
+
+    // Verify that the text updated for both the users.
+    expect(textLeft).toEqual(textRight);
+  });
+});

--- a/packages/components/shared-text/tests/sharedText.test.ts
+++ b/packages/components/shared-text/tests/sharedText.test.ts
@@ -12,7 +12,7 @@ describe("sharedText", () => {
     await page.goto(globals.PATH, { waitUntil: "load" });
   });
 
-  it ("Title of the document is same for both the users", async() => {
+  test("The title of the document is the same for both users", async() => {
     const getTitles = async (index: number) => {
       return page.evaluate((i: number) => {
         const titleElements = document.getElementsByClassName("title-bar");
@@ -30,12 +30,10 @@ describe("sharedText", () => {
     expect(titleLeft).not.toEqual("");
 
     const titleRight = await getTitles(1);
-    expect(titleRight).not.toEqual("");
-
     expect(titleLeft).toEqual(titleRight);
   });
 
-  it ("Typing text for one user updates both the users", async() => {
+  test("the text typed by one user updates the text for the other user", async() => {
     const getText = async (index: number) => {
       return page.evaluate((i: number) => {
         const titleElements = document.getElementsByClassName("flow-view");

--- a/packages/components/shared-text/tests/sharedText.test.ts
+++ b/packages/components/shared-text/tests/sharedText.test.ts
@@ -48,7 +48,7 @@ describe("sharedText", () => {
       }, index);
     }
 
-    const word: string = "sharedTestText";
+    const word: string = "sharedTextTest";
     // Type a word in one of the documents. There are two classes with name "flow-view",
     // one for each user. This will pick the first class it finds and type in that.
     await page.type('[class=flow-view]', word, {delay: 10});

--- a/packages/components/shared-text/tests/sharedText.test.ts
+++ b/packages/components/shared-text/tests/sharedText.test.ts
@@ -58,14 +58,15 @@ describe("sharedText", () => {
     let textLeft = await getText(0);
     expect(textLeft).not.toEqual("");
     textLeft = textLeft.replace(/\s/g,'');
-    textLeft = textLeft.substring(0, word.length - 1);
+    textLeft = textLeft.substring(0, word.length);
 
     let textRight = await getText(1);
     expect(textRight).not.toEqual("");
     textRight = textRight.replace(/\s/g,'');
-    textRight = textRight.substring(0, word.length - 1);
+    textRight = textRight.substring(0, word.length);
 
     // Verify that the text updated for both the users.
-    expect(textLeft).toEqual(textRight);
+    expect(textLeft).toEqual(word);
+    expect(textRight).toEqual(word);
   });
 });

--- a/packages/components/shared-text/tsconfig.json
+++ b/packages/components/shared-text/tsconfig.json
@@ -7,6 +7,8 @@
     "compilerOptions": {
         "strictNullChecks": false,
         "outDir": "dist",
+        "jsx": "react",
+        "types": ["node", "react", "react-dom", "jest", "puppeteer", "jest-environment-puppeteer", "expect-puppeteer"]
     },
     "include": [
         "src/**/*.ts"


### PR DESCRIPTION
Added the following end-to-end tests for @fluid-example/shared-text:
- The titles for the documents for side by side users are the same.
- Text typed in one document is reflected on the other.

Fixed a couple of bugs where uncaught error / promise rejection was causing puppeteer to close the browser.

Fixes #493 