### PR TITLE
Add support to run build:docs correctly and able to specify multiple script to run

### DIFF
--- a/tools/fluid-build/src/fluidBuild.ts
+++ b/tools/fluid-build/src/fluidBuild.ts
@@ -106,7 +106,7 @@ async function main() {
             logStatus(`Symlink in ${options.fullSymlink ? "full" : options.fullSymlink === false ? "isolated" : "non-dependent"} mode`);
 
             // build the graph
-            const buildGraph = repo.createBuildGraph(options, options.buildScript);
+            const buildGraph = repo.createBuildGraph(options, options.buildScriptNames);
             timer.time("Build graph creation completed");
 
             if (options.clean) {

--- a/tools/fluid-build/src/fluidBuild/fluidRepo.ts
+++ b/tools/fluid-build/src/fluidBuild/fluidRepo.ts
@@ -16,6 +16,7 @@ import { FluidRepoBase } from "../common/fluidRepoBase";
 import { NpmDepChecker } from "./npmDepChecker";
 import { ISymlinkOptions, symlinkPackage } from "./symlinkUtils";
 import { BuildGraph } from "./buildGraph";
+import { logVerbose } from "../common/logging";
 
 export interface IPackageMatchedOptions {
     match: string[];
@@ -130,8 +131,8 @@ export class FluidRepo extends FluidRepoBase {
         return result.reduce((sum, value) => sum + value);
     }
 
-    public createBuildGraph(options: ISymlinkOptions, buildScript: string) {
-        return new BuildGraph(this.packages.packages, buildScript,
+    public createBuildGraph(options: ISymlinkOptions, buildScriptNames: string[]) {
+        return new BuildGraph(this.packages.packages, buildScriptNames,
             (pkg: Package) => {
                 const monoRepo = this.getMonoRepo(pkg);
                 return (dep: Package) => {
@@ -143,7 +144,8 @@ export class FluidRepo extends FluidRepoBase {
     private matchWithFilter(callback: (pkg: Package) => boolean) {
         let matched = false;
         this.packages.packages.forEach((pkg) => {
-            if (callback(pkg)) {
+            if (!pkg.matched && callback(pkg)) {
+                logVerbose(`${pkg.nameColored}: matched`);
                 pkg.setMatched();
                 matched = true;
             }

--- a/tools/fluid-build/src/fluidBuild/options.ts
+++ b/tools/fluid-build/src/fluidBuild/options.ts
@@ -14,7 +14,7 @@ interface FastBuildOptions extends IPackageMatchedOptions, ISymlinkOptions {
     showExec: boolean;
     clean: boolean;
     matchedOnly: boolean
-    buildScript: string;
+    buildScriptNames: string[];
     build?: boolean;
     vscode: boolean;
     symlink: boolean;
@@ -37,7 +37,7 @@ export const options: FastBuildOptions = {
     clean: false,
     match: [],
     matchedOnly: true,
-    buildScript: "build",
+    buildScriptNames: [],
     vscode: false,
     symlink: false,
     fullSymlink: undefined,
@@ -201,8 +201,8 @@ export function parseOptions(argv: string[]) {
 
         if (arg === "-s" || arg === "--script") {
             if (i !== process.argv.length - 1) {
-                options.buildScript = process.argv[++i];
-                options.build = true;
+                options.buildScriptNames.push(process.argv[++i]);
+                setBuild(true);
                 continue;
             }
             console.error("ERROR: Missing argument for --script");
@@ -261,5 +261,9 @@ export function parseOptions(argv: string[]) {
     if (error) {
         printUsage();
         process.exit(-1);
+    }
+
+    if (options.buildScriptNames.length === 0) {
+        options.buildScriptNames = [ "build" ];
     }
 }

--- a/tools/fluid-build/src/fluidBuild/tasks/leaf/apiExtractorTask.ts
+++ b/tools/fluid-build/src/fluidBuild/tasks/leaf/apiExtractorTask.ts
@@ -1,0 +1,16 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { TscDependentTask } from "./tscTask";
+
+export class ApiExtractorTask extends TscDependentTask {
+    protected get doneFile() {
+        // TODO: This assume there is only one api-extractor task per package
+        return "api-extractor.done.build.log";
+    }
+    protected get configFileFullPath() {
+        return this.getPackageFileFullPath("api-extractor.json");
+    }
+};

--- a/tools/fluid-build/src/fluidBuild/tasks/npmTask.ts
+++ b/tools/fluid-build/src/fluidBuild/tasks/npmTask.ts
@@ -8,7 +8,6 @@ import { Task, TaskExec } from "./task";
 import { LeafTask } from "./leaf/leafTask";
 import { logVerbose } from "../../common/logging";
 import { BuildResult, BuildPackage } from "../buildGraph";
-
 export class NPMTask extends Task {
     constructor(node: BuildPackage, command: string, protected readonly subTasks: Task[]) {
         super(node, command);

--- a/tools/fluid-build/src/fluidBuild/tasks/taskFactory.ts
+++ b/tools/fluid-build/src/fluidBuild/tasks/taskFactory.ts
@@ -11,6 +11,7 @@ import { Task } from "./task";
 import { TscTask } from "./leaf/tscTask";
 import { getExecutableFromCommand } from "../../common/utils";
 import { TsLintTask, EsLintTask } from "./leaf/lintTasks";
+import { ApiExtractorTask } from "./leaf/apiExtractorTask";
 import { WebpackTask } from "./leaf/webpackTask";
 import { LesscTask, CopyfilesTask, EchoTask, GenVerTask } from "./leaf/miscTasks";
 
@@ -25,6 +26,7 @@ const executableToLeafTask: { [key: string]: new (node: BuildPackage, command: s
     copyfiles: CopyfilesTask,
     echo: EchoTask,
     "gen-version": GenVerTask,
+    "api-extractor": ApiExtractorTask,
 };
 
 export class TaskFactory {
@@ -65,4 +67,9 @@ export class TaskFactory {
         return new UnknownLeafTask(node, command);
     }
 
-}
+    public static CreateScriptTasks(node: BuildPackage, scripts: string[]) {
+        if (scripts.length === 0) { return undefined; }
+        const tasks = scripts.map(value => TaskFactory.Create(node, `npm run ${value}`));
+        return tasks.length == 1? tasks[0] : new NPMTask(node, `npm run ${scripts.map(name => `npm run ${name}`).join(" && ")}`, tasks);
+    }
+};


### PR DESCRIPTION
You can now specify multiple -s <script> flags and able to build those together
e.g. `-s build -s build:docs` will run both build and build:docs together.

Improve copyfiles command dependencies and argument parsing and add api extractor task for property dependency for build:docs.