### PR TITLE
Add dispose event to container runtime

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -689,6 +689,17 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         ReportConnectionTelemetry(this.context.clientId, this.deltaManager, this.logger);
     }
 
+    public on(event: "batchEnd", listener: (error: any, op: ISequencedDocumentMessage) => void): this;
+    public on(event: "dirtyDocument" | "disconnected" | "dispose" | "savedDocument", listener: () => void): this;
+    public on(event: "leader" | "noleader", listener: (clientId?: string) => void): this;
+    public on(event: "localHelp", listener: (message: IHelpMessage) => void): this;
+    public on(event: "op", listener: (message: ISequencedDocumentMessage) => void): this;
+    public on(event: "signal", listener: (message: IInboundSignalMessage, local: boolean) => void): this;
+
+    public on(event: string | symbol, listener: (...args: any[]) => void): this {
+        return super.on(event, listener);
+    }
+
     public dispose(): void {
         if (this._disposed) {
             return;
@@ -706,6 +717,9 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
                 this.logger.sendErrorEvent({ eventName: "ComponentContextDisposeError", componentId }, error);
             });
         }
+
+        this.emit("dispose");
+        this.removeAllListeners();
     }
 
     public get IComponentTokenProvider() {
@@ -1029,10 +1043,6 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         if (this.leader) {
             this.runTaskAnalyzer();
         }
-    }
-
-    public on(event: string | symbol, listener: (...args: any[]) => void): this {
-        return super.on(event, listener);
     }
 
     /**

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -690,8 +690,12 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
     }
 
     public on(event: "batchEnd", listener: (error: any, op: ISequencedDocumentMessage) => void): this;
-    public on(event: "dirtyDocument" | "disconnected" | "dispose" | "savedDocument", listener: () => void): this;
-    public on(event: "leader" | "noleader", listener: (clientId?: string) => void): this;
+    public on(
+        event: "dirtyDocument" | "disconnected" | "dispose" | "savedDocument",
+        listener: () => void): this;
+    public on(
+        event: "leader" | "noleader",
+        listener: (clientId?: string) => void): this;
     public on(event: "localHelp", listener: (message: IHelpMessage) => void): this;
     public on(event: "op", listener: (message: ISequencedDocumentMessage) => void): this;
     public on(event: "signal", listener: (message: IInboundSignalMessage, local: boolean) => void): this;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -689,21 +689,6 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         ReportConnectionTelemetry(this.context.clientId, this.deltaManager, this.logger);
     }
 
-    public on(event: "batchEnd", listener: (error: any, op: ISequencedDocumentMessage) => void): this;
-    public on(
-        event: "dirtyDocument" | "disconnected" | "dispose" | "savedDocument",
-        listener: () => void): this;
-    public on(
-        event: "leader" | "noleader",
-        listener: (clientId?: string) => void): this;
-    public on(event: "localHelp", listener: (message: IHelpMessage) => void): this;
-    public on(event: "op", listener: (message: ISequencedDocumentMessage) => void): this;
-    public on(event: "signal", listener: (message: IInboundSignalMessage, local: boolean) => void): this;
-
-    public on(event: string | symbol, listener: (...args: any[]) => void): this {
-        return super.on(event, listener);
-    }
-
     public dispose(): void {
         if (this._disposed) {
             return;
@@ -1052,6 +1037,10 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
         if (this.leader) {
             this.runTaskAnalyzer();
         }
+    }
+
+    public on(event: string | symbol, listener: (...args: any[]) => void): this {
+        return super.on(event, listener);
     }
 
     /**

--- a/packages/runtime/runtime-definitions/src/components.ts
+++ b/packages/runtime/runtime-definitions/src/components.ts
@@ -28,6 +28,7 @@ import {
     ConnectionState,
     IClientDetails,
     IDocumentMessage,
+    IHelpMessage,
     IQuorum,
     ISequencedDocumentMessage,
     ISnapshotTree,
@@ -36,6 +37,7 @@ import {
 } from "@microsoft/fluid-protocol-definitions";
 
 import { IProvideComponentRegistry } from "./componentRegistry";
+import { IInboundSignalMessage } from "./protocol";
 import { IChannel } from ".";
 
 /**
@@ -382,6 +384,18 @@ export interface IHostRuntime extends
     readonly submitSignalFn: (contents: any) => void;
     readonly snapshotFn: (message: string) => Promise<void>;
     readonly scope: IComponent;
+
+    on(event: "batchBegin", listener: (op: ISequencedDocumentMessage) => void): this;
+    on(event: "batchEnd", listener: (error: any, op: ISequencedDocumentMessage) => void): this;
+    on(
+        event: "dirtyDocument" | "disconnected" | "dispose" | "savedDocument",
+        listener: () => void): this;
+    on(
+        event: "leader" | "noleader",
+        listener: (clientId?: string) => void): this;
+    on(event: "localHelp", listener: (message: IHelpMessage) => void): this;
+    on(event: "op", listener: (message: ISequencedDocumentMessage) => void): this;
+    on(event: "signal", listener: (message: IInboundSignalMessage, local: boolean) => void): this;
 
     /**
      * Returns the runtime of the component.

--- a/packages/runtime/runtime-definitions/src/components.ts
+++ b/packages/runtime/runtime-definitions/src/components.ts
@@ -388,10 +388,10 @@ export interface IHostRuntime extends
     on(event: "batchBegin", listener: (op: ISequencedDocumentMessage) => void): this;
     on(event: "batchEnd", listener: (error: any, op: ISequencedDocumentMessage) => void): this;
     on(
-        event: "dirtyDocument" | "disconnected" | "dispose" | "savedDocument",
+        event: "dirtyDocument" | "disconnected" | "dispose" | "joining" | "savedDocument",
         listener: () => void): this;
     on(
-        event: "leader" | "noleader",
+        event: "connected" | "leader" | "noleader",
         listener: (clientId?: string) => void): this;
     on(event: "localHelp", listener: (message: IHelpMessage) => void): this;
     on(event: "op", listener: (message: ISequencedDocumentMessage) => void): this;


### PR DESCRIPTION
Fixes #1712
Contianer services don't directly register with the container runtime and instead hook in through events.  Container presence manager wants to do something on container runtime dispose, but the runtime can't call dispose on the presence manager, so we add the "dispose" event.

Also add "on" declarations for all of ContainerRuntime's emitted events for the listener type chex