### PR TITLE
Add Bin Entry to Make Running Tinylicous Easier

### DIFF
--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -26,7 +26,7 @@
     "docker:build": "docker build -t tinylicious .",
     "docker:start": "docker run --rm -t -p 3000:3000 tinylicious"
   },
-  "bin": "node dist/index.js",
+  "bin": "dist/index.js",
   "dependencies": {
     "@microsoft/fluid-core-utils": "^0.13.17538",
     "@microsoft/fluid-gitresources": "^0.1002.0",

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -26,6 +26,7 @@
     "docker:build": "docker build -t tinylicious .",
     "docker:start": "docker run --rm -t -p 3000:3000 tinylicious"
   },
+  "bin": "node dist/index.js",
   "dependencies": {
     "@microsoft/fluid-core-utils": "^0.13.17538",
     "@microsoft/fluid-gitresources": "^0.1002.0",

--- a/server/tinylicious/src/index.ts
+++ b/server/tinylicious/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /*!
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.


### PR DESCRIPTION
This will allow tinylicious to be installed via npm and then running tinylicious from a command line will start it.