### PR TITLE
Bump-Version: detect the branch to determine whether we want to bump the minor or the patch version

### DIFF
--- a/tools/build-server-resources/build-version.js
+++ b/tools/build-server-resources/build-version.js
@@ -59,13 +59,15 @@ function parseFileVersion(file_version, build_num) {
 /**
  * Compute the build suffix
  *
+ * The suffix follows the CSemVer-CI format, see https://csemver.org/ 
+ *
  * If the build is trigger by tags, no suffix is needed (those are released bits).
  * Otherwise it is a CI only build, and we add the following suffix depending on the branch
  *     PRs:               refs/pull/*                             | ci.<build_number>.dev
  *     Official branches: refs/heads/master, refs/heads/release/* | ci.<build_number>.official
  *     Manual builds:     <all others>                            | ci.<build_number>.manual
  */
-function getBuildSuffix(env_build_branch, build_num) {
+function getBuildSuffix(env_build_branch, build_num, isFull) {
     // Split the branch
     const build_branch = env_build_branch.split('/');
     if (build_branch[0] !== 'refs') {
@@ -78,6 +80,10 @@ function getBuildSuffix(env_build_branch, build_num) {
     // Tag releases
     if (build_branch[1] === 'tags') {
         return "";
+    }
+
+    if (!isFull) {
+        return `${build_num}`;
     }
 
     // PRs
@@ -122,13 +128,43 @@ function getFullVersion(file_version, env_build_num, env_build_branch) {
     // Azure DevOp pass in the build number as $(buildNum).$(buildAttempt).
     // Get the Build number and ignore the attempt number.
     const build_num = parseInt(env_build_num.split('.')[0]);
+
     const { release_version, prerelease_version, isBackCompat } = parseFileVersion(file_version, build_num);
-    const build_suffix = isBackCompat? "" : getBuildSuffix(env_build_branch, build_num);
+    const build_suffix = isBackCompat ? "" : getBuildSuffix(env_build_branch, build_num, true);
     const fullVersion = generateFullVersion(release_version, prerelease_version, build_suffix);
     return fullVersion;
 }
 
+/* A simpler CI version that append the build number at the end in the prerelease */
+function generateSimpleVersion(release_version, prerelease_version, build_suffix) {
+    // Generate the full version string
+    if (prerelease_version) {
+        if (build_suffix) {
+            return `${release_version}-${prerelease_version}.${build_suffix}`;
+        }
+        return `${release_version}-${prerelease_version}`;
+    }
+
+    if (build_suffix) {
+        return `${release_version}-${build_suffix}`;
+    }
+
+    return release_version;
+}
+
+function getSimpleVersion(file_version, env_build_num, env_build_branch) {
+    // Azure DevOp pass in the build number as $(buildNum).$(buildAttempt).
+    // Get the Build number and ignore the attempt number.
+    const build_num = parseInt(env_build_num.split('.')[0]);
+
+    const { release_version, prerelease_version, isBackCompat } = parseFileVersion(file_version, build_num);
+    const build_suffix = isBackCompat ? "" : getBuildSuffix(env_build_branch, build_num, false);
+    const fullVersion = generateSimpleVersion(release_version, prerelease_version, build_suffix);
+    return fullVersion;
+}
+
 function main() {
+    const isFull = process.argv[1] === "--full";
     const env_build_num = process.env["VERSION_BUILDNUMBER"];
     const env_build_branch = process.env["VERSION_BUILDBRANCH"];
     const file_version = getFileVersion();
@@ -146,7 +182,12 @@ function main() {
         console.error("ERROR: Missing VERSION_BUILD_BRANCH environment variable");
         process.exit(4);
     }
-    console.log(getFullVersion(file_version, env_build_num, env_build_branch));
+
+    if (isFull) {
+        console.log(getFullVersion(file_version, env_build_num, env_build_branch));
+    } else {
+        console.log(getSimpleVersion(file_version, env_build_num, env_build_branch));
+    }
 }
 
 main();
@@ -155,8 +196,8 @@ main();
 const assert = require("assert").strict;
 function test() {
     // Test version <= 0.15, no prerelease
-    assert.equal(getFullVersion("0.15.0", "12345.0", "refs/pull/blah"), "0.15.12345");
-    assert.equal(getFullVersion("0.15.0", "12345.0", "refs/heads/master"), "0.15.12345");
+    assert.equal(getFullVersion("0.15.0", "12345", "refs/pull/blah"), "0.15.12345");
+    assert.equal(getFullVersion("0.15.0", "12345", "refs/heads/master"), "0.15.12345");
     assert.equal(getFullVersion("0.15.0", "12345.0", "refs/heads/release/0.15"), "0.15.12345");
     assert.equal(getFullVersion("0.15.0", "12345.0", "refs/heads/blah"), "0.15.12345");
     assert.equal(getFullVersion("0.15.0", "12345.0", "refs/tags/v0.15.x"), "0.15.12345");
@@ -182,6 +223,33 @@ function test() {
     assert.equal(getFullVersion("0.16.0-beta.2.1", "12345.0", "refs/heads/blah"), "0.16.0-beta.2.1.ci.12345.manual");
     assert.equal(getFullVersion("0.16.0-beta", "12345.0", "refs/tags/v0.16.0"), "0.16.0-beta");
 
+    // Test version <= 0.15, no prerelease
+    assert.equal(getSimpleVersion("0.15.0", "12345.0", "refs/pull/blah"), "0.15.12345");
+    assert.equal(getSimpleVersion("0.15.0", "12345.0", "refs/heads/master"), "0.15.12345");
+    assert.equal(getSimpleVersion("0.15.0", "12345.0", "refs/heads/release/0.15"), "0.15.12345");
+    assert.equal(getSimpleVersion("0.15.0", "12345.0", "refs/heads/blah"), "0.15.12345");
+    assert.equal(getSimpleVersion("0.15.0", "12345.0", "refs/tags/v0.15.x"), "0.15.12345");
+
+    // Test version <= 0.15, with prerelease
+    assert.equal(getSimpleVersion("0.15.0-rc", "12345.0", "refs/pull/blah"), "0.15.12345-rc");
+    assert.equal(getSimpleVersion("0.15.0-alpha.1", "12345.0", "refs/heads/master"), "0.15.12345-alpha.1");
+    assert.equal(getSimpleVersion("0.15.0-beta.2.1", "12345.0", "refs/heads/release/0.15"), "0.15.12345-beta.2.1");
+    assert.equal(getSimpleVersion("0.15.0-beta.2.1", "12345.0", "refs/heads/blah"), "0.15.12345-beta.2.1");
+    assert.equal(getSimpleVersion("0.15.0-beta", "12345.0", "refs/tags/v0.15.x"), "0.15.12345-beta");
+
+    // Test version >= 0.16, no prerelease
+    assert.equal(getSimpleVersion("0.16.0", "12345.0", "refs/pull/blah"), "0.16.0-12345");
+    assert.equal(getSimpleVersion("0.16.0", "12345.0", "refs/heads/master"), "0.16.0-12345");
+    assert.equal(getSimpleVersion("0.16.0", "12345.0", "refs/heads/release/0.16.0"), "0.16.0-12345");
+    assert.equal(getSimpleVersion("0.16.0", "12345.0", "refs/heads/blah"), "0.16.0-12345");
+    assert.equal(getSimpleVersion("0.16.0", "12345.0", "refs/tags/v0.16.0"), "0.16.0");
+
+    // Test version >= 0.16, with prerelease
+    assert.equal(getSimpleVersion("0.16.0-rc", "12345.0", "refs/pull/blah"), "0.16.0-rc.12345");
+    assert.equal(getSimpleVersion("0.16.0-alpha.1", "12345.0", "refs/heads/master"), "0.16.0-alpha.1.12345");
+    assert.equal(getSimpleVersion("0.16.0-beta.2.1", "12345.0", "refs/heads/release/0.16.1"), "0.16.0-beta.2.1.12345");
+    assert.equal(getSimpleVersion("0.16.0-beta.2.1", "12345.0", "refs/heads/blah"), "0.16.0-beta.2.1.12345");
+    assert.equal(getSimpleVersion("0.16.0-beta", "12345.0", "refs/tags/v0.16.0"), "0.16.0-beta");
     console.log("Test passed!");
 }
 

--- a/tools/fluid-build/src/bumpVersion/bumpVersion.ts
+++ b/tools/fluid-build/src/bumpVersion/bumpVersion.ts
@@ -92,7 +92,7 @@ function collectVersions(repo: FluidRepoBase, generatorPackage: Package, templat
     return versions;
 }
 
-async function bumpGeneratorFluid(buildPackages: Map<string, Package>, generatorPackage: Package, templatePackage: Package) {
+async function bumpGeneratorFluid(buildPackages: Map<string, Package>, generatorPackage: Package, templatePackage: Package, versionBump: string) {
     console.log("Bumping generator version");
 
     for (const { name, dev } of templatePackage.combinedDependencies) {
@@ -106,8 +106,8 @@ async function bumpGeneratorFluid(buildPackages: Map<string, Package>, generator
         }
     }
     await templatePackage.savePackageJson();
-    await execWithErrorAsync("npm version minor", { cwd: templatePackage.directory }, templatePackage.directory, false);
-    await execWithErrorAsync("npm version minor", { cwd: generatorPackage.directory }, generatorPackage.directory, false);
+    await execWithErrorAsync(`npm version ${versionBump}`, { cwd: templatePackage.directory }, templatePackage.directory, false);
+    await execWithErrorAsync(`npm version ${versionBump}`, { cwd: generatorPackage.directory }, generatorPackage.directory, false);
 }
 
 async function main() {
@@ -176,9 +176,10 @@ async function main() {
     }
     console.log();
 
+    const versionBump = "preminor --preid=alpha";
     const bumpMonoRepo = async (monoRepo: MonoRepo) => {
         const repoPath = repo.getMonoRepoPath(monoRepo)!;
-        return await execWithErrorAsync("npx lerna version minor --no-push --no-git-tag-version -y && npm run build:genver", {
+        return await execWithErrorAsync(`npx lerna version ${versionBump} --no-push --no-git-tag-version -y && npm run build:genver`, {
             cwd: repoPath,
         }, repoPath, false);
     }
@@ -193,7 +194,7 @@ async function main() {
 
     for (const pkg of packageNeedBump) {
         console.log(`Bumping ${pkg.name}`);
-        let cmd = "npm version minor";
+        let cmd = `npm version ${versionBump}`;
         if (pkg.getScript("build:genver")) {
             cmd += " && npm run build:genver";
         }
@@ -203,7 +204,7 @@ async function main() {
     // Package json has changed. Reload.
     repo.reload();
 
-    await bumpGeneratorFluid(buildPackages, generatorPackage, templatePackage);
+    await bumpGeneratorFluid(buildPackages, generatorPackage, templatePackage, versionBump);
 
     // Generate has changed. Reload.
     generatorPackage.reload();

--- a/tools/fluid-build/src/bumpVersion/bumpVersion.ts
+++ b/tools/fluid-build/src/bumpVersion/bumpVersion.ts
@@ -130,6 +130,7 @@ async function main() {
     }
 
     const versionBump = result.stdout == "master\n" ? "minor" : "patch";
+    console.log(`Bumping ${versionBump} version`);
 
     // Load the package
     const repo = new FluidRepoBase(resolvedRoot);


### PR DESCRIPTION
Add simpler versioning scheme for now, and we can switch the full one later when we need it.