### PR TITLE
component-core-interfaces to use symbols instead of strings for interface keys

### DIFF
--- a/examples/components/codemirror/src/codemirror.ts
+++ b/examples/components/codemirror/src/codemirror.ts
@@ -205,8 +205,8 @@ export class CodeMirrorComponent
         return collection;
     }
 
-    public get IComponentLoadable() { return this; }
-    public get IComponentRouter() { return this; }
+    public get [IComponentLoadable]() { return this; }
+    public get [IComponentRouter]() { return this; }
     public get IComponentHTMLVisual() { return this; }
 
     public url: string;

--- a/examples/components/drawer/src/drawer.ts
+++ b/examples/components/drawer/src/drawer.ts
@@ -45,8 +45,8 @@ export class Drawer extends EventEmitter implements
         { pkg: "@fluid-example/table-view", name: "Table", version: "^0.10.0", icon: "Table" },
     ];
 
-    public get IComponentLoadable() { return this; }
-    public get IComponentRouter() { return this; }
+    public get [IComponentLoadable]() { return this; }
+    public get [IComponentRouter]() { return this; }
     public get IComponentHTMLVisual() { return this; }
 
     public url: string;

--- a/examples/components/key-value-cache/src/index.ts
+++ b/examples/components/key-value-cache/src/index.ts
@@ -55,7 +55,7 @@ class KeyValue implements IKeyValue, IComponent, IComponentRouter {
         return kevValue;
     }
 
-    public get IComponentRouter() { return this; }
+    public get [IComponentRouter]() { return this; }
     public get IKeyValue() { return this; }
 
     private _root: ISharedMap | undefined;

--- a/examples/components/persona/src/persona.ts
+++ b/examples/components/persona/src/persona.ts
@@ -34,8 +34,8 @@ export class Persona extends EventEmitter implements
 
     private static readonly subDirectory = "persona";
 
-    public get IComponentLoadable() { return this; }
-    public get IComponentRouter() { return this; }
+    public get [IComponentLoadable]() { return this; }
+    public get [IComponentRouter]() { return this; }
     public get IComponentHTMLVisual() { return this; }
 
     public url: string;

--- a/examples/components/prosemirror/src/prosemirror.ts
+++ b/examples/components/prosemirror/src/prosemirror.ts
@@ -109,8 +109,8 @@ export class ProseMirror extends EventEmitter
         return collection;
     }
 
-    public get IComponentLoadable() { return this; }
-    public get IComponentRouter() { return this; }
+    public get [IComponentLoadable]() { return this; }
+    public get [IComponentRouter]() { return this; }
     public get IComponentHTMLVisual() { return this; }
     public get IRichTextEditor() { return this.collabManager; }
 

--- a/examples/components/smde/src/smde.ts
+++ b/examples/components/smde/src/smde.ts
@@ -7,6 +7,7 @@ import { strict as assert } from "assert";
 import { EventEmitter } from "events";
 import {
     IComponent,
+    IComponentConfiguration,
     IComponentLoadable,
     IComponentRouter,
     IRequest,
@@ -43,8 +44,8 @@ export class Smde extends EventEmitter implements
         return collection;
     }
 
-    public get IComponentLoadable() { return this; }
-    public get IComponentRouter() { return this; }
+    public get [IComponentLoadable]() { return this; }
+    public get [IComponentRouter]() { return this; }
     public get IComponentHTMLView() { return this; }
 
     public url: string;
@@ -202,7 +203,7 @@ export class Smde extends EventEmitter implements
     // TODO: this should be an utility.
     private isReadonly() {
         const runtimeAsComponent = this.context.hostRuntime as IComponent;
-        const scopes = runtimeAsComponent.IComponentConfiguration?.scopes;
+        const scopes = runtimeAsComponent[IComponentConfiguration]?.scopes;
         return scopes !== undefined && !scopes.includes("doc:write");
     }
 }

--- a/examples/components/spaces/src/dataModel.ts
+++ b/examples/components/spaces/src/dataModel.ts
@@ -84,8 +84,9 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
 
     public removeCollectionItem(instance: IComponent): void {
         let componentUrl: string;
-        if (instance.IComponentLoadable) {
-            componentUrl = instance.IComponentLoadable.url;
+        const loadable = instance[IComponentLoadable];
+        if (loadable) {
+            componentUrl = loadable.url;
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
             this.removeComponent(componentUrl);
         }
@@ -145,7 +146,7 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
         return this.getComponent<IComponent>(id)
             .then((returnedComponent) => {
                 if (returnedComponent) {
-                    if (returnedComponent.IComponentLoadable) {
+                    if (returnedComponent[IComponentLoadable]) {
                         this.componentSubDirectory.set(id, defaultModel);
                         return returnedComponent;
                     } else {

--- a/examples/components/vltava/src/components/tabs/dataModel.ts
+++ b/examples/components/vltava/src/components/tabs/dataModel.ts
@@ -5,7 +5,10 @@
 
 import { EventEmitter } from "events";
 
-import { IComponent } from "@microsoft/fluid-component-core-interfaces";
+import {
+    IComponent,
+    IComponentLoadable,
+} from "@microsoft/fluid-component-core-interfaces";
 import {
     ISharedDirectory,
     IDirectory,
@@ -68,7 +71,7 @@ export class TabsDataModel extends EventEmitter implements ITabsDataModel {
     public async createTab(type: string): Promise<string> {
         const newId = uuid();
         const component = await this.createAndAttachComponent(newId, type);
-        this.tabs.set(newId, component.IComponentHandle);
+        this.tabs.set(newId, component[IComponentLoadable]?.handle);
         this.emit("newTab", true);
         return newId;
     }

--- a/examples/components/vltava/src/containerServices/match-maker/matchMaker.ts
+++ b/examples/components/vltava/src/containerServices/match-maker/matchMaker.ts
@@ -95,7 +95,8 @@ export class MatchMaker extends BaseContainerService implements IComponentInterf
             discoverable.discoverableInterfaces.forEach((interfaceName) => {
                 assert(
                     component[interfaceName],
-                    `Component registering discoverable interface: [${interfaceName}] but does not implement it.`,
+                    `Component registering discoverable interface: [${interfaceName.toString()}]
+                    but does not implement it.`,
                 );
             });
             this.registerDiscoverableInterfaces(discoverable);

--- a/examples/components/vltava/tests/matchMaker.spec.ts
+++ b/examples/components/vltava/tests/matchMaker.spec.ts
@@ -34,7 +34,7 @@ class MockComponentDiscoverableInterfaces implements IComponentDiscoverableInter
     public get IComponentDiscoverableInterfaces() { return this; }
 
     // Note these have to exist to hack our way through the type check assert
-    public get IComponentLoadable() { return this; }
+    public get [IComponentLoadable]() { return this; }
     public get IComponentHandle() { return this; }
 
     public constructor(
@@ -48,7 +48,7 @@ class MockComponentDiscoverableAndDiscoverInterfaces
     public get IComponentDiscoverableInterfaces() { return this; }
 
     // Note these have to exist to hack our way through the type check assert
-    public get IComponentLoadable() { return this; }
+    public get [IComponentLoadable]() { return this; }
 
     public constructor(
         public readonly discoverableInterfaces: (keyof IComponent)[],

--- a/packages/agents/flow-intel/src/index.ts
+++ b/packages/agents/flow-intel/src/index.ts
@@ -15,7 +15,7 @@ export class TextAnalyzer implements IComponentRouter, IComponentRunnable {
         private readonly insightsMap: ISharedMap,
         private readonly config: ITokenConfig) { }
 
-    public get IComponentRouter() { return this; }
+    public get [IComponentRouter]() { return this; }
     public get IComponentRunnable() { return this; }
 
     public async run() {

--- a/packages/agents/intelligence-runner/src/index.ts
+++ b/packages/agents/intelligence-runner/src/index.ts
@@ -10,7 +10,7 @@ import { IntelRunner, ITokenConfig } from "./intelRunner";
 
 export class TextAnalyzer implements IComponentRouter, IComponentRunnable {
 
-    public get IComponentRouter() { return this; }
+    public get [IComponentRouter]() { return this; }
     public get IComponentRunnable() { return this; }
 
     constructor(

--- a/packages/agents/spellchecker/src/index.ts
+++ b/packages/agents/spellchecker/src/index.ts
@@ -24,7 +24,7 @@ declare module "@microsoft/fluid-component-core-interfaces" {
 
 export class SpellChecker implements IComponentRouter, ISpellChecker {
 
-    public get IComponentRouter() { return this; }
+    public get [IComponentRouter]() { return this; }
     public get ISpellChecker() { return this; }
 
     public run(sharedString: Sequence.SharedString, dictionary?: MergeTree.TST<number>) {

--- a/packages/agents/translator/src/index.ts
+++ b/packages/agents/translator/src/index.ts
@@ -19,7 +19,7 @@ export class Translator implements IComponentRouter, IComponentRunnable {
         private readonly insightsMap: ISharedMap,
         private readonly config: ITokenConfig) {}
 
-    public get IComponentRouter() { return this; }
+    public get [IComponentRouter]() { return this; }
     public get IComponentRunnable() { return this; }
 
     public async run() {

--- a/packages/components/agent-scheduler/src/scheduler.ts
+++ b/packages/components/agent-scheduler/src/scheduler.ts
@@ -8,6 +8,7 @@ import { EventEmitter } from "events";
 import {
     IComponent,
     IComponentHandle,
+    IComponentLoadable,
     IComponentRouter,
     IComponentRunnable,
     IRequest,
@@ -55,9 +56,9 @@ class AgentScheduler extends EventEmitter implements IAgentScheduler, IComponent
         return agentScheduler;
     }
 
-    public get IComponentLoadable() { return this; }
+    public get [IComponentLoadable]() { return this; }
     public get IAgentScheduler() { return this; }
-    public get IComponentRouter() { return this; }
+    public get [IComponentRouter]() { return this; }
 
     private get clientId(): string {
         if (!this.runtime.isAttached) {
@@ -387,8 +388,8 @@ export class TaskManager implements ITaskManager {
     }
 
     public get IAgentScheduler() { return this.scheduler; }
-    public get IComponentLoadable() { return this; }
-    public get IComponentRouter() { return this; }
+    public get [IComponentLoadable]() { return this; }
+    public get [IComponentRouter]() { return this; }
     public get ITaskManager() { return this; }
 
     public get url() { return this.scheduler.url; }
@@ -456,7 +457,7 @@ export class TaskManager implements ITaskManager {
         }
 
         const rawComponent = response.value as IComponent;
-        const agent = rawComponent.IComponentRunnable;
+        const agent = rawComponent[IComponentRunnable];
         if (agent === undefined) {
             return Promise.reject("Component does not implement IComponentRunnable");
         }

--- a/packages/components/clicker/src/agent.ts
+++ b/packages/components/clicker/src/agent.ts
@@ -11,7 +11,7 @@ export class ClickerAgent implements IComponentRouter, IComponentRunnable {
 
     constructor(private readonly counter: Counter) { }
 
-    public get IComponentRouter() { return this; }
+    public get [IComponentRouter]() { return this; }
     public get IComponentRunnable() { return this; }
 
     public async run() {

--- a/packages/components/client-ui-lib/src/controls/flowView.ts
+++ b/packages/components/client-ui-lib/src/controls/flowView.ts
@@ -4595,7 +4595,7 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
     public insertNewCollectionComponent(collection: IComponentCollection, inline = false) {
         // TODO - we may want to have a shared component collection?
         const instance = collection.createCollectionItem();
-        const loadable = instance.IComponentLoadable;
+        const loadable = instance[IComponentLoadable];
 
         const props = {
             crefTest: {

--- a/packages/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
+++ b/packages/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
@@ -47,7 +47,7 @@ export class ExternalComponentLoader extends PrimedComponent
     public get IComponentCallable() { return this; }
 
     public setViewComponent(component: IComponentLoadable) {
-        this.root.set(this.viewComponentMapID, component.IComponentLoadable.url);
+        this.root.set(this.viewComponentMapID, component.url);
         this.viewComponentP = Promise.resolve(component);
     }
 

--- a/packages/components/image-collection/src/images.ts
+++ b/packages/components/image-collection/src/images.ts
@@ -21,9 +21,9 @@ import { IComponentHTMLOptions, IComponentHTMLView } from "@microsoft/fluid-view
 
 export class ImageComponent implements
     IComponentLoadable, IComponentHTMLView, IComponentRouter, IComponentLayout {
-    public get IComponentLoadable() { return this; }
+    public get [IComponentLoadable]() { return this; }
     public get IComponentHTMLView() { return this; }
-    public get IComponentRouter() { return this; }
+    public get [IComponentRouter]() { return this; }
     public get IComponentLayout() { return this; }
 
     // Video def has a preferred aspect ratio
@@ -71,9 +71,9 @@ export class ImageCollection extends SharedComponent<ISharedDirectory> implement
     public create() { this.initialize(); }
     public async load() { this.initialize(); }
 
-    public get IComponentLoadable() { return this; }
+    public get [IComponentLoadable]() { return this; }
     public get IComponentCollection() { return this; }
-    public get IComponentRouter() { return this; }
+    public get [IComponentRouter]() { return this; }
 
     private readonly images = new Map<string, ImageComponent>();
 
@@ -122,7 +122,7 @@ export class ImageCollection extends SharedComponent<ISharedDirectory> implement
                     this.root.get(key),
                     `${this.url}/${key}`,
                     key,
-                    this.runtime.IComponentHandleContext));
+                    this.runtime[IComponentHandleContext]));
         }
 
         this.root.on("valueChanged", (changed) => {
@@ -134,7 +134,7 @@ export class ImageCollection extends SharedComponent<ISharedDirectory> implement
                     this.root.get(changed.key),
                     `${this.url}/${changed.key}`,
                     changed.key,
-                    this.runtime.IComponentHandleContext);
+                    this.runtime[IComponentHandleContext]);
                 this.images.set(changed.key, player);
             }
         });

--- a/packages/components/math/src/mathComponent.ts
+++ b/packages/components/math/src/mathComponent.ts
@@ -422,8 +422,8 @@ export class MathInstance extends EventEmitter implements IComponentLoadable, IC
     IComponentHTMLVisual {
     public static defaultOptions: IMathOptions = { display: "inline" };
 
-    public get IComponentLoadable() { return this; }
-    public get IComponentRouter() { return this; }
+    public get [IComponentLoadable]() { return this; }
+    public get [IComponentRouter]() { return this; }
     public get IComponentHTMLVisual() { return this; }
 
     public handle: ComponentHandle;
@@ -527,9 +527,9 @@ export class MathCollection extends SharedComponent<ISharedDirectory> implements
         this.initialize();
     }
 
-    public get IComponentLoadable() { return this; }
+    public get [IComponentLoadable]() { return this; }
     public get IComponentCollection() { return this; }
-    public get IComponentRouter() { return this; }
+    public get [IComponentRouter]() { return this; }
 
     private combinedMathText: Sequence.SharedString;
 
@@ -561,7 +561,7 @@ export class MathCollection extends SharedComponent<ISharedDirectory> implements
 
     public createCollectionItem(options?: IMathOptions): MathInstance {
         const leafId = `math-${Date.now()}`;
-        return new MathInstance(`${this.url}/${leafId}`, leafId, this.runtime.IComponentHandleContext, this, options);
+        return new MathInstance(`${this.url}/${leafId}`, leafId, this.runtime[IComponentHandleContext], this, options);
     }
 
     public getText(instance: MathInstance) {
@@ -628,7 +628,7 @@ export class MathCollection extends SharedComponent<ISharedDirectory> implements
                     options = mathMarker.properties.componentOptions;
                 }
                 mathMarker.mathInstance = new MathInstance(
-                    `${this.url}/${id}`, id, this.runtime.IComponentHandleContext, this, options, true);
+                    `${this.url}/${id}`, id, this.runtime[IComponentHandleContext], this, options, true);
             }
             return mathMarker.mathInstance as MathInstance;
         }

--- a/packages/components/monaco/src/chaincode.ts
+++ b/packages/components/monaco/src/chaincode.ts
@@ -5,7 +5,10 @@
 
 // inspiration for this example taken from https://github.com/agentcooper/typescript-play
 import { PrimedComponent } from "@microsoft/fluid-aqueduct";
-import { IComponentHandle } from "@microsoft/fluid-component-core-interfaces";
+import {
+    IComponentHandle,
+    IComponentLoadable,
+} from "@microsoft/fluid-component-core-interfaces";
 import { IComponentLayout } from "@microsoft/fluid-framework-experimental";
 import {
     IMergeTreeGroupMsg,
@@ -75,7 +78,7 @@ export class MonacoRunner extends PrimedComponent implements
     }
 
     public get IComponentHTMLView() { return this; }
-    public get IComponentLoadable() { return this; }
+    public get [IComponentLoadable]() { return this; }
     public get IComponentLayout() { return this; }
 
     /**

--- a/packages/components/progress-bars/src/progressBars.ts
+++ b/packages/components/progress-bars/src/progressBars.ts
@@ -93,9 +93,9 @@ export class ProgressBar extends EventEmitter implements
         this.handle = new ComponentHandle(this, keyId, context);
     }
 
-    public get IComponentLoadable() { return this; }
+    public get [IComponentLoadable]() { return this; }
     public get IComponentHTMLVisual() { return this; }
-    public get IComponentRouter() { return this; }
+    public get [IComponentRouter]() { return this; }
 
     public addView(scope?: IComponent) {
         return new ProgressBarView(this);
@@ -130,8 +130,8 @@ export class ProgressCollection
         return collection;
     }
 
-    public get IComponentLoadable() { return this; }
-    public get IComponentRouter() { return this; }
+    public get [IComponentLoadable]() { return this; }
+    public get [IComponentRouter]() { return this; }
     public get IComponentCollection() { return this; }
 
     public url: string;
@@ -144,7 +144,7 @@ export class ProgressCollection
         super();
 
         this.url = context.id;
-        this.handle = new ComponentHandle(this, "", this.runtime.IComponentHandleContext);
+        this.handle = new ComponentHandle(this, "", this.runtime[IComponentHandleContext]);
     }
 
     public changeValue(key: string, newValue: number) {
@@ -202,7 +202,7 @@ export class ProgressCollection
                     this.root.get(key),
                     `${this.url}/${key}`,
                     key,
-                    this.runtime.IComponentHandleContext,
+                    this.runtime[IComponentHandleContext],
                     this));
         }
 
@@ -216,7 +216,7 @@ export class ProgressCollection
                         this.root.get(changed.key),
                         `${this.url}/${changed.key}`,
                         changed.key,
-                        this.runtime.IComponentHandleContext,
+                        this.runtime[IComponentHandleContext],
                         this));
                 this.emit("progressAdded", `/${changed.key}`);
             }

--- a/packages/components/scribe/src/scribe.ts
+++ b/packages/components/scribe/src/scribe.ts
@@ -384,8 +384,8 @@ export class Scribe
         return collection;
     }
 
-    public get IComponentLoadable() { return this; }
-    public get IComponentRouter() { return this; }
+    public get [IComponentLoadable]() { return this; }
+    public get [IComponentRouter]() { return this; }
     public get IComponentHTMLView() { return this; }
 
     public url: string;

--- a/packages/components/shared-map-visualizer/src/maps.ts
+++ b/packages/components/shared-map-visualizer/src/maps.ts
@@ -36,7 +36,7 @@ async function updateOrCreateKey(key: string, map: ISharedMap, container: JQuery
     let keyElement = container.find(`>.${key}`);
     const newElement = keyElement.length === 0;
 
-    const isCollab = value ? (value as IComponent).IComponentHandle !== undefined : false;
+    const isCollab = value ? (value as IComponent)[IComponentHandle] !== undefined : false;
 
     if (newElement) {
         keyElement = $(`<div class="${key} ${isCollab ? "collab-object" : ""}"></div>`);
@@ -165,8 +165,8 @@ export class ProgressCollection
         return collection;
     }
 
-    public get IComponentLoadable() { return this; }
-    public get IComponentRouter() { return this; }
+    public get [IComponentLoadable]() { return this; }
+    public get [IComponentRouter]() { return this; }
     public get IComponentHTMLView() { return this; }
 
     public url: string;

--- a/packages/components/shared-text/src/component.ts
+++ b/packages/components/shared-text/src/component.ts
@@ -52,7 +52,7 @@ async function getHandle(runtimeP: Promise<IComponentRuntime>): Promise<ICompone
     }
 
     const component = request.value as IComponent;
-    return component.IComponentLoadable.handle;
+    return component[IComponentLoadable]?.handle;
 }
 
 export class SharedTextRunner
@@ -66,7 +66,7 @@ export class SharedTextRunner
         return runner;
     }
 
-    public get IComponentLoadable() { return this; }
+    public get [IComponentLoadable]() { return this; }
     public get IComponentHTMLView() { return this; }
     public get ISharedString() { return this.sharedString; }
 

--- a/packages/components/video-players/src/videoPlayers.ts
+++ b/packages/components/video-players/src/videoPlayers.ts
@@ -80,9 +80,9 @@ export class VideoPlayer implements
     private playerDiv: HTMLDivElement;
 
     public get IComponentHTMLView() { return this; }
-    public get IComponentRouter() { return this; }
+    public get [IComponentRouter]() { return this; }
     public get IComponentLayout() { return this; }
-    public get IComponentLoadable() { return this; }
+    public get [IComponentLoadable]() { return this; }
 
     // Video def has a preferred aspect ratio
     public aspectRatio?: number;
@@ -166,8 +166,8 @@ export class VideoPlayerCollection extends SharedComponent<ISharedDirectory> imp
     public create() { this.initialize().catch((error) => { this.context.error(error); }); }
     public async load() { await this.initialize(); }
 
-    public get IComponentRouter() { return this; }
-    public get IComponentLoadable() { return this; }
+    public get [IComponentRouter]() { return this; }
+    public get [IComponentLoadable]() { return this; }
     public get IComponentCollection() { return this; }
 
     private readonly videoPlayers = new Map<string, VideoPlayer>();
@@ -223,7 +223,7 @@ export class VideoPlayerCollection extends SharedComponent<ISharedDirectory> imp
                 new VideoPlayer(
                     this.root.get(key),
                     `${this.url}/${key}`,
-                    this.runtime.IComponentHandleContext,
+                    this.runtime[IComponentHandleContext],
                     key,
                     youTubeApi,
                     this));
@@ -237,7 +237,7 @@ export class VideoPlayerCollection extends SharedComponent<ISharedDirectory> imp
                 const player = new VideoPlayer(
                     this.root.get(changed.key),
                     `${this.url}/${changed.key}`,
-                    this.runtime.IComponentHandleContext,
+                    this.runtime[IComponentHandleContext],
                     changed.key,
                     youTubeApi,
                     this);

--- a/packages/framework/aqueduct/src/components/blobHandle.ts
+++ b/packages/framework/aqueduct/src/components/blobHandle.ts
@@ -20,9 +20,9 @@ import { ISharedDirectory } from "@microsoft/fluid-map";
  * and loads blob.
  */
 export class BlobHandle implements IComponentHandle {
-    public get IComponentRouter(): IComponentRouter { return this; }
-    public get IComponentHandleContext(): IComponentHandleContext { return this; }
-    public get IComponentHandle(): IComponentHandle { return this; }
+    public get [IComponentRouter](): IComponentRouter { return this; }
+    public get [IComponentHandleContext](): IComponentHandleContext { return this; }
+    public get [IComponentHandle](): IComponentHandle { return this; }
 
     public get isAttached(): boolean {
         return true;

--- a/packages/framework/aqueduct/src/components/primedComponent.ts
+++ b/packages/framework/aqueduct/src/components/primedComponent.ts
@@ -3,7 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import { IComponentHandle, IRequest, IResponse } from "@microsoft/fluid-component-core-interfaces";
+import {
+    IComponentHandle,
+    IComponentHandleContext,
+    IRequest,
+    IResponse,
+} from "@microsoft/fluid-component-core-interfaces";
+
 import { ISharedDirectory, MapFactory, SharedDirectory } from "@microsoft/fluid-map";
 import { ITaskManager } from "@microsoft/fluid-runtime-definitions";
 // eslint-disable-next-line import/no-internal-modules
@@ -76,7 +82,7 @@ export abstract class PrimedComponent extends SharedComponent {
         });
         const path = `${this.bigBlobs}${uuid()}`;
         this.root.set(path, blob);
-        return new BlobHandle(path, this.root, this.runtime.IComponentHandleContext);
+        return new BlobHandle(path, this.root, this.runtime[IComponentHandleContext]);
     }
 
     /**

--- a/packages/framework/aqueduct/src/components/sharedComponent.ts
+++ b/packages/framework/aqueduct/src/components/sharedComponent.ts
@@ -7,6 +7,7 @@ import { EventEmitter } from "events";
 import {
     IComponent,
     IComponentHandle,
+    IComponentHandleContext,
     IComponentLoadable,
     IComponentRouter,
     IProvideComponentHandle,
@@ -29,9 +30,9 @@ export abstract class SharedComponent extends EventEmitter implements IComponent
     public get disposed() { return this._disposed; }
 
     public get id() { return this.runtime.id; }
-    public get IComponentRouter() { return this; }
-    public get IComponentLoadable() { return this; }
-    public get IComponentHandle() { return this.innerHandle; }
+    public get [IComponentRouter]() { return this; }
+    public get [IComponentLoadable]() { return this; }
+    public get [IComponentHandle]() { return this.innerHandle; }
 
     /**
      * Handle to a shared component
@@ -43,7 +44,7 @@ export abstract class SharedComponent extends EventEmitter implements IComponent
         protected readonly context: IComponentContext,
     ) {
         super();
-        this.innerHandle = new ComponentHandle(this, this.url, runtime.IComponentHandleContext);
+        this.innerHandle = new ComponentHandle(this, this.url, runtime[IComponentHandleContext]);
 
         // Container event handlers
         this.runtime.once("dispose", () => {

--- a/packages/framework/aqueduct/src/containerServices/containerServices.ts
+++ b/packages/framework/aqueduct/src/containerServices/containerServices.ts
@@ -17,7 +17,7 @@ export type ContainerServiceRegistryEntries = Iterable<[string, (runtime: IHostR
  */
 export abstract class BaseContainerService implements IComponentRouter {
 
-    public get IComponentRouter() { return this; }
+    public get [IComponentRouter]() { return this; }
 
     constructor(protected readonly runtime: IHostRuntime){
     }
@@ -87,7 +87,7 @@ export const generateContainerServicesRequestHandler =
             }
 
             const service = await factory.getService(runtime);
-            const router = service.IComponentRouter;
+            const router = service[IComponentRouter];
             let subRequest = request.createSubRequest(2);
             if (router) {
                 // If the service is also a router then we will route to it

--- a/packages/framework/component-base/src/sharedcomponent.ts
+++ b/packages/framework/component-base/src/sharedcomponent.ts
@@ -6,6 +6,7 @@
 import { EventEmitter } from "events";
 import {
     IComponentHandle,
+    IComponentHandleContext,
     IComponentLoadable,
     IComponentRouter,
     IRequest,
@@ -21,10 +22,9 @@ export abstract class SharedComponent<
 > extends EventEmitter implements IComponentLoadable, IProvideComponentHandle, IComponentRouter {
     private _handle?: IComponentHandle<this>;
 
-    public get IComponentRouter() { return this; }
-    public get IComponentLoadable() { return this; }
-    public get IComponentHandle() { return this.handle; }
-    public get IProvideComponentHandle() { return this; }
+    public get [IComponentRouter]() { return this; }
+    public get [IComponentLoadable]() { return this; }
+    public get [IComponentHandle]() { return this.handle; }
 
     /**
      * Handle to a shared component
@@ -60,7 +60,7 @@ export abstract class SharedComponent<
             this._handle = new ComponentHandle(
                 this,
                 "",
-                this.runtime.IComponentHandleContext);
+                this.runtime[IComponentHandleContext]);
         }
 
         return this._handle;
@@ -69,7 +69,7 @@ export abstract class SharedComponent<
     /**
      * Absolute URL to the component within the document
      */
-    public get url() { return this.runtime.IComponentHandleContext.path; }
+    public get url() { return this.runtime[IComponentHandleContext].path; }
 
     // #endregion IComponentLoadable
 

--- a/packages/loader/component-core-interfaces/src/componentLoadable.ts
+++ b/packages/loader/component-core-interfaces/src/componentLoadable.ts
@@ -5,8 +5,11 @@
 
 import { IComponentHandle } from "./handles";
 
+
+export const IComponentLoadable = Symbol.for("IComponentLoadable");
+
 export interface IProvideComponentLoadable {
-    readonly IComponentLoadable: IComponentLoadable;
+    readonly [IComponentLoadable]: IComponentLoadable;
 }
 /**
  * A shared component has a URL from which it can be referenced
@@ -20,16 +23,21 @@ export interface IComponentLoadable extends IProvideComponentLoadable {
     handle?: IComponentHandle;
 }
 
+export const IComponentRunnable = Symbol.for("IComponentRunnable");
+
 export interface IProvideComponentRunnable {
-    readonly IComponentRunnable: IComponentRunnable;
+    readonly [IComponentRunnable]: IComponentRunnable;
 }
+
 export interface IComponentRunnable {
     run(...args: any[]): Promise<void>;
     stop?(reason?: string): void;
 }
 
+export const IComponentConfiguration = Symbol.for("IComponentConfiguration");
+
 export interface IProvideComponentConfiguration {
-    readonly IComponentConfiguration: IComponentConfiguration;
+    readonly [IComponentConfiguration]: IComponentConfiguration;
 }
 
 export interface IComponentConfiguration extends IProvideComponentConfiguration {

--- a/packages/loader/component-core-interfaces/src/componentRouter.ts
+++ b/packages/loader/component-core-interfaces/src/componentRouter.ts
@@ -19,11 +19,13 @@ export interface IResponse {
     headers?: { [key: string]: any };
 }
 
+export const IComponentRouter = Symbol.for("IComponentRouter");
+
 /**
  * Request routing
  */
 export interface IProvideComponentRouter {
-    readonly IComponentRouter: IComponentRouter;
+    readonly [IComponentRouter]: IComponentRouter;
 }
 export interface IComponentRouter extends IProvideComponentRouter {
     request(request: IRequest): Promise<IResponse>;

--- a/packages/loader/component-core-interfaces/src/handles.ts
+++ b/packages/loader/component-core-interfaces/src/handles.ts
@@ -7,8 +7,10 @@ import { IComponentRouter } from "./componentRouter";
 import { IComponent } from "./components";
 import { IComponentLoadable } from "./componentLoadable";
 
+export const IComponentHandleContext = Symbol.for("IComponentHandleContext");
+
 export interface IProvideComponentHandleContext {
-    readonly IComponentHandleContext: IComponentHandleContext;
+    readonly [IComponentHandleContext]: IComponentHandleContext;
 }
 
 /**
@@ -43,8 +45,10 @@ export interface IComponentHandleContext extends IComponentRouter, IProvideCompo
     bind(handle: IComponentHandle): void;
 }
 
+export const IComponentHandle = Symbol.for("IComponentHandle");
+
 export interface IProvideComponentHandle {
-    readonly IComponentHandle: IComponentHandle;
+    readonly [IComponentHandle]: IComponentHandle;
 }
 
 /**

--- a/packages/loader/component-core-interfaces/src/serializer.ts
+++ b/packages/loader/component-core-interfaces/src/serializer.ts
@@ -16,6 +16,8 @@ export interface ISerializedHandle {
     url: string;
 }
 
+export const IComponentSerializer = Symbol.for("IComponentSerializer");
+
 export interface IProvideComponentSerializer {
     readonly IComponentSerializer: IComponentSerializer;
 }

--- a/packages/loader/container-loader/src/nullRuntime.ts
+++ b/packages/loader/container-loader/src/nullRuntime.ts
@@ -29,7 +29,7 @@ export class NullRuntime extends EventEmitter implements IRuntime {
         throw new Error("Not implemented");
     }
 
-    public get IComponentHandleContext(): IComponentHandleContext {
+    public get [IComponentHandleContext](): IComponentHandleContext {
         throw new Error("Not implemented");
     }
 

--- a/packages/loader/execution-context-loader/src/webWorkerLoader.ts
+++ b/packages/loader/execution-context-loader/src/webWorkerLoader.ts
@@ -47,7 +47,7 @@ export class WebWorkerLoader implements ILoader, IComponentRunnable, IComponentR
     constructor(private readonly proxy: Comlink.Remote<IProxyLoader>) {
     }
 
-    public get IComponentRouter() { return this; }
+    public get [IComponentRouter]() { return this; }
     public get IComponentRunnable() { return this; }
 
     public async request(request: IRequest): Promise<IResponse> {

--- a/packages/runtime/cell/src/cell.ts
+++ b/packages/runtime/cell/src/cell.ts
@@ -3,7 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { ISerializedHandle } from "@microsoft/fluid-component-core-interfaces";
+import {
+    ISerializedHandle,
+    IComponentHandleContext,
+} from "@microsoft/fluid-component-core-interfaces";
 import { fromBase64ToUtf8 } from "@microsoft/fluid-common-utils";
 import {
     FileMode,
@@ -270,7 +273,7 @@ export class SharedCell extends SharedObject implements ISharedCell {
         // a POJO for the op
         const stringified = this.runtime.IComponentSerializer.stringify(
             value,
-            this.runtime.IComponentHandleContext,
+            this.runtime[IComponentHandleContext],
             this.handle);
         return JSON.parse(stringified);
     }
@@ -288,7 +291,7 @@ export class SharedCell extends SharedObject implements ISharedCell {
         }
 
         return value !== undefined
-            ? this.runtime.IComponentSerializer.parse(JSON.stringify(value), this.runtime.IComponentHandleContext)
+            ? this.runtime.IComponentSerializer.parse(JSON.stringify(value), this.runtime[IComponentHandleContext])
             : value;
     }
 }

--- a/packages/runtime/component-runtime/src/componentHandle.ts
+++ b/packages/runtime/component-runtime/src/componentHandle.ts
@@ -15,9 +15,9 @@ import {
 export class ComponentHandle implements IComponentHandle {
     private bound: Set<IComponentHandle> | undefined;
 
-    public get IComponentRouter(): IComponentRouter { return this; }
-    public get IComponentHandleContext(): IComponentHandleContext { return this; }
-    public get IComponentHandle(): IComponentHandle { return this; }
+    public get [IComponentRouter](): IComponentRouter { return this; }
+    public get [IComponentHandleContext](): IComponentHandleContext { return this; }
+    public get [IComponentHandle](): IComponentHandle { return this; }
 
     public get isAttached(): boolean {
         return this.routeContext.isAttached;
@@ -55,8 +55,9 @@ export class ComponentHandle implements IComponentHandle {
     }
 
     public async request(request: IRequest): Promise<IResponse> {
-        if (this.value.IComponentRouter) {
-            return this.value.IComponentRouter.request(request);
+        const router = this.value[IComponentRouter];
+        if (router) {
+            return router.request(request);
         } else {
             return { status: 404, mimeType: "text/plain", value: `${request.url} not found` };
         }

--- a/packages/runtime/component-runtime/src/componentRuntime.ts
+++ b/packages/runtime/component-runtime/src/componentRuntime.ts
@@ -9,6 +9,7 @@ import { ITelemetryLogger } from "@microsoft/fluid-common-definitions";
 import {
     IComponentHandle,
     IComponentHandleContext,
+    IComponentRouter,
     IRequest,
     IResponse,
 } from "@microsoft/fluid-component-core-interfaces";
@@ -96,7 +97,7 @@ export class ComponentRuntime extends EventEmitter implements IComponentRuntime,
         return runtime;
     }
 
-    public get IComponentRouter() { return this; }
+    public get [IComponentRouter]() { return this; }
 
     public get connectionState(): ConnectionState {
         return this.componentContext.connectionState;
@@ -131,12 +132,12 @@ export class ComponentRuntime extends EventEmitter implements IComponentRuntime,
     }
 
     public get routeContext(): IComponentHandleContext {
-        return this.componentContext.hostRuntime.IComponentHandleContext;
+        return this.componentContext.hostRuntime[IComponentHandleContext];
     }
 
     public get IComponentSerializer() { return this.componentContext.hostRuntime.IComponentSerializer; }
 
-    public get IComponentHandleContext() { return this; }
+    public get [IComponentHandleContext]() { return this; }
     public get IComponentRegistry() { return this.componentRegistry; }
 
     private _disposed = false;

--- a/packages/runtime/consensus-ordered-collection/package.json
+++ b/packages/runtime/consensus-ordered-collection/package.json
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-component-core-interfaces": "^0.16.0",
     "@microsoft/fluid-protocol-definitions": "^0.1004.0-0",
     "@microsoft/fluid-runtime-definitions": "^0.16.0",
     "@microsoft/fluid-shared-object-base": "^0.16.0",

--- a/packages/runtime/consensus-ordered-collection/src/consensusOrderedCollection.ts
+++ b/packages/runtime/consensus-ordered-collection/src/consensusOrderedCollection.ts
@@ -5,6 +5,7 @@
 
 import * as assert from "assert";
 import { fromBase64ToUtf8 } from "@microsoft/fluid-common-utils";
+import { IComponentHandleContext } from "@microsoft/fluid-component-core-interfaces";
 import {
     FileMode,
     ISequencedDocumentMessage,
@@ -445,13 +446,13 @@ export class ConsensusOrderedCollection<T = any> extends SharedObject implements
     private serializeValue(value) {
         return this.runtime.IComponentSerializer.stringify(
             value,
-            this.runtime.IComponentHandleContext,
+            this.runtime[IComponentHandleContext],
             this.handle);
     }
 
     private deserializeValue(content: string) {
         return this.runtime.IComponentSerializer.parse(
             content,
-            this.runtime.IComponentHandleContext);
+            this.runtime[IComponentHandleContext]);
     }
 }

--- a/packages/runtime/container-runtime/src/componentHandleContext.ts
+++ b/packages/runtime/container-runtime/src/componentHandleContext.ts
@@ -6,14 +6,15 @@
 import {
     IComponentHandle,
     IComponentHandleContext,
+    IComponentRouter,
     IRequest,
     IResponse,
 } from "@microsoft/fluid-component-core-interfaces";
 import { IRuntime } from "@microsoft/fluid-container-definitions";
 
 export class ComponentHandleContext implements IComponentHandleContext {
-    public get IComponentRouter() { return this; }
-    public get IComponentHandleContext() { return this; }
+    public get [IComponentRouter]() { return this; }
+    public get [IComponentHandleContext]() { return this; }
     public readonly isAttached = true;
 
     constructor(

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -498,7 +498,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
 
     public readonly IComponentSerializer: IComponentSerializer = new ComponentSerializer();
 
-    public readonly IComponentHandleContext: IComponentHandleContext;
+    public readonly [IComponentHandleContext]: IComponentHandleContext;
 
     public readonly logger: ITelemetryLogger;
     public readonly previousState: IPreviousState;
@@ -569,7 +569,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         this.chunkMap = new Map<string, string[]>(chunks);
 
         const expContainerContext = this.context as IExperimentalContainerContext;
-        this.IComponentHandleContext = new ComponentHandleContext("", this);
+        this[IComponentHandleContext] = new ComponentHandleContext("", this);
 
         // useContext - back-compat: 0.14 uploadSummary
         const useContext: boolean = expContainerContext.isExperimentalContainerContext ?

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -48,10 +48,10 @@ export interface ISummarizer extends IComponentRouter, IComponentRunnable, IComp
  * Summarizer is responsible for coordinating when to send generate and send summaries.
  * It is the main entry point for summary work.
  */
-export class Summarizer implements ISummarizer {
-    public get IComponentRouter() { return this; }
+export class Summarizer implements ISummarizer, IComponentRouter, IComponentRunnable, IComponentLoadable {
+    public get [IComponentRouter]() { return this; }
     public get IComponentRunnable() { return this; }
-    public get IComponentLoadable() { return this; }
+    public get [IComponentLoadable]() { return this; }
     public get ISummarizer() { return this; }
 
     private readonly logger: ITelemetryLogger;

--- a/packages/runtime/map/src/directory.ts
+++ b/packages/runtime/map/src/directory.ts
@@ -6,6 +6,7 @@
 import * as assert from "assert";
 import * as path from "path";
 import { fromBase64ToUtf8 } from "@microsoft/fluid-common-utils";
+import { IComponentHandleContext } from "@microsoft/fluid-component-core-interfaces";
 import { addBlobToTree } from "@microsoft/fluid-protocol-base";
 import {
     ISequencedDocumentMessage,
@@ -915,7 +916,7 @@ export class SharedDirectory extends SharedObject implements ISharedDirectory {
                     const handler = localValue.getOpHandler(op.value.opName);
                     const previousValue = localValue.value;
                     const translatedValue = this.runtime.IComponentSerializer.parse(
-                        JSON.stringify(op.value.value), this.runtime.IComponentHandleContext);
+                        JSON.stringify(op.value.value), this.runtime[IComponentHandleContext]);
                     handler.process(previousValue, translatedValue, local, message);
                     const event: IDirectoryValueChanged = { key: op.key, path: op.path, previousValue };
                     this.emit("valueChanged", event, local, message);
@@ -1031,7 +1032,7 @@ class SubDirectory implements IDirectory {
         const serializableValue = makeSerializable(
             localValue,
             this.runtime.IComponentSerializer,
-            this.runtime.IComponentHandleContext,
+            this.runtime[IComponentHandleContext],
             this.directory.handle);
 
         this.setCore(
@@ -1067,7 +1068,7 @@ class SubDirectory implements IDirectory {
         const transformedValue = params
             ? JSON.parse(this.runtime.IComponentSerializer.stringify(
                 params,
-                this.runtime.IComponentHandleContext,
+                this.runtime[IComponentHandleContext],
                 this.directory.handle))
             : params;
 
@@ -1409,7 +1410,7 @@ class SubDirectory implements IDirectory {
         for (const [key, localValue] of this._storage) {
             const value = localValue.makeSerialized(
                 this.runtime.IComponentSerializer,
-                this.runtime.IComponentHandleContext,
+                this.runtime[IComponentHandleContext],
                 this.directory.handle);
             const res: [string, ISerializedValue] = [key, value];
             yield res;

--- a/packages/runtime/map/src/localValues.ts
+++ b/packages/runtime/map/src/localValues.ts
@@ -245,7 +245,7 @@ export class LocalValueMaker {
             const translatedValue = parseHandles(
                 serializable.value,
                 this.runtime.IComponentSerializer,
-                this.runtime.IComponentHandleContext);
+                this.runtime[IComponentHandleContext]);
 
             return new PlainLocalValue(translatedValue);
         } else if (this.valueTypes.has(serializable.type)) {
@@ -254,7 +254,7 @@ export class LocalValueMaker {
             serializable.value = parseHandles(
                 serializable.value,
                 this.runtime.IComponentSerializer,
-                this.runtime.IComponentHandleContext);
+                this.runtime[IComponentHandleContext]);
 
             const localValue = valueType.factory.load(emitter, serializable.value);
             return new ValueTypeLocalValue(localValue, valueType);

--- a/packages/runtime/map/src/mapKernel.ts
+++ b/packages/runtime/map/src/mapKernel.ts
@@ -4,7 +4,7 @@
  */
 
 import { EventEmitter } from "events";
-import { IComponentHandle } from "@microsoft/fluid-component-core-interfaces";
+import { IComponentHandle, IComponentHandleContext } from "@microsoft/fluid-component-core-interfaces";
 import { ISequencedDocumentMessage } from "@microsoft/fluid-protocol-definitions";
 import { IComponentRuntime } from "@microsoft/fluid-runtime-definitions";
 import { makeHandlesSerializable, parseHandles, ValueType } from "@microsoft/fluid-shared-object-base";
@@ -317,7 +317,7 @@ export class MapKernel {
         const serializableValue = makeSerializable(
             localValue,
             this.runtime.IComponentSerializer,
-            this.runtime.IComponentHandleContext,
+            this.runtime[IComponentHandleContext],
             this.handle);
 
         this.setCore(
@@ -347,7 +347,7 @@ export class MapKernel {
         const transformedValue = makeHandlesSerializable(
             params,
             this.runtime.IComponentSerializer,
-            this.runtime.IComponentHandleContext,
+            this.runtime[IComponentHandleContext],
             this.handle);
 
         // This is a special form of serialized valuetype only used for set, containing info for initialization.
@@ -406,7 +406,7 @@ export class MapKernel {
         this.data.forEach((localValue, key) => {
             serializableMapData[key] = localValue.makeSerialized(
                 this.runtime.IComponentSerializer,
-                this.runtime.IComponentHandleContext,
+                this.runtime[IComponentHandleContext],
                 this.handle);
         });
         return serializableMapData;
@@ -418,7 +418,7 @@ export class MapKernel {
             serializableMapData[key] = makeSerializable(
                 localValue,
                 this.runtime.IComponentSerializer,
-                this.runtime.IComponentHandleContext,
+                this.runtime[IComponentHandleContext],
                 this.handle);
         });
         return serializableMapData;
@@ -665,7 +665,7 @@ export class MapKernel {
                     const translatedValue = parseHandles(
                         op.value.value,
                         this.runtime.IComponentSerializer,
-                        this.runtime.IComponentHandleContext);
+                        this.runtime[IComponentHandleContext]);
                     handler.process(previousValue, translatedValue, local, message);
                     const event: IValueChanged = { key: op.key, previousValue };
                     this.eventEmitter.emit("valueChanged", event, local, message, this);
@@ -709,7 +709,7 @@ export class MapKernel {
             const translatedParams = makeHandlesSerializable(
                 params,
                 this.runtime.IComponentSerializer,
-                this.runtime.IComponentHandleContext,
+                this.runtime[IComponentHandleContext],
                 this.handle);
 
             const op: IMapValueTypeOperation = {

--- a/packages/runtime/matrix/src/matrix.ts
+++ b/packages/runtime/matrix/src/matrix.ts
@@ -4,6 +4,7 @@
  */
 
 import { strict as assert } from "assert";
+import { IComponentHandleContext } from "@microsoft/fluid-component-core-interfaces";
 import {
     FileMode,
     ISequencedDocumentMessage,
@@ -149,7 +150,7 @@ export class SharedMatrix<T extends Serializable = Serializable> extends SharedO
             makeHandlesSerializable(
                 message,
                 this.runtime.IComponentSerializer,
-                this.runtime.IComponentHandleContext,
+                this.runtime[IComponentHandleContext],
                 this.handle,
             ),
         );
@@ -184,7 +185,7 @@ export class SharedMatrix<T extends Serializable = Serializable> extends SharedO
     }
 
     protected processCore(rawMessage: ISequencedDocumentMessage, local: boolean) {
-        const msg = parseHandles(rawMessage, this.runtime.IComponentSerializer, this.runtime.IComponentHandleContext);
+        const msg = parseHandles(rawMessage, this.runtime.IComponentSerializer, this.runtime[IComponentHandleContext]);
 
         const contents = msg.contents;
 
@@ -296,7 +297,7 @@ export class SharedMatrix<T extends Serializable = Serializable> extends SharedO
             type: TreeEntry[TreeEntry.Blob],
             value: {
                 contents: serializer !== undefined
-                    ? serializer.stringify(chunk, this.runtime.IComponentHandleContext, this.handle)
+                    ? serializer.stringify(chunk, this.runtime[IComponentHandleContext], this.handle)
                     : JSON.stringify(chunk),
                 encoding: "utf-8",
             },
@@ -309,7 +310,7 @@ export class SharedMatrix<T extends Serializable = Serializable> extends SharedO
 
         const serializer = this.runtime.IComponentSerializer;
         const cellData = serializer !== undefined
-            ? serializer.parse(utf8, this.runtime.IComponentHandleContext)
+            ? serializer.parse(utf8, this.runtime[IComponentHandleContext])
             : JSON.parse(utf8);
 
         this.cells = SparseArray2D.load(cellData[0]);

--- a/packages/runtime/merge-tree/src/client.ts
+++ b/packages/runtime/merge-tree/src/client.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { IComponentHandle } from "@microsoft/fluid-component-core-interfaces";
+import { IComponentHandle, IComponentHandleContext } from "@microsoft/fluid-component-core-interfaces";
 import { ISequencedDocumentMessage, MessageType } from "@microsoft/fluid-protocol-definitions";
 import { IComponentRuntime, IObjectStorageService } from "@microsoft/fluid-runtime-definitions";
 import { ITelemetryLogger } from "@microsoft/fluid-common-definitions";
@@ -921,7 +921,7 @@ export class Client {
         return snap.emit(
             tardisMsgs,
             runtime.IComponentSerializer,
-            runtime.IComponentHandleContext,
+            runtime[IComponentHandleContext],
             handle);
     }
 

--- a/packages/runtime/merge-tree/src/snapshotLoader.ts
+++ b/packages/runtime/merge-tree/src/snapshotLoader.ts
@@ -4,6 +4,7 @@
  */
 
 import * as assert from "assert";
+import { IComponentHandleContext } from "@microsoft/fluid-component-core-interfaces";
 import { fromBase64ToUtf8 } from "@microsoft/fluid-common-utils";
 import { ISequencedDocumentMessage } from "@microsoft/fluid-protocol-definitions";
 import { IComponentRuntime, IObjectStorageService } from "@microsoft/fluid-runtime-definitions";
@@ -92,7 +93,7 @@ export class SnapshotLoader {
         const chunk = Snapshot.processChunk(
             header,
             this.runtime.IComponentSerializer,
-            this.runtime.IComponentHandleContext);
+            this.runtime[IComponentHandleContext]);
         const segs = chunk.segmentTexts.map(this.specToSegment);
         this.mergeTree.reloadFromSegments(segs);
 
@@ -131,7 +132,7 @@ export class SnapshotLoader {
             services,
             Snapshot.body,
             this.runtime.IComponentSerializer,
-            this.runtime.IComponentHandleContext);
+            this.runtime[IComponentHandleContext]);
 
         this.runtime.logger.shipAssert(
             chunk1.chunkLengthChars + chunk2.chunkLengthChars === chunk1.totalLengthChars,

--- a/packages/runtime/runtime-definitions/src/components.ts
+++ b/packages/runtime/runtime-definitions/src/components.ts
@@ -45,11 +45,11 @@ export interface IComponentRuntime extends
     IComponentRouter,
     Partial<IProvideComponentRegistry>,
     IDisposable {
-    readonly IComponentRouter: IComponentRouter;
+    readonly [IComponentRouter]: IComponentRouter;
 
     readonly IComponentSerializer: IComponentSerializer;
 
-    readonly IComponentHandleContext: IComponentHandleContext;
+    readonly [IComponentHandleContext]: IComponentHandleContext;
 
     readonly options: any;
 

--- a/packages/runtime/runtime-test-utils/src/mocks.ts
+++ b/packages/runtime/runtime-test-utils/src/mocks.ts
@@ -9,6 +9,7 @@ import { ITelemetryLogger } from "@microsoft/fluid-common-definitions";
 import {
     IComponentHandle,
     IComponentHandleContext,
+    IComponentRouter,
     IRequest,
     IResponse,
 } from "@microsoft/fluid-component-core-interfaces";
@@ -323,8 +324,8 @@ export class MockQuorum implements IQuorum, EventEmitter{
 export class MockRuntime extends EventEmitter
     implements IComponentRuntime, IComponentHandleContext {
 
-    public get IComponentHandleContext(): IComponentHandleContext { return this; }
-    public get IComponentRouter() { return this; }
+    public get [IComponentHandleContext](): IComponentHandleContext { return this; }
+    public get [IComponentRouter]() { return this; }
 
     public readonly IComponentSerializer = new ComponentSerializer();
 

--- a/packages/runtime/runtime-utils/src/componentHandle.ts
+++ b/packages/runtime/runtime-utils/src/componentHandle.ts
@@ -9,6 +9,7 @@ import {
     IComponentHandleContext,
     IRequest,
     IResponse,
+    IComponentRouter,
 } from "@microsoft/fluid-component-core-interfaces";
 
 /**
@@ -17,9 +18,9 @@ import {
  * as well as shared objects (see ComponentRuntime.request for details)
  */
 export class ComponentHandle implements IComponentHandle {
-    public get IComponentRouter() { return this; }
-    public get IComponentHandleContext() { return this; }
-    public get IComponentHandle() { return this; }
+    public get [IComponentRouter]() { return this; }
+    public get [IComponentHandleContext]() { return this; }
+    public get [IComponentHandle]() { return this; }
 
     public readonly isAttached = true;
     private componentP: Promise<IComponent> | undefined;
@@ -54,7 +55,7 @@ export class ComponentHandle implements IComponentHandle {
 
     public async request(request: IRequest): Promise<IResponse> {
         const component = await this.get() as IComponent;
-        const router = component.IComponentRouter;
+        const router = component[IComponentRouter];
 
         return router
             ? router.request(request)

--- a/packages/runtime/runtime-utils/src/test/utils.ts
+++ b/packages/runtime/runtime-utils/src/test/utils.ts
@@ -3,14 +3,18 @@
  * Licensed under the MIT License.
  */
 
-import { IComponentHandle, IComponentHandleContext } from "@microsoft/fluid-component-core-interfaces";
+import {
+    IComponentHandle,
+    IComponentHandleContext,
+    IComponentRouter,
+} from "@microsoft/fluid-component-core-interfaces";
 import { ComponentHandle } from "../componentHandle";
 
 export const mockHandleContext: IComponentHandleContext = {
     path: "",
     isAttached: false,
-    IComponentRouter: undefined as any,
-    IComponentHandleContext: undefined as any,
+    [IComponentRouter]: undefined as any,
+    [IComponentHandleContext]: undefined as any,
 
     attach: () => {
         throw new Error("Method not implemented.");

--- a/packages/runtime/sequence/src/sequence.ts
+++ b/packages/runtime/sequence/src/sequence.ts
@@ -5,6 +5,7 @@
 
 import * as assert from "assert";
 import { ChildLogger, Deferred, fromBase64ToUtf8 } from "@microsoft/fluid-common-utils";
+import { IComponentHandleContext } from "@microsoft/fluid-component-core-interfaces";
 import { IValueChanged, MapKernel } from "@microsoft/fluid-map";
 import * as MergeTree from "@microsoft/fluid-merge-tree";
 import {
@@ -309,7 +310,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
         const translated = makeHandlesSerializable(
             message,
             this.runtime.IComponentSerializer,
-            this.runtime.IComponentHandleContext,
+            this.runtime[IComponentHandleContext],
             this.handle);
         this.submitLocalMessage(translated);
     }
@@ -533,7 +534,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
         const message = parseHandles(
             rawMessage,
             this.runtime.IComponentSerializer,
-            this.runtime.IComponentHandleContext);
+            this.runtime[IComponentHandleContext]);
 
         const ops: MergeTree.IMergeTreeOp[] = [];
         function transfromOps(event: SequenceDeltaEvent) {

--- a/packages/runtime/shared-object-common/src/handle.ts
+++ b/packages/runtime/shared-object-common/src/handle.ts
@@ -6,6 +6,7 @@
 import {
     IComponentHandle,
     IComponentHandleContext,
+    IComponentRouter,
     IRequest,
     IResponse,
 } from "@microsoft/fluid-component-core-interfaces";
@@ -25,9 +26,9 @@ export class SharedObjectComponentHandle implements IComponentHandle {
      */
     private bound: Set<IComponentHandle> | undefined;
 
-    public get IComponentHandle() { return this; }
-    public get IComponentRouter() { return this; }
-    public get IComponentHandleContext() { return this; }
+    public get [IComponentHandle]() { return this; }
+    public get [IComponentRouter]() { return this; }
+    public get [IComponentHandleContext]() { return this; }
 
     /**
      * Whether services have been attached for the associated shared object.

--- a/packages/runtime/shared-object-common/src/sharedObject.ts
+++ b/packages/runtime/shared-object-common/src/sharedObject.ts
@@ -5,7 +5,11 @@
 
 import * as assert from "assert";
 import { ITelemetryErrorEvent, ITelemetryLogger } from "@microsoft/fluid-common-definitions";
-import { IComponentHandle } from "@microsoft/fluid-component-core-interfaces";
+import {
+    IComponentHandle,
+    IComponentHandleContext,
+    IComponentLoadable,
+} from "@microsoft/fluid-component-core-interfaces";
 import {
     IComponent,
 } from "@microsoft/fluid-container-definitions";
@@ -36,7 +40,7 @@ export abstract class SharedObject extends EventEmitterWithErrorHandling impleme
 
     public get ISharedObject() { return this; }
     public get IChannel() { return this; }
-    public get IComponentLoadable() { return this; }
+    public get [IComponentLoadable]() { return this; }
 
     /**
      * The handle referring to this SharedObject
@@ -98,7 +102,7 @@ export abstract class SharedObject extends EventEmitterWithErrorHandling impleme
         this.handle = new SharedObjectComponentHandle(
             this,
             id,
-            runtime.IComponentHandleContext);
+            runtime[IComponentHandleContext]);
 
         // Runtime could be null since some package hasn't turn on strictNullChecks yet
         // We should remove the null check once that is done

--- a/server/admin/src/childLoader.ts
+++ b/server/admin/src/childLoader.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 import { createLoader, IHostConfig } from "@microsoft/fluid-base-host";
-import { IComponent } from "@microsoft/fluid-component-core-interfaces";
+import { IComponent, IComponentRouter } from "@microsoft/fluid-component-core-interfaces";
 import { Container, Loader } from "@microsoft/fluid-container-loader";
 import { BaseTelemetryNullLogger, Deferred } from "@microsoft/fluid-core-utils";
 import { OdspDocumentServiceFactory } from "@microsoft/fluid-odsp-driver";
@@ -128,7 +128,7 @@ class KeyValueLoader {
             return;
         }
         const component = response.value as IComponent;
-        const keyValue = (component.IComponentRouter as unknown) as IKeyValue;
+        const keyValue = (component[IComponentRouter]) as IKeyValue;
         winston.info(`Resolved key-value component`);
         this.kvDeferred.resolve(keyValue);
     }

--- a/server/gateway/src/childLoader.ts
+++ b/server/gateway/src/childLoader.ts
@@ -3,7 +3,10 @@
  * Licensed under the MIT License.
  */
 import { parse } from "url";
-import { IComponent } from "@microsoft/fluid-component-core-interfaces";
+import {
+    IComponent,
+    IComponentRouter,
+} from "@microsoft/fluid-component-core-interfaces";
 import { IProxyLoaderFactory } from "@microsoft/fluid-container-definitions";
 import { Container, Loader } from "@microsoft/fluid-container-loader";
 import { BaseTelemetryNullLogger, Deferred } from "@microsoft/fluid-common-utils";
@@ -136,7 +139,7 @@ class KeyValueLoader {
             return;
         }
         const component = response.value as IComponent;
-        const keyValue = (component.IComponentRouter as unknown) as IKeyValue;
+        const keyValue = (component[IComponentRouter]) as IKeyValue;
         winston.info(`Resolved key-value component`);
         this.kvDeferred.resolve(keyValue);
     }


### PR DESCRIPTION
This change updates all the interfaces in component-core-interfaces to also export a symbol and for those symbols to be used as the key on the provider interface.

I want to do this for all the interfaces but since they are pretty disruptive I think we should do them in waves.

Why do we need this? This allows us to represent our interfaces at runtime. This is really powerful for many reasons but has specifically come up in my PR about adding IoC into the framework:
https://github.com/microsoft/FluidFramework/pull/1658

Everything works the same as before but the syntax has changed a bit.

### What does this change?

It means that instead of doing:
```typescript
// old
component.IComponentRouter

// new
component[IComponentRouter]
```

```typescript
// old
public get IComponentRouter() { return this; }

// new
public get [IComponentRouter]() { return this; }
```

### Something else cool.
Both the interface and the symbol can have the same name and because Typescript is awesome it knows how to resolve everything correctly.

```typescript
import { IComponentFoo } from "./iComponentFoo";

export class Foo implements IComponentFoo {
    public get [IComponentFoo](): IComponentFoo { return this; }
}
```
