### PR TITLE
Remove gateway shadowdom

### DIFF
--- a/server/gateway/src/controllers/loader.ts
+++ b/server/gateway/src/controllers/loader.ts
@@ -168,12 +168,6 @@ export async function initialize(
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     const container = await baseHost.loadAndRender(url, div, pkg ? pkg.details : undefined);
 
-    // Move the div hosting components into a shadow so it doesn't catch external formatting
-    const shadowHostDiv = document.createElement("div");
-    document.body.insertBefore(shadowHostDiv, div);
-    const shadowRoot = shadowHostDiv.attachShadow({mode: "open"});
-    shadowRoot.appendChild(div);
-
     container.on("error", (error) => {
         console.error(error);
     });


### PR DESCRIPTION
Fixes #1459
#1187 Added a shadowdom in gateway surrounding all the content with the intention of insulating it from the navbar styling, which was causing some components in waterpark to style strangely.  Although most (some?) components work fine with it, others don't because some of their codepaths require explicitly accounting for the shadowdom because of where it is placed.  Individual components should not be responsible for explicitly accounting for the shadow because of this one use environment.  I will follow up with another change separately to address styling conflicts in a way that does not rely on individual component changes.