### PR TITLE
Container modules with strong typing and without ioc library (V2)

### DIFF
--- a/examples/components/dice-roller/src/index.ts
+++ b/examples/components/dice-roller/src/index.ts
@@ -4,14 +4,43 @@
  */
 
 import {
+    ModuleManager,
     SimpleModuleInstantiationFactory,
 } from "@microsoft/fluid-aqueduct";
 
+// eslint-disable-next-line import/no-internal-modules
+import { IComponentFoo } from "@microsoft/fluid-aqueduct/src/helpers/IComponentFoo";
+
 import { DiceRollerInstantiationFactory } from "./main";
+
+class Foo implements IComponentFoo {
+    public get IComponentFoo() { return this; }
+    public foo() {
+        alert("foo ya!");
+    }
+}
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 const pkg = require("../package.json");
 const componentName = pkg.name as string;
+
+const generateFluidExport = ():  SimpleModuleInstantiationFactory => {
+    const moduleManager = new ModuleManager();
+    moduleManager.register(
+        IComponentFoo,
+        new Foo(),
+    );
+
+    return new SimpleModuleInstantiationFactory(
+        componentName,
+        new Map([
+            [componentName, Promise.resolve(DiceRollerInstantiationFactory)],
+        ]),
+        undefined,
+        undefined,
+        moduleManager,
+    );
+};
 
 /**
  * This does setup for the Container. The SimpleModuleInstantiationFactory also enables dynamic loading in the
@@ -24,9 +53,4 @@ const componentName = pkg.name as string;
  * In this example, we are only registering a single component, but more complex examples will register multiple
  * components.
  */
-export const fluidExport = new SimpleModuleInstantiationFactory(
-    componentName,
-    new Map([
-        [componentName, Promise.resolve(DiceRollerInstantiationFactory)],
-    ]),
-);
+export const fluidExport = generateFluidExport();

--- a/examples/components/dice-roller/src/main.tsx
+++ b/examples/components/dice-roller/src/main.tsx
@@ -7,6 +7,11 @@ import {
     PrimedComponent,
     PrimedComponentFactory,
 } from "@microsoft/fluid-aqueduct";
+
+// eslint-disable-next-line import/no-internal-modules
+import {IComponentFoo} from "@microsoft/fluid-aqueduct/src/helpers/IComponentFoo";
+
+
 import { IComponentHTMLView } from "@microsoft/fluid-view-interfaces";
 
 import * as React from "react";
@@ -15,7 +20,7 @@ import * as ReactDOM from "react-dom";
 /**
  * Dice roller example using view interfaces and stock component classes.
  */
-export class DiceRoller extends PrimedComponent<IComponentHTMLView> implements IComponentHTMLView {
+export class DiceRoller extends PrimedComponent<{},IComponentFoo> implements IComponentHTMLView {
     public get IComponentHTMLView() { return this; }
 
     /**
@@ -38,6 +43,7 @@ export class DiceRoller extends PrimedComponent<IComponentHTMLView> implements I
 
             ReactDOM.render(
                 <div>
+                    {this.scope.IComponentFoo.foo()}
                     <span style={{ fontSize: 50 }}>{this.getDiceChar(diceValue)}</span>
                     <button onClick={this.rollDice.bind(this)}>Roll</button>
                 </div>,

--- a/examples/components/dice-roller/src/main.tsx
+++ b/examples/components/dice-roller/src/main.tsx
@@ -74,5 +74,10 @@ export class DiceRoller extends PrimedComponent<IComponentFoo> implements ICompo
  */
 export const DiceRollerInstantiationFactory = new PrimedComponentFactory(
     DiceRoller,
+    {IComponentFoo},
+    {},
     [],
+    undefined,
+    undefined,
+    "dice-roller",
 );

--- a/examples/components/dice-roller/src/main.tsx
+++ b/examples/components/dice-roller/src/main.tsx
@@ -33,6 +33,10 @@ export class DiceRoller extends PrimedComponent<IComponentFoo> implements ICompo
         this.root.set("diceValue", 1);
     }
 
+    protected async componentHasInitialized() {
+        this.scope.IComponentFoo?.foo();
+    }
+
     /**
      * Render the dice.
      */
@@ -43,7 +47,6 @@ export class DiceRoller extends PrimedComponent<IComponentFoo> implements ICompo
 
             ReactDOM.render(
                 <div>
-                    {this.scope.IComponentFoo?.foo()}
                     <span style={{ fontSize: 50 }}>{this.getDiceChar(diceValue)}</span>
                     <button onClick={this.rollDice.bind(this)}>Roll</button>
                 </div>,

--- a/examples/components/dice-roller/src/main.tsx
+++ b/examples/components/dice-roller/src/main.tsx
@@ -20,7 +20,7 @@ import * as ReactDOM from "react-dom";
 /**
  * Dice roller example using view interfaces and stock component classes.
  */
-export class DiceRoller extends PrimedComponent<{},IComponentFoo> implements IComponentHTMLView {
+export class DiceRoller extends PrimedComponent<IComponentFoo> implements IComponentHTMLView {
     public get IComponentHTMLView() { return this; }
 
     /**
@@ -43,7 +43,7 @@ export class DiceRoller extends PrimedComponent<{},IComponentFoo> implements ICo
 
             ReactDOM.render(
                 <div>
-                    {this.scope.IComponentFoo.foo()}
+                    {this.scope.IComponentFoo?.foo()}
                     <span style={{ fontSize: 50 }}>{this.getDiceChar(diceValue)}</span>
                     <button onClick={this.rollDice.bind(this)}>Roll</button>
                 </div>,

--- a/examples/components/dice-roller/src/main.tsx
+++ b/examples/components/dice-roller/src/main.tsx
@@ -15,7 +15,7 @@ import * as ReactDOM from "react-dom";
 /**
  * Dice roller example using view interfaces and stock component classes.
  */
-export class DiceRoller extends PrimedComponent implements IComponentHTMLView {
+export class DiceRoller extends PrimedComponent<IComponentHTMLView> implements IComponentHTMLView {
     public get IComponentHTMLView() { return this; }
 
     /**

--- a/packages/framework/aqueduct/src/components/primedComponent.ts
+++ b/packages/framework/aqueduct/src/components/primedComponent.ts
@@ -3,7 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { IComponentHandle, IRequest, IResponse } from "@microsoft/fluid-component-core-interfaces";
+import {
+    IComponent,
+    IComponentHandle,
+    IRequest,
+    IResponse,
+} from "@microsoft/fluid-component-core-interfaces";
 import { ISharedDirectory, MapFactory, SharedDirectory } from "@microsoft/fluid-map";
 import { ITaskManager } from "@microsoft/fluid-runtime-definitions";
 // eslint-disable-next-line import/no-internal-modules
@@ -19,7 +24,9 @@ import { SharedComponent } from "./sharedComponent";
  * and registering channels with the runtime any new DDS that is set on the root
  * will automatically be registered.
  */
-export abstract class PrimedComponent extends SharedComponent {
+export abstract class PrimedComponent<O extends IComponent = {}, R extends IComponent = {}>
+    extends SharedComponent<O, R>
+{
     private internalRoot: ISharedDirectory | undefined;
     private internalTaskManager: ITaskManager | undefined;
     private readonly rootDirectoryId = "root";

--- a/packages/framework/aqueduct/src/components/sharedComponent.ts
+++ b/packages/framework/aqueduct/src/components/sharedComponent.ts
@@ -16,13 +16,15 @@ import {
 import { IComponentContext, IComponentRuntime } from "@microsoft/fluid-runtime-definitions";
 import { ComponentHandle } from "@microsoft/fluid-component-runtime";
 import { serviceRoutePathRoot } from "../containerServices";
+import { Scope } from "../container-modules";
 
 /**
  * This is a bare-bones base class that does basic setup and enables for factory on an initialize call.
  * You probably don't want to inherit from this component directly unless you are creating another base component class
  */
-// eslint-disable-next-line max-len
-export abstract class SharedComponent extends EventEmitter implements IComponentLoadable, IComponentRouter, IProvideComponentHandle {
+export abstract class SharedComponent<O extends IComponent = {}, R extends IComponent = {}> extends EventEmitter
+    implements IComponentLoadable, IComponentRouter, IProvideComponentHandle
+{
     private initializeP: Promise<void> | undefined;
     private readonly innerHandle: IComponentHandle<this>;
     private _disposed = false;
@@ -41,6 +43,7 @@ export abstract class SharedComponent extends EventEmitter implements IComponent
     public constructor(
         protected readonly runtime: IComponentRuntime,
         protected readonly context: IComponentContext,
+        protected readonly scope: Scope<O, R>,
     ) {
         super();
         this.innerHandle = new ComponentHandle(this, this.url, runtime.IComponentHandleContext);

--- a/packages/framework/aqueduct/src/container-modules/IComponentModuleManager.ts
+++ b/packages/framework/aqueduct/src/container-modules/IComponentModuleManager.ts
@@ -4,7 +4,11 @@
  */
 
 import { IComponent } from "@microsoft/fluid-component-core-interfaces";
-import { Module, Scope } from "./types";
+import {
+    Module,
+    Scope,
+    StrongOmitEmpty,
+} from "./types";
 
 declare module "@microsoft/fluid-component-core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -22,9 +26,9 @@ export interface IComponentModuleManager extends IProvideComponentModuleManager 
     readonly registeredModules: Iterable<(keyof IComponent)>;
     register<T extends IComponent>(type: (keyof IComponent & keyof T), value: Module<T>): void;
     unregister<T extends IComponent>(type: (keyof IComponent & keyof T)): Module<T> | undefined;
-    resolve<O extends IComponent, R extends IComponent = {}>(
-        optionalTypes: Record<(keyof O & keyof IComponent), keyof IComponent>,
-        requiredTypes: Record<(keyof R & keyof IComponent), keyof IComponent>,
+    resolve<O extends IComponent, R extends IComponent>(
+        optionalTypes: StrongOmitEmpty<keyof O & keyof IComponent>,
+        requiredTypes: StrongOmitEmpty<keyof R & keyof IComponent>,
     ): Scope<O, R>;
     has(types: keyof IComponent | (keyof IComponent)[]): boolean;
     resolveModule<T extends IComponent>(type: (keyof IComponent & keyof T)): Module<T> | undefined;

--- a/packages/framework/aqueduct/src/container-modules/IComponentModuleManager.ts
+++ b/packages/framework/aqueduct/src/container-modules/IComponentModuleManager.ts
@@ -26,6 +26,6 @@ export interface IComponentModuleManager extends IProvideComponentModuleManager 
         optionalTypes: Record<(keyof O & keyof IComponent), keyof IComponent>,
         requiredTypes: Record<(keyof R & keyof IComponent), keyof IComponent>,
     ): Scope<O, R>;
-    has(type: keyof IComponent): boolean;
+    has(types: keyof IComponent | (keyof IComponent)[]): boolean;
     resolveModule<T extends IComponent>(type: (keyof IComponent & keyof T)): Module<T> | undefined;
 }

--- a/packages/framework/aqueduct/src/container-modules/IComponentModuleManager.ts
+++ b/packages/framework/aqueduct/src/container-modules/IComponentModuleManager.ts
@@ -1,0 +1,31 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IComponent } from "@microsoft/fluid-component-core-interfaces";
+import { Module, Scope } from "./types";
+
+declare module "@microsoft/fluid-component-core-interfaces" {
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    export interface IComponent extends Readonly<Partial<IProvideComponentModuleManager>> { }
+}
+
+export const IComponentModuleManager: keyof IProvideComponentModuleManager = "IComponentModuleManager";
+
+export interface IProvideComponentModuleManager {
+    IComponentModuleManager: IComponentModuleManager;
+}
+
+export interface IComponentModuleManager extends IProvideComponentModuleManager {
+    parent: IComponentModuleManager | undefined;
+    readonly registeredModules: Iterable<(keyof IComponent)>;
+    register<T extends IComponent>(type: (keyof IComponent & keyof T), value: Module<T>): void;
+    unregister<T extends IComponent>(type: (keyof IComponent & keyof T)): Module<T> | undefined;
+    resolve<O extends IComponent, R extends IComponent = {}>(
+        optionalTypes: Record<(keyof O & keyof IComponent), keyof IComponent>,
+        requiredTypes: Record<(keyof R & keyof IComponent), keyof IComponent>,
+    ): Scope<O, R>;
+    has(type: keyof IComponent): boolean;
+    resolveModule<T extends IComponent>(type: (keyof IComponent & keyof T)): Module<T> | undefined;
+}

--- a/packages/framework/aqueduct/src/container-modules/IComponentModuleManager.ts
+++ b/packages/framework/aqueduct/src/container-modules/IComponentModuleManager.ts
@@ -5,10 +5,13 @@
 
 import { IComponent } from "@microsoft/fluid-component-core-interfaces";
 import {
-    Module,
     Scope,
     StrongOmitEmpty,
 } from "./types";
+
+import {
+    Provider,
+} from "./providers";
 
 declare module "@microsoft/fluid-component-core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -24,12 +27,12 @@ export interface IProvideComponentModuleManager {
 export interface IComponentModuleManager extends IProvideComponentModuleManager {
     parent: IComponentModuleManager | undefined;
     readonly registeredModules: Iterable<(keyof IComponent)>;
-    register<T extends IComponent>(type: (keyof IComponent & keyof T), value: Module<T>): void;
-    unregister<T extends IComponent>(type: (keyof IComponent & keyof T)): Module<T> | undefined;
+    register<T extends IComponent>(type: (keyof IComponent & keyof T), value: Provider<T>): void;
+    unregister<T extends IComponent>(type: (keyof IComponent & keyof T)): Provider<T> | undefined;
     resolve<O extends IComponent, R extends IComponent>(
         optionalTypes: StrongOmitEmpty<keyof O & keyof IComponent>,
         requiredTypes: StrongOmitEmpty<keyof R & keyof IComponent>,
     ): Scope<O, R>;
     has(types: keyof IComponent | (keyof IComponent)[]): boolean;
-    resolveModule<T extends IComponent>(type: (keyof IComponent & keyof T)): Module<T> | undefined;
+    getProvider<T extends IComponent>(type: (keyof IComponent & keyof T)): Provider<T> | undefined;
 }

--- a/packages/framework/aqueduct/src/container-modules/index.ts
+++ b/packages/framework/aqueduct/src/container-modules/index.ts
@@ -5,4 +5,4 @@
 
 export * from "./moduleManager";
 export * from "./IComponentModuleManager";
-export { Scope } from "./types";
+export { Module, Scope } from "./types";

--- a/packages/framework/aqueduct/src/container-modules/index.ts
+++ b/packages/framework/aqueduct/src/container-modules/index.ts
@@ -1,0 +1,7 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export * from "./moduleManager";
+export { Scope } from "./types";

--- a/packages/framework/aqueduct/src/container-modules/index.ts
+++ b/packages/framework/aqueduct/src/container-modules/index.ts
@@ -4,4 +4,5 @@
  */
 
 export * from "./moduleManager";
+export * from "./IComponentModuleManager";
 export { Scope } from "./types";

--- a/packages/framework/aqueduct/src/container-modules/moduleManager.ts
+++ b/packages/framework/aqueduct/src/container-modules/moduleManager.ts
@@ -13,11 +13,11 @@ import { IComponentModuleManager } from "./IComponentModuleManager";
 import {
     ClassProvider,
     ValueProvider,
-    ClassWithArgsProvider,
+    FactoryProvider,
     Provider,
     isValueProvider,
     isClassProvider,
-    isClassWithArgsProvider,
+    isFactoryProvider,
 } from "./providers";
 
 /**
@@ -63,7 +63,7 @@ export class ModuleManager implements IComponentModuleManager {
     public register<T extends IComponent>(
         type: (keyof IComponent & keyof T),
         // eslint-disable-next-line @typescript-eslint/unified-signatures
-        provider: ClassWithArgsProvider<T>,
+        provider: FactoryProvider<T>,
     ): void;
     public register<T extends IComponent>(
         type: (keyof IComponent & keyof T),
@@ -188,12 +188,12 @@ export class ModuleManager implements IComponentModuleManager {
             return provider.value;
         }
 
-        if(isClassWithArgsProvider(provider)) {
-            return new provider.ctor(...provider.args);
+        if(isClassProvider(provider)) {
+            return new provider.class();
         }
 
-        if(isClassProvider(provider)) {
-            return new provider.ctor();
+        if(isFactoryProvider(provider)) {
+            return provider.factory(this);
         }
     }
 }

--- a/packages/framework/aqueduct/src/container-modules/moduleManager.ts
+++ b/packages/framework/aqueduct/src/container-modules/moduleManager.ts
@@ -7,6 +7,7 @@ import { IComponent } from "@microsoft/fluid-component-core-interfaces";
 import { IHostRuntime } from "@microsoft/fluid-runtime-definitions";
 
 import { Module, Scope } from "./types";
+import { IComponentModuleManager } from "./IComponentModuleManager";
 
 export interface IModuleEntry<T> {
     readonly type: (keyof IComponent & keyof T);
@@ -19,14 +20,16 @@ export type ContainerModuleRegistryEntries = Iterable<IModuleEntry<any>>;
 /**
  * ModuleManager is similar to a IoC Container.
  */
-export class ModuleManager {
+export class ModuleManager implements IComponentModuleManager {
     private readonly modules = new Map<keyof IComponent, Module<any>>();
+
+    public get IComponentModuleManager() { return this; }
 
     public get registeredModules(): Iterable<(keyof IComponent)> {
         return this.modules.keys();
     }
 
-    public constructor(public parent?: ModuleManager) { }
+    public constructor(public parent: IComponentModuleManager | undefined = undefined) { }
 
     /**
      * Add a module to the Manager

--- a/packages/framework/aqueduct/src/container-modules/moduleManager.ts
+++ b/packages/framework/aqueduct/src/container-modules/moduleManager.ts
@@ -4,18 +4,9 @@
  */
 
 import { IComponent } from "@microsoft/fluid-component-core-interfaces";
-import { IHostRuntime } from "@microsoft/fluid-runtime-definitions";
 
 import { Module, Scope } from "./types";
 import { IComponentModuleManager } from "./IComponentModuleManager";
-
-export interface IModuleEntry<T> {
-    readonly type: (keyof IComponent & keyof T);
-    readonly ctor: (runtime?: IHostRuntime) => Promise<T>;
-    readonly optional: boolean;
-}
-
-export type ContainerModuleRegistryEntries = Iterable<IModuleEntry<any>>;
 
 /**
  * ModuleManager is similar to a IoC Container.

--- a/packages/framework/aqueduct/src/container-modules/moduleManager.ts
+++ b/packages/framework/aqueduct/src/container-modules/moduleManager.ts
@@ -1,0 +1,134 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IComponent } from "@microsoft/fluid-component-core-interfaces";
+import { IHostRuntime } from "@microsoft/fluid-runtime-definitions";
+
+import { Module, Scope } from "./types";
+
+export interface IModuleEntry<T> {
+    readonly type: (keyof IComponent & keyof T);
+    readonly ctor: (runtime?: IHostRuntime) => Promise<T>;
+    readonly optional: boolean;
+}
+
+export type ContainerModuleRegistryEntries = Iterable<IModuleEntry<any>>;
+
+/**
+ * ModuleManager is similar to a IoC Container.
+ */
+export class ModuleManager {
+    private readonly modules = new Map<keyof IComponent, Module<any>>();
+
+    public get registeredModules(): Iterable<(keyof IComponent)> {
+        return this.modules.keys();
+    }
+
+    public constructor(public parent?: ModuleManager) { }
+
+    /**
+     * Add a module to the Manager
+     * @param type - Type of module being registered
+     * @param value - An implementation of the type being registered.
+     * @throws - If passing a type that's already registered
+     */
+    public register<T extends IComponent>(type: (keyof IComponent & keyof T), value: Module<T>): void {
+        // Maybe support having an array of modules?
+        if (this.has(type)){
+            throw new Error(`Attempting to register a module of type ${type} that's already existing`);
+        }
+
+        this.modules.set(type, value);
+    }
+
+    /**
+     * Remove a module from the Manager
+     * @param type - Type of module to be remove
+     * @returns - Module removed if any
+     */
+    public unregister<T extends IComponent>(type: (keyof IComponent & keyof T)): Module<T> | undefined {
+        const module = this.modules.get(type);
+        if (module){
+            this.modules.delete(type);
+        }
+
+        return module;
+    }
+
+    /**
+     * Resolve takes optional and required types and returns an object that will be primed with the
+     * defined types based off objects that has been previously registered with the ModuleManager.
+     *
+     * Resolution happens first in the child then upwards to the parent.
+     *
+     * resolve ensure that the corresponding types property match's the keys of the provided type using Record
+     *
+     * @param optionalTypes - optional types to be in the Scope object
+     * @param requiredTypes - required types that need to be in the Scope object
+     */
+    public resolve<O extends IComponent, R extends IComponent = {}>(
+        optionalTypes: Record<(keyof O & keyof IComponent), keyof IComponent>,
+        requiredTypes: Record<(keyof R & keyof IComponent), keyof IComponent>,
+    ): Scope<O, R> {
+        const optionalValues = Object.values(optionalTypes);
+        const requiredValues = Object.values(requiredTypes);
+
+        if (optionalValues === [] && requiredValues === []) {
+            // There was nothing passed in so we can return
+            return {} as any;
+        }
+
+        // Ensure there are no shared types
+        // Maybe I can just use Omit and do a type check instead
+        requiredValues.forEach((r) => {
+            if (optionalValues.indexOf(r) > 0) {
+                throw new Error(`Type cannot be defined as both optional and required. [Type:${r}]`);
+            }
+        });
+
+        const s = this.generateRequired<R>(requiredTypes);
+        const o = this.generateOptional<O>(optionalTypes);
+        return { ...s, ...o };
+    }
+
+    public has(type: keyof IComponent): boolean {
+        return this.modules.has(type);
+    }
+
+    public resolveModule<T extends IComponent>(type: (keyof IComponent & keyof T)): Module<T> | undefined {
+        // If we have it return it
+        const module = this.modules.get(type);
+        if (module) {
+            return module;
+        }
+
+        if (this.parent) {
+            return this.parent.resolveModule(type);
+        }
+
+        return undefined;
+    }
+
+    private generateRequired<T extends IComponent>(
+        types: Record<(keyof T & keyof IComponent), keyof IComponent>,
+    ) {
+        return Object.assign({}, ...Array.from(Object.values(types), (t) => {
+            const module = this.resolveModule(t);
+            if (!module) {
+                throw new Error(`Object attempted to be created without required module ${t}`);
+            }
+
+            return ({[t]: module});
+        }));
+    }
+
+    private generateOptional<T extends IComponent>(
+        types: Record<(keyof T & keyof IComponent), keyof IComponent>,
+    ) {
+        return Object.assign({}, ...Array.from(Object.values(types), (t) => {
+            return ({[t]: this.resolveModule(t)});
+        }));
+    }
+}

--- a/packages/framework/aqueduct/src/container-modules/moduleManager.ts
+++ b/packages/framework/aqueduct/src/container-modules/moduleManager.ts
@@ -96,8 +96,14 @@ export class ModuleManager implements IComponentModuleManager {
         return { ...s, ...o };
     }
 
-    public has(type: keyof IComponent): boolean {
-        return this.modules.has(type);
+    public has(types: keyof IComponent | (keyof IComponent)[]): boolean {
+        if (Array.isArray(types)) {
+            return types.every((type) => {
+                return this.modules.has(type);
+            });
+        }
+
+        return this.modules.has(types);
     }
 
     public resolveModule<T extends IComponent>(type: (keyof IComponent & keyof T)): Module<T> | undefined {

--- a/packages/framework/aqueduct/src/container-modules/moduleManager.ts
+++ b/packages/framework/aqueduct/src/container-modules/moduleManager.ts
@@ -72,8 +72,8 @@ export class ModuleManager implements IComponentModuleManager {
      * @param requiredTypes - required types that need to be in the Scope object
      */
     public resolve<O extends IComponent, R extends IComponent = {}>(
-        optionalTypes: Record<(keyof O & keyof IComponent), keyof IComponent>,
-        requiredTypes: Record<(keyof R & keyof IComponent), keyof IComponent>,
+        optionalTypes: Record<keyof O & keyof IComponent, keyof O & keyof IComponent>,
+        requiredTypes: Record<keyof R & keyof IComponent, keyof R & keyof IComponent>,
     ): Scope<O, R> {
         const optionalValues = Object.values(optionalTypes);
         const requiredValues = Object.values(requiredTypes);

--- a/packages/framework/aqueduct/src/container-modules/moduleManager.ts
+++ b/packages/framework/aqueduct/src/container-modules/moduleManager.ts
@@ -13,9 +13,11 @@ import { IComponentModuleManager } from "./IComponentModuleManager";
 import {
     ClassProvider,
     ValueProvider,
+    ClassWithArgsProvider,
     Provider,
     isValueProvider,
     isClassProvider,
+    isClassWithArgsProvider,
 } from "./providers";
 
 /**
@@ -57,6 +59,11 @@ export class ModuleManager implements IComponentModuleManager {
     public register<T extends IComponent>(
         type: (keyof IComponent & keyof T),
         provider: ClassProvider<T>,
+    ): void;
+    public register<T extends IComponent>(
+        type: (keyof IComponent & keyof T),
+        // eslint-disable-next-line @typescript-eslint/unified-signatures
+        provider: ClassWithArgsProvider<T>,
     ): void;
     public register<T extends IComponent>(
         type: (keyof IComponent & keyof T),
@@ -179,6 +186,10 @@ export class ModuleManager implements IComponentModuleManager {
 
         if(isValueProvider(provider)) {
             return provider.value;
+        }
+
+        if(isClassWithArgsProvider(provider)) {
+            return new provider.ctor(...provider.args);
         }
 
         if(isClassProvider(provider)) {

--- a/packages/framework/aqueduct/src/container-modules/providers.ts
+++ b/packages/framework/aqueduct/src/container-modules/providers.ts
@@ -6,38 +6,30 @@
 import { IComponent } from "@microsoft/fluid-component-core-interfaces";
 import { Module } from "./types";
 
+import { IComponentModuleManager } from "./IComponentModuleManager";
+
 export interface ClassProvider<T extends IComponent> {
-    ctor: new () => T;
+    class: new () => T;
 }
 
 export const isClassProvider = <T>(
     provider: Provider<T>,
 ): provider is ClassProvider<T> => {
     return (
-        (provider as ClassProvider<T>).ctor !== undefined &&
-        (provider as ClassWithArgsProvider<T>).args === undefined
+        (provider as ClassProvider<T>).class !== undefined
     );
 };
 
-export interface ClassWithArgsProvider
-<
-    T extends IComponent,
-    K extends new (...args: any[]) => T = new (...args: any[]) => T,
-    P extends ConstructorParameters<K> = ConstructorParameters<K>,
-> {
-    ctor: K;
-    args: P;
+export interface FactoryProvider<T extends IComponent> {
+    factory: (manager?: IComponentModuleManager) => T;
 }
 
 // , K extends ConstructorParameters<T>
 
-export const isClassWithArgsProvider = <T>(
+export const isFactoryProvider = <T>(
     provider: Provider<T>,
-): provider is ClassWithArgsProvider<T> => {
-    return (
-        (provider as ClassWithArgsProvider<T>).ctor !== undefined &&
-        (provider as ClassWithArgsProvider<T>).args !== undefined
-    );
+): provider is FactoryProvider<T> => {
+    return (provider as FactoryProvider<T>).factory !== undefined;
 };
 
 export interface ValueProvider<T extends IComponent> {
@@ -52,13 +44,13 @@ export const isValueProvider = <T>(
 
 export type Provider<T = any> =
     | ClassProvider<T>
-    | ClassWithArgsProvider<T>
+    | FactoryProvider<T>
     | ValueProvider<T>;
 
 export const isProvider = (provider: any): provider is Provider => {
     return (
         isValueProvider(provider) ||
         isClassProvider(provider) ||
-        isClassWithArgsProvider(provider)
+        isFactoryProvider(provider)
     );
 };

--- a/packages/framework/aqueduct/src/container-modules/providers.ts
+++ b/packages/framework/aqueduct/src/container-modules/providers.ts
@@ -7,13 +7,37 @@ import { IComponent } from "@microsoft/fluid-component-core-interfaces";
 import { Module } from "./types";
 
 export interface ClassProvider<T extends IComponent> {
-    ctor: new (...args: any[]) => T;
+    ctor: new () => T;
 }
 
 export const isClassProvider = <T>(
     provider: Provider<T>,
 ): provider is ClassProvider<T> => {
-    return (provider as ClassProvider<T>).ctor !== undefined;
+    return (
+        (provider as ClassProvider<T>).ctor !== undefined &&
+        (provider as ClassWithArgsProvider<T>).args === undefined
+    );
+};
+
+export interface ClassWithArgsProvider
+<
+    T extends IComponent,
+    K extends new (...args: any[]) => T = new (...args: any[]) => T,
+    P extends ConstructorParameters<K> = ConstructorParameters<K>,
+> {
+    ctor: K;
+    args: P;
+}
+
+// , K extends ConstructorParameters<T>
+
+export const isClassWithArgsProvider = <T>(
+    provider: Provider<T>,
+): provider is ClassWithArgsProvider<T> => {
+    return (
+        (provider as ClassWithArgsProvider<T>).ctor !== undefined &&
+        (provider as ClassWithArgsProvider<T>).args !== undefined
+    );
 };
 
 export interface ValueProvider<T extends IComponent> {
@@ -28,11 +52,13 @@ export const isValueProvider = <T>(
 
 export type Provider<T = any> =
     | ClassProvider<T>
+    | ClassWithArgsProvider<T>
     | ValueProvider<T>;
 
 export const isProvider = (provider: any): provider is Provider => {
     return (
         isValueProvider(provider) ||
-        isClassProvider(provider)
+        isClassProvider(provider) ||
+        isClassWithArgsProvider(provider)
     );
 };

--- a/packages/framework/aqueduct/src/container-modules/providers.ts
+++ b/packages/framework/aqueduct/src/container-modules/providers.ts
@@ -1,0 +1,38 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IComponent } from "@microsoft/fluid-component-core-interfaces";
+import { Module } from "./types";
+
+export interface ClassProvider<T extends IComponent> {
+    ctor: new (...args: any[]) => T;
+}
+
+export const isClassProvider = <T>(
+    provider: Provider<T>,
+): provider is ClassProvider<T> => {
+    return (provider as ClassProvider<T>).ctor !== undefined;
+};
+
+export interface ValueProvider<T extends IComponent> {
+    value: Module<T>;
+}
+
+export const isValueProvider = <T>(
+    provider: Provider<T>,
+): provider is ValueProvider<T> => {
+    return (provider as ValueProvider<T>).value !== undefined;
+};
+
+export type Provider<T = any> =
+    | ClassProvider<T>
+    | ValueProvider<T>;
+
+export const isProvider = (provider: any): provider is Provider => {
+    return (
+        isValueProvider(provider) ||
+        isClassProvider(provider)
+    );
+};

--- a/packages/framework/aqueduct/src/container-modules/types.ts
+++ b/packages/framework/aqueduct/src/container-modules/types.ts
@@ -4,11 +4,28 @@
  */
 import { IComponent } from "@microsoft/fluid-component-core-interfaces";
 
-type OptionalModule<T extends IComponent> =
-    { [type in (keyof IComponent & keyof T)]: T[type] | undefined };
+/**
+ * Strong is a condensed version of Record specifically for IComponent
+ */
+export type Strong<K extends keyof IComponent> = {
+    [P in K]: P;
+};
+
+/**
+ * StrongOmitEmpty takes strong and simply Omits the requirement for providing
+ * and empty string if we are using Empty.
+ */
+export type StrongOmitEmpty<K extends keyof IComponent> = Omit<Strong<K>, "">;
 
 export type Module<T extends IComponent> =
     { [type in (keyof IComponent & keyof T)]: T[type] };
+
+/**
+ * Note: This is can also be represented as `Module<T> | undefined` but typescript
+ * says it's too complex to represent so we have to duplicate some code.
+ */
+type OptionalModule<T extends IComponent> =
+    { [type in (keyof IComponent & keyof T)]: T[type] | undefined };
 
 /**
  * A Scope is a collection of optional and required modules.

--- a/packages/framework/aqueduct/src/container-modules/types.ts
+++ b/packages/framework/aqueduct/src/container-modules/types.ts
@@ -13,4 +13,4 @@ export type Module<T extends IComponent> =
 /**
  * A Scope is a collection of optional and required modules.
  */
-export type Scope<O, R = {}> = OptionalModule<O> & Module<R>;
+export type Scope<O extends IComponent, R extends IComponent = {}> = OptionalModule<O> & Module<R>;

--- a/packages/framework/aqueduct/src/container-modules/types.ts
+++ b/packages/framework/aqueduct/src/container-modules/types.ts
@@ -1,0 +1,16 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { IComponent } from "@microsoft/fluid-component-core-interfaces";
+
+type OptionalModule<T extends IComponent> =
+    { [type in (keyof IComponent & keyof T)]: T[type] | undefined };
+
+export type Module<T extends IComponent> =
+    { [type in (keyof IComponent & keyof T)]: T[type] };
+
+/**
+ * A Scope is a collection of optional and required modules.
+ */
+export type Scope<O, R = {}> = OptionalModule<O> & Module<R>;

--- a/packages/framework/aqueduct/src/helpers/IComponentFoo.ts
+++ b/packages/framework/aqueduct/src/helpers/IComponentFoo.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+declare module "@microsoft/fluid-component-core-interfaces" {
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    export interface IComponent extends Readonly<Partial<IProvideComponentFoo>> { }
+}
+
+export const IComponentFoo: keyof IProvideComponentFoo = "IComponentFoo";
+
+export interface IProvideComponentFoo {
+    IComponentFoo: IComponentFoo;
+}
+
+export interface IComponentFoo extends IProvideComponentFoo {
+    foo(): void;
+}

--- a/packages/framework/aqueduct/src/helpers/primedComponentFactory.ts
+++ b/packages/framework/aqueduct/src/helpers/primedComponentFactory.ts
@@ -24,6 +24,8 @@ export class PrimedComponentFactory<T extends PrimedComponent, O extends ICompon
             context: IComponentContext,
             scope: Scope<O, R>,
         ) => T,
+        optionalTypes: Record<(keyof O & keyof IComponent), keyof IComponent>,
+        requiredTypes: Record<(keyof R & keyof IComponent), keyof IComponent>,
         sharedObjects: readonly ISharedObjectFactory[] = [],
         registryEntries?: NamedComponentRegistryEntries,
         onDemandInstantiation = true,
@@ -42,6 +44,6 @@ export class PrimedComponentFactory<T extends PrimedComponent, O extends ICompon
             mergedObjects.push(SharedMap.getFactory());
         }
 
-        super(ctor, mergedObjects, registryEntries, onDemandInstantiation, type);
+        super(ctor, mergedObjects, registryEntries, onDemandInstantiation, type, optionalTypes, requiredTypes);
     }
 }

--- a/packages/framework/aqueduct/src/helpers/primedComponentFactory.ts
+++ b/packages/framework/aqueduct/src/helpers/primedComponentFactory.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { IComponent } from "@microsoft/fluid-component-core-interfaces";
 import { DirectoryFactory, MapFactory, SharedDirectory, SharedMap } from "@microsoft/fluid-map";
 import {
     IComponentContext,
@@ -10,12 +11,19 @@ import {
     NamedComponentRegistryEntries,
 } from "@microsoft/fluid-runtime-definitions";
 import { ISharedObjectFactory } from "@microsoft/fluid-shared-object-base";
-import { SharedComponent } from "../components";
+
+import { PrimedComponent } from "../components";
+import { Scope } from "../container-modules";
 import { SharedComponentFactory } from "./sharedComponentFactory";
 
-export class PrimedComponentFactory extends SharedComponentFactory {
+export class PrimedComponentFactory<T extends PrimedComponent, O extends IComponent, R extends IComponent>
+    extends SharedComponentFactory<T, O, R>
+{
     constructor(
-        ctor: new (runtime: IComponentRuntime, context: IComponentContext) => SharedComponent,
+        ctor: new (runtime: IComponentRuntime,
+            context: IComponentContext,
+            scope: Scope<O, R>,
+        ) => T,
         sharedObjects: readonly ISharedObjectFactory[] = [],
         registryEntries?: NamedComponentRegistryEntries,
         onDemandInstantiation = true,

--- a/packages/framework/aqueduct/src/helpers/primedComponentFactory.ts
+++ b/packages/framework/aqueduct/src/helpers/primedComponentFactory.ts
@@ -24,8 +24,8 @@ export class PrimedComponentFactory<T extends PrimedComponent, O extends ICompon
             context: IComponentContext,
             scope: Scope<O, R>,
         ) => T,
-        optionalTypes: Record<(keyof O & keyof IComponent), keyof IComponent>,
-        requiredTypes: Record<(keyof R & keyof IComponent), keyof IComponent>,
+        optionalModuleTypes: Record<keyof O & keyof IComponent, keyof O & keyof IComponent>,
+        requiredModuleTypes: Record<keyof R & keyof IComponent, keyof R & keyof IComponent>,
         sharedObjects: readonly ISharedObjectFactory[] = [],
         registryEntries?: NamedComponentRegistryEntries,
         onDemandInstantiation = true,
@@ -44,6 +44,12 @@ export class PrimedComponentFactory<T extends PrimedComponent, O extends ICompon
             mergedObjects.push(SharedMap.getFactory());
         }
 
-        super(ctor, mergedObjects, registryEntries, onDemandInstantiation, type, optionalTypes, requiredTypes);
+        super(ctor,
+            optionalModuleTypes,
+            requiredModuleTypes,
+            mergedObjects,
+            registryEntries,
+            onDemandInstantiation,
+            type);
     }
 }

--- a/packages/framework/aqueduct/src/helpers/sharedComponentFactory.ts
+++ b/packages/framework/aqueduct/src/helpers/sharedComponentFactory.ts
@@ -15,15 +15,21 @@ import {
     NamedComponentRegistryEntries,
 } from "@microsoft/fluid-runtime-definitions";
 import { ISharedObjectFactory } from "@microsoft/fluid-shared-object-base";
+
 // eslint-disable-next-line import/no-internal-modules
 import { SharedComponent } from "../components/sharedComponent";
+import { Scope } from "../container-modules";
 
-export class SharedComponentFactory implements IComponentFactory, Partial<IProvideComponentRegistry> {
+export class SharedComponentFactory<T extends SharedComponent, O extends IComponent, R  extends IComponent>
+implements IComponentFactory, Partial<IProvideComponentRegistry>
+{
     private readonly sharedObjectRegistry: ISharedObjectRegistry;
     private readonly registry: IComponentRegistry | undefined;
 
     constructor(
-        private readonly ctor: new (runtime: IComponentRuntime, context: IComponentContext) => SharedComponent,
+        private readonly ctor: new (runtime: IComponentRuntime,
+            context: IComponentContext,
+            scope: Scope<O, R>) => T,
         sharedObjects: readonly ISharedObjectFactory[],
         registryEntries?: NamedComponentRegistryEntries,
         private readonly onDemandInstantiation = true,
@@ -81,7 +87,7 @@ export class SharedComponentFactory implements IComponentFactory, Partial<IProvi
      */
     private async instantiateInstance(runtime: ComponentRuntime, context: IComponentContext) {
         // Create a new instance of our component
-        const instance = new this.ctor(runtime, context);
+        const instance = new this.ctor(runtime, context, {} as any);
         await instance.initialize();
         return instance;
     }

--- a/packages/framework/aqueduct/src/helpers/sharedComponentFactory.ts
+++ b/packages/framework/aqueduct/src/helpers/sharedComponentFactory.ts
@@ -43,12 +43,12 @@ implements IComponentFactory, Partial<IProvideComponentRegistry>
         private readonly ctor: new (runtime: IComponentRuntime,
             context: IComponentContext,
             scope: Scope<O, R>) => T,
+        private readonly optionalModuleTypes: Record<keyof O & keyof IComponent, keyof O & keyof IComponent>,
+        private readonly requiredModuleTypes: Record<keyof R & keyof IComponent, keyof R & keyof IComponent>,
         sharedObjects: readonly ISharedObjectFactory[],
         registryEntries?: NamedComponentRegistryEntries,
         private readonly onDemandInstantiation = true,
         public readonly type: string = "",
-        private readonly optionalModuleTypes: Record<(keyof O & keyof IComponent), keyof IComponent> = {} as any,
-        private readonly requiredModuleTypes: Record<(keyof R & keyof IComponent), keyof IComponent> = {} as any,
     ) {
         if (registryEntries !== undefined) {
             this.registry = new ComponentRegistry(registryEntries);

--- a/packages/framework/aqueduct/src/helpers/sharedComponentFactory.ts
+++ b/packages/framework/aqueduct/src/helpers/sharedComponentFactory.ts
@@ -24,15 +24,6 @@ import {
     Scope,
 } from "../container-modules";
 
-import { IComponentFoo } from "./IComponentFoo";
-
-export class Foo implements IComponentFoo {
-    public get IComponentFoo() { return this; }
-    public foo() {
-        alert("foo ya!");
-    }
-}
-
 export class SharedComponentFactory<T extends SharedComponent, O extends IComponent, R  extends IComponent>
 implements IComponentFactory, Partial<IProvideComponentRegistry>
 {

--- a/packages/framework/aqueduct/src/helpers/sharedComponentFactory.ts
+++ b/packages/framework/aqueduct/src/helpers/sharedComponentFactory.ts
@@ -101,7 +101,7 @@ implements IComponentFactory, Partial<IProvideComponentRegistry>
         runtime: ComponentRuntime,
         context: IComponentContext,
         moduleManager: ModuleManager) {
-        const scope = moduleManager.resolve<IComponentFoo>({IComponentFoo}, {});
+        const scope = moduleManager.resolve<{},IComponentFoo>({},{IComponentFoo});
         // Create a new instance of our component
         const instance = new this.ctor(runtime, context, scope as any);
         await instance.initialize();

--- a/packages/framework/aqueduct/src/helpers/simpleContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/helpers/simpleContainerRuntimeFactory.ts
@@ -16,6 +16,12 @@ import {
     ContainerServiceRegistryEntries,
 } from "../containerServices";
 
+import { ModuleManager } from "../container-modules";
+
+// TODO: Foo is a place holder. Will be removed.
+import { Foo } from "./sharedComponentFactory";
+import { IComponentFoo } from "./IComponentFoo";
+
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class SimpleContainerRuntimeFactory {
     public static readonly defaultComponentId = "default";
@@ -30,7 +36,10 @@ export class SimpleContainerRuntimeFactory {
         serviceRegistry: ContainerServiceRegistryEntries = [],
         requestHandlers: RuntimeRequestHandler[] = [],
     ): Promise<ContainerRuntime> {
-        // Debug(`instantiateRuntime(chaincode=${chaincode},registry=${JSON.stringify(registry)})`);
+
+        const moduleManager = new ModuleManager();
+        moduleManager.register(IComponentFoo, new Foo());
+
         const runtime = await ContainerRuntime.load(
             context,
             registryEntries,

--- a/packages/framework/aqueduct/src/helpers/simpleContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/helpers/simpleContainerRuntimeFactory.ts
@@ -19,8 +19,8 @@ import {
 import { ModuleManager } from "../container-modules";
 
 // TODO: Foo is a place holder. Will be removed.
-import { Foo } from "./sharedComponentFactory";
-import { IComponentFoo } from "./IComponentFoo";
+// import { Foo } from "./sharedComponentFactory";
+// import { IComponentFoo } from "./IComponentFoo";
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class SimpleContainerRuntimeFactory {
@@ -35,11 +35,11 @@ export class SimpleContainerRuntimeFactory {
         registryEntries: NamedComponentRegistryEntries,
         serviceRegistry: ContainerServiceRegistryEntries = [],
         requestHandlers: RuntimeRequestHandler[] = [],
+        // TODO: This probably shouldn't be the module manager but some registry or list or something
+        moduleManager: ModuleManager = new ModuleManager(),
     ): Promise<ContainerRuntime> {
-
-        const moduleManager = new ModuleManager();
-        moduleManager.register(IComponentFoo, new Foo());
-
+        // We can set the parent module manager to the one provided by the host.
+        moduleManager.parent = context.scope.IComponentModuleManager;
         const runtime = await ContainerRuntime.load(
             context,
             registryEntries,

--- a/packages/framework/aqueduct/src/helpers/simpleContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/helpers/simpleContainerRuntimeFactory.ts
@@ -49,7 +49,9 @@ export class SimpleContainerRuntimeFactory {
                 generateContainerServicesRequestHandler(serviceRegistry),
                 ...requestHandlers,
                 componentRuntimeRequestHandler,
-            ]);
+            ],
+            undefined,
+            moduleManager);
         // Debug("runtime loaded.");
 
         // On first boot create the base component

--- a/packages/framework/aqueduct/src/helpers/simpleModuleInstantiationFactory.ts
+++ b/packages/framework/aqueduct/src/helpers/simpleModuleInstantiationFactory.ts
@@ -12,6 +12,7 @@ import {
     NamedComponentRegistryEntries,
 } from "@microsoft/fluid-runtime-definitions";
 
+import { ModuleManager } from "../container-modules";
 import { ContainerServiceRegistryEntries } from "../containerServices";
 import { SimpleContainerRuntimeFactory } from "./";
 
@@ -35,6 +36,7 @@ export class SimpleModuleInstantiationFactory implements
         private readonly registryEntries: NamedComponentRegistryEntries,
         private readonly serviceRegistry: ContainerServiceRegistryEntries = [],
         private readonly requestHandlers: RuntimeRequestHandler[] = [],
+        private readonly moduleManager: ModuleManager = new ModuleManager(),
     ) {
         this.registry = new ComponentRegistry(registryEntries);
     }
@@ -51,6 +53,7 @@ export class SimpleModuleInstantiationFactory implements
             this.registryEntries,
             this.serviceRegistry,
             this.requestHandlers,
+            this.moduleManager,
         );
     }
 }

--- a/packages/framework/aqueduct/src/index.ts
+++ b/packages/framework/aqueduct/src/index.ts
@@ -15,4 +15,5 @@
 
 export * from "./components";
 export * from "./containerServices";
+export * from "./container-modules";
 export * from "./helpers";

--- a/packages/framework/aqueduct/src/test/containerModules.spec.ts
+++ b/packages/framework/aqueduct/src/test/containerModules.spec.ts
@@ -27,6 +27,11 @@ class MockLoadable implements IComponentLoadable {
     public get url() { return "url123"; }
 }
 
+class MockLoadableWithArgs implements IComponentLoadable{
+    public constructor(public readonly url: string) { }
+    public get IComponentLoadable() { return this; }
+}
+
 class MockComponentConfiguration implements IComponentConfiguration {
     public get IComponentConfiguration() { return this; }
     public get canReconnect() { return false; }
@@ -44,6 +49,15 @@ describe("Routerlicious", () => {
                 const s = manager.resolve<IComponentLoadable>({IComponentLoadable}, {});
                 assert(s.IComponentLoadable, "Optional IComponentLoadable was registered");
                 assert(s.IComponentLoadable === module, "IComponentLoadable is valid");
+            });
+
+            it(`One Optional Module registered via class`, async () => {
+                const manager = new ModuleManager();
+                manager.register(IComponentLoadable, {ctor: MockLoadableWithArgs, args: ["foo"]});
+
+                const s = manager.resolve<IComponentLoadable>({IComponentLoadable}, {});
+                assert(s.IComponentLoadable, "Optional IComponentLoadable was registered");
+                assert(s.IComponentLoadable?.url === "foo", "IComponentLoadable is valid");
             });
 
             it(`One Optional Module registered via class`, async () => {

--- a/packages/framework/aqueduct/src/test/containerModules.spec.ts
+++ b/packages/framework/aqueduct/src/test/containerModules.spec.ts
@@ -1,0 +1,186 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as assert from "assert";
+
+import {
+    IComponentConfiguration,
+    IComponentLoadable,
+} from "@microsoft/fluid-component-core-interfaces";
+
+import { ModuleManager } from "../container-modules";
+
+export interface IFoo {
+    foo: string;
+}
+
+export class Foo {
+    public foo() {
+        console.log("foo");
+    }
+}
+
+class MockLoadable implements IComponentLoadable {
+    public get IComponentLoadable() { return this; }
+    public get url() { return "url123"; }
+}
+
+class MockComponentConfiguration implements IComponentConfiguration {
+    public get IComponentConfiguration() { return this; }
+    public get canReconnect() { return false; }
+    public get scopes() { return ["hello"]; }
+}
+
+describe("Routerlicious", () => {
+    describe("Aqueduct", () => {
+        describe("ContainerModules", () => {
+            it(`One Optional Module registered`, async () => {
+                const manager = new ModuleManager();
+                manager.register(IComponentLoadable, new MockLoadable());
+
+                const s = manager.resolve<IComponentLoadable>({IComponentLoadable}, {});
+                assert(s.IComponentLoadable, "Optional IComponentLoadable was registered");
+            });
+
+            it(`Multiple Optional Module all registered`, async () => {
+                const manager = new ModuleManager();
+                manager.register(IComponentLoadable, new MockLoadable());
+                manager.register(IComponentConfiguration, new MockComponentConfiguration());
+
+                const s = manager.resolve<IComponentLoadable & IComponentConfiguration>(
+                    {IComponentLoadable,IComponentConfiguration}, {});
+                assert(s.IComponentLoadable, "Optional IComponentLoadable was registered");
+                assert(s.IComponentConfiguration, "Optional IComponentConfiguration was registered");
+            });
+
+            it(`Multiple Optional Module none registered`, async () => {
+                const manager = new ModuleManager();
+                const s = manager.resolve<IComponentLoadable & IComponentConfiguration>(
+                    {IComponentLoadable,IComponentConfiguration}, {});
+                assert(!s.IComponentLoadable, "Optional IComponentLoadable was not registered");
+                assert(!s.IComponentConfiguration, "Optional IComponentConfiguration was not registered");
+            });
+
+            it(`Two Optional Module one registered`, async () => {
+                const manager = new ModuleManager();
+                manager.register(IComponentLoadable, new MockLoadable());
+                const s = manager.resolve<IComponentLoadable & IComponentConfiguration>(
+                    {IComponentLoadable,IComponentConfiguration}, {});
+                assert(s.IComponentLoadable, "Optional IComponentLoadable was registered");
+                assert(!s.IComponentConfiguration, "Optional IComponentConfiguration was not registered");
+            });
+
+            it(`One Required Module registered`, async () => {
+                const manager = new ModuleManager();
+                manager.register(IComponentLoadable, new MockLoadable());
+
+                const s = manager.resolve<{}, IComponentLoadable>(
+                    {},
+                    {IComponentLoadable},
+                );
+
+                assert(s.IComponentLoadable, "Required IComponentLoadable was registered");
+            });
+
+            it(`Multiple Required Module all registered`, async () => {
+                const manager = new ModuleManager();
+                manager.register(IComponentLoadable, new MockLoadable());
+                manager.register(IComponentConfiguration, new MockComponentConfiguration());
+
+                const s = manager.resolve<{}, IComponentLoadable & IComponentConfiguration>(
+                    {},
+                    {IComponentLoadable, IComponentConfiguration},
+                );
+
+                assert(s.IComponentLoadable, "Required IComponentLoadable was registered");
+                assert(s.IComponentConfiguration, "Required IComponentConfiguration was registered");
+            });
+
+            it(`Required Module not registered should throw`, async () => {
+                const manager = new ModuleManager();
+
+                assert.throws(() => manager.resolve<{}, IComponentLoadable>(
+                    {},
+                    {IComponentLoadable},
+                ), Error);
+            });
+
+            it(`Optional Module found in Parent`, async () => {
+                const parentManager = new ModuleManager();
+                parentManager.register(IComponentLoadable, new MockLoadable());
+                const manager = new ModuleManager(parentManager);
+
+                const s = manager.resolve<IComponentLoadable>({IComponentLoadable}, {});
+                assert(s.IComponentLoadable, "Optional IComponentLoadable was registered");
+            });
+
+            it(`Optional Module found in Parent and Child`, async () => {
+                const parentManager = new ModuleManager();
+                parentManager.register(IComponentLoadable, new MockLoadable());
+                const manager = new ModuleManager(parentManager);
+                manager.register(IComponentConfiguration, new MockComponentConfiguration());
+
+                const s = manager.resolve<IComponentLoadable & IComponentConfiguration>(
+                    {IComponentLoadable, IComponentConfiguration}, {});
+                assert(s.IComponentLoadable, "Optional IComponentLoadable was registered");
+            });
+
+            it(`Optional Module in Parent and Child resolves Child`, async () => {
+                const parentManager = new ModuleManager();
+                parentManager.register(IComponentLoadable, new MockLoadable());
+                const manager = new ModuleManager(parentManager);
+                const childLoadableModule = new MockLoadable();
+                manager.register(IComponentLoadable, childLoadableModule);
+
+                const s = manager.resolve<IComponentLoadable>(
+                    {IComponentLoadable}, {});
+                assert(s.IComponentLoadable === childLoadableModule, "Child Module loaded");
+            });
+
+            it(`Required Module found in Parent`, async () => {
+                const parentManager = new ModuleManager();
+                parentManager.register(IComponentLoadable, new MockLoadable());
+                const manager = new ModuleManager(parentManager);
+
+                const s = manager.resolve<{}, IComponentLoadable>({}, {IComponentLoadable});
+                assert(s.IComponentLoadable, "Required IComponentLoadable was registered");
+            });
+
+            it(`Required Module found in Parent and Child`, async () => {
+                const parentManager = new ModuleManager();
+                parentManager.register(IComponentLoadable, new MockLoadable());
+                const manager = new ModuleManager(parentManager);
+                manager.register(IComponentConfiguration, new MockComponentConfiguration());
+
+                const s = manager.resolve<{}, IComponentLoadable & IComponentConfiguration>(
+                    {}, {IComponentLoadable, IComponentConfiguration});
+                assert(s.IComponentLoadable, "Required IComponentLoadable was registered");
+                assert(s.IComponentConfiguration, "Required IComponentConfiguration was registered");
+            });
+
+            it(`Registering the same type twice throws`, async () => {
+                const manager = new ModuleManager();
+                manager.register(IComponentLoadable, new MockLoadable());
+                assert.throws(() => manager.register(IComponentLoadable, new MockLoadable()), Error);
+            });
+
+            it(`Registering then Unregistering`, async () => {
+                const manager = new ModuleManager();
+                manager.register(IComponentLoadable, new MockLoadable());
+                manager.unregister(IComponentLoadable);
+                assert(!manager.has(IComponentLoadable), "Manager doesn't have IComponentLoadable");
+                assert(Array.from(manager.registeredModules).length === 0, "Manager has no modules");
+            });
+
+            it(`Registering then Unregistering then registering`, async () => {
+                const manager = new ModuleManager();
+                manager.register(IComponentLoadable, new MockLoadable());
+                manager.unregister(IComponentLoadable);
+                manager.register(IComponentLoadable, new MockLoadable());
+                assert(manager.has(IComponentLoadable), "Manager has IComponentLoadable");
+            });
+        });
+    });
+});

--- a/packages/framework/aqueduct/src/test/containerModules.spec.ts
+++ b/packages/framework/aqueduct/src/test/containerModules.spec.ts
@@ -53,20 +53,23 @@ describe("Routerlicious", () => {
 
             it(`One Optional Module registered via class`, async () => {
                 const manager = new ModuleManager();
-                manager.register(IComponentLoadable, {ctor: MockLoadableWithArgs, args: ["foo"]});
-
-                const s = manager.resolve<IComponentLoadable>({IComponentLoadable}, {});
-                assert(s.IComponentLoadable, "Optional IComponentLoadable was registered");
-                assert(s.IComponentLoadable?.url === "foo", "IComponentLoadable is valid");
-            });
-
-            it(`One Optional Module registered via class`, async () => {
-                const manager = new ModuleManager();
-                manager.register(IComponentLoadable, {ctor: MockLoadable});
+                manager.register(IComponentLoadable, {class: MockLoadable});
 
                 const s = manager.resolve<IComponentLoadable>({IComponentLoadable}, {});
                 assert(s.IComponentLoadable, "Optional IComponentLoadable was registered");
                 assert(s.IComponentLoadable?.url === "url123", "IComponentLoadable is valid");
+            });
+
+            it(`One Optional Module registered via factory`, async () => {
+                const manager = new ModuleManager();
+                const url = "Foo123";
+
+                const factory = () => new MockLoadableWithArgs(url);
+                manager.register(IComponentLoadable, {factory});
+
+                const s = manager.resolve<IComponentLoadable>({IComponentLoadable}, {});
+                assert(s.IComponentLoadable, "Optional IComponentLoadable was registered");
+                assert(s.IComponentLoadable?.url === url, "IComponentLoadable is valid");
             });
 
             it(`Multiple Optional Module all registered`, async () => {

--- a/packages/framework/aqueduct/src/test/containerModules.spec.ts
+++ b/packages/framework/aqueduct/src/test/containerModules.spec.ts
@@ -36,18 +36,29 @@ class MockComponentConfiguration implements IComponentConfiguration {
 describe("Routerlicious", () => {
     describe("Aqueduct", () => {
         describe("ContainerModules", () => {
-            it(`One Optional Module registered`, async () => {
+            it(`One Optional Module registered via value`, async () => {
                 const manager = new ModuleManager();
-                manager.register(IComponentLoadable, new MockLoadable());
+                const module = new MockLoadable();
+                manager.register(IComponentLoadable, {value: module});
 
                 const s = manager.resolve<IComponentLoadable>({IComponentLoadable}, {});
                 assert(s.IComponentLoadable, "Optional IComponentLoadable was registered");
+                assert(s.IComponentLoadable === module, "IComponentLoadable is valid");
+            });
+
+            it(`One Optional Module registered via class`, async () => {
+                const manager = new ModuleManager();
+                manager.register(IComponentLoadable, {ctor: MockLoadable});
+
+                const s = manager.resolve<IComponentLoadable>({IComponentLoadable}, {});
+                assert(s.IComponentLoadable, "Optional IComponentLoadable was registered");
+                assert(s.IComponentLoadable?.url === "url123", "IComponentLoadable is valid");
             });
 
             it(`Multiple Optional Module all registered`, async () => {
                 const manager = new ModuleManager();
-                manager.register(IComponentLoadable, new MockLoadable());
-                manager.register(IComponentConfiguration, new MockComponentConfiguration());
+                manager.register(IComponentLoadable, {value: new MockLoadable()});
+                manager.register(IComponentConfiguration, {value: new MockComponentConfiguration()});
 
                 const s = manager.resolve<IComponentLoadable & IComponentConfiguration>(
                     {IComponentLoadable,IComponentConfiguration}, {});
@@ -65,7 +76,7 @@ describe("Routerlicious", () => {
 
             it(`Two Optional Module one registered`, async () => {
                 const manager = new ModuleManager();
-                manager.register(IComponentLoadable, new MockLoadable());
+                manager.register(IComponentLoadable, {value: new MockLoadable()});
                 const s = manager.resolve<IComponentLoadable & IComponentConfiguration>(
                     {IComponentLoadable,IComponentConfiguration}, {});
                 assert(s.IComponentLoadable, "Optional IComponentLoadable was registered");
@@ -74,7 +85,7 @@ describe("Routerlicious", () => {
 
             it(`One Required Module registered`, async () => {
                 const manager = new ModuleManager();
-                manager.register(IComponentLoadable, new MockLoadable());
+                manager.register(IComponentLoadable, {value: new MockLoadable()});
 
                 const s = manager.resolve<{}, IComponentLoadable>(
                     {},
@@ -86,7 +97,7 @@ describe("Routerlicious", () => {
 
             it(`One Required Module registered`, async () => {
                 const manager = new ModuleManager();
-                manager.register(IComponentLoadable, new MockLoadable());
+                manager.register(IComponentLoadable, {value: new MockLoadable()});
 
                 const s = manager.resolve<Empty, IComponentLoadable>(
                     {},
@@ -98,8 +109,8 @@ describe("Routerlicious", () => {
 
             it(`Multiple Required Module all registered`, async () => {
                 const manager = new ModuleManager();
-                manager.register(IComponentLoadable, new MockLoadable());
-                manager.register(IComponentConfiguration, new MockComponentConfiguration());
+                manager.register(IComponentLoadable, {value: new MockLoadable()});
+                manager.register(IComponentConfiguration, {value: new MockComponentConfiguration()});
 
                 const s = manager.resolve<Empty, IComponentLoadable & IComponentConfiguration>(
                     {},
@@ -121,7 +132,7 @@ describe("Routerlicious", () => {
 
             it(`Optional Module found in Parent`, async () => {
                 const parentManager = new ModuleManager();
-                parentManager.register(IComponentLoadable, new MockLoadable());
+                parentManager.register(IComponentLoadable, {value: new MockLoadable()});
                 const manager = new ModuleManager(parentManager);
 
                 const s = manager.resolve<IComponentLoadable>({IComponentLoadable}, {});
@@ -130,9 +141,9 @@ describe("Routerlicious", () => {
 
             it(`Optional Module found in Parent and Child`, async () => {
                 const parentManager = new ModuleManager();
-                parentManager.register(IComponentLoadable, new MockLoadable());
+                parentManager.register(IComponentLoadable, {value: new MockLoadable()});
                 const manager = new ModuleManager(parentManager);
-                manager.register(IComponentConfiguration, new MockComponentConfiguration());
+                manager.register(IComponentConfiguration, {value: new MockComponentConfiguration()});
 
                 const s = manager.resolve<IComponentLoadable & IComponentConfiguration>(
                     {IComponentLoadable, IComponentConfiguration}, {});
@@ -141,10 +152,10 @@ describe("Routerlicious", () => {
 
             it(`Optional Module in Parent and Child resolves Child`, async () => {
                 const parentManager = new ModuleManager();
-                parentManager.register(IComponentLoadable, new MockLoadable());
+                parentManager.register(IComponentLoadable, {value: new MockLoadable()});
                 const manager = new ModuleManager(parentManager);
                 const childLoadableModule = new MockLoadable();
-                manager.register(IComponentLoadable, childLoadableModule);
+                manager.register(IComponentLoadable, {value: childLoadableModule});
 
                 const s = manager.resolve<IComponentLoadable>(
                     {IComponentLoadable}, {});
@@ -153,7 +164,7 @@ describe("Routerlicious", () => {
 
             it(`Required Module found in Parent`, async () => {
                 const parentManager = new ModuleManager();
-                parentManager.register(IComponentLoadable, new MockLoadable());
+                parentManager.register(IComponentLoadable, {value: new MockLoadable()});
                 const manager = new ModuleManager(parentManager);
 
                 const s = manager.resolve<{}, IComponentLoadable>({}, {IComponentLoadable});
@@ -162,9 +173,9 @@ describe("Routerlicious", () => {
 
             it(`Required Module found in Parent and Child`, async () => {
                 const parentManager = new ModuleManager();
-                parentManager.register(IComponentLoadable, new MockLoadable());
+                parentManager.register(IComponentLoadable, {value: new MockLoadable()});
                 const manager = new ModuleManager(parentManager);
-                manager.register(IComponentConfiguration, new MockComponentConfiguration());
+                manager.register(IComponentConfiguration, {value: new MockComponentConfiguration()});
 
                 const s = manager.resolve<{}, IComponentLoadable & IComponentConfiguration>(
                     {}, {IComponentLoadable, IComponentConfiguration});
@@ -174,13 +185,13 @@ describe("Routerlicious", () => {
 
             it(`Registering the same type twice throws`, async () => {
                 const manager = new ModuleManager();
-                manager.register(IComponentLoadable, new MockLoadable());
-                assert.throws(() => manager.register(IComponentLoadable, new MockLoadable()), Error);
+                manager.register(IComponentLoadable, {value: new MockLoadable()});
+                assert.throws(() => manager.register(IComponentLoadable, {value: new MockLoadable()}), Error);
             });
 
             it(`Registering then Unregistering`, async () => {
                 const manager = new ModuleManager();
-                manager.register(IComponentLoadable, new MockLoadable());
+                manager.register(IComponentLoadable, {value: new MockLoadable()});
                 manager.unregister(IComponentLoadable);
                 assert(!manager.has(IComponentLoadable), "Manager doesn't have IComponentLoadable");
                 assert(Array.from(manager.registeredModules).length === 0, "Manager has no modules");
@@ -188,9 +199,9 @@ describe("Routerlicious", () => {
 
             it(`Registering then Unregistering then registering`, async () => {
                 const manager = new ModuleManager();
-                manager.register(IComponentLoadable, new MockLoadable());
+                manager.register(IComponentLoadable, {value: new MockLoadable()});
                 manager.unregister(IComponentLoadable);
-                manager.register(IComponentLoadable, new MockLoadable());
+                manager.register(IComponentLoadable, {value: new MockLoadable()});
                 assert(manager.has(IComponentLoadable), "Manager has IComponentLoadable");
             });
         });

--- a/packages/framework/aqueduct/src/test/containerModules.spec.ts
+++ b/packages/framework/aqueduct/src/test/containerModules.spec.ts
@@ -10,7 +10,7 @@ import {
     IComponentLoadable,
 } from "@microsoft/fluid-component-core-interfaces";
 
-import { ModuleManager } from "../container-modules";
+import { ModuleManager, Empty } from "../container-modules";
 
 export interface IFoo {
     foo: string;
@@ -84,12 +84,24 @@ describe("Routerlicious", () => {
                 assert(s.IComponentLoadable, "Required IComponentLoadable was registered");
             });
 
+            it(`One Required Module registered`, async () => {
+                const manager = new ModuleManager();
+                manager.register(IComponentLoadable, new MockLoadable());
+
+                const s = manager.resolve<Empty, IComponentLoadable>(
+                    {},
+                    {IComponentLoadable},
+                );
+
+                assert(s.IComponentLoadable, "Required IComponentLoadable was registered");
+            });
+
             it(`Multiple Required Module all registered`, async () => {
                 const manager = new ModuleManager();
                 manager.register(IComponentLoadable, new MockLoadable());
                 manager.register(IComponentConfiguration, new MockComponentConfiguration());
 
-                const s = manager.resolve<{}, IComponentLoadable & IComponentConfiguration>(
+                const s = manager.resolve<Empty, IComponentLoadable & IComponentConfiguration>(
                     {},
                     {IComponentLoadable, IComponentConfiguration},
                 );

--- a/packages/server/local-test-utils/src/testHost.ts
+++ b/packages/server/local-test-utils/src/testHost.ts
@@ -176,7 +176,7 @@ export class TestHost {
                 [
                     ...componentRegistry,
                     [TestRootComponent.type, Promise.resolve(
-                        new PrimedComponentFactory(TestRootComponent, sharedObjectFactories),
+                        new PrimedComponentFactory(TestRootComponent, {} as any, {} as any, sharedObjectFactories),
                     )],
                 ],
                 this.containerServiceRegistry),

--- a/packages/server/local-test-utils/src/testHost.ts
+++ b/packages/server/local-test-utils/src/testHost.ts
@@ -48,7 +48,7 @@ class TestRootComponent extends PrimedComponent implements IComponentRunnable {
     };
 
     constructor(runtime: IComponentRuntime, context: IComponentContext) {
-        super(runtime, context);
+        super(runtime, context, {} as any);
     }
 
     // eslint-disable-next-line @typescript-eslint/promise-function-async


### PR DESCRIPTION
This change is an alternative/evolution of #1658 which used the inversify ioc library to do container module injection into SharedComponents. There were some concerns/problems around inversify and this change is an attempt to side step the need for an ioc library while still getting all the goodness similar to ioc.

This PR also addressed another concern/problem that @ChumpChief raised about wanting to know if a Component can be loaded/create. Ie. there will be components that have hard requirements on services/modules provided by the container. We want to know before we create this compoennt if creation will fail. You could also imagine that we only want to show a components to the user that we know won't fail on creation because they require service from the container that are not avaiable.

Something things to note. This PR has some crazy typings and because of that I wrote a bunch of test to help ensure that the ModuleManager is doing what it's supposed to. You will also notice that these types have bled everywhere. While this might look mess, the nice is that typescript is awesome and infers most of types from other places so you don't need to keep declaring. The definitions just look ugly.

## Why?
Quick blurb on why. The goal here is to consolidate the notion of scope and container service from the developer and give stronger typing for things provided by the component and wanted by the component.

## So what did I do?

I didn't want to re-write an ioc container mainly because it's overkill for our scenario. It also uses the `reflect-metadata` package which is a global that needs to be loaded only once on the page. This is difficult to do if you need it and you don't know if your parent will have already included it. Also as @christiango pointed out `inversify`+`reflect-metadata` is 20+kb bumb to the pkg size which is pretty big for what we get. There were also justified concerns from @curtisman about forcing people to use inversify.

So instead of doing true ioc what we really need to do is create an object that can expose things the developer defines using the IComponent paradigm. In order to do this and provide type safety there was a bunch of type craziness (at least for me). If you have thoughts on how to simplify my crazy types I'm all ears. I've tried a bunch of variations to make it as readable as possible.

I've created a ModuleManager which allows Modules to be registered against it. Modules are simply a `type` and an `object` of that same type. Ex:
```typescript
const moduleManager = new ModuleManager()
moduleManager.register(IComponentFoo, new Foo())
``` 

Someone can then resolve against the ModuleManager and provide a collection of optional and required types that they want. The ModuleManager resolves things that has been registered against it with the types asked for. Optional types are always `type | undefined`. If a required type is not in the ModuleManager an exception is thrown. In the end the result is an object that has a the name of the type asked for and a reference to the type object (the same paradigm as IComponent discovery)

Ex:
```typescript
// Optional IComponentFoo
moduleManager.resolve<IComponentFoo>({IComponentFoo});

// Optional IComponentFoo and IComponentBar
moduleManager.resolve<IComponentFoo & IComponentBar>({IComponentFoo, IComponentBar});

// Optional IComponentFoo required IComponentBar
moduleManager.resolve<IComponentFoo, IComponentBar>({IComponentFoo}, {IComponentBar});
```

**Note:** This is a Draft pr and there are thing that need to get better. My goal was to get people looking to agree on a direction. My big exploration left is around module creation and making is so we can inject hostRuntime into modules and lazy load modules.

**Note2:** This is currently in the framework but I'm currently thinking that a module collection should replace the existing scope. I'm not really convicted on this statement but if all we use scope for is propagating strongly typed modules around then it's probably worth it. We can also keep scope as a proxy and keep the framework utilizing it.

## Developer Model

### Component Developers

#### Optional and Required Modules
Component developer now can choose to define `optional` and `required` container modules. They do this by including the IComponent interface types they want on their Primed/Shared Component

```typescript
// Define IComponentFoo as optional
export class DiceRoller extends PrimedComponent<IComponentFoo> implements IComponentHTMLView {...}

// Define IComponentFoo and IComponentBar as optional
export class DiceRoller extends PrimedComponent<IComponentFoo & IComponentBar> implements IComponentHTMLView {...}

// Define IComponentFoo and IComponentBar as optional (alternative)
type DiceRollerOptionalModules = IComponentFoo & IComponentBar;
export class DiceRoller extends PrimedComponent<DiceRollerOptionalModules> implements IComponentHTMLView {...}

// Define IComponentBar as required
export class DiceRoller extends PrimedComponent<{}, IComponentBar> implements IComponentHTMLView {...}

// Define IComponentFoo as optional and IComponentBar as required
export class DiceRoller extends PrimedComponent<IComponentFoo, IComponentBar> implements IComponentHTMLView {...}
```

#### modules exposed as `this.scope`
Developers will have access to a `this.scope` object that will be typed correctly to the `optional`&`required` types they defined.

```typescript
// Define IComponentFoo as required
export class DiceRoller extends PrimedComponent<IComponentFoo, IComponentBar>{
    // ...
    protected async componentHasInitialized() {
        // ? required because it's IComponentFoo | undefined
        this.scope.IComponentFoo?.foo();

        // IComponentBar will always be available
        this.scope.IComponentBar.bar();
    }
    // ...
}
```

#### Factory symbols now required
As well as defining the types in PrimedComponents developers are required to pass in a string identifier into their factory that denotes the interfaces they've declared (this is because interfaces don't exist at runtime and we need to construct the scope object correctly)

These params are typed so you can only input the interfaces you've defined and you have to input them. You'll also notice that `PrimedComponentFactory` pull the types from `DiceRoller` so we don't need to define them again.

```typescript
export const DiceRollerInstantiationFactory = new PrimedComponentFactory(
    DiceRoller,
    {IComponentFoo}, // OPTIONAL
    {IComponentBar}, // REQUIRED
);
```

#### Create will fail if container does not support required modules
One of the cool things about this change is that because we know the required modules for a Component we can check them against the current container before creating the component. Building off of @heliocliu work in the create call we now check to see if the required services are met by the Container in the Factory. We also expose a `canCreateComponent` that others can use to see if the component will fail due to required modules not being on the container. This all happens in `SharedComponentFactory`


### Container Developers

This still need thought but currently they need to create and inject a `ModuleManager` into the runtime. As I said above this needs to be improved so I won't go into the details.

**Things to note:** If the Hosting Application provides a ModuleManager it will be registered as the parent. Resolution happens from child to parent so if the Container doesn't provide it we will look to the HostingApplication. ModuleManager expose information so the Container can see what the Hosting Application provided and not provide or overwrite their services.