### PR TITLE
Increase puppeteer test timeouts

### DIFF
--- a/examples/components/spaces/tests/spaces.test.ts
+++ b/examples/components/spaces/tests/spaces.test.ts
@@ -6,13 +6,12 @@
 import { globals } from "../jest.config";
 
 describe("spaces", () => {
-
+    jest.setTimeout(15000);
     beforeEach(async () => {
         await page.goto(globals.PATH, { waitUntil: "load" });
-    }, 10000);
+    });
 
     it("There's a button to be clicked", async () => {
-        jest.setTimeout(10000);
         await expect(page).toClick("button", { text: "Edit: true" });
-    }, 10000);
+    });
   });

--- a/examples/components/vltava/tests/vltava.test.ts
+++ b/examples/components/vltava/tests/vltava.test.ts
@@ -6,7 +6,7 @@
 import { globals } from "../jest.config";
 
 describe("vltava", () => {
-
+    jest.setTimeout(10000);
     beforeEach(async () => {
       await page.goto(globals.PATH, { waitUntil: "load" });
     });

--- a/packages/components/canvas/test/canvas.test.ts
+++ b/packages/components/canvas/test/canvas.test.ts
@@ -7,6 +7,7 @@ import { ElementHandle } from "puppeteer";
 import { globals } from "../jest.config";
 
 describe("canvas", () => {
+    jest.setTimeout(10000);
     beforeEach(async () => {
         await page.goto(globals.PATH, { waitUntil: "load" });
     });

--- a/packages/components/clicker/tests/clicker.test.ts
+++ b/packages/components/clicker/tests/clicker.test.ts
@@ -6,6 +6,7 @@
 import { globals } from "../jest.config";
 
 describe("clicker", () => {
+    jest.setTimeout(10000);
 
     beforeEach(async () => {
       await page.goto(globals.PATH, { waitUntil: "load" });

--- a/packages/components/external-component-loader/test/external-component-loader.test.ts
+++ b/packages/components/external-component-loader/test/external-component-loader.test.ts
@@ -7,6 +7,8 @@ import * as path from "path";
 import { globals } from "../jest.config";
 
 describe("external-component-loader", () => {
+    jest.setTimeout(10000);
+
     beforeEach(async () => {
         await page.goto(globals.PATH, { waitUntil: "load" });
     });

--- a/packages/components/todo/tests/todo.test.ts
+++ b/packages/components/todo/tests/todo.test.ts
@@ -6,7 +6,7 @@
 import { globals } from "../jest.config";
 
 describe("ToDo", () => {
-  jest.setTimeout(10000);
+  jest.setTimeout(15000);
 
   beforeEach(async () => {
     await page.goto(globals.PATH, { waitUntil: "load" });

--- a/packages/test/context-reload/tests/contextReload.test.ts
+++ b/packages/test/context-reload/tests/contextReload.test.ts
@@ -7,6 +7,7 @@ import { Deferred } from "@microsoft/fluid-common-utils";
 import { globals } from "../jest.config";
 
 describe("context reload", () => {
+    jest.setTimeout(10000);
     beforeEach(async () => {
       await page.goto(globals.PATH, { waitUntil: "load" });
     });


### PR DESCRIPTION
Seeing some instability in the CI.
So increase timeout on all the puppeteer tests.