### PR TITLE
Fluid-Build: fix install

### DIFF
--- a/tools/fluid-build/src/fluidBuild/fluidRepo.ts
+++ b/tools/fluid-build/src/fluidBuild/fluidRepo.ts
@@ -49,7 +49,7 @@ export class FluidRepo extends FluidRepoBase {
         }
         const installScript = "npm i";
         const installPromises: Promise<ExecAsyncResult>[] = [];
-        for (const dir of [...this.packageInstallDirectories, ...this.clientMonoRepo.repoPath, ...this.serverMonoRepo.repoPath]) {
+        for (const dir of [...this.packageInstallDirectories, this.clientMonoRepo.repoPath, this.serverMonoRepo.repoPath]) {
             installPromises.push(execWithErrorAsync(installScript, { cwd: dir }, dir));
         }
         const rets = await Promise.all(installPromises);


### PR DESCRIPTION
Shouldn't spread a string.

Also move the script check to after install so that we don't warn about not able to load the linked ts-common-config.json when the repo is not in the installed state.