### PR TITLE
Perform safe summarize on failed summary as well as nack

### DIFF
--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -468,8 +468,8 @@ export class RunningSummarizer implements IDisposable {
 
     private async trySummarizeCore(reason: string): Promise<void> {
         const result = await this.summarize(reason, false);
-        if (result === false) {
-            // On nack, try again in safe mode
+        if (result !== true) {
+            // On nack or error, try again in safe mode
             await this.summarize(reason, true);
         }
     }


### PR DESCRIPTION
Fixes #1793, because now we get an error when the server doesn't send a summary ack op, but still actually acked the summary.