### PR TITLE
Use @typescript-eslint/no-unused-expressions warning Pt1

### DIFF
--- a/common/build/eslint-config-fluid/no-tslint.js
+++ b/common/build/eslint-config-fluid/no-tslint.js
@@ -99,6 +99,7 @@ module.exports = {
         "@typescript-eslint/no-parameter-properties": "off",
         "@typescript-eslint/no-require-imports": "error",
         "@typescript-eslint/no-this-alias": "error",
+        "@typescript-eslint/no-unused-expressions": "error",
         "@typescript-eslint/no-unused-vars": [
             "error",
             {
@@ -140,7 +141,7 @@ module.exports = {
             }
         ],
         "@typescript-eslint/triple-slash-reference": "error",
-        "@typescript-eslint/type-annotation-spacing": "error", 
+        "@typescript-eslint/type-annotation-spacing": "error",
         "@typescript-eslint/unbound-method": [
             "error",
             {
@@ -283,7 +284,7 @@ module.exports = {
         "no-undef-init": "error",
         "no-underscore-dangle": "off",
         "no-unsafe-finally": "error",
-        "no-unused-expressions": "error",
+        "no-unused-expressions": "off",
         "no-unused-labels": "error",
         "no-unused-vars": "off",
         "no-var": "error",


### PR DESCRIPTION
Part 1 of #1416 

Add warning for @typescript-eslint/no-unused-expressions and remove warning for no-unused-expressions.  Part 2 later will update consumers to use the new version, and update error supressions as appropriate.

The new warning doesn't trigger for TS's optionals which transpile down to ternarys which trigger the old warning.