### PR TITLE
Gateway strict null checks

### DIFF
--- a/server/gateway/src/alfred.ts
+++ b/server/gateway/src/alfred.ts
@@ -40,19 +40,19 @@ export class Alfred implements IAlfred {
     public async getFullTree(
         tenantId: string,
         documentId: string,
-    ): Promise<{ cache: IGitCache; code: string | IFluidCodeDetails }> {
+    ): Promise<{ cache: IGitCache; code: IFluidCodeDetails | null }> {
         const gitManager = this.getGitManager(tenantId);
         const versions = await gitManager.getCommits(documentId, 1);
         if (versions.length === 0) {
             // eslint-disable-next-line no-null/no-null
-            return { cache: { blobs: [], commits: [], refs: { [documentId]: null }, trees: [] }, code: null };
+            return { cache: { blobs: [], commits: [], refs: { [documentId]: null as unknown as string }, trees: [] }, code: null };
         }
 
         const fullTree = await gitManager.getFullTree(versions[0].sha);
 
         // TODO this needs to be summary aware
         // eslint-disable-next-line no-null/no-null
-        let code: string | IFluidCodeDetails = null;
+        let code: IFluidCodeDetails | null = null;
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if (fullTree.quorumValues) {
             let quorumValues;
@@ -94,7 +94,7 @@ export class Alfred implements IAlfred {
         return gitManager.getCommit(sha);
     }
 
-    public async getLatestVersion(tenantId: string, documentId: string): Promise<ICommit> {
+    public async getLatestVersion(tenantId: string, documentId: string): Promise<ICommit | null> {
         const versions = await this.getVersions(tenantId, documentId, 1);
         if (versions.length === 0) {
             // eslint-disable-next-line no-null/no-null

--- a/server/gateway/src/alfred.ts
+++ b/server/gateway/src/alfred.ts
@@ -44,7 +44,7 @@ export class Alfred implements IAlfred {
         const gitManager = this.getGitManager(tenantId);
         const versions = await gitManager.getCommits(documentId, 1);
         if (versions.length === 0) {
-            // eslint-disable-next-line no-null/no-null
+            // eslint-disable-next-line no-null/no-null, max-len
             return { cache: { blobs: [], commits: [], refs: { [documentId]: null as unknown as string }, trees: [] }, code: null };
         }
 

--- a/server/gateway/src/app.ts
+++ b/server/gateway/src/app.ts
@@ -292,8 +292,7 @@ export function create(
     // The below is to check to make sure the session is available (redis could have gone down for instance) and if
     // not return an error
     app.use((request, response, next) => {
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        if (!request.session) {
+        if (request.session === undefined) {
             return next(new Error("Session not available"));
         } else {
             next();     // otherwise continue

--- a/server/gateway/src/app.ts
+++ b/server/gateway/src/app.ts
@@ -313,12 +313,9 @@ export function create(
     const routes = gatewayRoutes.create(config, cache, alfred, tenants, getFingerprintUrl);
 
     app.use((request, response, next) => {
-        // eslint-disable-next-line max-len
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-non-null-assertion
-        if (!request.session!.guest) {
+        if (request.session?.guest !== undefined) {
             const name = getRandomName(" ", true);
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            request.session!.guest = {
+            request.session.guest = {
                 displayName: name,
                 sub: `guest-${v4()}`,
                 name,

--- a/server/gateway/src/app.ts
+++ b/server/gateway/src/app.ts
@@ -313,10 +313,12 @@ export function create(
     const routes = gatewayRoutes.create(config, cache, alfred, tenants, getFingerprintUrl);
 
     app.use((request, response, next) => {
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        if (!request.session.guest) {
+        // eslint-disable-next-line max-len
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-non-null-assertion
+        if (!request.session!.guest) {
             const name = getRandomName(" ", true);
-            request.session.guest = {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            request.session!.guest = {
                 displayName: name,
                 sub: `guest-${v4()}`,
                 name,

--- a/server/gateway/src/childLoader.ts
+++ b/server/gateway/src/childLoader.ts
@@ -160,14 +160,16 @@ process.on("message", async (message: IIncomingMessage) => {
                 status: true,
                 type: message.type,
             };
-            process.send(initSuccessMessage);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            process.send!(initSuccessMessage);
         }, (err) => {
             const initFailMessage: IOutgoingMessage = {
                 status: false,
                 type: message.type,
                 value: err,
             };
-            process.send(initFailMessage);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            process.send!(initFailMessage);
         });
     } else {
         if (cache === undefined) {
@@ -176,14 +178,16 @@ process.on("message", async (message: IIncomingMessage) => {
                 type: message.type,
                 value: `Called before initialization`,
             };
-            process.send(getFailMessage);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            process.send!(getFailMessage);
         } else {
             const getSuccessMessage: IOutgoingMessage = {
                 status: true,
                 type: message.type,
                 value: cache.get(message.param as string),
             };
-            process.send(getSuccessMessage);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            process.send!(getSuccessMessage);
         }
     }
 });

--- a/server/gateway/src/controllers/services.ts
+++ b/server/gateway/src/controllers/services.ts
@@ -12,9 +12,10 @@ import {
 /**
  * Host services provides a collection of interfaces exposed by a gateway host
  */
-// tslint:disable-next-line:no-empty-interface
-export interface IHostServices extends
-    IProvideDocumentFactory,
-    IProvideMicrosoftGraph,
-    IProvidePackageManager {
+/* eslint-disable @typescript-eslint/no-empty-interface, @typescript-eslint/indent */
+export interface IHostServices extends Partial<
+    IProvideDocumentFactory
+    & IProvideMicrosoftGraph
+    & IProvidePackageManager> {
 }
+/* eslint-enable @typescript-eslint/no-empty-interface, @typescript-eslint/indent */

--- a/server/gateway/src/controllers/workerLoader.ts
+++ b/server/gateway/src/controllers/workerLoader.ts
@@ -57,7 +57,7 @@ class WorkerLoader implements ILoader, IComponentRunnable {
                 new BaseTelemetryNullLogger());
         }
         const documentService: IDocumentService = await factory.createDocumentService(this.resolved);
-        this.container = await Container.load(
+        const container = await Container.load(
             this.id,
             documentService,
             new WebCodeLoader(),
@@ -67,18 +67,17 @@ class WorkerLoader implements ILoader, IComponentRunnable {
             request,
             this.resolved,
             new BaseTelemetryNullLogger());
+        this.container = container;
 
         if (this.container.deltaManager.referenceSequenceNumber <= this.fromSequenceNumber) {
             await new Promise((resolve, reject) => {
                 const opHandler = (message: ISequencedDocumentMessage) => {
                     if (message.sequenceNumber > this.fromSequenceNumber) {
                         resolve();
-                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                        this.container!.removeListener("op", opHandler);
+                        container.removeListener("op", opHandler);
                     }
                 };
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                this.container!.on("op", opHandler);
+                container.on("op", opHandler);
             });
         }
 

--- a/server/gateway/src/controllers/workerLoader.ts
+++ b/server/gateway/src/controllers/workerLoader.ts
@@ -26,8 +26,8 @@ import * as Comlink from "comlink";
 // Loader class to load a container and proxy component interfaces from within a web worker.
 // Only supports IComponentRunnable for now.
 class WorkerLoader implements ILoader, IComponentRunnable {
-    private container: Container;
-    private runnable: IComponentRunnable;
+    private container: Container | undefined;
+    private runnable: IComponentRunnable | undefined;
 
     constructor(
         private readonly id: string,
@@ -73,10 +73,12 @@ class WorkerLoader implements ILoader, IComponentRunnable {
                 const opHandler = (message: ISequencedDocumentMessage) => {
                     if (message.sequenceNumber > this.fromSequenceNumber) {
                         resolve();
-                        this.container.removeListener("op", opHandler);
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                        this.container!.removeListener("op", opHandler);
                     }
                 };
-                this.container.on("op", opHandler);
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                this.container!.on("op", opHandler);
             });
         }
 
@@ -92,7 +94,8 @@ class WorkerLoader implements ILoader, IComponentRunnable {
     }
 
     public async resolve(request: IRequest): Promise<IContainer> {
-        return this.container;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return this.container!;
     }
 
     public async run(...args: any[]): Promise<void> {

--- a/server/gateway/src/gatewayUrlResolver.ts
+++ b/server/gateway/src/gatewayUrlResolver.ts
@@ -4,6 +4,8 @@
  */
 
 import { isSpoTenant, resolveFluidUrl, spoGetResolvedUrl } from "@fluid-example/tiny-web-host";
+import { IFluidCodeDetails } from "@microsoft/fluid-container-definitions";
+import { IFluidResolvedUrl } from "@microsoft/fluid-driver-definitions";
 import { IClientConfig } from "@microsoft/fluid-odsp-utils";
 import { ScopeType } from "@microsoft/fluid-protocol-definitions";
 import { IAlfredUser, RouterliciousUrlResolver } from "@microsoft/fluid-routerlicious-urlresolver";
@@ -14,10 +16,8 @@ import { Provider } from "nconf";
 // eslint-disable-next-line import/no-internal-modules
 import * as uuid from "uuid/v4";
 import { IAlfred } from "./interfaces";
-import { IFluidResolvedUrl, IResolvedUrl } from "@microsoft/fluid-driver-definitions";
-import { IFluidCodeDetails } from "@microsoft/fluid-container-definitions";
 
-type FullTree = {
+interface FullTree {
     cache: IGitCache,
     code: IFluidCodeDetails | null,
 }
@@ -30,7 +30,7 @@ export function resolveUrl(
     documentId: string,
     scopes: ScopeType[],
     request: Request,
-): [Promise<IFluidResolvedUrl | IResolvedUrl>, Promise<undefined | FullTree>] {
+): [Promise<IFluidResolvedUrl>, Promise<undefined | FullTree>] {
     if (isSpoTenant(tenantId)) {
         const microsoftConfiguration = config.get("login:microsoft");
         const clientConfig: IClientConfig = {
@@ -65,6 +65,7 @@ export function resolveUrl(
         const resolverList = [new RouterliciousUrlResolver(endPointConfig, undefined, appTenants, scopes, user)];
         const resolvedP = resolveFluidUrl(request, resolverList);
         const fullTreeP = alfred.getFullTree(tenantId, documentId);
-        return [resolvedP, fullTreeP];
+        // RouterliciousUrlResolver only resolves as IFluidResolvedUrl
+        return [resolvedP as Promise<IFluidResolvedUrl>, fullTreeP];
     }
 }

--- a/server/gateway/src/gatewayUrlResolver.ts
+++ b/server/gateway/src/gatewayUrlResolver.ts
@@ -7,13 +7,20 @@ import { isSpoTenant, resolveFluidUrl, spoGetResolvedUrl } from "@fluid-example/
 import { IClientConfig } from "@microsoft/fluid-odsp-utils";
 import { ScopeType } from "@microsoft/fluid-protocol-definitions";
 import { IAlfredUser, RouterliciousUrlResolver } from "@microsoft/fluid-routerlicious-urlresolver";
-import { IAlfredTenant } from "@microsoft/fluid-server-services-client";
+import { IAlfredTenant, IGitCache } from "@microsoft/fluid-server-services-client";
 import { chooseCelaName } from "@microsoft/fluid-server-services-core";
 import { Request } from "express";
 import { Provider } from "nconf";
 // eslint-disable-next-line import/no-internal-modules
 import * as uuid from "uuid/v4";
 import { IAlfred } from "./interfaces";
+import { IFluidResolvedUrl, IResolvedUrl } from "@microsoft/fluid-driver-definitions";
+import { IFluidCodeDetails } from "@microsoft/fluid-container-definitions";
+
+type FullTree = {
+    cache: IGitCache,
+    code: IFluidCodeDetails | null,
+}
 
 export function resolveUrl(
     config: Provider,
@@ -23,7 +30,7 @@ export function resolveUrl(
     documentId: string,
     scopes: ScopeType[],
     request: Request,
-) {
+): [Promise<IFluidResolvedUrl | IResolvedUrl>, Promise<undefined | FullTree>] {
     if (isSpoTenant(tenantId)) {
         const microsoftConfiguration = config.get("login:microsoft");
         const clientConfig: IClientConfig = {

--- a/server/gateway/src/gatewayUrlResolver.ts
+++ b/server/gateway/src/gatewayUrlResolver.ts
@@ -38,8 +38,7 @@ export function resolveUrl(
             clientSecret: microsoftConfiguration.secret,
         };
         const resolvedP = spoGetResolvedUrl(tenantId, documentId,
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            request.session!.tokens, clientConfig);
+            request.session?.tokens, clientConfig);
         const fullTreeP = Promise.resolve(undefined);
         return [resolvedP, fullTreeP];
     } else {

--- a/server/gateway/src/gatewayUrlResolver.ts
+++ b/server/gateway/src/gatewayUrlResolver.ts
@@ -31,7 +31,8 @@ export function resolveUrl(
             clientSecret: microsoftConfiguration.secret,
         };
         const resolvedP = spoGetResolvedUrl(tenantId, documentId,
-            request.session.tokens, clientConfig);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            request.session!.tokens, clientConfig);
         const fullTreeP = Promise.resolve(undefined);
         return [resolvedP, fullTreeP];
     } else {

--- a/server/gateway/src/interfaces.ts
+++ b/server/gateway/src/interfaces.ts
@@ -11,13 +11,13 @@ import { ITenantManager } from "@microsoft/fluid-server-services-core";
 export interface IAlfred {
     createFork(tenantId: string, id: string): Promise<string>;
 
-    getFullTree(tenantId: string, documentId: string): Promise<{ cache: IGitCache; code: string | IFluidCodeDetails }>;
+    getFullTree(tenantId: string, documentId: string): Promise<{ cache: IGitCache; code: IFluidCodeDetails | null }>;
 
     getVersions(tenantId: string, documentId: string, count: number): Promise<ICommitDetails[]>;
 
     getVersion(tenantId: string, documentId: string, sha: string): Promise<ICommit>;
 
-    getLatestVersion(tenantId: string, documentId: string): Promise<ICommit>;
+    getLatestVersion(tenantId: string, documentId: string): Promise<ICommit | null>;
 
     getTenantManager(): ITenantManager;
 }

--- a/server/gateway/src/routes/api/api.ts
+++ b/server/gateway/src/routes/api/api.ts
@@ -19,7 +19,8 @@ import { IJWTClaims } from "../../utils";
 
 // Although probably the case we want a default behavior here. Maybe just the URL?
 async function getWebComponent(url: UrlWithStringQuery): Promise<IWebResolvedUrl> {
-    const result = await Axios.get(url.href);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const result = await Axios.get(url.href!);
 
     return {
         data: result.data,

--- a/server/gateway/src/routes/api/api.ts
+++ b/server/gateway/src/routes/api/api.ts
@@ -59,8 +59,8 @@ async function getInternalComponent(
     const regex = url.protocol === "fluid:"
         ? /^\/([^/]*)\/([^/]*)(\/?.*)$/
         : /^\/loader\/([^/]*)\/([^/]*)(\/?.*)$/;
-    // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
-    const match = url.path.match(regex);
+    // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec, @typescript-eslint/no-non-null-assertion
+    const match = url.path!.match(regex);
 
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!match) {

--- a/server/gateway/src/routes/fastLoader.ts
+++ b/server/gateway/src/routes/fastLoader.ts
@@ -70,11 +70,12 @@ export function create(
         const documentId = rawPath.substring(0, slash !== -1 ? slash : rawPath.length);
         const path = rawPath.substring(slash !== -1 ? slash : rawPath.length);
 
-        const tenantId = getParam(request.params, "tenantId");
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const tenantId = getParam(request.params, "tenantId")!;
         const chaincode = request.query.chaincode;
 
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        const user: IAlfredUser = (request.user) ? {
+        const user: IAlfredUser | undefined = (request.user) ? {
             displayName: request.user.name,
             id: request.user.oid,
             name: request.user.name,

--- a/server/gateway/src/routes/fastLoader.ts
+++ b/server/gateway/src/routes/fastLoader.ts
@@ -14,7 +14,7 @@ import * as safeStringify from "json-stringify-safe";
 import * as jwt from "jsonwebtoken";
 import { Provider } from "nconf";
 import * as winston from "winston";
-import { getConfig, getParam, getUserDetails } from "../utils";
+import { getConfig, getUserDetails } from "../utils";
 import { defaultPartials } from "./partials";
 
 function createLoaderScript(
@@ -70,8 +70,7 @@ export function create(
         const documentId = rawPath.substring(0, slash !== -1 ? slash : rawPath.length);
         const path = rawPath.substring(slash !== -1 ? slash : rawPath.length);
 
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const tenantId = getParam(request.params, "tenantId")!;
+        const tenantId = request.params.tenantId;
         const chaincode = request.query.chaincode;
 
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions

--- a/server/gateway/src/routes/fork.ts
+++ b/server/gateway/src/routes/fork.ts
@@ -15,8 +15,10 @@ export function create(alfred: IAlfred, ensureLoggedIn: any): Router {
      * Loads count number of latest commits.
      */
     router.get("/:tenantId/:id", ensureLoggedIn(), (request, response) => {
-        const tenantId = getParam(request.params, "tenantId");
-        const documentId = getParam(request.params, "id");
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const tenantId = getParam(request.params, "tenantId")!;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const documentId = getParam(request.params, "id")!;
 
         const forkP = alfred.createFork(tenantId, documentId);
         forkP.then(

--- a/server/gateway/src/routes/fork.ts
+++ b/server/gateway/src/routes/fork.ts
@@ -6,7 +6,6 @@
 import { Router } from "express";
 import * as safeStringify from "json-stringify-safe";
 import { IAlfred } from "../interfaces";
-import { getParam } from "../utils";
 
 export function create(alfred: IAlfred, ensureLoggedIn: any): Router {
     const router: Router = Router();
@@ -15,10 +14,8 @@ export function create(alfred: IAlfred, ensureLoggedIn: any): Router {
      * Loads count number of latest commits.
      */
     router.get("/:tenantId/:id", ensureLoggedIn(), (request, response) => {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const tenantId = getParam(request.params, "tenantId")!;
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const documentId = getParam(request.params, "id")!;
+        const tenantId = request.params.tenantId;
+        const documentId = request.params.id;
 
         const forkP = alfred.createFork(tenantId, documentId);
         forkP.then(

--- a/server/gateway/src/routes/frontpage.ts
+++ b/server/gateway/src/routes/frontpage.ts
@@ -13,7 +13,7 @@ import * as winston from "winston";
 import { spoEnsureLoggedIn } from "../gatewayOdspUtils";
 import { resolveUrl } from "../gatewayUrlResolver";
 import { IAlfred, IKeyValueWrapper } from "../interfaces";
-import { getConfig, getParam, getUserDetails } from "../utils";
+import { getConfig, getUserDetails } from "../utils";
 import { defaultPartials } from "./partials";
 
 export function create(
@@ -45,8 +45,7 @@ export function create(
      * Loading of a specific fluid document.
      */
     router.get("/:docId?", spoEnsureLoggedIn(), ensureLoggedIn(), async (request, response) => {
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        const docId = getParam(request.params, "docId") || await getDocId();
+        const docId = request.params.docId ?? await getDocId();
         winston.info(`Loading FrontPage from ${docId}`);
         if (docId === undefined) {
             response.status(500).end("No document found");

--- a/server/gateway/src/routes/loader.ts
+++ b/server/gateway/src/routes/loader.ts
@@ -72,7 +72,8 @@ export function create(
                 const documentId = rawPath.substring(0, slash !== -1 ? slash : rawPath.length);
                 const path = rawPath.substring(slash !== -1 ? slash : rawPath.length);
 
-                const tenantId = getParam(request.params, "tenantId");
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                const tenantId = getParam(request.params, "tenantId")!;
 
                 const search = parse(request.url).search;
                 const scopes = [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite];

--- a/server/gateway/src/routes/loader.ts
+++ b/server/gateway/src/routes/loader.ts
@@ -17,7 +17,7 @@ import * as winston from "winston";
 import { spoEnsureLoggedIn } from "../gatewayOdspUtils";
 import { resolveUrl } from "../gatewayUrlResolver";
 import { IAlfred, IKeyValueWrapper } from "../interfaces";
-import { getConfig, getJWTClaims, getParam, getUserDetails } from "../utils";
+import { getConfig, getJWTClaims, getUserDetails } from "../utils";
 import { defaultPartials } from "./partials";
 
 export function create(
@@ -72,8 +72,7 @@ export function create(
                 const documentId = rawPath.substring(0, slash !== -1 ? slash : rawPath.length);
                 const path = rawPath.substring(slash !== -1 ? slash : rawPath.length);
 
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                const tenantId = getParam(request.params, "tenantId")!;
+                const tenantId = request.params.tenantId;
 
                 const search = parse(request.url).search;
                 const scopes = [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite];

--- a/server/gateway/src/routes/loader.ts
+++ b/server/gateway/src/routes/loader.ts
@@ -132,15 +132,12 @@ export function create(
                 });
 
                 const scriptsP = pkgP.then((pkg) => {
-                    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-                    if (!pkg) {
+                    if (pkg === undefined) {
                         return [];
                     }
 
-                    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-                    const umd = pkg.pkg.fluid && pkg.pkg.fluid.browser && pkg.pkg.fluid.browser.umd;
-                    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-                    if (!umd) {
+                    const umd = pkg.pkg.fluid?.browser?.umd;
+                    if (umd === undefined) {
                         return [];
                     }
 
@@ -163,11 +160,12 @@ export function create(
 
                 Promise.all([resolvedP, fullTreeP, pkgP, scriptsP, timingsP])
                     .then(([resolved, fullTree, pkg, scripts, timings]) => {
-                        // eslint-disable-next-line max-len
-                        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-non-null-assertion
-                        resolved!.url += path + (search ? search : "");
+                        // Bug in TS3.7: https://github.com/microsoft/TypeScript/issues/33752
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                        resolved!.url += path + (search ?? "");
                         winston.info(`render ${tenantId}/${documentId} +${Date.now() - start}`);
 
+                        // Bug in TS3.7: https://github.com/microsoft/TypeScript/issues/33752
                         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                         timings!.push(Date.now() - start);
 

--- a/server/gateway/src/routes/loader.ts
+++ b/server/gateway/src/routes/loader.ts
@@ -85,7 +85,6 @@ export function create(
                     tenantId,
                     config.get("error:track"));
 
-                // eslint-disable-next-line @typescript-eslint/promise-function-async
                 const pkgP = fullTreeP.then((fullTree) => {
                     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
                     if (fullTree && fullTree.code) {
@@ -165,11 +164,13 @@ export function create(
 
                 Promise.all([resolvedP, fullTreeP, pkgP, scriptsP, timingsP])
                     .then(([resolved, fullTree, pkg, scripts, timings]) => {
-                        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-                        resolved.url += path + (search ? search : "");
+                        // eslint-disable-next-line max-len
+                        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-non-null-assertion
+                        resolved!.url += path + (search ? search : "");
                         winston.info(`render ${tenantId}/${documentId} +${Date.now() - start}`);
 
-                        timings.push(Date.now() - start);
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                        timings!.push(Date.now() - start);
 
                         response.render(
                             "loader",

--- a/server/gateway/src/routes/loaderFramed.ts
+++ b/server/gateway/src/routes/loaderFramed.ts
@@ -87,7 +87,6 @@ export function create(
                     tenantId,
                     config.get("error:track"));
 
-                // eslint-disable-next-line @typescript-eslint/promise-function-async
                 const pkgP = fullTreeP.then((fullTree) => {
                     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
                     if (fullTree && fullTree.code) {
@@ -167,11 +166,13 @@ export function create(
 
                 Promise.all([resolvedP, fullTreeP, pkgP, scriptsP, timingsP])
                     .then(([resolved, fullTree, pkg, scripts, timings]) => {
-                        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-                        resolved.url += path + (search ? search : "");
+                        // eslint-disable-next-line max-len
+                        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-non-null-assertion
+                        resolved!.url += path + (search ? search : "");
                         winston.info(`render ${tenantId}/${documentId} +${Date.now() - start}`);
 
-                        timings.push(Date.now() - start);
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                        timings!.push(Date.now() - start);
 
                         response.render(
                             "loaderHost",

--- a/server/gateway/src/routes/loaderFramed.ts
+++ b/server/gateway/src/routes/loaderFramed.ts
@@ -74,7 +74,8 @@ export function create(
                 const documentId = rawPath.substring(0, slash !== -1 ? slash : rawPath.length);
                 const path = rawPath.substring(slash !== -1 ? slash : rawPath.length);
 
-                const tenantId = getParam(request.params, "tenantId");
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                const tenantId = getParam(request.params, "tenantId")!;
 
                 const search = parse(request.url).search;
                 const scopes = [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite];

--- a/server/gateway/src/routes/loaderFramed.ts
+++ b/server/gateway/src/routes/loaderFramed.ts
@@ -165,19 +165,19 @@ export function create(
 
                 Promise.all([resolvedP, fullTreeP, pkgP, scriptsP, timingsP])
                     .then(([resolved, fullTree, pkg, scripts, timings]) => {
-                        // eslint-disable-next-line max-len
-                        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-non-null-assertion
-                        resolved!.url += path + (search ? search : "");
+                        // Bug in TS3.7: https://github.com/microsoft/TypeScript/issues/33752
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                        resolved!.url += path + (search ?? "");
                         winston.info(`render ${tenantId}/${documentId} +${Date.now() - start}`);
 
+                        // Bug in TS3.7: https://github.com/microsoft/TypeScript/issues/33752
                         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                         timings!.push(Date.now() - start);
 
                         response.render(
                             "loaderHost",
                             {
-                                // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-                                cache: fullTree ? JSON.stringify(fullTree.cache) : undefined,
+                                cache: fullTree !== undefined ? JSON.stringify(fullTree.cache) : undefined,
                                 chaincode: JSON.stringify(pkg),
                                 clientId: config.get("login:microsoft").clientId,
                                 config: workerConfig,

--- a/server/gateway/src/routes/loaderFramed.ts
+++ b/server/gateway/src/routes/loaderFramed.ts
@@ -17,7 +17,7 @@ import * as winston from "winston";
 import { spoEnsureLoggedIn } from "../gatewayOdspUtils";
 import { resolveUrl } from "../gatewayUrlResolver";
 import { IAlfred, IKeyValueWrapper } from "../interfaces";
-import { getConfig, getParam, getUserDetails } from "../utils";
+import { getConfig, getUserDetails } from "../utils";
 
 export function create(
     config: Provider,
@@ -74,8 +74,7 @@ export function create(
                 const documentId = rawPath.substring(0, slash !== -1 ? slash : rawPath.length);
                 const path = rawPath.substring(slash !== -1 ? slash : rawPath.length);
 
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                const tenantId = getParam(request.params, "tenantId")!;
+                const tenantId = request.params.tenantId;
 
                 const search = parse(request.url).search;
                 const scopes = [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite];

--- a/server/gateway/src/routes/templates.ts
+++ b/server/gateway/src/routes/templates.ts
@@ -15,8 +15,8 @@ import { defaultPartials } from "./partials";
 const readDir = promisify(fs.readdir);
 
 interface ITemplate {
-    ext: string;
-    full: string;
+    ext: string | null;
+    full: string | null;
     name: string;
 }
 

--- a/server/gateway/src/routes/versions.ts
+++ b/server/gateway/src/routes/versions.ts
@@ -16,8 +16,10 @@ export function create(alfred: IAlfred, ensureLoggedIn: any): Router {
      * Loads count number of latest commits.
      */
     router.get("/:tenantId/:id", ensureLoggedIn(), (request, response) => {
-        const tenantId = getParam(request.params, "tenantId");
-        const documentId = getParam(request.params, "id");
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const tenantId = getParam(request.params, "tenantId")!;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const documentId = getParam(request.params, "id")!;
 
         const versionsP = alfred.getVersions(tenantId, documentId, 10);
         versionsP.then(

--- a/server/gateway/src/routes/versions.ts
+++ b/server/gateway/src/routes/versions.ts
@@ -6,7 +6,7 @@
 import { Router } from "express";
 import * as safeStringify from "json-stringify-safe";
 import { IAlfred } from "../interfaces";
-import { getParam, getUserDetails } from "../utils";
+import { getUserDetails } from "../utils";
 import { defaultPartials } from "./partials";
 
 export function create(alfred: IAlfred, ensureLoggedIn: any): Router {
@@ -16,10 +16,8 @@ export function create(alfred: IAlfred, ensureLoggedIn: any): Router {
      * Loads count number of latest commits.
      */
     router.get("/:tenantId/:id", ensureLoggedIn(), (request, response) => {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const tenantId = getParam(request.params, "tenantId")!;
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const documentId = getParam(request.params, "id")!;
+        const tenantId = request.params.tenantId;
+        const documentId = request.params.id;
 
         const versionsP = alfred.getVersions(tenantId, documentId, 10);
         versionsP.then(

--- a/server/gateway/src/routes/waterpark.ts
+++ b/server/gateway/src/routes/waterpark.ts
@@ -54,7 +54,8 @@ export function create(
             },
             jwtKey);
 
-        const documentId = getParam(request.params, "id");
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const documentId = getParam(request.params, "id")!;
         const path = request.params[0];
         const tenantId = appTenants[0].id;
         const scopes = [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite];

--- a/server/gateway/src/routes/waterpark.ts
+++ b/server/gateway/src/routes/waterpark.ts
@@ -67,7 +67,6 @@ export function create(
             tenantId,
             config.get("error:track"));
 
-        // eslint-disable-next-line @typescript-eslint/promise-function-async
         const pkgP = fullTreeP.then((fullTree) => {
             // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             if (path) {
@@ -127,13 +126,16 @@ export function create(
             .then(([resolved, fullTree, pkg, scripts, timings]) => {
                 // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
                 if (!pkg) {
-                    resolved.url += `${path}`;
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    resolved!.url += `${path}`;
                 } else {
-                    resolved.url += `?chaincode=${chaincode}`;
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    resolved!.url += `?chaincode=${chaincode}`;
                 }
                 winston.info(`render ${tenantId}/${documentId} +${Date.now() - start}`);
 
-                timings.push(Date.now() - start);
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                timings!.push(Date.now() - start);
 
                 response.render(
                     "loader",

--- a/server/gateway/src/routes/waterpark.ts
+++ b/server/gateway/src/routes/waterpark.ts
@@ -123,16 +123,18 @@ export function create(
 
         Promise.all([resolvedP, fullTreeP, pkgP, scriptsP, timingsP])
             .then(([resolved, fullTree, pkg, scripts, timings]) => {
-                // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-                if (!pkg) {
+                if (pkg === undefined) {
+                    // Bug in TS3.7: https://github.com/microsoft/TypeScript/issues/33752
                     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     resolved!.url += `${path}`;
                 } else {
+                    // Bug in TS3.7: https://github.com/microsoft/TypeScript/issues/33752
                     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     resolved!.url += `?chaincode=${chaincode}`;
                 }
                 winston.info(`render ${tenantId}/${documentId} +${Date.now() - start}`);
 
+                // Bug in TS3.7: https://github.com/microsoft/TypeScript/issues/33752
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 timings!.push(Date.now() - start);
 

--- a/server/gateway/src/routes/waterpark.ts
+++ b/server/gateway/src/routes/waterpark.ts
@@ -16,7 +16,7 @@ import * as winston from "winston";
 import { spoEnsureLoggedIn } from "../gatewayOdspUtils";
 import { resolveUrl } from "../gatewayUrlResolver";
 import { IAlfred } from "../interfaces";
-import { getConfig, getParam, getUserDetails } from "../utils";
+import { getConfig, getUserDetails } from "../utils";
 import { defaultPartials } from "./partials";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -54,8 +54,7 @@ export function create(
             },
             jwtKey);
 
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const documentId = getParam(request.params, "id")!;
+        const documentId = request.params.id;
         const path = request.params[0];
         const tenantId = appTenants[0].id;
         const scopes = [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite];

--- a/server/gateway/src/runner.ts
+++ b/server/gateway/src/runner.ts
@@ -18,8 +18,8 @@ import * as app from "./app";
 import { IAlfred } from "./interfaces";
 
 export class GatewayRunner implements utils.IRunner {
-    private server: IWebServer;
-    private runningDeferred: Deferred<void>;
+    private server: IWebServer | undefined;
+    private runningDeferred: Deferred<void> | undefined;
 
     constructor(
         private readonly serverFactory: IWebServerFactory,
@@ -60,15 +60,19 @@ export class GatewayRunner implements utils.IRunner {
     // eslint-disable-next-line @typescript-eslint/promise-function-async
     public stop(): Promise<void> {
         // Close the underlying server and then resolve the runner once closed
-        this.server.close().then(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        this.server!.close().then(
             () => {
-                this.runningDeferred.resolve();
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                this.runningDeferred!.resolve();
             },
             (error) => {
-                this.runningDeferred.reject(error);
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                this.runningDeferred!.reject(error);
             });
 
-        return this.runningDeferred.promise;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return this.runningDeferred!.promise;
     }
 
     /**
@@ -86,10 +90,12 @@ export class GatewayRunner implements utils.IRunner {
         // handle specific listen errors with friendly messages
         switch (error.code) {
             case "EACCES":
-                this.runningDeferred.reject(`${bind} requires elevated privileges`);
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                this.runningDeferred!.reject(`${bind} requires elevated privileges`);
                 break;
             case "EADDRINUSE":
-                this.runningDeferred.reject(`${bind} is already in use`);
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                this.runningDeferred!.reject(`${bind} is already in use`);
                 break;
             default:
                 throw error;
@@ -100,7 +106,8 @@ export class GatewayRunner implements utils.IRunner {
      * Event listener for HTTP server "listening" event.
      */
     private onListening() {
-        const addr = this.server.httpServer.address();
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const addr = this.server!.httpServer.address();
         const bind = typeof addr === "string"
             ? `pipe ${addr}`
             : `port ${addr.port}`;

--- a/server/gateway/src/runner.ts
+++ b/server/gateway/src/runner.ts
@@ -10,6 +10,7 @@ import {
     IWebServer,
     IWebServerFactory,
     MongoManager,
+    IHttpServer,
 } from "@microsoft/fluid-server-services-core";
 import * as utils from "@microsoft/fluid-server-services-utils";
 import { Provider } from "nconf";
@@ -52,7 +53,7 @@ export class GatewayRunner implements utils.IRunner {
         // Listen on provided port, on all network interfaces.
         httpServer.listen(this.port);
         httpServer.on("error", (error) => this.onError(error));
-        httpServer.on("listening", () => this.onListening());
+        httpServer.on("listening", () => this.onListening(httpServer));
 
         return this.runningDeferred.promise;
     }
@@ -105,9 +106,8 @@ export class GatewayRunner implements utils.IRunner {
     /**
      * Event listener for HTTP server "listening" event.
      */
-    private onListening() {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const addr = this.server!.httpServer.address();
+    private onListening(httpServer: IHttpServer) {
+        const addr = httpServer.address();
         const bind = typeof addr === "string"
             ? `pipe ${addr}`
             : `port ${addr.port}`;

--- a/server/gateway/src/test/routes.spec.ts
+++ b/server/gateway/src/test/routes.spec.ts
@@ -6,6 +6,7 @@
 import * as nconf from "nconf";
 import * as path from "path";
 import * as supertest from "supertest";
+import { ICache, MongoManager } from "@microsoft/fluid-server-services-core";
 import { Alfred } from "../alfred";
 import * as app from "../app";
 
@@ -26,9 +27,9 @@ describe("Gateway", () => {
                 defaultConfig,
                 alf,
                 [{ id: "git", key: "git" }],
-                null,
-                null,
-                null);
+                null as unknown as ICache,
+                null as unknown as MongoManager,
+                "");
             testServer = supertest(gateway);
         });
 

--- a/server/gateway/src/utils.ts
+++ b/server/gateway/src/utils.ts
@@ -5,9 +5,6 @@
 
 import { IClient } from "@microsoft/fluid-protocol-definitions";
 import { Request } from "express";
-// In this case we want @types/express-serve-static-core, not express-serve-static-core, and so disable the lint rule
-// tslint:disable-next-line:no-implicit-dependencies
-import { Params } from "express-serve-static-core"; // eslint-disable-line import/no-unresolved
 import * as _ from "lodash";
 
 export interface ICachedPackage {
@@ -48,8 +45,6 @@ export function getConfig(
     return JSON.stringify(updatedConfig);
 }
 
-export const getParam = (params: Params, key: string) => Array.isArray(params) ? undefined : params[key];
-
 /**
  * Helper function to return a relative range (if local) or the specific chaincode package version
  */
@@ -59,8 +54,7 @@ export function getVersion() {
     return `${version.endsWith(".0") ? "^" : ""}${version}`;
 }
 
-// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-non-null-assertion
-const getUser = (request: Request) => request.user ? request.user : request.session!.guest;
+const getUser = (request: Request) => request.user ?? request.session?.guest;
 
 export function getJWTClaims(request: Request): IJWTClaims {
     const user = getUser(request);

--- a/server/gateway/src/utils.ts
+++ b/server/gateway/src/utils.ts
@@ -59,8 +59,8 @@ export function getVersion() {
     return `${version.endsWith(".0") ? "^" : ""}${version}`;
 }
 
-// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-const getUser = (request: Request) => request.user ? request.user : request.session.guest;
+// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-non-null-assertion
+const getUser = (request: Request) => request.user ? request.user : request.session!.guest;
 
 export function getJWTClaims(request: Request): IJWTClaims {
     const user = getUser(request);

--- a/server/gateway/tsconfig.json
+++ b/server/gateway/tsconfig.json
@@ -6,7 +6,6 @@
     ],
     "compilerOptions": {
         "strict": true,
-        "strictNullChecks": false,
         "rootDir": "./src",
         "jsx": "react",
         "outDir": "./dist",


### PR DESCRIPTION
Was looking at cases that base-host's initializeContainer/loadAndRender might be used without a pkg argument, and realized Gateway didn't have strictNullChecks enabled.

This change is basically a bare-minimum approach to get it enabled, using non-null-assertions where we are currently making non-null assumptions today, and casts where we are sneaking nulls into interfaces that don't expect null.