### PR TITLE
Use UUIDs for clientId instead of concatenated strings

### DIFF
--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -8,8 +8,7 @@
   "sideEffects": false,
   "main": "dist/index.js",
   "browser": {
-    "winston": false,
-    "moniker": "@microsoft/fluid-server-services-client/dist/dockerNames.js"
+    "winston": false
   },
   "types": "dist/index.d.ts",
   "scripts": {
@@ -58,7 +57,6 @@
     "double-ended-queue": "^2.1.0-0",
     "jsonwebtoken": "^8.4.0",
     "lodash": "^4.17.11",
-    "moniker": "^0.1.2",
     "nconf": "^0.10.0",
     "semver": "^6.3.0",
     "uuid": "^3.3.2"

--- a/server/routerlicious/packages/lambdas/src/utils/clientIdGenerator.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/clientIdGenerator.ts
@@ -2,8 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-
-import * as moniker from "moniker";
+import * as uuid from "uuid";
 
 export const generateClientId = (): string =>
-    moniker.choose();
+    `trevor${uuid()}`;

--- a/server/routerlicious/packages/lambdas/src/utils/clientIdGenerator.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/clientIdGenerator.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import * as uuid from "uuid";
+// eslint-disable-next-line import/no-internal-modules
+import * as uuid from "uuid/v4";
 
 export const generateClientId = (): string => uuid();

--- a/server/routerlicious/packages/lambdas/src/utils/clientIdGenerator.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/clientIdGenerator.ts
@@ -4,5 +4,4 @@
  */
 import * as uuid from "uuid";
 
-export const generateClientId = (): string =>
-    `trevor${uuid()}`;
+export const generateClientId = (): string => uuid();


### PR DESCRIPTION
This will help avoid collisions when there are a large number of clients

fixes: #1543 