### PR TITLE
Add readonly view

### DIFF
--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -130,6 +130,7 @@ export interface IDeltaManager<T, U> extends EventEmitter, IDeltaSender, IDispos
     on(event: "pong" | "processTime", listener: (latency: number) => void);
     on(event: "connect", listener: (details: IConnectionDetails) => void);
     on(event: "disconnect", listener: (reason: string) => void);
+    on(event: "readonly", listener: (readonly: boolean) => void);
 }
 
 export interface IDeltaQueue<T> extends EventEmitter, IDisposable {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -227,6 +227,10 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         return this._deltaManager.readonly;
     }
 
+    public forceReadonly(readonly: boolean) {
+        this._deltaManager.forceReadonly(readonly);
+    }
+
     public get closed(): boolean {
         return this._closed;
     }

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -89,7 +89,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
     private readonlyPermissions: boolean | undefined;
 
     // tracks host requiring read-only mode.
-    private readonlyView = false;
+    private readonlyRuntime = false;
 
     // Connection mode used when reconnecting on error or disconnect.
     private readonly defaultReconnectionMode: ConnectionMode;
@@ -206,22 +206,22 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
      * This is independent from file permissions and type of type of conneciton
      */
     public get readonly(): boolean | undefined {
-        return this.readonlyPermissions || this.readonlyView;
+        return this.readonlyPermissions || this.readonlyRuntime;
     }
 
     /**
-     * Sets or resets read-only view.
+     * Sends signal to runtime (and components) to be read-only.
      * Hosts may have read only views, indicating to components that no edits are allowed.
-     * This is independent from  this.readonlyPermissions (permissions) and this.connectionMode
+     * This is independent from this.readonlyPermissions (permissions) and this.connectionMode
      * (server can return "write" mode even when asked for "read")
-     * Leveraging same "readonly" event as components should behave the same in such case
+     * Leveraging same "readonly" event as runtime & components should behave the same in such case
      * as in read-only permissions.
-     * But this.active can be used by some DDSs to figure out if ops can be sent (
-     * for example, read-only view still participates in code proposals / upgrades decisions)
+     * But this.active can be used by some DDSs to figure out if ops can be sent
+     * (for example, read-only view still participates in code proposals / upgrades decisions)
      */
-    public setReadonlyView(readonly: boolean) {
+    public setReadonlyRuntime(readonly: boolean) {
         const oldValue = this.readonly;
-        this.readonlyView = readonly;
+        this.readonlyRuntime = readonly;
         if (oldValue !== this.readonly) {
             this.emit("readonly", this.readonly);
         }


### PR DESCRIPTION
Raising as a draft.
This comes from Teams requirement to have read-only view. I.e. the host controls it.
I'm relying on same mechanism ("readonly" event / property) on delta manager to propagate notifications to components, as that's convenient way / place to do it.
That said, having it on DeltaManager feels wrong, but I'm not sure I see better mechanism to achieve similar simplicity.
I also worry about conflicting (or close) terms used as we now have view-only mode (expose as this.active), read-only permissions and read-only view.

Q: Dropping connection and establishing view-only connection in such mode might be something to add here, not sure if it makes picture clearer / better, 

Thoughts?