### PR TITLE
First summary ackhandle in Create New flow

### DIFF
--- a/packages/loader/container-definitions/src/chaincode.ts
+++ b/packages/loader/container-definitions/src/chaincode.ts
@@ -229,7 +229,7 @@ export interface IExperimentalContainerContext extends IContainerContext {
 
     isAttached(): boolean;
 
-    loadedFromVersion(): IVersion | undefined;
+    getLoadedFromVersion(): IVersion | undefined;
 
     createSummary(): Promise<ISummaryTree>;
 }

--- a/packages/loader/container-definitions/src/chaincode.ts
+++ b/packages/loader/container-definitions/src/chaincode.ts
@@ -23,6 +23,7 @@ import {
     ITree,
     MessageType,
     ISummaryTree,
+    IVersion,
 } from "@microsoft/fluid-protocol-definitions";
 import { IAudience } from "./audience";
 import { IBlobManager } from "./blobs";
@@ -227,6 +228,8 @@ export interface IExperimentalContainerContext extends IContainerContext {
     isExperimentalContainerContext: true;
 
     isAttached(): boolean;
+
+    loadedFromVersion(): IVersion | undefined;
 
     createSummary(): Promise<ISummaryTree>;
 }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -213,10 +213,15 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
     private manualReconnectInProgress = false;
     private readonly connectionTransitionTimes: number[] = [];
     private messageCountAfterDisconnection: number = 0;
+    private _loadedFromVersion: IVersion | undefined;
 
     private lastVisible: number | undefined;
 
     private _closed = false;
+
+    public get loadedFromVersion(): IVersion | undefined {
+        return this._loadedFromVersion;
+    }
 
     public get readonly(): boolean | undefined {
         return this._deltaManager.readonly;
@@ -1263,6 +1268,7 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         const version = await this.getVersion(specifiedVersion || this.id);
 
         if (version) {
+            this._loadedFromVersion = version;
             return await this.storageService!.getSnapshotTree(version) || undefined;
         } else if (specifiedVersion) {
             // We should have a defined version to load from if specified version requested

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -212,7 +212,7 @@ export class ContainerContext extends EventEmitter implements IContainerContext,
         return this.runtime!.snapshot(tagMessage, fullTree);
     }
 
-    public loadedFromVersion(): IVersion | undefined {
+    public getLoadedFromVersion(): IVersion | undefined {
         return this.container.loadedFromVersion;
     }
 

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -38,6 +38,7 @@ import {
     ITree,
     MessageType,
     ISummaryTree,
+    IVersion,
 } from "@microsoft/fluid-protocol-definitions";
 import { BlobManager } from "./blobManager";
 import { Container } from "./container";
@@ -209,6 +210,10 @@ export class ContainerContext extends EventEmitter implements IContainerContext,
 
     public async snapshot(tagMessage: string = "", fullTree: boolean = false): Promise<ITree | null> {
         return this.runtime!.snapshot(tagMessage, fullTree);
+    }
+
+    public loadedFromVersion(): IVersion | undefined {
+        return this.container.loadedFromVersion;
     }
 
     /**

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -569,7 +569,10 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         // useContext - back-compat: 0.14 uploadSummary
         const useContext: boolean = expContainerContext.isExperimentalContainerContext ?
             true : this.storage.uploadSummaryWithContext !== undefined;
-        this.latestSummaryAck = { proposalHandle: undefined, ackHandle: undefined };
+        this.latestSummaryAck = {
+            proposalHandle: undefined,
+            ackHandle: expContainerContext.isExperimentalContainerContext && expContainerContext.loadedFromVersion()
+                ? expContainerContext.loadedFromVersion().id : undefined };
         this.summaryTracker = new SummaryTracker(
             useContext,
             "", // fullPath - the root is unnamed

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -571,8 +571,8 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
             true : this.storage.uploadSummaryWithContext !== undefined;
         this.latestSummaryAck = {
             proposalHandle: undefined,
-            ackHandle: expContainerContext.isExperimentalContainerContext && expContainerContext.loadedFromVersion()
-                ? expContainerContext.loadedFromVersion().id : undefined };
+            ackHandle: expContainerContext.isExperimentalContainerContext && expContainerContext.getLoadedFromVersion()
+                ? expContainerContext.getLoadedFromVersion().id : undefined };
         this.summaryTracker = new SummaryTracker(
             useContext,
             "", // fullPath - the root is unnamed


### PR DESCRIPTION
This is one of the bug that I found during testing using r11s.
When the summarizer client joins after the container is attached in Create new flow, it loads from the summary made during attach call. The ackHandle needs to updated from the version because it will not update itself  from summary ack op because there is no summary ack op when we uploaded the summary in attach call by calling createDocument api.