### PR TITLE
Add test route in webpack component loader

### DIFF
--- a/packages/components/todo/webpack.config.js
+++ b/packages/components/todo/webpack.config.js
@@ -44,7 +44,7 @@ module.exports = env => {
         devServer: {
             publicPath: '/dist',
             stats: "minimal",
-            before: (app, server) => fluidRoute.before(app, server),
+            before: (app, server) => fluidRoute.before(app, server, env),
             after: (app, server) => fluidRoute.after(app, server, __dirname, env),
         }
     }, isProduction

--- a/packages/hosts/base-host/src/host.ts
+++ b/packages/hosts/base-host/src/host.ts
@@ -115,28 +115,9 @@ export class BaseHost {
         return container;
     }
 
-    public async initializeContainerForCreateNew(pkg: IFluidCodeDetails) {
-        const loader = await this.getLoader();
-        return loader.createDetachedContainer(pkg);
-    }
-
     public async getComponent(url: string) {
         const loader = await this.getLoader();
         const response = await loader.request({ url });
-
-        if (response.status !== 200 ||
-            !(
-                response.mimeType === "fluid/component" ||
-                response.mimeType === "prague/component"
-            )) {
-            return undefined;
-        }
-
-        return response.value as IComponent;
-    }
-
-    public async getComponentForCreateNew(container: Container) {
-        const response = await container.request({ url: "/" });
 
         if (response.status !== 200 ||
             !(

--- a/packages/hosts/base-host/src/host.ts
+++ b/packages/hosts/base-host/src/host.ts
@@ -115,9 +115,28 @@ export class BaseHost {
         return container;
     }
 
+    public async initializeContainerForCreateNew(pkg: IFluidCodeDetails) {
+        const loader = await this.getLoader();
+        return loader.createDetachedContainer(pkg);
+    }
+
     public async getComponent(url: string) {
         const loader = await this.getLoader();
         const response = await loader.request({ url });
+
+        if (response.status !== 200 ||
+            !(
+                response.mimeType === "fluid/component" ||
+                response.mimeType === "prague/component"
+            )) {
+            return undefined;
+        }
+
+        return response.value as IComponent;
+    }
+
+    public async getComponentForCreateNew(container: Container) {
+        const response = await container.request({ url: "/" });
 
         if (response.status !== 200 ||
             !(

--- a/packages/server/local-test-utils/src/sessionStorageTestDb.ts
+++ b/packages/server/local-test-utils/src/sessionStorageTestDb.ts
@@ -129,7 +129,7 @@ class SessionStorageCollection<T> implements ICollection<T> {
 
     public async insertOne(value: any): Promise<any> {
         if (this.findOneInternal(value)) {
-            throw new Error("existing object");
+            return;
         }
 
         return this.insertInternal(value);

--- a/packages/server/local-test-utils/src/sessionStorageTestDb.ts
+++ b/packages/server/local-test-utils/src/sessionStorageTestDb.ts
@@ -128,8 +128,13 @@ class SessionStorageCollection<T> implements ICollection<T> {
     }
 
     public async insertOne(value: any): Promise<any> {
-        if (this.findOneInternal(value)) {
-            return;
+        const presentVal = this.findOneInternal(value);
+        // Only raise error when the object is present and the value is not equal.
+        if (presentVal) {
+            if (JSON.stringify(presentVal) === JSON.stringify(value)) {
+                return;
+            }
+            throw new Error("Existing Object!!");
         }
 
         return this.insertInternal(value);

--- a/packages/tools/webpack-component-loader/README.md
+++ b/packages/tools/webpack-component-loader/README.md
@@ -13,6 +13,7 @@ The following environment variables can be defined when running webpack-dev-serv
 | `tenantId` | Tenant ID for your host. If you supply this you must supply a tenant secret |
 | `tenantSecret` | Secret for your tenant |
 | `bearerSecret` | Secret for your bearer |
+| `openMode` | Mode to start the container(Detached container flow/attached container flow) |
 
 
 | modes | description |
@@ -23,6 +24,11 @@ The following environment variables can be defined when running webpack-dev-serv
 | `tinylicous` | Run against a local instance of tinylicious |
 | `spo-df` | Use SharePoint DogFood server with your personal OneDrive for storage |
 | `spo` | Use SharePoint server with your personal OneDrive for storage |
+
+| openMode | description |
+| ---------| ----------- |
+| `detached` | Start the container in detached mode. Attach the container when user clicks on attach button |
+| `attached`   | Starts container in attached mode |
 
 To connect to a remote server, a host, tenant ID, tenant secret, and npm registry must be provided. These can be
 provided in the following ways (looked for in the following order):

--- a/packages/tools/webpack-component-loader/package.json
+++ b/packages/tools/webpack-component-loader/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@microsoft/fluid-aqueduct": "^0.15.0",
     "@microsoft/fluid-base-host": "^0.15.0",
+    "@microsoft/fluid-common-utils": "^0.14.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-container-definitions": "^0.15.0",
     "@microsoft/fluid-container-loader": "^0.15.0",

--- a/packages/tools/webpack-component-loader/src/routes.ts
+++ b/packages/tools/webpack-component-loader/src/routes.ts
@@ -238,11 +238,11 @@ const fluid = (req: express.Request, res: express.Response, baseDir: string, opt
                         console.log("Fully attached!");
                     },
                     (error) => {
-                        console.error(error);
+                        alert(error);
                     });
             }
         })
-        .catch((error) => console.error(error));
+        .catch((error) => alert(error));
     </script>
 </body>
 </html>`;

--- a/packages/tools/webpack-component-loader/src/routes.ts
+++ b/packages/tools/webpack-component-loader/src/routes.ts
@@ -212,37 +212,16 @@ const fluid = (req: express.Request, res: express.Response, baseDir: string, opt
         var options = ${JSON.stringify(options)};
         var fluidStarted = false;
         const attached = "${req.params.openMode}" !== "detached";
-        const containerP = FluidLoader.start(
+        FluidLoader.start(
             "${documentId}",
             pkgJson,
             options,
             document.getElementById("content"),
+            document.getElementById("attach-button"),
+            document.getElementById("text"),
             attached)
-        .then(({container, urlD}) => {
-            fluidStarted = true;
-            const textarea = document.getElementById("text");
-            const attachButton = document.getElementById("attach-button");
-            if (attached) {
-                attachButton.style.display = "none";
-                textarea.style.display = "none";
-                urlD.resolve(window.location.href);
-            }
-            attachButton.disabled = false;
-            attachButton.onclick = () => {
-                container.attach({url: window.location.href}).then(
-                    () => {
-                        const text = window.location.href.replace("create", container.id);
-                        textarea.innerText = text;
-                        urlD.resolve(text);
-                        attachButton.style.display = "none"; 
-                        console.log("Fully attached!");
-                    },
-                    (error) => {
-                        alert(error);
-                    });
-            }
-        })
-        .catch((error) => alert(error));
+        .then(() => fluidStarted = true)
+        .catch((error) => console.error(error));
     </script>
 </body>
 </html>`;

--- a/packages/tools/webpack-component-loader/src/routes.ts
+++ b/packages/tools/webpack-component-loader/src/routes.ts
@@ -222,7 +222,7 @@ const fluid = (req: express.Request, res: express.Response, baseDir: string, opt
             fluidStarted = true;
             const textarea = document.getElementById("text");
             const attachButton = document.getElementById("attach-button");
-            if ("${req.params.openMode}" !== "detached") {
+            if (attached) {
                 attachButton.style.display = "none";
                 textarea.style.display = "none";
                 urlD.resolve(window.location.href);


### PR DESCRIPTION
1.) Add test route for create new for r11s.
2.) Add test route for create new for odsp.
Detached mode opens with a button and text area. The button is to attach the container after which it disappears. The contianer url appears in the text area once it is attached.