### PR TITLE
client UTs fail if built with latest server bits

### DIFF
--- a/server/routerlicious/packages/test-utils/src/testHistorian.ts
+++ b/server/routerlicious/packages/test-utils/src/testHistorian.ts
@@ -98,7 +98,9 @@ export class TestHistorian implements IHistorian {
         let commit = await this.commits.findOne({ _id: sha });
         if (!commit) {
             const ref = await this.getRef(`refs/heads/${sha}`);
-            commit = await this.commits.findOne({ _id: ref.object.sha });
+            if (ref !== undefined) {
+                commit = await this.commits.findOne({ _id: ref.object.sha });
+            }
         }
         if (commit) {
             return {


### PR DESCRIPTION
Client UTs fail if client builds are built with latest version of server dependencies.
See [here for example](https://offnet.visualstudio.com/officenet/_build/results?buildId=22280&view=logs&j=275f1d19-1bd8-5591-b06b-07d489ea915a&t=e553b5d8-21f0-59ad-51a3-60ad4a6f02e3&l=505)
This is a regression of [this commit](https://github.com/microsoft/FluidFramework/commit/89db7cbcc384fa84fa7baa71fdfcf4e98d206ae1#diff-ac330be48e27fa7c14b05d6ffb4d5655) submitted today