### PR TITLE
Fix typing for raiseConnectedEvent() & changeConnectionState()

### DIFF
--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -387,7 +387,7 @@ export class Quorum extends EventEmitter implements IQuorum {
         return immediateNoOp;
     }
 
-    public changeConnectionState(value: ConnectionState, clientId: string) {
+    public changeConnectionState(value: ConnectionState, clientId?: string) {
         if (value === ConnectionState.Disconnected) {
             this.localProposals.forEach((deferral) => {
                 deferral.reject("Client got disconnected");

--- a/server/routerlicious/packages/protocol-base/src/utils.ts
+++ b/server/routerlicious/packages/protocol-base/src/utils.ts
@@ -21,7 +21,7 @@ export const isSystemType = (type: string) => (
         type === MessageType.ClientLeave ||
         type === MessageType.Fork);
 
-export function raiseConnectedEvent(emitter: EventEmitter, state: ConnectionState, clientId: string) {
+export function raiseConnectedEvent(emitter: EventEmitter, state: ConnectionState, clientId?: string) {
     if (state === ConnectionState.Connected) {
         emitter.emit("connected", clientId);
     } else if (state === ConnectionState.Connecting) {


### PR DESCRIPTION
raiseConnectedEvent() & changeConnectionState() methods on various objects incorrectly specify clientId as string, whereas it is string | undefined.
This server part of the fix, client changes will follow.