### PR TITLE
expose document storage

### DIFF
--- a/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
+++ b/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
@@ -11,6 +11,7 @@ import {
 import {
     DefaultMetricClient,
     IDatabaseManager,
+    IDocumentStorage,
     IOrderer,
     IOrdererManager,
     IWebSocketServer,
@@ -143,14 +144,24 @@ export class LocalDeltaConnectionServer implements ILocalDeltaConnectionServer {
             new DefaultMetricClient(),
             logger);
 
-        return new LocalDeltaConnectionServer(webSocketServer, databaseManager, testOrderer, testDbFactory);
+        return new LocalDeltaConnectionServer(
+            webSocketServer,
+            databaseManager,
+            testOrderer,
+            testDbFactory,
+            testStorage);
     }
 
     private constructor(
         public webSocketServer: IWebSocketServer,
         public databaseManager: IDatabaseManager,
         private readonly testOrdererManager: TestOrderManager,
-        public testDbFactory: ITestDbFactory) { }
+        public testDbFactory: ITestDbFactory,
+        private readonly _documentStorage: IDocumentStorage) { }
+
+    public get documentStorage(): IDocumentStorage {
+        return this._documentStorage;
+    }
 
     /**
      * Returns true if there are any received ops that are not yet ordered.

--- a/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
+++ b/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
@@ -157,11 +157,7 @@ export class LocalDeltaConnectionServer implements ILocalDeltaConnectionServer {
         public databaseManager: IDatabaseManager,
         private readonly testOrdererManager: TestOrderManager,
         public testDbFactory: ITestDbFactory,
-        private readonly _documentStorage: IDocumentStorage) { }
-
-    public get documentStorage(): IDocumentStorage {
-        return this._documentStorage;
-    }
+        public documentStorage: IDocumentStorage) { }
 
     /**
      * Returns true if there are any received ops that are not yet ordered.


### PR DESCRIPTION
To test the new createDocument api in localServer and to create the document with summary, we want to expose this storage so that it can be used in resolver/driver.