### PR TITLE
Calculate term in deli using epoch

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
@@ -27,8 +27,11 @@ export interface ICheckpointParams extends IDeliCheckpoint {
 export interface IDeliCheckpoint {
     branchMap: IRangeTrackerSnapshot;
     clients: IClientSequenceNumber[];
+    durableSequenceNumber: number;
     logOffset: number;
     sequenceNumber: number;
+    epoch: number;
+    term: number;
 }
 
 export class CheckpointContext {

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -85,6 +85,7 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
                 // Increment term if epoch changed since the last checkpoint. Epoch should always move forward
                 // but there is no need to enforce it.
                 if (leaderEpoch !== lastCheckpoint.epoch) {
+                    // TODO: Set sequence number to DSN when clients are updated to resubmit.
                     ++lastCheckpoint.term;
                     lastCheckpoint.epoch = leaderEpoch;
                 }

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -30,11 +30,16 @@ export const ActivityCheckingTimeout = 30 * 1000;
 // Timeout for sending consolidated no-ops.
 export const NoopConsolidationTimeout = 250;
 
-const DefaultDeliCheckpoint: IDeliCheckpoint = {
-    branchMap: undefined,
-    clients: undefined,
-    logOffset: -1,
-    sequenceNumber: 0,
+const getDefaultCheckpooint = (epoch: number): IDeliCheckpoint => {
+    return {
+        branchMap: undefined,
+        clients: undefined,
+        durableSequenceNumber: 0,
+        epoch,
+        logOffset: -1,
+        sequenceNumber: 0,
+        term: 1,
+    };
 };
 
 export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaFactory {
@@ -50,8 +55,7 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
     public async create(config: Provider, context: IContext): Promise<IPartitionLambda> {
         const documentId = config.get("documentId");
         const tenantId = config.get("tenantId");
-
-        context.log.info(`Leader epoch in ${tenantId}/${documentId}: ${config.get("leaderEpoch")}`);
+        const leaderEpoch = config.get("leaderEpoch") as number;
 
         // Lookup the last sequence number stored
         // TODO - is this storage specific to the orderer in place? Or can I generalize the output context?
@@ -62,25 +66,42 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
         }
 
         // Migrate the db object to new schema if applicable.
-        dbObject = await migrateSchema(dbObject, this.collection);
+        dbObject = await migrateSchema(dbObject, this.collection, leaderEpoch, 1);
+
+        let lastCheckpoint: IDeliCheckpoint;
 
         // Restore deli state if not present in the cache. Mongodb casts undefined as null so we are checking
         // both to be safe. Empty sring denotes a cache that was cleared due to a service summary
         // eslint-disable-next-line no-null/no-null
         if (dbObject.deli === undefined || dbObject.deli === null) {
             context.log.info(`New document. Setting empty deli checkpoint for ${tenantId}/${documentId}`);
-            dbObject.deli = JSON.stringify(DefaultDeliCheckpoint);
-        } else if (dbObject.deli === "") {
-            context.log.info(`Loading deli state from service summary for ${tenantId}/${documentId}`);
-            dbObject.deli = await this.loadStateFromSummary(tenantId, documentId, context.log);
+            lastCheckpoint = getDefaultCheckpooint(leaderEpoch);
         } else {
-            context.log.info(`Loading deli state from cache for ${tenantId}/${documentId}`);
+            lastCheckpoint = dbObject.deli === "" ?
+                await this.loadStateFromSummary(tenantId, documentId, leaderEpoch, context.log) :
+                JSON.parse(dbObject.deli);
+
+            if (lastCheckpoint.epoch !== undefined && lastCheckpoint.term !== undefined) {
+                // Increment term if epoch changed since the last checkpoint. Epoch should always move forward
+                // but there is no need to enforce it.
+                if (leaderEpoch !== lastCheckpoint.epoch) {
+                    ++lastCheckpoint.term;
+                    lastCheckpoint.epoch = leaderEpoch;
+                }
+            } else {
+                // Back-compat for old documents.
+                lastCheckpoint.epoch = leaderEpoch;
+                lastCheckpoint.term = 1;
+                lastCheckpoint.durableSequenceNumber = lastCheckpoint.sequenceNumber;
+            }
         }
 
+        // Should the lambda reaize that term has flipped to send a no-op message at the beginning?
         return new DeliLambda(
             context,
             tenantId,
             documentId,
+            lastCheckpoint,
             dbObject,
             // It probably shouldn't take the collection - I can manage that
             this.collection,
@@ -100,7 +121,11 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
     }
 
     // When deli cache is cleared, we need to hydrate from summary.
-    private async loadStateFromSummary(tenantId: string, documentId: string, logger: ILogger): Promise<string> {
+    private async loadStateFromSummary(
+        tenantId: string,
+        documentId: string,
+        leaderEpoch: number,
+        logger: ILogger): Promise<IDeliCheckpoint> {
         const tenant = await this.tenantManager.getTenant(tenantId);
         const gitManager = tenant.gitManager;
 
@@ -108,18 +133,17 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
 
         if (!existingRef) {
             logger.error(`No service summary present for ${tenantId}/${documentId}`);
-            return JSON.stringify(DefaultDeliCheckpoint);
+            return getDefaultCheckpooint(leaderEpoch);
         } else {
             try {
                 const content = await gitManager.getContent(existingRef.object.sha, ".serviceProtocol/deli");
-                const deliState = Buffer.from(content.content, content.encoding).toString();
-                return deliState;
+                return JSON.parse(Buffer.from(content.content, content.encoding).toString()) as IDeliCheckpoint;
             } catch (exception) {
                 // We should really fail when no service summary is present.
                 // For now we are just logging it for better telemetry.
                 logger.error(`Error fetching deli state from summary: ${tenantId}/${documentId}`);
                 logger.error(JSON.stringify(exception));
-                return JSON.stringify(DefaultDeliCheckpoint);
+                return getDefaultCheckpooint(leaderEpoch);
             }
         }
     }

--- a/server/routerlicious/packages/lambdas/src/deli/migrateDbObject.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/migrateDbObject.ts
@@ -13,15 +13,22 @@ import { IDeliCheckpoint } from "./checkpointContext";
 
 // One time migration script per document for updating to latest schema.
 // Eventually we can remove it along with legacy fields.
-export async function migrateSchema(object: IDocument, collection: ICollection<IDocument>): Promise<IDocument> {
+export async function migrateSchema(
+    object: IDocument,
+    collection: ICollection<IDocument>,
+    epoch: number,
+    term: number): Promise<IDocument> {
     if (object.version !== undefined) {
         return object;
     } else {
         const deliState: IDeliCheckpoint = {
             branchMap: object.branchMap,
             clients: object.clients,
+            durableSequenceNumber: object.sequenceNumber,
+            epoch,
             logOffset: object.logOffset,
             sequenceNumber: object.sequenceNumber,
+            term,
         };
         await collection.update(
             {

--- a/server/routerlicious/packages/lambdas/src/test/deli/checkpointContext.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/deli/checkpointContext.spec.ts
@@ -19,8 +19,11 @@ describe("Routerlicious", () => {
                 return {
                     branchMap: null,
                     clients: null,
+                    durableSequenceNumber: 0,
+                    epoch: 0,
                     logOffset,
                     sequenceNumber,
+                    term: 1,
                     queuedMessage: {
                         offset: logOffset,
                         partition: 1,

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -59,8 +59,11 @@ const DefaultScribe: IScribe = {
 const DefaultDeli: IDeliCheckpoint = {
     branchMap: undefined,
     clients: undefined,
+    durableSequenceNumber: 0,
+    epoch: 0,
     logOffset: -1,
     sequenceNumber: 0,
+    term: 1,
 };
 
 class WebSocketSubscriber implements ISubscriber {
@@ -343,10 +346,12 @@ export class LocalOrderer implements IOrderer {
             this.deliContext,
             async (lambdaSetup, context) => {
                 const documentCollection = await lambdaSetup.documentCollectionP();
+                const lastCheckpoint = JSON.parse(this.dbObject.deli);
                 return new DeliLambda(
                     context,
                     this.tenantId,
                     this.documentId,
+                    lastCheckpoint,
                     this.dbObject,
                     documentCollection,
                     this.deltasKafka,


### PR DESCRIPTION
Changes in scribe lambda is pure refactoring. Major changes:

1. Calculates term in deli using "current_epoch" and "epoch_from_last_checkpoint". Adds dsn, epoch, and term in checkpoint. The changes are only internal to deli and nothing gets passed into the sequenced message yet.

2. 'epoch' and 'term' are passed into deli lambda only for checkpointing now. They should never change during the lifetime of lambda. In future, we will add term into sequenced message.

3. During a term change, we should also update "sequence number" to "dsn". To be safe, we should do that when clients are ready to resubmit.

Term calculation should always work except for one case: when a message is sequenced and broadcasted but deli crashes before any checkpointing. Since the last term was never stored, same term will be recalculated with potential message loss. To work around this, we should make the factory (not the lambda) do one checkpoint before handing over the control to lambda.