### PR TITLE
Increase puppeteer test timeout for spaces

### DIFF
--- a/examples/components/spaces/tests/spaces.test.ts
+++ b/examples/components/spaces/tests/spaces.test.ts
@@ -6,7 +6,7 @@
 import { globals } from "../jest.config";
 
 describe("spaces", () => {
-    jest.setTimeout(15000);
+    jest.setTimeout(20000);
     beforeEach(async () => {
         await page.goto(globals.PATH, { waitUntil: "load" });
     });


### PR DESCRIPTION
Locally, the test takes 11s running by itself, on the CI machine it takes around 13s, which is cuttting close to the limit 15s and causing some instability in the CI.

Up the limit to 20s.