### PR TITLE
Fix for ProseMirror not working properly.

### DIFF
--- a/examples/components/prosemirror/package.json
+++ b/examples/components/prosemirror/package.json
@@ -27,6 +27,7 @@
     "start:r11s": "webpack-dev-server --config webpack.config.js --package package.json --env.mode r11s",
     "start:spo": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo",
     "start:spo-df": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo-df",
+    "start:tinylicious": "webpack-dev-server --config webpack.config.js --package package.json --env.mode tinylicious",
     "tsc": "tsc",
     "verdaccio": "npm publish --registry https://packages.wu2.prague.office-int.com",
     "webpack": "webpack --env=\"production\"",

--- a/examples/components/prosemirror/src/fluidCollabManager.ts
+++ b/examples/components/prosemirror/src/fluidCollabManager.ts
@@ -301,6 +301,8 @@ export class FluidCollabManager extends EventEmitter implements IRichTextEditor 
 
         // eslint-disable-next-line dot-notation
         window["easyView"] = editorView;
+
+        return editorView;
     }
 
     private getCurrentState() {

--- a/examples/components/prosemirror/src/prosemirror.ts
+++ b/examples/components/prosemirror/src/prosemirror.ts
@@ -59,18 +59,11 @@ function createTreeMarkerOps(
 
 class ProseMirrorView implements IComponentHTMLView {
     private content: HTMLDivElement;
-    private readonly editorView: EditorView;
+    private editorView: EditorView;
     private textArea: HTMLDivElement;
-    private readonly collabManager: FluidCollabManager;
-
     public get IComponentHTMLView() { return this; }
 
-    public constructor(
-        private readonly text: SharedString,
-        private readonly runtime: IComponentRuntime,
-    ) {
-        this.collabManager = new FluidCollabManager(this.text, this.runtime.loader);
-    }
+    public constructor(private readonly collabManager: FluidCollabManager) {}
 
     public render(elm: HTMLElement, options?: IComponentHTMLOptions): void {
         // Create base textarea
@@ -91,7 +84,7 @@ class ProseMirrorView implements IComponentHTMLView {
         }
 
         if (!this.editorView) {
-            this.collabManager.setupEditor(this.textArea);
+            this.editorView = this.collabManager.setupEditor(this.textArea);
         }
     }
 
@@ -118,6 +111,7 @@ export class ProseMirror extends EventEmitter
     public text: SharedString;
     private root: ISharedMap;
     private collabManager: FluidCollabManager;
+    private view: ProseMirrorView;
 
     constructor(
         private readonly runtime: IComponentRuntime,
@@ -160,7 +154,10 @@ export class ProseMirror extends EventEmitter
     }
 
     public addView(): IComponentHTMLView {
-        return new ProseMirrorView(this.text, this.runtime);
+        if (!this.view) {
+            this.view = new ProseMirrorView(this.collabManager);
+        }
+        return this.view;
     }
 }
 


### PR DESCRIPTION
Fixes #1776.

The bug is that ProseMirror creates an instance of FluidCollabManager without creating an EditorView. So the local state of this collab manager is never updated and results in an assert when the remote state does not match the local state.

ProseMirror still partly works because ProseMirrorView creates another FluidCollabManager with an EditorView and that one works correctly.