### PR TITLE
Added metadata to ContainerRuntime to support features such as Last Edited User / Time.

### DIFF
--- a/packages/runtime/runtime-definitions/src/components.ts
+++ b/packages/runtime/runtime-definitions/src/components.ts
@@ -35,6 +35,7 @@ import {
 } from "@microsoft/fluid-protocol-definitions";
 
 import { IProvideComponentRegistry } from "./componentRegistry";
+import { RuntimeMetadata } from "./metadata";
 import { IChannel } from ".";
 
 /**
@@ -366,6 +367,7 @@ export interface IHostRuntime extends
     readonly snapshotFn: (message: string) => Promise<void>;
     readonly closeFn: () => void;
     readonly scope: IComponent;
+    readonly metadata: RuntimeMetadata;
 
     /**
      * Returns the runtime of the component.

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -9,6 +9,7 @@ export * from "./componentFactory";
 export * from "./componentRegistry";
 export * from "./components";
 export * from "./jsonable";
+export * from "./metadata";
 export * from "./protocol";
 export * from "./serializable";
 export * from "./storage";

--- a/packages/runtime/runtime-definitions/src/metadata.ts
+++ b/packages/runtime/runtime-definitions/src/metadata.ts
@@ -1,0 +1,13 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { Jsonable, JsonableObject } from "./jsonable";
+
+export type RuntimeMetadata = JsonableObject<Jsonable>;
+
+// Represents the structure of metadata on the ContainerRuntime. This can be used for storing things
+// like the document's last edit user / time.
+export interface IContainerRuntimeMetadata {
+    content: RuntimeMetadata;
+}


### PR DESCRIPTION
Fixes #1489 .

This change adds metadata support to container runtime:
- Added an optional parameter to ContainerRuntime.load that can be used to pass a metadata object during runtime creation.
- Added a getter to IHostRuntime to provide access to the metadata.
- The metadata will be added to the summary content when summarizing.

This can be used to support container level features such as the document's Last Edited User / Time. For example:
- An app owned metadata object is passed to the ContainerRuntime.load from instantiateRuntime.
- The app can listen for appropriate ops and add / update the user and time information in the metadata object.
- Components in the app can read the metadata from the runtime and get the user / time information.