### PR TITLE
Forward deli state to scribe and create summaries

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
@@ -19,12 +19,15 @@ export interface IClientSequenceNumber {
     scopes: string[];
 }
 
-export interface ICheckpoint {
+export interface ICheckpoint extends IDeliCheckpoint {
+    queuedMessage: IQueuedMessage;
+}
+
+export interface IDeliCheckpoint {
     branchMap: IRangeTrackerSnapshot;
     clients: IClientSequenceNumber[];
     logOffset: number;
     sequenceNumber: number;
-    queuedMessage: IQueuedMessage;
 }
 
 export class CheckpointContext {

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -427,7 +427,7 @@ export class ScribeLambda extends SequencedLambda {
                 path: "logTail",
                 type: TreeEntry[TreeEntry.Blob],
                 value: {
-                    contents: JSON.stringify(logTail),
+                    contents: JSON.stringify(logTail.map((log) => log.operation)),
                     encoding: "utf-8",
                 },
             },

--- a/server/routerlicious/packages/protocol-definitions/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/protocol.ts
@@ -182,6 +182,10 @@ export interface ISequencedDocumentSystemMessage extends ISequencedDocumentMessa
     data: string;
 }
 
+export interface ISequencedDocumentAugmentedMessage extends ISequencedDocumentMessage {
+    additionalContent: string;
+}
+
 export interface IContentMessage {
 
     clientId: string;


### PR DESCRIPTION
* Deli forwards its checkpoint state to scribe with summary and noClient ops
* Scribe also writes it's checkpoint state to summaries
* Eventually Deli or Scribe will clear its cache to boot only from summaries
