### PR TITLE
Vltava is a view, not a visual, and facePile names have underscores

### DIFF
--- a/examples/components/vltava/src/components/anchor/anchor.ts
+++ b/examples/components/vltava/src/components/anchor/anchor.ts
@@ -5,8 +5,8 @@
 
 import {
     IComponentHandle,
-    IComponentHTMLVisual,
-    IProvideComponentHTMLVisual,
+    IComponentHTMLView,
+    IProvideComponentHTMLView,
 } from "@microsoft/fluid-component-core-interfaces";
 import { PrimedComponent, PrimedComponentFactory } from "@microsoft/fluid-aqueduct";
 
@@ -15,9 +15,9 @@ import uuid from "uuid/v4";
 /**
  * Anchor is an default component is responsible for managing creation and the default component
  */
-export class Anchor extends PrimedComponent implements IProvideComponentHTMLVisual {
+export class Anchor extends PrimedComponent implements IProvideComponentHTMLView {
     private readonly defaultComponentId = "default-component-id";
-    private defaultComponentInternal: IComponentHTMLVisual | undefined;
+    private defaultComponentInternal: IComponentHTMLView | undefined;
 
     private get defaultComponent() {
         if (!this.defaultComponentInternal) {
@@ -33,7 +33,7 @@ export class Anchor extends PrimedComponent implements IProvideComponentHTMLVisu
         return Anchor.factory;
     }
 
-    public get IComponentHTMLVisual() { return this.defaultComponent; }
+    public get IComponentHTMLView() { return this.defaultComponent; }
 
     protected async componentInitializingFirstTime(props: any) {
         const defaultComponent = await this.createAndAttachComponent(uuid(), "vltava");
@@ -43,6 +43,6 @@ export class Anchor extends PrimedComponent implements IProvideComponentHTMLVisu
     protected async componentHasInitialized() {
         this.defaultComponentInternal =
             (await this.root.get<IComponentHandle>(this.defaultComponentId).get())
-                .IComponentHTMLVisual;
+                .IComponentHTMLView;
     }
 }

--- a/examples/components/vltava/src/components/vltava/facePile.tsx
+++ b/examples/components/vltava/src/components/vltava/facePile.tsx
@@ -29,7 +29,7 @@ export const VltavaFacepile = (props: IVltavaFacepileProps) => {
     props.users.forEach((personaName) => {
         // Split the names on spaces and underscores
         const nameParts = personaName.split(" ")
-            .reduce((acc, val) => { acc.push(...val.split("_")); return acc; }, new Array());
+            .reduce((acc: string[], val) => { acc.push(...val.split("_")); return acc; }, []);
         const imageInitials = nameParts.reduce((acc, val) => acc.concat(val.substr(0, 1)), "");
         // This is just a way to iterate through all colors in PersonaInitialColor in order
         const initialsColor =

--- a/examples/components/vltava/src/components/vltava/facePile.tsx
+++ b/examples/components/vltava/src/components/vltava/facePile.tsx
@@ -27,7 +27,10 @@ export const VltavaFacepile = (props: IVltavaFacepileProps) => {
     const facepilePersonas: IFacepilePersona[] = [];
     let count = 0;
     props.users.forEach((personaName) => {
-        const imageInitials = `${personaName.substring(0,1)}${personaName.split(" ")[1].substring(0,1)}`;
+        // Split the names on spaces and underscores
+        const nameParts = personaName.split(" ")
+            .reduce((acc, val) => { acc.push(...val.split("_")); return acc; }, new Array());
+        const imageInitials = nameParts.reduce((acc, val) => acc.concat(val.substr(0, 1)), "");
         // This is just a way to iterate through all colors in PersonaInitialColor in order
         const initialsColor =
             PersonaInitialsColor[


### PR DESCRIPTION
Fixes two issues:

1. `Anchor` expected `Vltava` to be an `IComponentHTMLVisual` but it is now an `IComponentHTMLView`, updating the expectation to be a view.
2. Client names seem to be separated by an underscore rather than a space on r11s, so updating to support either one.