### PR TITLE
Perf/Scale improvements for Deli

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/clientSeqManager.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/clientSeqManager.ts
@@ -51,7 +51,7 @@ export class ClientSequenceNumberManager {
         const clients: IClientSequenceNumber[] = [];
         for (const [, value] of this.clientNodeMap) {
             const source = value.value;
-            clients.push({...source});
+            clients.push({ ...source });
         }
         return clients;
     }

--- a/server/routerlicious/packages/lambdas/src/deli/clientSeqManager.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/clientSeqManager.ts
@@ -51,8 +51,7 @@ export class ClientSequenceNumberManager {
         const clients: IClientSequenceNumber[] = [];
         for (const [, value] of this.clientNodeMap) {
             const source = value.value;
-            const copy = Object.assign({}, source);
-            clients.push(copy);
+            clients.push({...source});
         }
         return clients;
     }

--- a/server/routerlicious/packages/lambdas/src/deli/clientSeqManager.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/clientSeqManager.ts
@@ -51,7 +51,17 @@ export class ClientSequenceNumberManager {
     public cloneValues(): IClientSequenceNumber[] {
         const clients: IClientSequenceNumber[] = [];
         for (const [, value] of this.clientNodeMap) {
-            clients.push(_.clone(value.value));
+            const source = value.value;
+            const copy: IClientSequenceNumber = {
+                canEvict: source.canEvict,
+                clientId: source.clientId,
+                clientSequenceNumber: source.clientSequenceNumber,
+                lastUpdate: source.lastUpdate,
+                nack: source.nack,
+                referenceSequenceNumber: source.referenceSequenceNumber,
+                scopes: source.scopes,
+            };
+            clients.push(copy);
         }
         return clients;
     }

--- a/server/routerlicious/packages/lambdas/src/deli/clientSeqManager.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/clientSeqManager.ts
@@ -4,7 +4,6 @@
  */
 
 import { Heap, IComparer, IHeapNode } from "@microsoft/fluid-common-utils";
-import * as _ from "lodash";
 import { IClientSequenceNumber } from "./checkpointContext";
 
 const SequenceNumberComparer: IComparer<IClientSequenceNumber> = {
@@ -52,15 +51,7 @@ export class ClientSequenceNumberManager {
         const clients: IClientSequenceNumber[] = [];
         for (const [, value] of this.clientNodeMap) {
             const source = value.value;
-            const copy: IClientSequenceNumber = {
-                canEvict: source.canEvict,
-                clientId: source.clientId,
-                clientSequenceNumber: source.clientSequenceNumber,
-                lastUpdate: source.lastUpdate,
-                nack: source.nack,
-                referenceSequenceNumber: source.referenceSequenceNumber,
-                scopes: source.scopes,
-            };
+            const copy = Object.assign({}, source);
             clients.push(copy);
         }
         return clients;


### PR DESCRIPTION
As part of getting ready for our //build demo we've been running scale testing against our deployment of Routerlicious services. We noticed Deli becomes a bottleneck at some point, because it doesn't scale horizontally if there are a lot of clients connected to a single document.

After taking a series of performance profiles of the service with a large load on it, we pinpointed two things that this change is fixing:
- ~~`words` function in `node_modules/binary/index.js` was super hot, it's called from kafka client when reading data. It was using `obj[key]` property access with dynamically generated keys, which the JavaScript VM isn't able to optimize very well. I'm manually unrolling the loop and replacing `obj[key]` access with `obj.key`, which makes this method orders of magnitude faster.~~
- `cloneValues` in `clientSeqManager.ts` is using `clone()` from `lodash`, which is super slow because it's *reflecting* over the shape of the object being cloned. In a profile it would show up as being responsible for ~50% of CPU time. After changing with a manual clone it's down to ~20%. Still much more than it should, but much better than before. Somebody should probably look into making the entire checkpointing process better.

