### PR TITLE
Check function availability before calling it

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -572,7 +572,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         this.latestSummaryAck = {
             proposalHandle: undefined,
             ackHandle: expContainerContext.isExperimentalContainerContext && expContainerContext.getLoadedFromVersion
-                ? expContainerContext.getLoadedFromVersion().id : undefined };
+                && expContainerContext.getLoadedFromVersion() ? expContainerContext.getLoadedFromVersion().id : undefined };
         this.summaryTracker = new SummaryTracker(
             useContext,
             "", // fullPath - the root is unnamed

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -572,7 +572,8 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         this.latestSummaryAck = {
             proposalHandle: undefined,
             ackHandle: expContainerContext.isExperimentalContainerContext && expContainerContext.getLoadedFromVersion
-                && expContainerContext.getLoadedFromVersion() ? expContainerContext.getLoadedFromVersion().id : undefined };
+                && expContainerContext.getLoadedFromVersion()
+                ? expContainerContext.getLoadedFromVersion().id : undefined };
         this.summaryTracker = new SummaryTracker(
             useContext,
             "", // fullPath - the root is unnamed

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -571,7 +571,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
             true : this.storage.uploadSummaryWithContext !== undefined;
         this.latestSummaryAck = {
             proposalHandle: undefined,
-            ackHandle: expContainerContext.isExperimentalContainerContext && expContainerContext.getLoadedFromVersion()
+            ackHandle: expContainerContext.isExperimentalContainerContext && expContainerContext.getLoadedFromVersion
                 ? expContainerContext.getLoadedFromVersion().id : undefined };
         this.summaryTracker = new SummaryTracker(
             useContext,


### PR DESCRIPTION
Related to issue: https://github.com/microsoft/FluidFramework/issues/1531 .
When we load the new runtime with old loader, this broke. 