### PR TITLE
fix test historian for create commit.

### DIFF
--- a/server/routerlicious/packages/services-core/src/document.ts
+++ b/server/routerlicious/packages/services-core/src/document.ts
@@ -39,7 +39,7 @@ export interface IExperimentalDocumentStorage extends IDocumentStorage {
         documentId: string,
         summary: ISummaryTree,
         sequenceNumber: number,
-        values: [string, ICommittedProposal][]);
+        values: [string, ICommittedProposal][]): Promise<IDocumentDetails>;
 }
 
 export interface IFork {

--- a/server/routerlicious/packages/services/src/storage.ts
+++ b/server/routerlicious/packages/services/src/storage.ts
@@ -81,7 +81,7 @@ export class DocumentStorage implements IDocumentStorage, IExperimentalDocumentS
         summary: ISummaryTree,
         sequenceNumber: number,
         values: [string, ICommittedProposal][],
-    ) {
+    ): Promise<IDocumentDetails> {
         const tenant = await this.tenantManager.getTenant(tenantId);
         const gitManager = tenant.gitManager;
 

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -20,6 +20,8 @@
     "eslint:fix": "eslint --ext=ts,tsx --format stylish src --fix",
     "lint": "npm run eslint",
     "lint:fix": "npm run eslint:fix",
+    "test": "mocha --recursive dist/test -r make-promises-safe",
+    "test:coverage": "nyc npm test -- --reporter mocha-junit-reporter --reporter-options mochaFile=nyc/junit-report.xml",
     "tsc": "tsc"
   },
   "dependencies": {
@@ -40,6 +42,7 @@
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/lodash": "^4.14.118",
     "@types/node": "^10.14.6",
+    "@types/mocha": "^5.2.5",
     "@types/string-hash": "^1.1.1",
     "@typescript-eslint/eslint-plugin": "~2.17.0",
     "@typescript-eslint/parser": "~2.17.0",
@@ -53,6 +56,8 @@
     "eslint-plugin-react": "~7.18.0",
     "eslint-plugin-unicorn": "~15.0.1",
     "rimraf": "^2.6.2",
+    "mocha": "^5.2.0",
+    "mocha-junit-reporter": "^1.18.0",
     "typescript": "~3.7.4"
   }
 }

--- a/server/routerlicious/packages/test-utils/src/test/testsForHistorian.spec.ts
+++ b/server/routerlicious/packages/test-utils/src/test/testsForHistorian.spec.ts
@@ -25,8 +25,7 @@ describe("Test for TestUtils", () => {
         };
         const putCommit = await gitManager.createCommit(commitParams);
         await gitManager.createRef(documentId, putCommit.sha);
-        const ref = await gitManager.getRef(documentId)
-        const getCommit = await gitManager.getCommit(ref.object.sha);
+        const getCommit = await gitManager.getCommit(documentId);
         assert.equal(getCommit.sha, putCommit.sha, "Sha not equal of commits!!");
         assert.equal(getCommit.message, commitParams.message, "Sha not equal of commits!!");
     });

--- a/server/routerlicious/packages/test-utils/src/test/testsForHistorian.spec.ts
+++ b/server/routerlicious/packages/test-utils/src/test/testsForHistorian.spec.ts
@@ -27,6 +27,6 @@ describe("Test for TestUtils", () => {
         await gitManager.createRef(documentId, putCommit.sha);
         const getCommit = await gitManager.getCommit(documentId);
         assert.equal(getCommit.sha, putCommit.sha, "Sha not equal of commits!!");
-        assert.equal(getCommit.message, commitParams.message, "Sha not equal of commits!!");
+        assert.equal(getCommit.message, commitParams.message, "Message not equal of commits!!");
     });
 });

--- a/server/routerlicious/packages/test-utils/src/test/testsForHistorian.spec.ts
+++ b/server/routerlicious/packages/test-utils/src/test/testsForHistorian.spec.ts
@@ -1,0 +1,33 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as assert from "assert";
+import { TestHistorian } from "../testHistorian";
+import { GitManager } from "@microsoft/fluid-server-services-client";
+import { ICreateCommitParams } from "@microsoft/fluid-gitresources";
+
+describe("Test for TestUtils", () => {
+    it("Historian", async () => {
+        const historian = new TestHistorian();
+        const gitManager = new GitManager(historian);
+        const documentId = "documentId";
+        const commitParams: ICreateCommitParams = {
+            author: {
+                date: new Date().toISOString(),
+                email: "dummy@microsoft.com",
+                name: "Routerlicious Service",
+            },
+            message: "New document",
+            parents: [],
+            tree: "tree",
+        };
+        const putCommit = await gitManager.createCommit(commitParams);
+        await gitManager.createRef(documentId, putCommit.sha);
+        const ref = await gitManager.getRef(documentId)
+        const getCommit = await gitManager.getCommit(ref.object.sha);
+        assert.equal(getCommit.sha, putCommit.sha, "Sha not equal of commits!!");
+        assert.equal(getCommit.message, commitParams.message, "Sha not equal of commits!!");
+    });
+});

--- a/server/routerlicious/packages/test-utils/src/testDocumentStorage.ts
+++ b/server/routerlicious/packages/test-utils/src/testDocumentStorage.ts
@@ -91,7 +91,7 @@ export class TestDocumentStorage implements IDocumentStorage, IExperimentalDocum
                 email: "dummy@microsoft.com",
                 name: "Routerlicious Service",
             },
-            message: "New document",
+            message: documentId,
             parents: [],
             tree: gitTree.sha,
         };

--- a/server/routerlicious/packages/test-utils/src/testDocumentStorage.ts
+++ b/server/routerlicious/packages/test-utils/src/testDocumentStorage.ts
@@ -91,7 +91,7 @@ export class TestDocumentStorage implements IDocumentStorage, IExperimentalDocum
                 email: "dummy@microsoft.com",
                 name: "Routerlicious Service",
             },
-            message: documentId,
+            message: "New document",
             parents: [],
             tree: gitTree.sha,
         };

--- a/server/routerlicious/packages/test-utils/src/testHistorian.ts
+++ b/server/routerlicious/packages/test-utils/src/testHistorian.ts
@@ -129,13 +129,15 @@ export class TestHistorian implements IHistorian {
 
     public async getRef(ref: string): Promise<git.IRef> {
         const val = await this.refs.findOne({ _id: ref});
-        return {
-            ref: val.value.ref,
-            url: "",
-            object: { sha: val.value.sha,
+        if (val) {
+            return {
+                ref: val.value.ref,
                 url: "",
-                type: "" },
-        };
+                object: { sha: val.value.sha,
+                    url: "",
+                    type: "" },
+            };
+        }
     }
 
     public async createRef(params: git.ICreateRefParams): Promise<git.IRef> {

--- a/server/routerlicious/packages/test-utils/src/testHistorian.ts
+++ b/server/routerlicious/packages/test-utils/src/testHistorian.ts
@@ -97,7 +97,7 @@ export class TestHistorian implements IHistorian {
     public async getCommit(sha: string): Promise<git.ICommit> {
         let commit = await this.commits.findOne({ _id: sha });
         if (!commit) {
-            const ref = await this.getRef(gitHashFile(Buffer.from(`refs/heads/${sha}`)));
+            const ref = await this.getRef(`refs/heads/${sha}`);
             commit = await this.commits.findOne({ _id: ref.object.sha });
         }
         if (commit) {
@@ -141,9 +141,8 @@ export class TestHistorian implements IHistorian {
     }
 
     public async createRef(params: git.ICreateRefParams): Promise<git.IRef> {
-        const _id = gitHashFile(Buffer.from(params.ref));
-        await this.refs.insertOne({_id, value: params});
-        return this.getRef(_id);
+        await this.refs.insertOne({_id: params.ref, value: params});
+        return this.getRef(params.ref);
     }
 
     // eslint-disable-next-line @typescript-eslint/promise-function-async

--- a/server/routerlicious/packages/test-utils/src/testHistorian.ts
+++ b/server/routerlicious/packages/test-utils/src/testHistorian.ts
@@ -113,7 +113,7 @@ export class TestHistorian implements IHistorian {
     }
 
     public async createCommit(commit: git.ICreateCommitParams): Promise<git.ICommit> {
-        const _id = gitHashFile(Buffer.from(commit.tree));
+        const _id = commit.message ?? gitHashFile(Buffer.from(commit.tree));
         await this.commits.insertOne({ _id, value: commit });
         return this.getCommit(_id);
     }

--- a/server/routerlicious/packages/test-utils/src/testHistorian.ts
+++ b/server/routerlicious/packages/test-utils/src/testHistorian.ts
@@ -95,8 +95,7 @@ export class TestHistorian implements IHistorian {
     }
 
     public async getCommit(sha: string): Promise<git.ICommit> {
-        const ref = await this.getRef(sha);
-        const commit = await this.commits.findOne({ _id: ref.object.sha });
+        const commit = await this.commits.findOne({ _id: sha });
         if (commit) {
             return {
                 author: {} as Partial<git.IAuthor> as git.IAuthor,
@@ -125,8 +124,8 @@ export class TestHistorian implements IHistorian {
     }
 
     public async getRef(ref: string): Promise<git.IRef> {
-        const id = gitHashFile(Buffer.from(`refs/heads/${ref}`));
-        const val = await this.refs.findOne(id);
+        const _id = ref.split("/").pop();
+        const val = await this.refs.findOne({ _id});
         return {
             ref,
             url: val.value.ref,
@@ -137,16 +136,9 @@ export class TestHistorian implements IHistorian {
     }
 
     public async createRef(params: git.ICreateRefParams): Promise<git.IRef> {
-        const _id = gitHashFile(Buffer.from(params.ref));
+        const _id = params.ref.split("/").pop();
         await this.refs.insertOne({_id, value: params});
-        const ref: git.IRef = {
-            ref: _id,
-            url: params.ref,
-            object: { sha: _id,
-                url: params.ref,
-                type: "ref" },
-        };
-        return ref;
+        return this.getRef(_id);
     }
 
     // eslint-disable-next-line @typescript-eslint/promise-function-async

--- a/server/routerlicious/packages/test-utils/tsconfig.json
+++ b/server/routerlicious/packages/test-utils/tsconfig.json
@@ -8,7 +8,8 @@
         "strict": true,
         "strictNullChecks": false,
         "rootDir": "./src",
-        "outDir": "./dist"
+        "outDir": "./dist",
+        "types": [ "mocha" ]
     },
     "include": [
         "src/**/*"


### PR DESCRIPTION
In test historian, we create the commit with the hash as id but when we request it, we request it with the doucment id and so we are unable to find the desired container.
Problem: In actiual historian, we can get a commit either by the sha or the referce to sha. TestHistorian was not implemented in same way.