### PR TITLE
Integrating odsp driver with create new

### DIFF
--- a/packages/drivers/iframe-socket-storage/src/outerDocumentServiceFactory.ts
+++ b/packages/drivers/iframe-socket-storage/src/outerDocumentServiceFactory.ts
@@ -113,7 +113,6 @@ export class DocumentServiceFactoryProxy implements IDocumentServiceFactoryProxy
             tokens: {},
             type: "fluid",
             url: this.resolvedUrl.url,
-            openMode: this.resolvedUrl.openMode,
         });
     }
 

--- a/packages/drivers/local-driver/src/testResolver.ts
+++ b/packages/drivers/local-driver/src/testResolver.ts
@@ -10,10 +10,17 @@ import {
     IUrlResolver,
     IExperimentalUrlResolver,
 } from "@microsoft/fluid-driver-definitions";
-import { ScopeType, ISummaryTree, ICommittedProposal } from "@microsoft/fluid-protocol-definitions";
+import {
+    ScopeType,
+    ISummaryTree,
+} from "@microsoft/fluid-protocol-definitions";
 import { generateToken } from "@microsoft/fluid-server-services-client";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
 import { IExperimentalDocumentStorage } from "@microsoft/fluid-server-services-core";
+import {
+    getDocAttributesFromProtocolSummary,
+    getQuorumValuesFromProtocolSummary,
+} from "@microsoft/fluid-driver-utils";
 
 /**
  * Resolves URLs by providing fake URLs which succeed with the other
@@ -40,9 +47,7 @@ export class TestResolver implements IUrlResolver, IExperimentalUrlResolver {
     }
 
     public async createContainer(
-        summary: ISummaryTree,
-        sequenceNumber: number,
-        values: [string, ICommittedProposal][],
+        createNewSummary: ISummaryTree,
         request: IRequest,
     ): Promise<IResolvedUrl> {
         if (!this.testDeltaConnectionServer) {
@@ -53,12 +58,21 @@ export class TestResolver implements IUrlResolver, IExperimentalUrlResolver {
         if (!(expDocumentStorage && expDocumentStorage.isExperimentalDocumentStorage)) {
             throw new Error("Storage has no experimental features!!");
         }
+
+        const protocolSummary = createNewSummary.tree[".protocol"] as ISummaryTree;
+        const appSummary = createNewSummary.tree[".app"] as ISummaryTree;
+        if (!(protocolSummary && appSummary)) {
+            throw new Error("Protocol and App Summary required in the full summary");
+        }
+        const documentAttributes = getDocAttributesFromProtocolSummary(protocolSummary);
+        const quorumValues = getQuorumValuesFromProtocolSummary(protocolSummary);
+        const sequenceNumber = documentAttributes.sequenceNumber;
         await expDocumentStorage.createDocument(
             this.tenantId,
             this.id,
-            summary,
+            appSummary,
             sequenceNumber,
-            values,
+            quorumValues,
         );
         return this.resolveHelper();
     }

--- a/packages/drivers/odsp-socket-storage/src/contracts.ts
+++ b/packages/drivers/odsp-socket-storage/src/contracts.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IResolvedUrlBase, ISummaryContext, OpenMode } from "@microsoft/fluid-driver-definitions";
+import { IResolvedUrlBase, ISummaryContext } from "@microsoft/fluid-driver-definitions";
 import * as resources from "@microsoft/fluid-gitresources";
 import * as api from "@microsoft/fluid-protocol-definitions";
 import { INewFileInfo } from "./createFile";
@@ -18,8 +18,6 @@ export interface IOdspResolvedUrl extends IResolvedUrlBase {
 
     // URL to send to fluid, contains the documentId and the path
     url: string;
-
-    openMode?: OpenMode;
 
     createNewOptions?: ICreateNewOptions;
 

--- a/packages/drivers/odsp-socket-storage/src/contracts.ts
+++ b/packages/drivers/odsp-socket-storage/src/contracts.ts
@@ -8,6 +8,11 @@ import * as resources from "@microsoft/fluid-gitresources";
 import * as api from "@microsoft/fluid-protocol-definitions";
 import { INewFileInfo } from "./createFile";
 
+export interface ICreateNewOptions {
+    createNewSummary?: api.ISummaryTree,
+    newFileInfoPromise: Promise<INewFileInfo>,
+}
+
 export interface IOdspResolvedUrl extends IResolvedUrlBase {
     type: "fluid";
 
@@ -16,7 +21,7 @@ export interface IOdspResolvedUrl extends IResolvedUrlBase {
 
     openMode?: OpenMode;
 
-    newFileInfoPromise?: Promise<INewFileInfo>;
+    createNewOptions?: ICreateNewOptions;
 
     // A hashed identifier that is unique to this document
     hashedDocumentId: string;

--- a/packages/drivers/odsp-socket-storage/src/createFile.ts
+++ b/packages/drivers/odsp-socket-storage/src/createFile.ts
@@ -3,8 +3,18 @@
  * Licensed under the MIT License.
  */
 
+import * as assert from "assert";
 import { Deferred } from "@microsoft/fluid-common-utils";
-import { IOdspResolvedUrl } from "./contracts";
+import { getGitType } from "@microsoft/fluid-protocol-base";
+import { getDocAttributesFromProtocolSummary } from "@microsoft/fluid-driver-utils";
+import { SummaryType, ISummaryTree, ISummaryBlob, MessageType } from "@microsoft/fluid-protocol-definitions";
+import {
+    IOdspResolvedUrl,
+    ISnapshotTree,
+    SnapshotTreeValue,
+    SnapshotTreeEntry,
+    SnapshotType,
+} from "./contracts";
 import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth";
 import { IOdspCache } from "./odspCache";
 import { OdspDriverUrlResolver } from "./odspDriverUrlResolver";
@@ -42,6 +52,7 @@ export async function createNewFluidFile(
     getStorageToken: (siteUrl: string, refresh: boolean) => Promise<string | null>,
     newFileInfoPromise: Promise<INewFileInfo> | undefined,
     cache: IOdspCache,
+    createNewSummary?: ISummaryTree,
 ): Promise<IOdspResolvedUrl> {
     if (!newFileInfoPromise) {
         throw new Error("Odsp driver needs to create a new file but no newFileInfo supplied");
@@ -58,6 +69,10 @@ export async function createNewFluidFile(
     if (isInvalidFileName(newFileInfo.filename)) {
         throw new Error("Invalid filename. Please try again.");
     }
+    let containerSnapshot: ISnapshotTree | undefined;
+    if (createNewSummary) {
+        containerSnapshot = convertSummaryIntoContainerSnapshot(createNewSummary);
+    }
     // We don't want to create a new file for different instances of a driver. So we cache the
     // response of previous create request as a deferred promise because this is async and we don't
     // know the order of execution of this code by driver instances.
@@ -65,7 +80,7 @@ export async function createNewFluidFile(
     cache.sessionStorage.put(key, odspResolvedUrlDeferred.promise);
     let fileResponse: IFileCreateResponse;
     try {
-        fileResponse = await createNewFluidFileHelper(newFileInfo, getStorageToken);
+        fileResponse = await createNewFluidFileHelper(newFileInfo, getStorageToken, containerSnapshot);
         const odspUrl = createOdspUrl(fileResponse.siteUrl, fileResponse.driveId, fileResponse.itemId, "/");
         const resolver = new OdspDriverUrlResolver();
         resolvedUrl = await resolver.resolve({ url: odspUrl });
@@ -87,38 +102,179 @@ export async function createNewFluidFile(
 async function createNewFluidFileHelper(
     newFileInfo: INewFileInfo,
     getStorageToken: (siteUrl: string, refresh: boolean) => Promise<string | null>,
+    containerSnapshot?: ISnapshotTree,
 ): Promise<IFileCreateResponse> {
     const fileResponse = await getWithRetryForTokenRefresh(async (refresh: boolean) => {
         const storageToken = await getStorageToken(newFileInfo.siteUrl, refresh);
 
         const encodedFilename = encodeURIComponent(`${newFileInfo.filename}.fluid`);
 
-        const initialUrl =
-            `${newFileInfo.siteUrl}/_api/v2.1/drives/${newFileInfo.driveId}/items/root:/${encodeURIComponent(
-                newFileInfo.filePath,
-            )}/${encodedFilename}:/content?@name.conflictBehavior=rename&select=id,name,parentReference`;
-        const { url, headers } = getUrlAndHeadersWithAuth(initialUrl, storageToken);
+        let fetchResponse: Response;
+        if (containerSnapshot) {
+            const initialUrl =
+                `${newFileInfo.siteUrl}/_api/v2.1/drives/${newFileInfo.driveId}/items/root:/` +
+                `${encodeURIComponent(newFileInfo.filePath)}/${encodedFilename}` +
+                `:/opStream/snapshots/snapshot?@name.conflictBehavior=rename`;
+            const { url, headers } = getUrlAndHeadersWithAuth(initialUrl, storageToken);
+            headers["Content-Type"] = "application/json";
+            // Currently the api to create new file with snapshot is under a feature gate. So we have to
+            // add this header to enter into that gate.
+            headers["X-Tempuse-Allow-Singlepost"] = "1";
+            const postBody = JSON.stringify(containerSnapshot);
+            fetchResponse = await fetch(url, {
+                body: postBody,
+                method: "POST",
+                headers,
+            });
+            if (fetchResponse.status !== 200) {
+                // We encounter status=-1 if url path including filename length exceeds 400 characters.
+                if (fetchResponse.status === -1) {
+                    throwOdspNetworkError(`Unknown Error. File path length exceeding 400 characters
+                        could cause this error`, fetchResponse.status, false);
+                }
 
-        const fetchResponse = await fetch(url, {
-            method: "PUT",
-            headers,
-        });
-
-        if (fetchResponse.status !== 201) {
-            // We encounter status=-1 if url path including filename length exceeds 400 characters.
-            if (fetchResponse.status === -1) {
-                throwOdspNetworkError("Unknown Error. File path length exceeding 400 characters could cause this error",
-                    fetchResponse.status, false);
+                throwOdspNetworkError("Failed to create file with snapshot", fetchResponse.status, true);
             }
 
-            throwOdspNetworkError("Failed to create file", fetchResponse.status, true);
-        }
+            const response = await fetchResponse.json();
+            if (!response || !response.itemId) {
+                throwOdspNetworkError("Could not parse drive item from Vroom response", fetchResponse.status, false);
+            }
+            return {
+                itemId: response.itemId,
+                siteUrl: newFileInfo.siteUrl,
+                driveId: newFileInfo.driveId,
+                filename: newFileInfo.filename,
+            };
+        } else {
+            const initialUrl =
+                `${newFileInfo.siteUrl}/_api/v2.1/drives/${newFileInfo.driveId}/items/root:/${encodeURIComponent(
+                    newFileInfo.filePath,
+                )}/${encodedFilename}:/content?@name.conflictBehavior=rename&select=id,name,parentReference`;
+            const { url, headers } = getUrlAndHeadersWithAuth(initialUrl, storageToken);
+            fetchResponse = await fetch(url, {
+                method: "PUT",
+                headers,
+            });
+            if (fetchResponse.status !== 201) {
+                // We encounter status=-1 if url path including filename length exceeds 400 characters.
+                if (fetchResponse.status === -1) {
+                    throwOdspNetworkError(`Unknown Error. File path length exceeding 400 characters
+                        could cause this error`, fetchResponse.status, false);
+                }
 
-        const item = await fetchResponse.json();
-        if (!item || !item.id) {
-            throwOdspNetworkError("Could not parse drive item from Vroom response", fetchResponse.status, false);
+                throwOdspNetworkError("Failed to create file", fetchResponse.status, true);
+            }
+
+            const item = await fetchResponse.json();
+            if (!item || !item.id) {
+                throwOdspNetworkError("Could not parse drive item from Vroom response", fetchResponse.status, false);
+            }
+            return {
+                itemId: item.id,
+                siteUrl: newFileInfo.siteUrl,
+                driveId: newFileInfo.driveId,
+                filename: item.name,
+            };
         }
-        return { itemId: item.id, siteUrl: newFileInfo.siteUrl, driveId: newFileInfo.driveId, filename: item.name };
     });
     return fileResponse;
+}
+
+function convertSummaryIntoContainerSnapshot(createNewSummary: ISummaryTree) {
+    const appSummary = createNewSummary.tree[".app"] as ISummaryTree;
+    const protocolSummary = createNewSummary.tree[".protocol"] as ISummaryTree;
+    if (!(appSummary && protocolSummary)) {
+        throw new Error("App and protocol summary required for create new path!!");
+    }
+    const documentAttributes = getDocAttributesFromProtocolSummary(protocolSummary);
+    // Currently for the scenarios we have we don't have ops in the detached container. So the
+    // sequence number would always be 0 here. However odsp requires to have atleast 1 snapshot.
+    assert(documentAttributes.sequenceNumber === 0, "Sequence No for detached container snapshot should be 0");
+    documentAttributes.sequenceNumber = 1;
+    const attributesSummaryBlob: ISummaryBlob = {
+        type: SummaryType.Blob,
+        content: JSON.stringify(documentAttributes),
+    };
+    protocolSummary.tree.attributes = attributesSummaryBlob;
+    const convertedCreateNewSummary: ISummaryTree = {
+        type: SummaryType.Tree,
+        tree: {
+            ".protocol": protocolSummary,
+            ".app": appSummary,
+        },
+    };
+    const snapshotTree = convertSummaryToSnapshotTreeForCreateNew(convertedCreateNewSummary);
+    const snapshot = {
+        entries: snapshotTree.entries ?? [],
+        message: "app",
+        sequenceNumber: 1,
+        sha: snapshotTree.id,
+        type: SnapshotType.Container,
+        ops: [{
+            op: {
+                clientId: null,
+                clientSequenceNumber: -1,
+                contents: null,
+                minimumSequenceNumber: 0,
+                referenceSequenceNumber: -1,
+                sequenceNumber: 1,
+                timestamp: Date.now(),
+                traces: [],
+                type: MessageType.NoOp,
+            },
+            sequenceNumber: 1,
+        }],
+    };
+    return snapshot;
+}
+
+/**
+ * Converts a summary tree to ODSP tree
+ */
+export function convertSummaryToSnapshotTreeForCreateNew(summary: ISummaryTree): ISnapshotTree {
+    const snapshotTree: ISnapshotTree = {
+        entries: [],
+    }!;
+
+    const keys = Object.keys(summary.tree);
+    for (const key of keys) {
+        const summaryObject = summary.tree[key];
+
+        let value: SnapshotTreeValue;
+
+        switch (summaryObject.type) {
+            case SummaryType.Tree: {
+                value = convertSummaryToSnapshotTreeForCreateNew(summaryObject);
+                break;
+            }
+            case SummaryType.Blob: {
+                const content = typeof summaryObject.content === "string" ?
+                    summaryObject.content : summaryObject.content.toString("base64");
+                const encoding = typeof summaryObject.content === "string" ? "utf-8" : "base64";
+
+                value = {
+                    content,
+                    encoding,
+                };
+                break;
+            }
+            case SummaryType.Handle: {
+                throw new Error("No handle should be present for first summary!!");
+            }
+            default: {
+                throw new Error(`Unknown tree type ${summaryObject.type}`);
+            }
+        }
+
+        const entry: SnapshotTreeEntry = {
+            mode: "100644",
+            path: encodeURIComponent(key),
+            type: getGitType(summaryObject),
+            value,
+        };
+        snapshotTree.entries?.push(entry);
+    }
+
+    return snapshotTree;
 }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
@@ -10,7 +10,6 @@ import {
     IDocumentDeltaStorageService,
     IDocumentService,
     IResolvedUrl,
-    OpenMode,
     IDocumentStorageService,
 } from "@microsoft/fluid-driver-definitions";
 import {
@@ -72,8 +71,7 @@ export class OdspDocumentService implements IDocumentService {
             "fluid:telemetry:OdspDriver",
             logger,
             { docId: odspResolvedUrl.hashedDocumentId });
-        const openMode = odspResolvedUrl.openMode;
-        if (openMode === OpenMode.CreateNew && odspResolvedUrl.createNewOptions) {
+        if (odspResolvedUrl.createNewOptions) {
             const createNewOptions = odspResolvedUrl.createNewOptions;
             const createNewSummary = createNewOptions.createNewSummary;
             const event = PerformanceEvent.start(templogger,

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
@@ -3,15 +3,15 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryBaseLogger } from "@microsoft/fluid-common-definitions";
+import { ITelemetryBaseLogger, ITelemetryLogger } from "@microsoft/fluid-common-definitions";
 import { DebugLogger, PerformanceEvent, TelemetryLogger, TelemetryNullLogger } from "@microsoft/fluid-common-utils";
 import {
     IDocumentDeltaConnection,
     IDocumentDeltaStorageService,
     IDocumentService,
-    IDocumentStorageService,
     IResolvedUrl,
     OpenMode,
+    IDocumentStorageService,
 } from "@microsoft/fluid-driver-definitions";
 import {
     ConnectionMode,
@@ -42,7 +42,6 @@ const lastAfdConnectionTimeMsKey = "LastAfdConnectionTimeMs";
  * clients
  */
 export class OdspDocumentService implements IDocumentService {
-
     /**
      * @param appId - app id used for telemetry for network requests.
      * @param getStorageToken - function that can provide the storage token for a given site. This is
@@ -69,11 +68,34 @@ export class OdspDocumentService implements IDocumentService {
         isFirstTimeDocumentOpened = true,
     ): Promise<IDocumentService> {
         let odspResolvedUrl: IOdspResolvedUrl = resolvedUrl as IOdspResolvedUrl;
-        if (odspResolvedUrl.openMode === OpenMode.CreateNew && odspResolvedUrl.newFileInfoPromise) {
-            odspResolvedUrl = await createNewFluidFile(
-                getStorageToken,
-                odspResolvedUrl.newFileInfoPromise,
-                cache);
+        const templogger: ITelemetryLogger = DebugLogger.mixinDebugLogger(
+            "fluid:telemetry:OdspDriver",
+            logger,
+            { docId: odspResolvedUrl.hashedDocumentId });
+        const openMode = odspResolvedUrl.openMode;
+        if (openMode === OpenMode.CreateNew && odspResolvedUrl.createNewOptions) {
+            const createNewOptions = odspResolvedUrl.createNewOptions;
+            const createNewSummary = createNewOptions.createNewSummary;
+            const event = PerformanceEvent.start(templogger,
+                {
+                    eventName: "CreateNew",
+                    isWithSummaryUpload: createNewSummary ? true : false,
+                });
+            try {
+                odspResolvedUrl = await createNewFluidFile(
+                    getStorageToken,
+                    odspResolvedUrl.createNewOptions.newFileInfoPromise,
+                    cache,
+                    createNewSummary);
+                const props = {
+                    hashedDocumentId: odspResolvedUrl.hashedDocumentId,
+                    itemId: odspResolvedUrl.itemId,
+                };
+                event.end(props);
+            } catch(error) {
+                event.cancel(undefined, error);
+                throw error;
+            }
         }
         return new OdspDocumentService(
             appId,

--- a/packages/drivers/odsp-socket-storage/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDriverUrlResolver.ts
@@ -5,8 +5,9 @@
 
 import * as assert from "assert";
 import { IRequest } from "@microsoft/fluid-component-core-interfaces";
-import { IUrlResolver, OpenMode } from "@microsoft/fluid-driver-definitions";
-import { IOdspResolvedUrl } from "./contracts";
+import { IUrlResolver, OpenMode, IExperimentalUrlResolver } from "@microsoft/fluid-driver-definitions";
+import { ISummaryTree } from "@microsoft/fluid-protocol-definitions";
+import { IOdspResolvedUrl, ICreateNewOptions } from "./contracts";
 import { getHashedDocumentId } from "./odspUtils";
 import { getApiRoot } from "./odspUrlHelper";
 
@@ -27,33 +28,20 @@ function removeBeginningSlash(str: string): string {
     return str;
 }
 
-export class OdspDriverUrlResolver implements IUrlResolver {
+export class OdspDriverUrlResolver implements IUrlResolver, IExperimentalUrlResolver {
+    public readonly isExperimentalUrlResolver = true;
     constructor() { }
 
     public async resolve(request: IRequest): Promise<IOdspResolvedUrl> {
-        if (request.headers && request.headers.openMode === OpenMode.CreateNew && request.headers.newFileInfoPromise) {
-            const [, queryString] = request.url.split("?");
-
-            const searchParams = new URLSearchParams(queryString);
-
-            const uniqueId = searchParams.get("uniqueId");
-            if (uniqueId === null) {
-                throw new Error("ODSP URL for new file should contain the uniqueId");
+        if (request.headers) {
+            assert((request.headers.openMode === OpenMode.CreateNew)
+                === (request.headers.newFileInfoPromise !== undefined));
+            if (request.headers.newFileInfoPromise) {
+                const createNewOptions: ICreateNewOptions = {
+                    newFileInfoPromise: request.headers.newFileInfoPromise,
+                };
+                return this.resolveHelperForCreateNew(request.url, createNewOptions);
             }
-            return {
-                type: "fluid",
-                endpoints: {
-                    snapshotStorageUrl: "",
-                },
-                openMode: OpenMode.CreateNew,
-                newFileInfoPromise: request.headers.newFileInfoPromise,
-                tokens: {},
-                url: `fluid-odsp://placeholder/placeholder/${uniqueId}?version=null`,
-                hashedDocumentId: "",
-                siteUrl: "",
-                driveId: "",
-                itemId: "",
-            };
         }
         const { siteUrl, driveId, itemId, path } = this.decodeOdspUrl(request.url);
         const hashedDocumentId = getHashedDocumentId(driveId, itemId);
@@ -80,6 +68,47 @@ export class OdspDriverUrlResolver implements IUrlResolver {
             siteUrl,
             driveId,
             itemId,
+        };
+    }
+
+    public async createContainer(
+        createNewSummary: ISummaryTree,
+        request: IRequest,
+    ): Promise<IOdspResolvedUrl> {
+        if(!request.headers) {
+            throw new Error("Request should contian headers!!");
+        }
+        assert(request.headers.openMode === OpenMode.CreateNew);
+        assert(request.headers.newFileInfoPromise);
+        const createNewOptions: ICreateNewOptions = {
+            createNewSummary,
+            newFileInfoPromise: request.headers.newFileInfoPromise,
+        };
+        return this.resolveHelperForCreateNew(request.url, createNewOptions);
+    }
+
+    private resolveHelperForCreateNew(url: string, createNewOptions: ICreateNewOptions): IOdspResolvedUrl {
+        const [, queryString] = url.split("?");
+
+        const searchParams = new URLSearchParams(queryString);
+
+        const uniqueId = searchParams.get("uniqueId");
+        if (uniqueId === null) {
+            throw new Error("ODSP URL for new file should contain the uniqueId");
+        }
+        return {
+            type: "fluid",
+            endpoints: {
+                snapshotStorageUrl: "",
+            },
+            openMode: OpenMode.CreateNew,
+            createNewOptions,
+            tokens: {},
+            url: `fluid-odsp://placeholder/placeholder/${uniqueId}?version=null`,
+            hashedDocumentId: "",
+            siteUrl: "",
+            driveId: "",
+            itemId: "",
         };
     }
 

--- a/packages/drivers/odsp-socket-storage/src/odspUrlHelper.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspUrlHelper.ts
@@ -94,12 +94,10 @@ export async function getOdspUrlParts(url: URL): Promise<IOdspUrlParts|undefined
         // 5: Drive ID portion of Item ID
         joinSessionMatch = /(.*)\/v2\.1\/drive(s\/([\dA-Za-z]+))?\/items\/(([\dA-Za-z]+)!\d+)/.exec(pathname);
 
-        // eslint-disable-next-line no-null/no-null
         if (joinSessionMatch === null) {
             // Try again but with the OData format ( `/drives('ABC123')/items('ABC123!456')` )
             joinSessionMatch = /(.*)\/v2\.1\/drives\('([\dA-Za-z]+)'\)\/items\('(([\dA-Za-z]+)!\d+)'\)/.exec(pathname);
 
-            // eslint-disable-next-line no-null/no-null
             if (joinSessionMatch === null) {
                 return undefined;
             }
@@ -112,7 +110,6 @@ export async function getOdspUrlParts(url: URL): Promise<IOdspUrlParts|undefined
     } else {
         joinSessionMatch = /(.*)\/_api\/v2.1\/drives\/([^/]*)\/items\/([^/]*)(.*)/.exec(pathname);
 
-        // eslint-disable-next-line no-null/no-null
         if (joinSessionMatch === null) {
             return undefined;
         }

--- a/packages/drivers/odsp-socket-storage/src/vroom.ts
+++ b/packages/drivers/odsp-socket-storage/src/vroom.ts
@@ -10,7 +10,7 @@ import { IOdspCache } from "./odspCache";
 import { fetchHelper, getWithRetryForTokenRefresh, throwOdspNetworkError } from "./odspUtils";
 import { getApiRoot } from "./odspUrlHelper";
 
-const getOrigin = (url: string) => new URL(url).origin;
+export const getOrigin = (url: string) => new URL(url).origin;
 
 /**
  * Makes join session call on SPO

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-driver-definitions": "^0.15.0",
+    "@microsoft/fluid-driver-utils": "^0.15.0",
     "@microsoft/fluid-protocol-definitions": "^0.1003.0",
     "@microsoft/fluid-server-services-client": "^0.1003.0",
     "nconf": "^0.10.0"

--- a/packages/drivers/routerlicious-urlResolver/src/urlResolver.ts
+++ b/packages/drivers/routerlicious-urlResolver/src/urlResolver.ts
@@ -13,7 +13,7 @@ import {
     IUrlResolver,
     IExperimentalUrlResolver,
 } from "@microsoft/fluid-driver-definitions";
-import { IUser, ScopeType, ISummaryTree, ICommittedProposal } from "@microsoft/fluid-protocol-definitions";
+import { IUser, ScopeType, ISummaryTree } from "@microsoft/fluid-protocol-definitions";
 import { generateToken, IAlfredTenant } from "@microsoft/fluid-server-services-client";
 import { Provider } from "nconf";
 
@@ -141,9 +141,7 @@ export class RouterliciousUrlResolver implements IUrlResolver, IExperimentalUrlR
     }
 
     public async createContainer(
-        summary: ISummaryTree,
-        sequenceNumber: number,
-        values: [string, ICommittedProposal][],
+        createNewSummary: ISummaryTree,
         request: IRequest,
     ): Promise<IResolvedUrl> {
         throw new Error("Method not implemented.");

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -44,6 +44,7 @@ import {
     OnlineStatus,
     isOnline,
     ensureFluidResolvedUrl,
+    combineAppAndProtocolSummary,
 } from "@microsoft/fluid-driver-utils";
 import {
     buildSnapshotTree,
@@ -76,6 +77,7 @@ import {
     IVersion,
     MessageType,
     TreeEntry,
+    ISummaryTree,
 } from "@microsoft/fluid-protocol-definitions";
 import * as jwtDecode from "jwt-decode";
 import { Audience } from "./audience";
@@ -419,13 +421,11 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
         assert(!this.deltaManager.inbound.length);
         // Get the document state post attach - possibly can just call attach but we need to change the semantics
         // around what the attach means as far as async code goes.
-        const summary = await this.context.createSummary();
+        const appSummary: ISummaryTree = await this.context.createSummary();
         if (!this.protocolHandler) {
             throw new Error("Protocol Handler is undefined");
         }
-        const protocolHandler = this.protocolHandler;
-        const quorumSnapshot = protocolHandler.quorum.snapshot();
-
+        const protocolSummary = this.protocolHandler.captureSummary();
         this.originalRequest = request;
         // Actually go and create the resolved document
         const expUrlResolver = this.urlResolver as IExperimentalUrlResolver;
@@ -433,49 +433,47 @@ export class Container extends EventEmitterWithErrorHandling implements IContain
             throw new Error("Not an Experimental UrlResolver");
         }
         const resolvedUrl = await expUrlResolver.createContainer(
-            summary,
-            protocolHandler.sequenceNumber,
-            quorumSnapshot.values,
+            combineAppAndProtocolSummary(appSummary, protocolSummary),
             request);
+        try {
+            ensureFluidResolvedUrl(resolvedUrl);
+            this.service = await this.serviceFactory.createDocumentService(resolvedUrl);
 
-        ensureFluidResolvedUrl(resolvedUrl);
+            this._canReconnect = !(request.headers?.[LoaderHeader.reconnect] === false);
+            const parsedUrl = parseUrl(resolvedUrl.url);
+            if (!parsedUrl) {
+                throw new Error("Unable to parse Url");
+            }
+            const [, docId] = parsedUrl.id.split("/");
+            this._id = decodeURI(docId);
 
-        if (!this.serviceFactory) {
-            throw new Error("Provide callback to get factory from resolved url");
+            this.storageService = await this.getDocumentStorageService();
+
+            // This we can probably just pass the storage service to the blob manager - although ideally
+            // there just isn't a blob manager
+            this.blobManager = await this.loadBlobManager(this.storageService, undefined);
+            this.attached = true;
+
+            const startConnectionP = this.connectToDeltaStream();
+            startConnectionP.catch((error) => {
+                debug(`Error in connecting to delta stream from unpaused case ${error}`);
+            });
+
+            // We know this is create new flow.
+            this._existing = false;
+            this._parentBranch = this._id;
+
+            // Propagate current connection state through the system.
+            const connected = this.connectionState === ConnectionState.Connected;
+            assert(!connected || this._deltaManager.connectionMode === "read");
+            this.propagateConnectionState();
+            this.resume();
+        } catch (error) {
+            const err = createIError(error, true);
+            this.raiseCriticalError(err);
+            this.close();
+            throw error;
         }
-        const service = await this.serviceFactory.createDocumentService(resolvedUrl);
-
-        this.service = service;
-        this._canReconnect = !(request.headers?.[LoaderHeader.reconnect] === false);
-        const parsedUrl = parseUrl(resolvedUrl.url);
-        if (!parsedUrl) {
-            throw new Error("Unable to parse Url");
-        }
-        const [, docId] = parsedUrl.id.split("/");
-        this._id = decodeURI(docId);
-
-        this.storageService = await this.getDocumentStorageService();
-
-        // This we can probably just pass the storage service to the blob manager - although ideally
-        // there just isn't a blob manager
-        this.blobManager = await this.loadBlobManager(this.storageService, undefined);
-
-        this.attached = true;
-
-        const startConnectionP = this.connectToDeltaStream();
-        startConnectionP.catch((error) => {
-            debug(`Error in connecting to delta stream from unpaused case ${error}`);
-        });
-
-        await startConnectionP.then((details) => {
-            this._existing = details.existing;
-            this._parentBranch = details.parentBranch;
-        });
-
-        // Propagate current connection state through the system.
-        const connected = this.connectionState === ConnectionState.Connected;
-        assert(!connected || this._deltaManager.connectionMode === "read");
-        this.propagateConnectionState();
     }
 
     public async request(path: IRequest): Promise<IResponse> {

--- a/packages/loader/driver-definitions/src/urlResolver.ts
+++ b/packages/loader/driver-definitions/src/urlResolver.ts
@@ -22,12 +22,6 @@ export interface IFluidResolvedUrl extends IResolvedUrlBase {
     url: string;
     tokens: { [name: string]: string };
     endpoints: { [name: string]: string };
-    openMode?: OpenMode;
-}
-
-export enum OpenMode {
-    "CreateNew",
-    "OpenExisting",
 }
 
 export interface IUrlResolver {

--- a/packages/loader/driver-definitions/src/urlResolver.ts
+++ b/packages/loader/driver-definitions/src/urlResolver.ts
@@ -4,7 +4,7 @@
  */
 
 import { IRequest } from "@microsoft/fluid-component-core-interfaces";
-import { ISummaryTree, ICommittedProposal } from "@microsoft/fluid-protocol-definitions";
+import { ISummaryTree } from "@microsoft/fluid-protocol-definitions";
 
 export type IResolvedUrl = IWebResolvedUrl | IFluidResolvedUrl;
 
@@ -43,9 +43,7 @@ export interface IExperimentalUrlResolver extends IUrlResolver {
     readonly isExperimentalUrlResolver: true;
     // Creates a new document on the host with the provided options. Returns the resolved URL.
     createContainer(
-        summary: ISummaryTree,
-        sequenceNumber: number,
-        values: [string, ICommittedProposal][],
+        createNewSummary: ISummaryTree,
         request: IRequest,
     ): Promise<IResolvedUrl>;
 }

--- a/packages/loader/driver-utils/src/index.ts
+++ b/packages/loader/driver-utils/src/index.ts
@@ -10,3 +10,4 @@ export * from "./network";
 export * from "./readAndParse";
 export * from "./error";
 export * from "./fluidResolvedUrl";
+export * from "./summaryForCreateNew";

--- a/packages/loader/driver-utils/src/summaryForCreateNew.ts
+++ b/packages/loader/driver-utils/src/summaryForCreateNew.ts
@@ -1,0 +1,55 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    ISummaryTree,
+    SummaryType,
+    ISummaryBlob,
+    ICommittedProposal,
+    IDocumentAttributes,
+} from "@microsoft/fluid-protocol-definitions";
+
+/**
+ * Combine the app summary and protocol summary in 1 tree.
+ * @param appSummary - Summary of the app.
+ * @param protocolSummary - Summary of the protocol.
+ */
+export function combineAppAndProtocolSummary(
+    appSummary: ISummaryTree,
+    protocolSummary: ISummaryTree,
+): ISummaryTree {
+    const createNewSummary: ISummaryTree = {
+        type: SummaryType.Tree,
+        tree: {
+            ".protocol": protocolSummary,
+            ".app": appSummary,
+        },
+    };
+    return createNewSummary;
+}
+
+/**
+ * Extract the attributes from the protocol summary.
+ * @param protocolSummary - protocol summary from which the values are to be extracted.
+ */
+export function getDocAttributesFromProtocolSummary(
+    protocolSummary: ISummaryTree,
+): IDocumentAttributes {
+    const attributesBlob = protocolSummary.tree[".attributes"] as ISummaryBlob;
+    const documentAttributes = JSON.parse(attributesBlob.content as string) as IDocumentAttributes;
+    return documentAttributes;
+}
+
+/**
+ * Extract quorum values from the protocol summary.
+ * @param protocolSummary - protocol summary from which the values are to be extracted.
+ */
+export function getQuorumValuesFromProtocolSummary(
+    protocolSummary: ISummaryTree,
+): [string, ICommittedProposal][] {
+    const quorumValuesBlob = protocolSummary.tree.quorumValues as ISummaryBlob;
+    const quorumValues = JSON.parse(quorumValuesBlob.content as string) as [string, ICommittedProposal][];
+    return quorumValues;
+}

--- a/packages/runtime/runtime-test-utils/package.json
+++ b/packages/runtime/runtime-test-utils/package.json
@@ -27,6 +27,7 @@
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-container-definitions": "^0.15.0",
     "@microsoft/fluid-driver-definitions": "^0.15.0",
+    "@microsoft/fluid-driver-utils": "^0.15.0",
     "@microsoft/fluid-gitresources": "^0.1003.0",
     "@microsoft/fluid-protocol-definitions": "^0.1003.0",
     "@microsoft/fluid-runtime-definitions": "^0.15.0",

--- a/packages/test/end-to-end/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/end-to-end/src/test/detachedContainerTests.spec.ts
@@ -62,8 +62,6 @@ describe("Detached Container", () => {
         assert.equal(container.isAttached(), true, "Container should be attached");
         assert.equal(container.closed, false, "Container should be open");
         assert.equal(container.deltaManager.inbound.length, 0, "Inbound queue should be empty");
-        assert.equal(container.connectionState, ConnectionState.Connected,
-            "Container should be in connected state!!");
         assert.equal(container.id, "documentId", "Doc id is not matching!!");
     });
 


### PR DESCRIPTION
1.) Changed api for createContainer in url resolver to include create new summary instead of seq no and quorum values because that would serve both odsp and r11s driver.
2.) Single network call is used to create a file and post the container snapshot with a special header.
3.) Currently the container snapshot must have at least 1 op so added a NoOp.