### PR TITLE
Fix getComponentRuntime with Wait

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -825,15 +825,16 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         this.verifyNotClosed();
 
         if (!this.contextsDeferred.has(id)) {
-            if (!wait) {
-                return Promise.reject(`Process ${id} does not exist`);
-            }
-
             // Add in a deferred that will resolve once the process ID arrives
             this.contextsDeferred.set(id, new Deferred<ComponentContext>());
         }
+        const deferredContext = this.contextsDeferred.get(id);
 
-        const componentContext = await this.contextsDeferred.get(id).promise;
+        if (!wait && !deferredContext.isCompleted) {
+            return Promise.reject(`Process ${id} does not exist`);
+        }
+
+        const componentContext = await deferredContext.promise;
         return componentContext.realize();
     }
 

--- a/samples/chaincode/drawer/src/grid.tsx
+++ b/samples/chaincode/drawer/src/grid.tsx
@@ -4,13 +4,9 @@
  */
 
 import * as React from "react";
-/* eslint-disable import/no-internal-modules */
-import { FocusZone } from "office-ui-fabric-react/lib/FocusZone";
-import { List } from "office-ui-fabric-react/lib/List";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { ITheme, getTheme, mergeStyleSets } from "@uifabric/styling";
-import { IRectangle } from "office-ui-fabric-react";
-/* eslint-enable import/no-internal-modules */
+import { IRectangle, FocusZone, List } from "office-ui-fabric-react";
 
 export interface IListGridExampleProps {
     items: any[];


### PR DESCRIPTION
Fixes #1386 

The issues was that if anyone called getComponentRuntime with wait === true, all subsequent calls with wait being true or false would wait, because of the deferredContext added by the waiting call