### PR TITLE
Add a configurable maxNumberOfClientsPerDocument to Alfred

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -54,6 +54,7 @@ data:
         "alfred": {
             "kafkaClientId": "{{ template "alfred.fullname" . }}",
             "maxMessageSize": "16KB",
+            "maxNumberOfClientsPerDocument": {{ .Values.alfred.maxNumberOfClientsPerDocument }},
             "topic": "{{ .Values.kafka.topics.rawdeltas }}",
             "bucket": "snapshots",
             "restJsonSize": "50mb",

--- a/server/routerlicious/kubernetes/tools/generateChart.js
+++ b/server/routerlicious/kubernetes/tools/generateChart.js
@@ -45,7 +45,7 @@ alfred:
   cert: wu2-tls-certificate
   tenants: []
   key: VBQyoGpEYrTn3XQPtXW3K8fFDd
-  maxNumberOfClientsPerDocument: 500
+  maxNumberOfClientsPerDocument: 1000000
 
 login:
   microsoft:

--- a/server/routerlicious/kubernetes/tools/generateChart.js
+++ b/server/routerlicious/kubernetes/tools/generateChart.js
@@ -45,6 +45,7 @@ alfred:
   cert: wu2-tls-certificate
   tenants: []
   key: VBQyoGpEYrTn3XQPtXW3K8fFDd
+  maxNumberOfClientsPerDocument: 500
 
 login:
   microsoft:

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -116,7 +116,7 @@ export function configureWebSocketServices(
     clientManager: core.IClientManager,
     metricLogger: core.IMetricClient,
     logger: core.ILogger,
-    maxNumberOfClientsPerDocument: number = 9999999) {
+    maxNumberOfClientsPerDocument: number = 1000000) {
 
 
     webSocketServer.on("connection", (socket: core.IWebSocket) => {
@@ -200,7 +200,9 @@ export function configureWebSocketServices(
             const [details, clients] = await Promise.all([detailsP, clientsP]);
 
             if (clients.length > maxNumberOfClientsPerDocument) {
-                return Promise.reject(`Reached connected client limit for document ${claims.documentId} in tenant ${claims.tenantId}`);
+                return Promise.reject(
+                    `Reached connected client limit for document ${claims.documentId}` +
+                    ` in tenant ${claims.tenantId}`);
             }
 
             await clientManager.addClient(

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -201,10 +201,10 @@ export function configureWebSocketServices(
 
             if (clients.length > maxNumberOfClientsPerDocument) {
                 return Promise.reject({
-                        code: 400,
-                        message: "Too many clients are already connected to this document.",
-                        retryAfter: 5*60
-                    });
+                    code: 400,
+                    message: "Too many clients are already connected to this document.",
+                    retryAfter: 5*60,
+                });
             }
 
             await clientManager.addClient(

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -203,7 +203,7 @@ export function configureWebSocketServices(
                 return Promise.reject({
                         code: 400,
                         message: "Too many clients are already connected to this document.",
-                        retryAfter: 5*60*1000
+                        retryAfter: 5*60
                     });
             }
 

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -115,7 +115,8 @@ export function configureWebSocketServices(
     contentCollection: core.ICollection<any>,
     clientManager: core.IClientManager,
     metricLogger: core.IMetricClient,
-    logger: core.ILogger) {
+    logger: core.ILogger,
+    maxNumberOfClientsPerDocument: number = 9999999) {
 
 
     webSocketServer.on("connection", (socket: core.IWebSocket) => {
@@ -198,7 +199,7 @@ export function configureWebSocketServices(
 
             const [details, clients] = await Promise.all([detailsP, clientsP]);
 
-            if (clients.length > 500) {
+            if (clients.length > maxNumberOfClientsPerDocument) {
                 return Promise.reject(`Reached connected client limit for document ${claims.documentId} in tenant ${claims.tenantId}`);
             }
 

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -200,9 +200,10 @@ export function configureWebSocketServices(
             const [details, clients] = await Promise.all([detailsP, clientsP]);
 
             if (clients.length > maxNumberOfClientsPerDocument) {
-                return Promise.reject(
-                    `Reached connected client limit for document ${claims.documentId}` +
-                    ` in tenant ${claims.tenantId}`);
+                return Promise.reject({
+                        code: 400,
+                        message: "Too many clients are already connected to this document.",
+                    });
             }
 
             await clientManager.addClient(

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -203,6 +203,7 @@ export function configureWebSocketServices(
                 return Promise.reject({
                         code: 400,
                         message: "Too many clients are already connected to this document.",
+                        retryAfter: 5*60*1000
                     });
             }
 

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -36,7 +36,7 @@
     "alfred": {
         "kafkaClientId": "alfred",
         "maxMessageSize": "16KB",
-        "maxNumberOfClientsPerDocument": 500,
+        "maxNumberOfClientsPerDocument": 1000000,
         "topic": "rawdeltas",
         "bucket": "snapshots",
         "restJsonSize": "50mb",

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -36,6 +36,7 @@
     "alfred": {
         "kafkaClientId": "alfred",
         "maxMessageSize": "16KB",
+        "maxNumberOfClientsPerDocument": 500,
         "topic": "rawdeltas",
         "bucket": "snapshots",
         "restJsonSize": "50mb",

--- a/server/routerlicious/packages/routerlicious/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious/src/alfred/runner.ts
@@ -60,6 +60,7 @@ export class AlfredRunner implements utils.IRunner {
 
         const httpServer = this.server.httpServer;
 
+        const maxNumberOfClientsPerDocument = this.config.get("alfred:maxNumberOfClientsPerDocument");
         // Register all the socket.io stuff
         configureWebSocketServices(
             this.server.webSocketServer,
@@ -69,7 +70,8 @@ export class AlfredRunner implements utils.IRunner {
             this.contentCollection,
             this.clientManager,
             createMetricClient(this.metricClientConfig),
-            winston);
+            winston,
+            maxNumberOfClientsPerDocument);
 
         // Listen on provided port, on all network interfaces.
         httpServer.listen(this.port);

--- a/server/service/config.json
+++ b/server/service/config.json
@@ -29,6 +29,7 @@
     "alfred": {
         "kafkaClientId": "alfred",
         "maxMessageSize": "16KB",
+        "maxNumberOfClientsPerDocument": 500,
         "topic": "rawdeltas2",
         "bucket": "snapshots",
         "restJsonSize": "50mb",

--- a/server/service/config.json
+++ b/server/service/config.json
@@ -29,7 +29,7 @@
     "alfred": {
         "kafkaClientId": "alfred",
         "maxMessageSize": "16KB",
-        "maxNumberOfClientsPerDocument": 500,
+        "maxNumberOfClientsPerDocument": 1000000,
         "topic": "rawdeltas2",
         "bucket": "snapshots",
         "restJsonSize": "50mb",

--- a/server/tinylicious/config.json
+++ b/server/tinylicious/config.json
@@ -15,7 +15,8 @@
         }
     },
     "alfred": {
-        "maxMessageSize": "16KB"
+        "maxMessageSize": "16KB",
+        "maxNumberOfClientsPerDocument": 500
     },
     "mongo": {
         "endpoint": "mongodb://mongodb:27017",

--- a/server/tinylicious/config.json
+++ b/server/tinylicious/config.json
@@ -16,7 +16,7 @@
     },
     "alfred": {
         "maxMessageSize": "16KB",
-        "maxNumberOfClientsPerDocument": 500
+        "maxNumberOfClientsPerDocument": 1000000
     },
     "mongo": {
         "endpoint": "mongodb://mongodb:27017",


### PR DESCRIPTION
This change adds a configurable limit of clients that at any given point in time can be connected to a Fluid document.

I validated it by deploying to Teolicious with a reasonably low value and testing manually. When the limit is reached "connect_document" fails with the right error.

Open question - what should be the default number? 