### PR TITLE
Always Specifiy ClientId on Load From Snapshot

### DIFF
--- a/packages/runtime/merge-tree/src/snapshotLoader.ts
+++ b/packages/runtime/merge-tree/src/snapshotLoader.ts
@@ -100,6 +100,14 @@ export class SnapshotLoader {
         // TODO currently only assumes two levels of branching
         const branching = branchId === this.runtime.documentId ? 0 : 1;
 
+        // specify a default client id, "snapshot" here as we
+        // should enter collaboration/op sending mode if we load
+        // a snapshot in any case (summary or attach message)
+        // once we get a client id this will be called with that
+        // clientId in the connected event
+        // TODO: this won't support rehydrating a detached container
+        // we need to think more holistically about the dds state machine
+        // now that we differentiate attached vs local
         this.client.startOrUpdateCollaboration(
             this.runtime.clientId ?? "snapshot",
             // tslint:disable-next-line:no-suspicious-comment

--- a/packages/runtime/merge-tree/src/snapshotLoader.ts
+++ b/packages/runtime/merge-tree/src/snapshotLoader.ts
@@ -100,6 +100,14 @@ export class SnapshotLoader {
         // TODO currently only assumes two levels of branching
         const branching = branchId === this.runtime.documentId ? 0 : 1;
 
+        // specify a default client id, "snapshot" here as we
+        // should enter collaboration/op sending mode if we load
+        // a snapshot in any case(summary or attach message)
+        // once we get a client id this will be called with that
+        // clientId
+        // TODO: this won't support rehydrating a detached container
+        // we need to this more holistically about the dds state machine
+        // now that we differentiate attached vs local
         this.client.startOrUpdateCollaboration(
             this.runtime.clientId ?? "snapshot",
             // tslint:disable-next-line:no-suspicious-comment

--- a/packages/runtime/merge-tree/src/snapshotLoader.ts
+++ b/packages/runtime/merge-tree/src/snapshotLoader.ts
@@ -101,7 +101,7 @@ export class SnapshotLoader {
         const branching = branchId === this.runtime.documentId ? 0 : 1;
 
         this.client.startOrUpdateCollaboration(
-            this.runtime.clientId,
+            this.runtime.clientId ?? "snapshot",
             // tslint:disable-next-line:no-suspicious-comment
             // TODO: Make 'minSeq' non-optional once the new snapshot format becomes the default?
             //       (See https://github.com/microsoft/FluidFramework/issues/84)


### PR DESCRIPTION
in the change for startOrUpdateCollaboration i missed a case where we load from snapshot/attach message, in which case we need to start collaboration on the merge tree before we have a client id to apply outstanding ops. in that case we'll got back to the old behavior and specific a default client id until our real one shows up.