### PR TITLE
createDirectoryWithInterception that provides support for features like user attribution

### DIFF
--- a/packages/framework/dds-interceptions/README.md
+++ b/packages/framework/dds-interceptions/README.md
@@ -4,42 +4,33 @@ This package provides factory methods to create a wrapper around some of the bas
 
 ## Shared String With Interception
 
-It provides `createSharedStringWithInterception` that accepts a SharedString, the component context and a callback, and returns a SharedString object:
+It provides the createSharedStringWithInterception function that accepts a SharedString, the component context and a callback, and returns a SharedString object:
 ```typescript
 function createSharedStringWithInterception(
     sharedString: SharedString,
     context: IComponentContext,
-    propertyInterceptionCallback: (props?: MergeTree.PropertySet) => MergeTree.PropertySet): SharedString;
+    propertyInterceptionCallback: (props?: MergeTree.PropertySet) => MergeTree.PropertySet): SharedString);
 ```
 
 When a function is called that modifies the SharedString (for example, insertText), it calls the propertyInterceptionCallback function with the provided properties. The callback funtion can then provide the new set of properties that it wants to set. The operation in the called function and any operations in the callback function are batched, i.e., they are guaranteed to in order and will be applied together.
 
-Example: To support a feature like simple user attribution, the app can append the user information to the properties in the callback. The user information can than be retrieved by getting the properties at any position.
+For example, to support a feature like simple user attribution, the app can append the user information to the properties in the callback. The user information can than be retrieved by getting the properties at any position.
 
-## Shared Map With Interception
+## Shared Directory / Sub Directory With Interception
 
-It provides `createSharedMapWithInterception` that accepts a SharedMap, the component context and a callback, and returns a SharedMap object:
+It provides `createdDirectoryWithInterception` that accepts an IDirectory object, the component context and a callback, and returns an IDirectory object:
 ```typescript
-function createSharedMapWithInterception(
-    sharedMap: SharedMap,
+function createDirectoryWithInterception<T extends IDirectory>(
+    baseDirectory: T,
     context: IComponentContext,
-    interceptionCallback: (key: string) => void): SharedMap;
+    setInterceptionCallback: (baseDirectory: IDirectory, subDirectory: IDirectory, key: string, value: any) => void): T;
 ```
+It can be used to wrap a SharedDirectory or one of it's subdirectories to get an interception callback when set is called on the object. The callback funtion is passed the following:
+- baseDirectory: This is the outermost directory in this directory structure that was wrapped. For example, when a SharedDirectory (say 'root') is wrapped, then a set on it or any of its sub directories will be passed 'root' as the baseDirectory.
+- subDirectory: This is the directory that the set is called on and which calls the callback.
+- key: They key that set was called with.
+- value: They value that set was called with.
 
-When set is called on the SharedMap, it calls the interceptionCallback function with the given key. The callback funtion can perform any operation on the key. The original set operation and any operations in the callback function are batched, i.e., they are guaranteed to in order and will be applied together.
+The original set operation and any operations in the callback function are batched, i.e., they are guaranteed to in order and will be applied together.
 
-Example: To support a feature like simple user attribution, in the callback, the app can set the user information in a separate SharedMap against the same key. Or it could set the user information in the same underlying SharedMap against a key dervied from the original key - say against "key.attribute".
-
-## Shared Directory With Interception
-
-It provides `createSharedDirectoryWithInterception` that accepts a SharedDirectory, the component context and a callback, and returns a SharedDirectory object:
-```typescript
-function createSharedDirectoryWithInterception(
-    sharedDirectory: SharedDirectory,
-    context: IComponentContext,
-    interceptionCallback: (key: string) => void): SharedDirectory;
-```
-
-When set is called on the SharedDirectory, it calls the interceptionCallback function with the given key. The callback funtion can perform any operation on the key. The original set operation and any operations in the callback function are batched, i.e., they are guaranteed to in order and will be applied together.
-
-Example: To support a feature like simple user attribution, in the callback, the app can set the user information in a subDirectory of the original SharedDirectory against the same key.
+Example: To support a feature like simple user attribution, in the callback, the app can set the user information in a sub directory of the original object against the same key.

--- a/packages/framework/dds-interceptions/README.md
+++ b/packages/framework/dds-interceptions/README.md
@@ -4,14 +4,42 @@ This package provides factory methods to create a wrapper around some of the bas
 
 ## Shared String With Interception
 
-It provides the createSharedStringWithInterception function that accepts a SharedString, the component context and a callback, and returns a SharedString object:
+It provides `createSharedStringWithInterception` that accepts a SharedString, the component context and a callback, and returns a SharedString object:
 ```typescript
 function createSharedStringWithInterception(
     sharedString: SharedString,
     context: IComponentContext,
-    propertyInterceptionCallback: (props?: MergeTree.PropertySet) => MergeTree.PropertySet): SharedString);
+    propertyInterceptionCallback: (props?: MergeTree.PropertySet) => MergeTree.PropertySet): SharedString;
 ```
 
 When a function is called that modifies the SharedString (for example, insertText), it calls the propertyInterceptionCallback function with the provided properties. The callback funtion can then provide the new set of properties that it wants to set. The operation in the called function and any operations in the callback function are batched, i.e., they are guaranteed to in order and will be applied together.
 
-For example, to support a feature like simple user attribution, the app can append the user information to the properties in the callback. The user information can than be retrieved by getting the properties at any position.
+Example: To support a feature like simple user attribution, the app can append the user information to the properties in the callback. The user information can than be retrieved by getting the properties at any position.
+
+## Shared Map With Interception
+
+It provides `createSharedMapWithInterception` that accepts a SharedMap, the component context and a callback, and returns a SharedMap object:
+```typescript
+function createSharedMapWithInterception(
+    sharedMap: SharedMap,
+    context: IComponentContext,
+    interceptionCallback: (key: string) => void): SharedMap;
+```
+
+When set is called on the SharedMap, it calls the interceptionCallback function with the given key. The callback funtion can perform any operation on the key. The original set operation and any operations in the callback function are batched, i.e., they are guaranteed to in order and will be applied together.
+
+Example: To support a feature like simple user attribution, in the callback, the app can set the user information in a separate SharedMap against the same key. Or it could set the user information in the same underlying SharedMap against a key dervied from the original key - say against "key.attribute".
+
+## Shared Directory With Interception
+
+It provides `createSharedDirectoryWithInterception` that accepts a SharedDirectory, the component context and a callback, and returns a SharedDirectory object:
+```typescript
+function createSharedDirectoryWithInterception(
+    sharedDirectory: SharedDirectory,
+    context: IComponentContext,
+    interceptionCallback: (key: string) => void): SharedDirectory;
+```
+
+When set is called on the SharedDirectory, it calls the interceptionCallback function with the given key. The callback funtion can perform any operation on the key. The original set operation and any operations in the callback function are batched, i.e., they are guaranteed to in order and will be applied together.
+
+Example: To support a feature like simple user attribution, in the callback, the app can set the user information in a subDirectory of the original SharedDirectory against the same key.

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -49,9 +49,10 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
+    "@microsoft/fluid-map": "^0.14.0",
     "@microsoft/fluid-merge-tree": "^0.14.0",
-    "@microsoft/fluid-sequence": "^0.14.0",
-    "@microsoft/fluid-runtime-definitions": "^0.14.0"
+    "@microsoft/fluid-runtime-definitions": "^0.14.0",
+    "@microsoft/fluid-sequence": "^0.14.0"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/framework/dds-interceptions/src/map/index.ts
+++ b/packages/framework/dds-interceptions/src/map/index.ts
@@ -3,5 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export * from "./sequence";
-export * from "./map";
+export * from "./sharedDirectoryWithInterception";

--- a/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
@@ -3,42 +3,184 @@
  * Licensed under the MIT License.
  */
 
-import { IDirectory, SharedDirectory } from "@microsoft/fluid-map";
+import * as assert from "assert";
+import { IDirectory } from "@microsoft/fluid-map";
 import { IComponentContext } from "@microsoft/fluid-runtime-definitions";
 
 /**
- * - Create a new object from the passed ShareDirectory.
- * - Modify the set method to call the setInterceptionCallback before calling set on the underlying SharedDirectory.
- * - The setInterceptionCallback and the call to the underlying SharedDirectory are wrapped around an
- *   orderSequentially call to batch any operations that might happen in the callback.
+ * - Create a new object from the passed subDirectory.
+ * - Modify the set method to call the setInterceptionCallback before calling set on the underlying object.
+ * - The setInterceptionCallback and the call to the underlying object are wrapped around an orderSequentially
+ *   call to batch any operations that might happen in the callback.
+ * - Modify the sub directory methods to create / return a wrapper object that in turn intercepts the set method and
+ *   calls the setInterceptionCallback.
+ * - When a sub directory is created from this directory, this base directory object is passed to it which is passed
+ *   into the interception callback.
  *
- * @param sharedDirectory - The underlying SharedDirectory
+ * @param baseDirectory - The base directory in the directory structure that is passed to the interception callback
+ * @param subDirectory - The underlying object that is to be intercepted
  * @param context - The IComponentContext that will be used to call orderSequentially
  * @param setInterceptionCallback - The interception callback to be called
  *
- * @returns A new SharedDirectory that intercepts the set method and calls the setInterceptionCallback.
+ * @returns A new sub directory that intercepts the set method and calls the setInterceptionCallback.
  */
-export function createSharedDirectoryWithInterception(
-    sharedDirectory: SharedDirectory,
+function createSubDirectoryWithInterception(
+    baseDirectory: IDirectory,
+    subDirectory: IDirectory,
     context: IComponentContext,
-    setInterceptionCallback: (sharedDirectory: IDirectory, key: string, value: any) => void): SharedDirectory {
-    const sharedDirectoryWithInterception = Object.create(sharedDirectory);
+    setInterceptionCallback: (
+        baseDirectory: IDirectory,
+        subDirectory: IDirectory,
+        key: string,
+        value: any) => void): IDirectory {
+    const subDirectoryWithInterception = Object.create(subDirectory);
 
-    sharedDirectoryWithInterception.set = (key: string, value: any) => {
+    // executingCallback keeps track of whether set is called recursively from the setInterceptionCallback.
+    let executingCallback: boolean = false;
+
+    subDirectoryWithInterception.set = (key: string, value: any) => {
         let directory;
+        // Set should not be called on the wrapped object from the interception callback as this will lead to
+        // infinite recursion.
+        assert(executingCallback === false, "set called recursively from the interception callback");
+
         context.hostRuntime.orderSequentially(() => {
-            setInterceptionCallback(sharedDirectory, key, value);
-            directory = sharedDirectory.set(key, value);
+            directory = subDirectory.set(key, value);
+            executingCallback = true;
+            setInterceptionCallback(baseDirectory, subDirectory, key, value);
+            executingCallback = false;
         });
         return directory;
     };
 
-    sharedDirectoryWithInterception.createSubDirectory = (subdirName: string): IDirectory => {
-        const subDirectory = sharedDirectory.createSubDirectory(subdirName);
-        const subDirectoryWithInterception =
-            createSharedDirectoryWithInterception(subDirectory as SharedDirectory, context, setInterceptionCallback);
-        return subDirectoryWithInterception as IDirectory;
+    subDirectoryWithInterception.createSubDirectory = (subdirName: string): IDirectory => {
+        const subSubDirectory = subDirectory.createSubDirectory(subdirName);
+        return createSubDirectoryWithInterception(baseDirectory, subSubDirectory, context, setInterceptionCallback);
     };
 
-    return sharedDirectoryWithInterception as SharedDirectory;
+    subDirectoryWithInterception.getSubDirectory = (subdirName: string): IDirectory => {
+        const subSubDirectory = subDirectory.getSubDirectory(subdirName);
+        return subSubDirectory === undefined ?
+            subSubDirectory :
+            createSubDirectoryWithInterception(baseDirectory, subSubDirectory, context, setInterceptionCallback);
+    };
+
+    subDirectoryWithInterception.subdirectories = (): IterableIterator<[string, IDirectory]> => {
+        const localDirectoriesIterator = subDirectory.subdirectories();
+        const iterator = {
+            next(): IteratorResult<[string, IDirectory]> {
+                const nextVal = localDirectoriesIterator.next();
+                if (nextVal.done) {
+                    return { value: undefined, done: true };
+                } else {
+                    // Wrap the stored subdirectory in the interception wrapper.
+                    const subDir = createSubDirectoryWithInterception(
+                        baseDirectory,
+                        nextVal.value[1],
+                        context,
+                        setInterceptionCallback);
+                    return { value: [nextVal.value[0], subDir], done: false };
+                }
+            },
+            [Symbol.iterator]() {
+                return this;
+            },
+        };
+        return iterator;
+    };
+
+    subDirectoryWithInterception.getWorkingDirectory = (relativePath: string): IDirectory => {
+        const subSubDirectory = subDirectory.getWorkingDirectory(relativePath);
+        return createSubDirectoryWithInterception(baseDirectory, subSubDirectory, context, setInterceptionCallback);
+    };
+
+    return subDirectoryWithInterception as IDirectory;
+}
+
+/**
+ * - Create a new object from the passed IDirectory object.
+ * - Modify the set method to call the setInterceptionCallback before calling set on the underlying object.
+ * - The setInterceptionCallback and the call to the underlying object are wrapped around an orderSequentially
+ *   call to batch any operations that might happen in the callback.
+ * - Modify the sub directory methods to create / return a wrapper object that in turn intercepts the set method and
+ *   calls the setInterceptionCallback.
+ * - When a sub directory is created from this directory, this directory object is passed to it which is passed into
+ *   the interception callback.
+ *
+ * @param baseDirectory - The underlying object that is to be intercepted
+ * @param context - The IComponentContext that will be used to call orderSequentially
+ * @param setInterceptionCallback - The interception callback to be called
+ *
+ * @returns A new IDirectory object that intercepts the set method and calls the setInterceptionCallback.
+ */
+export function createDirectoryWithInterception<T extends IDirectory>(
+    baseDirectory: T,
+    context: IComponentContext,
+    setInterceptionCallback: (
+        baseDirectory: IDirectory,
+        subDirectory: IDirectory,
+        key: string,
+        value: any) => void): T {
+    const directoryWithInterception = Object.create(baseDirectory);
+
+    // executingCallback keeps track of whether set is called recursively from the setInterceptionCallback.
+    let executingCallback: boolean = false;
+
+    directoryWithInterception.set = (key: string, value: any) => {
+        let directory;
+        // Set should not be called on the wrapped object from the interception callback as this will lead to
+        // infinite recursion.
+        assert(executingCallback === false, "set called recursively from the interception callback");
+
+        context.hostRuntime.orderSequentially(() => {
+            directory = baseDirectory.set(key, value);
+            executingCallback = true;
+            setInterceptionCallback(baseDirectory, baseDirectory, key, value);
+            executingCallback = false;
+        });
+        return directory;
+    };
+
+    directoryWithInterception.createSubDirectory = (subdirName: string): IDirectory => {
+        const subDirectory = baseDirectory.createSubDirectory(subdirName);
+        return createSubDirectoryWithInterception(baseDirectory, subDirectory, context, setInterceptionCallback);
+    };
+
+    directoryWithInterception.getSubDirectory = (subdirName: string): IDirectory => {
+        const subDirectory = baseDirectory.getSubDirectory(subdirName);
+        return subDirectory === undefined ?
+            subDirectory :
+            createSubDirectoryWithInterception(baseDirectory, subDirectory, context, setInterceptionCallback);
+    };
+
+    directoryWithInterception.subdirectories = (): IterableIterator<[string, IDirectory]> => {
+        const localDirectoriesIterator = baseDirectory.subdirectories();
+        const iterator = {
+            next(): IteratorResult<[string, IDirectory]> {
+                const nextVal = localDirectoriesIterator.next();
+                if (nextVal.done) {
+                    return { value: undefined, done: true };
+                } else {
+                    // Wrap the stored subdirectory in the interception wrapper.
+                    const subDir = createSubDirectoryWithInterception(
+                        baseDirectory,
+                        nextVal.value[1],
+                        context,
+                        setInterceptionCallback);
+                    return { value: [nextVal.value[0], subDir], done: false };
+                }
+            },
+            [Symbol.iterator]() {
+                return this;
+            },
+        };
+        return iterator;
+    };
+
+    directoryWithInterception.getWorkingDirectory = (relativePath: string): IDirectory => {
+        const subDirectory = baseDirectory.getWorkingDirectory(relativePath);
+        return createSubDirectoryWithInterception(baseDirectory, subDirectory, context, setInterceptionCallback);
+    };
+
+    return directoryWithInterception as T;
 }

--- a/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
@@ -1,0 +1,44 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IDirectory, SharedDirectory } from "@microsoft/fluid-map";
+import { IComponentContext } from "@microsoft/fluid-runtime-definitions";
+
+/**
+ * - Create a new object from the passed ShareDirectory.
+ * - Modify the set method to call the setInterceptionCallback before calling set on the underlying SharedDirectory.
+ * - The setInterceptionCallback and the call to the underlying SharedDirectory are wrapped around an
+ *   orderSequentially call to batch any operations that might happen in the callback.
+ *
+ * @param sharedDirectory - The underlying SharedDirectory
+ * @param context - The IComponentContext that will be used to call orderSequentially
+ * @param setInterceptionCallback - The interception callback to be called
+ *
+ * @returns A new SharedDirectory that intercepts the set method and calls the setInterceptionCallback.
+ */
+export function createSharedDirectoryWithInterception(
+    sharedDirectory: SharedDirectory,
+    context: IComponentContext,
+    setInterceptionCallback: (sharedDirectory: IDirectory, key: string, value: any) => void): SharedDirectory {
+    const sharedDirectoryWithInterception = Object.create(sharedDirectory);
+
+    sharedDirectoryWithInterception.set = (key: string, value: any) => {
+        let directory;
+        context.hostRuntime.orderSequentially(() => {
+            setInterceptionCallback(sharedDirectory, key, value);
+            directory = sharedDirectory.set(key, value);
+        });
+        return directory;
+    };
+
+    sharedDirectoryWithInterception.createSubDirectory = (subdirName: string): IDirectory => {
+        const subDirectory = sharedDirectory.createSubDirectory(subdirName);
+        const subDirectoryWithInterception =
+            createSharedDirectoryWithInterception(subDirectory as SharedDirectory, context, setInterceptionCallback);
+        return subDirectoryWithInterception as IDirectory;
+    };
+
+    return sharedDirectoryWithInterception as SharedDirectory;
+}

--- a/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
@@ -24,15 +24,15 @@ import { IComponentContext } from "@microsoft/fluid-runtime-definitions";
  *
  * @returns A new sub directory that intercepts the set method and calls the setInterceptionCallback.
  */
-function createSubDirectoryWithInterception(
-    baseDirectory: IDirectory,
-    subDirectory: IDirectory,
+function createSubDirectoryWithInterception<T extends IDirectory>(
+    baseDirectory: T,
+    subDirectory: T,
     context: IComponentContext,
     setInterceptionCallback: (
         baseDirectory: IDirectory,
         subDirectory: IDirectory,
         key: string,
-        value: any) => void): IDirectory {
+        value: any) => void): T {
     const subDirectoryWithInterception = Object.create(subDirectory);
 
     // executingCallback keeps track of whether set is called recursively from the setInterceptionCallback.
@@ -97,7 +97,7 @@ function createSubDirectoryWithInterception(
         return createSubDirectoryWithInterception(baseDirectory, subSubDirectory, context, setInterceptionCallback);
     };
 
-    return subDirectoryWithInterception as IDirectory;
+    return subDirectoryWithInterception;
 }
 
 /**
@@ -116,12 +116,14 @@ function createSubDirectoryWithInterception(
  *
  * @returns A new IDirectory object that intercepts the set method and calls the setInterceptionCallback.
  */
+// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export function createDirectoryWithInterception<T extends IDirectory>(
     baseDirectory: T,
     context: IComponentContext,
-    setInterceptionCallback: (baseDirectory: IDirectory, subDirectory: IDirectory, key: string, value: any) => void):
-    T {
-    const directory =
-        createSubDirectoryWithInterception(baseDirectory, baseDirectory, context, setInterceptionCallback);
-    return directory as T;
+    setInterceptionCallback: (
+        baseDirectory: IDirectory,
+        subDirectory: IDirectory,
+        key: string,
+        value: any) => void): T {
+    return createSubDirectoryWithInterception(baseDirectory, baseDirectory, context, setInterceptionCallback);
 }

--- a/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
@@ -47,8 +47,11 @@ function createSubDirectoryWithInterception(
         context.hostRuntime.orderSequentially(() => {
             directory = subDirectory.set(key, value);
             executingCallback = true;
-            setInterceptionCallback(baseDirectory, subDirectory, key, value);
-            executingCallback = false;
+            try {
+                setInterceptionCallback(baseDirectory, subDirectory, key, value);
+            } finally {
+                executingCallback = false;
+            }
         });
         return directory;
     };

--- a/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
@@ -1,0 +1,106 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as assert from "assert";
+import { MockDeltaConnectionFactory, MockRuntime, MockStorage } from "@microsoft/fluid-test-runtime-utils";
+import { SharedDirectory, IDirectory } from "@microsoft/fluid-map";
+import { IComponentContext } from "@microsoft/fluid-runtime-definitions";
+import { createSharedDirectoryWithInterception } from "../map";
+
+describe("Shared Directory with Interception", () => {
+    describe("Simple User Attribution", () => {
+        /**
+         * The following tests test simple user attribution in SharedDirecory with interception.
+         * In the callback function of the SharedDirectory with interception, it sets the user
+         * attribution information in a sub-directory of the underlying SharedDirectory against the same key.
+         */
+        const userId = "Fake User";
+        const documentId = "fakeId";
+        const attributionDirectoryName = "user-attribution";
+        let deltaConnectionFactory: MockDeltaConnectionFactory;
+        let sharedDirectory: SharedDirectory;
+        let sharedDirectoryWithInterception: SharedDirectory;
+        let componentContext: IComponentContext;
+
+        function orderSequentially(callback: () => void): void {
+            callback();
+        }
+
+        function interceptionCb(directory: IDirectory, key: string, value: any): void {
+            if (!directory.hasSubDirectory(attributionDirectoryName)) {
+                directory.createSubDirectory(attributionDirectoryName);
+            }
+            const attributionDirectory: IDirectory = directory.getSubDirectory(attributionDirectoryName);
+            attributionDirectory.set(key, userId);
+        }
+
+        beforeEach(() => {
+            const runtime = new MockRuntime();
+            deltaConnectionFactory = new MockDeltaConnectionFactory();
+            sharedDirectory = new SharedDirectory(documentId, runtime);
+            runtime.services = {
+                deltaConnection: deltaConnectionFactory.createDeltaConnection(runtime),
+                objectStorage: new MockStorage(undefined),
+            };
+            runtime.attach();
+
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            componentContext = { hostRuntime: { orderSequentially } } as IComponentContext;
+            sharedDirectoryWithInterception =
+                createSharedDirectoryWithInterception(sharedDirectory, componentContext, interceptionCb);
+        });
+
+        it("should be able to intercept SharedDirectory set method in the interception", async () => {
+            const key: string = "color";
+            const value: string = "green";
+            sharedDirectoryWithInterception.set(key, value);
+            assert.equal(sharedDirectoryWithInterception.get(key), value);
+
+            const attributionDirectory: IDirectory =
+                sharedDirectoryWithInterception.getSubDirectory(attributionDirectoryName);
+            assert.equal(attributionDirectory.get(key), userId);
+
+            // Verify that the attributionDirectory doesn't create another attribution sub directory. The
+            // attributionDirectory is created via the underlying shared directory and not via the shared
+            // directory with attribution.
+            assert.equal(attributionDirectory.getSubDirectory(attributionDirectoryName), undefined);
+        });
+
+        it("should be able to see changes made by the interception from the underlying shared directory", async () => {
+            const key: string = "style";
+            const value: string = "bold";
+            sharedDirectoryWithInterception.set(key, value);
+            assert.equal(sharedDirectory.get(key), value);
+
+            const attributionDirectory: IDirectory = sharedDirectory.getSubDirectory(attributionDirectoryName);
+            assert.equal(attributionDirectory.get(key), userId);
+        });
+
+        it("should be able to see changes made by the underlying shared directory from the interception", async () => {
+            const key: string = "font";
+            const value: string = "Arial";
+            sharedDirectory.set(key, value);
+            assert.equal(sharedDirectoryWithInterception.get(key), value);
+
+            const attributionDirectory: IDirectory =
+                sharedDirectoryWithInterception.getSubDirectory(attributionDirectoryName);
+            // The attributionDirectory should not exist because there should be no interception.
+            assert.equal(attributionDirectory, undefined);
+        });
+
+        it("should be able create a sub directory with interception from the shared directory", async () => {
+            const key: string = "font";
+            const value: string = "Arial";
+
+            const subDirectoryWithInterception = sharedDirectoryWithInterception.createSubDirectory("foo");
+            subDirectoryWithInterception.set(key, value);
+            assert.equal(subDirectoryWithInterception.get(key), value);
+
+            const attributionDirectory: IDirectory =
+                subDirectoryWithInterception.getSubDirectory(attributionDirectoryName);
+            assert.equal(attributionDirectory.get(key), userId);
+        });
+    });
+});

--- a/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
@@ -11,11 +11,6 @@ import { createDirectoryWithInterception } from "../map";
 
 describe("Shared Directory with Interception", () => {
     describe("Simple User Attribution", () => {
-        /**
-         * The following tests test simple user attribution in SharedDirecory with interception.
-         * In the callback function of the SharedDirectory with interception, it sets the user
-         * attribution information in a sub-directory of the underlying SharedDirectory against the same key.
-         */
         const userId = "Fake User";
         const documentId = "fakeId";
         const attributionDirectoryName = "attribution";
@@ -128,7 +123,7 @@ describe("Shared Directory with Interception", () => {
             const key: string = "level";
             let value: string = "root";
             root.set(key, value);
-            assert.equal(root.get(value), "root", "The value should match the value that was set");
+            assert.equal(root.get(key), value, "The value should match the value that was set");
 
             // Verify that attribution directory `/attribution` was created for root and the user attribute
             // set on it.
@@ -237,11 +232,11 @@ describe("Shared Directory with Interception", () => {
         });
 
         /**
-         * This test creates a wrapper shared directory. It then creates a subdirectory and creates another wrapper
+         * This test creates a wrapped shared directory. It then creates a subdirectory and creates another wrapper
          * from the subdirectory. It verifies that the callback for both the root directory and subdirectory is
          * called on a set on the wrapped subdirectory.
          */
-        it("should be able to get a wrapped subDirectory via getSubDirectory and getWorkingDirectory", async () => {
+        it("should be able to wrap a subDirectory in another interception wrapper", async () => {
             const root = createDirectoryWithInterception(sharedDirectory, componentContext, setInterceptionCb);
 
             // Create a sub directory via the wrapper and wrap it in another interception wrapper.

--- a/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
@@ -5,7 +5,7 @@
 
 import * as assert from "assert";
 import { MockDeltaConnectionFactory, MockRuntime, MockStorage } from "@microsoft/fluid-test-runtime-utils";
-import { SharedDirectory, IDirectory } from "@microsoft/fluid-map";
+import { IDirectory, SharedDirectory, DirectoryFactory } from "@microsoft/fluid-map";
 import { IComponentContext } from "@microsoft/fluid-runtime-definitions";
 import { createDirectoryWithInterception } from "../map";
 
@@ -90,7 +90,7 @@ describe("Shared Directory with Interception", () => {
         beforeEach(() => {
             const runtime = new MockRuntime();
             deltaConnectionFactory = new MockDeltaConnectionFactory();
-            sharedDirectory = new SharedDirectory(documentId, runtime);
+            sharedDirectory = new SharedDirectory(documentId, runtime, DirectoryFactory.Attributes);
             runtime.services = {
                 deltaConnection: deltaConnectionFactory.createDeltaConnection(runtime),
                 objectStorage: new MockStorage(undefined),
@@ -261,7 +261,7 @@ describe("Shared Directory with Interception", () => {
                 userAttribution.userEmail, userEmail, "The email set via foo's interception callback should exist");
         });
 
-        it("should be able to see changes made by the underlying shared directory from the wrapper", async () => {
+        it("should be able to see changes made by the wrapper from the underlying shared directory", async () => {
             const sharedDirectoryWithInterception =
                 createDirectoryWithInterception(sharedDirectory, componentContext, setInterceptionCb);
             const key: string = "style";

--- a/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
@@ -104,7 +104,8 @@ describe("Shared Directory with Interception", () => {
         // Verifies that the props are stored correctly in the attribution sub directory - a sub directory
         // of the given directory with name `attributionDirectoryName`.
         function verifySubDirectoryArrtibution(directory: IDirectory, key: string, value: string, props?: any) {
-            assert.equal(directory.get(key), value);
+            assert.equal(directory.get(key), value, "The retrieved value should match the value that was set");
+
             const attributionDir = directory.getSubDirectory(attributionDirectoryName);
             if (props === undefined) {
                 assert.equal(
@@ -122,7 +123,8 @@ describe("Shared Directory with Interception", () => {
         // Verifies that the props are stored correctly in the given directory under a key derived from the
         // given key - under attributionKey(key).
         function verifyDirectoryAttribution(directory: IDirectory, key: string, value: string, props?: any) {
-            assert.equal(directory.get(key), value);
+            assert.equal(directory.get(key), value, "The retrieved value should match the value that was set");
+
             if (props === undefined) {
                 assert.equal(
                     directory.get(attributionKey(key)),
@@ -158,7 +160,7 @@ describe("Shared Directory with Interception", () => {
             const key: string = "level";
             let value: string = "root";
             root.set(key, value);
-            assert.equal(root.get(key), value, "The value should match the value that was set");
+            assert.equal(root.get(key), value, "The retrieved value should match the value that was set");
 
             // Verify that attribution directory `/attribution` was created for root and the user attribute
             // set on it.
@@ -170,7 +172,7 @@ describe("Shared Directory with Interception", () => {
             const foo = root.createSubDirectory("foo");
             value = "level1";
             foo.set(key, value);
-            assert.equal(foo.get(key), value, "The value should match the value that was set");
+            assert.equal(foo.get(key), value, "The retrieved value should match the value that was set");
 
             // Verify that attribution directory `/attribution/foo` was created for /foo and the user attribute
             // set on it.
@@ -182,7 +184,7 @@ describe("Shared Directory with Interception", () => {
             const bar = foo.createSubDirectory("bar");
             value = "level2";
             bar.set(key, value);
-            assert.equal(bar.get(key), value, "The value should match the value that was set");
+            assert.equal(bar.get(key), value, "The retrieved value should match the value that was set");
 
             // Verify that attribution directory `/attribution/foo/bar` was created for /foo/bar and the user
             // attribute set on it.
@@ -290,7 +292,12 @@ describe("Shared Directory with Interception", () => {
             verifyDirectoryAttribution(sharedDirectoryWithInterception, key, value);
         });
 
-        it("should assert if set is called from the callback as it will cause infinite recursion", async () => {
+        /**
+         * This test calls set on the wrapper from the interception callback which will cause an infinite
+         * recursion. Verify that the wrapper detects this and asserts.
+         * Also, verify that the object is not unusable after the assert.
+         */
+        it("should assert if set is called on the wrapper from the callback causing infinite recursion", async () => {
             // eslint-disable-next-line prefer-const
             let sharedDirectoryWithInterception: SharedDirectory;
 

--- a/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
@@ -7,7 +7,7 @@ import * as assert from "assert";
 import { MockDeltaConnectionFactory, MockRuntime, MockStorage } from "@microsoft/fluid-test-runtime-utils";
 import { SharedDirectory, IDirectory } from "@microsoft/fluid-map";
 import { IComponentContext } from "@microsoft/fluid-runtime-definitions";
-import { createSharedDirectoryWithInterception } from "../map";
+import { createDirectoryWithInterception } from "../map";
 
 describe("Shared Directory with Interception", () => {
     describe("Simple User Attribution", () => {
@@ -18,22 +18,78 @@ describe("Shared Directory with Interception", () => {
          */
         const userId = "Fake User";
         const documentId = "fakeId";
-        const attributionDirectoryName = "user-attribution";
+        const attributionDirectoryName = "attribution";
+        const attributionKey = (key: string) => `${key}.attribution`;
         let deltaConnectionFactory: MockDeltaConnectionFactory;
         let sharedDirectory: SharedDirectory;
-        let sharedDirectoryWithInterception: SharedDirectory;
         let componentContext: IComponentContext;
+
+        // This function gets / creates the attribution directory for the given subdirectory path.
+        function getAttributionDirectory(root: IDirectory, path: string) {
+            if (!root.hasSubDirectory(attributionDirectoryName)) {
+                root.createSubDirectory(attributionDirectoryName);
+            }
+
+            let currentSubDir = root.getSubDirectory(attributionDirectoryName);
+            if (path === "/") {
+                return currentSubDir;
+            }
+
+            let prevSubDir = currentSubDir;
+            const subdirs = path.substr(1).split("/");
+            for (const subdir of subdirs) {
+                currentSubDir = currentSubDir.getSubDirectory(subdir);
+                if (currentSubDir === undefined) {
+                    currentSubDir = prevSubDir.createSubDirectory(subdir);
+                    break;
+                }
+                prevSubDir = currentSubDir;
+            }
+            return currentSubDir;
+        }
+
+        /**
+         * This callback creates / gets an attribution directory that mirrors the actual directory. It sets the
+         * user attribute in the attribution directory against the same key used in the original set.
+         * For example - For directory /foo, it sets the attribute in /attribution/foo.
+         */
+        function mirrorDirectoryInterceptionCb(
+            baseDirectory: IDirectory,
+            subDirectory: IDirectory,
+            key: string,
+            value: any): void {
+            const attributionDirectory: IDirectory = getAttributionDirectory(baseDirectory, subDirectory.absolutePath);
+            attributionDirectory.set(key, { userId });
+        }
+
+        /**
+         * This callback creates / gets an attribution directory that is a subdirectory of the given directory. It sets
+         * the user attribute in the attribution directory againist the same key used in the original set.
+         * For example - For directory /foo, it sets the attribute in /foo/attribute
+         */
+        function subDirectoryinterceptionCb(
+            baseDirectory: IDirectory,
+            subDirectory: IDirectory,
+            key: string,
+            value: any): void {
+            if (!subDirectory.hasSubDirectory(attributionDirectoryName)) {
+                subDirectory.createSubDirectory(attributionDirectoryName);
+            }
+            const attributionDirectory: IDirectory = subDirectory.getSubDirectory(attributionDirectoryName);
+            attributionDirectory.set(key, { userId });
+        }
+
+        // This callback sets the user attribution in the subdirectory against a key derived from the original key.
+        function setInterceptionCb(
+            baseDirectory: IDirectory,
+            subDirectory: IDirectory,
+            key: string,
+            value: any): void {
+            subDirectory.set(attributionKey(key), { userId });
+        }
 
         function orderSequentially(callback: () => void): void {
             callback();
-        }
-
-        function interceptionCb(directory: IDirectory, key: string, value: any): void {
-            if (!directory.hasSubDirectory(attributionDirectoryName)) {
-                directory.createSubDirectory(attributionDirectoryName);
-            }
-            const attributionDirectory: IDirectory = directory.getSubDirectory(attributionDirectoryName);
-            attributionDirectory.set(key, userId);
         }
 
         beforeEach(() => {
@@ -48,59 +104,220 @@ describe("Shared Directory with Interception", () => {
 
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             componentContext = { hostRuntime: { orderSequentially } } as IComponentContext;
-            sharedDirectoryWithInterception =
-                createSharedDirectoryWithInterception(sharedDirectory, componentContext, interceptionCb);
         });
 
-        it("should be able to intercept SharedDirectory set method in the interception", async () => {
-            const key: string = "color";
-            const value: string = "green";
-            sharedDirectoryWithInterception.set(key, value);
-            assert.equal(sharedDirectoryWithInterception.get(key), value);
+        /**
+         * This test create two levels of directories as shown below:
+         * /
+         * /foo
+         * /foo/bar
+         *
+         * It mirrors this directory structure for storing attributes as shown below. It uses the baseDirectory
+         * in the interception callback to create this.
+         * /attribution
+         * /attribution/foo
+         * /attribution/foo/bar
+         *
+         * It tests that the wrapper returns the correct baseDirectory (root in this case). It also tests that the
+         * subdirectory created via the wrapper calls is wrapped and calls the interception callback.
+         */
+        it("should be able to create an attribution directory tree mirroring the actual directory tree", async () => {
+            const root = createDirectoryWithInterception(
+                sharedDirectory, componentContext, mirrorDirectoryInterceptionCb);
 
-            const attributionDirectory: IDirectory =
-                sharedDirectoryWithInterception.getSubDirectory(attributionDirectoryName);
-            assert.equal(attributionDirectory.get(key), userId);
+            const key: string = "level";
+            let value: string = "root";
+            root.set(key, value);
+            assert.equal(root.get(value), "root", "The value should match the value that was set");
 
-            // Verify that the attributionDirectory doesn't create another attribution sub directory. The
-            // attributionDirectory is created via the underlying shared directory and not via the shared
-            // directory with attribution.
-            assert.equal(attributionDirectory.getSubDirectory(attributionDirectoryName), undefined);
+            // Verify that attribution directory `/attribution` was created for root and the user attribute
+            // set on it.
+            const rootAttribution = root.getSubDirectory(attributionDirectoryName);
+            assert.equal(
+                rootAttribution.get(key).userId, userId, "The userId set via interception callback should exist");
+
+            // Create the level 1 directory `/foo`.
+            const foo = root.createSubDirectory("foo");
+            value = "level1";
+            foo.set(key, value);
+            assert.equal(foo.get(key), value, "The value should match the value that was set");
+
+            // Verify that attribution directory `/attribution/foo` was created for /foo and the user attribute
+            // set on it.
+            const fooAttribution = rootAttribution.getSubDirectory("foo");
+            assert.equal(
+                fooAttribution.get(key).userId, userId, "The userId set via interception callback should exist");
+
+            // Create the level 2 directory `/foo/bar`.
+            const bar = foo.createSubDirectory("bar");
+            value = "level2";
+            bar.set(key, value);
+            assert.equal(bar.get(key), value, "The value should match the value that was set");
+
+            // Verify that attribution directory `/attribution/foo/bar` was created for /foo/bar and the user
+            // attribute set on it.
+            const barAttribution = fooAttribution.getSubDirectory("bar");
+            assert.equal(
+                barAttribution.get(key).userId, userId, "The userId set via interception callback should exist");
         });
 
-        it("should be able to see changes made by the interception from the underlying shared directory", async () => {
+        /**
+         * This test create two levels of directories as shown below:
+         * /
+         * /foo
+         * /foo/bar
+         *
+         * It creates an attribution subdirectory for each of the subdirectories as shown below:
+         * /attribution
+         * /foo/attribution
+         * /foo/bar/attribution
+         *
+         * It tests that the wrapper returns the correct subDirectory.
+         */
+        it("should be able to create an attribution directory for each subdirectory", async () => {
+            const root = createDirectoryWithInterception(sharedDirectory, componentContext, subDirectoryinterceptionCb);
+            const key: string = "level";
+            let value: string = "root";
+            root.set(key, value);
+            assert.equal(root.get(key), value, "The value should match the value that was set");
+
+            // Verify that attribution directory `/attribution` was created for root and the user attribute
+            // set on it.
+            const rootAttribution = root.getSubDirectory(attributionDirectoryName);
+            assert.equal(
+                rootAttribution.get(key).userId, userId, "The userId set via interception callback should exist");
+
+            // Create the level 1 directory `/foo`.
+            const foo = root.createSubDirectory("foo");
+            value = "level1";
+            foo.set(key, value);
+            assert.equal(foo.get(key), value, "The value should match the value that was set");
+
+            // Verify that attribution directory `/foo/attribution` was created for /foo and the user attribute
+            // set on it.
+            const fooAttribution = foo.getSubDirectory(attributionDirectoryName);
+            assert.equal(
+                fooAttribution.get(key).userId, userId, "The userId set via interception callback should exist");
+
+            // Create the level 2 directory `/foo/bar`.
+            const bar = foo.createSubDirectory("bar");
+            value = "level2";
+            bar.set(key, value);
+            assert.equal(bar.get(key), value, "The value should match the value that was set");
+
+            // Verify that attribution directory `/foo/bar/attribution` was created for bar and the user attribute
+            // set on it.
+            const barAttribution = bar.getSubDirectory(attributionDirectoryName);
+            assert.equal(
+                barAttribution.get(key).userId, userId, "The userId set via interception callback should exist");
+        });
+
+        it("should be able to get a wrapped subDirectory via getSubDirectory and getWorkingDirectory", async () => {
+            const root = createDirectoryWithInterception(sharedDirectory, componentContext, subDirectoryinterceptionCb);
+
+            // Create a sub directory and get it via getSubDirectory.
+            root.createSubDirectory("foo");
+            const foo = root.getSubDirectory("foo");
+            // Set a key and verify that user attribute is set via the interception callback.
+            let key: string = "color";
+            foo.set(key, "green");
+            const fooAttribution = foo.getSubDirectory(attributionDirectoryName);
+            assert.equal(
+                fooAttribution.get(key).userId, userId, "The userId set via interception callback should exist");
+
+            // Create a sub directory via the unwrapped object and get its working directory via the wrapper.
+            sharedDirectory.createSubDirectory("bar");
+            const bar = root.getWorkingDirectory("bar");
+            // Set a key and verify that user attribute is set via the interception callback.
+            key = "permission";
+            bar.set(key, "read");
+            const barAttribution = bar.getSubDirectory(attributionDirectoryName);
+            assert.equal(
+                barAttribution.get(key).userId, userId, "The userId set via interception callback should exist");
+        });
+
+        /**
+         * This test creates a wrapper shared directory. It then creates a subdirectory and creates another wrapper
+         * from the subdirectory. It verifies that the callback for both the root directory and subdirectory is
+         * called on a set on the wrapped subdirectory.
+         */
+        it("should be able to get a wrapped subDirectory via getSubDirectory and getWorkingDirectory", async () => {
+            const root = createDirectoryWithInterception(sharedDirectory, componentContext, setInterceptionCb);
+
+            // Create a sub directory via the wrapper and wrap it in another interception wrapper.
+            const foo = root.createSubDirectory("foo");
+            const userEmail = "test@microsoft.com";
+            // Interception callback to be used for wrapping the subdirectory that adds user email to the attribution.
+            function interceptionCb(baseDirectory, subDirectory, key, value) {
+                const attributes = subDirectory.get(attributionKey(key));
+                subDirectory.set(attributionKey(key), { ...attributes, userEmail });
+            }
+            const fooWithAttribution = createDirectoryWithInterception(foo, componentContext, interceptionCb);
+
+            // Set a key and verify that user id and user email are set via the interception callbacks.
+            const permKey: string = "permission";
+            fooWithAttribution.set(permKey, "write");
+            assert.equal(fooWithAttribution.get(permKey), "write", "The value should match the value that was set");
+
+            const userAttribution = fooWithAttribution.get(attributionKey(permKey));
+            assert.equal(
+                userAttribution.userId, userId, "The userId set via root's interception callback should exist");
+            assert.equal(
+                userAttribution.userEmail, userEmail, "The email set via foo's interception callback should exist");
+        });
+
+        it("should be able to see changes made by the underlying shared directory from the wrapper", async () => {
+            const sharedDirectoryWithInterception =
+                createDirectoryWithInterception(sharedDirectory, componentContext, setInterceptionCb);
             const key: string = "style";
             const value: string = "bold";
             sharedDirectoryWithInterception.set(key, value);
-            assert.equal(sharedDirectory.get(key), value);
-
-            const attributionDirectory: IDirectory = sharedDirectory.getSubDirectory(attributionDirectoryName);
-            assert.equal(attributionDirectory.get(key), userId);
+            assert.equal(
+                sharedDirectory.get(key), value, "The value should match the value that was set by the wrapper");
+            assert.equal(
+                sharedDirectory.get(attributionKey(key)).userId,
+                userId,
+                "The userId set via wrapper's interception callback should exist");
         });
 
-        it("should be able to see changes made by the underlying shared directory from the interception", async () => {
+        it("should be able to see changes made by the underlying shared directory from the wrapper", async () => {
+            const sharedDirectoryWithInterception =
+                createDirectoryWithInterception(sharedDirectory, componentContext, setInterceptionCb);
             const key: string = "font";
             const value: string = "Arial";
             sharedDirectory.set(key, value);
-            assert.equal(sharedDirectoryWithInterception.get(key), value);
-
-            const attributionDirectory: IDirectory =
-                sharedDirectoryWithInterception.getSubDirectory(attributionDirectoryName);
-            // The attributionDirectory should not exist because there should be no interception.
-            assert.equal(attributionDirectory, undefined);
+            assert.equal(
+                sharedDirectoryWithInterception.get(key),
+                value,
+                "The value should match the value that was set by the unwrapper map");
+            assert.equal(
+                sharedDirectory.get(attributionKey(key)),
+                undefined,
+                "The userId should not be set because the interception is not called");
         });
 
-        it("should be able create a sub directory with interception from the shared directory", async () => {
-            const key: string = "font";
-            const value: string = "Arial";
+        it("should assert it set is called from the callback as it will cause infinite recursion", async () => {
+            // eslint-disable-next-line prefer-const
+            let sharedDirectoryWithInterception: SharedDirectory;
+            // Interception callback that calls a set on the wrapped object causing an infinite recursion.
+            function recursiveInterceptionCb(baseDirectory, subDirectory, key, value) {
+                sharedDirectoryWithInterception.set(attributionKey(key), userId);
+            }
 
-            const subDirectoryWithInterception = sharedDirectoryWithInterception.createSubDirectory("foo");
-            subDirectoryWithInterception.set(key, value);
-            assert.equal(subDirectoryWithInterception.get(key), value);
+            // Create the interception wrapper with the above callback. The set method should throw an assertion as this
+            // will cause infinite recursion.
+            sharedDirectoryWithInterception =
+                createDirectoryWithInterception(sharedDirectory, componentContext, recursiveInterceptionCb);
 
-            const attributionDirectory: IDirectory =
-                subDirectoryWithInterception.getSubDirectory(attributionDirectoryName);
-            assert.equal(attributionDirectory.get(key), userId);
+            let asserted: boolean = false;
+            try {
+                sharedDirectoryWithInterception.set("color", "green");
+            } catch (error) {
+                assert(error instanceof assert.AssertionError,
+                    "We should have caught an assert in the set method because it detects an infinite recursion");
+                asserted = true;
+            }
+            assert.equal(asserted, true, "The set call should have asserted because it detects inifinite recursion");
         });
     });
 });


### PR DESCRIPTION
Fixes #1363 .

Added the following method:
"createDirectoryWithInterception" which creates a wrapper around an IDirectory object, basically a SharedDirectory or SubDirectory. It takes an IDirectory object, the component context and an interception callback. It returns an object of the same IDirectory that was pased. The function looks as follows:
```
function createDirectoryWithInterception<T extends IDirectory>(
    baseDirectory: T,
    context: IComponentContext,
    setInterceptionCallback: (
        baseDirectory: IDirectory,
        subDirectory: IDirectory,
        key: string,
        value: any) => void): T
```
This wrapper overrides the set method and the subdirectory creation / retrieval methods to call the setInterceptionCallback provided when creating the wrapper. The callback and the call to the underlying object is wrapped around orderSequentially so that they are batched together.

Apps can use this to support features like user attribution where the callback can add user information to the same underlying directory against a new key (probably derived from the original key) or in a subdirectory of the actual directory.