### PR TITLE
Remove Waterpark exceptions

### DIFF
--- a/examples/components/external-component-loader/.eslintrc.js
+++ b/examples/components/external-component-loader/.eslintrc.js
@@ -6,8 +6,5 @@
 module.exports = {
     "extends": [
         "@microsoft/eslint-config-fluid"
-    ],
-    "rules": {
-        "@typescript-eslint/no-use-before-define": "off"
-    }
+    ]
 }

--- a/examples/components/external-component-loader/.eslintrc.js
+++ b/examples/components/external-component-loader/.eslintrc.js
@@ -8,7 +8,6 @@ module.exports = {
         "@microsoft/eslint-config-fluid"
     ],
     "rules": {
-        "@typescript-eslint/no-use-before-define": "off",
-        "@typescript-eslint/strict-boolean-expressions": "off"
+        "@typescript-eslint/no-use-before-define": "off"
     }
 }

--- a/examples/components/external-component-loader/src/urlRegistry.ts
+++ b/examples/components/external-component-loader/src/urlRegistry.ts
@@ -81,8 +81,7 @@ export class UrlRegistry implements IComponentRegistry {
             const entrypointName = fluidPackage.fluid.browser.umd.library;
             const scripts = fluidPackage.fluid.browser.umd.files;
 
-            if (entrypointName && scripts) {
-
+            if (entrypointName !== undefined && scripts !== undefined) {
                 while (this.loadingEntrypoints.has(entrypointName)) {
                     await this.loadingEntrypoints.get(entrypointName);
                 }

--- a/examples/components/external-component-loader/src/urlRegistry.ts
+++ b/examples/components/external-component-loader/src/urlRegistry.ts
@@ -38,8 +38,7 @@ export class UrlRegistry implements IComponentRegistry {
 
     public get IComponentRegistry() { return this; }
 
-    public async get(name: string): Promise<ComponentRegistryEntry> {
-
+    public async get(name: string): Promise<ComponentRegistryEntry | undefined> {
         if (!this.urlRegistryMap.has(name)
             && (name.startsWith("http://") || name.startsWith("https://"))) {
 
@@ -96,7 +95,7 @@ export class UrlRegistry implements IComponentRegistry {
                         scripts.map(
                             async (bundle) => loadScript(`${name}/${bundle}`));
 
-                    const errors = [];
+                    const errors: any[] = [];
                     while (scriptLoadPromises.length > 0) {
                         try {
                             await scriptLoadPromises.shift();

--- a/examples/components/external-component-loader/src/urlRegistry.ts
+++ b/examples/components/external-component-loader/src/urlRegistry.ts
@@ -10,6 +10,25 @@ import {
     IComponentRegistry,
 } from "@microsoft/fluid-runtime-definitions";
 
+// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+async function loadScript(scriptUrl: string): Promise<{}> {
+    return new Promise((resolve, reject) => {
+        const script = document.createElement("script");
+        script.src = scriptUrl;
+
+        // Dynamically added scripts are async by default. By setting async to false, we are enabling the scripts
+        // to be downloaded in parallel, but executed in order. This ensures that a script is executed after all of
+        // its dependencies have been loaded and executed.
+        script.async = false;
+
+        script.onload = resolve;
+        script.onerror = () => reject(new Error(`Failed to download the script at url: ${scriptUrl}`));
+
+        document.head.appendChild(script);
+    });
+}
+
+
 /**
  * A component registry that can load component via their url
  */
@@ -123,22 +142,4 @@ export class UrlRegistry implements IComponentRegistry {
             }
         }
     }
-}
-
-// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
-async function loadScript(scriptUrl: string): Promise<{}> {
-    return new Promise((resolve, reject) => {
-        const script = document.createElement("script");
-        script.src = scriptUrl;
-
-        // Dynamically added scripts are async by default. By setting async to false, we are enabling the scripts
-        // to be downloaded in parallel, but executed in order. This ensures that a script is executed after all of
-        // its dependencies have been loaded and executed.
-        script.async = false;
-
-        script.onload = resolve;
-        script.onerror = () => reject(new Error(`Failed to download the script at url: ${scriptUrl}`));
-
-        document.head.appendChild(script);
-    });
 }

--- a/examples/components/external-component-loader/src/urlRegistry.ts
+++ b/examples/components/external-component-loader/src/urlRegistry.ts
@@ -10,9 +10,8 @@ import {
     IComponentRegistry,
 } from "@microsoft/fluid-runtime-definitions";
 
-// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
-async function loadScript(scriptUrl: string): Promise<{}> {
-    return new Promise((resolve, reject) => {
+const loadScript = async (scriptUrl: string) => {
+    return new Promise<void>((resolve, reject) => {
         const script = document.createElement("script");
         script.src = scriptUrl;
 
@@ -21,13 +20,12 @@ async function loadScript(scriptUrl: string): Promise<{}> {
         // its dependencies have been loaded and executed.
         script.async = false;
 
-        script.onload = resolve;
+        script.onload = () => resolve();
         script.onerror = () => reject(new Error(`Failed to download the script at url: ${scriptUrl}`));
 
         document.head.appendChild(script);
     });
-}
-
+};
 
 /**
  * A component registry that can load component via their url

--- a/examples/components/external-component-loader/src/urlRegistry.ts
+++ b/examples/components/external-component-loader/src/urlRegistry.ts
@@ -10,8 +10,8 @@ import {
     IComponentRegistry,
 } from "@microsoft/fluid-runtime-definitions";
 
-const loadScript = async (scriptUrl: string) => {
-    return new Promise<void>((resolve, reject) => {
+const loadScript = async (scriptUrl: string) =>
+    new Promise<void>((resolve, reject) => {
         const script = document.createElement("script");
         script.src = scriptUrl;
 
@@ -25,7 +25,6 @@ const loadScript = async (scriptUrl: string) => {
 
         document.head.appendChild(script);
     });
-};
 
 /**
  * A component registry that can load component via their url

--- a/examples/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
+++ b/examples/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
@@ -60,15 +60,16 @@ export class ExternalComponentLoader extends PrimedComponent
             return;
         }
 
-        if (this.savedElement) {
-            while (this.savedElement.firstChild) {
+        if (this.savedElement !== undefined) {
+            // eslint-disable-next-line no-null/no-null
+            while (this.savedElement.firstChild !== null) {
                 this.savedElement.removeChild(this.savedElement.firstChild);
             }
         }
 
         this.savedElement = element;
 
-        if (this.savedElement) {
+        if (this.savedElement !== undefined) {
             const mainDiv = document.createElement("div");
             this.savedElement.appendChild(mainDiv);
 
@@ -109,12 +110,12 @@ export class ExternalComponentLoader extends PrimedComponent
             inputDiv.append(editableButton);
             editableButton.textContent = "Toggle Edit";
             editableButton.onclick = () => {
-                if (this.callbacks?.toggleEditable) {
+                if (this.callbacks?.toggleEditable !== undefined) {
                     this.callbacks.toggleEditable();
                 }
             };
 
-            if (this.error) {
+            if (this.error !== undefined) {
                 const errorDiv = document.createElement("div");
                 inputDiv.appendChild(errorDiv);
                 errorDiv.innerText = this.error;
@@ -124,7 +125,7 @@ export class ExternalComponentLoader extends PrimedComponent
 
     protected async componentHasInitialized() {
         const viewComponentHandle = this.root.get<IComponentHandle>(this.viewComponentMapID);
-        if (viewComponentHandle) {
+        if (viewComponentHandle !== undefined) {
             this.viewComponentP = viewComponentHandle.get();
         }
     }
@@ -161,7 +162,7 @@ export class ExternalComponentLoader extends PrimedComponent
             const pkgReg = await urlReg.IComponentRegistry.get(url) as IComponent;
             let componentRuntime: IComponentRuntime;
             const id = uuid();
-            if (pkgReg.IComponentDefaultFactoryName) {
+            if (pkgReg.IComponentDefaultFactoryName !== undefined) {
                 componentRuntime = await this.context.hostRuntime.createComponent(
                     id,
                     [
@@ -170,7 +171,7 @@ export class ExternalComponentLoader extends PrimedComponent
                         url,
                         pkgReg.IComponentDefaultFactoryName.getDefaultFactoryName(),
                     ]);
-            } else if (pkgReg.IComponentFactory) {
+            } else if (pkgReg.IComponentFactory !== undefined) {
                 componentRuntime = await this.context.hostRuntime.createComponent(
                     id,
                     [
@@ -195,7 +196,7 @@ export class ExternalComponentLoader extends PrimedComponent
             });
         } catch (error) {
             this.error = error;
-            if (this.savedElement) {
+            if (this.savedElement !== undefined) {
                 this.render(this.savedElement);
             }
         }

--- a/examples/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
+++ b/examples/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
@@ -56,7 +56,6 @@ export class ExternalComponentLoader extends PrimedComponent
     }
 
     public render(element: HTMLElement) {
-
         if (element === undefined) {
             return;
         }
@@ -130,65 +129,66 @@ export class ExternalComponentLoader extends PrimedComponent
         const value = input.value;
         input.value = "";
         this.error = undefined;
-        if (value !== undefined && value.length > 0) {
-            let url = value;
-            if (url.startsWith("@")) {
-                url = `https://pragueauspkn-3873244262.azureedge.net/${url}`;
-            }
-
-            try {
-                // eslint-disable-next-line @typescript-eslint/no-misused-promises
-                if (this.viewComponentP) {
-                    const viewComponent = await this.viewComponentP;
-                    if (viewComponent && viewComponent.IComponentCollection && this.runtime.IComponentRegistry) {
-                        const urlReg = await this.runtime.IComponentRegistry.get("url");
-                        const pkgReg = await urlReg.IComponentRegistry.get(url) as IComponent;
-                        let componentRuntime: IComponentRuntime;
-                        const id = uuid();
-                        if (pkgReg.IComponentDefaultFactoryName) {
-                            componentRuntime = await this.context.hostRuntime.createComponent(
-                                id,
-                                [
-                                    ...this.context.packagePath,
-                                    "url",
-                                    url,
-                                    pkgReg.IComponentDefaultFactoryName.getDefaultFactoryName(),
-                                ]);
-                        } else if (pkgReg.IComponentFactory) {
-                            componentRuntime = await this.context.hostRuntime.createComponent(
-                                id,
-                                [
-                                    ...this.context.packagePath,
-                                    "url",
-                                    url,
-                                ]);
-                        } else {
-                            throw new Error(`${url} is not a factory, and does not provide default component name`);
-                        }
-
-                        const response: IResponse = await componentRuntime.request({ url: "/" });
-                        let component: IComponent = response.value as IComponent;
-                        componentRuntime.attach();
-                        if (component.IComponentCollection !== undefined) {
-                            component = component.IComponentCollection.createCollectionItem();
-                        }
-                        viewComponent.IComponentCollection.createCollectionItem({
-                            handle: component.IComponentHandle,
-                            type: value,
-                            id,
-                        });
-                    } else {
-                        throw new Error("View component is empty or is not an IComponentCollection!!");
-                    }
-                } else {
-                    throw new Error("View component promise not set!!");
-                }
-            } catch (error) {
-                this.error = error;
-                this.render(this.savedElement);
-            }
-        } else {
+        if (value === undefined || value.length === 0) {
             input.style.backgroundColor = "#FEE";
+            return;
+        }
+
+        let url = value;
+        if (url.startsWith("@")) {
+            url = `https://pragueauspkn-3873244262.azureedge.net/${url}`;
+        }
+
+        try {
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
+            if (this.viewComponentP) {
+                const viewComponent = await this.viewComponentP;
+                if (viewComponent && viewComponent.IComponentCollection && this.runtime.IComponentRegistry) {
+                    const urlReg = await this.runtime.IComponentRegistry.get("url");
+                    const pkgReg = await urlReg.IComponentRegistry.get(url) as IComponent;
+                    let componentRuntime: IComponentRuntime;
+                    const id = uuid();
+                    if (pkgReg.IComponentDefaultFactoryName) {
+                        componentRuntime = await this.context.hostRuntime.createComponent(
+                            id,
+                            [
+                                ...this.context.packagePath,
+                                "url",
+                                url,
+                                pkgReg.IComponentDefaultFactoryName.getDefaultFactoryName(),
+                            ]);
+                    } else if (pkgReg.IComponentFactory) {
+                        componentRuntime = await this.context.hostRuntime.createComponent(
+                            id,
+                            [
+                                ...this.context.packagePath,
+                                "url",
+                                url,
+                            ]);
+                    } else {
+                        throw new Error(`${url} is not a factory, and does not provide default component name`);
+                    }
+
+                    const response: IResponse = await componentRuntime.request({ url: "/" });
+                    let component: IComponent = response.value as IComponent;
+                    componentRuntime.attach();
+                    if (component.IComponentCollection !== undefined) {
+                        component = component.IComponentCollection.createCollectionItem();
+                    }
+                    viewComponent.IComponentCollection.createCollectionItem({
+                        handle: component.IComponentHandle,
+                        type: value,
+                        id,
+                    });
+                } else {
+                    throw new Error("View component is empty or is not an IComponentCollection!!");
+                }
+            } else {
+                throw new Error("View component promise not set!!");
+            }
+        } catch (error) {
+            this.error = error;
+            this.render(this.savedElement);
         }
     }
 }

--- a/examples/components/external-component-loader/src/waterParkModuleInstantiationFactory.ts
+++ b/examples/components/external-component-loader/src/waterParkModuleInstantiationFactory.ts
@@ -6,6 +6,7 @@
 import {
     ContainerRuntimeFactoryWithDefaultComponent,
 } from "@microsoft/fluid-aqueduct";
+import { IComponent, IComponentLoadable } from "@microsoft/fluid-component-core-interfaces";
 import { IHostRuntime, NamedComponentRegistryEntries } from "@microsoft/fluid-runtime-definitions";
 import { SpacesComponentName } from "@fluid-example/spaces";
 import * as uuid from "uuid";
@@ -48,13 +49,13 @@ export class WaterParkModuleInstantiationFactory extends ContainerRuntimeFactory
     }
 
     protected async containerInitializingFirstTime(runtime: IHostRuntime) {
-        const viewComponent = await createAndAttachComponent<any>(
+        const viewComponent = await createAndAttachComponent<IComponent & IComponentLoadable>(
             runtime, ContainerRuntimeFactoryWithDefaultComponent.defaultComponentId, this.viewComponentName);
         const loaderComponent = await createAndAttachComponent<ExternalComponentLoader>(
             runtime, uuid(), this.loaderComponentName);
 
         // Only add the component toolbar if the view component supports it
-        if (viewComponent.IComponentToolbarConsumer) {
+        if (viewComponent.IComponentToolbarConsumer !== undefined) {
             await viewComponent.IComponentToolbarConsumer
                 .setComponentToolbar(loaderComponent.id, this.loaderComponentName, loaderComponent.handle);
         }

--- a/examples/components/external-component-loader/tsconfig.json
+++ b/examples/components/external-component-loader/tsconfig.json
@@ -5,7 +5,6 @@
         "node_modules"
     ],
     "compilerOptions": {
-        "strictNullChecks": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/packages/framework/view-adapters/src/htmlview/htmlViewAdapter.tsx
+++ b/packages/framework/view-adapters/src/htmlview/htmlViewAdapter.tsx
@@ -4,7 +4,7 @@
  */
 
 import { IComponent } from "@microsoft/fluid-component-core-interfaces";
-import { IComponentHTMLOptions, IComponentHTMLView, IComponentReactViewable } from "@microsoft/fluid-view-interfaces";
+import { IComponentHTMLOptions, IComponentHTMLView } from "@microsoft/fluid-view-interfaces";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
@@ -52,7 +52,7 @@ export class HTMLViewAdapter implements IComponentHTMLView {
 
         const reactViewable = this.component.IComponentReactViewable;
         if (reactViewable !== undefined) {
-            ReactDOM.render(<ReactViewableEmbeddedComponent component={reactViewable} />, elm);
+            ReactDOM.render(reactViewable.createJSXElement(), elm);
             return;
         }
 
@@ -114,12 +114,3 @@ export class HTMLViewAdapter implements IComponentHTMLView {
         }
     }
 }
-
-interface IReactProps {
-    component: IComponentReactViewable;
-}
-
-/**
- * Embeds a Fluid Component that supports IComponentReactViewable
- */
-const ReactViewableEmbeddedComponent = (props: IReactProps) => props.component.createJSXElement();

--- a/packages/framework/view-adapters/src/react/reactViewAdapter.tsx
+++ b/packages/framework/view-adapters/src/react/reactViewAdapter.tsx
@@ -4,7 +4,7 @@
  */
 
 import { IComponent } from "@microsoft/fluid-component-core-interfaces";
-import { IComponentHTMLView, IComponentHTMLVisual, IComponentReactViewable } from "@microsoft/fluid-view-interfaces";
+import { IComponentHTMLView, IComponentHTMLVisual } from "@microsoft/fluid-view-interfaces";
 import * as React from "react";
 
 export interface IEmbeddedComponentProps {
@@ -31,7 +31,7 @@ export class ReactViewAdapter extends React.Component<IEmbeddedComponentProps> {
 
         const reactViewable = this.props.component.IComponentReactViewable;
         if (reactViewable !== undefined) {
-            this.element = <ReactEmbeddedComponent component={reactViewable}/>;
+            this.element = reactViewable.createJSXElement();
             return;
         }
 
@@ -113,12 +113,3 @@ class HTMLVisualEmbeddedComponent extends React.Component<IHTMLVisualProps, { }>
         return <span style={this.props.style} ref={this.ref}></span>;
     }
 }
-
-interface IReactProps {
-    component: IComponentReactViewable;
-}
-
-/**
- * Embeds a Fluid Component that supports IComponentReactViewable
- */
-const ReactEmbeddedComponent = (props: IReactProps) => props.component.createJSXElement();


### PR DESCRIPTION
Enables strict null checks, strict boolean expressions, no use before define.  Also inverts some conditionals for less nesting, and a small simplification in the view adapters that's been bothering me.

Unfortunately I'm having trouble pulling packages from auspkn at the moment, so haven't been able to verify things are still working as expected, will make sure to do that before merging.