### PR TITLE
Fix ODSP join [0.14]

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/odspUtils.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspUtils.ts
@@ -158,8 +158,12 @@ export function fetchHelper(
         try {
             const text = await response.text();
 
+            const clonedHeadersObj = { "body-size": text.length.toString() };
+            for (const [key, value] of response.headers.entries()) {
+                clonedHeadersObj[key] = value;
+            }
             const res = {
-                headers: new FetchHeaders({ ...response.headers, "body-size": text.length }),
+                headers: new FetchHeaders(clonedHeadersObj),
                 content: JSON.parse(text),
             };
             return res;

--- a/packages/drivers/odsp-socket-storage/src/odspUtils.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspUtils.ts
@@ -4,7 +4,12 @@
  */
 
 import { isOnline, FatalError, NetworkError, ThrottlingError, OnlineStatus } from "@microsoft/fluid-driver-utils";
-import { default as fetch, RequestInfo as FetchRequestInfo, RequestInit as FetchRequestInit } from "node-fetch";
+import {
+    default as fetch,
+    RequestInfo as FetchRequestInfo,
+    RequestInit as FetchRequestInit,
+    Headers as FetchHeaders,
+} from "node-fetch";
 import * as sha from "sha.js";
 import { IOdspSocketError } from "./contracts";
 import { debug } from "./debug";
@@ -152,9 +157,9 @@ export function fetchHelper(
         // succeeds on retry.
         try {
             const text = await response.text();
-            response.headers.set("body-size", text.length.toString());
+
             const res = {
-                headers: response.headers,
+                headers: new FetchHeaders({ ...response.headers, "body-size": text.length }),
                 content: JSON.parse(text),
             };
             return res;

--- a/packages/drivers/odsp-socket-storage/src/odspUtils.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspUtils.ts
@@ -158,12 +158,12 @@ export function fetchHelper(
         try {
             const text = await response.text();
 
-            const clonedHeadersObj = { "body-size": text.length.toString() };
+            const newHeaders = new FetchHeaders({ "body-size": text.length.toString() });
             for (const [key, value] of response.headers.entries()) {
-                clonedHeadersObj[key] = value;
+                newHeaders.set(key, value);
             }
             const res = {
-                headers: new FetchHeaders(clonedHeadersObj),
+                headers: newHeaders,
                 content: JSON.parse(text),
             };
             return res;

--- a/packages/drivers/odsp-socket-storage/src/vroom.ts
+++ b/packages/drivers/odsp-socket-storage/src/vroom.ts
@@ -105,7 +105,7 @@ export async function getSocketStorageDiscovery(
     // consecutive join session calls because the server moved. If there is nothing in cache or the
     // response was cached an hour ago, then we make the join session call again. Never expire the
     // joinsession result. On error, the delta connection will invalidate it.
-    const cachedResultP: Promise<ISocketStorageDiscovery> = cache.sessionStorage.get(joinSessionKey);
+    const cachedResultP: Promise<ISocketStorageDiscovery> = await cache.sessionStorage.get(joinSessionKey);
     if (cachedResultP !== undefined) {
         const content = await cachedResultP;
         // Update result to keep it alive for another hour


### PR DESCRIPTION
Follow up from PR #1271 - add `await` to get promise of promise from ODSP cache.
Fixes error: "websocket endpoint should be defined".

Follow up from PR #1267 - use node-fetch `Headers` object.
Fixes error (similar): "Failed to execute 'set' on 'Headers': Headers are immutable".