### PR TITLE
Error translation in routerlicious driver

### DIFF
--- a/packages/drivers/routerlicious-socket-storage/package.json
+++ b/packages/drivers/routerlicious-socket-storage/package.json
@@ -28,6 +28,7 @@
     "@microsoft/fluid-common-utils": "^0.14.0",
     "@microsoft/fluid-driver-base": "^0.16.0",
     "@microsoft/fluid-driver-definitions": "^0.16.0",
+    "@microsoft/fluid-driver-utils": "^0.16.0",
     "@microsoft/fluid-gitresources": "^0.1004.0-0",
     "@microsoft/fluid-protocol-base": "^0.1004.0-0",
     "@microsoft/fluid-protocol-definitions": "^0.1004.0-0",

--- a/packages/drivers/routerlicious-socket-storage/src/documentDeltaConnection.ts
+++ b/packages/drivers/routerlicious-socket-storage/src/documentDeltaConnection.ts
@@ -1,0 +1,58 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { DocumentDeltaConnection } from "@microsoft/fluid-driver-base";
+import { createNetworkError } from "@microsoft/fluid-driver-utils";
+import { IDocumentDeltaConnection, IError } from "@microsoft/fluid-driver-definitions";
+import { IClient } from "@microsoft/fluid-protocol-definitions";
+
+/**
+ * Returns specific network error based on error object.
+ */
+const errorObjectFromSocketError = (socketError: any, canRetry: boolean): IError => {
+    return createNetworkError(
+        socketError.message,
+        canRetry,
+        socketError.code,
+        socketError.retryAfter);
+};
+
+/**
+ * Wrapper over the shared one for driver specific translation.
+ */
+export class R11sDocumentDeltaConnection extends DocumentDeltaConnection implements IDocumentDeltaConnection {
+    public static async create(
+        tenantId: string,
+        id: string,
+        token: string | null,
+        io: SocketIOClientStatic,
+        client: IClient,
+        url: string): Promise<IDocumentDeltaConnection> {
+        try {
+            const connection = await DocumentDeltaConnection.create(
+                tenantId,
+                id,
+                token,
+                io,
+                client,
+                url,
+            );
+            return connection;
+        } catch (errorObject) {
+            // Test if it's a NetworkError. Note that there might be no SocketError on it in case we hit
+            // nonrecoverable socket.io protocol errors! So we test canRetry property first - if it false,
+            // that means protocol is broken and reconnecting will not help.
+
+            // TODO: Add more cases as we feel appropriate.
+            if (errorObject !== null && typeof errorObject === "object" && errorObject.canRetry) {
+                const socketError = errorObject.socketError;
+                if (typeof socketError === "object" && socketError !== null) {
+                    throw errorObjectFromSocketError(socketError, true);
+                }
+            }
+            throw errorObject;
+        }
+    }
+}

--- a/packages/drivers/routerlicious-socket-storage/src/documentService.ts
+++ b/packages/drivers/routerlicious-socket-storage/src/documentService.ts
@@ -4,7 +4,6 @@
  */
 
 import { fromUtf8ToBase64 } from "@microsoft/fluid-common-utils";
-import { DocumentDeltaConnection } from "@microsoft/fluid-driver-base";
 import * as api from "@microsoft/fluid-driver-definitions";
 import { IClient, IErrorTrackingService } from "@microsoft/fluid-protocol-definitions";
 import { GitManager, Historian, ICredentials, IGitCache } from "@microsoft/fluid-server-services-client";
@@ -12,6 +11,7 @@ import Axios from "axios";
 import * as io from "socket.io-client";
 import { DeltaStorageService, DocumentDeltaStorageService } from "./deltaStorageService";
 import { DocumentStorageService } from "./documentStorageService";
+import { R11sDocumentDeltaConnection } from "./documentDeltaConnection";
 import { NullBlobStorageService } from "./nullBlobStorageService";
 import { TokenProvider } from "./tokens";
 
@@ -102,7 +102,7 @@ export class DocumentService implements api.IDocumentService {
      * @returns returns the document delta stream service for routerlicious driver.
      */
     public async connectToDeltaStream(client: IClient): Promise<api.IDocumentDeltaConnection> {
-        return DocumentDeltaConnection.create(
+        return R11sDocumentDeltaConnection.create(
             this.tenantId,
             this.documentId,
             this.tokenProvider.token,

--- a/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
+++ b/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
@@ -349,8 +349,8 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
      *  (not on Fluid protocol level)
      */
     public disconnect(socketProtocolError: boolean = false) {
-        this.socket.disconnect();
         this.removeTrackedListeners(false);
+        this.socket.disconnect();
     }
 
     protected async initialize(connectMessage: IConnect, timeout: number) {


### PR DESCRIPTION
1. This addresses the driver changes required for #1643 

2. Bugfix in shared-driver. Calling disconnect with the listeners on was always firing disconnect error rather then the original cause.

3. Error translation in r11s driver.
