### PR TITLE
Trim IEventProvider to `tiny-emitter` subset

### DIFF
--- a/common/lib/common-definitions/src/events.ts
+++ b/common/lib/common-definitions/src/events.ts
@@ -8,12 +8,8 @@ export interface IEvent {
 }
 
 export interface IEventProvider<TEvent extends IEvent> {
-    readonly addListener: TEvent;
     readonly on: TEvent;
     readonly once: TEvent;
-    readonly prependListener: TEvent;
-    readonly prependOnceListener: TEvent;
-    readonly removeListener: TEvent;
     readonly off: TEvent;
 }
 


### PR DESCRIPTION
How would you feel about trimming IEventProvider back a little further to just `on()`, `off()` and `once`?

I ask because `on()`, `off()`, and `once()` is a popular subset for micro-implementations:

https://www.npmjs.com/package/tiny-emitter
https://www.npmjs.com/package/event-lite

Some nano-implementations also skip `once()`, but since you can build `once()` from `on()`/`off()`, I'm inclined to keep it.

https://www.npmjs.com/package/mitt
https://www.npmjs.com/package/@protobufjs/eventemitter

Eliding prependListener/OnceListener is common, even among implementations that are less focused on bundle-size:

https://www.npmjs.com/package/eventemitter3