### PR TITLE
Fluid-Build: Add bump version tool to help increment the minor version 

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:full:compile": "lerna run build:full:compile --stream",
     "build:gendocs": "api-documenter markdown -i _api-extractor-temp/doc-models -o docs/api",
     "build:genver": "lerna run build:genver --stream --parallel",
-    "bump-version": "lerna version minor --no-push --no-git-tag-version && npm run build:genver",
+    "bump-version": "node ./tools/fluid-build/dist/bumpVersion/bumpVersion.js --root .",
     "ci:build": "npm run build:genver && lerna run build:compile:min --stream",
     "ci:test": "npm run test:report;t1=$?;npm run test:copyresults; exit $t1",
     "ci:test:coverage": "npm run test:coverage;t1=$?;npm run test:copyresults; exit $t1",

--- a/server/routerlicious/packages/protocol-definitions/package.json
+++ b/server/routerlicious/packages/protocol-definitions/package.json
@@ -26,7 +26,7 @@
     "tsc:watch": "tsc --watch"
   },
   "dependencies": {
-    "@microsoft/fluid-common-definitions": "^0.14.0"
+    "@microsoft/fluid-common-definitions": "^0.13.0"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",

--- a/tools/fluid-build/bin/fluid-bump-version
+++ b/tools/fluid-build/bin/fluid-bump-version
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../dist/bumpVersion/bumpVersion.js');

--- a/tools/fluid-build/package.json
+++ b/tools/fluid-build/package.json
@@ -8,7 +8,8 @@
   "main": "dist/fluidBuild.js",
   "bin": {
     "fluid-build": "bin/fluid-build",
-    "fluid-layer-check": "bin/fluid-layer-check"
+    "fluid-layer-check": "bin/fluid-layer-check",
+    "fluid-bump-version": "bin/fluid-bump-version"
   },
   "scripts": {
     "build": "tsc -b",

--- a/tools/fluid-build/src/bumpVersion/bumpVersion.ts
+++ b/tools/fluid-build/src/bumpVersion/bumpVersion.ts
@@ -1,0 +1,147 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+
+import * as path from "path";
+import { commonOptions, commonOptionString, parseOption } from "../common/commonOptions";
+import { Timer } from "../common/timer";
+import { getResolvedFluidRoot } from "../common/fluidUtils";
+import { FluidRepoBase, MonoRepo } from "../common/fluidRepoBase";
+import * as semver from "semver";
+import { Package } from "../common/npmPackage";
+import { execWithErrorAsync, ExecAsyncResult } from "../common/utils";
+import { logVerbose } from "../common/logging";
+
+function printUsage() {
+    console.log(
+        `
+Usage: fluid-bump-version <options>
+Options:
+${commonOptionString}
+`);
+}
+
+function versionCheck() {
+    const pkg = require(path.join(__dirname, "..", "..", "package.json"));
+    const builtVersion = "0.0.5";
+    if (pkg.version > builtVersion) {
+        console.warn(`WARNING: layer-check is out of date, please rebuild (built: ${builtVersion}, package: ${pkg.version})\n`);
+    }
+}
+
+function parseOptions(argv: string[]) {
+    let error = false;
+    for (let i = 2; i < process.argv.length; i++) {
+        const argParsed = parseOption(argv, i);
+        if (argParsed < 0) {
+            error = true;
+            break;
+        }
+        if (argParsed > 0) {
+            i += argParsed - 1;
+            continue;
+        }
+
+        const arg = process.argv[i];
+
+        if (arg === "-?" || arg === "--help") {
+            printUsage();
+            process.exit(0);
+        }
+
+        console.error(`ERROR: Invalid arguments ${arg}`);
+        error = true;
+        break;
+    }
+
+    if (error) {
+        printUsage();
+        process.exit(-1);
+    }
+}
+
+parseOptions(process.argv);
+
+async function main() {
+    const timer = new Timer(commonOptions.timer);
+
+    versionCheck();
+
+    const resolvedRoot = await getResolvedFluidRoot();
+
+    // Load the package
+    const repo = new FluidRepoBase(resolvedRoot);
+    const packages = repo.packages;
+    timer.time("Package scan completed");
+
+    const packageNeedBump = new Set<Package>();
+    let serverNeedBump = false;
+    const buildPackages = repo.createPackageMap();
+
+    
+    const checkPackageNeedBump = (pkg: Package) => {
+        for (const { name: dep, version } of pkg.combinedDependencies) {
+            const depBuildPackage = buildPackages.get(dep);
+            if (depBuildPackage && semver.satisfies(depBuildPackage.version, version)) {
+                const depMonoRepo = repo.getMonoRepo(depBuildPackage);
+
+                if (depMonoRepo === MonoRepo.None) {
+                    if (!packageNeedBump.has(depBuildPackage)) {
+                        packageNeedBump.add(depBuildPackage);
+                        logVerbose(`${depBuildPackage.nameColored}: Add from ${pkg.nameColored} ${version}`)
+                        checkPackageNeedBump(depBuildPackage);
+                    }
+                } else if (depMonoRepo === MonoRepo.Server) {
+                    serverNeedBump = true;
+                }
+            }
+        }
+    };
+
+    const checkMonoRepoNeedBump = (checkRepo: MonoRepo) => {
+        packages.packages.forEach(pkg => {
+            const monoRepo = repo.getMonoRepo(pkg);
+            if (monoRepo !== checkRepo) {
+                return;
+            }
+            checkPackageNeedBump(pkg);
+        });
+    };
+
+
+
+    checkMonoRepoNeedBump(MonoRepo.Client);
+
+    if (serverNeedBump) {
+        checkMonoRepoNeedBump(MonoRepo.Server);
+    }
+
+
+    const bumpMonoRepo = async (monoRepo: MonoRepo) => {
+        const repoPath = repo.getMonoRepoPath(monoRepo)!;
+        return await execWithErrorAsync("npx lerna version minor --no-push --no-git-tag-version -y && npm run build:genver", {
+            cwd: repoPath,
+        }, repoPath, false);
+    }
+
+    console.log("Bumping client version");
+    await bumpMonoRepo(MonoRepo.Client)
+
+    if (serverNeedBump) {
+        console.log("Bumping server version");
+        await bumpMonoRepo(MonoRepo.Server);
+    }
+
+    for (const pkg of packageNeedBump) {    
+        console.log(`Bumping ${pkg.name}`);
+        let cmd = "npm version minor";
+        if (pkg.getScript("build:genver")) {
+            cmd += " && npm run build:genver";
+        }
+        await execWithErrorAsync(cmd, { cwd: pkg.directory }, pkg.directory, false);
+    }
+}
+
+main();

--- a/tools/fluid-build/src/common/fluidRepoBase.ts
+++ b/tools/fluid-build/src/common/fluidRepoBase.ts
@@ -4,7 +4,13 @@
  */
 
 import * as path from "path";
-import { Packages } from "./npmPackage";
+import { Package, Packages } from "./npmPackage";
+
+export enum MonoRepo {
+    None,
+    Client,
+    Server,
+};
 
 export class FluidRepoBase {
     // TODO: Should read lerna.json to determine
@@ -21,5 +27,39 @@ export class FluidRepoBase {
     public readonly packages: Packages;
     constructor(protected readonly resolvedRoot: string) {
         this.packages = Packages.load(this.baseDirectories);
+    }
+
+    public getMonoRepo(pkg: Package) {
+        return pkg.directory.startsWith(this.serverDirectory) ? MonoRepo.Server :
+            pkg.directory.startsWith(this.clientDirectory) || pkg.directory.startsWith(this.exampleDirectory) ? MonoRepo.Client : MonoRepo.None
+    }
+
+    public isSameMonoRepo(monoRepo: MonoRepo, pkg: Package) {
+        return monoRepo !== MonoRepo.None && monoRepo === this.getMonoRepo(pkg);
+    }
+
+    public getMonoRepoPath(monoRepo: MonoRepo) {
+        switch (monoRepo) {
+            case MonoRepo.Client:
+                return path.join(this.clientDirectory, "..");
+            case MonoRepo.Server:
+                return path.join(this.serverDirectory, "..");
+            default:
+                return undefined;
+        }
+    }
+    public getMonoRepoNodeModulePath(monoRepo: MonoRepo) {
+        switch (monoRepo) {
+            case MonoRepo.Client:
+                return path.join(this.clientDirectory, "..", "node_modules");
+            case MonoRepo.Server:
+                return path.join(this.serverDirectory, "..", "node_modules");
+            default:
+                return undefined;
+        }
+    }
+
+    public createPackageMap() {
+        return new Map<string, Package>(this.packages.packages.map(pkg => [pkg.name, pkg]));
     }
 };

--- a/tools/fluid-build/src/common/utils.ts
+++ b/tools/fluid-build/src/common/utils.ts
@@ -58,9 +58,9 @@ export async function execAsync(command: string, options: child_process.ExecOpti
     });
 }
 
-export async function execWithErrorAsync(command: string, options: child_process.ExecOptions, errorPrefix: string): Promise<ExecAsyncResult> {
+export async function execWithErrorAsync(command: string, options: child_process.ExecOptions, errorPrefix: string, warning: boolean = true): Promise<ExecAsyncResult> {
     const ret = await execAsync(command, options);
-    printExecError(ret, command, errorPrefix);
+    printExecError(ret, command, errorPrefix, warning);
     return ret;
 }
 
@@ -72,16 +72,16 @@ async function rimrafAsync(deletePath: string) {
 
 export async function rimrafWithErrorAsync(deletePath: string, errorPrefix: string) {
     const ret = await rimrafAsync(deletePath);
-    printExecError(ret, `rimraf ${deletePath}`, errorPrefix);
+    printExecError(ret, `rimraf ${deletePath}`, errorPrefix, true);
     return ret;
 }
 
-function printExecError(ret: ExecAsyncResult, command: string, errorPrefix: string) {
+function printExecError(ret: ExecAsyncResult, command: string, errorPrefix: string, warning: boolean) {
     if (ret.error) {
         console.error(`${errorPrefix}: error during command ${command}`);
         console.error(`${errorPrefix}: ${ret.error.message}`);
         console.error(ret.stdout ? `${errorPrefix}: ${ret.stdout}\n${ret.stderr}` : `${errorPrefix}: ${ret.stderr}`);
-    } else if (ret.stderr) {
+    } else if (warning && ret.stderr) {
         // no error code but still error messages, treat them is non fatal warnings
         console.warn(`${errorPrefix}: warning during command ${command}`);
         console.warn(`${errorPrefix}: ${ret.stderr}`);

--- a/tools/fluid-build/src/fluidBuild/fluidPackageCheck.ts
+++ b/tools/fluid-build/src/fluidBuild/fluidPackageCheck.ts
@@ -4,13 +4,8 @@
  */
 
 import { FluidRepo } from "./fluidRepo";
+import { MonoRepo } from "../common/fluidRepoBase";
 import { Package } from "../common/npmPackage";
-
-export enum MonoRepo {
-    None,
-    Client,
-    Server,
-};
 
 export class FluidPackageCheck {
     constructor(private readonly repoType: MonoRepo) {

--- a/tools/fluid-build/src/fluidBuild/fluidRepo.ts
+++ b/tools/fluid-build/src/fluidBuild/fluidRepo.ts
@@ -11,7 +11,7 @@ import {
     ExecAsyncResult,
     execWithErrorAsync,
 } from "../common/utils";
-import { FluidPackageCheck, MonoRepo } from "./fluidPackageCheck";
+import { FluidPackageCheck } from "./fluidPackageCheck";
 import { FluidRepoBase } from "../common/fluidRepoBase";
 import { NpmDepChecker } from "./npmDepChecker";
 import { ISymlinkOptions, symlinkPackage } from "./symlinkUtils";
@@ -44,25 +44,6 @@ export class FluidRepo extends FluidRepoBase {
         return Packages.clean(this.packages.packages, false);
     }
 
-    public getMonoRepo(pkg: Package) {
-        return pkg.directory.startsWith(this.serverDirectory) ? MonoRepo.Server :
-            pkg.directory.startsWith(this.clientDirectory) || pkg.directory.startsWith(this.exampleDirectory) ? MonoRepo.Client : MonoRepo.None
-    }
-
-    public isSameMonoRepo(monoRepo: MonoRepo, pkg: Package) {
-        return monoRepo !== MonoRepo.None && monoRepo === this.getMonoRepo(pkg);
-    }
-
-    public getMonoRepoNodeModePath(monoRepo: MonoRepo) {
-        switch (monoRepo) {
-            case MonoRepo.Client:
-                return path.join(this.clientDirectory, "..", "node_modules");
-            case MonoRepo.Server:
-                return path.join(this.serverDirectory, "..", "node_modules");
-            default:
-                return undefined;
-        }
-    }
     public async install(nohoist: boolean) {
         if (nohoist) {
             return this.packages.noHoistInstall(this.resolvedRoot);
@@ -140,9 +121,8 @@ export class FluidRepo extends FluidRepoBase {
     }
 
     public async symlink(options: ISymlinkOptions) {
-        const packageMap = new Map<string, Package>(this.packages.packages.map(pkg => [pkg.name, pkg]));
         // Only do parallel if we are checking only
-        const result = await this.packages.forEachAsync(pkg => symlinkPackage(this, pkg, packageMap, options), !options.symlink);
+        const result = await this.packages.forEachAsync(pkg => symlinkPackage(this, pkg, this.createPackageMap(), options), !options.symlink);
         return result.reduce((sum, value) => sum + value);
     }
 

--- a/tools/fluid-build/src/fluidBuild/symlinkUtils.ts
+++ b/tools/fluid-build/src/fluidBuild/symlinkUtils.ts
@@ -126,7 +126,7 @@ export interface ISymlinkOptions {
 export async function symlinkPackage(repo: FluidRepo, pkg: Package, buildPackages: Map<string, Package>, options: ISymlinkOptions) {
     let changed = 0;
     const monoRepo = repo.getMonoRepo(pkg);
-    const monoRepoNodeModulePath = repo.getMonoRepoNodeModePath(monoRepo);
+    const monoRepoNodeModulePath = repo.getMonoRepoNodeModulePath(monoRepo);
     for (const { name: dep, version } of pkg.combinedDependencies) {
         const depBuildPackage = buildPackages.get(dep);
         // Check and fix link if it is a known package and version satisfy the version.


### PR DESCRIPTION
When we need to bump the minor version for the client, if it depends on the current version of the server or the common packages, those packages version will need to bump as well.

This tool will detect what needs to be bump.

Also revert a change for protocol-definition depending on 0.14 of common-definitions.  There is not change between 0.13 and 0.14 and there is not need to advance the dependency.