### PR TITLE
Add --no-live-reload flag for webpack-dev-server with jest test

### DIFF
--- a/examples/components/spaces/jest-puppeteer.config.js
+++ b/examples/components/spaces/jest-puppeteer.config.js
@@ -5,7 +5,7 @@
 
 module.exports = {
   server: {
-    command: "npm run start -- --port 8084",
+    command: "npm run start -- --no-live-reload --port 8084",
     port: 8084,
     launchTimeout:10000,
     usedPortAction: 'error'

--- a/examples/components/vltava/jest-puppeteer.config.js
+++ b/examples/components/vltava/jest-puppeteer.config.js
@@ -5,7 +5,7 @@
 
 module.exports = {
   server: {
-    command: "npm run start -- --port 8085",
+    command: "npm run start -- --no-live-reload --port 8085",
     port: 8085,
     launchTimeout:10000,
     usedPortAction: 'error'

--- a/packages/components/canvas/jest-puppeteer.config.js
+++ b/packages/components/canvas/jest-puppeteer.config.js
@@ -5,7 +5,7 @@
 
 module.exports = {
   server: {
-    command: "npm run start -- --port 8083",
+    command: "npm run start -- --no-live-reload --port 8083",
     port: 8083,
     launchTimeout:10000,
     usedPortAction: 'error'

--- a/packages/components/dice-roller/jest-puppeteer.config.js
+++ b/packages/components/dice-roller/jest-puppeteer.config.js
@@ -5,7 +5,7 @@
 
 module.exports = {
   server: {
-    command: "npm run start -- --port 8081",
+    command: "npm run start -- --no-live-reload --port 8081",
     port: 8081,
     launchTimeout:10000,
     usedPortAction: 'error'

--- a/packages/components/external-component-loader/jest-puppeteer.config.js
+++ b/packages/components/external-component-loader/jest-puppeteer.config.js
@@ -5,7 +5,7 @@
 
 module.exports = {
   server: {
-    command: "npm run start -- --port 8082",
+    command: "npm run start -- --no-live-reload --port 8082",
     port: 8082,
     launchTimeout:10000,
     usedPortAction: 'error'

--- a/packages/components/pond/jest-puppeteer.config.js
+++ b/packages/components/pond/jest-puppeteer.config.js
@@ -5,7 +5,7 @@
 
 module.exports = {
   server: {
-    command: "npm run start -- --port 8718",
+    command: "npm run start -- --no-live-reload --port 8718",
     port: 8718,
     launchTimeout: 10000,
     usedPortAction: 'error'

--- a/packages/components/shared-text/jest-puppeteer.config.js
+++ b/packages/components/shared-text/jest-puppeteer.config.js
@@ -5,7 +5,7 @@
 
 module.exports = {
   server: {
-    command: "npm run start -- --port 8087",
+    command: "npm run start -- --no-live-reload --port 8087",
     port: 8087,
     launchTimeout: 10000,
     usedPortAction: 'error'

--- a/packages/components/todo/jest-puppeteer.config.js
+++ b/packages/components/todo/jest-puppeteer.config.js
@@ -5,7 +5,7 @@
 
 module.exports = {
   server: {
-    command: "npm run start -- --port 8086",
+    command: "npm run start -- --no-live-reload --port 8086",
     port: 8086,
     launchTimeout:10000,
     usedPortAction: 'error'

--- a/packages/test/context-reload/jest-puppeteer.config.js
+++ b/packages/test/context-reload/jest-puppeteer.config.js
@@ -5,7 +5,7 @@
 
 module.exports = {
   server: {
-    command: "npm run start -- --port 8088",
+    command: "npm run start -- --no-live-reload --port 8088",
     port: 8088,
     launchTimeout: 10000,
     usedPortAction: 'error',


### PR DESCRIPTION
It doesn't need live reload and it might help with reliability.