### PR TITLE
0.14->0.15 Don't try to read non-exisitent attributes (#1691)

### DIFF
--- a/packages/runtime/component-runtime/src/channelStorageService.ts
+++ b/packages/runtime/component-runtime/src/channelStorageService.ts
@@ -33,6 +33,10 @@ export class ChannelStorageService implements IObjectStorageService {
         }
     }
 
+    public contains(path: string){
+        return this.flattenedTree[path] !== undefined;
+    }
+
     // eslint-disable-next-line @typescript-eslint/promise-function-async
     public read(path: string): Promise<string> {
         const id = this.getIdForPath(path);

--- a/packages/runtime/component-runtime/src/remoteChannelContext.ts
+++ b/packages/runtime/component-runtime/src/remoteChannelContext.ts
@@ -111,9 +111,12 @@ export class RemoteChannelContext implements IChannelContext {
     private async loadChannel(): Promise<IChannel> {
         assert(!this.isLoaded);
 
-        let attributes = await readAndParse<IChannelAttributes | undefined>(
-            this.services.objectStorage,
-            ".attributes");
+        let attributes: IChannelAttributes | undefined;
+        if(this.services.objectStorage.contains(".attributes")){
+            attributes = await readAndParse<IChannelAttributes | undefined>(
+                this.services.objectStorage,
+                ".attributes");
+        }
 
         let factory: ISharedObjectFactory | undefined;
         // this is a back-compat case where


### PR DESCRIPTION
Trying to read a non-existent blob results in a failed call to read, as the blobid will be undefined, as it can't be found in the tree.