### PR TITLE
Fix test script and server package version

### DIFF
--- a/examples/components/spaces/package.json
+++ b/examples/components/spaces/package.json
@@ -24,6 +24,7 @@
     "start:r11s": "webpack-dev-server --config webpack.config.js --package package.json --env.mode r11s",
     "start:spo": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo",
     "start:spo-df": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo-df",
+    "test": "npm run test:jest",
     "test:jest": "jest",
     "tsc": "tsc",
     "webpack": "webpack --env.production",

--- a/packages/components/canvas/package.json
+++ b/packages/components/canvas/package.json
@@ -26,6 +26,7 @@
     "start:r11s": "webpack-dev-server --config webpack.config.js --package package.json --env.mode r11s",
     "start:spo": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo",
     "start:spo-df": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo-df",
+    "test": "npm run test:jest",
     "test:jest": "jest",
     "tsc": "tsc",
     "webpack": "webpack --env.production",

--- a/packages/components/clicker/package.json
+++ b/packages/components/clicker/package.json
@@ -27,6 +27,7 @@
     "start:spo": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo",
     "start:spo-df": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo-df",
     "start:tinylicious": "webpack-dev-server --config webpack.config.js --package package.json --env.mode tinylicious",
+    "test": "npm run test:jest",
     "test:jest": "jest",
     "tsc": "tsc",
     "webpack": "webpack --env.production",

--- a/packages/components/dice-roller/package.json
+++ b/packages/components/dice-roller/package.json
@@ -26,6 +26,7 @@
     "start:r11s": "webpack-dev-server --config webpack.config.js --package package.json --env.mode r11s",
     "start:spo": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo",
     "start:spo-df": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo-df",
+    "test": "npm run test:jest",
     "test:jest": "jest",
     "tsc": "tsc",
     "webpack": "webpack --env.production",

--- a/packages/components/external-component-loader/package.json
+++ b/packages/components/external-component-loader/package.json
@@ -26,6 +26,7 @@
     "start:r11s": "webpack-dev-server --config webpack.config.js --package package.json --env.mode r11s",
     "start:spo": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo",
     "start:spo-df": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo-df",
+    "test": "npm run test:jest",
     "test:buildclicker": "cd ../clicker && test -e dist/main.bundle.js || npm run webpack",
     "test:jest": "npm run test:buildclicker && jest",
     "tsc": "tsc",

--- a/packages/components/pond/package.json
+++ b/packages/components/pond/package.json
@@ -26,6 +26,7 @@
     "start:r11s": "webpack-dev-server --config webpack.config.js --package package.json --env.mode r11s",
     "start:spo": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo",
     "start:spo-df": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo-df",
+    "test": "npm run test:jest",
     "test:jest": "jest",
     "tsc": "tsc",
     "webpack": "webpack --env.production",

--- a/packages/components/shared-text/package.json
+++ b/packages/components/shared-text/package.json
@@ -28,6 +28,7 @@
     "start:r11s": "webpack-dev-server --config webpack.config.js --package package.json --env.mode r11s",
     "start:spo": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo",
     "start:spo-df": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo-df",
+    "test": "npm run test:jest",
     "test:jest": "jest",
     "tsc": "tsc",
     "webpack": "webpack --env.production",

--- a/packages/components/todo/package.json
+++ b/packages/components/todo/package.json
@@ -27,6 +27,7 @@
     "start:spo": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo",
     "start:spo-df": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo-df",
     "start:tinylicious": "webpack-dev-server --config webpack.config.js --package package.json --env.mode tinylicious",
+    "test": "npm run test:jest",
     "test:jest": "jest",
     "tsc": "tsc",
     "webpack": "webpack --env.production",

--- a/packages/test/context-reload/package.json
+++ b/packages/test/context-reload/package.json
@@ -21,6 +21,7 @@
     "start": "webpack-dev-server --config webpack.config.js --package package.json",
     "start:localhost": "webpack-dev-server --config webpack.config.js --package package.json --env.mode localhost",
     "start:r11s": "webpack-dev-server --config webpack.config.js --package package.json --env.mode r11s",
+    "test": "npm run test:jest",
     "test:jest": "npm run build-v2 && jest",
     "tsc": "tsc",
     "verdaccio": "npm publish --registry https://packages.wu2.prague.office-int.com",

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fluid-gitresources",
-  "version": "0.1004.0-0",
+  "version": "0.1004.0",
   "description": "Git resource definitions",
   "license": "MIT",
   "author": "Microsoft",

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fluid-server-kafka-orderer",
-  "version": "0.1004.0-0",
+  "version": "0.1004.0",
   "description": "Fluid ordering services",
   "repository": "microsoft/FluidFramework",
   "license": "MIT",

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fluid-server-lambdas-driver",
-  "version": "0.1004.0-0",
+  "version": "0.1004.0",
   "description": "Driver components for the Fluid service lambdas.",
   "repository": "microsoft/FluidFramework",
   "license": "MIT",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fluid-server-lambdas",
-  "version": "0.1004.0-0",
+  "version": "0.1004.0",
   "description": "Fluid service lambdas",
   "repository": "microsoft/FluidFramework",
   "license": "MIT",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fluid-server-local-server",
-  "version": "0.1004.0-0",
+  "version": "0.1004.0",
   "description": "Local server implementation",
   "repository": "microsoft/FluidFramework",
   "license": "MIT",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fluid-server-memory-orderer",
-  "version": "0.1004.0-0",
+  "version": "0.1004.0",
   "description": "Fluid ordering services",
   "repository": "microsoft/FluidFramework",
   "license": "MIT",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fluid-protocol-base",
-  "version": "0.1004.0-0",
+  "version": "0.1004.0",
   "description": "Fluid protocol base",
   "repository": "microsoft/FluidFramework",
   "license": "MIT",

--- a/server/routerlicious/packages/protocol-definitions/package.json
+++ b/server/routerlicious/packages/protocol-definitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fluid-protocol-definitions",
-  "version": "0.1004.0-0",
+  "version": "0.1004.0",
   "description": "Fluid protocol definitions",
   "repository": "microsoft/FluidFramework",
   "license": "MIT",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fluid-server-routerlicious",
-  "version": "0.1004.0-0",
+  "version": "0.1004.0",
   "description": "Server to assign sequence numbers and route deltas between connected clients",
   "repository": "microsoft/FluidFramework",
   "license": "MIT",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fluid-server-services-client",
-  "version": "0.1004.0-0",
+  "version": "0.1004.0",
   "description": "Isomorphic services for communicating with Fluid",
   "repository": "microsoft/FluidFramework",
   "license": "MIT",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fluid-server-services-core",
-  "version": "0.1004.0-0",
+  "version": "0.1004.0",
   "description": "Fluid services core definitions",
   "repository": "microsoft/FluidFramework",
   "license": "MIT",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fluid-server-services-utils",
-  "version": "0.1004.0-0",
+  "version": "0.1004.0",
   "description": "Fluid service lambdas",
   "repository": "microsoft/FluidFramework",
   "license": "MIT",

--- a/server/routerlicious/packages/services-utils/src/packageVersion.ts
+++ b/server/routerlicious/packages/services-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@microsoft/fluid-server-services-utils";
-export const pkgVersion = "0.1004.0";
+export const pkgVersion = "0.1004.0-0";

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fluid-server-services",
-  "version": "0.1004.0-0",
+  "version": "0.1004.0",
   "description": "Fluid service lambdas",
   "repository": "microsoft/FluidFramework",
   "license": "MIT",

--- a/server/routerlicious/packages/services/src/packageVersion.ts
+++ b/server/routerlicious/packages/services/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@microsoft/fluid-server-services";
-export const pkgVersion = "0.1004.0";
+export const pkgVersion = "0.1004.0-0";

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fluid-server-test-utils",
-  "version": "0.1004.0-0",
+  "version": "0.1004.0",
   "description": "Fluid test utility methods",
   "repository": "microsoft/FluidFramework",
   "license": "MIT",

--- a/tools/fluid-build/src/common/npmPackage.ts
+++ b/tools/fluid-build/src/common/npmPackage.ts
@@ -144,7 +144,7 @@ export class Package {
     }
 
     public getScript(name: string): string | undefined {
-        return this.packageJson.scripts[name];
+        return this.packageJson.scripts? this.packageJson.scripts[name] : undefined;
     }
 
     public async cleanNodeModules() {


### PR DESCRIPTION
Make sure packages that has test:jest also have a "test" script to direct to it.
Also change the server package version back to 0.1004.0 without the -0.

Add command argument support for build_version.js to ease testing.