### PR TITLE
Update BREAKING.md with reduced component interface

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -8,6 +8,7 @@
 - [`IComponentHandle` - Moved type parameter from get to interface](#icomponenthandle-type-parameter-moved)
 - [Changes to the render interfaces](#changes-to-the-render-interfaces)
 - [Old runtime container cannot load new components](#old-runtime-container-cannot-load-new-components)
+- [PrimedComponent and SharedComponent interfaces are now more restrictive](#restricted-component-interfaces)
 
 ## Packages move and renamed
 
@@ -96,6 +97,18 @@ The rendering interfaces have undergone several changes:
 ## Old runtime container cannot load new components
 
 The way that summaries are generated has changed in such a way that the runtime container is backwards compatible with 0.13 components, but 0.13 runtime container cannot load 0.14 or later components.
+
+## PrimedComponent and SharedComponent interfaces are now more restrictive
+The following class variables have been changed from public -> protected
+In PrimedComponent:
+- root
+- taskManager
+- writeBlob
+In SharedComponent:
+- asComponent
+If you still need to access these methods, you can still do so by overloading the needed method in your class
+and making it public.
+An example of this can be seen in primedComponent.spec.ts 
 
 # 0.13 Breaking Changes
 


### PR DESCRIPTION
Replaying this PR on the release/0.14 branch:
https://github.com/microsoft/FluidFramework/pull/1485/files