### PR TITLE
createSharedMapWithInterception that provides support for features like user attribution

### DIFF
--- a/packages/framework/dds-interceptions/README.md
+++ b/packages/framework/dds-interceptions/README.md
@@ -26,7 +26,7 @@ function createSharedMapWithInterception(
     setInterceptionCallback: (sharedMap: ISharedMap, key: string, value: any) => void): SharedMap;
 ```
 
-When set is called on the SharedMap, it calls setInterceptionCallback with the underlying SharedMap, the given key and value. The callback funtion can then perform operations on either the underlying SharedMap or any other DDS. The original set operation and any operations in the callback are batched, i.e., they are guaranteed to be in order and will be applied together.
+When set is called on the SharedMap, it calls setInterceptionCallback with the underlying SharedMap, the key and value that the set was called with. The callback funtion can then perform operations on either the underlying SharedMap or any other DDS. The original set operation and any operations in the callback are batched, i.e., they are guaranteed to be in order and will be applied together.
 
 ## Shared Directory / Sub Directory With Interception
 

--- a/packages/framework/dds-interceptions/README.md
+++ b/packages/framework/dds-interceptions/README.md
@@ -28,6 +28,8 @@ function createSharedMapWithInterception(
 
 When set is called on the SharedMap, it calls setInterceptionCallback with the underlying SharedMap, the key and value that the set was called with. The callback funtion can then perform operations on either the underlying SharedMap or any other DDS. The original set operation and any operations in the callback are batched, i.e., they are guaranteed to be in order and will be applied together.
 
+Example: To support a feature like simple user attribution, in the callback, the app can set the user information in the underlying SharedMap against a key dervied from the original key - say against "key.attribute". Or, it could use a separate SharedMap to store the user information against the same key.
+
 ## Shared Directory / Sub Directory With Interception
 
 It provides `createdDirectoryWithInterception` that accepts an IDirectory object, the component context and a callback, and returns an IDirectory object:
@@ -44,3 +46,5 @@ It can be used to wrap a SharedDirectory or one of it's subdirectories to get an
 - value: They value that set was called with.
 
 The original set operation and any operations in the callback function are batched, i.e., they are guaranteed to in order and will be applied together.
+
+Example: To support a feature like simple user attribution, in the callback, the app can set the user information in a sub directory of the original object against the same key.

--- a/packages/framework/dds-interceptions/README.md
+++ b/packages/framework/dds-interceptions/README.md
@@ -12,7 +12,7 @@ function createSharedStringWithInterception(
     propertyInterceptionCallback: (props?: MergeTree.PropertySet) => MergeTree.PropertySet): SharedString;
 ```
 
-When a function is called that modifies the SharedString (for example, insertText), it calls the propertyInterceptionCallback function with the provided properties. The callback funtion can then provide the new set of properties that it wants to set. The operation in the called function and any operations in the callback function are batched, i.e., they are guaranteed to in order and will be applied together.
+When a function is called that modifies the SharedString (for example, insertText), it calls propertyInterceptionCallback with the provided properties. The callback funtion can then provide the new set of properties that it wants to set. The operation in the called function and any operations in the callback function are batched, i.e., they are guaranteed to in order and will be applied together.
 
 For example, to support a feature like simple user attribution, the app can append the user information to the properties in the callback. The user information can than be retrieved by getting the properties at any position.
 
@@ -23,11 +23,12 @@ It provides `createSharedMapWithInterception` that accepts a SharedMap, the comp
 function createSharedMapWithInterception(
     sharedMap: SharedMap,
     context: IComponentContext,
-    interceptionCallback: (key: string) => void): SharedMap;
+    setInterceptionCallback: (sharedMap: SharedMap, key: string, value: any) => void): SharedMap;
 ```
 
-When set is called on the SharedMap, it calls the interceptionCallback function with the given key. The callback funtion can perform any operation on the key. The original set operation and any operations in the callback function are batched, i.e., they are guaranteed to in order and will be applied together.
+When set is called on the SharedMap, it calls setInterceptionCallback with the underlying SharedMap, the given key and value. The callback funtion can then perform operations on either the underlying SharedMap or any other DDS. The original set operation and any operations in the callback function are batched, i.e., they are guaranteed to be in order and will be applied together.
 
+<<<<<<< HEAD
 Example: To support a feature like simple user attribution, in the callback, the app can set the user information in a separate SharedMap against the same key. Or it could set the user information in the same underlying SharedMap against a key dervied from the original key - say against "key.attribute".
 
 ## Shared Directory / Sub Directory With Interception
@@ -48,3 +49,6 @@ It can be used to wrap a SharedDirectory or one of it's subdirectories to get an
 The original set operation and any operations in the callback function are batched, i.e., they are guaranteed to in order and will be applied together.
 
 Example: To support a feature like simple user attribution, in the callback, the app can set the user information in a sub directory of the original object against the same key.
+=======
+Example: To support a feature like simple user attribution, in the callback, the app can set the user information in the passed SharedMap against a key dervied from the original key - say against "key.attribute". Or, it could use a separate SharedMap to store the user information against the same key.
+>>>>>>> Added the underlying shared map and the value to the callback. Removed shared directory from this PR.

--- a/packages/framework/dds-interceptions/README.md
+++ b/packages/framework/dds-interceptions/README.md
@@ -12,7 +12,7 @@ function createSharedStringWithInterception(
     propertyInterceptionCallback: (props?: MergeTree.PropertySet) => MergeTree.PropertySet): SharedString;
 ```
 
-When a function is called that modifies the SharedString (for example, insertText), it calls propertyInterceptionCallback with the provided properties. The callback funtion can then provide the new set of properties that it wants to set. The operation in the called function and any operations in the callback function are batched, i.e., they are guaranteed to in order and will be applied together.
+When a function is called that modifies the SharedString (for example, insertText), it calls propertyInterceptionCallback with the provided properties. The callback funtion can then provide the new set of properties that it wants to set. The operation in the called function and any operations in the callback are batched, i.e., they are guaranteed to be in order and will be applied together.
 
 For example, to support a feature like simple user attribution, the app can append the user information to the properties in the callback. The user information can than be retrieved by getting the properties at any position.
 
@@ -26,10 +26,7 @@ function createSharedMapWithInterception(
     setInterceptionCallback: (sharedMap: SharedMap, key: string, value: any) => void): SharedMap;
 ```
 
-When set is called on the SharedMap, it calls setInterceptionCallback with the underlying SharedMap, the given key and value. The callback funtion can then perform operations on either the underlying SharedMap or any other DDS. The original set operation and any operations in the callback function are batched, i.e., they are guaranteed to be in order and will be applied together.
-
-<<<<<<< HEAD
-Example: To support a feature like simple user attribution, in the callback, the app can set the user information in a separate SharedMap against the same key. Or it could set the user information in the same underlying SharedMap against a key dervied from the original key - say against "key.attribute".
+When set is called on the SharedMap, it calls setInterceptionCallback with the underlying SharedMap, the given key and value. The callback funtion can then perform operations on either the underlying SharedMap or any other DDS. The original set operation and any operations in the callback are batched, i.e., they are guaranteed to be in order and will be applied together.
 
 ## Shared Directory / Sub Directory With Interception
 
@@ -47,8 +44,3 @@ It can be used to wrap a SharedDirectory or one of it's subdirectories to get an
 - value: They value that set was called with.
 
 The original set operation and any operations in the callback function are batched, i.e., they are guaranteed to in order and will be applied together.
-
-Example: To support a feature like simple user attribution, in the callback, the app can set the user information in a sub directory of the original object against the same key.
-=======
-Example: To support a feature like simple user attribution, in the callback, the app can set the user information in the passed SharedMap against a key dervied from the original key - say against "key.attribute". Or, it could use a separate SharedMap to store the user information against the same key.
->>>>>>> Added the underlying shared map and the value to the callback. Removed shared directory from this PR.

--- a/packages/framework/dds-interceptions/README.md
+++ b/packages/framework/dds-interceptions/README.md
@@ -4,17 +4,31 @@ This package provides factory methods to create a wrapper around some of the bas
 
 ## Shared String With Interception
 
-It provides the createSharedStringWithInterception function that accepts a SharedString, the component context and a callback, and returns a SharedString object:
+It provides `createSharedStringWithInterception` that accepts a SharedString, the component context and a callback, and returns a SharedString object:
 ```typescript
 function createSharedStringWithInterception(
     sharedString: SharedString,
     context: IComponentContext,
-    propertyInterceptionCallback: (props?: MergeTree.PropertySet) => MergeTree.PropertySet): SharedString);
+    propertyInterceptionCallback: (props?: MergeTree.PropertySet) => MergeTree.PropertySet): SharedString;
 ```
 
 When a function is called that modifies the SharedString (for example, insertText), it calls the propertyInterceptionCallback function with the provided properties. The callback funtion can then provide the new set of properties that it wants to set. The operation in the called function and any operations in the callback function are batched, i.e., they are guaranteed to in order and will be applied together.
 
 For example, to support a feature like simple user attribution, the app can append the user information to the properties in the callback. The user information can than be retrieved by getting the properties at any position.
+
+## Shared Map With Interception
+
+It provides `createSharedMapWithInterception` that accepts a SharedMap, the component context and a callback, and returns a SharedMap object:
+```typescript
+function createSharedMapWithInterception(
+    sharedMap: SharedMap,
+    context: IComponentContext,
+    interceptionCallback: (key: string) => void): SharedMap;
+```
+
+When set is called on the SharedMap, it calls the interceptionCallback function with the given key. The callback funtion can perform any operation on the key. The original set operation and any operations in the callback function are batched, i.e., they are guaranteed to in order and will be applied together.
+
+Example: To support a feature like simple user attribution, in the callback, the app can set the user information in a separate SharedMap against the same key. Or it could set the user information in the same underlying SharedMap against a key dervied from the original key - say against "key.attribute".
 
 ## Shared Directory / Sub Directory With Interception
 

--- a/packages/framework/dds-interceptions/README.md
+++ b/packages/framework/dds-interceptions/README.md
@@ -23,7 +23,7 @@ It provides `createSharedMapWithInterception` that accepts a SharedMap, the comp
 function createSharedMapWithInterception(
     sharedMap: SharedMap,
     context: IComponentContext,
-    setInterceptionCallback: (sharedMap: SharedMap, key: string, value: any) => void): SharedMap;
+    setInterceptionCallback: (sharedMap: ISharedMap, key: string, value: any) => void): SharedMap;
 ```
 
 When set is called on the SharedMap, it calls setInterceptionCallback with the underlying SharedMap, the given key and value. The callback funtion can then perform operations on either the underlying SharedMap or any other DDS. The original set operation and any operations in the callback are batched, i.e., they are guaranteed to be in order and will be applied together.

--- a/packages/framework/dds-interceptions/src/map/index.ts
+++ b/packages/framework/dds-interceptions/src/map/index.ts
@@ -4,4 +4,3 @@
  */
 
 export * from "./sharedMapWithInterception";
-export * from "./sharedDirectoryWithInterception";

--- a/packages/framework/dds-interceptions/src/map/index.ts
+++ b/packages/framework/dds-interceptions/src/map/index.ts
@@ -3,4 +3,5 @@
  * Licensed under the MIT License.
  */
 
+export * from "./sharedMapWithInterception";
 export * from "./sharedDirectoryWithInterception";

--- a/packages/framework/dds-interceptions/src/map/index.ts
+++ b/packages/framework/dds-interceptions/src/map/index.ts
@@ -3,4 +3,6 @@
  * Licensed under the MIT License.
  */
 
+export * from "./sharedDirectoryWithInterception";
 export * from "./sharedMapWithInterception";
+

--- a/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-<<<<<<< HEAD
 import * as assert from "assert";
 import { IDirectory } from "@microsoft/fluid-map";
 import { IComponentContext } from "@microsoft/fluid-runtime-definitions";
@@ -53,39 +52,10 @@ function createSubDirectoryWithInterception<T extends IDirectory>(
             } finally {
                 executingCallback = false;
             }
-=======
-import { SharedDirectory } from "@microsoft/fluid-map";
-import { IComponentContext } from "@microsoft/fluid-runtime-definitions";
-
-/**
- * - Create a new object from the passed ShareDirectory.
- * - Modify the set method to call the interceptionCallback before calling set on the underlying SharedDirectory.
- * - The interceptionCallback and the call to the underlying SharedDirectory are wrapped around an
- *   orderSequentially call to batch any operations that might happen in the callback.
- *
- * @param sharedDirectory - The underlying SharedDirectory
- * @param context - The IComponentContext that will be used to call orderSequentially
- * @param interceptionCallback - The interception callback to be called
- *
- * @returns A new SharedDirectory that intercepts the set method and calls the interceptionCallback.
- */
-export function createSharedDirectoryWithInterception(
-    sharedDirectory: SharedDirectory,
-    context: IComponentContext,
-    interceptionCallback: (key: string) => void): SharedDirectory {
-    const sharedDirectoryWithInterception = Object.create(sharedDirectory);
-
-    sharedDirectoryWithInterception.set = (key: string, value: any) => {
-        let directory;
-        context.hostRuntime.orderSequentially(() => {
-            interceptionCallback(key);
-            directory = sharedDirectory.set(key, value);
->>>>>>> SharedMap and SharedDirectory with Interception that creates a wrapper to support features like user attribution.
         });
         return directory;
     };
 
-<<<<<<< HEAD
     subDirectoryWithInterception.createSubDirectory = (subdirName: string): IDirectory => {
         const subSubDirectory = subDirectory.createSubDirectory(subdirName);
         return createSubDirectoryWithInterception(baseDirectory, subSubDirectory, context, setInterceptionCallback);
@@ -156,7 +126,4 @@ export function createDirectoryWithInterception<T extends IDirectory>(
         key: string,
         value: any) => void): T {
     return createSubDirectoryWithInterception(baseDirectory, baseDirectory, context, setInterceptionCallback);
-=======
-    return sharedDirectoryWithInterception as SharedDirectory;
->>>>>>> SharedMap and SharedDirectory with Interception that creates a wrapper to support features like user attribution.
 }

--- a/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+<<<<<<< HEAD
 import * as assert from "assert";
 import { IDirectory } from "@microsoft/fluid-map";
 import { IComponentContext } from "@microsoft/fluid-runtime-definitions";
@@ -52,10 +53,39 @@ function createSubDirectoryWithInterception<T extends IDirectory>(
             } finally {
                 executingCallback = false;
             }
+=======
+import { SharedDirectory } from "@microsoft/fluid-map";
+import { IComponentContext } from "@microsoft/fluid-runtime-definitions";
+
+/**
+ * - Create a new object from the passed ShareDirectory.
+ * - Modify the set method to call the interceptionCallback before calling set on the underlying SharedDirectory.
+ * - The interceptionCallback and the call to the underlying SharedDirectory are wrapped around an
+ *   orderSequentially call to batch any operations that might happen in the callback.
+ *
+ * @param sharedDirectory - The underlying SharedDirectory
+ * @param context - The IComponentContext that will be used to call orderSequentially
+ * @param interceptionCallback - The interception callback to be called
+ *
+ * @returns A new SharedDirectory that intercepts the set method and calls the interceptionCallback.
+ */
+export function createSharedDirectoryWithInterception(
+    sharedDirectory: SharedDirectory,
+    context: IComponentContext,
+    interceptionCallback: (key: string) => void): SharedDirectory {
+    const sharedDirectoryWithInterception = Object.create(sharedDirectory);
+
+    sharedDirectoryWithInterception.set = (key: string, value: any) => {
+        let directory;
+        context.hostRuntime.orderSequentially(() => {
+            interceptionCallback(key);
+            directory = sharedDirectory.set(key, value);
+>>>>>>> SharedMap and SharedDirectory with Interception that creates a wrapper to support features like user attribution.
         });
         return directory;
     };
 
+<<<<<<< HEAD
     subDirectoryWithInterception.createSubDirectory = (subdirName: string): IDirectory => {
         const subSubDirectory = subDirectory.createSubDirectory(subdirName);
         return createSubDirectoryWithInterception(baseDirectory, subSubDirectory, context, setInterceptionCallback);
@@ -126,4 +156,7 @@ export function createDirectoryWithInterception<T extends IDirectory>(
         key: string,
         value: any) => void): T {
     return createSubDirectoryWithInterception(baseDirectory, baseDirectory, context, setInterceptionCallback);
+=======
+    return sharedDirectoryWithInterception as SharedDirectory;
+>>>>>>> SharedMap and SharedDirectory with Interception that creates a wrapper to support features like user attribution.
 }

--- a/packages/framework/dds-interceptions/src/map/sharedMapWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/map/sharedMapWithInterception.ts
@@ -8,26 +8,26 @@ import { IComponentContext } from "@microsoft/fluid-runtime-definitions";
 
 /**
  * - Create a new object from the passed SharedMap.
- * - Modify the set method to call the interceptionCallback before calling set on the underlying SharedMap.
- * - The interceptionCallback and the call to the underlying SharedMap are wrapped around an
+ * - Modify the set method to call the setInterceptionCallback before calling set on the underlying SharedMap.
+ * - The setInterceptionCallback and the call to the underlying SharedMap are wrapped around an
  *   orderSequentially call to batch any operations that might happen in the callback.
  *
  * @param sharedMap - The underlying SharedMap
  * @param context - The IComponentContext that will be used to call orderSequentially
- * @param interceptionCallback - The interception callback to be called
+ * @param setInterceptionCallback - The interception callback to be called
  *
- * @returns A new SharedMap that intercepts the set method and calls the interceptionCallback.
+ * @returns A new SharedMap that intercepts the set method and calls the setInterceptionCallback.
  */
 export function createSharedMapWithInterception(
     sharedMap: SharedMap,
     context: IComponentContext,
-    interceptionCallback: (sharedMap: SharedMap, key: string, value: any) => void): SharedMap {
+    setInterceptionCallback: (sharedMap: SharedMap, key: string, value: any) => void): SharedMap {
     const sharedMapWithInterception = Object.create(sharedMap);
 
     sharedMapWithInterception.set = (key: string, value: any) => {
         let map;
         context.hostRuntime.orderSequentially(() => {
-            interceptionCallback(sharedMap, key, value);
+            setInterceptionCallback(sharedMap, key, value);
             map = sharedMap.set(key, value);
         });
         return map;

--- a/packages/framework/dds-interceptions/src/map/sharedMapWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/map/sharedMapWithInterception.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { SharedMap } from "@microsoft/fluid-map";
+import { ISharedMap, SharedMap } from "@microsoft/fluid-map";
 import { IComponentContext } from "@microsoft/fluid-runtime-definitions";
 
 /**
@@ -21,14 +21,14 @@ import { IComponentContext } from "@microsoft/fluid-runtime-definitions";
 export function createSharedMapWithInterception(
     sharedMap: SharedMap,
     context: IComponentContext,
-    setInterceptionCallback: (sharedMap: SharedMap, key: string, value: any) => void): SharedMap {
+    setInterceptionCallback: (sharedMap: ISharedMap, key: string, value: any) => void): SharedMap {
     const sharedMapWithInterception = Object.create(sharedMap);
 
     sharedMapWithInterception.set = (key: string, value: any) => {
         let map;
         context.hostRuntime.orderSequentially(() => {
-            setInterceptionCallback(sharedMap, key, value);
             map = sharedMap.set(key, value);
+            setInterceptionCallback(sharedMap, key, value);
         });
         return map;
     };

--- a/packages/framework/dds-interceptions/src/map/sharedMapWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/map/sharedMapWithInterception.ts
@@ -21,13 +21,13 @@ import { IComponentContext } from "@microsoft/fluid-runtime-definitions";
 export function createSharedMapWithInterception(
     sharedMap: SharedMap,
     context: IComponentContext,
-    interceptionCallback: (key: string) => void): SharedMap {
+    interceptionCallback: (sharedMap: SharedMap, key: string, value: any) => void): SharedMap {
     const sharedMapWithInterception = Object.create(sharedMap);
 
     sharedMapWithInterception.set = (key: string, value: any) => {
         let map;
         context.hostRuntime.orderSequentially(() => {
-            interceptionCallback(key);
+            interceptionCallback(sharedMap, key, value);
             map = sharedMap.set(key, value);
         });
         return map;

--- a/packages/framework/dds-interceptions/src/map/sharedMapWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/map/sharedMapWithInterception.ts
@@ -37,8 +37,11 @@ export function createSharedMapWithInterception(
         context.hostRuntime.orderSequentially(() => {
             map = sharedMap.set(key, value);
             executingCallback = true;
-            setInterceptionCallback(sharedMap, key, value);
-            executingCallback = false;
+            try {
+                setInterceptionCallback(sharedMap, key, value);
+            } finally {
+                executingCallback = false;
+            }
         });
         return map;
     };

--- a/packages/framework/dds-interceptions/src/map/sharedMapWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/map/sharedMapWithInterception.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-//import * as assert from "assert";
+import * as assert from "assert";
 import { ISharedMap, SharedMap } from "@microsoft/fluid-map";
 import { IComponentContext } from "@microsoft/fluid-runtime-definitions";
 
@@ -25,21 +25,20 @@ export function createSharedMapWithInterception(
     setInterceptionCallback: (sharedMap: ISharedMap, key: string, value: any) => void): SharedMap {
     const sharedMapWithInterception = Object.create(sharedMap);
 
-    // executingCallback keeps track of whether set is called from the setInterceptionCallback. In that case,
-    // we do not call the callback again because that would result in infinite recursion. We will still set
-    // the key to keep the behavior similar to if set was called on the underlying SharedMap.
+    // executingCallback keeps track of whether set is called recursively from the setInterceptionCallback.
     let executingCallback: boolean = false;
 
     sharedMapWithInterception.set = (key: string, value: any) => {
         let map;
+        // Set should not be called on the wrapped object from the interception callback as this will lead to
+        // infinite recursion.
+        assert(executingCallback === false, "set called recursively from the interception callback");
+
         context.hostRuntime.orderSequentially(() => {
             map = sharedMap.set(key, value);
-            // If we are in the middle of executing a previous callback, do not call it again.
-            if (!executingCallback) {
-                executingCallback = true;
-                setInterceptionCallback(sharedMap, key, value);
-                executingCallback = false;
-            }
+            executingCallback = true;
+            setInterceptionCallback(sharedMap, key, value);
+            executingCallback = false;
         });
         return map;
     };

--- a/packages/framework/dds-interceptions/src/map/sharedMapWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/map/sharedMapWithInterception.ts
@@ -1,0 +1,37 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { SharedMap } from "@microsoft/fluid-map";
+import { IComponentContext } from "@microsoft/fluid-runtime-definitions";
+
+/**
+ * - Create a new object from the passed SharedMap.
+ * - Modify the set method to call the interceptionCallback before calling set on the underlying SharedMap.
+ * - The interceptionCallback and the call to the underlying SharedMap are wrapped around an
+ *   orderSequentially call to batch any operations that might happen in the callback.
+ *
+ * @param sharedMap - The underlying SharedMap
+ * @param context - The IComponentContext that will be used to call orderSequentially
+ * @param interceptionCallback - The interception callback to be called
+ *
+ * @returns A new SharedMap that intercepts the set method and calls the interceptionCallback.
+ */
+export function createSharedMapWithInterception(
+    sharedMap: SharedMap,
+    context: IComponentContext,
+    interceptionCallback: (key: string) => void): SharedMap {
+    const sharedMapWithInterception = Object.create(sharedMap);
+
+    sharedMapWithInterception.set = (key: string, value: any) => {
+        let map;
+        context.hostRuntime.orderSequentially(() => {
+            interceptionCallback(key);
+            map = sharedMap.set(key, value);
+        });
+        return map;
+    };
+
+    return sharedMapWithInterception as SharedMap;
+}

--- a/packages/framework/dds-interceptions/src/test/sharedMapWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedMapWithInterception.spec.ts
@@ -5,7 +5,7 @@
 
 import * as assert from "assert";
 import { MockDeltaConnectionFactory, MockRuntime, MockStorage } from "@microsoft/fluid-test-runtime-utils";
-import { SharedMap } from "@microsoft/fluid-map";
+import { ISharedMap, SharedMap } from "@microsoft/fluid-map";
 import { IComponentContext } from "@microsoft/fluid-runtime-definitions";
 import { createSharedMapWithInterception } from "../map";
 
@@ -28,7 +28,7 @@ describe("Shared Map with Interception", () => {
             callback();
         }
 
-        function interceptionCb(map: SharedMap, key: string, value: any): void {
+        function interceptionCb(map: ISharedMap, key: string, value: any): void {
             map.set(attributionKey(key), userId);
         }
 

--- a/packages/framework/dds-interceptions/src/test/sharedMapWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedMapWithInterception.spec.ts
@@ -5,7 +5,7 @@
 
 import * as assert from "assert";
 import { MockDeltaConnectionFactory, MockRuntime, MockStorage } from "@microsoft/fluid-test-runtime-utils";
-import { ISharedMap, SharedMap } from "@microsoft/fluid-map";
+import { ISharedMap, SharedMap, MapFactory } from "@microsoft/fluid-map";
 import { IComponentContext } from "@microsoft/fluid-runtime-definitions";
 import { createSharedMapWithInterception } from "../map";
 
@@ -34,7 +34,7 @@ describe("Shared Map with Interception", () => {
         beforeEach(() => {
             const runtime = new MockRuntime();
             deltaConnectionFactory = new MockDeltaConnectionFactory();
-            sharedMap = new SharedMap(documentId, runtime);
+            sharedMap = new SharedMap(documentId, runtime, MapFactory.Attributes);
             runtime.services = {
                 deltaConnection: deltaConnectionFactory.createDeltaConnection(runtime),
                 objectStorage: new MockStorage(undefined),

--- a/packages/framework/dds-interceptions/src/test/sharedMapWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedMapWithInterception.spec.ts
@@ -28,8 +28,8 @@ describe("Shared Map with Interception", () => {
             callback();
         }
 
-        function interceptionCb(key: string): void {
-            sharedMap.set(attributionKey(key), userId);
+        function interceptionCb(map: SharedMap, key: string, value: any): void {
+            map.set(attributionKey(key), userId);
         }
 
         beforeEach(() => {

--- a/packages/framework/dds-interceptions/src/test/sharedMapWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedMapWithInterception.spec.ts
@@ -1,0 +1,76 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as assert from "assert";
+import { MockDeltaConnectionFactory, MockRuntime, MockStorage } from "@microsoft/fluid-test-runtime-utils";
+import { SharedMap } from "@microsoft/fluid-map";
+import { IComponentContext } from "@microsoft/fluid-runtime-definitions";
+import { createSharedMapWithInterception } from "../map";
+
+describe("Shared Map with Interception", () => {
+    describe("Simple User Attribution", () => {
+        /**
+         * The following tests test simple user attribution in SharedMap with interception.
+         * In the callback function of the SharedMap with inteception, it sets the user
+         * attribution information in the underlying SharedMap against <key>.attribution.
+         */
+        const userId = "Fake User";
+        const documentId = "fakeId";
+        const attributionKey = (key: string) => `${key}.attribution`;
+        let deltaConnectionFactory: MockDeltaConnectionFactory;
+        let sharedMap: SharedMap;
+        let sharedMapWithInterception: SharedMap;
+        let componentContext: IComponentContext;
+
+        function orderSequentially(callback: () => void): void {
+            callback();
+        }
+
+        function interceptionCb(key: string): void {
+            sharedMap.set(attributionKey(key), userId);
+        }
+
+        beforeEach(() => {
+            const runtime = new MockRuntime();
+            deltaConnectionFactory = new MockDeltaConnectionFactory();
+            sharedMap = new SharedMap(documentId, runtime);
+            runtime.services = {
+                deltaConnection: deltaConnectionFactory.createDeltaConnection(runtime),
+                objectStorage: new MockStorage(undefined),
+            };
+            runtime.attach();
+
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            componentContext = { hostRuntime: { orderSequentially } } as IComponentContext;
+            sharedMapWithInterception =
+                createSharedMapWithInterception(sharedMap, componentContext, interceptionCb);
+        });
+
+        it("should be able to intercept SharedMap set method in the interception", async () => {
+            const key: string = "color";
+            const value: string = "green";
+            sharedMapWithInterception.set(key, value);
+            assert.equal(sharedMapWithInterception.get(key), value);
+            assert.equal(sharedMapWithInterception.get(attributionKey(key)), userId);
+        });
+
+        it("should be able to see changes made by the interception from the underlying shared map", async () => {
+            const key: string = "style";
+            const value: string = "bold";
+            sharedMapWithInterception.set(key, value);
+            assert.equal(sharedMap.get(key), value);
+            assert.equal(sharedMap.get(attributionKey(key)), userId);
+        });
+
+        it("should be able to see changes made by the underlying shared map from the interception", async () => {
+            const key: string = "font";
+            const value: string = "Arial";
+            sharedMap.set(key, value);
+            assert.equal(sharedMapWithInterception.get(key), value);
+            // The userId should not exist because there should be no interception.
+            assert.equal(sharedMapWithInterception.get(attributionKey(key)), undefined);
+        });
+    });
+});

--- a/packages/framework/dds-interceptions/src/test/sharedStringWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedStringWithInterception.spec.ts
@@ -21,10 +21,16 @@ describe("Shared String with Interception", () => {
         const documentId = "fakeId";
         let deltaConnectionFactory: MockDeltaConnectionFactory;
         let sharedString: SharedString;
+        let sharedStringWithInterception: SharedString;
         let componentContext: IComponentContext;
 
         function orderSequentially(callback: () => void): void {
             callback();
+        }
+
+        function propertyInterceptionCb(props?: MergeTree.PropertySet): MergeTree.PropertySet {
+            const newProps = { ...props, userId };
+            return newProps;
         }
 
         beforeEach(() => {
@@ -39,17 +45,11 @@ describe("Shared String with Interception", () => {
 
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             componentContext = { hostRuntime: { orderSequentially } } as IComponentContext;
+            sharedStringWithInterception =
+                createSharedStringWithInterception(sharedString, componentContext, propertyInterceptionCb);
         });
 
-        function propertyInterceptionCb(props?: MergeTree.PropertySet): MergeTree.PropertySet {
-            const newProps = { ...props, userId };
-            return newProps;
-        }
-
         it("should be able to intercept SharedString methods by the interception", async () => {
-            const sharedStringWithInterception =
-                createSharedStringWithInterception(sharedString, componentContext, propertyInterceptionCb);
-
             // Insert text into shared string.
             sharedStringWithInterception.insertText(0, "123", { style: "bold" });
             assert.equal(sharedStringWithInterception.getText(), "123", "The text should match the inserted text");
@@ -76,9 +76,6 @@ describe("Shared String with Interception", () => {
         });
 
         it("should be able to see changes made by the interception from the underlying shared string", async () => {
-            const sharedStringWithInterception =
-                createSharedStringWithInterception(sharedString, componentContext, propertyInterceptionCb);
-
             // Insert text via the shared string with interception.
             sharedStringWithInterception.insertText(0, "123", { style: "bold" });
 
@@ -108,9 +105,6 @@ describe("Shared String with Interception", () => {
         });
 
         it("should be able to see changes made by the underlying shared string from the interception", async () => {
-            const sharedStringWithInterception =
-                createSharedStringWithInterception(sharedString, componentContext, propertyInterceptionCb);
-
             // Insert text via the underlying shared string.
             sharedString.insertText(0, "123", { style: "bold" });
 

--- a/packages/framework/dds-interceptions/src/test/sharedStringWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedStringWithInterception.spec.ts
@@ -49,7 +49,7 @@ describe("Shared String with Interception", () => {
                 createSharedStringWithInterception(sharedString, componentContext, propertyInterceptionCb);
         });
 
-        it("should be able to intercept SharedString methods by the interception", async () => {
+        it("should be able to intercept SharedString methods by the wrapper", async () => {
             // Insert text into shared string.
             sharedStringWithInterception.insertText(0, "123", { style: "bold" });
             assert.equal(sharedStringWithInterception.getText(), "123", "The text should match the inserted text");
@@ -75,8 +75,8 @@ describe("Shared String with Interception", () => {
             assert.equal(propsAfterAnnotate.userId, userId, "The userId set via interception callback should exist");
         });
 
-        it("should be able to see changes made by the interception from the underlying shared string", async () => {
-            // Insert text via the shared string with interception.
+        it("should be able to see changes made by the wrapper from the underlying shared string", async () => {
+            // Insert text via the shared string with interception wrapper.
             sharedStringWithInterception.insertText(0, "123", { style: "bold" });
 
             // Get the text and properties via the underlying shared string.
@@ -85,7 +85,7 @@ describe("Shared String with Interception", () => {
             assert.equal(props.style, "bold", "The style set via insertText should exist");
             assert.equal(props.userId, userId, "The userId set via interception callback should exist");
 
-            // Replace text via the shared string with interception.
+            // Replace text via the shared string with interception wrapper.
             sharedStringWithInterception.replaceText(2, 3, "aaa", { style: "italics" });
 
             // Get the text and properties via the underlying shared string.
@@ -94,7 +94,7 @@ describe("Shared String with Interception", () => {
             assert.equal(propsAfterReplace.style, "italics", "The new style set via replaceText should exist");
             assert.equal(propsAfterReplace.userId, userId, "The userId set via interception callback should exist");
 
-            // Annotate via the shared string with interception.
+            // Annotate via the shared string with interception wrapper.
             sharedStringWithInterception.annotateRange(0, 5, { color: "green" });
 
             // Get the text and properties via the underlying shared string.
@@ -104,11 +104,11 @@ describe("Shared String with Interception", () => {
             assert.equal(propsAfterAnnotate.userId, userId, "The userId set via interception callback should exist");
         });
 
-        it("should be able to see changes made by the underlying shared string from the interception", async () => {
+        it("should be able to see changes made by the underlying shared string from the wrapper", async () => {
             // Insert text via the underlying shared string.
             sharedString.insertText(0, "123", { style: "bold" });
 
-            // Get the text and properties via the shared string interception.
+            // Get the text and properties via the shared string with interception wrapper.
             assert.equal(sharedStringWithInterception.getText(), "123", "The text should match the inserted text");
             const props = sharedStringWithInterception.getPropertiesAtPosition(2);
             assert.equal(props.style, "bold", "The style set via insertText should exist");
@@ -118,7 +118,7 @@ describe("Shared String with Interception", () => {
             // Replace text via the underlying shared string.
             sharedString.replaceText(2, 3, "aaa", { style: "italics" });
 
-            // Get the text and properties via the shared string interception.
+            // Get the text and properties via the shared string wtih interception wrapper.
             assert.equal(sharedStringWithInterception.getText(), "12aaa", "The text should match the replaced text");
             const propsAfterReplace = sharedStringWithInterception.getPropertiesAtPosition(2);
             assert.equal(propsAfterReplace.style, "italics", "The new style set via replaceText should exist");
@@ -128,7 +128,7 @@ describe("Shared String with Interception", () => {
             // Annotate via the underlying shared string.
             sharedString.annotateRange(0, 5, { color: "green" });
 
-            // Get the text and properties via the shared string with interception.
+            // Get the text and properties via the shared string with interception wrapper.
             const propsAfterAnnotate = sharedStringWithInterception.getPropertiesAtPosition(2);
             assert.equal(propsAfterAnnotate.style, "italics", "The previous style should exist");
             assert.equal(propsAfterAnnotate.color, "green", "The color set via annotateRange should exist");


### PR DESCRIPTION
Fixes #1363 .

Added the following method:
"createSharedMapWithInterception" which creates a wrapper around SharedMap. It takes a SharedMap, the component context and an interception callback. It returns a SharedMap. The function looks as follows:
```
function createSharedMapWithInterception(
    sharedMap: SharedMap,
    context: IComponentContext,
    setInterceptionCallback: (sharedMap: ISharedMap, key: string, value: any) => void): SharedMap;
```

This wrapper override the set method to call the setInterceptionCallback provided when creating the wrapper. The callback and the call to the underlying object is wrapped around orderSequentially so that they are batched together.

Apps can use this to support features like user attribution where the callback can add user information to the same underlying map against a new key (probably derived from the original key).