### PR TITLE
Fix Shared Text Test

### DIFF
--- a/packages/server/local-test-utils/src/sessionStorageTestDb.ts
+++ b/packages/server/local-test-utils/src/sessionStorageTestDb.ts
@@ -131,7 +131,7 @@ class SessionStorageCollection<T> implements ICollection<T> {
         const presentVal = this.findOneInternal(value);
         // Only raise error when the object is present and the value is not equal.
         if (presentVal) {
-            if (presentVal._id === value._id) {
+            if (JSON.stringify(presentVal) === JSON.stringify(value)) {
                 return;
             }
             throw new Error("Existing Object!!");

--- a/packages/server/local-test-utils/src/sessionStorageTestDb.ts
+++ b/packages/server/local-test-utils/src/sessionStorageTestDb.ts
@@ -131,7 +131,7 @@ class SessionStorageCollection<T> implements ICollection<T> {
         const presentVal = this.findOneInternal(value);
         // Only raise error when the object is present and the value is not equal.
         if (presentVal) {
-            if (JSON.stringify(presentVal) === JSON.stringify(value)) {
+            if (presentVal._id === value._id) {
                 return;
             }
             throw new Error("Existing Object!!");


### PR DESCRIPTION
This test had a couple problems. It was including divs when getting the text, which included presence information, and it wasn't waiting for the document to converge. I ran the old version is a loop for 100 iterations which reproduced the failure. After the fix the test passed all 100 iterations.

Fixes #1752