### PR TITLE
Do not call token provider for a socket token in ODC

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
@@ -204,7 +204,7 @@ export class OdspDocumentService implements IDocumentService, IExperimentalDocum
     ) {
 
         this.joinSessionKey = `${this.odspResolvedUrl.hashedDocumentId}/joinsession`;
-
+        this.isOdc = isOdcOrigin(new URL(this.odspResolvedUrl.endpoints.snapshotStorageUrl).origin);
         this.logger = DebugLogger.mixinDebugLogger(
             "fluid:telemetry:OdspDriver",
             logger,

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
@@ -309,8 +309,9 @@ export class OdspDocumentService implements IDocumentService, IExperimentalDocum
         // Attempt to connect twice, in case we used expired token.
         return getWithRetryForTokenRefresh<IDocumentDeltaConnection>(async (refresh: boolean) => {
             // For ODC, we just use the token from joinsession
+            const socketTokenPromise = this.isOdc ? Promise.resolve("") : this.getWebsocketToken(refresh);
             const [websocketEndpoint, webSocketToken, io] =
-                await Promise.all([this.joinSession(), this.isOdc ? Promise.resolve("") : this.getWebsocketToken(refresh), this.socketIOClientP]);
+                await Promise.all([this.joinSession(), socketTokenPromise, this.socketIOClientP]);
 
             // This check exists because of a typescript bug.
             // Issue: https://github.com/microsoft/TypeScript/issues/33752

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
@@ -313,7 +313,7 @@ export class OdspDocumentService implements IDocumentService, IExperimentalDocum
                     this.joinSession(),
                     // For ODC, we just use the token from joinsession
                     this.isOdc ? Promise.resolve("") : this.getWebsocketToken(refresh),
-                    this.socketIOClientP
+                    this.socketIOClientP,
                 ]);
 
             // This check exists because of a typescript bug.

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
@@ -176,6 +176,7 @@ export class OdspDocumentService implements IDocumentService, IExperimentalDocum
 
     private readonly joinSessionKey: string;
 
+    private readonly isOdc: boolean;
 
     /**
      * @param appId - app id used for telemetry for network requests
@@ -209,7 +210,7 @@ export class OdspDocumentService implements IDocumentService, IExperimentalDocum
             logger,
             {
                 docId: this.odspResolvedUrl.hashedDocumentId,
-                odc: isOdcOrigin(new URL(this.odspResolvedUrl.endpoints.snapshotStorageUrl).origin),
+                odc: this.isOdc,
             });
 
         this.getStorageToken = async (refresh: boolean, name?: string) => {
@@ -311,7 +312,7 @@ export class OdspDocumentService implements IDocumentService, IExperimentalDocum
                 await Promise.all([
                     this.joinSession(),
                     // For ODC, we just use the token from joinsession
-                    isOdcOrigin(new URL(this.snapshotStorageUrl).origin) ? Promise.resolve("") : this.getWebsocketToken(refresh),
+                    this.isOdc ? Promise.resolve("") : this.getWebsocketToken(refresh),
                     this.socketIOClientP
                 ]);
 

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
@@ -308,13 +308,9 @@ export class OdspDocumentService implements IDocumentService, IExperimentalDocum
     public async connectToDeltaStream(client: IClient, mode: ConnectionMode): Promise<IDocumentDeltaConnection> {
         // Attempt to connect twice, in case we used expired token.
         return getWithRetryForTokenRefresh<IDocumentDeltaConnection>(async (refresh: boolean) => {
+            // For ODC, we just use the token from joinsession
             const [websocketEndpoint, webSocketToken, io] =
-                await Promise.all([
-                    this.joinSession(),
-                    // For ODC, we just use the token from joinsession
-                    this.isOdc ? Promise.resolve("") : this.getWebsocketToken(refresh),
-                    this.socketIOClientP,
-                ]);
+                await Promise.all([this.joinSession(), this.isOdc ? Promise.resolve("") : this.getWebsocketToken(refresh), this.socketIOClientP]);
 
             // This check exists because of a typescript bug.
             // Issue: https://github.com/microsoft/TypeScript/issues/33752


### PR DESCRIPTION
Skip calling token provider for ODC and just use the joinSession token

@GaryWilber @AndreiZe (because I can't seem to add reviewers)