### PR TITLE
Always run spawned summarizer, but call stop immediately if shouldnt

### DIFF
--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -97,8 +97,17 @@ export class Summarizer implements ISummarizer {
             // Cleanup after running
             if (this.runtime.connected) {
                 if (this.runningSummarizer) {
-                    // let running summarizer finish
-                    await this.runningSummarizer.waitStop();
+                    // Let running summarizer finish if no other summarizer client in quorum
+                    let hasOtherSummarizerClient = false;
+                    for (const [clientId, member] of this.runtime.getQuorum().getMembers()) {
+                        if (clientId !== this.runtime.clientId && member.client.details?.type === "summarizer") {
+                            hasOtherSummarizerClient = true;
+                            break;
+                        }
+                    }
+                    if (hasOtherSummarizerClient === false) {
+                        await this.runningSummarizer.waitStop();
+                    }
                 }
                 this.runtime.closeFn(`Summarizer: ${this.stopReason ?? "runEnded"}`);
             }

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -44,6 +44,7 @@ export interface ISummarizer extends IComponentRouter, IComponentRunnable, IComp
      * Returns a promise that will be resolved with the next Summarizer after context reload
      */
     setSummarizer(): Promise<Summarizer>;
+    stop(reason?: string): void;
 }
 
 /**

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -265,15 +265,16 @@ export class SummaryManager extends EventEmitter implements IDisposable {
                 } else {
                     this.state = SummaryManagerState.Off;
                 }
-            }
-            this.setNextSummarizer(summarizer.setSummarizer());
-            this.run(summarizer);
-            const shouldSummarizeState = this.getShouldSummarizeState();
-            if (shouldSummarizeState.shouldSummarize === false) {
-                // eslint-disable-next-line max-len
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion
-                summarizer.stop!(shouldSummarizeState.stopReason);
-                this.state = SummaryManagerState.Off;
+            } else {
+                this.setNextSummarizer(summarizer.setSummarizer());
+                this.run(summarizer);
+                const shouldSummarizeState = this.getShouldSummarizeState();
+                if (shouldSummarizeState.shouldSummarize === false) {
+                    // eslint-disable-next-line max-len
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion
+                    summarizer.stop!(shouldSummarizeState.stopReason);
+                    this.state = SummaryManagerState.Off;
+                }
             }
         }, (error) => {
             this.logger.sendErrorEvent({ eventName: "CreateSummarizerError", attempt }, error);

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -263,10 +263,6 @@ export class SummaryManager extends EventEmitter implements IDisposable {
                 } else {
                     this.state = SummaryManagerState.Off;
                 }
-            } else if (this.quorumHeap.getSummarizerCount() > 0) {
-                // Do not call run at all if another summarizer already exists
-                summarizer.stop("otherSummarizer");
-                this.state = SummaryManagerState.Off;
             } else {
                 this.setNextSummarizer(summarizer.setSummarizer());
                 this.run(summarizer);

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -5,7 +5,7 @@
 
 import { EventEmitter } from "events";
 import { ITelemetryLogger, IDisposable } from "@microsoft/fluid-common-definitions";
-import { IComponent, IComponentRunnable, IRequest } from "@microsoft/fluid-component-core-interfaces";
+import { IComponent, IRequest } from "@microsoft/fluid-component-core-interfaces";
 import { IContainerContext, LoaderHeader } from "@microsoft/fluid-container-definitions";
 import { ChildLogger, Heap, IComparer, IHeapNode, PerformanceEvent, PromiseTimer } from "@microsoft/fluid-common-utils";
 import { ISequencedClient } from "@microsoft/fluid-protocol-definitions";

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -58,6 +58,13 @@ enum SummaryManagerState {
 const defaultMaxRestarts = 5;
 const defaultInitialDelayMs = 5000;
 
+type ShouldSummarizeState = {
+    shouldSummarize: true;
+} | {
+    shouldSummarize: false;
+    stopReason: string;
+};
+
 export class SummaryManager extends EventEmitter implements IDisposable {
     private readonly logger: ITelemetryLogger;
     private readonly quorumHeap = new QuorumHeap();
@@ -79,7 +86,7 @@ export class SummaryManager extends EventEmitter implements IDisposable {
     }
 
     private get shouldSummarize() {
-        return this.connected && !this.disposed && this.clientId === this.summarizer;
+        return this.getShouldSummarizeState().shouldSummarize === true;
     }
 
     constructor(
@@ -147,15 +154,15 @@ export class SummaryManager extends EventEmitter implements IDisposable {
         this.refreshSummarizer();
     }
 
-    private getStopReason(): string | undefined {
+    private getShouldSummarizeState(): ShouldSummarizeState {
         if (!this.connected) {
-            return "parentNotConnected";
+            return { shouldSummarize: false, stopReason: "parentNotConnected" };
         } else if (this.clientId !== this.summarizer) {
-            return "parentShouldNotSummarize";
+            return { shouldSummarize: false, stopReason: "parentShouldNotSummarize" };
         } else if (this.disposed) {
-            return "disposed";
+            return { shouldSummarize: false, stopReason: "disposed" };
         } else {
-            return undefined;
+            return { shouldSummarize: true };
         }
     }
 
@@ -170,9 +177,10 @@ export class SummaryManager extends EventEmitter implements IDisposable {
         // Transition states depending on shouldSummarize, which is a calculated
         // property that is only true if this client is connected and has the
         // computed summarizer client id
+        const shouldSummarizeState = this.getShouldSummarizeState();
         switch (this.state) {
             case SummaryManagerState.Off: {
-                if (this.shouldSummarize) {
+                if (shouldSummarizeState.shouldSummarize === true) {
                     this.start();
                 }
                 return;
@@ -183,7 +191,7 @@ export class SummaryManager extends EventEmitter implements IDisposable {
                 return;
             }
             case SummaryManagerState.Running: {
-                if (!this.shouldSummarize) {
+                if (shouldSummarizeState.shouldSummarize === false) {
                     // Only need to check defined in case we are between
                     // finally and then states; stopping should trigger
                     // a change in states when the running summarizer closes
@@ -191,7 +199,7 @@ export class SummaryManager extends EventEmitter implements IDisposable {
                     if (this.runningSummarizer) {
                         // eslint-disable-next-line max-len
                         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion
-                        this.runningSummarizer.stop!(this.getStopReason());
+                        this.runningSummarizer.stop!(shouldSummarizeState.stopReason);
                     }
                 }
                 return;
@@ -231,13 +239,14 @@ export class SummaryManager extends EventEmitter implements IDisposable {
                 } else {
                     this.state = SummaryManagerState.Off;
                 }
-            } else if (this.shouldSummarize) {
-                this.setNextSummarizer(summarizer.setSummarizer());
-                this.run(summarizer);
-            } else {
+            }
+            this.setNextSummarizer(summarizer.setSummarizer());
+            this.run(summarizer);
+            const shouldSummarizeState = this.getShouldSummarizeState();
+            if (shouldSummarizeState.shouldSummarize === false) {
                 // eslint-disable-next-line max-len
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion
-                summarizer.stop!(this.getStopReason());
+                summarizer.stop!(shouldSummarizeState.stopReason);
                 this.state = SummaryManagerState.Off;
             }
         }, (error) => {


### PR DESCRIPTION
The fix to perform one last summary after closing doesn't necessarily recover busted documents where the server is rejecting all main client ops, because the main client runs too slowly, disconnects and never calls `run` on the spawned summarizer.  Now it will always call `run` if created, but call `stop` immediately afterwards if needed.  This should give the summarizer a chance to run that "one last summary" on these busted docs to recover them.