### PR TITLE
Updated TestResolver to get documentId from the passed request

### DIFF
--- a/packages/hosts/local-web-host/src/index.ts
+++ b/packages/hosts/local-web-host/src/index.ts
@@ -51,7 +51,8 @@ export async function createLocalContainerFactory(
         {},
         new Map<string, IProxyLoaderFactory>());
 
-    const url = "fluid://localhost/localContainer";
+    const documentId = uuid();
+    const url = `fluid://localhost/${documentId}`;
 
     return async () => {
 

--- a/packages/hosts/local-web-host/src/index.ts
+++ b/packages/hosts/local-web-host/src/index.ts
@@ -25,9 +25,7 @@ export async function createLocalContainerFactory(
     entryPoint: Partial<IProvideRuntimeFactory & IProvideComponentFactory & IFluidModule>,
 ): Promise<() => Promise<Container>> {
 
-    const documentId = uuid();
-
-    const urlResolver = new TestResolver(documentId);
+    const urlResolver = new TestResolver();
 
     const deltaConn = LocalDeltaConnectionServer.create();
     const documentServiceFactory = new TestDocumentServiceFactory(deltaConn);
@@ -53,9 +51,11 @@ export async function createLocalContainerFactory(
         {},
         new Map<string, IProxyLoaderFactory>());
 
+    const url = "fluid://localhost/localContainer";
+
     return async () => {
 
-        const container = await loader.resolve({ url: documentId });
+        const container = await loader.resolve({ url });
 
         await initializeContainerCode(container, {} as any as IFluidCodeDetails);
 

--- a/packages/server/local-test-utils/src/testDataStore.ts
+++ b/packages/server/local-test-utils/src/testDataStore.ts
@@ -47,7 +47,7 @@ export class TestDataStore {
             { blockUpdateMarkers: true },
             scope || {},
             new Map<string, IProxyLoaderFactory>());
-        const baseUrl = `https://test.com/tenantId/documentId/${encodeURIComponent(componentId)}`;
+        const baseUrl = `https://test.com/${encodeURIComponent(componentId)}`;
         const url = `${baseUrl}${
             // Ensure '/' separator when concatenating 'baseUrl' and 'path'.
             (path && path.charAt(0)) !== "/" ? "/" : ""

--- a/packages/test/end-to-end/src/test/container.spec.ts
+++ b/packages/test/end-to-end/src/test/container.spec.ts
@@ -20,11 +20,13 @@ import { MockDocumentDeltaConnection } from "@microsoft/fluid-test-loader-utils"
 import { LocalCodeLoader } from "@microsoft/fluid-test-utils";
 
 describe("Container", () => {
+    const id = "fluid-test://localhost/containerTest";
+    const testRequest: IRequest = { url: id };
+
     let testDeltaConnectionServer: ILocalDeltaConnectionServer;
     let testResolver: TestResolver;
     let testResolved: IFluidResolvedUrl;
     let deltaConnection: MockDocumentDeltaConnection;
-    const testRequest: IRequest = { url: "" };
     let serviceFactory: Readonly<IDocumentServiceFactory>;
     let codeLoader: LocalCodeLoader;
     let loader: Loader;

--- a/packages/test/end-to-end/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/end-to-end/src/test/detachedContainerTests.spec.ts
@@ -17,7 +17,8 @@ import {
 } from "@microsoft/fluid-test-utils";
 
 describe("Detached Container", () => {
-    const id = "fluid-test://localhost/detachedContainerTest";
+    const documentId = "detachedContainerTest";
+    const id = `fluid-test://localhost/${documentId}`;
     const testRequest: IRequest = { url: id };
     const pkg: IFluidCodeDetails = {
         package: "detachedContainerTestPackage",
@@ -55,7 +56,7 @@ describe("Detached Container", () => {
         assert.equal(container.deltaManager.inbound.length, 0, "Inbound queue should be empty");
         assert.equal(container.connectionState, ConnectionState.Connected,
             "Container should be in connected state!!");
-        assert.equal(container.id, "documentId", "Doc id is not matching!!");
+        assert.equal(container.id, documentId, "Doc id is not matching!!");
     });
 
     it("Components in detached container", async () => {

--- a/packages/test/end-to-end/src/test/error.spec.ts
+++ b/packages/test/end-to-end/src/test/error.spec.ts
@@ -18,10 +18,12 @@ import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@micros
 import { LocalCodeLoader } from "@microsoft/fluid-test-utils";
 
 describe("Errors Types", () => {
+    const id = "fluid-test://localhost/errorTest";
+    const testRequest: IRequest = { url: id };
+
     let testDeltaConnectionServer: ILocalDeltaConnectionServer;
     let testResolver: TestResolver;
     let testResolved: IFluidResolvedUrl;
-    const testRequest: IRequest = { url: "" };
     let serviceFactory: IDocumentServiceFactory;
     let codeLoader: LocalCodeLoader;
     let loader: Loader;

--- a/packages/test/utils/src/localLoader.ts
+++ b/packages/test/utils/src/localLoader.ts
@@ -31,7 +31,7 @@ export function createLocalLoader(
     deltaConnectionServer: ILocalDeltaConnectionServer,
 ): ILoader {
 
-    const urlResolver = new TestResolver("documentId", deltaConnectionServer);
+    const urlResolver = new TestResolver(deltaConnectionServer);
     const documentServiceFactory = new TestDocumentServiceFactory(deltaConnectionServer);
     const codeLoader: ICodeLoader = new LocalCodeLoader(packageEntries);
 

--- a/packages/tools/webpack-component-loader/src/loader.ts
+++ b/packages/tools/webpack-component-loader/src/loader.ts
@@ -103,7 +103,7 @@ function wrapIfComponentPackage(packageJson: IFluidPackage, fluidModule: IFluidM
     return fluidModule;
 }
 
-function getUrlResolver(documentId: string, options: RouteOptions): IUrlResolver {
+function getUrlResolver(options: RouteOptions): IUrlResolver {
     switch (options.mode) {
         case "docker":
             return new InsecureUrlResolver(
@@ -142,7 +142,7 @@ function getUrlResolver(documentId: string, options: RouteOptions): IUrlResolver
                 { accessToken: options.odspAccessToken });
 
         default: // Local
-            return new TestResolver(documentId);
+            return new TestResolver();
     }
 }
 
@@ -227,7 +227,7 @@ export async function start(
         }
     }
 
-    const urlResolver = getUrlResolver(documentId, options);
+    const urlResolver = getUrlResolver(options);
 
     // Construct a request
     const url = window.location.href;


### PR DESCRIPTION
Fixes #1706.

Currently, TestResolver is bound to a single container because it uses a fixed documentId for resolving a request.
Updated it to extract the documentId from the passed request.