### PR TITLE
Prevent false SummaryAckWaitTimeout errors [0.14]

### DIFF
--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -451,7 +451,7 @@ export class RunningSummarizer implements IDisposable {
         this.summarizeTimer.start();
 
         try {
-            return this.summarizeCore(reason, safe);
+            return await this.summarizeCore(reason, safe);
         } finally {
             this.summarizeTimer.clear();
             this.pendingAckTimer.clear();


### PR DESCRIPTION
Use return await to ensure execution before finally block.  This was causing it to (sometimes??) clear the timer before starting it, because it ran the finally block first.  Then it would not actually clear the timer when it should, causing the timer to fire errors incorrectly.

Targeting 0.14 since this error clutters telemetry errors and generates a lot of feedback.  It is also a relatively simple change.