### PR TITLE
Added cell properties support in TableDocument

### DIFF
--- a/packages/components/table-document/src/document.ts
+++ b/packages/components/table-document/src/document.ts
@@ -68,8 +68,8 @@ export class TableDocument extends PrimedComponent implements ITable {
         return this.matrix.getItem(row, col);
     }
 
-    public setCellValue(row: number, col: number, value: TableDocumentItem) {
-        this.matrix.setItems(row, col, [value]);
+    public setCellValue(row: number, col: number, value: TableDocumentItem, props?: PropertySet) {
+        this.matrix.setItems(row, col, [value], props);
         this.workbook.invalidate(row, col);
     }
 
@@ -104,6 +104,14 @@ export class TableDocument extends PrimedComponent implements ITable {
 
     public getColProperties(col: number): PropertySet {
         return this.maybeCols.getPropertiesAtPosition(col);
+    }
+
+    public annotateCell(row: number, col: number, properties: PropertySet, op?: ICombiningOp) {
+        this.matrix.annotatePosition(row, col, properties, op);
+    }
+
+    public getCellProperties(row: number, col: number): PropertySet {
+        return this.matrix.getPositionProperties(row, col);
     }
 
     // For internal use by TableSlice: Please do not use.

--- a/packages/components/table-document/src/document.ts
+++ b/packages/components/table-document/src/document.ts
@@ -68,8 +68,8 @@ export class TableDocument extends PrimedComponent implements ITable {
         return this.matrix.getItem(row, col);
     }
 
-    public setCellValue(row: number, col: number, value: TableDocumentItem, props?: PropertySet) {
-        this.matrix.setItems(row, col, [value], props);
+    public setCellValue(row: number, col: number, value: TableDocumentItem, properties?: PropertySet) {
+        this.matrix.setItems(row, col, [value], properties);
         this.workbook.invalidate(row, col);
     }
 
@@ -106,8 +106,8 @@ export class TableDocument extends PrimedComponent implements ITable {
         return this.maybeCols.getPropertiesAtPosition(col);
     }
 
-    public annotateCell(row: number, col: number, properties: PropertySet, op?: ICombiningOp) {
-        this.matrix.annotatePosition(row, col, properties, op);
+    public annotateCell(row: number, col: number, properties: PropertySet) {
+        this.matrix.annotatePosition(row, col, properties);
     }
 
     public getCellProperties(row: number, col: number): PropertySet {

--- a/packages/components/table-document/src/slice.ts
+++ b/packages/components/table-document/src/slice.ts
@@ -57,9 +57,9 @@ export class TableSlice extends PrimedComponent implements ITable {
         return this.doc.getCellValue(row, col);
     }
 
-    public setCellValue(row: number, col: number, value: TableDocumentItem) {
+    public setCellValue(row: number, col: number, value: TableDocumentItem, properties?: PropertySet) {
         this.validateInSlice(row, col);
-        this.doc.setCellValue(row, col, value);
+        this.doc.setCellValue(row, col, value, properties);
     }
 
     public annotateRows(startRow: number, endRow: number, properties: PropertySet, op?: ICombiningOp) {
@@ -82,6 +82,16 @@ export class TableSlice extends PrimedComponent implements ITable {
     public getColProperties(col: number): PropertySet {
         this.validateInSlice(undefined, col);
         return this.doc.getColProperties(col);
+    }
+
+    public annotateCell(row: number, col: number, properties: PropertySet) {
+        this.validateInSlice(row, col);
+        this.doc.annotateCell(row, col, properties);
+    }
+
+    public getCellProperties(row: number, col: number): PropertySet {
+        this.validateInSlice(row, col);
+        return this.doc.getCellProperties(row, col);
     }
 
     public insertRows(startRow: number, numRows: number) {

--- a/packages/components/table-document/src/table.ts
+++ b/packages/components/table-document/src/table.ts
@@ -17,13 +17,15 @@ export interface ITable {
     readonly numCols: number;
 
     getCellValue(row: number, col: number): TableDocumentItem;
-    setCellValue(row: number, col: number, value: TableDocumentItem);
+    setCellValue(row: number, col: number, value: TableDocumentItem, properties?: PropertySet);
     evaluateFormula(formula: string): TableDocumentItem;
     evaluateCell(row: number, col: number): TableDocumentItem;
     annotateRows(startRow: number, endRow: number, properties: PropertySet, op?: ICombiningOp);
     getRowProperties(row: number): PropertySet;
     annotateCols(startCol: number, endCol: number, properties: PropertySet, op?: ICombiningOp);
     getColProperties(col: number): PropertySet;
+    annotateCell(row: number, col: number, properties: PropertySet);
+    getCellProperties(row: number, col: number): PropertySet;
     insertRows(startRow: number, numRows: number): void;
     removeRows(startRow: number, numRows: number): void;
     insertCols(startCol: number, numCols: number): void;

--- a/packages/runtime/sequence/src/sparsematrix.ts
+++ b/packages/runtime/sequence/src/sparsematrix.ts
@@ -11,6 +11,7 @@ import {
     ISegment,
     PropertySet,
     LocalReferenceCollection,
+    ICombiningOp,
 } from "@microsoft/fluid-merge-tree";
 import {
     IChannelAttributes,
@@ -285,6 +286,16 @@ export class SparseMatrix extends SharedSegmentSequence<MatrixSegment> {
 
     public removeCols(col: number, numCols: number) {
         this.moveAsPadding(col, maxCol - numCols, numCols);
+    }
+
+    public annotatePosition(row: number, col: number, props: PropertySet, op?: ICombiningOp) {
+        const pos = rowColToPosition(row, col);
+        this.annotateRange(pos, pos + 1, props, op);
+    }
+
+    public getPositionProperties(row: number, col: number) {
+        const pos = rowColToPosition(row, col);
+        return this.getPropertiesAtPosition(pos);
     }
 
     // For each row, moves 'numCols' items starting from 'srcCol' and inserts 'numCols' padding

--- a/packages/runtime/sequence/src/sparsematrix.ts
+++ b/packages/runtime/sequence/src/sparsematrix.ts
@@ -11,7 +11,6 @@ import {
     ISegment,
     PropertySet,
     LocalReferenceCollection,
-    ICombiningOp,
 } from "@microsoft/fluid-merge-tree";
 import {
     IChannelAttributes,
@@ -288,9 +287,9 @@ export class SparseMatrix extends SharedSegmentSequence<MatrixSegment> {
         this.moveAsPadding(col, maxCol - numCols, numCols);
     }
 
-    public annotatePosition(row: number, col: number, props: PropertySet, op?: ICombiningOp) {
+    public annotatePosition(row: number, col: number, props: PropertySet) {
         const pos = rowColToPosition(row, col);
-        this.annotateRange(pos, pos + 1, props, op);
+        this.annotateRange(pos, pos + 1, props);
     }
 
     public getPositionProperties(row: number, col: number) {


### PR DESCRIPTION
Fixes #1360

Added an optional param "props?: PropertySet" to setCellValue that can be used to add properties to a cell.
Also, added methods to annotate a cell and get properties of a cell.