### PR TITLE
Whitespace fixup for client packages and examples

### DIFF
--- a/examples/components/badge/package.json
+++ b/examples/components/badge/package.json
@@ -42,7 +42,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",

--- a/examples/components/badge/src/BadgeView.tsx
+++ b/examples/components/badge/src/BadgeView.tsx
@@ -48,7 +48,6 @@ export interface IBadgeViewState {
 }
 
 export class BadgeView extends React.Component<IBadgeViewProps, IBadgeViewState> {
-
     private readonly defaultColor: string = "#fff";
     private readonly animation: string = "all 0.15s ease-in";
     private readonly cardPadding: string = "16px 24px";

--- a/examples/components/blob-manager/package.json
+++ b/examples/components/blob-manager/package.json
@@ -35,7 +35,7 @@
     "@types/node": "^10.14.6"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@typescript-eslint/eslint-plugin": "~2.17.0",
     "@typescript-eslint/parser": "~2.17.0",

--- a/examples/components/canvas/package.json
+++ b/examples/components/canvas/package.json
@@ -42,7 +42,7 @@
     "@microsoft/fluid-view-interfaces": "^0.16.0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/components/chat/package.json
+++ b/examples/components/chat/package.json
@@ -37,7 +37,7 @@
     "request": "^2.88.0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",
     "@types/react-dom": "^16.9.4",

--- a/examples/components/chat/src/chat/index.tsx
+++ b/examples/components/chat/src/chat/index.tsx
@@ -20,7 +20,7 @@ export function renderChat(runtime: Runtime, hostElement: HTMLElement) {
 }
 
 function renderCore(runtime: Runtime, opHistory: ISequencedDocumentMessage[], hostElement: HTMLElement) {
-    const user = runtime.clientId? runtime.getQuorum().getMember(runtime.clientId) : undefined;
+    const user = runtime.clientId ? runtime.getQuorum().getMember(runtime.clientId) : undefined;
     const userName = (user?.client.user as any).name;
     ReactDOM.render(
         <Provider theme={themes.teams}>

--- a/examples/components/chat/src/runtime/runtime.ts
+++ b/examples/components/chat/src/runtime/runtime.ts
@@ -119,5 +119,4 @@ export class Runtime extends EventEmitter {
             throw new Error("Runtime is closed");
         }
     }
-
 }

--- a/examples/components/clicker/package.json
+++ b/examples/components/clicker/package.json
@@ -43,7 +43,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/components/clicker/src/agent.ts
+++ b/examples/components/clicker/src/agent.ts
@@ -8,7 +8,6 @@ import { Counter } from "@microsoft/fluid-map";
 
 // Sample agent to run.
 export class ClickerAgent implements IComponentRouter, IComponentRunnable {
-
     constructor(private readonly counter: Counter) { }
 
     public get IComponentRouter() { return this; }

--- a/examples/components/client-ui-lib/package.json
+++ b/examples/components/client-ui-lib/package.json
@@ -65,7 +65,7 @@
     "shape-detector": "^0.2.1"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/debug": "^0.0.31",
     "@types/jsdom": "^12.0.0",

--- a/examples/components/client-ui-lib/src/blob/blobUtils.ts
+++ b/examples/components/client-ui-lib/src/blob/blobUtils.ts
@@ -10,7 +10,6 @@ export async function blobUploadHandler(
     dragZone: HTMLDivElement,
     document: api.Document,
     blobDisplayCB: (file: IGenericBlob) => void) {
-
     dragZone.ondrop = (event) => {
         event.dataTransfer.dropEffect = "copy";
         event.preventDefault();

--- a/examples/components/client-ui-lib/src/controls/canvasCommon.ts
+++ b/examples/components/client-ui-lib/src/controls/canvasCommon.ts
@@ -20,7 +20,6 @@ export function getShapes(
     endPoint: IInkPoint,
     pen: IPen,
     circleInclusive: SegmentCircleInclusive): IShape[] {
-
     const dirVector = new Vector(
         endPoint.x - startPoint.x,
         endPoint.y - startPoint.y);

--- a/examples/components/client-ui-lib/src/controls/cursor.ts
+++ b/examples/components/client-ui-lib/src/controls/cursor.ts
@@ -123,5 +123,4 @@ export class Cursor {
     protected blinkCursor() {
         this.editSpan.classList.add("blinking");
     }
-
 }

--- a/examples/components/client-ui-lib/src/controls/flowContainer.ts
+++ b/examples/components/client-ui-lib/src/controls/flowContainer.ts
@@ -43,7 +43,6 @@ export class FlowContainer extends ui.Component {
         private readonly overlayInkMap: ISharedMap,
         private readonly image: Image,
         private readonly options?: Record<string, any>) {
-
         super(element);
 
         // TODO the below code is becoming controller like and probably doesn't belong in a constructor. Likely

--- a/examples/components/client-ui-lib/src/controls/flowView.ts
+++ b/examples/components/client-ui-lib/src/controls/flowView.ts
@@ -665,7 +665,6 @@ function showPositionInLine(
     text: string,
     cursorPos: number,
     presenceInfo?: ILocalPresenceInfo) {
-
     if (lineContext.deferredAttach) {
         addToRerenderList(lineContext);
     } else {
@@ -1284,7 +1283,6 @@ function renderTable(
     layoutInfo: ILayoutContext,
     targetTranslation: string,
     defer = false) {
-
     const flowView = layoutInfo.flowView;
     const sharedString = flowView.sharedString;
     const tablePos = sharedString.getPosition(table);
@@ -1499,7 +1497,6 @@ function gatherOverlayLayer(
     start: number,
     end: number,
     context: IOverlayMarker[]) {
-
     if (MergeTree.Marker.is(segment)) {
         if ((segment.refType === MergeTree.ReferenceType.Simple) &&
             (segment.hasSimpleType("inkOverlay"))) {
@@ -1568,7 +1565,7 @@ export interface IExcludedRectangle extends ui.Rectangle {
 }
 
 function makeExcludedRectangle(x: number, y: number, w: number, h: number, id?: string) {
-    const r = <IExcludedRectangle>new ui.Rectangle(x, y, w, h);
+    const r = <IExcludedRectangle> new ui.Rectangle(x, y, w, h);
     r.id = id;
     r.left = true;
     r.curY = 0;
@@ -1677,7 +1674,7 @@ export class Viewport {
                         exclu.floatL = true;
                     }
                 }
-                let excluDiv = <IRefDiv>this.viewHasInclusion(irdoc.referenceDocId);
+                let excluDiv = <IRefDiv> this.viewHasInclusion(irdoc.referenceDocId);
 
                 // Move the inclusion
                 if (excluDiv) {
@@ -2129,7 +2126,6 @@ function renderFlow(layoutContext: ILayoutContext, targetTranslation: string, de
         indentPct: number,
         indentSymbol: Paragraph.ISymbol,
         contentPct: number) {
-
         const pgBreaks = <IFlowBreakInfo[]>endPGMarker.cache.breaks;
         let lineDiv: ILineDiv;
         let lineDivHeight = docContext.defaultLineDivHeight;
@@ -3116,7 +3112,6 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
         public sharedString: Sequence.SharedString,
         public status: Status,
         public options?: Record<string, any>) {
-
         super(element);
 
         // Enable element to receive focus (see Example 1):
@@ -3488,7 +3483,6 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
                 }
                 elm = elm.previousElementSibling as ILineDiv;
             }
-
         } else {
             let elm = viewportDiv.firstElementChild as ILineDiv;
             while (elm) {
@@ -3578,7 +3572,6 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
                         position = targetLineDiv.lineEnd;
                     }
                 }
-
             } else if (elm.tagName === "SPAN") {
                 const span = this.getSegSpan(elm as ISegSpan);
                 if (span) {
@@ -5216,7 +5209,6 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
         refseq: number,
         oldpos: number,
         posAdjust = 0) {
-
         const remotePosInfo: IRemotePresenceInfo = {
             origMark: -1,
             origPos: oldpos + posAdjust,

--- a/examples/components/client-ui-lib/src/controls/overlayCanvas.ts
+++ b/examples/components/client-ui-lib/src/controls/overlayCanvas.ts
@@ -164,7 +164,6 @@ export class DrawingContext {
 
         this.updatePosition();
     }
-
 }
 
 /**
@@ -456,7 +455,7 @@ export class OverlayCanvas extends ui.Component {
         };
     }
 
-    /*// Returns a stroke in training format.
+    /* // Returns a stroke in training format.
     private printStroke(): string {
         let stroke = "points: [";
         for (let point of this.pointsToRecognize) {

--- a/examples/components/client-ui-lib/src/controls/title.ts
+++ b/examples/components/client-ui-lib/src/controls/title.ts
@@ -6,7 +6,6 @@
 import * as ui from "../ui";
 
 export class Title extends ui.Component {
-
     public viewportRect: ui.Rectangle;
     public viewportDiv: HTMLDivElement;
 

--- a/examples/components/client-ui-lib/src/controls/video.ts
+++ b/examples/components/client-ui-lib/src/controls/video.ts
@@ -63,7 +63,6 @@ export class Video extends ui.Component {
     }
 
     private async handleVideoMap() {
-
         this.videoMap.get("time").then((time) => {
             if (!isNaN(time)) {
                 this.video.currentTime = time;

--- a/examples/components/client-ui-lib/src/text/paragraph.ts
+++ b/examples/components/client-ui-lib/src/text/paragraph.ts
@@ -95,7 +95,6 @@ function makeGlue(
     textSegment: MergeTree.TextSegment,
     stretch: number,
     shrink: number) {
-
     return <IPGGlue>{ type: ParagraphItemType.Glue, width, text, segment: textSegment, stretch, shrink };
 }
 
@@ -245,7 +244,6 @@ export class ParagraphLexer<TContext> {
     }
 }
 
-
 export function clearContentCaches(pgMarker: IParagraphMarker) {
     pgMarker.cache = undefined;
     pgMarker.itemCache = undefined;
@@ -386,7 +384,6 @@ const maxListDistance = 400;
 
 export function getListCacheInfo(
     sharedString: SharedString, tile: IParagraphMarker, tilePos: number, precedingTileCache?: ITilePos[]) {
-
     if (isListTile(tile)) {
         if (tile.listCache === undefined) {
             if (tile.properties.series) {

--- a/examples/components/client-ui-lib/src/text/table.ts
+++ b/examples/components/client-ui-lib/src/text/table.ts
@@ -38,7 +38,6 @@ function createRelativeMarkerOp(
     relativePos1: MergeTree.IRelativePosition,
     id: string, refType: MergeTree.ReferenceType, rangeLabels: string[],
     tileLabels?: string[], props?: MergeTree.PropertySet) {
-
     if (!props) {
         props = <MergeTree.MapLike<any>>{
         };
@@ -65,7 +64,6 @@ export function createMarkerOp(
     pos1: number, id: string,
     refType: MergeTree.ReferenceType, rangeLabels: string[], tileLabels?: string[],
     props?: MergeTree.PropertySet) {
-
     if (!props) {
         props = <MergeTree.MapLike<any>>{
         };
@@ -95,7 +93,6 @@ function createCellBegin(
     cellEndId: string,
     cellId: string,
     extraProperties?: MergeTree.PropertySet) {
-
     const cellEndRelPos = <MergeTree.IRelativePosition>{
         before: true,
         id: cellEndId,
@@ -536,7 +533,6 @@ export class Column {
     }
 }
 
-
 export class Row {
     public table: Table;
     public pos: number;
@@ -718,7 +714,6 @@ export function parseColumns(sharedString: SharedString, pos: number, table: Tab
     return nextPos;
 }
 
-
 export function succinctPrintTable(tableMarker: ITableMarker, tableMarkerPos: number, sharedString: SharedString) {
     const id = tableMarker.getId();
     const endId = endPrefix + id;
@@ -811,7 +806,6 @@ export function insertHoleFixer(
 
 export function parseTable(
     tableMarker: ITableMarker, tableMarkerPos: number, sharedString: SharedString, fontInfo?: Paragraph.IFontInfo) {
-
     const id = tableMarker.getId();
     const endId = endPrefix + id;
     const endTableMarker = <MergeTree.Marker>sharedString.getMarkerFromId(endId);
@@ -863,4 +857,3 @@ export function parseTable(
 export const rowIsMoribund = (rowMarker: IRowMarker) => rowMarker.properties && rowMarker.properties.moribund;
 
 export const cellIsMoribund = (cellMarker: ICellMarker) => cellMarker.properties && cellMarker.properties.moribund;
-

--- a/examples/components/client-ui-lib/src/utils/youtubeHelper.ts
+++ b/examples/components/client-ui-lib/src/utils/youtubeHelper.ts
@@ -56,7 +56,6 @@ export class YouTubeWrapper {
     private readonly player: any;
 
     constructor(private videoId: string, divId: string, onPlayerLoad: (event) => void, onStateChange: (event) => void) {
-
         this.player = new window.YT.Player(divId, {
             events: {
                 onReady: (event) => {

--- a/examples/components/codemirror/package.json
+++ b/examples/components/codemirror/package.json
@@ -45,7 +45,7 @@
     "codemirror": "^5.48.4"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",

--- a/examples/components/codemirror/src/codemirror.ts
+++ b/examples/components/codemirror/src/codemirror.ts
@@ -197,7 +197,6 @@ class CodemirrorView implements IComponentHTMLView {
 export class CodeMirrorComponent
     extends EventEmitter
     implements IComponentLoadable, IComponentRouter, IComponentHTMLVisual {
-
     public static async load(runtime: IComponentRuntime, context: IComponentContext) {
         const collection = new CodeMirrorComponent(runtime, context);
         await collection.initialize();

--- a/examples/components/codemirror/src/presence.ts
+++ b/examples/components/codemirror/src/presence.ts
@@ -145,7 +145,6 @@ export class CodeMirrorPresenceManager extends EventEmitter {
         });
 
         this.presenceManager.on("newPresence", (presenceInfo: IPresenceInfo) => {
-
             const previousUserInfo = this.presenceMap.get(presenceInfo.userId);
 
             if (previousUserInfo) {
@@ -194,7 +193,6 @@ export class CodeMirrorPresenceManager extends EventEmitter {
             cursorDot.style.position = "absolute";
             cursorDot.style.marginTop = "-2px";
             cursor.appendChild(cursorDot);
-
 
             const newUserInfo: ICodeMirrorPresenceInfo = {
                 cursor,

--- a/examples/components/containers/monaco/package.json
+++ b/examples/components/containers/monaco/package.json
@@ -39,7 +39,7 @@
     "@microsoft/fluid-runtime-definitions": "^0.16.0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@typescript-eslint/eslint-plugin": "~2.17.0",
     "@typescript-eslint/parser": "~2.17.0",

--- a/examples/components/dice-roller/package.json
+++ b/examples/components/dice-roller/package.json
@@ -39,7 +39,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/components/draft-js/package.json
+++ b/examples/components/draft-js/package.json
@@ -45,7 +45,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/draft-js": "^0.10.34",

--- a/examples/components/draft-js/src/FluidEditor.tsx
+++ b/examples/components/draft-js/src/FluidEditor.tsx
@@ -155,7 +155,7 @@ export class FluidEditor extends React.Component<IProps, IState> {
                 const insertedText = newText.substring(start, newSelectionAbsolute.end);
 
                 if (insertedText.includes("\n")) {
-                    debugger; //TODO Can you paste newlines?
+                    debugger; // TODO Can you paste newlines?
                 }
 
                 const styleProp = draftStyleToSharedTextProp(editorState.getCurrentInlineStyle());

--- a/examples/components/drawer/package.json
+++ b/examples/components/drawer/package.json
@@ -50,7 +50,7 @@
     "semver": "^6.3.0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",

--- a/examples/components/external-component-loader/package.json
+++ b/examples/components/external-component-loader/package.json
@@ -49,7 +49,7 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/components/external-component-loader/src/urlRegistry.ts
+++ b/examples/components/external-component-loader/src/urlRegistry.ts
@@ -26,7 +26,6 @@ export class UrlRegistry implements IComponentRegistry {
     private readonly webloader = new WebCodeLoader(new SemVerCdnCodeResolver());
 
     constructor() {
-
         // Stash on the window so multiple instance can coordinate
         const loadingPackagesKey = `${UrlRegistry.WindowKeyPrefix}LoadingPackages`;
         if (window[loadingPackagesKey] === undefined) {
@@ -38,7 +37,6 @@ export class UrlRegistry implements IComponentRegistry {
     public get IComponentRegistry() { return this; }
 
     public async get(name: string): Promise<ComponentRegistryEntry | undefined> {
-
         if (!this.urlRegistryMap.has(name)) {
             this.urlRegistryMap.set(name, this.loadEntrypoint(name));
         }
@@ -46,9 +44,9 @@ export class UrlRegistry implements IComponentRegistry {
         return this.urlRegistryMap.get(name);
     }
 
-    private async loadEntrypoint(name: string): Promise<IComponent| undefined>{
-        if(this.isUrl(name)){
-            if(!this.loadingPackages.has(name)){
+    private async loadEntrypoint(name: string): Promise<IComponent| undefined> {
+        if (this.isUrl(name)) {
+            if (!this.loadingPackages.has(name)) {
                 this.loadingPackages.set(name, this.loadPackage(name));
             }
         }
@@ -78,12 +76,10 @@ export class UrlRegistry implements IComponentRegistry {
                 packageJson.fluid.browser.umd.files.map(
                     (file) => this.isUrl(file) ? file : `${url}/${file}`);
             return packageJson;
-
         }
     }
 
-    private isUrl(name: string){
+    private isUrl(name: string) {
         return name.startsWith("http://") || name.startsWith("https://");
     }
 }
-

--- a/examples/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
+++ b/examples/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
@@ -25,7 +25,6 @@ export const WaterParkLoaderName = `${pkg.name}-loader`;
  */
 export class ExternalComponentLoader extends PrimedComponent
     implements IComponentHTMLView, IComponentCallable<IComponentCallbacks> {
-
     private static readonly defaultComponents = [
         "@fluid-example/todo",
         "@fluid-example/math",

--- a/examples/components/external-component-loader/src/waterParkLoader/waterParkLoaderInstantiationFactory.ts
+++ b/examples/components/external-component-loader/src/waterParkLoader/waterParkLoaderInstantiationFactory.ts
@@ -14,4 +14,3 @@ export const WaterParkLoaderInstantiationFactory: IComponentFactory = new Primed
     [],
     [["url", Promise.resolve(new UrlRegistry())]],
 );
-

--- a/examples/components/flow-scroll/package.json
+++ b/examples/components/flow-scroll/package.json
@@ -54,7 +54,7 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-local-test-utils": "^0.16.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",

--- a/examples/components/flow-scroll/src/host/host.ts
+++ b/examples/components/flow-scroll/src/host/host.ts
@@ -180,7 +180,6 @@ export class HostView implements IComponentHTMLView, SearchMenu.ISearchMenuHost 
             ];
             /* eslint-enable max-len */
 
-
             const baseSearchCommands = new TST<SearchMenu.ISearchMenuCommand<HostView>>();
             for (const command of commands) {
                 baseSearchCommands.put(command.key, command);

--- a/examples/components/flow-scroll/src/host/template/index.ts
+++ b/examples/components/flow-scroll/src/host/template/index.ts
@@ -12,7 +12,7 @@ export async function importDoc(doc: FlowDocument, file: string) {
 
     try {
         while (true) {
-            const {done, value} = await reader.read();
+            const { done, value } = await reader.read();
             if (done) {
                 break;
             }

--- a/examples/components/flow-util-lib/package.json
+++ b/examples/components/flow-util-lib/package.json
@@ -52,7 +52,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/benchmark": "^1.0.31",
     "@types/mocha": "^5.2.5",

--- a/examples/components/flow-util-lib/src/resizeobserver/index.ts
+++ b/examples/components/flow-util-lib/src/resizeobserver/index.ts
@@ -13,13 +13,13 @@ const template = isBrowser && new Template(
         { tag: "div", ref: "observer", props: { className: style.observer }, children: [
             { tag: "div", ref: "expand", props: { className: style.expand }, children: [
                 { tag: "div", ref: "expandChild", props: { className: style.expandChild } },
-            ]},
+            ] },
             { tag: "div", ref: "shrink", props: { className: style.shrink }, children: [
-                { tag: "div", props: { className: style.shrinkChild }},
-            ]},
-        ]},
+                { tag: "div", props: { className: style.shrinkChild } },
+            ] },
+        ] },
         { tag: "span", ref: "slot" },
-    ]},
+    ] },
 );
 
 interface IResizeObserverInit {

--- a/examples/components/flow-util-lib/src/template.ts
+++ b/examples/components/flow-util-lib/src/template.ts
@@ -17,7 +17,7 @@ class Cursor {
     private static readonly previous = { suffix: "p", property: "previousElementSibling",  fn: (element: Element) => element.previousElementSibling };
     /* eslint-enable max-len */
 
-    public readonly pathFns = new Map<string, (element: Element) => Element>();
+    public readonly pathFns = new Map<string,(element: Element) => Element>();
     // eslint-disable-next-line no-null/no-null
     private element: Element | null = null;
     private path: string = "";
@@ -109,7 +109,7 @@ export class Template {
     }
 
     private readonly content: Element;
-    private readonly refs = new Map<string, (root: Element) => Element>();
+    private readonly refs = new Map<string,(root: Element) => Element>();
 
     constructor(content: ITemplateNode) {
         const refToPath = new Map<string, number[]>();

--- a/examples/components/flow-util-lib/test/sequence.ts
+++ b/examples/components/flow-util-lib/test/sequence.ts
@@ -5,5 +5,5 @@
 
 export function randomSequence(length: number) {
     // eslint-disable-next-line no-bitwise
-    return Array.from({length}, () => (Math.random() * length * 2) | 0);
+    return Array.from({ length }, () => (Math.random() * length * 2) | 0);
 }

--- a/examples/components/flow-util-lib/test/strings.spec.ts
+++ b/examples/components/flow-util-lib/test/strings.spec.ts
@@ -19,7 +19,7 @@ function test(left: string, right: string) {
     const leftAsString = typeof left === "string" ? `'${left}'` : `${left}`;
     const rightAsString = typeof right === "string" ? `'${right}'` : `${right}`;
 
-    it (`${leftAsString} ~= ${rightAsString} -> ${expected}`, () => {
+    it(`${leftAsString} ~= ${rightAsString} -> ${expected}`, () => {
         assert.strictEqual(areStringsEquivalent(left, right), expected);
     });
 }

--- a/examples/components/github-comment/package.json
+++ b/examples/components/github-comment/package.json
@@ -41,7 +41,7 @@
     "markdown-it": "^9.1.0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",

--- a/examples/components/github-comment/src/main.tsx
+++ b/examples/components/github-comment/src/main.tsx
@@ -108,7 +108,6 @@ export class GithubComment extends TextareaNoReact implements IComponentHTMLView
 
         return fluidComponent;
     }
-
 } // End GithubComment class
 
 /**

--- a/examples/components/image-collection/package.json
+++ b/examples/components/image-collection/package.json
@@ -38,7 +38,7 @@
     "@types/node": "^10.14.6"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@typescript-eslint/eslint-plugin": "~2.17.0",
     "@typescript-eslint/parser": "~2.17.0",

--- a/examples/components/image-gallery/package.json
+++ b/examples/components/image-gallery/package.json
@@ -37,7 +37,7 @@
     "react-image-gallery": "^0.9.1"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",
     "@types/react-dom": "^16.9.4",

--- a/examples/components/key-value-cache/package.json
+++ b/examples/components/key-value-cache/package.json
@@ -41,7 +41,7 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",

--- a/examples/components/key-value-cache/src/index.ts
+++ b/examples/components/key-value-cache/src/index.ts
@@ -49,7 +49,6 @@ declare module "@microsoft/fluid-component-core-interfaces" {
 }
 
 class KeyValue implements IKeyValue, IComponent, IComponentRouter {
-
     public static async load(runtime: IComponentRuntime, context: IComponentContext) {
         const kevValue = new KeyValue(runtime, context);
         await kevValue.initialize();
@@ -137,7 +136,6 @@ export class KeyValueFactoryComponent implements IRuntimeFactory, IComponentFact
         const pathForComponent = trailingSlash !== -1 ? requestUrl.substr(trailingSlash) : requestUrl;
         const component = await runtime.getComponentRuntime(componentId, true);
         return component.request({ url: pathForComponent });
-
     }
 
     public instantiateComponent(context: IComponentContext): void {

--- a/examples/components/markflow/package.json
+++ b/examples/components/markflow/package.json
@@ -47,7 +47,7 @@
     "remark": "^11.0.1"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-local-test-utils": "^0.16.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",

--- a/examples/components/markflow/src/document/index.ts
+++ b/examples/components/markflow/src/document/index.ts
@@ -475,7 +475,7 @@ export class FlowDocument extends PrimedComponent<IFlowDocumentEvents> {
     protected async componentHasInitialized() {
         const handle = await this.root.wait<IComponentHandle<SharedString>>("text");
         this.maybeSharedString = await handle.get();
-        if(this.maybeSharedString !== undefined){
+        if (this.maybeSharedString !== undefined) {
             this.forwardEvent(this.maybeSharedString, "sequenceDelta", "maintenance");
         }
     }

--- a/examples/components/markflow/src/host/host.ts
+++ b/examples/components/markflow/src/host/host.ts
@@ -22,18 +22,17 @@ const template = new Template(
                 { tag: "div", props: { className: styles.title }, children: [
                     { tag: "h1", ref: "titleText" },
                     { tag: "hr" },
-                ]},
+                ] },
                 { tag: "div", props: { className: styles.outline }, children: [
                     { tag: "p", ref: "slot", props: { className: styles.slot } },
-                ]},
-            ]},
-        ]},
-        { tag: "div", ref: "search", props: { className: styles.searchMenu }},
-        { tag: "div", ref: "status", props: { className: styles.status }},
-    ]});
+                ] },
+            ] },
+        ] },
+        { tag: "div", ref: "search", props: { className: styles.searchMenu } },
+        { tag: "div", ref: "status", props: { className: styles.status } },
+    ] });
 
 export class WebflowView implements IComponentHTMLView {
-
     public get IComponentHTMLView() { return this; }
 
     private searchMenu?: SearchMenuView;

--- a/examples/components/markflow/src/host/searchmenu/index.css.d.ts
+++ b/examples/components/markflow/src/host/searchmenu/index.css.d.ts
@@ -8,4 +8,3 @@ declare const styles: {
     readonly "input": string;
 };
 export = styles;
-

--- a/examples/components/markflow/src/markdown/index.css.d.ts
+++ b/examples/components/markflow/src/markdown/index.css.d.ts
@@ -30,4 +30,3 @@ declare const styles: {
     readonly "root": string;
 };
 export = styles;
-

--- a/examples/components/markflow/src/plaintext/formatter.ts
+++ b/examples/components/markflow/src/plaintext/formatter.ts
@@ -40,7 +40,6 @@ export class PlainTextFormatter<TState extends IFormatterState> extends RootForm
     public onChange() { }
 
     public onKeyDown(layout: Layout, state: Readonly<TState>, caret: Caret, e: KeyboardEvent) {
-
         switch (e.code) {
             // Note: Chrome 69 delivers backspace on 'keydown' only (i.e., 'keypress' is not fired.)
             case KeyCode.backspace: {

--- a/examples/components/math/package.json
+++ b/examples/components/math/package.json
@@ -46,7 +46,7 @@
     "katex": "^0.10.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/node": "^10.14.6",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/examples/components/math/src/mathComponent.ts
+++ b/examples/components/math/src/mathComponent.ts
@@ -415,7 +415,6 @@ export class MathView implements IComponentHTMLView, IComponentCursor, IComponen
 
         Caret.caretLeave(this.containerElement, cursorDirectionToDirection[direction], cursorElement.getBoundingClientRect());
     }
-
 }
 
 export class MathInstance extends EventEmitter implements IComponentLoadable, IComponentRouter,
@@ -668,7 +667,6 @@ export class MathCollection extends SharedComponent<ISharedDirectory> implements
                     const startPos = this.getStartPos(instance);
                     instance.remoteEdit(pos - startPos, len, event.deltaOperation === MergeTree.MergeTreeDeltaType.INSERT);
                 }
-
             }
         });
     }

--- a/examples/components/monaco/package.json
+++ b/examples/components/monaco/package.json
@@ -44,7 +44,7 @@
     "monaco-editor": "^0.15.6"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/examples/components/monaco/src/chaincode.ts
+++ b/examples/components/monaco/src/chaincode.ts
@@ -61,7 +61,6 @@ const defaultCompilerOptions = {
  */
 export class MonacoRunner extends PrimedComponent implements
     IComponentHTMLView, IComponentLayout {
-
     /**
      * Get a new MonacoRunner with the given runtime.
      * @param runtime The runtime for the MonacoRunner

--- a/examples/components/musica/package.json
+++ b/examples/components/musica/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.4.4",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",

--- a/examples/components/musica/src/PianoUtility.ts
+++ b/examples/components/musica/src/PianoUtility.ts
@@ -12,14 +12,14 @@ const firstNote = MidiNumbers.fromNote("c3");
 const lastNote = MidiNumbers.fromNote("f5");
 
 const presenceColors = [
-    "#8B0400" /*maroon*/,
-    "#BF5D24" /*orange*/,
-    "#E6AF1F" /*gold*/,
-    "#95A84F" /*olive green*/,
-    "#4AA02C" /*Leevi"s favorite color!!*/,
-    "#599E8E" /*seafoam green*/,
-    "#C791CB" /*light blue*/,
-    "#E73B65" /*pink*/,
+    "#8B0400" /* maroon */,
+    "#BF5D24" /* orange */,
+    "#E6AF1F" /* gold */,
+    "#95A84F" /* olive green */,
+    "#4AA02C" /* Leevi"s favorite color!! */,
+    "#599E8E" /* seafoam green */,
+    "#C791CB" /* light blue */,
+    "#E73B65" /* pink */,
 ];
 
 // Exports

--- a/examples/components/musica/src/index.tsx
+++ b/examples/components/musica/src/index.tsx
@@ -30,7 +30,6 @@ export class Musica extends PrimedComponent implements IComponentHTMLView {
 
     protected async componentHasInitialized() {
         this.player = new Player(audioContext);
-
     }
 
     private player: Player | undefined;

--- a/examples/components/owned-map/package.json
+++ b/examples/components/owned-map/package.json
@@ -45,7 +45,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",

--- a/examples/components/owned-map/src/index.tsx
+++ b/examples/components/owned-map/src/index.tsx
@@ -70,7 +70,6 @@ export class OwnedMap extends PrimedComponent implements IComponentHTMLView {
     }
 
     private doRender(host: HTMLElement) {
-
         let title = "Not Defined Yet!";
         let amOwner = false;
         let change = (e) => alert("Map Not defined");
@@ -85,7 +84,6 @@ export class OwnedMap extends PrimedComponent implements IComponentHTMLView {
             } else {
                 console.log(" Non Owner");
             }
-
         }
 
         ReactDOM.render(

--- a/examples/components/owned-map/src/ownedMapFactory.ts
+++ b/examples/components/owned-map/src/ownedMapFactory.ts
@@ -33,7 +33,6 @@ export class OwnedMapFactory implements ISharedObjectFactory {
         services: ISharedObjectServices,
         branchId: string,
         attributes: IChannelAttributes): Promise<ISharedMap> {
-
         const map = new OwnedSharedMap(id, runtime, attributes);
         await map.load(branchId, services);
 

--- a/examples/components/persona/package.json
+++ b/examples/components/persona/package.json
@@ -47,7 +47,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",

--- a/examples/components/pollster/package.json
+++ b/examples/components/pollster/package.json
@@ -38,7 +38,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",
     "@types/react": "^16.9.15",

--- a/examples/components/pond/package.json
+++ b/examples/components/pond/package.json
@@ -43,7 +43,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/components/pond/src/index.tsx
+++ b/examples/components/pond/src/index.tsx
@@ -34,7 +34,6 @@ export const PondName = pkg.name as string;
  *  - Component creation and storage using Handles
  */
 export class Pond extends PrimedComponent implements IComponentHTMLView {
-
     private readonly clickerKey = "clicker";
     private readonly clickerWithInitialValueKey = "clicker-with-initial-value";
 

--- a/examples/components/pond/src/internal-components/clicker.tsx
+++ b/examples/components/pond/src/internal-components/clicker.tsx
@@ -111,7 +111,7 @@ class CounterReactView extends React.Component<CounterProps, CounterState> {
 
     render() {
         return (
-            <div style={{border: "1px dotted blue"}}>
+            <div style={{ border: "1px dotted blue" }}>
                 <h3>Clicker</h3>
                 <h5>Clicker on the root directory increments 1</h5>
                 <div>

--- a/examples/components/pond/src/internal-components/clickerWithInitialValue.tsx
+++ b/examples/components/pond/src/internal-components/clickerWithInitialValue.tsx
@@ -87,7 +87,6 @@ export class ClickerWithInitialValueFactory extends PrimedComponentFactory {
     );
 }
 
-
 // ----- REACT STUFF -----
 
 interface CounterProps {
@@ -120,7 +119,7 @@ class CounterReactView extends React.Component<CounterProps, CounterState> {
 
     render() {
         return (
-            <div style={{border: "1px dotted red"}}>
+            <div style={{ border: "1px dotted red" }}>
                 <h3>Clicker With Initial Value</h3>
                 <h5>Created with initial value of 100. Increments 5.</h5>
                 <div>

--- a/examples/components/primitives/package.json
+++ b/examples/components/primitives/package.json
@@ -39,7 +39,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",

--- a/examples/components/progress-bars/package.json
+++ b/examples/components/progress-bars/package.json
@@ -37,7 +37,7 @@
     "bootstrap": "^3.3.7"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@typescript-eslint/eslint-plugin": "~2.17.0",
     "@typescript-eslint/parser": "~2.17.0",

--- a/examples/components/progress-bars/src/progressBars.ts
+++ b/examples/components/progress-bars/src/progressBars.ts
@@ -122,7 +122,6 @@ export class ProgressBar extends EventEmitter implements
 export class ProgressCollection
     extends EventEmitter
     implements IComponentLoadable, IComponentRouter, IComponentCollection {
-
     public static async load(runtime: IComponentRuntime, context: IComponentContext) {
         const collection = new ProgressCollection(runtime, context);
         await collection.initialize();

--- a/examples/components/prosemirror/package.json
+++ b/examples/components/prosemirror/package.json
@@ -60,7 +60,7 @@
     "prosemirror-view": "^1.10.3"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",

--- a/examples/components/prosemirror/src/prompt.ts
+++ b/examples/components/prosemirror/src/prompt.ts
@@ -164,7 +164,6 @@ export class TextField extends Field {
     }
 }
 
-
 // ::- A field class for dropdown fields based on a plain `<select>`
 // tag. Expects an option `options`, which should be an array of
 // `{value: string, label: string}` objects, or a function taking a

--- a/examples/components/prosemirror/src/prosemirror.ts
+++ b/examples/components/prosemirror/src/prosemirror.ts
@@ -34,7 +34,6 @@ function createTreeMarkerOps(
     endMarkerPos: number,
     nodeType: string,
 ): IMergeTreeInsertMsg[] {
-
     const endMarkerProps = createMap<any>();
     endMarkerProps[reservedRangeLabelsKey] = [treeRangeLabel];
     endMarkerProps[nodeTypeKey] = nodeType;

--- a/examples/components/scoreboard/package.json
+++ b/examples/components/scoreboard/package.json
@@ -37,7 +37,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",

--- a/examples/components/scoreboard/src/winnerText.tsx
+++ b/examples/components/scoreboard/src/winnerText.tsx
@@ -17,7 +17,6 @@ interface WinnerTextState {
 }
 
 export class WinnerText extends React.Component<WinnerTextProps, WinnerTextState> {
-
     constructor(props: WinnerTextProps) {
         super(props);
         this.state = WinnerText.determineWinner(props.directory);

--- a/examples/components/scribe/package.json
+++ b/examples/components/scribe/package.json
@@ -46,7 +46,7 @@
     "bootstrap": "^3.3.7"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/examples/components/scribe/src/scribe.ts
+++ b/examples/components/scribe/src/scribe.ts
@@ -376,7 +376,6 @@ const html =
 export class Scribe
     extends EventEmitter
     implements IComponentLoadable, IComponentRouter, IComponentHTMLView {
-
     public static async load(runtime: IComponentRuntime, context: IComponentContext) {
         const collection = new Scribe(runtime, context);
         await collection.initialize();

--- a/examples/components/search-menu/package.json
+++ b/examples/components/search-menu/package.json
@@ -27,7 +27,7 @@
     "@types/node": "^10.14.6"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@typescript-eslint/eslint-plugin": "~2.17.0",
     "@typescript-eslint/parser": "~2.17.0",

--- a/examples/components/search-menu/src/cursor.ts
+++ b/examples/components/search-menu/src/cursor.ts
@@ -123,5 +123,4 @@ export class Cursor {
     protected blinkCursor() {
         this.editSpan.classList.add("blinking");
     }
-
 }

--- a/examples/components/search-menu/src/searchMenu.ts
+++ b/examples/components/search-menu/src/searchMenu.ts
@@ -96,7 +96,6 @@ export function selectionListBoxCreate(
     itemHeight: number,
     offsetY: number,
     varHeight?: number): ISelectionListBox {
-
     const listContainer = document.createElement("div");
     let items: ISearchMenuCommand[];
     let itemCapacity: number;

--- a/examples/components/shared-map-visualizer/package.json
+++ b/examples/components/shared-map-visualizer/package.json
@@ -44,7 +44,7 @@
     "jquery": "^3.3.1"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/jquery": "^3.3.6",

--- a/examples/components/shared-map-visualizer/src/maps.ts
+++ b/examples/components/shared-map-visualizer/src/maps.ts
@@ -157,7 +157,6 @@ async function displayMap(
 export class ProgressCollection
     extends EventEmitter
     implements IComponentLoadable, IComponentRouter, IComponentHTMLView {
-
     public static async load(runtime: IComponentRuntime, context: IComponentContext) {
         const collection = new ProgressCollection(runtime, context);
         await collection.initialize();

--- a/examples/components/shared-text/src/component.ts
+++ b/examples/components/shared-text/src/component.ts
@@ -58,7 +58,6 @@ async function getHandle(runtimeP: Promise<IComponentRuntime>): Promise<ICompone
 export class SharedTextRunner
     extends EventEmitter
     implements IComponentHTMLView, IComponentLoadable, IProvideSharedString {
-
     public static async load(runtime: ComponentRuntime, context: IComponentContext): Promise<SharedTextRunner> {
         const runner = new SharedTextRunner(runtime, context);
         await runner.initialize();

--- a/examples/components/simple-component-embed/package.json
+++ b/examples/components/simple-component-embed/package.json
@@ -34,7 +34,7 @@
     "@microsoft/fluid-view-interfaces": "^0.16.0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/examples/components/simple-data-share/package.json
+++ b/examples/components/simple-data-share/package.json
@@ -37,7 +37,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",
     "@types/react-dom": "^16.9.4",

--- a/examples/components/smde/package.json
+++ b/examples/components/smde/package.json
@@ -47,7 +47,7 @@
     "simplemde": "^1.11.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",

--- a/examples/components/spaces/package.json
+++ b/examples/components/spaces/package.json
@@ -18,6 +18,7 @@
     "eslint": "eslint --ext=ts,tsx --format stylish src",
     "eslint:fix": "eslint --ext=ts,tsx --format stylish src --fix",
     "lint": "npm run eslint",
+    "lint:fix": "npm run eslint:fix",
     "prepack": "npm run webpack",
     "start": "webpack-dev-server --config webpack.config.js --package package.json",
     "start:docker": "webpack-dev-server --config webpack.config.js --package package.json --env.mode docker",

--- a/examples/components/spaces/package.json
+++ b/examples/components/spaces/package.json
@@ -55,7 +55,7 @@
     "react-grid-layout": "^0.18.3"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",

--- a/examples/components/spaces/src/components/button.tsx
+++ b/examples/components/spaces/src/components/button.tsx
@@ -16,7 +16,7 @@ import { Manager } from "../container-services";
 const buttonStyle: React.CSSProperties = {
     WebkitUserSelect: "none", // Chrome-Safari
     MozUserSelect: "none", // Firefox
-    msUserSelect: "none", //IE10+
+    msUserSelect: "none", // IE10+
     textAlign:"center",
     width: "100%",
     height:"100%",
@@ -27,7 +27,7 @@ const buttonStyle: React.CSSProperties = {
 const textStyle: React.CSSProperties = {
     WebkitUserSelect: "none", // Chrome-Safari
     MozUserSelect: "none", // Firefox
-    msUserSelect: "none", //IE10+
+    msUserSelect: "none", // IE10+
     display:"inline-block",
     cursor: "pointer",
 };

--- a/examples/components/spaces/src/components/componentToolbar.tsx
+++ b/examples/components/spaces/src/components/componentToolbar.tsx
@@ -58,7 +58,7 @@ export class ComponentToolbar extends PrimedComponent
         }
     }
 
-    public changeEditState(isEditable: boolean){
+    public changeEditState(isEditable: boolean) {
         this.root.set("isEditable", isEditable);
     }
 
@@ -84,7 +84,6 @@ export class ComponentToolbar extends PrimedComponent
             div,
         );
     }
-
 }
 
 interface IComponentToolbarViewProps {
@@ -98,10 +97,9 @@ interface IComponentToolbarViewState {
 }
 
 class ComponentToolbarView extends React.Component<IComponentToolbarViewProps, IComponentToolbarViewState> {
-
     private readonly supportedComponentList: IContainerComponentDetails[];
 
-    constructor(props: IComponentToolbarViewProps){
+    constructor(props: IComponentToolbarViewProps) {
         super(props);
         this.supportedComponentList = props.supportedComponentList;
         this.state = {
@@ -109,7 +107,7 @@ class ComponentToolbarView extends React.Component<IComponentToolbarViewProps, I
         };
         props.root.on("valueChanged", (change, local) => {
             if (change.key === "isEditable") {
-                this.setState({isEditable: props.root.get("isEditable")});
+                this.setState({ isEditable: props.root.get("isEditable") });
             }
         });
     }
@@ -128,7 +126,7 @@ class ComponentToolbarView extends React.Component<IComponentToolbarViewProps, I
         }
     }
 
-    render(){
+    render() {
         const editableButtons: JSX.Element[] = [];
         this.supportedComponentList.forEach(((supportedComponent: IContainerComponentDetails) => {
             editableButtons.push(
@@ -147,7 +145,7 @@ class ComponentToolbarView extends React.Component<IComponentToolbarViewProps, I
             <div style={componentToolbarStyle}>
                 <Button
                     id="edit"
-                    iconProps={{ iconName: "BullseyeTargetEdit"}}
+                    iconProps={{ iconName: "BullseyeTargetEdit" }}
                     onClick={() => this.emitToggleEditable()}
                 >
                     {`Edit: ${this.state.isEditable}`}

--- a/examples/components/spaces/src/components/number.tsx
+++ b/examples/components/spaces/src/components/number.tsx
@@ -29,7 +29,7 @@ export class Number extends PrimedComponent implements IComponentHTMLView {
         return Number.factory;
     }
 
-    protected async componentInitializingFirstTime(){
+    protected async componentInitializingFirstTime() {
         this.root.createValueType("clicker-count", CounterValueType.Name, 0);
     }
 
@@ -61,8 +61,8 @@ interface INumberViewState {
     value: number;
 }
 
-class NumberView extends React.Component<INumberViewProps, INumberViewState>{
-    constructor(props: INumberViewProps){
+class NumberView extends React.Component<INumberViewProps, INumberViewState> {
+    constructor(props: INumberViewProps) {
         super(props);
 
         this.state = {
@@ -72,14 +72,14 @@ class NumberView extends React.Component<INumberViewProps, INumberViewState>{
 
     componentDidMount() {
         this.props.counter.on("incremented", (_, currentValue: number) =>{
-            this.setState({value:currentValue});
+            this.setState({ value:currentValue });
         });
     }
 
-    render(){
+    render() {
         return (
-            <div style={{textAlign:"center", width: "100%", height:"100%", border:"1px solid black"}}>
-                <h1 style={{display:"inline-block"}}>{this.state.value}</h1>
+            <div style={{ textAlign:"center", width: "100%", height:"100%", border:"1px solid black" }}>
+                <h1 style={{ display:"inline-block" }}>{this.state.value}</h1>
             </div>
         );
     }

--- a/examples/components/spaces/src/container-services/manager.ts
+++ b/examples/components/spaces/src/container-services/manager.ts
@@ -15,7 +15,7 @@ export class Manager extends BaseContainerService {
     registerProducer(type: string, listener: EventEmitter) {
         listener.on(type, () => {
             const map = this.registry.get(type);
-            if(map) {
+            if (map) {
                 // call all the callbacks
                 map.forEach((value) => value());
             }
@@ -24,7 +24,7 @@ export class Manager extends BaseContainerService {
 
     registerListener(type: string, callback: () => void) {
         const map = this.registry.get(type);
-        if(map) {
+        if (map) {
             // append to the map
             map.push(callback);
         }

--- a/examples/components/spaces/src/dataModel.ts
+++ b/examples/components/spaces/src/dataModel.ts
@@ -74,7 +74,7 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
 
     public createCollectionItem<T>(rawOptions: T): IComponent {
         const options = rawOptions as ISpacesCollectionOptions;
-        if (!options.handle || !options.type || !options.id){
+        if (!options.handle || !options.type || !options.id) {
             throw new Error("Tried to create a collection item in Spaces with invalid options");
         }
         // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/examples/components/spaces/src/index.ts
+++ b/examples/components/spaces/src/index.ts
@@ -52,7 +52,7 @@ export class InternalRegistry implements IComponentRegistry {
         const index = this.containerComponentArray.findIndex(
             (containerComponent) => name === containerComponent.type,
         );
-        if (index >= 0){
+        if (index >= 0) {
             return this.containerComponentArray[index].factory;
         }
 

--- a/examples/components/spaces/src/interfaces/componentCallable.ts
+++ b/examples/components/spaces/src/interfaces/componentCallable.ts
@@ -28,4 +28,3 @@ export interface IProvideComponentCallable {
 export interface IComponentCallable<T> extends IProvideComponentCallable {
     setComponentCallbacks(callbacks: T): void;
 }
-

--- a/examples/components/spaces/src/interfaces/componentToolbarConsumer.ts
+++ b/examples/components/spaces/src/interfaces/componentToolbarConsumer.ts
@@ -22,4 +22,3 @@ export interface IProvideComponentToolbarConsumer {
 export interface IComponentToolbarConsumer extends IProvideComponentToolbarConsumer {
     setComponentToolbar(id: string, type: string, handle: IComponentHandle): Promise<void>;
 }
-

--- a/examples/components/spaces/src/spaces.tsx
+++ b/examples/components/spaces/src/spaces.tsx
@@ -97,7 +97,6 @@ export class Spaces extends PrimedComponent
         }
     }
 
-
     private addToolbarListeners() {
         if (this.componentToolbar && this.componentToolbar.IComponentCallable) {
             this.componentToolbar.IComponentCallable.setComponentCallbacks({

--- a/examples/components/spaces/src/view.tsx
+++ b/examples/components/spaces/src/view.tsx
@@ -12,7 +12,6 @@ import "react-grid-layout/css/styles.css";
 const ReactGridLayout = WidthProvider(RGL);
 import { ISpacesDataModel } from "./dataModel";
 
-
 interface IEmbeddedComponentWrapperProps {
     id: string;
     getComponent: (componentId: string) => Promise<IComponent | undefined>;
@@ -41,7 +40,7 @@ const gridContainerStyle: React.CSSProperties = { paddingTop: "5rem" };
  * This wrapper handles the async-ness of loading a component.
  * This ideally shouldn't be here but is here for now to unblock me not knowing how to use ReactViewAdapter.
  */
-class EmbeddedComponentWrapper extends React.Component<IEmbeddedComponentWrapperProps, IEmbeddedComponentWrapperState>{
+class EmbeddedComponentWrapper extends React.Component<IEmbeddedComponentWrapperProps, IEmbeddedComponentWrapperState> {
     constructor(props) {
         super(props);
         this.state = {
@@ -99,7 +98,7 @@ export class SpacesGridView extends React.Component<ISpaceGridViewProps, ISpaceG
             }
         });
         this.props.dataModel.on("editableUpdated", (isEditable?: boolean) => {
-            this.setState({isEditable: isEditable || !this.state.isEditable});
+            this.setState({ isEditable: isEditable || !this.state.isEditable });
         });
     }
 

--- a/examples/components/sudoku/package.json
+++ b/examples/components/sudoku/package.json
@@ -44,7 +44,7 @@
     "sudokus": "^1.0.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@prague/url-generator": "^1.0.4",

--- a/examples/components/table-view/package.json
+++ b/examples/components/table-view/package.json
@@ -43,7 +43,7 @@
     "@microsoft/fluid-view-interfaces": "^0.16.0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",

--- a/examples/components/table-view/src/borderstyle.ts
+++ b/examples/components/table-view/src/borderstyle.ts
@@ -10,7 +10,6 @@ const enum StyleIndex {
 }
 
 export class BorderRect {
-
     public get min() { return [Math.min(this.start[0], this.end[0]), Math.min(this.start[1], this.end[1])]; }
     public get max() { return [Math.max(this.start[0], this.end[0]), Math.max(this.start[1], this.end[1])]; }
 

--- a/examples/components/table-view/src/grid.ts
+++ b/examples/components/table-view/src/grid.ts
@@ -39,7 +39,6 @@ const cellInputTemplate = new Template({ tag: "input", props: { className: style
 const numberExp = /^[+-]?\d*\.?\d+(?:[Ee][+-]?\d+)?$/;
 
 export class GridView {
-
     private get numRows() { return this.doc.numRows; }
     private get numCols() { return this.doc.numCols; }
     public readonly root = tableTemplate.clone();
@@ -409,9 +408,9 @@ export class GridView {
         const colStartLetter = this.numberToColumnLetter(colStart);
         const colEndLetter = this.numberToColumnLetter(colEnd);
 
-        const averageFormula = `=AVERAGE(${colStartLetter}${rowStart+1}:${colEndLetter}${rowEnd+1})`;
-        const countFormula = `=COUNT(${colStartLetter}${rowStart+1}:${colEndLetter}${rowEnd+1})`;
-        const sumFormula = `=SUM(${colStartLetter}${rowStart+1}:${colEndLetter}${rowEnd+1})`;
+        const averageFormula = `=AVERAGE(${colStartLetter}${rowStart + 1}:${colEndLetter}${rowEnd + 1})`;
+        const countFormula = `=COUNT(${colStartLetter}${rowStart + 1}:${colEndLetter}${rowEnd + 1})`;
+        const sumFormula = `=SUM(${colStartLetter}${rowStart + 1}:${colEndLetter}${rowEnd + 1})`;
 
         const avg = this.doc.evaluateFormula(averageFormula);
         const count = this.doc.evaluateFormula(countFormula);

--- a/examples/components/table-view/src/tableview.ts
+++ b/examples/components/table-view/src/tableview.ts
@@ -84,7 +84,7 @@ export class TableView extends PrimedComponent implements IComponentHTMLView {
 
             const addColsBtn = template.get(this.templateRoot, "addCols");
             addColsBtn.addEventListener("click", () => {
-                doc.insertCols(doc.numCols, 10 /*16384*/);
+                doc.insertCols(doc.numCols, 10 /* 16384 */);
             });
 
             const gotoInput = template.get(this.templateRoot, "goto") as HTMLInputElement;

--- a/examples/components/textarea-noreact/package.json
+++ b/examples/components/textarea-noreact/package.json
@@ -39,7 +39,7 @@
     "@microsoft/fluid-view-interfaces": "^0.16.0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",

--- a/examples/components/textarea-noreact/src/main.tsx
+++ b/examples/components/textarea-noreact/src/main.tsx
@@ -7,9 +7,8 @@
  * public loading scopes do NOT match the lines exactly!) into chunks.
  */
 
-/******************************************************************************/
 // Import the Fluid Framework "goo":
-/******************************************************************************/
+
 import {
     PrimedComponent,
     PrimedComponentFactory,
@@ -24,7 +23,6 @@ import {
     SharedString,
 } from "@microsoft/fluid-sequence";
 import { IComponentHTMLView } from "@microsoft/fluid-view-interfaces";
-/******************************************************************************/
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 const pkg = require("../package.json");
@@ -68,14 +66,13 @@ export class TextareaNoReact extends PrimedComponent implements IComponentHTMLVi
         this.textareaRootKey = "textareaString";
     }
 
-    /******************************************************************************/
     // One-time component setup:
-    /******************************************************************************/
+
     /**
-   * Initialization method that creates one SharedString collab. object and
-   * registers it on this component's root map (which itself is inherited from
-   * the PrimedComponent base class). This method is called only once.
-   */
+     * Initialization method that creates one SharedString collab. object and
+     * registers it on this component's root map (which itself is inherited from
+     * the PrimedComponent base class). This method is called only once.
+     */
     protected async componentInitializingFirstTime() {
         // Calling super.componentInitializingFirstTime() creates a root SharedMap.
         await super.componentInitializingFirstTime();
@@ -84,15 +81,12 @@ export class TextareaNoReact extends PrimedComponent implements IComponentHTMLVi
         this.root.set(this.textareaRootKey,
             SharedString.create(this.runtime).handle);
     }
-    /******************************************************************************/
 
-    /******************************************************************************/
     // Core app logic (in this case: fancy marker positioning and text updating):
-    /******************************************************************************/
 
     /**
-   * Helper method to force a DOM refresh of the <textarea>.
-   */
+     * Helper method to force a DOM refresh of the <textarea>.
+     */
     protected forceDOMUpdate(newText: string,
                              newSelectionStart?: number,
                              newSelectionEnd?: number) {
@@ -109,11 +103,11 @@ export class TextareaNoReact extends PrimedComponent implements IComponentHTMLVi
     }
 
     /**
-   * Update the current caret selection.
-   * We need to do this before we do any handleXChange action or we will have
-   * lost our cursor position and not be able to accurately update the shared
-   * string.
-   */
+     * Update the current caret selection.
+     * We need to do this before we do any handleXChange action or we will have
+     * lost our cursor position and not be able to accurately update the shared
+     * string.
+     */
     protected updateSelection() {
         // No access to React style refs, so a manual call is made to the DOM to
         // retrieve the current <textarea> (and more importantly the caret positions
@@ -136,17 +130,17 @@ export class TextareaNoReact extends PrimedComponent implements IComponentHTMLVi
     }
 
     /**
-   * Handle any incoming SequenceDeltaEvent(s) (fired off whenever an insertion,
-   * replacement, or removal is made to the primary SharedString of this
-   * component).
-   *
-   * Note that incoming events include events made by the local user, but that
-   * `event` has a flag to mark if the change is local. Much of the logic deals
-   * with how to update the user's selection markers if the incoming changes
-   * affect selected (highlighted) text.
-   *
-   * @param event Incoming delta on a SharedString
-   */
+     * Handle any incoming SequenceDeltaEvent(s) (fired off whenever an insertion,
+     * replacement, or removal is made to the primary SharedString of this
+     * component).
+     *
+     * Note that incoming events include events made by the local user, but that
+     * `event` has a flag to mark if the change is local. Much of the logic deals
+     * with how to update the user's selection markers if the incoming changes
+     * affect selected (highlighted) text.
+     *
+     * @param event Incoming delta on a SharedString
+     */
     protected async handleIncomingChange(event: SequenceDeltaEvent) {
         console.log("textarea-noreact: incoming change to shared string!");
 
@@ -232,16 +226,16 @@ export class TextareaNoReact extends PrimedComponent implements IComponentHTMLVi
     }
 
     /**
-   * Send a change to the SharedString when an event is detected on the
-   * <textarea>.
-   *
-   * No further changes are made to the <textarea> itself, but the current
-   * positions of the user's selection markers/carets are used to determine
-   * whether a insertion, replacement, or removal call is necessary for the
-   * SharedString.
-   *
-   * @param ev An outgoing Event on the titular <textarea>
-   */
+     * Send a change to the SharedString when an event is detected on the
+     * <textarea>.
+     *
+     * No further changes are made to the <textarea> itself, but the current
+     * positions of the user's selection markers/carets are used to determine
+     * whether a insertion, replacement, or removal call is necessary for the
+     * SharedString.
+     *
+     * @param ev An outgoing Event on the titular <textarea>
+     */
     protected async handleOutgoingChange(ev: Event) {
         console.log("textarea-noreact: outgoing change to shared string!");
 
@@ -280,19 +274,16 @@ export class TextareaNoReact extends PrimedComponent implements IComponentHTMLVi
                 newPosition + charactersModifiedCount);
         }
     }
-    /******************************************************************************/
 
-    /******************************************************************************/
     // HTML setup and rendering:
-    /******************************************************************************/
 
     /**
-   * Render the component page and setup necessary hooks.
-   *
-   * This method is called any time the page is opened/refreshed - the goal is
-   * to add any handlers, etc. that might be necessary for the component to
-   * function properly after such an event.
-   */
+     * Render the component page and setup necessary hooks.
+     *
+     * This method is called any time the page is opened/refreshed - the goal is
+     * to add any handlers, etc. that might be necessary for the component to
+     * function properly after such an event.
+     */
     public async render(div: HTMLElement) {
         console.log("textarea-noreact: render call");
 
@@ -331,9 +322,9 @@ export class TextareaNoReact extends PrimedComponent implements IComponentHTMLVi
     }
 
     /**
-   * Set up the HTML elements inside the provided host HTML element (usually a
-   * div).
-   */
+     * Set up the HTML elements inside the provided host HTML element (usually a
+     * div).
+     */
     protected createComponentDom(host: HTMLElement) {
         const textareaElement: HTMLTextAreaElement =
             document.createElement("textarea");
@@ -353,18 +344,15 @@ export class TextareaNoReact extends PrimedComponent implements IComponentHTMLVi
 
         host.appendChild(textareaElement);
     }
-    /******************************************************************************/
 
-    /******************************************************************************/
     // Component loading and export:
-    /******************************************************************************/
 
     /**
-   * Final (static!) load function that allows the runtime to make async calls
-   * while creating the object.
-   *
-   * Primarily boilerplate code.
-   */
+     * Final (static!) load function that allows the runtime to make async calls
+     * while creating the object.
+     *
+     * Primarily boilerplate code.
+     */
     public static async load(
         runtime: IComponentRuntime,
         context: IComponentContext): Promise<TextareaNoReact> {
@@ -405,4 +393,3 @@ export const TextareaNoReactInstantiationFactory =
             SharedString.getFactory(),
         ],
     );
-/******************************************************************************/

--- a/examples/components/textarea-noreact/src/main.tsx
+++ b/examples/components/textarea-noreact/src/main.tsx
@@ -7,7 +7,6 @@
  * public loading scopes do NOT match the lines exactly!) into chunks.
  */
 
-
 /******************************************************************************/
 // Import the Fluid Framework "goo":
 /******************************************************************************/
@@ -69,7 +68,6 @@ export class TextareaNoReact extends PrimedComponent implements IComponentHTMLVi
         this.textareaRootKey = "textareaString";
     }
 
-
     /******************************************************************************/
     // One-time component setup:
     /******************************************************************************/
@@ -87,7 +85,6 @@ export class TextareaNoReact extends PrimedComponent implements IComponentHTMLVi
             SharedString.create(this.runtime).handle);
     }
     /******************************************************************************/
-
 
     /******************************************************************************/
     // Core app logic (in this case: fancy marker positioning and text updating):
@@ -285,7 +282,6 @@ export class TextareaNoReact extends PrimedComponent implements IComponentHTMLVi
     }
     /******************************************************************************/
 
-
     /******************************************************************************/
     // HTML setup and rendering:
     /******************************************************************************/
@@ -359,7 +355,6 @@ export class TextareaNoReact extends PrimedComponent implements IComponentHTMLVi
     }
     /******************************************************************************/
 
-
     /******************************************************************************/
     // Component loading and export:
     /******************************************************************************/
@@ -379,7 +374,6 @@ export class TextareaNoReact extends PrimedComponent implements IComponentHTMLVi
 
         return fluidComponent;
     }
-
 
     // eslint-disable-next-line @typescript-eslint/promise-function-async
     public componentHasInitialized(): Promise<void> {

--- a/examples/components/todo/package.json
+++ b/examples/components/todo/package.json
@@ -48,7 +48,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",

--- a/examples/components/todo/src/Todo/Todo.tsx
+++ b/examples/components/todo/src/Todo/Todo.tsx
@@ -27,7 +27,6 @@ export const TodoName = `${pkg.name as string}-todo`;
 export class Todo extends PrimedComponent implements
     IComponentHTMLView,
     IComponentReactViewable {
-
     // DDS ids stored as variables to minimize simple string mistakes
     private readonly todoItemsKey = "todo-items";
     private readonly todoTitleKey = "todo-title";
@@ -101,7 +100,6 @@ export class Todo extends PrimedComponent implements
     // start public API surface for the Todo model, used by the view
 
     public async addTodoItemComponent(props?: any) {
-
         // Create a new todo item
         const component = await this.createAndAttachComponent(TodoItemName, props);
 

--- a/examples/components/todo/src/TodoItem/TodoItem.tsx
+++ b/examples/components/todo/src/TodoItem/TodoItem.tsx
@@ -40,7 +40,6 @@ export class TodoItem extends PrimedComponent
     implements
     IComponentHTMLView,
     IComponentReactViewable {
-
     private text: SharedString;
     private innerIdCell: ISharedCell;
     private baseUrl: string = "";

--- a/examples/components/todo/src/TodoItem/TodoItemView.tsx
+++ b/examples/components/todo/src/TodoItem/TodoItemView.tsx
@@ -78,7 +78,7 @@ export class TodoItemView extends React.Component<TodoItemViewProps, TodoItemVie
                     <button
                         name="toggleInnerVisible"
                         style={this.buttonStyle}
-                        onClick={() => {this.setState({innerComponentVisible: !this.state.innerComponentVisible}); }}>
+                        onClick={() => {this.setState({ innerComponentVisible: !this.state.innerComponentVisible }); }}>
                         {this.state.innerComponentVisible ? "▲" : "▼"}
                     </button>
                     <button

--- a/examples/components/tourofheroes/package.json
+++ b/examples/components/tourofheroes/package.json
@@ -57,7 +57,7 @@
     "zone.js": "^0.8.29"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/react-dom": "^16.9.4",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/examples/components/tourofheroes/src/app/app.module.ts
+++ b/examples/components/tourofheroes/src/app/app.module.ts
@@ -40,5 +40,3 @@ export class AppModule {
         router.navigate([path ? path : "/dashboard"], { skipLocationChange: !!path });
     }
 }
-
-

--- a/examples/components/tourofheroes/src/app/hero.service.ts
+++ b/examples/components/tourofheroes/src/app/hero.service.ts
@@ -399,7 +399,6 @@ export class HeroService {
      */
     private handleError<T>(operation = "operation", result?: T) {
         return (error: any): Observable<T> => {
-
             // TODO: send the error to remote logging infrastructure
             console.error(error); // Log to console instead
 

--- a/examples/components/tourofheroes/src/app/hero.service.ts
+++ b/examples/components/tourofheroes/src/app/hero.service.ts
@@ -367,7 +367,7 @@ export class HeroService {
         return null;
     }
 
-    //////// Save methods //////////
+    // Save methods
 
     /** POST: add a new hero to the server */
     addHero(hero: Hero): Observable<Hero> {

--- a/examples/components/tourofheroes/src/app/heroes/heroes.component.ts
+++ b/examples/components/tourofheroes/src/app/heroes/heroes.component.ts
@@ -42,5 +42,4 @@ export class HeroesComponent implements OnInit {
         this.heroes = this.heroes.filter((h) => h !== hero);
         this.heroService.deleteHero(hero).subscribe();
     }
-
 }

--- a/examples/components/tourofheroes/src/app/messages/messages.component.ts
+++ b/examples/components/tourofheroes/src/app/messages/messages.component.ts
@@ -12,7 +12,6 @@ import { MessageService } from "../message.service";
     styleUrls: ["./messages.component.css"],
 })
 export class MessagesComponent implements OnInit {
-
     constructor(public messageService: MessageService) { }
 
     ngOnInit() {

--- a/examples/components/type-race/package.json
+++ b/examples/components/type-race/package.json
@@ -37,7 +37,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",

--- a/examples/components/video-players/package.json
+++ b/examples/components/video-players/package.json
@@ -38,7 +38,7 @@
     "@types/node": "^10.14.6"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@typescript-eslint/eslint-plugin": "~2.17.0",
     "@typescript-eslint/parser": "~2.17.0",

--- a/examples/components/video-players/src/videoPlayers.ts
+++ b/examples/components/video-players/src/videoPlayers.ts
@@ -75,7 +75,6 @@ interface IYouTubePlayer {
 
 export class VideoPlayer implements
     IComponentLoadable, IComponentHTMLView, IComponentRouter, IComponentLayout {
-
     private player: IYouTubePlayer;
     private playerDiv: HTMLDivElement;
 

--- a/examples/components/vltava/package.json
+++ b/examples/components/vltava/package.json
@@ -58,7 +58,7 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",
     "@types/node": "^10.14.6",

--- a/examples/components/vltava/src/components/anchor/anchor.ts
+++ b/examples/components/vltava/src/components/anchor/anchor.ts
@@ -7,7 +7,6 @@ import { IComponentHandle } from "@microsoft/fluid-component-core-interfaces";
 import { PrimedComponent, PrimedComponentFactory } from "@microsoft/fluid-aqueduct";
 import { IComponentHTMLView, IProvideComponentHTMLView } from "@microsoft/fluid-view-interfaces";
 
-
 export const AnchorName = "anchor";
 
 /**

--- a/examples/components/vltava/src/components/tabs/dataModel.ts
+++ b/examples/components/vltava/src/components/tabs/dataModel.ts
@@ -39,7 +39,6 @@ export interface ITabsDataModel extends EventEmitter {
 }
 
 export class TabsDataModel extends EventEmitter implements ITabsDataModel {
-
     private tabs: IDirectory;
 
     constructor(

--- a/examples/components/vltava/src/components/tabs/newTabButton.tsx
+++ b/examples/components/vltava/src/components/tabs/newTabButton.tsx
@@ -56,7 +56,7 @@ export const NewTabButton: React.FunctionComponent<IButtonExampleProps> =
                 },
             );
         });
-        const menuProps: IContextualMenuProps = {items};
+        const menuProps: IContextualMenuProps = { items };
         return (
             <IconButton
                 split

--- a/examples/components/vltava/src/components/tabs/view.tsx
+++ b/examples/components/vltava/src/components/tabs/view.tsx
@@ -26,7 +26,6 @@ export interface ITabsViewState {
     tabIndex: number;
 }
 
-
 export class TabsView extends React.Component<ITabsViewProps, ITabsViewState> {
     constructor(props: ITabsViewProps) {
         super(props);
@@ -72,7 +71,7 @@ export class TabsView extends React.Component<ITabsViewProps, ITabsViewState> {
 
         return (
             <Tabs
-                style={{ display: "flex", flexDirection: "column"}}
+                style={{ display: "flex", flexDirection: "column" }}
                 selectedIndex={this.state.tabIndex}
                 onSelect={(tabIndex) => this.setState({ tabIndex })}>
                 <TabList>
@@ -81,7 +80,7 @@ export class TabsView extends React.Component<ITabsViewProps, ITabsViewState> {
                         <NewTabButton createTab={this.createNewTab} components={this.props.dataModel.getNewTabTypes()}/>
                     </li>
                 </TabList>
-                <div style={{position: "relative"}}>
+                <div style={{ position: "relative" }}>
                     {tabPanel}
                 </div>
             </Tabs>
@@ -92,4 +91,3 @@ export class TabsView extends React.Component<ITabsViewProps, ITabsViewState> {
         await this.props.dataModel.createTab(type);
     }
 }
-

--- a/examples/components/vltava/src/components/vltava/view.tsx
+++ b/examples/components/vltava/src/components/vltava/view.tsx
@@ -18,7 +18,6 @@ interface IVltavaViewState {
     view: JSX.Element;
 }
 
-
 export class VltavaView extends React.Component<IVltavaViewProps,IVltavaViewState> {
     constructor(props: IVltavaViewProps) {
         super(props);
@@ -29,7 +28,7 @@ export class VltavaView extends React.Component<IVltavaViewProps,IVltavaViewStat
         };
 
         props.dataModel.on("membersChanged", (users) => {
-            this.setState({users});
+            this.setState({ users });
         });
     }
 
@@ -38,7 +37,6 @@ export class VltavaView extends React.Component<IVltavaViewProps,IVltavaViewStat
         this.setState({
             view: <ReactViewAdapter component={component} />,
         });
-
     }
 
     render() {
@@ -50,7 +48,7 @@ export class VltavaView extends React.Component<IVltavaViewProps,IVltavaViewStat
                         height: "50px",
                         textAlign: "center",
                         borderBottom:"1px solid lightgray",
-                        boxSizing:"border-box"}}
+                        boxSizing:"border-box" }}
                 >
                     <div>
                         <h2>

--- a/examples/components/vltava/src/containerServices/match-maker/matchMaker.ts
+++ b/examples/components/vltava/src/containerServices/match-maker/matchMaker.ts
@@ -70,7 +70,6 @@ export const unregisterWithMatchMaker = async (
  * registerWithMatchMaker and unregisterWithMatchMaker functions.
  */
 export class MatchMaker extends BaseContainerService implements IComponentInterfacesRegistry {
-
     private readonly discoverableInterfacesMap: Map<keyof IComponent, IComponentDiscoverableInterfaces[]> = new Map();
 
     private readonly discoverInterfacesMap: Map<keyof IComponent, IComponentDiscoverInterfaces[]> = new Map();
@@ -82,12 +81,12 @@ export class MatchMaker extends BaseContainerService implements IComponentInterf
     ) {
         // Discover needs to go first to ensure we don't alert the component registering of itself.
         const discover = (component as IProvideComponentDiscoverInterfaces).IComponentDiscoverInterfaces;
-        if (discover){
+        if (discover) {
             this.registerDiscoverInterfaces(discover);
         }
 
         const discoverable = (component as IProvideComponentDiscoverableInterfaces).IComponentDiscoverableInterfaces;
-        if (discoverable){
+        if (discoverable) {
             // The below code is some crazy typescript magic that checks to see that the interface the component
             // is declaring as discoverable is implemented by the component itself. We can do this because
             // `keyof IComponent` allows us to iterate though to check if the component also implements a getter
@@ -106,7 +105,7 @@ export class MatchMaker extends BaseContainerService implements IComponentInterf
         component: IProvideComponentDiscoverInterfaces | IProvideComponentDiscoverableInterfaces,
     ) {
         const discoverable = (component as IProvideComponentDiscoverableInterfaces).IComponentDiscoverableInterfaces;
-        if (discoverable){
+        if (discoverable) {
             discoverable.discoverableInterfaces.forEach((interfaceName) => {
                 let interfacesMap = this.discoverableInterfacesMap.get(interfaceName);
                 if (interfacesMap) {
@@ -117,7 +116,7 @@ export class MatchMaker extends BaseContainerService implements IComponentInterf
         }
 
         const discover = (component as IProvideComponentDiscoverInterfaces).IComponentDiscoverInterfaces;
-        if (discover){
+        if (discover) {
             discover.interfacesToDiscover.forEach((interfaceName) => {
                 let interfacesMap = this.discoverInterfacesMap.get(interfaceName);
                 if (interfacesMap) {
@@ -132,7 +131,7 @@ export class MatchMaker extends BaseContainerService implements IComponentInterf
         // For each discover interface we will add it to the map
         discover.interfacesToDiscover.forEach((interfaceName) => {
             // If it's the first interface of its type add it to the the map
-            if (!this.discoverInterfacesMap.has(interfaceName)){
+            if (!this.discoverInterfacesMap.has(interfaceName)) {
                 this.discoverInterfacesMap.set(interfaceName, []);
             }
 
@@ -155,7 +154,7 @@ export class MatchMaker extends BaseContainerService implements IComponentInterf
         // For each discover interface we will add it to the map
         discoverableComponent.discoverableInterfaces.forEach((interfaceName) => {
             // If it's the first interface of its type add it to the the map
-            if (!this.discoverableInterfacesMap.has(interfaceName)){
+            if (!this.discoverableInterfacesMap.has(interfaceName)) {
                 this.discoverableInterfacesMap.set(interfaceName, []);
             }
 

--- a/examples/components/vltava/src/index.ts
+++ b/examples/components/vltava/src/index.ts
@@ -41,7 +41,7 @@ export class InternalRegistry implements IComponentRegistry, IComponentRegistryD
         const index = this.containerComponentArray.findIndex(
             (containerComponent) => name === containerComponent.type,
         );
-        if (index >= 0){
+        if (index >= 0) {
             return this.containerComponentArray[index].factory;
         }
 

--- a/examples/components/webflow/package.json
+++ b/examples/components/webflow/package.json
@@ -74,7 +74,7 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-local-test-utils": "^0.16.0",
     "@microsoft/fluid-webpack-component-loader": "^0.16.0",

--- a/examples/components/webflow/src/document/index.ts
+++ b/examples/components/webflow/src/document/index.ts
@@ -131,7 +131,6 @@ export interface IFlowDocumentEvents extends IEvent {
 }
 
 export class FlowDocument extends SharedComponent<ISharedDirectory, IFlowDocumentEvents> {
-
     private static readonly factory = new SharedComponentFactory<FlowDocument>(
         documentType,
         FlowDocument,
@@ -167,7 +166,7 @@ export class FlowDocument extends SharedComponent<ISharedDirectory, IFlowDocumen
 
         this.maybeSharedString = SharedString.create(this.runtime, "text");
         this.root.set("text", this.maybeSharedString.handle);
-        if(this.maybeSharedString !== undefined){
+        if (this.maybeSharedString !== undefined) {
             this.forwardEvent(this.maybeSharedString, "sequenceDelta", "maintenance");
         }
     }
@@ -179,7 +178,7 @@ export class FlowDocument extends SharedComponent<ISharedDirectory, IFlowDocumen
 
         const handle = await this.root.wait<IComponentHandle<SharedString>>("text");
         this.maybeSharedString = await handle.get();
-        if(this.maybeSharedString !== undefined){
+        if (this.maybeSharedString !== undefined) {
             this.forwardEvent(this.maybeSharedString, "sequenceDelta", "maintenance");
         }
     }

--- a/examples/components/webflow/src/document/index.ts
+++ b/examples/components/webflow/src/document/index.ts
@@ -478,7 +478,6 @@ export class FlowDocument extends SharedComponent<ISharedDirectory, IFlowDocumen
         return s.join("");
     }
 
-
     private getOppositeMarker(marker: Marker, oldPrefixLength: number, newPrefix: string) {
         return this.sharedString.getMarkerFromId(`${newPrefix}${marker.getId().slice(oldPrefixLength)}`);
     }

--- a/examples/components/webflow/src/host/searchmenu/index.css.d.ts
+++ b/examples/components/webflow/src/host/searchmenu/index.css.d.ts
@@ -8,4 +8,3 @@ declare const styles: {
     readonly "input": string;
 };
 export = styles;
-

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/node": "^10.14.6",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/examples/hosts/iframe-host/src/inframehost.ts
+++ b/examples/hosts/iframe-host/src/inframehost.ts
@@ -20,7 +20,7 @@ import { IRequest, IResponse, IComponent } from "@microsoft/fluid-component-core
 import { IDocumentServiceFactory, IUrlResolver } from "@microsoft/fluid-driver-definitions";
 import { ISequencedDocumentMessage, ITree, ConnectionState } from "@microsoft/fluid-protocol-definitions";
 
-class ProxyRuntime implements IRuntime{
+class ProxyRuntime implements IRuntime {
     private _disposed = false;
     public get disposed() { return this._disposed; }
 
@@ -45,20 +45,18 @@ class ProxyRuntime implements IRuntime{
     }
 }
 
-class ProxyChaincode implements IRuntimeFactory{
-
+class ProxyChaincode implements IRuntimeFactory {
     async instantiateRuntime(context: IContainerContext): Promise<IRuntime> {
         return new ProxyRuntime();
     }
 
-    get IRuntimeFactory(){
+    get IRuntimeFactory() {
         return this;
     }
 }
 
-class ProxyCodeLoader implements ICodeLoader{
-
-    async load(){
+class ProxyCodeLoader implements ICodeLoader {
+    async load() {
         return Promise.resolve({ fluidExport: new ProxyChaincode() });
     }
 }
@@ -79,7 +77,7 @@ export interface IFrameOuterHostConfig{
 
 export class IFrameOuterHost {
     private readonly loader: Loader;
-    constructor(private readonly hostConfig: IFrameOuterHostConfig){
+    constructor(private readonly hostConfig: IFrameOuterHostConfig) {
         // todo
         // disable summaries
         // set as non-user client
@@ -93,8 +91,7 @@ export class IFrameOuterHost {
         );
     }
 
-    public async load(request: IRequest, iframe: HTMLIFrameElement): Promise<Container>{
-
+    public async load(request: IRequest, iframe: HTMLIFrameElement): Promise<Container> {
         const proxy = await IFrameDocumentServiceProxyFactory.create(
             MultiDocumentServiceFactory.create(this.hostConfig.documentServiceFactory),
             iframe,
@@ -108,7 +105,7 @@ export class IFrameOuterHost {
         await new Promise((resolve)=>setTimeout(() => resolve(), 200));
 
         const container = await this.loader.resolve(request);
-        if(!container.getQuorum().has("code")){
+        if (!container.getQuorum().has("code")) {
             // we'll never propose the code, so wait for them to do it
             await new Promise((resolve) => container.once("contextChanged", () => resolve()));
         }

--- a/examples/hosts/iframe-host/src/inner.ts
+++ b/examples/hosts/iframe-host/src/inner.ts
@@ -18,7 +18,7 @@ async function getComponentAndRender(baseHost: BaseHost, url: string, div: HTMLD
     view.render(div, { display: "block" });
 }
 
-export async function runInner(divId: string){
+export async function runInner(divId: string) {
     const div = document.getElementById(divId) as HTMLDivElement;
 
     const pkg: IFluidCodeDetails = {

--- a/examples/hosts/iframe-host/src/outer.ts
+++ b/examples/hosts/iframe-host/src/outer.ts
@@ -36,7 +36,7 @@ const getTinyliciousDocumentServiceFactory =
         true,
         undefined);
 
-export async function loadFrame(iframeId: string, logId: string){
+export async function loadFrame(iframeId: string, logId: string) {
     const iframe = document.getElementById(iframeId) as HTMLIFrameElement;
 
     const urlResolver = getTinyliciousResolver();
@@ -50,7 +50,6 @@ export async function loadFrame(iframeId: string, logId: string){
 
     const proxyContainer = await host.load(createRequest(), iframe);
 
-
     const text = document.getElementById(logId) as HTMLDivElement;
     const quorum = proxyContainer.getQuorum();
 
@@ -62,7 +61,7 @@ export async function loadFrame(iframeId: string, logId: string){
                 }));
         };
 
-    quorum.getMembers().forEach((client)=>text.innerHTML+=`Quorum: client: ${JSON.stringify(client)}<br/>`);
+    quorum.getMembers().forEach((client)=>text.innerHTML += `Quorum: client: ${JSON.stringify(client)}<br/>`);
     log(quorum, "Quorum", "error", "addMember", "removeMember");
     log(proxyContainer, "Container", "error", "connected","disconnected");
 }
@@ -77,7 +76,7 @@ async function getComponentAndRender(baseHost: BaseHost, url: string, div: HTMLD
     view.render(div, { display: "block" });
 }
 
-export async function loadDiv(divId: string){
+export async function loadDiv(divId: string) {
     const div = document.getElementById(divId) as HTMLDivElement;
 
     const urlResolver = getTinyliciousResolver();
@@ -108,12 +107,9 @@ export async function loadDiv(divId: string){
     });
 }
 
-export async function runOuter(iframeId: string, divId: string, logId: string){
-
+export async function runOuter(iframeId: string, divId: string, logId: string) {
     await Promise.all([
         loadFrame(iframeId, logId),
         loadDiv(divId).catch(),
     ]);
-
 }
-

--- a/examples/hosts/iframe-host/src/outer.ts
+++ b/examples/hosts/iframe-host/src/outer.ts
@@ -57,7 +57,7 @@ export async function loadFrame(iframeId: string, logId: string) {
         (emitter: {on(event: string, listener: (...args: any[]) => void)}, name: string, ...events: string[]) => {
             events.forEach((event)=>
                 emitter.on(event, (...args)=>{
-                    text.innerHTML+=`${name}: ${event}: ${JSON.stringify(args)}<br/>`;
+                    text.innerHTML += `${name}: ${event}: ${JSON.stringify(args)}<br/>`;
                 }));
         };
 

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2159,9 +2159,9 @@
 			}
 		},
 		"@microsoft/eslint-config-fluid": {
-			"version": "0.15.22637",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2feslint-config-fluid/-/eslint-config-fluid-0.15.22637.tgz",
-			"integrity": "sha512-WSqvZgK8lAorQR2egur3HDwOpaXLP53LFL8XO8S8kVyCwUsw5vhSRYLrv7QihRoZ+w8N4f3LMh/0ffBQaZSS8w==",
+			"version": "0.16.0-24425",
+			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2feslint-config-fluid/-/eslint-config-fluid-0.16.0-24425.tgz",
+			"integrity": "sha512-E9HqI9ivVk/8qFMVLnWGnHvh8Os4iWvdPrvHEUzZbTP7wBib599ivGTYFmH7OIJ5wrLYvQBW3hO9qqI/rWiBjA==",
 			"requires": {
 				"@typescript-eslint/eslint-plugin": "~2.17.0",
 				"@typescript-eslint/parser": "~2.17.0",

--- a/packages/agents/flow-intel-viewer/package.json
+++ b/packages/agents/flow-intel-viewer/package.json
@@ -30,7 +30,7 @@
     "@microsoft/fluid-view-interfaces": "^0.16.0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/node": "^10.14.6",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/packages/agents/flow-intel/package.json
+++ b/packages/agents/flow-intel/package.json
@@ -27,7 +27,7 @@
     "request": "^2.88.0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/node": "^10.14.6",
     "@types/request": "^2.47.1",

--- a/packages/agents/flow-intel/src/analytics/resumeAnalytics.ts
+++ b/packages/agents/flow-intel/src/analytics/resumeAnalytics.ts
@@ -75,7 +75,6 @@ class ResumeAnalyticsIntelligentService implements IIntelligentService {
                 });
         });
     }*/
-
 }
 
 export class ResumeAnalyticsFactory implements IIntelligentServiceFactory {

--- a/packages/agents/flow-intel/src/index.ts
+++ b/packages/agents/flow-intel/src/index.ts
@@ -9,7 +9,6 @@ import { ISharedMap } from "@microsoft/fluid-map";
 import { IntelRunner, ITokenConfig } from "./intelRunner";
 
 export class TextAnalyzer implements IComponentRouter, IComponentRunnable {
-
     constructor(
         private readonly document: FlowDocument,
         private readonly insightsMap: ISharedMap,

--- a/packages/agents/flow-intel/src/serviceManager.ts
+++ b/packages/agents/flow-intel/src/serviceManager.ts
@@ -40,7 +40,6 @@ export class IntelligentServicesManager {
     public process() {
         this.document.on("sequenceDelta", () => {
             if (!this.intelInvoked) {
-
                 // And then run plugin insights rate limited
                 this.rateLimiter = new RateLimiter(
                     async () => {
@@ -90,6 +89,5 @@ export class IntelligentServicesManager {
                 }
             }
         }
-
     }
 }

--- a/packages/agents/intelligence-runner/package.json
+++ b/packages/agents/intelligence-runner/package.json
@@ -28,7 +28,7 @@
     "request": "^2.88.0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/node": "^10.14.6",
     "@types/request": "^2.47.1",

--- a/packages/agents/intelligence-runner/src/analytics/resumeAnalytics.ts
+++ b/packages/agents/intelligence-runner/src/analytics/resumeAnalytics.ts
@@ -75,7 +75,6 @@ class ResumeAnalyticsIntelligentService implements IIntelligentService {
                 });
         });
     }*/
-
 }
 
 export class ResumeAnalyticsFactory implements IIntelligentServiceFactory {

--- a/packages/agents/intelligence-runner/src/index.ts
+++ b/packages/agents/intelligence-runner/src/index.ts
@@ -9,7 +9,6 @@ import * as Sequence from "@microsoft/fluid-sequence";
 import { IntelRunner, ITokenConfig } from "./intelRunner";
 
 export class TextAnalyzer implements IComponentRouter, IComponentRunnable {
-
     public get IComponentRouter() { return this; }
     public get IComponentRunnable() { return this; }
 

--- a/packages/agents/intelligence-runner/src/serviceManager.ts
+++ b/packages/agents/intelligence-runner/src/serviceManager.ts
@@ -30,7 +30,6 @@ export class IntelligentServicesManager {
     public process() {
         this.sharedString.on("op", (msg: ISequencedDocumentMessage) => {
             if (!this.intelInvoked) {
-
                 // And then run plugin insights rate limited
                 this.rateLimiter = new RateLimiter(
                     async () => {

--- a/packages/agents/snapshotter/package.json
+++ b/packages/agents/snapshotter/package.json
@@ -25,7 +25,7 @@
     "@microsoft/fluid-protocol-definitions": "^0.1004.1-0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/node": "^10.14.6",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/packages/agents/spellchecker/package.json
+++ b/packages/agents/spellchecker/package.json
@@ -28,7 +28,7 @@
     "request": "^2.88.0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/node": "^10.14.6",
     "@types/request": "^2.47.1",

--- a/packages/agents/spellchecker/src/index.ts
+++ b/packages/agents/spellchecker/src/index.ts
@@ -25,7 +25,6 @@ declare module "@microsoft/fluid-component-core-interfaces" {
 }
 
 export class SpellChecker implements IComponentRouter, ISpellChecker {
-
     public get IComponentRouter() { return this; }
     public get ISpellChecker() { return this; }
 
@@ -50,5 +49,4 @@ export class SpellChecker implements IComponentRouter, ISpellChecker {
         const spellchecker = new Spellchecker(sharedString, dict);
         spellchecker.checkSharedString();
     }
-
 }

--- a/packages/agents/spellchecker/src/spellchecker.ts
+++ b/packages/agents/spellchecker/src/spellchecker.ts
@@ -86,7 +86,6 @@ class Speller {
             } else if (MergeTree.TextSegment.is(segment)) {
                 pgText += segment.text;
             } else {
-
                 throw new Error("Unknown SegmentType");
             }
             return true;

--- a/packages/agents/translator/package.json
+++ b/packages/agents/translator/package.json
@@ -29,7 +29,7 @@
     "request": "^2.88.0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/node": "^10.14.6",
     "@types/request": "^2.47.1",

--- a/packages/agents/translator/src/index.ts
+++ b/packages/agents/translator/src/index.ts
@@ -13,7 +13,6 @@ interface ITokenConfig {
 }
 
 export class Translator implements IComponentRouter, IComponentRunnable {
-
     constructor(
         private readonly sharedString: Sequence.SharedString,
         private readonly insightsMap: ISharedMap,

--- a/packages/components/agent-scheduler/package.json
+++ b/packages/components/agent-scheduler/package.json
@@ -59,7 +59,7 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/debug": "^0.0.31",
     "@types/mocha": "^5.2.5",

--- a/packages/components/agent-scheduler/src/scheduler.ts
+++ b/packages/components/agent-scheduler/src/scheduler.ts
@@ -33,7 +33,6 @@ import { v4 as uuid } from "uuid";
 const UnattachedClientId = `${uuid()}_unattached`;
 
 class AgentScheduler extends EventEmitter implements IAgentScheduler, IComponent, IComponentRouter {
-
     public static async load(runtime: IComponentRuntime, context: IComponentContext) {
         let root: ISharedMap;
         let scheduler: ConsensusRegisterCollection<string | null>;
@@ -78,7 +77,7 @@ class AgentScheduler extends EventEmitter implements IAgentScheduler, IComponent
     // List of all tasks client is capable of running (essentially expressed desire to run)
     // Client will proactively attempt to pick them up these tasks if they are not assigned to other clients.
     // This is a strict superset of tasks running in the client.
-    private readonly locallyRunnableTasks = new Map<string, () => Promise<void>>();
+    private readonly locallyRunnableTasks = new Map<string,() => Promise<void>>();
 
     // Set of registered tasks client is currently running.
     // It's subset of this.locallyRunnableTasks
@@ -88,7 +87,6 @@ class AgentScheduler extends EventEmitter implements IAgentScheduler, IComponent
         private readonly runtime: IComponentRuntime,
         private readonly context: IComponentContext,
         private readonly scheduler: ConsensusRegisterCollection<string | null>) {
-
         super();
     }
 
@@ -374,12 +372,11 @@ class AgentScheduler extends EventEmitter implements IAgentScheduler, IComponent
     }
 
     private sendErrorEvent(eventName: string, error: any, key?: string) {
-        this.runtime.logger.sendErrorEvent({eventName, key}, error);
+        this.runtime.logger.sendErrorEvent({ eventName, key }, error);
     }
 }
 
 export class TaskManager implements ITaskManager {
-
     public static async load(runtime: IComponentRuntime, context: IComponentContext): Promise<TaskManager> {
         const agentScheduler = await AgentScheduler.load(runtime, context);
         return new TaskManager(agentScheduler, runtime, context);

--- a/packages/components/table-document/package.json
+++ b/packages/components/table-document/package.json
@@ -53,7 +53,7 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-local-test-utils": "^0.16.0",
     "@microsoft/fluid-server-local-server": "^0.1004.1-0",

--- a/packages/components/table-document/src/document.ts
+++ b/packages/components/table-document/src/document.ts
@@ -27,7 +27,6 @@ import { debug } from "./debug";
 import { TableSlice } from "./slice";
 import { ITable, TableDocumentItem } from "./table";
 
-
 export interface ITableDocumentEvents extends IEvent{
     (event: "op",
         listener: (op: ISequencedDocumentMessage, local: boolean, target: SharedNumberSequence | SparseMatrix) => void);

--- a/packages/components/table-document/src/test/table.spec.ts
+++ b/packages/components/table-document/src/test/table.spec.ts
@@ -78,7 +78,7 @@ describe("TableDocument", () => {
 
     describe("local get/set", () => {
         // GitHub Issue #1683 - Cannot roundtrip non-finite numbers.
-        for (const value of ["", "string", 0 /*, -Infinity, +Infinity */]) {
+        for (const value of ["", "string", 0 /* , -Infinity, +Infinity */]) {
             it(`roundtrip ${JSON.stringify(value)}`, async () => {
                 table.insertRows(0, 1);
                 table.insertCols(0, 1);

--- a/packages/drivers/create-new-driver/package.json
+++ b/packages/drivers/create-new-driver/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/mocha": "^5.2.5",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/packages/drivers/create-new-driver/src/creationDeltaStorageService.ts
+++ b/packages/drivers/create-new-driver/src/creationDeltaStorageService.ts
@@ -12,7 +12,6 @@ import { CreationServerMessagesHandler } from ".";
  * Provides access to the false delta storage.
  */
 export class CreationDeltaStorageService implements IDocumentDeltaStorageService {
-
     constructor(private readonly serverMessagesHandler: CreationServerMessagesHandler) {
     }
 

--- a/packages/drivers/create-new-driver/src/creationDocumentDeltaConnection.ts
+++ b/packages/drivers/create-new-driver/src/creationDocumentDeltaConnection.ts
@@ -27,7 +27,6 @@ const protocolVersions = ["^0.4.0", "^0.3.0", "^0.2.0", "^0.1.0"];
  * ops and then emit them.
  */
 export class CreationDocumentDeltaConnection extends EventEmitter implements IDocumentDeltaConnection {
-
     private _details: IConnected | undefined;
 
     private get details(): IConnected {

--- a/packages/drivers/create-new-driver/src/creationDocumentService.ts
+++ b/packages/drivers/create-new-driver/src/creationDocumentService.ts
@@ -14,7 +14,6 @@ import { CreationServerMessagesHandler } from "./creationDriverServer";
  * The DocumentService connects to in memory endpoints for storage/socket for faux document service.
  */
 export class CreationDocumentService implements api.IDocumentService {
-
     private readonly creationServer: CreationServerMessagesHandler;
     constructor(
         private readonly documentId: string,

--- a/packages/drivers/create-new-driver/src/creationDocumentServiceFactory.ts
+++ b/packages/drivers/create-new-driver/src/creationDocumentServiceFactory.ts
@@ -16,7 +16,6 @@ import { CreationDocumentService } from "./creationDocumentService";
  * lie to runtime that there is an actual connection to server.
  */
 export class CreationDocumentServiceFactory implements IDocumentServiceFactory {
-
     public readonly protocolName = "fluid-creation:";
     constructor() {
     }

--- a/packages/drivers/create-new-driver/src/creationDriverServer.ts
+++ b/packages/drivers/create-new-driver/src/creationDriverServer.ts
@@ -30,7 +30,6 @@ interface IAugmentedDocumentMessage {
  * Server implementation used by Creation driver.
  */
 export class CreationServerMessagesHandler {
-
     public static getInstance(documentId: string): CreationServerMessagesHandler {
         if (CreationServerMessagesHandler.urlMap.has(documentId)) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -73,7 +72,6 @@ export class CreationServerMessagesHandler {
                 }
             }, Number.MAX_VALUE);
     }
-
 
     private createClientId() {
         return `newFileCreationClient${this.totalClients}`;

--- a/packages/drivers/create-new-driver/src/test/creationDeltaConnection.spec.ts
+++ b/packages/drivers/create-new-driver/src/test/creationDeltaConnection.spec.ts
@@ -11,7 +11,6 @@ import { CreationDriverUrlResolver } from "../creationDriverUrlResolver";
 import { CreationServerMessagesHandler } from "..";
 
 describe("Creation Driver", () => {
-
     let service: IDocumentService;
     let client: IClient;
     let documentDeltaConnection1: IDocumentDeltaConnection;
@@ -21,14 +20,14 @@ describe("Creation Driver", () => {
     beforeEach(async () => {
         const resolver: CreationDriverUrlResolver = new CreationDriverUrlResolver();
         const factory = new CreationDocumentServiceFactory();
-        resolved = (await resolver.resolve({url: `http://fluid.com?uniqueId=${docId}`})) as IFluidResolvedUrl;
+        resolved = (await resolver.resolve({ url: `http://fluid.com?uniqueId=${docId}` })) as IFluidResolvedUrl;
         service = await factory.createDocumentService(resolved);
         client = {
             mode: "write",
-            details: {capabilities: {interactive: false}},
+            details: { capabilities: { interactive: false } },
             permission: ["write"],
             scopes: [ScopeType.DocWrite],
-            user: {id: "user1"},
+            user: { id: "user1" },
         };
     });
 

--- a/packages/drivers/file-socket-storage/package.json
+++ b/packages/drivers/file-socket-storage/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/debug": "^0.0.31",
     "@types/node": "^10.14.6",

--- a/packages/drivers/file-socket-storage/src/fileDeltaStorageService.ts
+++ b/packages/drivers/file-socket-storage/src/fileDeltaStorageService.ts
@@ -12,7 +12,6 @@ import * as api from "@microsoft/fluid-protocol-definitions";
  * Provides access to the underlying delta storage on the local file storage for file driver.
  */
 export class FileDeltaStorageService implements IDocumentDeltaStorageService {
-
     private readonly messages: api.ISequencedDocumentMessage[];
     private lastOps: api.ISequencedDocumentMessage[] = [];
 

--- a/packages/drivers/file-socket-storage/src/fileDocumentServiceFactory.ts
+++ b/packages/drivers/file-socket-storage/src/fileDocumentServiceFactory.ts
@@ -18,7 +18,6 @@ import { FileDocumentService } from "./fileDocumentService";
  * use the local file storage as underlying storage.
  */
 export class FileDocumentServiceFactory implements IDocumentServiceFactory {
-
     public readonly protocolName = "fluid-file:";
     constructor(
         private readonly storage: IDocumentStorageService,

--- a/packages/drivers/fluid-debugger/package.json
+++ b/packages/drivers/fluid-debugger/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.14.6",

--- a/packages/drivers/fluid-debugger/src/fluidDebuggerController.ts
+++ b/packages/drivers/fluid-debugger/src/fluidDebuggerController.ts
@@ -111,7 +111,6 @@ export class DebugReplayController extends ReplayController implements IDebugger
     }
 
     public onSnapshotFileSelection(file: File) {
-
         if (!/^snapshot.*\.json/.exec(file.name)) {
             alert(`Incorrect file name: ${file.name}`);
             return;
@@ -167,7 +166,6 @@ export class DebugReplayController extends ReplayController implements IDebugger
         prevRequest: Promise<void>,
         index: number,
         version: IVersion): Promise<void> {
-
         if (this.isSelectionMade()) {
             return;
         }
@@ -182,7 +180,6 @@ export class DebugReplayController extends ReplayController implements IDebugger
             this.ui.updateVersionText(this.versionCount);
             this.ui.updateVersion(index, version, seqV);
         }
-
     }
 
     public async initStorage(documentStorageService: IDocumentStorageService): Promise<boolean> {

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -32,7 +32,7 @@
     "@microsoft/fluid-odsp-driver": "^0.16.0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/mocha": "^5.2.5",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/packages/drivers/fluidapp-odsp-urlResolver/src/test/fluidAppUrlResolver.spec.ts
+++ b/packages/drivers/fluidapp-odsp-urlResolver/src/test/fluidAppUrlResolver.spec.ts
@@ -8,7 +8,6 @@ import { IOdspResolvedUrl } from "@microsoft/fluid-odsp-driver";
 import { FluidAppOdspUrlResolver } from "../urlResolver";
 
 describe("Fluid App Url Resolver", () => {
-
     it("Should resolve the fluid app urls correctly", async () => {
         const urlResolver = new FluidAppOdspUrlResolver();
         // eslint-disable-next-line max-len

--- a/packages/drivers/fluidapp-odsp-urlResolver/src/urlResolver.ts
+++ b/packages/drivers/fluidapp-odsp-urlResolver/src/urlResolver.ts
@@ -14,7 +14,6 @@ const fluidOfficeServers = [
 ];
 
 export class FluidAppOdspUrlResolver implements IUrlResolver {
-
     public async resolve(request: IRequest): Promise<IResolvedUrl | undefined> {
         const reqUrl = new URL(request.url);
         const server = reqUrl.hostname.toLowerCase();

--- a/packages/drivers/iframe-socket-storage/package.json
+++ b/packages/drivers/iframe-socket-storage/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/debug": "^0.0.31",
     "@types/mocha": "^5.2.5",

--- a/packages/drivers/iframe-socket-storage/src/innerDocumentDeltaConnection.ts
+++ b/packages/drivers/iframe-socket-storage/src/innerDocumentDeltaConnection.ts
@@ -38,7 +38,6 @@ export class InnerDocumentDeltaConnection extends EventEmitter implements IDocum
     public static async create(
         connection: IConnected,
         outerProxy: Comlink.Remote<IOuterDocumentDeltaConnectionProxy>): Promise<IDocumentDeltaConnection> {
-
         const tempEmitter = new EventEmitter();
 
         const forwardEvent = (event: string, args: any[]) =>{
@@ -180,7 +179,6 @@ export class InnerDocumentDeltaConnection extends EventEmitter implements IDocum
      * @param listener - listener for the event
      */
     public on(event: string, listener: (...args: any[]) => void): this {
-
         this.tempEmitter.on(
             event,
             (...args: any[]) => {

--- a/packages/drivers/iframe-socket-storage/src/innerDocumentServiceFactory.ts
+++ b/packages/drivers/iframe-socket-storage/src/innerDocumentServiceFactory.ts
@@ -18,16 +18,14 @@ import { InnerUrlResolver } from "./innerUrlResolver";
  * Connects to the outerDocumentService factory across the iframe boundary
  */
 export class InnerDocumentServiceFactory implements IDocumentServiceFactory {
-
-    public static async create(): Promise<InnerDocumentServiceFactory>{
-
+    public static async create(): Promise<InnerDocumentServiceFactory> {
         let outerProxy: Comlink.Remote<IDocumentServiceFactoryProxy>;
         const create = async () => {
             // If the parent endpoint does not exist, returns empty proxy silently (no connection/failure case)
-            if(outerProxy === undefined){
+            if (outerProxy === undefined) {
                 outerProxy = Comlink.wrap<IDocumentServiceFactoryProxy>(Comlink.windowEndpoint(window.parent));
             }
-            if(outerProxy){
+            if (outerProxy) {
                 await outerProxy.connected();
                 return outerProxy;
             }
@@ -36,7 +34,7 @@ export class InnerDocumentServiceFactory implements IDocumentServiceFactory {
         const evtListener = (resolve) => {
             create()
                 .then((value)=>{
-                    if(value){
+                    if (value) {
                         resolve(value);
                     }
                 })
@@ -67,7 +65,6 @@ export class InnerDocumentServiceFactory implements IDocumentServiceFactory {
     }
 
     public async createDocumentService(): Promise<IDocumentService> {
-
         const outerDocumentServiceProxy = await this.outerProxy.createDocumentService();
 
         return InnerDocumentService.create(this.outerProxy.clients[outerDocumentServiceProxy]);

--- a/packages/drivers/iframe-socket-storage/src/innerUrlResolver.ts
+++ b/packages/drivers/iframe-socket-storage/src/innerUrlResolver.ts
@@ -10,7 +10,6 @@ import { IResolvedUrl, IUrlResolver } from "@microsoft/fluid-driver-definitions"
  * A UrlResolver that returns a fixed url
  */
 export class InnerUrlResolver implements IUrlResolver {
-
     constructor(private readonly resolved: IResolvedUrl) {
     }
 

--- a/packages/drivers/iframe-socket-storage/src/outerDocumentServiceFactory.ts
+++ b/packages/drivers/iframe-socket-storage/src/outerDocumentServiceFactory.ts
@@ -123,9 +123,7 @@ export class DocumentServiceFactoryProxy implements IDocumentServiceFactoryProxy
         });
     }
 
-
     private createProxy(frame: HTMLIFrameElement) {
-
         // Host guarantees that frame and contentWindow are both loaded
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const iframeContentWindow = frame.contentWindow!;
@@ -141,7 +139,6 @@ export class DocumentServiceFactoryProxy implements IDocumentServiceFactoryProxy
         iframeContentWindow.window.postMessage("EndpointExposed", "*");
         Comlink.expose(proxy, Comlink.windowEndpoint(iframeContentWindow));
     }
-
 
     private getStorage(storage: IDocumentStorageService): IDocumentStorageService {
         return {
@@ -189,7 +186,6 @@ export class DocumentServiceFactoryProxy implements IDocumentServiceFactoryProxy
     }
 
     private getOuterDocumentDeltaConnection(deltaStream: IDocumentDeltaConnection) {
-
         const pendingOps: { type: string, args: any[] }[] = [];
 
         for (const event of socketIOEvents) {
@@ -251,13 +247,11 @@ export class DocumentServiceFactoryProxy implements IDocumentServiceFactoryProxy
     }
 }
 
-
 /**
  * Creates a proxy outerdocumentservice from either a resolvedURL or a request
  * Remotes the real connection to an iframe
  */
 export class IFrameDocumentServiceProxyFactory {
-
     public static async create(
         documentServiceFactory: IDocumentServiceFactory,
         frame: HTMLIFrameElement,
@@ -288,7 +282,6 @@ export class IFrameDocumentServiceProxyFactory {
     }
 
     public async createDocumentServiceFromRequest(request: IRequest): Promise<IDocumentServiceFactoryProxy> {
-
         const resolvedUrl = await this.urlResolver.resolve(request);
         ensureFluidResolvedUrl(resolvedUrl);
 

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -38,7 +38,7 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/node": "^10.14.6",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/packages/drivers/local-driver/src/testDocumentServiceFactory.ts
+++ b/packages/drivers/local-driver/src/testDocumentServiceFactory.ts
@@ -18,7 +18,6 @@ import { createTestDocumentService } from "./testDocumentService";
  * Implementation of document service factory for testing.
  */
 export class TestDocumentServiceFactory implements IDocumentServiceFactory {
-
     public readonly protocolName = "fluid-test:";
     /**
      * @param localDeltaConnectionServer - delta connection server for ops
@@ -34,7 +33,7 @@ export class TestDocumentServiceFactory implements IDocumentServiceFactory {
         ensureFluidResolvedUrl(resolvedUrl);
 
         const parsedUrl = parse(resolvedUrl.url);
-        const [, tenantId, documentId] = parsedUrl.path? parsedUrl.path.split("/") : [];
+        const [, tenantId, documentId] = parsedUrl.path ? parsedUrl.path.split("/") : [];
         if (!documentId || !tenantId) {
             throw new Error(`Couldn't parse resolved url. [documentId:${documentId}][tenantId:${tenantId}]`);
         }

--- a/packages/drivers/odsp-socket-storage/package.json
+++ b/packages/drivers/odsp-socket-storage/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/debug": "^0.0.31",
     "@types/mocha": "^5.2.5",

--- a/packages/drivers/odsp-socket-storage/src/getUrlAndHeadersWithAuth.ts
+++ b/packages/drivers/odsp-socket-storage/src/getUrlAndHeadersWithAuth.ts
@@ -32,7 +32,6 @@ export function getUrlAndHeadersWithAuth(url: string, token: string | null): { u
     if (tokenIsQueryParam) {
         // The token itself is a query param
         tokenQueryParam += token.substring(1);
-
     } else {
         tokenQueryParam += `access_token=${encodeURIComponent(token)}`;
     }

--- a/packages/drivers/odsp-socket-storage/src/odspCache.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspCache.ts
@@ -75,7 +75,6 @@ export class CacheBase {
             this.cache.delete(key);
         }
     }
-
 }
 
 export class LocalCache extends CacheBase implements ICache {
@@ -89,7 +88,6 @@ export class SessionCache extends CacheBase implements ISessionCache {
         return this.cache.get(key);
     }
 }
-
 
 export class OdspCache implements IOdspCache {
     public readonly localStorage: ICache;

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentDeltaConnection.ts
@@ -72,7 +72,6 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
         url: string,
         timeoutMs: number = 20000,
         telemetryLogger: ITelemetryLogger = new TelemetryNullLogger()): Promise<IDocumentDeltaConnection> {
-
         const socketReferenceKey = `${url},${tenantId},${webSocketId}`;
 
         const socketReference = OdspDocumentDeltaConnection.getOrCreateSocketIoReference(
@@ -150,7 +149,6 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
             socketReference.clearTimer();
 
             debug(`Using existing socketio reference for ${key} (${socketReference.references})`);
-
         } else {
             const socket = io(
                 url,
@@ -176,7 +174,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
                 // The server always closes the socket after sending this message
                 // fully remove the socket reference now
                 // This raises "disconnect" event with proper error object.
-                OdspDocumentDeltaConnection.removeSocketIoReference(key, true /*socketProtocolError*/, error);
+                OdspDocumentDeltaConnection.removeSocketIoReference(key, true /* socketProtocolError */, error);
             });
 
             socketReference = new SocketReference(socket);

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
@@ -90,7 +90,7 @@ export class OdspDocumentService implements IDocumentService {
                     itemId: odspResolvedUrl.itemId,
                 };
                 event.end(props);
-            } catch(error) {
+            } catch (error) {
                 event.cancel(undefined, error);
                 throw error;
             }
@@ -124,7 +124,6 @@ export class OdspDocumentService implements IDocumentService {
     private readonly localStorageAvailable: boolean;
 
     private readonly joinSessionKey: string;
-
 
     /**
      * @param appId - app id used for telemetry for network requests
@@ -160,7 +159,6 @@ export class OdspDocumentService implements IDocumentService {
         private readonly isFirstTimeDocumentOpened = true,
         private readonly createNewFlag: boolean,
     ) {
-
         this.joinSessionKey = `${this.hashedDocumentId}/joinsession`;
 
         this.logger = DebugLogger.mixinDebugLogger(
@@ -502,5 +500,4 @@ export class OdspDocumentService implements IDocumentService {
             throw connectionError;
         });
     }
-
 }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
@@ -277,7 +277,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
                 if (refresh) {
                     // This is the most critical code path for boot.
                     // If we get incorrect / expired token first time, that adds up to latency of boot
-                    this.logger.sendErrorEvent({eventName: "TreeLatest_SecondCall"});
+                    this.logger.sendErrorEvent({ eventName: "TreeLatest_SecondCall" });
                 }
 
                 const odspCacheKey: string = `${this.documentId}/getlatest`;
@@ -543,7 +543,6 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
             appTree = trees[1];
 
             hierarchicalProtocolTree = buildHierarchy(protocolTree);
-
         } else {
             appTree = await this.readTree(appTreeId);
 
@@ -719,13 +718,11 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
                     id,
                     value,
                 };
-
             } else if (id) {
                 entry = {
                     ...baseEntry,
                     id,
                 };
-
             } else {
                 throw new Error(`Invalid tree entry for ${summaryObject.type}`);
             }

--- a/packages/drivers/odsp-socket-storage/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDriverUrlResolver.ts
@@ -91,7 +91,7 @@ export class OdspDriverUrlResolver implements IUrlResolver, IExperimentalUrlReso
         createNewSummary: ISummaryTree,
         request: IRequest,
     ): Promise<IOdspResolvedUrl> {
-        if(!request.headers) {
+        if (!request.headers) {
             throw new Error("Request should contian headers!!");
         }
         assert(request.headers.newFileInfoPromise);

--- a/packages/drivers/odsp-socket-storage/src/odspUtils.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspUtils.ts
@@ -36,7 +36,7 @@ export function throwOdspNetworkError(
         message,
         canRetry,
         statusCode,
-        undefined /*retryAfterSeconds*/,
+        undefined /* retryAfterSeconds */,
         online);
     (networkError as any).sprequestguid = sprequestguid;
     throw networkError;

--- a/packages/drivers/odsp-socket-storage/src/test/odspError.spec.ts
+++ b/packages/drivers/odsp-socket-storage/src/test/odspError.spec.ts
@@ -10,7 +10,6 @@ import { IOdspSocketError } from "../contracts";
 import { throwOdspNetworkError, errorObjectFromSocketError } from "../odspUtils";
 
 describe("Odsp Error", () => {
-
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const testResponse = { // Implements only part of Response.headers
         statusText: "testStatusText",
@@ -43,8 +42,8 @@ describe("Odsp Error", () => {
         const networkError: IError = createOdspNetworkError(
             "TestMessage",
             400,
-            true /*canRetry*/,
-            true /*includeResponse*/,
+            true /* canRetry */,
+            true /* includeResponse */,
             OnlineStatus[OnlineStatus.Offline],
         );
         if (networkError.errorType !== ErrorType.genericNetworkError) {
@@ -63,13 +62,13 @@ describe("Odsp Error", () => {
     });
 
     it("throwOdspNetworkError sprequestguid exist", async () => {
-        const error1: any = createOdspNetworkError("Error", 400, true /*canRetry*/, true /*includeResponse*/);
+        const error1: any = createOdspNetworkError("Error", 400, true /* canRetry*/, true /* includeResponse */);
         const errorBag = { ...error1.getCustomProperties() };
         assert.equal("xxx-xxx", errorBag.sprequestguid, "sprequestguid should be 'xxx-xxx'");
     });
 
     it("throwOdspNetworkError sprequestguid undefined", async () => {
-        const error1: any = createOdspNetworkError("Error", 400, true /*canRetry*/, false /*includeResponse*/);
+        const error1: any = createOdspNetworkError("Error", 400, true /* canRetry*/, false /* includeResponse */);
         const errorBag = { ...error1.getCustomProperties() };
         assert.equal(undefined, errorBag.sprequestguid, "sprequestguid should not be defined");
     });

--- a/packages/drivers/odsp-socket-storage/src/vroom.ts
+++ b/packages/drivers/odsp-socket-storage/src/vroom.ts
@@ -43,8 +43,8 @@ export async function fetchJoinSession(
             throwOdspNetworkError("Failed to acquire Vroom token", 400, true);
         }
 
-        const extraProps = refresh ? {secondAttempt: 1} : {};
-        const joinSessionEvent = PerformanceEvent.start(logger, { eventName: "JoinSession", ...extraProps});
+        const extraProps = refresh ? { secondAttempt: 1 } : {};
+        const joinSessionEvent = PerformanceEvent.start(logger, { eventName: "JoinSession", ...extraProps });
         try {
             // TODO Extract the auth header-vs-query logic out
             const siteOrigin = getOrigin(siteUrl);

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -31,7 +31,7 @@
     "@microsoft/fluid-odsp-driver": "^0.16.0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/mocha": "^5.2.5",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/packages/drivers/odsp-urlResolver/src/test/spoUrlResolver.spec.ts
+++ b/packages/drivers/odsp-urlResolver/src/test/spoUrlResolver.spec.ts
@@ -8,7 +8,6 @@ import { IOdspResolvedUrl } from "@microsoft/fluid-odsp-driver";
 import { OdspUrlResolver } from "../urlResolver";
 
 describe("Spo Url Resolver", () => {
-
     it("Should resolve the spo urls correctly", async () => {
         const urlResolver = new OdspUrlResolver();
         const url: string = "https://microsoft-my.sharepoint-df.com/_api/v2.1/drives/randomDrive/items/randomItem";

--- a/packages/drivers/odsp-urlResolver/src/urlResolver.ts
+++ b/packages/drivers/odsp-urlResolver/src/urlResolver.ts
@@ -14,7 +14,6 @@ import {
 } from "@microsoft/fluid-odsp-driver";
 
 export class OdspUrlResolver implements IUrlResolver {
-
     public async resolve(request: IRequest): Promise<IResolvedUrl | undefined> {
         if (isOdspUrl(request.url)) {
             const reqUrl = new URL(request.url);

--- a/packages/drivers/replay-socket-storage/package.json
+++ b/packages/drivers/replay-socket-storage/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/debug": "^0.0.31",
     "@types/mocha": "^5.2.5",

--- a/packages/drivers/replay-socket-storage/src/emptyDeltaStorageService.ts
+++ b/packages/drivers/replay-socket-storage/src/emptyDeltaStorageService.ts
@@ -7,7 +7,6 @@ import { IDocumentDeltaStorageService } from "@microsoft/fluid-driver-definition
 import * as api from "@microsoft/fluid-protocol-definitions";
 
 export class EmptyDeltaStorageService implements IDocumentDeltaStorageService {
-
     /**
      * Returns ops from the list of ops generated till now.
      * @param from - Ops are returned from + 1.

--- a/packages/drivers/replay-socket-storage/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-socket-storage/src/replayDocumentDeltaConnection.ts
@@ -193,7 +193,6 @@ export class ReplayDocumentDeltaConnection extends EventEmitter implements IDocu
     public static create(
         documentStorageService: IDocumentDeltaStorageService,
         controller: ReplayController): IDocumentDeltaConnection {
-
         const connection: IConnected = {
             claims: ReplayDocumentDeltaConnection.claims,
             clientId: "",

--- a/packages/drivers/replay-socket-storage/src/replayDocumentServiceFactory.ts
+++ b/packages/drivers/replay-socket-storage/src/replayDocumentServiceFactory.ts
@@ -9,7 +9,6 @@ import { ReplayControllerStatic } from "./replayDocumentDeltaConnection";
 import { ReplayDocumentService } from "./replayDocumentService";
 
 export class ReplayDocumentServiceFactory implements IDocumentServiceFactory {
-
     public static create(
         from: number,
         to: number,

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -31,7 +31,7 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/mocha": "^5.2.5",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/packages/drivers/routerlicious-socket-storage/package.json
+++ b/packages/drivers/routerlicious-socket-storage/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/debug": "^0.0.31",
     "@types/jwt-decode": "^2.2.1",

--- a/packages/drivers/routerlicious-socket-storage/src/registration.ts
+++ b/packages/drivers/routerlicious-socket-storage/src/registration.ts
@@ -28,7 +28,6 @@ export function createDocumentService(
     historianApi = true,
     credentials?,
     seedData?: IGitCache): IDocumentService {
-
     const service = new DocumentService(
         ordererUrl,
         deltaStorageUrl,

--- a/packages/drivers/routerlicious-socket-storage/src/tokens.ts
+++ b/packages/drivers/routerlicious-socket-storage/src/tokens.ts
@@ -19,7 +19,6 @@ export class TokenService implements ITokenService {
  * Checks the validation of a token.
  */
 export class TokenProvider implements ITokenProvider {
-
     constructor(public token: string) {
     }
 

--- a/packages/drivers/routerlicious-socket-storage/src/wsDeltaConnection.ts
+++ b/packages/drivers/routerlicious-socket-storage/src/wsDeltaConnection.ts
@@ -28,7 +28,6 @@ const protocolVersion = "^0.1.0";
  * Represents a connection to a stream of delta updates for routerlicious driver.
  */
 export class WSDeltaConnection extends EventEmitter implements IDocumentDeltaConnection {
-
     /**
      * Represents a connection to a stream of delta updates for routerlicious driver.
      *
@@ -45,7 +44,6 @@ export class WSDeltaConnection extends EventEmitter implements IDocumentDeltaCon
         token: string,
         client: IClient,
         urlStr: string): Promise<IDocumentDeltaConnection> {
-
         return new Promise<IDocumentDeltaConnection>((resolve, reject) => {
             const connection = new WSDeltaConnection(tenantId, id, token, client, urlStr);
 

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -34,7 +34,7 @@
     "nconf": "^0.10.0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/mocha": "^5.2.5",
     "@types/nconf": "^0.0.37",

--- a/packages/drivers/routerlicious-urlResolver/src/test/routerlicious-urlResolver.spec.ts
+++ b/packages/drivers/routerlicious-urlResolver/src/test/routerlicious-urlResolver.spec.ts
@@ -12,7 +12,6 @@ import { Provider } from "nconf";
 import { RouterliciousUrlResolver } from "../urlResolver";
 
 describe("Routerlicious Url Resolver", () => {
-
     const token = "dummy";
     it("Should resolve the Routerlicious urls correctly", async () => {
         const urlResolver = new RouterliciousUrlResolver(undefined, async () => Promise.resolve(token), []);
@@ -58,7 +57,7 @@ describe("Routerlicious Url Resolver", () => {
         };
         const urlResolver = new RouterliciousUrlResolver(config, async () => Promise.resolve(token), []);
 
-        const {endpoints, url} = (await urlResolver.resolve(request)) as IFluidResolvedUrl;
+        const { endpoints, url } = (await urlResolver.resolve(request)) as IFluidResolvedUrl;
 
         assert.equal(endpoints.storageUrl, "http://localhost:3001/repos/fluid", "Improperly Formed storageUrl");
         assert.equal(endpoints.deltaStorageUrl, "http://localhost:3003/deltas/fluid/damp-competition", "Improperly Formed deltaStorageUrl");
@@ -87,7 +86,7 @@ describe("Routerlicious Url Resolver", () => {
         };
 
         const urlResolver = new RouterliciousUrlResolver(config, async () => Promise.resolve(token), []);
-        const {endpoints, url} = (await urlResolver.resolve(request)) as IFluidResolvedUrl;
+        const { endpoints, url } = (await urlResolver.resolve(request)) as IFluidResolvedUrl;
 
         assert.equal(endpoints.storageUrl, "http://historian:3000/repos/fluid", "Improperly Formed storageUrl");
         assert.equal(endpoints.deltaStorageUrl, "http://alfred:3000/deltas/fluid/damp-competition", "Improperly Formed deltaStorageUrl");
@@ -115,14 +114,13 @@ describe("Routerlicious Url Resolver", () => {
         };
 
         const urlResolver = new RouterliciousUrlResolver(config, async () => Promise.resolve(token), []);
-        const {endpoints, url} = (await urlResolver.resolve(request)) as IFluidResolvedUrl;
+        const { endpoints, url } = (await urlResolver.resolve(request)) as IFluidResolvedUrl;
 
         assert.equal(endpoints.storageUrl, "http://smelly-wolf-historian:3000/repos/fluid", "Improperly Formed storageUrl");
         assert.equal(endpoints.deltaStorageUrl, "http://wiggly-wombat-alfred:3000/deltas/fluid/damp-competition", "Improperly Formed deltaStorageUrl");
         assert.equal(endpoints.ordererUrl, "http://wiggly-wombat-alfred:3000", "Improperly Formed OrdererUrl");
         assert.equal(url, "fluid://localhost:3003/fluid/damp-competition?chaincode=@fluid-example/shared-text@^0.11.0", "Improperly formed FluidURL");
     });
-
 
     it("Should handle deployed External request", async () => {
         const request: IRequest = {
@@ -145,7 +143,7 @@ describe("Routerlicious Url Resolver", () => {
         };
 
         const urlResolver = new RouterliciousUrlResolver(config, async () => Promise.resolve(token), []);
-        const {endpoints, url} = (await urlResolver.resolve(request)) as IFluidResolvedUrl;
+        const { endpoints, url } = (await urlResolver.resolve(request)) as IFluidResolvedUrl;
 
         assert.equal(endpoints.storageUrl, "https://historian.wu2-ppe.prague.office-int.com/repos/fluid", "Storage url does not match");
         assert.equal(endpoints.deltaStorageUrl, "https://alfred.wu2-ppe.prague.office-int.com/deltas/fluid/damp-competition", "Delta storage url does not match");

--- a/packages/drivers/routerlicious-urlResolver/src/urlResolver.ts
+++ b/packages/drivers/routerlicious-urlResolver/src/urlResolver.ts
@@ -24,7 +24,6 @@ const r11sServers = [
 ];
 
 export class RouterliciousUrlResolver implements IUrlResolver, IExperimentalUrlResolver {
-
     public readonly isExperimentalUrlResolver = true;
 
     constructor(
@@ -87,7 +86,6 @@ export class RouterliciousUrlResolver implements IUrlResolver, IExperimentalUrlR
             `${this.config ? parse(this.config.provider.get("worker:serverUrl")).host : serverSuffix}/` +
             `${encodeURIComponent(tenantId)}/` +
             `${encodeURIComponent(documentId)}`;
-
 
         // In case of any additional parameters add them back to the url
         if (reqUrl.search) {

--- a/packages/drivers/socket-storage-shared/package.json
+++ b/packages/drivers/socket-storage-shared/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@typescript-eslint/eslint-plugin": "~2.17.0",
     "@typescript-eslint/parser": "~2.17.0",

--- a/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
+++ b/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
@@ -71,7 +71,6 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
         client: IClient,
         url: string,
         timeoutMs: number = 20000): Promise<IDocumentDeltaConnection> {
-
         const socket = io(
             url,
             {

--- a/packages/framework/aqueduct-react/package.json
+++ b/packages/framework/aqueduct-react/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/node": "^10.14.6",
     "@types/react": "^16.9.15",

--- a/packages/framework/aqueduct-react/src/react/collaborativeCheckbox.tsx
+++ b/packages/framework/aqueduct-react/src/react/collaborativeCheckbox.tsx
@@ -43,7 +43,7 @@ export class CollaborativeCheckbox extends React.Component<IProps, IState> {
     }
 
     public render() {
-        return(
+        return (
             <input
                 type="checkbox"
                 aria-checked={this.state.checked}

--- a/packages/framework/aqueduct-react/src/react/collaborativeInput.tsx
+++ b/packages/framework/aqueduct-react/src/react/collaborativeInput.tsx
@@ -58,7 +58,7 @@ export class CollaborativeInput extends React.Component<IProps, IState> {
     }
 
     public render() {
-        return(
+        return (
             // There are a lot of different ways content can be inserted into a input box
             // and not all of them trigger a onBeforeInput event. To ensure we are grabbing
             // the correct selection before we modify the shared string we need to make sure
@@ -115,6 +115,6 @@ export class CollaborativeInput extends React.Component<IProps, IState> {
         const selectionEnd = this.inputElementRef.current.selectionEnd ? this.inputElementRef.current.selectionEnd : 0;
         // eslint-disable-next-line max-len
         const selectionStart = this.inputElementRef.current.selectionStart ? this.inputElementRef.current.selectionStart : 0;
-        this.setState({selectionEnd, selectionStart});
+        this.setState({ selectionEnd, selectionStart });
     }
 }

--- a/packages/framework/aqueduct-react/src/react/collaborativeTextArea.tsx
+++ b/packages/framework/aqueduct-react/src/react/collaborativeTextArea.tsx
@@ -55,7 +55,7 @@ export class CollaborativeTextArea extends React.Component<IProps, IState> {
 
             // If the event is our own then just insert the text
             if (event.isLocal) {
-                this.setState({text: newText});
+                this.setState({ text: newText });
                 return;
             }
 
@@ -108,7 +108,7 @@ export class CollaborativeTextArea extends React.Component<IProps, IState> {
                 }
             }
 
-            this.setState({text: newText});
+            this.setState({ text: newText });
             this.setCaretPosition(newCaretStart, newCaretEnd);
         });
     }
@@ -125,7 +125,7 @@ export class CollaborativeTextArea extends React.Component<IProps, IState> {
     // }
 
     public render() {
-        return(
+        return (
             // There are a lot of different ways content can be inserted into a textarea
             // and not all of them trigger a onBeforeInput event. To ensure we are grabbing
             // the correct selection before we modify the shared string we need to make sure
@@ -149,7 +149,7 @@ export class CollaborativeTextArea extends React.Component<IProps, IState> {
         // We need to set the value here to keep the input responsive to the user
         const newText = ev.currentTarget.value;
         const charactersModifiedCount = this.state.text.length - newText.length;
-        this.setState({text: newText});
+        this.setState({ text: newText });
 
         // Get the new caret position and use that to get the text that was inserted
         const newPosition = ev.currentTarget.selectionStart ? ev.currentTarget.selectionStart : 0;
@@ -180,6 +180,6 @@ export class CollaborativeTextArea extends React.Component<IProps, IState> {
 
         const selectionEnd = this.ref.current.selectionEnd ? this.ref.current.selectionEnd : 0;
         const selectionStart = this.ref.current.selectionStart ? this.ref.current.selectionStart : 0;
-        this.setState({selectionEnd, selectionStart});
+        this.setState({ selectionEnd, selectionStart });
     }
 }

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.14.6",

--- a/packages/framework/aqueduct/src/containerServices/containerServices.ts
+++ b/packages/framework/aqueduct/src/containerServices/containerServices.ts
@@ -16,10 +16,9 @@ export type ContainerServiceRegistryEntries = Iterable<[string, (runtime: IHostR
  * This class is a simple starter class for building a Container Service. It simply provides routing
  */
 export abstract class BaseContainerService implements IComponentRouter {
-
     public get IComponentRouter() { return this; }
 
-    constructor(protected readonly runtime: IHostRuntime){
+    constructor(protected readonly runtime: IHostRuntime) {
     }
 
     public async request(request: IRequest): Promise<IResponse> {
@@ -35,7 +34,6 @@ export abstract class BaseContainerService implements IComponentRouter {
  * ContainerService Factory that will only create one instance of the service for the Container.
  */
 class SingletonContainerServiceFactory {
-
     private service: Promise<IComponent> | undefined;
 
     public constructor(
@@ -107,11 +105,10 @@ export const generateContainerServicesRequestHandler =
             }
 
             // Otherwise we will just return the service
-            return{
+            return {
                 status: 200,
                 mimeType: "fluid/component",
                 value: service,
             };
         };
     };
-

--- a/packages/framework/aqueduct/src/test/containerServices.spec.ts
+++ b/packages/framework/aqueduct/src/test/containerServices.spec.ts
@@ -17,7 +17,6 @@ import {
 } from "../containerServices";
 
 class ContainerServiceMock extends BaseContainerService {
-
     public route: string = "";
 
     public async request(request: IRequest): Promise<IResponse> {
@@ -35,7 +34,7 @@ describe("Routerlicious", () => {
         describe("generateContainerServicesRequestHandler", () => {
             it(`Request to ${serviceRoutePathRoot} and no id should fail`, async () => {
                 const requestHandler = generateContainerServicesRequestHandler([]);
-                const requestParser = new RequestParser({url:`/${serviceRoutePathRoot}`});
+                const requestParser = new RequestParser({ url:`/${serviceRoutePathRoot}` });
 
                 const response = await requestHandler(requestParser, {} as IHostRuntime);
 
@@ -45,7 +44,7 @@ describe("Routerlicious", () => {
 
             it("Unknown service should return 404 with no services", async () => {
                 const requestHandler = generateContainerServicesRequestHandler([]);
-                const requestParser = new RequestParser({url:`/${serviceRoutePathRoot}/id1`});
+                const requestParser = new RequestParser({ url:`/${serviceRoutePathRoot}/id1` });
 
                 const response = await requestHandler(requestParser, {} as IHostRuntime);
 
@@ -57,7 +56,7 @@ describe("Routerlicious", () => {
                 const requestHandler = generateContainerServicesRequestHandler([
                     ["id1",async (r) => new ContainerServiceMock(r)],
                 ]);
-                const requestParser = new RequestParser({url:`/${serviceRoutePathRoot}/id2`});
+                const requestParser = new RequestParser({ url:`/${serviceRoutePathRoot}/id2` });
 
                 const response = await requestHandler(requestParser, {} as IHostRuntime);
 
@@ -69,7 +68,7 @@ describe("Routerlicious", () => {
                 const requestHandler = generateContainerServicesRequestHandler([
                     ["id1",async (r) => {return {};}],
                 ]);
-                const requestParser = new RequestParser({url:`/${serviceRoutePathRoot}/id1/subroute`});
+                const requestParser = new RequestParser({ url:`/${serviceRoutePathRoot}/id1/subroute` });
 
                 const response = await requestHandler(requestParser, {} as IHostRuntime);
 
@@ -82,7 +81,7 @@ describe("Routerlicious", () => {
                 const serviceMap = new Map();
                 serviceMap.set("id1", async (r) => service1);
                 const requestHandler = generateContainerServicesRequestHandler(serviceMap);
-                const requestParser = new RequestParser({url:`/${serviceRoutePathRoot}/id1`});
+                const requestParser = new RequestParser({ url:`/${serviceRoutePathRoot}/id1` });
 
                 const response = await requestHandler(requestParser, {} as IHostRuntime);
 
@@ -95,7 +94,7 @@ describe("Routerlicious", () => {
                 const requestHandler = generateContainerServicesRequestHandler([
                     ["id1", async (r) => new ContainerServiceMock(r)],
                 ]);
-                const requestParser = new RequestParser({url:`/${serviceRoutePathRoot}/id1`});
+                const requestParser = new RequestParser({ url:`/${serviceRoutePathRoot}/id1` });
 
                 const response1 = await requestHandler(requestParser, {} as IHostRuntime);
                 const response2 = await requestHandler(requestParser, {} as IHostRuntime);
@@ -109,7 +108,7 @@ describe("Routerlicious", () => {
                     ["id1", async (r) => new ContainerServiceMock(r)],
                     ["id2", async (r) => service2],
                 ]);
-                const requestParser = new RequestParser({url:`/${serviceRoutePathRoot}/id2`});
+                const requestParser = new RequestParser({ url:`/${serviceRoutePathRoot}/id2` });
 
                 const response = await requestHandler(requestParser, {} as IHostRuntime);
 
@@ -128,7 +127,7 @@ describe("Routerlicious", () => {
                     ["id1", async (r) => new ContainerServiceMock(r)],
                     ["id1", async (r) => service1],
                 ]);
-                const requestParser = new RequestParser({url:`/${serviceRoutePathRoot}/id1`});
+                const requestParser = new RequestParser({ url:`/${serviceRoutePathRoot}/id1` });
 
                 const response = await requestHandler(requestParser, {} as IHostRuntime);
 
@@ -140,7 +139,7 @@ describe("Routerlicious", () => {
             it("Sub-route should be persisted through", async () => {
                 const service1 = new ContainerServiceMock({} as IHostRuntime);
                 const requestHandler = generateContainerServicesRequestHandler([["id1", async (r) => service1]]);
-                const requestParser = new RequestParser({url:`/${serviceRoutePathRoot}/id1/sub1`});
+                const requestParser = new RequestParser({ url:`/${serviceRoutePathRoot}/id1/sub1` });
 
                 const response = await requestHandler(requestParser, {} as IHostRuntime);
 

--- a/packages/framework/component-base/package.json
+++ b/packages/framework/component-base/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.14.6",

--- a/packages/framework/component-base/src/sharedcomponent.ts
+++ b/packages/framework/component-base/src/sharedcomponent.ts
@@ -17,7 +17,6 @@ import { ISharedObject } from "@microsoft/fluid-shared-object-base";
 import { EventForwarder } from "@microsoft/fluid-common-utils";
 import { IEvent } from "@microsoft/fluid-common-definitions";
 
-
 export abstract class SharedComponent<
     TRoot extends ISharedObject = ISharedObject,
     TEvents extends IEvent = IEvent,

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-test-runtime-utils": "^0.16.0",
     "@types/debug": "^0.0.31",

--- a/packages/framework/dds-interceptions/src/map/index.ts
+++ b/packages/framework/dds-interceptions/src/map/index.ts
@@ -5,4 +5,3 @@
 
 export * from "./sharedDirectoryWithInterception";
 export * from "./sharedMapWithInterception";
-

--- a/packages/framework/dds-interceptions/src/test/sharedStringWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedStringWithInterception.spec.ts
@@ -17,7 +17,7 @@ describe("Shared String with Interception", () => {
      * information to the passed properties and returns it.
      */
     describe("Simple User Attribution", () => {
-        const userAttributes = { userId: "Fake User"};
+        const userAttributes = { userId: "Fake User" };
         const documentId = "fakeId";
         let deltaConnectionFactory: MockDeltaConnectionFactory;
         let sharedString: SharedString;
@@ -69,7 +69,7 @@ describe("Shared String with Interception", () => {
 
             // Replace text in the shared string.
             text = "aaa";
-            syleProps = { style: "italics "};
+            syleProps = { style: "italics " };
             sharedStringWithInterception.replaceText(2, 3, "aaa", syleProps);
             verifyString(sharedStringWithInterception, "12aaa", { ...syleProps, ...userAttributes }, 2);
 
@@ -92,7 +92,7 @@ describe("Shared String with Interception", () => {
 
             // Replace text via the shared string with interception wrapper.
             text = "aaa";
-            syleProps = { style: "italics "};
+            syleProps = { style: "italics " };
             sharedStringWithInterception.replaceText(2, 3, "aaa", syleProps);
             // Verify the text and properties via the underlying shared string.
             verifyString(sharedString, "12aaa", { ...syleProps, ...userAttributes }, 2);
@@ -117,7 +117,7 @@ describe("Shared String with Interception", () => {
 
             // Replace text via the underlying shared string.
             text = "aaa";
-            syleProps = { style: "italics "};
+            syleProps = { style: "italics " };
             sharedString.replaceText(2, 3, "aaa", syleProps);
             // Verify the text and properties via the interception wrapper. It should not have the user attributes.
             verifyString(sharedStringWithInterception, "12aaa", syleProps, 2);
@@ -126,7 +126,7 @@ describe("Shared String with Interception", () => {
             const colorProps = { color: "green" };
             sharedString.annotateRange(0, 5, colorProps);
             // Verify the text and properties via the interception wrapper. It should not have the user attributes.
-            verifyString(sharedStringWithInterception, "12aaa", { ...syleProps, ...colorProps}, 2);
+            verifyString(sharedStringWithInterception, "12aaa", { ...syleProps, ...colorProps }, 2);
         });
 
         /**

--- a/packages/framework/experimental/package.json
+++ b/packages/framework/experimental/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@typescript-eslint/eslint-plugin": "~2.17.0",
     "@typescript-eslint/parser": "~2.17.0",

--- a/packages/framework/framework-definitions/package.json
+++ b/packages/framework/framework-definitions/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@typescript-eslint/eslint-plugin": "~2.17.0",
     "@typescript-eslint/parser": "~2.17.0",

--- a/packages/framework/last-edited/package.json
+++ b/packages/framework/last-edited/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.14.6",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.14.6",

--- a/packages/framework/synthesize/src/dependencyContainer.ts
+++ b/packages/framework/synthesize/src/dependencyContainer.ts
@@ -35,7 +35,7 @@ export class DependencyContainer implements IComponentDependencySynthesizer {
      * {@inheritDoc (IComponentSynthesizer:interface).register}
      */
     public register<T extends keyof IComponent>(type: T, provider: ComponentProvider<T>): void {
-        if (this.has(type)){
+        if (this.has(type)) {
             throw new Error(`Attempting to register a provider of type ${type} that already exists`);
         }
 
@@ -46,7 +46,7 @@ export class DependencyContainer implements IComponentDependencySynthesizer {
      * {@inheritDoc (IComponentSynthesizer:interface).unregister}
      */
     public unregister<T extends keyof IComponent>(type: T): void {
-        if (this.providers.has(type)){
+        if (this.providers.has(type)) {
             this.providers.delete(type);
         }
     }
@@ -120,7 +120,7 @@ export class DependencyContainer implements IComponentDependencySynthesizer {
         return Object.assign({}, ...Array.from(values, (t) => {
             const provider = this.getProvider(t);
             if (!provider) {
-                return{get [t]() { return Promise.resolve(undefined); }};
+                return { get [t]() { return Promise.resolve(undefined); } };
             }
 
             return this.resolveProvider(provider, t);
@@ -129,26 +129,26 @@ export class DependencyContainer implements IComponentDependencySynthesizer {
 
     private resolveProvider<T extends keyof IComponent>(provider: ComponentProvider<T>, t: keyof IComponent) {
         // The double nested gets are required for lazy loading the provider resolution
-        if(typeof provider === "function"){
+        if (typeof provider === "function") {
             // eslint-disable-next-line @typescript-eslint/no-this-alias
             const self = this;
-            return {get [t]() {
+            return { get [t]() {
                 if (provider && typeof provider === "function") {
                     return Promise.resolve(provider(self)).then((p) => {
-                        if (p){
+                        if (p) {
                             return p[t];
                         }});
                 }
-            }};
+            } };
         }
 
-        return {get [t]() {
+        return { get [t]() {
             if (provider) {
                 return Promise.resolve(provider).then((p) => {
                     if (p) {
                         return p[t];
                     }});
             }
-        }};
+        } };
     }
 }

--- a/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
+++ b/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
@@ -31,7 +31,7 @@ describe("Routerlicious", () => {
                 const mock = new MockLoadable();
                 dc.register(IComponentLoadable, mock);
 
-                const s = dc.synthesize({IComponentLoadable}, {});
+                const s = dc.synthesize({ IComponentLoadable }, {});
                 const loadable = await s.IComponentLoadable;
                 assert(loadable, "Optional IComponentLoadable was registered");
                 assert(loadable === mock, "IComponentLoadable is expected");
@@ -43,7 +43,7 @@ describe("Routerlicious", () => {
                 const mock = new MockLoadable();
                 dc.register(IComponentLoadable, Promise.resolve(mock));
 
-                const s = dc.synthesize({IComponentLoadable}, {});
+                const s = dc.synthesize({ IComponentLoadable }, {});
                 const loadable = await s.IComponentLoadable;
                 assert(loadable, "Optional IComponentLoadable was registered");
                 assert(loadable === mock, "IComponentLoadable is expected");
@@ -56,7 +56,7 @@ describe("Routerlicious", () => {
                 const factory = () => mock;
                 dc.register(IComponentLoadable, factory);
 
-                const s = dc.synthesize({IComponentLoadable}, {});
+                const s = dc.synthesize({ IComponentLoadable }, {});
                 const loadable = await s.IComponentLoadable;
                 assert(loadable, "Optional IComponentLoadable was registered");
                 assert(loadable === mock, "IComponentLoadable is expected");
@@ -69,7 +69,7 @@ describe("Routerlicious", () => {
                 const factory = async () => mock;
                 dc.register(IComponentLoadable, factory);
 
-                const s = dc.synthesize({IComponentLoadable}, {});
+                const s = dc.synthesize({ IComponentLoadable }, {});
                 const loadable = await s.IComponentLoadable;
                 assert(loadable, "Optional IComponentLoadable was registered");
                 assert(loadable === mock, "IComponentLoadable is expected");
@@ -81,7 +81,7 @@ describe("Routerlicious", () => {
                 const mock = new MockLoadable();
                 dc.register(IComponentLoadable, mock);
 
-                const s = dc.synthesize({}, {IComponentLoadable});
+                const s = dc.synthesize({}, { IComponentLoadable });
                 const loadable = await s.IComponentLoadable;
                 assert(loadable, "Required IComponentLoadable was registered");
                 assert(loadable === mock, "IComponentLoadable is expected");
@@ -93,7 +93,7 @@ describe("Routerlicious", () => {
                 const mock = new MockLoadable();
                 dc.register(IComponentLoadable, Promise.resolve(mock));
 
-                const s = dc.synthesize({}, {IComponentLoadable});
+                const s = dc.synthesize({}, { IComponentLoadable });
                 const loadable = await s.IComponentLoadable;
                 assert(loadable, "Required IComponentLoadable was registered");
                 assert(loadable === mock, "IComponentLoadable is expected");
@@ -106,7 +106,7 @@ describe("Routerlicious", () => {
                 const factory = () => mock;
                 dc.register(IComponentLoadable, factory);
 
-                const s = dc.synthesize({}, {IComponentLoadable});
+                const s = dc.synthesize({}, { IComponentLoadable });
                 const loadable = await s.IComponentLoadable;
                 assert(loadable, "Required IComponentLoadable was registered");
                 assert(loadable === mock, "IComponentLoadable is expected");
@@ -119,7 +119,7 @@ describe("Routerlicious", () => {
                 const factory = async () => mock;
                 dc.register(IComponentLoadable, factory);
 
-                const s = dc.synthesize({}, {IComponentLoadable});
+                const s = dc.synthesize({}, { IComponentLoadable });
                 const loadable = await s.IComponentLoadable;
                 assert(loadable, "Required IComponentLoadable was registered");
                 assert(loadable === mock, "IComponentLoadable is expected");
@@ -133,7 +133,7 @@ describe("Routerlicious", () => {
                 const configMock = new MockComponentConfiguration();
                 dc.register(IComponentConfiguration, configMock);
 
-                const s = dc.synthesize({IComponentLoadable, IComponentConfiguration}, {});
+                const s = dc.synthesize({ IComponentLoadable, IComponentConfiguration }, {});
                 const loadable = await s.IComponentLoadable;
                 assert(loadable, "Optional IComponentLoadable was registered");
                 assert(loadable === loadableMock, "IComponentLoadable is expected");
@@ -148,7 +148,7 @@ describe("Routerlicious", () => {
                 const loadableMock = new MockLoadable();
                 dc.register(IComponentLoadable, loadableMock);
 
-                const s = dc.synthesize({IComponentLoadable, IComponentConfiguration}, {});
+                const s = dc.synthesize({ IComponentLoadable, IComponentConfiguration }, {});
                 const loadable = await s.IComponentLoadable;
                 assert(loadable, "Optional IComponentLoadable was registered");
                 assert(loadable === loadableMock, "IComponentLoadable is expected");
@@ -160,7 +160,7 @@ describe("Routerlicious", () => {
             it(`Two Optional Modules none registered`, async () => {
                 const dc = new DependencyContainer();
 
-                const s = dc.synthesize({IComponentLoadable, IComponentConfiguration}, {});
+                const s = dc.synthesize({ IComponentLoadable, IComponentConfiguration }, {});
                 const loadable = await s.IComponentLoadable;
                 assert(!loadable, "Optional IComponentLoadable was not registered");
                 const config = await s.IComponentConfiguration;
@@ -174,7 +174,7 @@ describe("Routerlicious", () => {
                 const configMock = new MockComponentConfiguration();
                 dc.register(IComponentConfiguration, configMock);
 
-                const s = dc.synthesize({}, {IComponentLoadable, IComponentConfiguration});
+                const s = dc.synthesize({}, { IComponentLoadable, IComponentConfiguration });
                 const loadable = await s.IComponentLoadable;
                 assert(loadable, "Required IComponentLoadable was registered");
                 assert(loadable === loadableMock, "IComponentLoadable is expected");
@@ -189,7 +189,7 @@ describe("Routerlicious", () => {
 
                 assert.throws(() => dc.synthesize(
                     {},
-                    {IComponentLoadable},
+                    { IComponentLoadable },
                 ), Error);
             });
 
@@ -199,7 +199,7 @@ describe("Routerlicious", () => {
                 parentDc.register(IComponentLoadable, mock);
                 const dc = new DependencyContainer(parentDc);
 
-                const s = dc.synthesize({IComponentLoadable}, {});
+                const s = dc.synthesize({ IComponentLoadable }, {});
                 const loadable = await s.IComponentLoadable;
                 assert(loadable, "Optional IComponentLoadable was registered");
                 assert(loadable === mock, "IComponentLoadable is expected");
@@ -214,7 +214,7 @@ describe("Routerlicious", () => {
                 const configMock = new MockComponentConfiguration();
                 dc.register(IComponentConfiguration, configMock);
 
-                const s = dc.synthesize({IComponentLoadable, IComponentConfiguration}, {});
+                const s = dc.synthesize({ IComponentLoadable, IComponentConfiguration }, {});
                 const loadable = await s.IComponentLoadable;
                 assert(loadable, "Optional IComponentLoadable was registered");
                 assert(loadable === loadableMock, "IComponentLoadable is expected");
@@ -231,7 +231,7 @@ describe("Routerlicious", () => {
                 const loadableMock = new MockLoadable();
                 dc.register(IComponentLoadable, loadableMock);
 
-                const s = dc.synthesize({IComponentLoadable}, {});
+                const s = dc.synthesize({ IComponentLoadable }, {});
                 const loadable = await s.IComponentLoadable;
                 assert(loadable, "Optional IComponentLoadable was registered");
                 assert(loadable === loadableMock, "IComponentLoadable is expected");
@@ -243,7 +243,7 @@ describe("Routerlicious", () => {
                 parentDc.register(IComponentLoadable, mock);
                 const dc = new DependencyContainer(parentDc);
 
-                const s = dc.synthesize({}, {IComponentLoadable});
+                const s = dc.synthesize({}, { IComponentLoadable });
                 const loadable = await s.IComponentLoadable;
                 assert(loadable, "Required IComponentLoadable was registered");
                 assert(loadable === mock, "IComponentLoadable is expected");
@@ -258,7 +258,7 @@ describe("Routerlicious", () => {
                 const configMock = new MockComponentConfiguration();
                 dc.register(IComponentConfiguration, configMock);
 
-                const s = dc.synthesize({}, {IComponentLoadable, IComponentConfiguration});
+                const s = dc.synthesize({}, { IComponentLoadable, IComponentConfiguration });
                 const loadable = await s.IComponentLoadable;
                 assert(loadable, "Required IComponentLoadable was registered");
                 assert(loadable === loadableMock, "IComponentLoadable is expected");
@@ -275,7 +275,7 @@ describe("Routerlicious", () => {
                 const loadableMock = new MockLoadable();
                 dc.register(IComponentLoadable, loadableMock);
 
-                const s = dc.synthesize({}, {IComponentLoadable});
+                const s = dc.synthesize({}, { IComponentLoadable });
                 const loadable = await s.IComponentLoadable;
                 assert(loadable, "Required IComponentLoadable was registered");
                 assert(loadable === loadableMock, "IComponentLoadable is expected");

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-test-runtime-utils": "^0.16.0",
     "@types/diff": "^3.5.1",

--- a/packages/framework/undo-redo/src/mapHandler.ts
+++ b/packages/framework/undo-redo/src/mapHandler.ts
@@ -31,7 +31,6 @@ export class SharedMapUndoRedoHandler {
  * Tracks a change on a shared map allows reverting it
  */
 export class SharedMapRevertable implements IRevertable {
-
     constructor(
         private readonly changed: IValueChanged,
         private readonly map: ISharedMap,

--- a/packages/framework/undo-redo/src/sequenceHandler.ts
+++ b/packages/framework/undo-redo/src/sequenceHandler.ts
@@ -21,7 +21,6 @@ import { IRevertable, UndoRedoStackManager } from "./undoRedoStackManager";
  * undo redo stack manager
  */
 export class SharedSegmentSequenceUndoRedoHandler {
-
     // eslint-disable-next-line max-len
     private readonly sequences = new Map<SharedSegmentSequence<ISegment>, SharedSegmentSequenceRevertable | undefined>();
 
@@ -60,7 +59,6 @@ interface ITrackedSharedSegmentSequenceRevertable {
  * Tracks a change on a shared segment sequence and allows reverting it
  */
 export class SharedSegmentSequenceRevertable implements IRevertable {
-
     private readonly tracking: ITrackedSharedSegmentSequenceRevertable[];
 
     constructor(

--- a/packages/framework/undo-redo/src/test/sequenceHandler.spec.ts
+++ b/packages/framework/undo-redo/src/test/sequenceHandler.spec.ts
@@ -73,7 +73,6 @@ describe("SharedSegmentSequenceUndoRedoHandler", () => {
         while (undoRedoStack.redoOperation()) { }
 
         assert.equal(sharedString.getText(), "");
-
     });
 
     it("Undo and Redo Insert", () => {
@@ -90,7 +89,6 @@ describe("SharedSegmentSequenceUndoRedoHandler", () => {
         while (undoRedoStack.redoOperation()) { }
 
         assert.equal(sharedString.getText(), text);
-
     });
 
     it("Undo and Redo Insert & Delete", () => {
@@ -111,7 +109,6 @@ describe("SharedSegmentSequenceUndoRedoHandler", () => {
         while (undoRedoStack.redoOperation()) { }
 
         assert.equal(sharedString.getText(), finalText, sharedString.getText());
-
     });
 
     it("Undo and redo insert of split segment", () => {

--- a/packages/framework/undo-redo/src/undoRedoStackManager.ts
+++ b/packages/framework/undo-redo/src/undoRedoStackManager.ts
@@ -49,7 +49,6 @@ class Stack<T> {
  * Helper class for creating the Undo and Redo stacks
  */
 class UndoRedoStack extends Stack<Stack<IRevertable> | undefined> {
-
     public push(item: Stack<IRevertable> | undefined) {
         if (item !== undefined) {
             // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/react": "^16.9.15",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/react": "^16.9.15",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/packages/hosts/base-host/package.json
+++ b/packages/hosts/base-host/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-test-runtime-utils": "^0.16.0",
     "@types/mocha": "^5.2.5",

--- a/packages/hosts/base-host/src/host.ts
+++ b/packages/hosts/base-host/src/host.ts
@@ -23,15 +23,14 @@ import { initializeContainerCode } from "./initializeContainerCode";
 async function createWebLoader(
     hostConfig: IBaseHostConfig,
     seedPackages?: Iterable<IFluidCodeDetails | [IFluidCodeDetails, IFluidModule]>): Promise<Loader> {
-
     // Create the web loader and prefetch the chaincode we will need
     const codeLoader = new WebCodeLoader(hostConfig.codeResolver, hostConfig.whiteList);
 
     if (seedPackages !== undefined) {
-        for(const pkg of seedPackages){
-            if(Array.isArray(pkg)){
+        for (const pkg of seedPackages) {
+            if (Array.isArray(pkg)) {
                 await codeLoader.seedModule(pkg[0], pkg[1]);
-            }else{
+            } else {
                 await codeLoader.seedModule(pkg);
             }
         }
@@ -62,7 +61,6 @@ export class BaseHost {
         hostConfig: IBaseHostConfig,
         seedPackages?: Iterable<IFluidCodeDetails | [IFluidCodeDetails, IFluidModule]>,
     ) {
-
         this.loaderP = createWebLoader(
             hostConfig,
             seedPackages,

--- a/packages/hosts/host-service-interfaces/package.json
+++ b/packages/hosts/host-service-interfaces/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/node": "^10.14.6",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/packages/hosts/local-web-host/package.json
+++ b/packages/hosts/local-web-host/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/node": "^10.14.6",
     "@types/react": "^16.9.15",

--- a/packages/hosts/local-web-host/src/index.ts
+++ b/packages/hosts/local-web-host/src/index.ts
@@ -23,12 +23,10 @@ import { HTMLViewAdapter } from "@microsoft/fluid-view-adapters";
 export async function createLocalContainerFactory(
     entryPoint: Partial<IProvideRuntimeFactory & IProvideComponentFactory & IFluidModule>,
 ): Promise<() => Promise<Container>> {
-
     const urlResolver = new TestResolver();
 
     const deltaConn = LocalDeltaConnectionServer.create();
     const documentServiceFactory = new TestDocumentServiceFactory(deltaConn);
-
 
     const factory: Partial<IProvideRuntimeFactory & IProvideComponentFactory> =
         entryPoint.fluidExport ? entryPoint.fluidExport : entryPoint;
@@ -42,7 +40,7 @@ export async function createLocalContainerFactory(
             );
 
     const codeLoader: ICodeLoader = {
-        load: async <T>() => ({fluidExport: runtimeFactory} as unknown as T),
+        load: async <T>() => ({ fluidExport: runtimeFactory } as unknown as T),
     };
 
     const loader =  new Loader(
@@ -57,7 +55,6 @@ export async function createLocalContainerFactory(
     const url = `fluid://localhost/${documentId}`;
 
     return async () => {
-
         const container = await loader.resolve({ url });
 
         await initializeContainerCode(container, {} as any as IFluidCodeDetails);

--- a/packages/hosts/react-web-host/package.json
+++ b/packages/hosts/react-web-host/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/node": "^10.14.6",
     "@types/react": "^16.9.15",

--- a/packages/hosts/react-web-host/src/host.tsx
+++ b/packages/hosts/react-web-host/src/host.tsx
@@ -41,7 +41,6 @@ export class FluidLoader extends React.Component<ILoaderProps, any> {
     }
 
     public async componentDidMount() {
-
         if (this.props.iframe) {
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
             loadIFramedFluidContainer(

--- a/packages/hosts/tiny-web-host/package.json
+++ b/packages/hosts/tiny-web-host/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/node": "^10.14.6",
     "@types/uuid": "^3.4.4",

--- a/packages/hosts/tiny-web-host/src/host.ts
+++ b/packages/hosts/tiny-web-host/src/host.ts
@@ -21,7 +21,7 @@ import { ContainerUrlResolver } from "@microsoft/fluid-routerlicious-host";
 import { RouterliciousUrlResolver } from "@microsoft/fluid-routerlicious-urlresolver";
 import { HTMLViewAdapter } from "@microsoft/fluid-view-adapters";
 import { v4 } from "uuid";
-import { SemVerCdnCodeResolver} from "@microsoft/fluid-web-code-loader";
+import { SemVerCdnCodeResolver } from "@microsoft/fluid-web-code-loader";
 import { IOdspTokenApi, IRouterliciousTokenApi, ITokenApis } from "./utils";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
@@ -56,7 +56,6 @@ export async function loadFluidContainer(
     clientSecret?: string,
     pkg?: IFluidCodeDetails,
 ): Promise<Container> {
-
     let resolved: IResolvedUrl;
 
     const codeDetails = pkg ?? parseUrlToResolvedPackage(url);
@@ -147,7 +146,6 @@ async function loadContainer(
     secret: string,
     pkg?: IFluidCodeDetails,
 ): Promise<Container> {
-
     let documentServiceFactory: IDocumentServiceFactory;
     const protocol = new URL(resolved.url).protocol;
     if (protocol === "fluid-odsp:") {
@@ -240,7 +238,6 @@ export async function loadIFramedFluidContainer(
     clientId?: string,
     secret?: string,
     libraryName: string = "tinyWebLoader"): Promise<void> {
-
     let scriptUrl: string;
     // main.bundle.js refers to the output of webpacking this file.
     if (packageJson.version.split(".")[2] === "0") {

--- a/packages/hosts/tiny-web-host/src/odspUtils.ts
+++ b/packages/hosts/tiny-web-host/src/odspUtils.ts
@@ -41,7 +41,6 @@ export async function spoGetResolvedUrl(
     id: string,
     serverTokens: { [server: string]: IOdspTokens } | undefined,
     clientConfig: IClientConfig) {
-
     const server = getSpoServer(tenantId);
     if (server === undefined) {
         return Promise.reject(`Invalid SPO tenantId ${tenantId}`);

--- a/packages/hosts/tiny-web-host/src/utils.ts
+++ b/packages/hosts/tiny-web-host/src/utils.ts
@@ -32,7 +32,6 @@ async function fetchSecret(tenant: string, getToken: () => Promise<string>): Pro
         default: {
             if (!getToken) {
                 throw new Error("Tenant Not Recognized. No getToken function provided.");
-
             }
             return getToken();
         }

--- a/packages/loader/component-core-interfaces/package.json
+++ b/packages/loader/component-core-interfaces/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/node": "^10.14.6",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/packages/loader/container-definitions/package.json
+++ b/packages/loader/container-definitions/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/node": "^10.14.6",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-test-loader-utils": "^0.16.0",
     "@types/debug": "^0.0.31",

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -394,7 +394,7 @@ export class Container
         }
         this._closed = true;
 
-        this._deltaManager.close(error, false /*raiseContainerError*/);
+        this._deltaManager.close(error, false /* raiseContainerError */);
 
         if (this.protocolHandler) {
             this.protocolHandler.close();
@@ -507,11 +507,9 @@ export class Container
             }
 
             await this.snapshotCore(tagMessage, fullTree);
-
         } catch (ex) {
             this.logger.logException({ eventName: "SnapshotExceptionError" }, ex);
             throw ex;
-
         } finally {
             if (this.deltaManager !== undefined) {
                 this.deltaManager.inbound.systemResume();
@@ -546,7 +544,7 @@ export class Container
                 // So there shouldn't be a need to record error here.
                 // But we have number of cases where reconnects do not happen, and no errors are recorded, so
                 // adding this log point for easier diagnostics
-                this.logger.sendTelemetryEvent({eventName: "setAutoReconnectError"}, error);
+                this.logger.sendTelemetryEvent({ eventName: "setAutoReconnectError" }, error);
             });
         }
     }
@@ -1026,7 +1024,6 @@ export class Container
             throw new Error(PackageNotFactoryError);
         }
         return factory;
-
     }
 
     private get client(): IClient {

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -45,7 +45,6 @@ import { Container } from "./container";
 import { NullRuntime } from "./nullRuntime";
 
 export class ContainerContext extends EventEmitter implements IContainerContext, IExperimentalContainerContext {
-
     public readonly isExperimentalContainerContext = true;
     public static async createOrLoad(
         container: Container,

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -645,9 +645,9 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
                     });
                     const closeError = createNetworkError(
                         "Failed to retrieve ops from storage: giving up after too many retries",
-                        false /*canRetry*/,
-                        undefined /*statusCode*/,
-                        undefined /*retryAfterSeconds*/,
+                        false /* canRetry */,
+                        undefined /* statusCode */,
+                        undefined /* retryAfterSeconds */,
                         "Online",
                     ) as IGenericNetworkError;
                     closeError.critical = true;
@@ -929,7 +929,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
             // Do not raise container error if we are closing just because we lost connection.
             // Those errors (like IdleDisconnect) would show up in telemetry dashboards and
             // are very misleading, as first initial reaction - some logic is broken.
-            this.close(createIError(error), criticalError /*raiseContainerError*/);
+            this.close(createIError(error), criticalError /* raiseContainerError */);
         }
 
         // If closed then we can't reconnect
@@ -1117,7 +1117,6 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
     }
 
     private catchUpCore(messages: ISequencedDocumentMessage[], telemetryEventSuffix?: string): void {
-
         // Apply current operations
         this.enqueueMessages(messages, telemetryEventSuffix);
 

--- a/packages/loader/container-loader/src/deltaManagerProxy.ts
+++ b/packages/loader/container-loader/src/deltaManagerProxy.ts
@@ -85,7 +85,6 @@ export class DeltaQueueProxy<T> extends EventForwarder implements IDeltaQueue<T>
 export class DeltaManagerProxy
     extends EventForwarder
     implements IDeltaManager<ISequencedDocumentMessage, IDocumentMessage> {
-
     public readonly inbound: IDeltaQueue<ISequencedDocumentMessage>;
     public readonly outbound: IDeltaQueue<IDocumentMessage[]>;
     public readonly inboundSignal: IDeltaQueue<ISignalMessage>;

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -51,7 +51,6 @@ function canUseCache(request: IRequest): boolean {
 }
 
 export class RelativeLoader extends EventEmitter implements ILoader {
-
     // Because the loader is passed to the container during construction we need to resolve the target container
     // after construction.
     private readonly containerDeferred = new Deferred<Container>();
@@ -110,15 +109,15 @@ export class RelativeLoader extends EventEmitter implements ILoader {
     }
 }
 
-function createCachedResolver(resolver: IUrlResolver){
+function createCachedResolver(resolver: IUrlResolver) {
     const cacheResolver = Object.create(resolver) as IUrlResolver;
     const resolveCache = new Map<string, Promise<IResolvedUrl | undefined>>();
     // eslint-disable-next-line @typescript-eslint/unbound-method
     cacheResolver.resolve = async (request: IRequest): Promise<IResolvedUrl | undefined> => {
-        if(!canUseCache(request)){
+        if (!canUseCache(request)) {
             return resolver.resolve(request);
         }
-        if(!resolveCache.has(request.url)){
+        if (!resolveCache.has(request.url)) {
             resolveCache.set(request.url, resolver.resolve(request));
         }
 
@@ -131,7 +130,6 @@ function createCachedResolver(resolver: IUrlResolver){
  * Manages Fluid resource loading
  */
 export class Loader extends EventEmitter implements ILoader, IExperimentalLoader {
-
     private readonly containers = new Map<string, Promise<Container>>();
     private readonly resolver: IUrlResolver;
     private readonly documentServiceFactory: IDocumentServiceFactory;
@@ -193,7 +191,6 @@ export class Loader extends EventEmitter implements ILoader, IExperimentalLoader
     }
 
     public async requestWorker(baseUrl: string, request: IRequest): Promise<IResponse> {
-
         // Currently the loader only supports web worker environment. Eventually we will
         // detect environment and bring appropiate loader (e.g., worker_thread for node).
         const supportedEnvironment = "webworker";
@@ -225,7 +222,6 @@ export class Loader extends EventEmitter implements ILoader, IExperimentalLoader
     private async resolveCore(
         request: IRequest,
     ): Promise<{ container: Container; parsed: IParsedUrl }> {
-
         const resolvedAsFluid = await this.resolver.resolve(request);
         ensureFluidResolvedUrl(resolvedAsFluid);
 
@@ -281,7 +277,6 @@ export class Loader extends EventEmitter implements ILoader, IExperimentalLoader
         }
 
         return { container, parsed };
-
     }
 
     private canUseCache(request: IRequest): boolean {

--- a/packages/loader/container-loader/src/nullRuntime.ts
+++ b/packages/loader/container-loader/src/nullRuntime.ts
@@ -84,7 +84,6 @@ export class NullRuntime extends EventEmitter implements IRuntime {
 }
 
 export class NullChaincode implements IRuntimeFactory {
-
     public async instantiateRuntime(context: IContainerContext): Promise<IRuntime> {
         return new NullRuntime();
     }

--- a/packages/loader/driver-definitions/package.json
+++ b/packages/loader/driver-definitions/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/node": "^10.14.6",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/packages/loader/driver-definitions/src/urlResolver.ts
+++ b/packages/loader/driver-definitions/src/urlResolver.ts
@@ -32,7 +32,6 @@ export interface IUrlResolver {
     resolve(request: IRequest): Promise<IResolvedUrl | undefined>;
 }
 
-
 export interface IExperimentalUrlResolver extends IUrlResolver {
     readonly isExperimentalUrlResolver: true;
     // Creates a new document on the host with the provided options. Returns the resolved URL.

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.14.6",

--- a/packages/loader/driver-utils/src/fluidResolvedUrl.ts
+++ b/packages/loader/driver-utils/src/fluidResolvedUrl.ts
@@ -8,7 +8,7 @@ import { IResolvedUrl, IFluidResolvedUrl } from "@microsoft/fluid-driver-definit
 export const isFluidResolvedUrl =
     (resolved: IResolvedUrl | undefined): resolved is IFluidResolvedUrl => resolved?.type === "fluid";
 
-export function ensureFluidResolvedUrl(resolved: IResolvedUrl | undefined): asserts resolved is IFluidResolvedUrl{
+export function ensureFluidResolvedUrl(resolved: IResolvedUrl | undefined): asserts resolved is IFluidResolvedUrl {
     if (!isFluidResolvedUrl(resolved)) {
         throw new Error(`resolved is not a fluid url. Type: ${resolved?.type}`);
     }

--- a/packages/loader/driver-utils/src/multiDocumentServiceFactory.ts
+++ b/packages/loader/driver-utils/src/multiDocumentServiceFactory.ts
@@ -11,20 +11,19 @@ import {
 } from "@microsoft/fluid-driver-definitions";
 import { ensureFluidResolvedUrl } from "./fluidResolvedUrl";
 
-export class MultiDocumentServiceFactory implements IDocumentServiceFactory{
-
-    public static create(documentServiceFactory: IDocumentServiceFactory | IDocumentServiceFactory[]){
-        if(Array.isArray(documentServiceFactory)){
-            const factories: IDocumentServiceFactory[]=[];
+export class MultiDocumentServiceFactory implements IDocumentServiceFactory {
+    public static create(documentServiceFactory: IDocumentServiceFactory | IDocumentServiceFactory[]) {
+        if (Array.isArray(documentServiceFactory)) {
+            const factories: IDocumentServiceFactory[] = [];
             documentServiceFactory.forEach((factory)=>{
                 const maybeMulti = factory as MultiDocumentServiceFactory;
-                if(maybeMulti.protocolToDocumentFactoryMap !== undefined){
+                if (maybeMulti.protocolToDocumentFactoryMap !== undefined) {
                     factories.push(... maybeMulti.protocolToDocumentFactoryMap.values());
-                }else{
+                } else {
                     factories.push(factory);
                 }
             });
-            if(factories.length === 1){
+            if (factories.length === 1) {
                 return factories[0];
             }
             return new MultiDocumentServiceFactory(factories);

--- a/packages/loader/driver-utils/src/multiUrlResolver.ts
+++ b/packages/loader/driver-utils/src/multiUrlResolver.ts
@@ -26,11 +26,10 @@ export async function configurableUrlResolver(
     return undefined;
 }
 
-export class MultiUrlResolver implements IUrlResolver{
-
-    public static create(urlResolver: IUrlResolver | IUrlResolver[]){
-        if(Array.isArray(urlResolver)){
-            if(urlResolver.length === 1){
+export class MultiUrlResolver implements IUrlResolver {
+    public static create(urlResolver: IUrlResolver | IUrlResolver[]) {
+        if (Array.isArray(urlResolver)) {
+            if (urlResolver.length === 1) {
                 return urlResolver[0];
             }
             return new MultiUrlResolver(urlResolver);
@@ -38,7 +37,7 @@ export class MultiUrlResolver implements IUrlResolver{
         return urlResolver;
     }
 
-    private constructor(private readonly urlResolvers: IUrlResolver[]){}
+    private constructor(private readonly urlResolvers: IUrlResolver[]) {}
 
     async resolve(request: IRequest): Promise<IResolvedUrl | undefined> {
         return configurableUrlResolver(this.urlResolvers, request);

--- a/packages/loader/execution-context-loader/package.json
+++ b/packages/loader/execution-context-loader/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/debug": "^0.0.31",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/packages/loader/loader-web/package.json
+++ b/packages/loader/loader-web/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/isomorphic-fetch": "^0.0.35",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/packages/loader/loader-web/src/scriptManager.ts
+++ b/packages/loader/loader-web/src/scriptManager.ts
@@ -18,14 +18,14 @@ export class ScriptManager {
         return window.document !== undefined;
     }
 
-    private static async protectEntrypoint<T>(library: string, callback: () => Promise<T>){
-        if (!this.isBrowser){
+    private static async protectEntrypoint<T>(library: string, callback: () => Promise<T>) {
+        if (!this.isBrowser) {
             return callback();
         }
         // if we are in a browser we need to ensure multiple
         // scripts aren't loaded with the same entry point
         // otherwise they could overwrite each other
-        while (this.loadingEntrypoints.has(library)){
+        while (this.loadingEntrypoints.has(library)) {
             await this.loadingEntrypoints.get(library);
         }
         const returnP = callback().finally(() => this.loadingEntrypoints.delete(library));
@@ -33,9 +33,9 @@ export class ScriptManager {
         return returnP;
     }
 
-    private static async internalLoadScript(scriptUrl: string, library: string): Promise<unknown>{
+    private static async internalLoadScript(scriptUrl: string, library: string): Promise<unknown> {
         if (!this.loadCache.has(scriptUrl)) {
-            while (this.loadingEntrypoints.has(library)){
+            while (this.loadingEntrypoints.has(library)) {
                 await this.loadingEntrypoints.get(library);
             }
             const scriptP = new Promise<unknown>((resolve, reject) => {

--- a/packages/loader/loader-web/src/semVerCdnCodeResolver.ts
+++ b/packages/loader/loader-web/src/semVerCdnCodeResolver.ts
@@ -9,11 +9,10 @@ import {
 import * as fetch from "isomorphic-fetch";
 import { extractPackageIdentifierDetails } from "./utils";
 
-
 class FluidPackage {
     private resolveP: Promise<IResolvedFluidCodeDetails> | undefined;
 
-    constructor(private readonly codeDetails: IFluidCodeDetails, private readonly packageUrl: string){}
+    constructor(private readonly codeDetails: IFluidCodeDetails, private readonly packageUrl: string) {}
 
     public async resolve(): Promise<IResolvedFluidCodeDetails> {
         if (this.resolveP === undefined) {
@@ -36,8 +35,8 @@ class FluidPackage {
             throw new Error(`Package ${packageJson.name} not a fluid module.`);
         }
         const files = packageJson.fluid.browser.umd.files;
-        for(let i=0;i<packageJson.fluid.browser.umd.files.length;i++){
-            if(!files[i].startsWith("http")){
+        for (let i = 0; i < packageJson.fluid.browser.umd.files.length; i++) {
+            if (!files[i].startsWith("http")) {
                 files[i] = `${this.packageUrl}/${files[i]}`;
             }
         }
@@ -62,7 +61,7 @@ class FluidPackage {
  * a per scope cdn, `config["@package_scope:cdn"]`. A scope specific cdn base will take precedence over
  * the global cdn.
  */
-export class SemVerCdnCodeResolver implements IFluidCodeResolver{
+export class SemVerCdnCodeResolver implements IFluidCodeResolver {
     // Cache goes CDN -> package -> entrypoint
     private readonly fluidPackageCache = new Map<string, FluidPackage>();
 

--- a/packages/loader/loader-web/src/utils.ts
+++ b/packages/loader/loader-web/src/utils.ts
@@ -14,7 +14,6 @@ export interface IPackageIdentifierDetails {
 }
 
 export function extractPackageIdentifierDetails(codeDetailsPackage: string | IFluidPackage): IPackageIdentifierDetails {
-
     const packageString = typeof codeDetailsPackage === "string"
         ? codeDetailsPackage // Just return it if it's a string e.g. "@fluid-example/clicker@0.1.1"
         : codeDetailsPackage.version === undefined // If it doesn't exist, let's make it from the package details

--- a/packages/loader/loader-web/src/webLoader.ts
+++ b/packages/loader/loader-web/src/webLoader.ts
@@ -23,14 +23,14 @@ export class WebCodeLoader implements ICodeLoader {
     public async seedModule(
         source: IFluidCodeDetails,
         maybeFluidModule?: IFluidModule,
-    ): Promise<void>{
+    ): Promise<void> {
         const resolved = await this.codeResolver.resolveCodeDetails(source);
-        if(resolved.resolvedPackageCacheId !== undefined
-            && this.loadedModules.has(resolved.resolvedPackageCacheId)){
+        if (resolved.resolvedPackageCacheId !== undefined
+            && this.loadedModules.has(resolved.resolvedPackageCacheId)) {
             return;
         }
         const fluidModule = maybeFluidModule ?? await this.load(source);
-        if(resolved.resolvedPackageCacheId !== undefined){
+        if (resolved.resolvedPackageCacheId !== undefined) {
             this.loadedModules.set(resolved.resolvedPackageCacheId, fluidModule);
         }
     }
@@ -42,9 +42,9 @@ export class WebCodeLoader implements ICodeLoader {
         source: IFluidCodeDetails,
     ): Promise<IFluidModule> {
         const resolved = await this.codeResolver.resolveCodeDetails(source);
-        if(resolved.resolvedPackageCacheId !== undefined){
+        if (resolved.resolvedPackageCacheId !== undefined) {
             const maybePkg = this.loadedModules.get(resolved.resolvedPackageCacheId);
-            if(maybePkg !== undefined){
+            if (maybePkg !== undefined) {
                 return maybePkg;
             }
         }
@@ -56,20 +56,20 @@ export class WebCodeLoader implements ICodeLoader {
             resolved.resolvedPackage.fluid.browser.umd,
         );
         let fluidModule: IFluidModule | undefined;
-        for(const script of loadedScripts){
+        for (const script of loadedScripts) {
             const maybeFluidModule = script.entryPoint as IFluidModule;
-            if(maybeFluidModule.fluidExport !== undefined){
-                if (fluidModule !== undefined){
+            if (maybeFluidModule.fluidExport !== undefined) {
+                if (fluidModule !== undefined) {
                     throw new Error("Multiple fluid modules loaded");
                 }
                 fluidModule = maybeFluidModule;
             }
         }
 
-        if(fluidModule?.fluidExport === undefined){
+        if (fluidModule?.fluidExport === undefined) {
             throw new Error("Entry point of loaded code package not a fluid module");
         }
-        if(resolved.resolvedPackageCacheId !== undefined){
+        if (resolved.resolvedPackageCacheId !== undefined) {
             this.loadedModules.set(resolved.resolvedPackageCacheId, fluidModule);
         }
         return fluidModule;

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -26,7 +26,7 @@
     "@microsoft/fluid-protocol-definitions": "^0.1004.1-0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@typescript-eslint/eslint-plugin": "~2.17.0",
     "@typescript-eslint/parser": "~2.17.0",

--- a/packages/runtime/cell/package.json
+++ b/packages/runtime/cell/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-test-runtime-utils": "^0.16.0",
     "@types/debug": "^0.0.31",

--- a/packages/runtime/cell/src/cell.ts
+++ b/packages/runtime/cell/src/cell.ts
@@ -177,7 +177,6 @@ export class SharedCell extends SharedObject<ISharedCellEvents> implements IShar
     protected async loadCore(
         branchId: string,
         storage: IObjectStorageService): Promise<void> {
-
         const rawContent = await storage.read(snapshotFileName);
 
         const content = rawContent !== undefined

--- a/packages/runtime/cell/src/cellFactory.ts
+++ b/packages/runtime/cell/src/cellFactory.ts
@@ -35,7 +35,6 @@ export class CellFactory implements ISharedObjectFactory {
         services: ISharedObjectServices,
         branchId: string,
         attributes: IChannelAttributes): Promise<ISharedCell> {
-
         const cell = new SharedCell(id, runtime, attributes);
         await cell.load(branchId, services);
         return cell;

--- a/packages/runtime/cell/src/test/cell.spec.ts
+++ b/packages/runtime/cell/src/test/cell.spec.ts
@@ -26,7 +26,6 @@ describe("Routerlicious", () => {
                 testCell.set("testValue");
                 assert.equal(testCell.get(), "testValue");
             });
-
         });
     });
 });

--- a/packages/runtime/client-api/package.json
+++ b/packages/runtime/client-api/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/debug": "^0.0.31",
     "@types/jwt-decode": "^2.2.1",

--- a/packages/runtime/client-api/src/api/codeLoader.ts
+++ b/packages/runtime/client-api/src/api/codeLoader.ts
@@ -99,7 +99,6 @@ export class Chaincode implements IComponentFactory {
 }
 
 export class ChaincodeFactory implements IRuntimeFactory {
-
     public get IRuntimeFactory() { return this; }
 
     /**

--- a/packages/runtime/client-api/src/api/document.ts
+++ b/packages/runtime/client-api/src/api/document.ts
@@ -58,7 +58,6 @@ export const getChaincodeRepo = (): string => chaincodeRepo;
  * A document is a collection of shared types.
  */
 export class Document extends EventEmitter {
-
     public get clientId(): string {
         return this.runtime.clientId;
     }

--- a/packages/runtime/component-runtime/package.json
+++ b/packages/runtime/component-runtime/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/debug": "^0.0.31",
     "@types/mocha": "^5.2.5",

--- a/packages/runtime/component-runtime/src/channelStorageService.ts
+++ b/packages/runtime/component-runtime/src/channelStorageService.ts
@@ -33,7 +33,7 @@ export class ChannelStorageService implements IObjectStorageService {
         }
     }
 
-    public contains(path: string){
+    public contains(path: string) {
         return this.flattenedTree[path] !== undefined;
     }
 

--- a/packages/runtime/component-runtime/src/remoteChannelContext.ts
+++ b/packages/runtime/component-runtime/src/remoteChannelContext.ts
@@ -49,7 +49,7 @@ export class RemoteChannelContext implements IChannelContext {
         private readonly branch: string,
         private readonly summaryTracker: ISummaryTracker,
         private readonly attachMessageType?: string,
-    ){
+    ) {
         this.services = createServiceEndpoints(
             this.id,
             this.componentContext.connectionState,
@@ -107,12 +107,11 @@ export class RemoteChannelContext implements IChannelContext {
         return snapshotChannel(channel);
     }
 
-
     private async loadChannel(): Promise<IChannel> {
         assert(!this.isLoaded);
 
         let attributes: IChannelAttributes | undefined;
-        if(this.services.objectStorage.contains(".attributes")){
+        if (this.services.objectStorage.contains(".attributes")) {
             attributes = await readAndParse<IChannelAttributes | undefined>(
                 this.services.objectStorage,
                 ".attributes");
@@ -124,8 +123,8 @@ export class RemoteChannelContext implements IChannelContext {
         // the attributes. Since old attach messages
         // will not have attributes we need to keep
         // this as long as we support old attach messages
-        if (attributes === undefined){
-            if(this.attachMessageType === undefined){
+        if (attributes === undefined) {
+            if (this.attachMessageType === undefined) {
                 throw new Error("Channel type not available");
             }
             factory = this.registry.get(this.attachMessageType);

--- a/packages/runtime/consensus-ordered-collection/package.json
+++ b/packages/runtime/consensus-ordered-collection/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-test-runtime-utils": "^0.16.0",
     "@types/debug": "^0.0.31",

--- a/packages/runtime/consensus-ordered-collection/src/consensusOrderedCollection.ts
+++ b/packages/runtime/consensus-ordered-collection/src/consensusOrderedCollection.ts
@@ -176,7 +176,7 @@ export class ConsensusOrderedCollection<T = any>
                 break;
             case ConsensusResult.Release:
                 this.release(result.acquireId);
-                this.emit("localRelease", result.value, true /*intentional*/);
+                this.emit("localRelease", result.value, true /* intentional */);
                 break;
             default:
                 assert(false);
@@ -233,7 +233,7 @@ export class ConsensusOrderedCollection<T = any>
             value: {
                 contents: this.serializeValue(Array.from(this.jobTracking.entries())),
                 encoding: "utf-8",
-            }});
+            } });
         return tree;
     }
 
@@ -279,7 +279,7 @@ export class ConsensusOrderedCollection<T = any>
                 acquireId,
             };
             this.submit(work).catch((error) => {
-                this.runtime.logger.sendErrorEvent({eventName: "ConsensusQueue_release"}, error);
+                this.runtime.logger.sendErrorEvent({ eventName: "ConsensusQueue_release" }, error);
             });
         }
     }
@@ -290,7 +290,7 @@ export class ConsensusOrderedCollection<T = any>
         if (rec !== undefined) {
             this.jobTracking.delete(acquireId);
             this.data.add(rec.value);
-            this.emit("add", rec.value, false /*newlyAdded*/);
+            this.emit("add", rec.value, false /* newlyAdded */);
         }
     }
 
@@ -304,7 +304,6 @@ export class ConsensusOrderedCollection<T = any>
     protected async loadCore(
         branchId: string,
         storage: IObjectStorageService): Promise<void> {
-
         assert(this.jobTracking.size === 0);
         const rawContentTracking = await storage.read(snapshotFileNameTracking);
         if (rawContentTracking !== undefined) {
@@ -325,9 +324,9 @@ export class ConsensusOrderedCollection<T = any>
     }
 
     protected onDisconnect() {
-        for (const [, {value, clientId}] of this.jobTracking) {
+        for (const [, { value, clientId }] of this.jobTracking) {
             if (clientId === this.runtime.clientId) {
-                this.emit("localRelease", value, false /*intentional*/);
+                this.emit("localRelease", value, false /* intentional */);
             }
         }
     }
@@ -383,7 +382,6 @@ export class ConsensusOrderedCollection<T = any>
 
     private async submit(
         message: IConsensusOrderedCollectionOperation): Promise<IConsensusOrderedCollectionValue<T> | undefined> {
-
         assert(!this.isLocal());
 
         const clientSequenceNumber = this.submitLocalMessage(message);
@@ -395,7 +393,7 @@ export class ConsensusOrderedCollection<T = any>
 
     private addCore(value: T) {
         this.data.add(value);
-        this.emit("add", value, true /*newlyAdded*/);
+        this.emit("add", value, true /* newlyAdded */);
     }
 
     private acquireCore(acquireId: string, clientId?: string): IConsensusOrderedCollectionValue<T> | undefined {
@@ -408,7 +406,7 @@ export class ConsensusOrderedCollection<T = any>
             acquireId,
             value,
         };
-        this.jobTracking.set(value2.acquireId, {value, clientId});
+        this.jobTracking.set(value2.acquireId, { value, clientId });
 
         this.emit("acquire", value, clientId);
         return value2;
@@ -430,7 +428,7 @@ export class ConsensusOrderedCollection<T = any>
 
     private removeClient(clientIdToRemove?: string) {
         const added: T[] = [];
-        for (const [acquireId, {value, clientId}] of this.jobTracking) {
+        for (const [acquireId, { value, clientId }] of this.jobTracking) {
             if (clientId === clientIdToRemove) {
                 this.jobTracking.delete(acquireId);
                 this.data.add(value);
@@ -440,7 +438,7 @@ export class ConsensusOrderedCollection<T = any>
 
         // Raise all events only after all state changes are completed,
         // to guarantee same ordering of operations if collection is manipulated from events.
-        added.map((value) => this.emit("add", value, false /*newlyAdded*/));
+        added.map((value) => this.emit("add", value, false /* newlyAdded */));
     }
 
     private serializeValue(value) {

--- a/packages/runtime/consensus-ordered-collection/src/consensusOrderedCollectionFactory.ts
+++ b/packages/runtime/consensus-ordered-collection/src/consensusOrderedCollectionFactory.ts
@@ -34,7 +34,6 @@ export class ConsensusQueueFactory implements IConsensusOrderedCollectionFactory
         services: ISharedObjectServices,
         branchId: string,
         attributes: IChannelAttributes): Promise<IConsensusOrderedCollection> {
-
         const collection = new ConsensusQueue(id, runtime, attributes);
         await collection.load(branchId, services);
         return collection;

--- a/packages/runtime/consensus-ordered-collection/src/test/consensusOrderedCollection.spec.ts
+++ b/packages/runtime/consensus-ordered-collection/src/test/consensusOrderedCollection.spec.ts
@@ -19,7 +19,6 @@ describe("Routerlicious", () => {
         output: any[],
         creator: () => IConsensusOrderedCollection,
         processMessages: () => void) {
-
         let testCollection: IConsensusOrderedCollection;
 
         async function removeItem() {

--- a/packages/runtime/consensus-register-collection/package.json
+++ b/packages/runtime/consensus-register-collection/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-test-runtime-utils": "^0.16.0",
     "@types/debug": "^0.0.31",

--- a/packages/runtime/consensus-register-collection/src/consensusRegisterCollection.ts
+++ b/packages/runtime/consensus-register-collection/src/consensusRegisterCollection.ts
@@ -223,7 +223,6 @@ export class ConsensusRegisterCollection<T>
     protected async loadCore(
         branchId: string,
         storage: IObjectStorageService): Promise<void> {
-
         const header = await storage.read(snapshotFileName);
         const data: { [key: string]: ILocalData } = header !== undefined ? JSON.parse(fromBase64ToUtf8(header)) : {};
 
@@ -263,7 +262,7 @@ export class ConsensusRegisterCollection<T>
                 case "write": {
                     // add back-compat for pre-0.14 versions
                     // when the refSeq property didn't exist
-                    if(op.refSeq === undefined){
+                    if (op.refSeq === undefined) {
                         op.refSeq = message.referenceSequenceNumber;
                     }
                     // Message can be delivered with delay - resubmitted on reconnect.

--- a/packages/runtime/consensus-register-collection/src/consensusRegisterCollectionFactory.ts
+++ b/packages/runtime/consensus-register-collection/src/consensusRegisterCollectionFactory.ts
@@ -34,7 +34,6 @@ export class ConsensusRegisterCollectionFactory implements IConsensusRegisterCol
         services: ISharedObjectServices,
         branchId: string,
         attributes: IChannelAttributes): Promise<IConsensusRegisterCollection> {
-
         const collection = new ConsensusRegisterCollection(id, runtime, attributes);
         await collection.load(branchId, services);
         return collection;

--- a/packages/runtime/consensus-register-collection/src/test/consensusRegisterCollection.spec.ts
+++ b/packages/runtime/consensus-register-collection/src/test/consensusRegisterCollection.spec.ts
@@ -16,7 +16,6 @@ describe("Routerlicious", () => {
         function generate(
             name: string,
             factory: IConsensusRegisterCollectionFactory) {
-
             let testCollection: IConsensusRegisterCollection;
             let runtime: MockRuntime;
 

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-test-runtime-utils": "^0.16.0",
     "@types/mocha": "^5.2.5",

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -225,7 +225,7 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
             packagePath,
             realizationFn,
         );
-        const response = await componentRuntime.request({url: "/"});
+        const response = await componentRuntime.request({ url: "/" });
         if (response.status !== 200 || response.mimeType !== "fluid/component") {
             throw new Error("Failed to create component");
         }
@@ -447,7 +447,6 @@ export abstract class ComponentContext extends EventEmitter implements IComponen
         } else {
             this.emit("notleader", this.clientId);
         }
-
     }
 
     public bindRuntime(componentRuntime: IComponentRuntime) {

--- a/packages/runtime/container-runtime/src/componentRegistry.ts
+++ b/packages/runtime/container-runtime/src/componentRegistry.ts
@@ -9,18 +9,15 @@ import {
 } from "@microsoft/fluid-runtime-definitions";
 
 export class ComponentRegistry implements IComponentRegistry {
-
     private readonly map: Map<string, Promise<ComponentRegistryEntry>>;
 
     public get IComponentRegistry() { return this; }
 
     constructor(namedEntries: NamedComponentRegistryEntries) {
-
         this.map = new Map(namedEntries);
     }
 
     public async get(name: string): Promise<ComponentRegistryEntry | undefined> {
-
         if (this.map.has(name)) {
             return this.map.get(name);
         }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -380,7 +380,6 @@ class ContainerRuntimeComponentRegistry extends ComponentRegistry {
  * It will define the component level mappings.
  */
 export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRuntime, IExperimentalRuntime {
-
     public readonly isExperimentalRuntime = true;
     /**
      * Load the components from a snapshot and returns the runtime.
@@ -712,7 +711,6 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
     }
 
     public get IComponentTokenProvider() {
-
         if (this.options && this.options.intelligence) {
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             return {

--- a/packages/runtime/container-runtime/src/requestHandlers.ts
+++ b/packages/runtime/container-runtime/src/requestHandlers.ts
@@ -16,7 +16,6 @@ export type RuntimeRequestHandler = (request: RequestParser, runtime: IHostRunti
 
 export const componentRuntimeRequestHandler: RuntimeRequestHandler =
     async (request: RequestParser, runtime: IHostRuntime) => {
-
         if (request.pathParts.length > 0) {
             let wait: boolean | undefined;
             if (request.headers && (typeof request.headers.wait) === "boolean") {

--- a/packages/runtime/container-runtime/src/requestParser.ts
+++ b/packages/runtime/container-runtime/src/requestParser.ts
@@ -8,7 +8,6 @@ import { IRequest } from "@microsoft/fluid-component-core-interfaces";
  * The Request Parser takes an IRequest provides parsing and sub request creation
  */
 export class RequestParser implements IRequest {
-
     /**
      * Splits the path of the url and decodes each path part
      * @param url - the url to get path parts of

--- a/packages/runtime/container-runtime/src/test/componentContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/componentContext.spec.ts
@@ -26,7 +26,6 @@ describe("Component Context Tests", () => {
     });
 
     describe("LocalComponentContext Initialization", () => {
-
         let localComponentContext: LocalComponentContext;
         let storage: IDocumentStorageService;
         let scope: IComponent;
@@ -134,7 +133,6 @@ describe("Component Context Tests", () => {
     });
 
     describe("RemoteComponentContext Initialization", () => {
-
         let remotedComponentContext: RemotedComponentContext;
         let componentAttributes: IComponentAttributes;
         const storage: Partial<IDocumentStorageService> = {};
@@ -216,6 +214,5 @@ describe("Component Context Tests", () => {
                 "Remote Component package does not match.");
             assert.equal(contents.snapshotFormatVersion, "0.1", "Remote Component snapshot version does not match.");
         });
-
     });
 });

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -346,7 +346,7 @@ describe("Runtime", () => {
                         clientId: clientId2,
                         sequenceNumber: 0,
                         type: MessageType.Operation,
-                        metadata: { foo: 1},
+                        metadata: { foo: 1 },
                     };
 
                     scheduleManager.beginOperation(client2Message as ISequencedDocumentMessage);

--- a/packages/runtime/container-runtime/src/test/requestHandlers.spec.ts
+++ b/packages/runtime/container-runtime/src/test/requestHandlers.spec.ts
@@ -37,7 +37,7 @@ describe("RequestParser", () => {
         });
 
         it("Component request with wait", async () => {
-            const requestParser = new RequestParser({ url: "/componentId", headers: {wait: true} });
+            const requestParser = new RequestParser({ url: "/componentId", headers: { wait: true } });
             const runtime: IHostRuntime = {
                 getComponentRuntime: async (id, wait): Promise<IComponentRuntime> => {
                     assert.equal(id, "componentId");
@@ -55,7 +55,7 @@ describe("RequestParser", () => {
         });
 
         it("Component request with sub route", async () => {
-            const requestParser = new RequestParser({ url: "/componentId/route", headers: {wait: true} });
+            const requestParser = new RequestParser({ url: "/componentId/route", headers: { wait: true } });
             const runtime: IHostRuntime = {
                 getComponentRuntime: async (id, wait): Promise<IComponentRuntime> => {
                     assert.equal(id, "componentId");

--- a/packages/runtime/container-runtime/src/test/summarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizer.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import * as assert from "assert";
-import { Deferred, TelemetryNullLogger} from "@microsoft/fluid-common-utils";
+import { Deferred, TelemetryNullLogger } from "@microsoft/fluid-common-utils";
 import {
     ISequencedDocumentMessage,
     ISummaryAck,

--- a/packages/runtime/ink/package.json
+++ b/packages/runtime/ink/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/uuid": "^3.4.4",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/packages/runtime/ink/src/ink.ts
+++ b/packages/runtime/ink/src/ink.ts
@@ -153,7 +153,6 @@ export class Ink extends SharedObject<IInkEvents> implements IInk {
         branchId: string,
         storage: IObjectStorageService,
     ): Promise<void> {
-
         const header = await storage.read(snapshotFileName);
         if (header !== undefined) {
             this.inkData = new InkData(

--- a/packages/runtime/ink/src/inkFactory.ts
+++ b/packages/runtime/ink/src/inkFactory.ts
@@ -50,7 +50,6 @@ export class InkFactory implements ISharedObjectFactory {
         services: ISharedObjectServices,
         branchId: string,
         attributes: IChannelAttributes): Promise<ISharedObject> {
-
         const ink = new Ink(runtime, id, attributes);
         await ink.load(branchId, services);
 

--- a/packages/runtime/map/package.json
+++ b/packages/runtime/map/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-test-runtime-utils": "^0.16.0",
     "@types/debug": "^0.0.31",

--- a/packages/runtime/map/src/directory.ts
+++ b/packages/runtime/map/src/directory.ts
@@ -332,7 +332,6 @@ export class DirectoryFactory {
         services: ISharedObjectServices,
         branchId: string,
         attributes: IChannelAttributes): Promise<ISharedDirectory> {
-
         const directory = new SharedDirectory(id, runtime, attributes);
         await directory.load(branchId, services);
 
@@ -661,7 +660,6 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
     protected async loadCore(
         branchId: string,
         storage: IObjectStorageService) {
-
         const header = await storage.read(snapshotFileName);
         const data = JSON.parse(fromBase64ToUtf8(header));
         const newFormat = data as IDirectoryNewStorageFormat;

--- a/packages/runtime/map/src/map.ts
+++ b/packages/runtime/map/src/map.ts
@@ -80,7 +80,6 @@ export class MapFactory implements ISharedObjectFactory {
         services: ISharedObjectServices,
         branchId: string,
         attributes: IChannelAttributes): Promise<ISharedMap> {
-
         const map = new SharedMap(id, runtime, attributes);
         await map.load(branchId, services);
 
@@ -309,7 +308,6 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
                     type: value.type,
                     value: value.value === undefined ? undefined : JSON.parse(value.value),
                 };
-
             }
         }
 
@@ -332,7 +330,6 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
     protected async loadCore(
         branchId: string,
         storage: IObjectStorageService) {
-
         const header = await storage.read(snapshotFileName);
 
         const data = fromBase64ToUtf8(header);

--- a/packages/runtime/map/src/test/map.spec.ts
+++ b/packages/runtime/map/src/test/map.spec.ts
@@ -217,7 +217,7 @@ describe("Routerlicious", () => {
                         },
                     });
 
-                    const services = new MockSharedObjectServices({header: content});
+                    const services = new MockSharedObjectServices({ header: content });
                     const map2 = await factory.load(runtime, "mapId", services, "branchId", factory.attributes);
                     assert(map2.get("key") === "value");
                 });
@@ -239,7 +239,7 @@ describe("Routerlicious", () => {
                     assert(tree.entries.length === 1);
                     assert((tree.entries[0].value as IBlob).contents === content);
 
-                    const services = new MockSharedObjectServices({header: content});
+                    const services = new MockSharedObjectServices({ header: content });
                     const map2 = await factory.load(runtime, "mapId", services, "branchId", factory.attributes);
                     assert(map2.get("key") === "value");
                 });

--- a/packages/runtime/matrix/package.json
+++ b/packages/runtime/matrix/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-local-test-utils": "^0.16.0",
     "@microsoft/fluid-test-runtime-utils": "^0.16.0",

--- a/packages/runtime/merge-tree/package.json
+++ b/packages/runtime/merge-tree/package.json
@@ -55,7 +55,7 @@
     "@microsoft/fluid-runtime-definitions": "^0.16.0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-test-runtime-utils": "^0.16.0",
     "@types/diff": "^3.5.1",

--- a/packages/runtime/merge-tree/src/client.ts
+++ b/packages/runtime/merge-tree/src/client.ts
@@ -99,7 +99,6 @@ export class Client {
         marker: Marker,
         props: Properties.PropertySet,
         consensusCallback: (m: Marker) => void): ops.IMergeTreeAnnotateMsg {
-
         const combiningOp: ops.ICombiningOp = {
             name: "consensus",
         };
@@ -129,7 +128,6 @@ export class Client {
         marker: Marker,
         props: Properties.PropertySet,
         combiningOp: ops.ICombiningOp): ops.IMergeTreeAnnotateMsg {
-
         const annotateOp =
             OpBuilder.createAnnotateMarkerOp(marker, props, combiningOp);
 
@@ -152,7 +150,6 @@ export class Client {
         end: number,
         props: Properties.PropertySet,
         combiningOp: ops.ICombiningOp): ops.IMergeTreeAnnotateMsg {
-
         const annotateOp = OpBuilder.createAnnotateRangeOp(
             start,
             end,
@@ -174,7 +171,6 @@ export class Client {
      * @param register - Optional. The name of the register to store the removed range in
      */
     public removeRangeLocal(start: number, end: number, register?: string) {
-
         const removeOp = OpBuilder.createRemoveRangeOp(start, end, register);
 
         if (this.applyRemoveRangeOp({ op: removeOp })) {
@@ -203,7 +199,6 @@ export class Client {
      * @param segment - The segment to insert
      */
     public insertAtReferencePositionLocal(refPos: ReferencePosition, segment: ISegment): ops.IMergeTreeInsertMsg {
-
         const pos = this.mergeTree.referencePositionToLocalPosition(
             refPos,
             this.getCurrentSeq(),
@@ -265,7 +260,6 @@ export class Client {
     public walkSegments<TClientData>(
         handler: ISegmentAction<TClientData>,
         start?: number, end?: number, accum?: TClientData, splitRange: boolean = false) {
-
         this.mergeTree.mapRange(
             {
                 leaf: handler,
@@ -474,7 +468,6 @@ export class Client {
     private getValidOpRange(
         op: ops.IMergeTreeAnnotateMsg | ops.IMergeTreeInsertMsg | ops.IMergeTreeRemoveMsg,
         clientArgs: IMergeTreeClientSequenceArgs): IIntegerRange {
-
         let start: number = op.pos1;
         if (start === undefined && op.relativePos1) {
             start = this.mergeTree.posFromRelativePos(
@@ -541,7 +534,6 @@ export class Client {
      * @param opArgs - The op arge to get the client sequence args for
      */
     private getClientSequenceArgs(opArgs: IMergeTreeDeltaOpArgs): IMergeTreeClientSequenceArgs {
-
         // If there this no sequenced message, then the op is local
         // and unacked, so use this clients sequenced args
         //
@@ -750,13 +742,10 @@ export class Client {
             // if inserted, we only need to send insert, as that will contain props
             // if pending properties send annotate
             if (segment.removedSeq === UnassignedSequenceNumber) {
-
                 op = OpBuilder.createRemoveRangeOp(
                     segmentPosition,
                     segmentPosition + segment.cachedLength);
-
             } else if (segment.seq === UnassignedSequenceNumber) {
-
                 op = OpBuilder.createInsertSegmentOp(
                     segmentPosition,
                     segment);
@@ -764,9 +753,7 @@ export class Client {
                 if (segment.propertyManager) {
                     segment.propertyManager.clearPendingProperties();
                 }
-
             } else if (segment.propertyManager && segment.propertyManager.hasPendingProperties()) {
-
                 const annotateInfo = segment.propertyManager.resetPendingPropertiesToOpDetails();
                 op = OpBuilder.createAnnotateRangeOp(
                     segmentPosition,
@@ -858,7 +845,6 @@ export class Client {
         remoteClientPosition: number,
         remoteClientRefSeq: number,
         remoteClientId: string): number {
-
         const shortRemoteClientId = this.getOrAddShortClientId(remoteClientId);
         return this.mergeTree.resolveRemoteClientPosition(
             remoteClientPosition,
@@ -1042,19 +1028,19 @@ export class Client {
         return this.mergeTree.getLength(segmentWindow.currentSeq, segmentWindow.clientId);
     }
 
-    startOrUpdateCollaboration(longClientId: string | undefined, minSeq = 0, currentSeq = 0, branchId = 0){
+    startOrUpdateCollaboration(longClientId: string | undefined, minSeq = 0, currentSeq = 0, branchId = 0) {
         // we should always have a client id if we are collaborating
         // if the client id is undefined we are likley bound to a detached
         // container, so we should keep going in local mode. once
         // the container attaches this will be called again on connect with the
         // client id
-        if(longClientId !== undefined){
-            if(this.longClientId === undefined){
+        if (longClientId !== undefined) {
+            if (this.longClientId === undefined) {
                 this.longClientId = longClientId;
                 this.addLongClientId(this.longClientId, branchId);
                 this.mergeTree.startCollaboration(
                     this.getShortClientId(this.longClientId), minSeq, currentSeq, branchId);
-            } else{
+            } else {
                 const oldClientId = this.longClientId;
                 const oldData = this.clientNameToIds.get(oldClientId).data;
                 this.longClientId = longClientId;
@@ -1063,7 +1049,6 @@ export class Client {
             }
         }
     }
-
 
     findTile(startPos: number | undefined, tileLabel: string, preceding = true) {
         const clientId = this.getClientId();

--- a/packages/runtime/merge-tree/src/collections.ts
+++ b/packages/runtime/merge-tree/src/collections.ts
@@ -26,7 +26,6 @@ export class Stack<T> {
     pop(): T | undefined {
         return this.items.pop();
     }
-
 }
 
 export function ListRemoveEntry<U>(entry: List<U>): List<U> {
@@ -98,7 +97,7 @@ export class List<T> {
     }
 
     some(fn: (data: T, l: List<T>) => boolean, rev?: boolean): T {
-        for (let entry = <List<T>>this; !(entry.isHead); entry = rev ? entry.prev : entry.next) {
+        for (let entry = <List<T>> this; !(entry.isHead); entry = rev ? entry.prev : entry.next) {
             if (fn(entry.data, entry)) {
                 return (entry.data);
             }
@@ -189,7 +188,6 @@ export class List<T> {
         this.prev = entry;
         return (entry);
     }
-
 }
 
 export interface Comparer<T> {
@@ -1005,7 +1003,6 @@ export class IntegerRangeTree implements IRBAugmentation<Base.IIntegerRange, Aug
     }
 }
 
-
 export interface IInterval {
     clone(): IInterval;
     compare(b: IInterval): number;
@@ -1329,5 +1326,4 @@ export class TST<T> {
         this.patternCollect(this.root, { text: "" }, 0, pattern, q);
         return q;
     }
-
 }

--- a/packages/runtime/merge-tree/src/localReference.ts
+++ b/packages/runtime/merge-tree/src/localReference.ts
@@ -123,10 +123,9 @@ interface IRefsAtOffest {
 }
 
 export class LocalReferenceCollection {
-
-    public static append(seg1: ISegment, seg2: ISegment){
-        if(seg2.localRefs && !seg2.localRefs.empty){
-            if(!seg1.localRefs){
+    public static append(seg1: ISegment, seg2: ISegment) {
+        if (seg2.localRefs && !seg2.localRefs.empty) {
+            if (!seg1.localRefs) {
                 seg1.localRefs = new LocalReferenceCollection(seg1);
             }
             seg1.localRefs.append(seg2.localRefs);
@@ -147,7 +146,6 @@ export class LocalReferenceCollection {
     }
 
     public [Symbol.iterator]() {
-
         const subiterators: IterableIterator<LocalReference>[] = [];
         for (const refs of this.refsByOffset) {
             if (refs) {
@@ -165,7 +163,6 @@ export class LocalReferenceCollection {
 
         const iterator = {
             next(): IteratorResult<LocalReference> {
-
                 while (subiterators.length > 0) {
                     const next = subiterators[0].next();
                     if (next.done === true) {
@@ -176,7 +173,6 @@ export class LocalReferenceCollection {
                 }
 
                 return { value: undefined, done: true };
-
             },
             [Symbol.iterator]() {
                 return this;
@@ -189,16 +185,16 @@ export class LocalReferenceCollection {
         this.refCount = 0;
         this.hierRefCount = 0;
         const detachSegments = (refs: LocalReference[]) =>{
-            if(refs){
+            if (refs) {
                 refs.forEach((r)=>{
-                    if(r.segment === this.segment){
+                    if (r.segment === this.segment) {
                         r.segment = undefined;
                     }
                 });
             }
         };
         for (let i = 0; i < this.refsByOffset.length; i++) {
-            if(this.refsByOffset[i]) {
+            if (this.refsByOffset[i]) {
                 detachSegments(this.refsByOffset[i].before);
                 detachSegments(this.refsByOffset[i].at);
                 detachSegments(this.refsByOffset[i].before);
@@ -227,7 +223,6 @@ export class LocalReferenceCollection {
     }
 
     public removeLocalRef(lref: LocalReference) {
-
         const tryRemoveRef = (refs: LocalReference[]) => {
             if (refs) {
                 const index = refs.indexOf(lref);
@@ -284,7 +279,6 @@ export class LocalReferenceCollection {
     }
 
     public split(offset: number, splitSeg: ISegment) {
-
         if (!this.empty) {
             splitSeg.localRefs =
             new LocalReferenceCollection(
@@ -305,7 +299,6 @@ export class LocalReferenceCollection {
     }
 
     public addBeforeTombstones(...refs: Iterable<LocalReference>[]) {
-
         const beforeRefs = [];
 
         for (const iterable of refs) {
@@ -336,7 +329,6 @@ export class LocalReferenceCollection {
     }
 
     public addAfterTombstones(...refs: Iterable<LocalReference>[]) {
-
         const afterRefs = [];
 
         for (const iterable of refs) {

--- a/packages/runtime/merge-tree/src/mergeTree.ts
+++ b/packages/runtime/merge-tree/src/mergeTree.ts
@@ -483,12 +483,10 @@ export abstract class BaseSegment extends MergeNode implements ISegment {
     abstract toJSONObject(): any;
 
     public ack(segmentGroup: SegmentGroup, opArgs: IMergeTreeDeltaOpArgs, mergeTree: MergeTree): boolean {
-
         const currentSegmentGroup = this.segmentGroups.dequeue();
         assert.equal(currentSegmentGroup, segmentGroup);
 
         switch (opArgs.op.type) {
-
             case ops.MergeTreeDeltaType.ANNOTATE:
                 assert(this.propertyManager);
                 this.propertyManager.ackPendingProperties(opArgs.op);
@@ -678,7 +676,6 @@ export class Marker extends BaseSegment implements ReferencePosition {
     nestBuddy: Marker;
     public static make(
         refType: ops.ReferenceType, props?: Properties.PropertySet) {
-
         const marker = new Marker(refType);
         if (props) {
             marker.addProperties(props);
@@ -1069,7 +1066,6 @@ function recordTileStart(
 function tileShift(
     node: IMergeNode, segpos: number, refSeq: number, clientId: number,
     offset: number, end: number, searchInfo: IReferenceSearchInfo) {
-
     if (node.isLeaf()) {
         const seg = node;
         if ((searchInfo.mergeTree.localNetLength(seg) > 0) && Marker.is(seg)) {
@@ -1088,7 +1084,6 @@ function tileShift(
         if (marker !== undefined) {
             searchInfo.tile = marker;
         }
-
     }
     return true;
 }
@@ -1111,7 +1106,6 @@ export type LocalReferenceMapper = (id: string) => LocalReference;
 
 // Represents a sequence of text segments
 export class MergeTree {
-
     // Maximum length of text segment to be considered to be merged with other segment.
     // Maximum segment length is at least 2x of it (not taking into account initial segment creation).
     // The bigger it is, the more expensive it is to break segment into sub-segments (on edits)
@@ -1373,7 +1367,6 @@ export class MergeTree {
                         prevSegment = undefined;
                     } else {
                         if (segment.seq <= this.collabWindow.minSeq) {
-
                             const canAppend = prevSegment
                                 && prevSegment.canAppend(segment)
                                 && Properties.matchProperties(prevSegment.properties, segment.properties)
@@ -1651,7 +1644,6 @@ export class MergeTree {
     }
 
     cloneSegments(refSeq: number, clientId: number, start = 0, end?: number) {
-
         const gatherSegment = (
             segment: ISegment, pos: number, refSeq: number, clientId: number, start: number,
             end: number, accumSegments: SegmentAccumulator) => {
@@ -2015,7 +2007,7 @@ export class MergeTree {
         let pos = -1;
         let marker: Marker;
         if (relativePos.id) {
-            marker = <Marker>this.getMarkerFromId(relativePos.id);
+            marker = <Marker> this.getMarkerFromId(relativePos.id);
         }
         if (marker) {
             pos = this.getPosition(marker, refseq, clientId);
@@ -2029,7 +2021,6 @@ export class MergeTree {
                     pos -= relativePos.offset;
                 }
             }
-
         }
         return pos;
     }
@@ -2066,7 +2057,6 @@ export class MergeTree {
     }
 
     public insertAtReferencePosition(referencePosition: ReferencePosition, insertSegment: ISegment, opArgs: IMergeTreeDeltaOpArgs): void {
-
         if (insertSegment.cachedLength === 0) {
             return;
         }
@@ -2176,7 +2166,6 @@ export class MergeTree {
         remoteClientPosition: number,
         remoteClientRefSeq: number,
         remoteClientId: number): number {
-
         const segmentInfo = this.getContainingSegment(
             remoteClientPosition,
             remoteClientRefSeq,
@@ -2196,7 +2185,6 @@ export class MergeTree {
     }
 
     private insertChildNode(block: IMergeBlock, child: IMergeNode, childIndex: number) {
-
         assert(block.childCount < MaxNodesInBlock);
 
         for (let i = block.childCount; i > childIndex; i--) {
@@ -2263,7 +2251,6 @@ export class MergeTree {
         // TODO: build tree from segs and insert all at once
         let insertPos = pos;
         for (const newSegment of newSegments) {
-
             segIsLocal = false;
             if (newSegment.cachedLength > 0) {
                 newSegment.seq = seq;
@@ -2278,7 +2265,7 @@ export class MergeTree {
                 const splitNode = this.insertingWalk(this.root, insertPos, refSeq, clientId, seq,
                     { leaf: onLeaf, candidateSegment: newSegment, continuePredicate: continueFrom });
 
-                if(newSegment.parent === undefined){
+                if (newSegment.parent === undefined) {
                     throw new Error(`MergeTree insert failed: ${JSON.stringify({
                         currentSeq: this.collabWindow.currentSeq,
                         minSeq: this.collabWindow.minSeq,
@@ -2571,7 +2558,6 @@ export class MergeTree {
             if (child.ordinal) {
                 if (olen !== (child.ordinal.length - 1)) {
                     console.log("node integrity issue");
-
                 }
                 if (i > 0) {
                     if (child.ordinal <= block.children[i - 1].ordinal) {
@@ -2585,7 +2571,6 @@ export class MergeTree {
             } else {
                 console.log(`node child ordinal not set ${i}`);
                 console.log(`??: prnt ${ordinalToArray(block.ordinal)}`);
-
             }
         }
     }

--- a/packages/runtime/merge-tree/src/mergeTreeTracking.ts
+++ b/packages/runtime/merge-tree/src/mergeTreeTracking.ts
@@ -7,7 +7,6 @@ import { ISegment } from "./mergeTree";
 import { SortedSegmentSet } from "./sortedSegmentSet";
 
 export class TrackingGroup {
-
     private readonly segmentSet: SortedSegmentSet;
 
     constructor() {

--- a/packages/runtime/merge-tree/src/opBuilder.ts
+++ b/packages/runtime/merge-tree/src/opBuilder.ts
@@ -24,7 +24,6 @@ import { PropertySet } from "./properties";
  */
 export function createAnnotateMarkerOp(
     marker: Marker, props: PropertySet, combiningOp: ICombiningOp): IMergeTreeAnnotateMsg {
-
     const id = marker.getId();
     if (!id) {
         return undefined;

--- a/packages/runtime/merge-tree/src/overlayTree.ts
+++ b/packages/runtime/merge-tree/src/overlayTree.ts
@@ -23,7 +23,6 @@ function createTreeMarkerOps(
     id: string,
     nodeType: string,
     beginMarkerProps?: MergeLib.PropertySet): [MergeLib.IMergeTreeInsertMsg, MergeLib.IMergeTreeInsertMsg] {
-
     const endMarkerProps = MergeLib.createMap<any>();
     endMarkerProps[MergeLib.reservedMarkerIdKey] = endIdFromId(id);
     endMarkerProps[MergeLib.reservedRangeLabelsKey] = [treeRangeLabel];

--- a/packages/runtime/merge-tree/src/partialLengths.ts
+++ b/packages/runtime/merge-tree/src/partialLengths.ts
@@ -392,7 +392,6 @@ export class PartialSequenceLengths {
         } else {
             seqPartialLen.len = seqPartialLen.seglen;
         }
-
     }
     public minLength = 0;
     public segmentCount = 0;
@@ -429,7 +428,6 @@ export class PartialSequenceLengths {
                 }
             }
         }
-
     }
 
     public getPartialLength(mergeTree: MergeTree, refSeq: number, clientId: number) {
@@ -530,7 +528,6 @@ export class PartialSequenceLengths {
             pLen += cli[cli.length - 1].len;
         }
         cli.push({ seq, len: pLen, seglen });
-
     }
 
     // Assumes sequence number already coalesced

--- a/packages/runtime/merge-tree/src/segmentPropertiesManager.ts
+++ b/packages/runtime/merge-tree/src/segmentPropertiesManager.ts
@@ -10,7 +10,6 @@ import { ICombiningOp, IMergeTreeAnnotateMsg } from "./ops";
 import * as Properties from "./properties";
 
 export class SegmentPropertiesManager {
-
     private pendingKeyUpdateCount: Properties.MapLike<number>;
     private pendingRewriteCount: number;
 
@@ -38,7 +37,6 @@ export class SegmentPropertiesManager {
         op?: ICombiningOp,
         seq?: number,
         collabWindow?: CollaborationWindow): Properties.PropertySet {
-
         if (!this.segment.properties) {
             this.pendingRewriteCount = 0;
             this.segment.properties = Properties.createMap<any>();
@@ -104,7 +102,6 @@ export class SegmentPropertiesManager {
             if (newValue === null) {
                 // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
                 delete this.segment.properties[key];
-
             } else {
                 this.segment.properties[key] = newValue;
             }

--- a/packages/runtime/merge-tree/src/snapshot.ts
+++ b/packages/runtime/merge-tree/src/snapshot.ts
@@ -33,7 +33,6 @@ export interface SnapshotHeader {
 }
 
 export class Snapshot {
-
     public static readonly header = "header";
     public static readonly body = "body";
 
@@ -63,7 +62,6 @@ export class Snapshot {
         allLengths: number[],
         approxSequenceLength: number,
         startIndex = 0): ops.MergeTreeChunk {
-
         const segs: SegmentSpec[] = [];
         let sequenceLength = 0;
         let segCount = 0;

--- a/packages/runtime/merge-tree/src/snapshotLoader.ts
+++ b/packages/runtime/merge-tree/src/snapshotLoader.ts
@@ -15,7 +15,6 @@ import { Snapshot } from "./snapshot";
 import { SnapshotLegacy } from "./snapshotlegacy";
 
 export class SnapshotLoader {
-
     constructor(
         private readonly runtime: IComponentRuntime,
         private readonly client: Client,
@@ -24,7 +23,6 @@ export class SnapshotLoader {
     public async initialize(
         branchId: string,
         services: IObjectStorageService): Promise<ISequencedDocumentMessage[]> {
-
         const headerP = services.read(Snapshot.header);
         // If loading from a snapshot load tardis messages
         // kick off loading in parallel to loading "body" chunk.
@@ -88,7 +86,6 @@ export class SnapshotLoader {
     private loadHeader(
         header: string,
         branchId: string): MergeTreeChunk {
-
         const chunk = Snapshot.processChunk(
             header,
             this.runtime.IComponentSerializer,

--- a/packages/runtime/merge-tree/src/snapshotlegacy.ts
+++ b/packages/runtime/merge-tree/src/snapshotlegacy.ts
@@ -29,9 +29,7 @@ export interface SnapChunk {
     buffer?: Buffer;
 }
 
-
 export class SnapshotLegacy {
-
     public static readonly header = "header";
     public static readonly body = "body";
     public static readonly tardis = "tardis";
@@ -63,7 +61,6 @@ export class SnapshotLegacy {
         allLengths: number[],
         approxSequenceLength: number,
         startIndex = 0): ops.MergeTreeChunk {
-
         const segs: ops.IJSONSegment[] = [];
         let sequenceLength = 0;
         let segCount = 0;

--- a/packages/runtime/merge-tree/src/test/beastTest.ts
+++ b/packages/runtime/merge-tree/src/test/beastTest.ts
@@ -161,9 +161,9 @@ export function fileTest1() {
             if ((animal.length > 0) && (!removedAnimals.includes(animal))) {
                 const prop = beast.get(animal);
                 const linProp = linearBeast.get(animal);
-                //log(`Trying key ${animal}`);
+                // log(`Trying key ${animal}`);
                 if (prop) {
-                    //printStringNumProperty(prop);
+                    // printStringNumProperty(prop);
                     if ((linProp === undefined) || (prop.key != linProp.key) || (prop.data != linProp.data)) {
                         log(`Linear BST does not match RB BST at key ${animal}`);
                     }
@@ -260,7 +260,7 @@ export function mergeTreeTest1() {
     fuzzySeg = makeCollabTextSegment("fuzzy, fuzzy ");
     checkInsertMergeTree(mergeTree, 4, fuzzySeg);
     checkMarkRemoveMergeTree(mergeTree, 4, 13);
-    //checkRemoveSegTree(segTree, 4, 13);
+    // checkRemoveSegTree(segTree, 4, 13);
     checkInsertMergeTree(mergeTree, 4, makeCollabTextSegment("fi"));
     mergeTree.map({ leaf: printTextSegment }, UniversalSequenceNumber, LocalClientId);
     const segoff = mergeTree.getContainingSegment(4, UniversalSequenceNumber, LocalClientId);
@@ -419,7 +419,6 @@ export function mergeTreeCheckedTest() {
                 errorCount++;
                 break;
             }
-
         }
         if ((i > 0) && (0 == (i % 1000))) {
             const perIter = (accumTime / (i + 1)).toFixed(3);
@@ -474,7 +473,6 @@ export function mergeTreeCheckedTest() {
                 errorCount++;
                 break;
             }
-
         }
         if ((i > 0) && (0 == (i % 1000))) {
             const perIter = (accumTime / (i + 1)).toFixed(3);
@@ -486,7 +484,6 @@ export function mergeTreeCheckedTest() {
     }
     return errorCount;
 }
-
 
 type SharedStringJSONSegment = MergeTree.IJSONTextSegment & MergeTree.IJSONMarkerSegment;
 
@@ -604,7 +601,7 @@ export function TestPack(verbose = true) {
         server.addClients(clients);
 
         function checkTextMatch() {
-            //log(`checking text match @${server.getCurrentSeq()}`);
+            // log(`checking text match @${server.getCurrentSeq()}`);
             let clockStart = clock();
             const serverText = server.getText();
             getTextTime += elapsedMicroseconds(clockStart);
@@ -622,8 +619,8 @@ export function TestPack(verbose = true) {
                 const cliText = client.getText();
                 if (cliText != serverText) {
                     log(`mismatch @${server.getCurrentSeq()} client @${client.getCurrentSeq()} id: ${client.getClientId()}`);
-                    //log(serverText);
-                    //log(cliText);
+                    // log(serverText);
+                    // log(cliText);
                     const diffParts = JsDiff.diffChars(serverText, cliText);
                     for (const diffPart of diffParts) {
                         let annotes = "";
@@ -681,7 +678,6 @@ export function TestPack(verbose = true) {
                 const insertMarkerOp = client.insertMarkerLocal(pos, MergeTree.ReferenceType.Tile,
                     { [MergeTree.reservedTileLabelsKey]: "test" });
                 server.enqueueMsg(client.makeOpMessage(insertMarkerOp, UnassignedSequenceNumber));
-
             }
             const insertTextOp = client.insertTextLocal(pos, text);
             server.enqueueMsg(client.makeOpMessage(insertTextOp, UnassignedSequenceNumber));
@@ -848,8 +844,8 @@ export function TestPack(verbose = true) {
                 if (verbose) {
                     log(`total time ${(totalTime / 1000000.0).toFixed(1)} check time ${(checkTime / 1000000.0).toFixed(1)}`);
                 }
-                //log(server.getText());
-                //log(server.mergeTree.toString());
+                // log(server.getText());
+                // log(server.mergeTree.toString());
             }
             return errorCount;
         }
@@ -922,8 +918,8 @@ export function TestPack(verbose = true) {
         function tail() {
             reportTiming(server);
             reportTiming(clients[2]);
-            //log(server.getText());
-            //log(server.mergeTree.toString());
+            // log(server.getText());
+            // log(server.mergeTree.toString());
         }
         return errorCount;
     }
@@ -1088,8 +1084,8 @@ export function TestPack(verbose = true) {
         }
         log(`sequence number: ${cliA.getCurrentSeq()} min: ${cliA.getCollabWindow().minSeq}`);
         //                log(cliA.mergeTree.toString());
-        //log(cliB.mergeTree.toString());
-        //log(cliA.getText());
+        // log(cliB.mergeTree.toString());
+        // log(cliA.getText());
         const aveWindow = ((minSegCount + maxSegCount) / 2).toFixed(1);
         const aveTime = (cliA.accumTime / cliA.accumOps).toFixed(3);
         const aveWindowTime = (cliA.accumWindowTime / cliA.accumOps).toFixed(3);
@@ -1097,7 +1093,7 @@ export function TestPack(verbose = true) {
             log(`accum time ${cliA.accumTime} us ops: ${cliA.accumOps} ave window ${aveWindow} ave time ${aveTime}`);
             log(`accum window time ${cliA.accumWindowTime} us ave window time ${aveWindowTime}; max ${cliA.maxWindowTime}`);
         }
-        //log(cliB.getText());
+        // log(cliB.getText());
         return errorCount;
     }
 
@@ -1149,7 +1145,7 @@ export function TestPack(verbose = true) {
                 }
             }
         }
-        const segs = <SharedStringJSONSegment[]>new MergeTree.SnapshotLegacy(cli.mergeTree, DebugLogger.create("fluid:snapshot")).extractSync();
+        const segs = <SharedStringJSONSegment[]> new MergeTree.SnapshotLegacy(cli.mergeTree, DebugLogger.create("fluid:snapshot")).extractSync();
         if (verbose) {
             for (const seg of segs) {
                 log(`${specToSegment(seg)}`);
@@ -1304,7 +1300,6 @@ function shuffle<T>(a: T[]) {
 
     // While there remain elements to shuffle...
     while (0 !== currentIndex) {
-
         // Pick a remaining element...
         randomIndex = Math.floor(Math.random() * currentIndex);
         currentIndex--;
@@ -1644,7 +1639,6 @@ export class DocumentTree {
                 const row = DocumentTree.generateRow(rowProbability);
                 items.push(row);
             }
-
         }
         return items;
     }
@@ -1759,4 +1753,3 @@ describe("Routerlicious", () => {
         }).timeout(testTimeout);
     });
 });
-

--- a/packages/runtime/merge-tree/src/test/client.applyMsg.spec.ts
+++ b/packages/runtime/merge-tree/src/test/client.applyMsg.spec.ts
@@ -28,7 +28,6 @@ describe("client.applyMsg", () => {
             const pos1 = Math.floor(len / 2);
             const imod6 = i % 6;
             switch (imod6) {
-
                 case 0:
                 case 5: {
                     const pos2 = Math.max(Math.floor((len - pos1) / 4) - imod6 + pos1, pos1 + 1);
@@ -43,7 +42,7 @@ describe("client.applyMsg", () => {
                 case 4: {
                     const str = `${i}`.repeat(imod6 + 5);
                     const msg = client.makeOpMessage(client.insertTextLocal(pos1, str), i + 1);
-                    changes.set(i, {msg, segmentGroup: client.mergeTree.pendingSegments.last()});
+                    changes.set(i, { msg, segmentGroup: client.mergeTree.pendingSegments.last() });
                     break;
                 }
 
@@ -58,7 +57,7 @@ describe("client.applyMsg", () => {
                         },
                         undefined);
                     const msg = client.makeOpMessage(op, i + 1);
-                    changes.set(i, { msg, segmentGroup: client.mergeTree.pendingSegments.last()});
+                    changes.set(i, { msg, segmentGroup: client.mergeTree.pendingSegments.last() });
                     break;
                 }
                 default:
@@ -71,7 +70,6 @@ describe("client.applyMsg", () => {
             const segments = changes.get(i).segmentGroup.segments;
             for (const seg of segments) {
                 switch (i % 6) {
-
                     case 0:
                     case 5:
                         assert.equal(seg.removedSeq, msg.sequenceNumber, "removed segment has unexpected id");
@@ -96,7 +94,6 @@ describe("client.applyMsg", () => {
     });
 
     it("insertTextLocal", () => {
-
         const op = client.insertTextLocal(0, "abc");
 
         const segmentInfo = client.getContainingSegment(0);
@@ -172,12 +169,10 @@ describe("client.applyMsg", () => {
     });
 
     it("multiple interleaved annotateSegmentLocal", () => {
-
         let annotateEnd: number = client.getText().length;
         const messages: ISequencedDocumentMessage[] = [];
         let sequenceNumber = 0;
         while (annotateEnd > 0) {
-
             const props = {
                 end: annotateEnd,
                 foo: "bar",

--- a/packages/runtime/merge-tree/src/test/client.conflictFarm.spec.ts
+++ b/packages/runtime/merge-tree/src/test/client.conflictFarm.spec.ts
@@ -28,8 +28,8 @@ const allOpertaions: TestOperation[] = [
 ];
 
 export const debugOptions: IConflictFarmConfig = {
-    minLength: {min: 2, max: 2},
-    clients: {min: 3, max: 3},
+    minLength: { min: 2, max: 2 },
+    clients: { min: 3, max: 3 },
     opsPerRoundRange: { min: 1, max: 100 },
     rounds: 1000,
     operations: allOpertaions,
@@ -38,25 +38,24 @@ export const debugOptions: IConflictFarmConfig = {
 };
 
 export const defaultOptions: IConflictFarmConfig = {
-    minLength: {min: 1, max: 512},
-    clients: {min: 1, max: 8},
-    opsPerRoundRange: {min: 1, max: 128},
+    minLength: { min: 1, max: 512 },
+    clients: { min: 1, max: 8 },
+    opsPerRoundRange: { min: 1, max: 128 },
     rounds: 8,
     operations: allOpertaions,
     growthFunc: (input: number) => input * 2,
 };
 
 export const longOptions: IConflictFarmConfig = {
-    minLength: {min: 1, max: 512},
-    clients: {min: 1, max: 32},
-    opsPerRoundRange: {min: 1, max: 512},
+    minLength: { min: 1, max: 512 },
+    clients: { min: 1, max: 32 },
+    opsPerRoundRange: { min: 1, max: 512 },
     rounds: 32,
     operations: allOpertaions,
     growthFunc: (input: number) => input * 2,
 };
 
 describe("MergeTree.Client", () => {
-
     // tslint:disable: mocha-no-side-effect-code
     const opts =
         defaultOptions;

--- a/packages/runtime/merge-tree/src/test/client.localReference.spec.ts
+++ b/packages/runtime/merge-tree/src/test/client.localReference.spec.ts
@@ -9,7 +9,6 @@ import { ReferenceType } from "../ops";
 import { TestClient } from "./";
 
 describe("MergeTree.Client", () => {
-
     it("Remove segment of non-sliding local reference", () => {
         const client1 = new TestClient();
         const client2 = new TestClient();
@@ -137,7 +136,6 @@ describe("MergeTree.Client", () => {
 
         assert.equal(c1LocalRef.toPosition(), client2.getLength() - 1);
     });
-
 
     it("Remove all segments with sliding local reference", () => {
         const client1 = new TestClient();

--- a/packages/runtime/merge-tree/src/test/client.spec.ts
+++ b/packages/runtime/merge-tree/src/test/client.spec.ts
@@ -10,7 +10,6 @@ import { TextSegment } from "../textSegment";
 import { TestClient } from "./testClient";
 
 describe("TestClient", () => {
-
     const localUserLongId = "localUser";
     let client: TestClient;
 
@@ -236,7 +235,7 @@ describe("TestClient", () => {
     describe(".annotateMarker", () => {
         it("annotate valid marker", () => {
             const insertOp = client.insertMarkerLocal(0, MergeTree.ReferenceType.Tile, {
-                [MergeTree.reservedMarkerIdKey]: "123"});
+                [MergeTree.reservedMarkerIdKey]: "123" });
             assert(insertOp);
             const markerInfo = client.getContainingSegment(0);
             const marker = markerInfo.segment as MergeTree.Marker;

--- a/packages/runtime/merge-tree/src/test/mergeTree.annotate.spec.ts
+++ b/packages/runtime/merge-tree/src/test/mergeTree.annotate.spec.ts
@@ -113,16 +113,13 @@ describe("MergeTree", () => {
                 });
 
                 it("unsequenced local", () => {
-
                     const segmentInfo =
                         mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
                     const segment = segmentInfo.segment as BaseSegment;
                     assert.equal(segment.properties.propertySource, "local");
-
                 });
 
                 it("unsequenced local after unsequenced local", () => {
-
                     mergeTree.annotateRange(
                         annotateStart,
                         annotateEnd,
@@ -139,11 +136,9 @@ describe("MergeTree", () => {
                         mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
                     const segment = segmentInfo.segment as BaseSegment;
                     assert.equal(segment.properties.secondProperty, "local");
-
                 });
 
                 it("unsequenced local split", () => {
-
                     const segmentInfo =
                         mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
                     const segment = segmentInfo.segment as BaseSegment;
@@ -151,11 +146,9 @@ describe("MergeTree", () => {
                     const splitSegment = segment.splitAt(splitPos) as BaseSegment;
 
                     assert.equal(splitSegment.properties.propertySource, "local");
-
                 });
 
                 it("unsequenced local after unsequenced local split", () => {
-
                     const secondChangeProps = {
                         secondChange: 1,
                     };
@@ -269,7 +262,6 @@ describe("MergeTree", () => {
                     assert.equal(splitSegment.properties.propertySource, "local");
                     assert.equal(splitSegment.properties.secondChange, 1);
                     assert.equal(splitSegment.properties.splitOnly, 1);
-
                 });
 
                 it("unsequenced local before remote", () => {
@@ -296,7 +288,6 @@ describe("MergeTree", () => {
                 });
 
                 it("sequenced local", () => {
-
                     mergeTree.ackPendingSegment(
                         {
                             op: {
@@ -315,11 +306,9 @@ describe("MergeTree", () => {
                     const segment = segmentInfo.segment as BaseSegment;
                     assert.equal(segment.segmentGroups.size, 0);
                     assert.equal(segment.properties.propertySource, "local");
-
                 });
 
                 it("sequenced local before remote", () => {
-
                     mergeTree.ackPendingSegment(
                         {
                             op: {
@@ -356,7 +345,6 @@ describe("MergeTree", () => {
                 });
 
                 it("three local changes", () => {
-
                     const segmentInfo =
                         mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
                     const segment = segmentInfo.segment as BaseSegment;
@@ -450,7 +438,6 @@ describe("MergeTree", () => {
                 });
 
                 it("two local changes with interleved remote", () => {
-
                     mergeTree.annotateRange(
                         annotateStart,
                         annotateEnd,
@@ -497,7 +484,6 @@ describe("MergeTree", () => {
                     assert.equal(segment.properties.remoteOnly, 1);
                     assert.equal(segment.properties.propertySource, "remote");
                     assert.equal(segment.properties.secondSource, "local2");
-
                 });
             });
             describe("remote first", () => {
@@ -520,17 +506,14 @@ describe("MergeTree", () => {
                     assert(segmentInfo.segment.segmentGroups.empty);
                 });
                 it("remote only", () => {
-
                     const segmentInfo =
                         mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
                     const segment = segmentInfo.segment as BaseSegment;
                     assert.equal(segment.properties.propertySource, "remote");
                     assert.equal(segment.properties.remoteProperty, 1);
-
                 });
 
                 it("split remote", () => {
-
                     const segmentInfo =
                         mergeTree.getContainingSegment(annotateStart, currentSequenceNumber, localClientId);
                     const segment = segmentInfo.segment as BaseSegment;
@@ -538,11 +521,9 @@ describe("MergeTree", () => {
                     const splitSegment = segment.splitAt(1) as BaseSegment;
                     assert.equal(splitSegment.properties.propertySource, "remote");
                     assert.equal(splitSegment.properties.remoteProperty, 1);
-
                 });
 
                 it("remote before unsequenced local", () => {
-
                     mergeTree.annotateRange(
                         annotateStart,
                         annotateEnd,
@@ -560,11 +541,9 @@ describe("MergeTree", () => {
                     const segment = segmentInfo.segment as BaseSegment;
                     assert.equal(segment.properties.propertySource, "local");
                     assert.equal(segment.properties.remoteProperty, 1);
-
                 });
 
                 it("remote before sequenced local", () => {
-
                     const props = {
                         propertySource: "local",
                     };
@@ -623,7 +602,6 @@ describe("MergeTree", () => {
                 });
 
                 it("unsequenced local after unsequenced local", () => {
-
                     mergeTree.annotateRange(
                         annotateStart,
                         annotateEnd,
@@ -642,7 +620,6 @@ describe("MergeTree", () => {
                     const segment = segmentInfo.segment as BaseSegment;
                     assert.equal(segment.properties.propertySource, "local2");
                     assert.equal(segment.properties.secondProperty, "local");
-
                 });
 
                 it("unsequenced local before remote", () => {
@@ -669,7 +646,6 @@ describe("MergeTree", () => {
                 });
 
                 it("sequenced local before remote", () => {
-
                     mergeTree.ackPendingSegment(
                         {
                             op: {
@@ -707,7 +683,6 @@ describe("MergeTree", () => {
                 });
 
                 it("two local changes with interleved remote", () => {
-
                     mergeTree.annotateRange(
                         annotateStart,
                         annotateEnd,
@@ -755,7 +730,6 @@ describe("MergeTree", () => {
                     assert(!segment.properties.remoteOnly);
                     assert(!segment.properties.propertySource);
                     assert.equal(segment.properties.secondSource, "local2");
-
                 });
             });
         });

--- a/packages/runtime/merge-tree/src/test/mergeTree.insert.deltaCallback.spec.ts
+++ b/packages/runtime/merge-tree/src/test/mergeTree.insert.deltaCallback.spec.ts
@@ -48,7 +48,7 @@ describe("MergeTree", () => {
                 UnassignedSequenceNumber,
                 "more ",
                 undefined,
-                {op: {type: MergeTreeDeltaType.INSERT}});
+                { op: { type: MergeTreeDeltaType.INSERT } });
 
             assert.equal(eventCalled, 1);
         });
@@ -70,7 +70,7 @@ describe("MergeTree", () => {
                 UnassignedSequenceNumber,
                 "more ",
                 undefined,
-                {op: {type: MergeTreeDeltaType.INSERT}});
+                { op: { type: MergeTreeDeltaType.INSERT } });
 
             assert.equal(eventCalled, 1);
         });
@@ -86,7 +86,7 @@ describe("MergeTree", () => {
                 UnassignedSequenceNumber,
                 "more ",
                 undefined,
-                {op: {type: MergeTreeDeltaType.INSERT}});
+                { op: { type: MergeTreeDeltaType.INSERT } });
 
             assert.deepStrictEqual(count, {
                 [MergeTreeDeltaType.INSERT]: 1,
@@ -108,7 +108,7 @@ describe("MergeTree", () => {
                 ++remoteSequenceNumber,
                 "more ",
                 undefined,
-                {op: {type: MergeTreeDeltaType.INSERT}});
+                { op: { type: MergeTreeDeltaType.INSERT } });
 
             assert.deepStrictEqual(count, {
                 [MergeTreeDeltaType.INSERT]: 1,
@@ -127,7 +127,7 @@ describe("MergeTree", () => {
                 UnassignedSequenceNumber,
                 ReferenceType.Simple,
                 undefined,
-                {op: {type: MergeTreeDeltaType.INSERT}});
+                { op: { type: MergeTreeDeltaType.INSERT } });
 
             assert.deepStrictEqual(count, {
                 [MergeTreeDeltaType.INSERT]: 1,

--- a/packages/runtime/merge-tree/src/test/mergeTree.markRangeRemoved.spec.ts
+++ b/packages/runtime/merge-tree/src/test/mergeTree.markRangeRemoved.spec.ts
@@ -39,7 +39,6 @@ describe("MergeTree.markRangeRemoved", () => {
     });
 
     it("remote remove followed by local insert", () => {
-
         client.applyMsg(
             client.makeOpMessage(
                 createRemoveRangeOp(0, client.getLength()),
@@ -68,7 +67,6 @@ describe("MergeTree.markRangeRemoved", () => {
     });
 
     it("remote remove followed by remote insert", () => {
-
         const removeMsg =
             client.makeOpMessage(
                 createRemoveRangeOp(0, client.getLength()),
@@ -113,7 +111,6 @@ describe("MergeTree.markRangeRemoved", () => {
     // Repro of issue #1213:
     // https://github.com/microsoft/FluidFramework/issues/1214
     it.skip("local and remote clients race to insert at position of removed segment", () => {
-
         // Note: This test constructs it's own TestClients to avoid being initialized with "hello world".
 
         // First we run through the ops from the perspective of a passive observer (i.e., all operations are remote).

--- a/packages/runtime/merge-tree/src/test/mergeTreeOperationRunner.ts
+++ b/packages/runtime/merge-tree/src/test/mergeTreeOperationRunner.ts
@@ -60,7 +60,6 @@ export function runMergeTreeOperationRunner(
     clients: readonly TestClient[],
     minLength: number,
     config: IMergeTreeOperationRunnerConfig) {
-
     let seq = startingSeq;
 
     // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -89,7 +88,6 @@ export function runMergeTreeOperationRunner(
                     op = client.insertTextLocal(
                         random.integer(0, len)(mt),
                         text);
-
                 } else {
                     let opIndex = random.integer(0, config.operations.length - 1)(mt);
                     const start = random.integer(0, len - 1)(mt);

--- a/packages/runtime/merge-tree/src/test/segmentGroupCollection.spec.ts
+++ b/packages/runtime/merge-tree/src/test/segmentGroupCollection.spec.ts
@@ -76,7 +76,6 @@ describe("segmentGroupCollection", () => {
         assert.equal(segmentCopy.segmentGroups.size, segmentGroupCount);
 
         while (!segment.segmentGroups.empty || !segmentCopy.segmentGroups.empty) {
-
             const segmentGroup = segment.segmentGroups.dequeue();
             const copySegmentGroup = segmentCopy.segmentGroups.dequeue();
 

--- a/packages/runtime/merge-tree/src/test/snapshotlegacy.spec.ts
+++ b/packages/runtime/merge-tree/src/test/snapshotlegacy.spec.ts
@@ -11,7 +11,6 @@ import { TestClient } from ".";
 
 describe("snapshot", () => {
     it("header only", async () => {
-
         const client1 = new TestClient();
         client1.startOrUpdateCollaboration("0");
         for (let i = 0; i < SnapshotLegacy.sizeOfFirstChunk; i++) {
@@ -40,7 +39,6 @@ describe("snapshot", () => {
         .timeout(5000);
 
     it("header and body", async () => {
-
         const clients = [new TestClient(), new TestClient(), new TestClient()];
         clients[0].startOrUpdateCollaboration("0");
         for (let i = 0; i < SnapshotLegacy.sizeOfFirstChunk + 10; i++) {

--- a/packages/runtime/merge-tree/src/test/testClient.ts
+++ b/packages/runtime/merge-tree/src/test/testClient.ts
@@ -40,7 +40,6 @@ const mt = random.engines.mt19937();
 mt.seedWithArray([0xDEADBEEF, 0xFEEDBED]);
 
 export class TestClient extends Client {
-
     public static searchChunkSize = 256;
 
     /**

--- a/packages/runtime/merge-tree/src/test/testClientLogger.ts
+++ b/packages/runtime/merge-tree/src/test/testClientLogger.ts
@@ -19,7 +19,6 @@ export class TestClientLogger {
     constructor(
         private readonly clients: readonly TestClient[],
         private readonly title?: string) {
-
         this.roundLogLines.push([
             "seq",
             "op",

--- a/packages/runtime/merge-tree/src/test/wordUnitTests.ts
+++ b/packages/runtime/merge-tree/src/test/wordUnitTests.ts
@@ -187,5 +187,3 @@ describe("Routerlicious", () => {
         }).timeout(testTimeout);
     });
 });
-
-

--- a/packages/runtime/merge-tree/src/textSegment.ts
+++ b/packages/runtime/merge-tree/src/textSegment.ts
@@ -123,7 +123,6 @@ export interface ITextAccumulator {
 }
 
 export class MergeTreeTextHelper {
-
     constructor(private readonly mergeTree: MergeTree) {}
 
     public getTextAndMarkers(refSeq: number, clientId: number, label: string, start?: number, end?: number) {
@@ -271,7 +270,6 @@ export class MergeTreeTextHelper {
                     accumText.parallelText.push(accumText.textSegment.text);
                     accumText.textSegment.text = "";
                 }
-
             }
         }
 

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@typescript-eslint/eslint-plugin": "~2.17.0",
     "@typescript-eslint/parser": "~2.17.0",

--- a/packages/runtime/runtime-definitions/src/componentFactory.ts
+++ b/packages/runtime/runtime-definitions/src/componentFactory.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-
 import { IComponent, IComponentLoadable } from "@microsoft/fluid-component-core-interfaces";
 import { IComponentContext } from "./components";
 

--- a/packages/runtime/runtime-test-utils/package.json
+++ b/packages/runtime/runtime-test-utils/package.json
@@ -38,7 +38,7 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/node": "^10.14.6",
     "@types/uuid": "^3.4.4",

--- a/packages/runtime/runtime-test-utils/src/mocks.ts
+++ b/packages/runtime/runtime-test-utils/src/mocks.ts
@@ -199,8 +199,7 @@ class MockDeltaConnection implements IDeltaConnection {
     }
 }
 
-export class MockQuorum implements IQuorum, EventEmitter{
-
+export class MockQuorum implements IQuorum, EventEmitter {
     private readonly map = new Map<string, any>();
     private readonly members: Map<string, ISequencedClient>;
     private readonly eventEmitter = new EventEmitter();
@@ -241,7 +240,6 @@ export class MockQuorum implements IQuorum, EventEmitter{
         }
     }
 
-
     getMembers(): Map<string, ISequencedClient> {
         return this.members;
     }
@@ -253,7 +251,6 @@ export class MockQuorum implements IQuorum, EventEmitter{
     dispose(): void {
         throw new Error("Method not implemented.");
     }
-
 
     addListener(event: string | symbol, listener: (...args: any[]) => void): this {
         throw new Error("Method not implemented.");
@@ -323,7 +320,6 @@ export class MockQuorum implements IQuorum, EventEmitter{
  */
 export class MockRuntime extends EventEmitter
     implements IComponentRuntime, IComponentHandleContext {
-
     public get IComponentHandleContext(): IComponentHandleContext { return this; }
     public get IComponentRouter() { return this; }
 
@@ -497,7 +493,6 @@ export class MockHistorian implements IHistorian {
                 if (blob.path === head) {
                     return this.read_r(tail, this.blobMap.get(blob.sha) as git.ITree);
                 }
-
             }
             assert(false, `historian.read() blob not found (recursive): ${head}`);
         }

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/benchmark": "^1.0.31",
     "@types/mocha": "^5.2.5",

--- a/packages/runtime/runtime-utils/src/test/serializer.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/serializer.spec.ts
@@ -94,8 +94,8 @@ describe("ComponentSerializer", () => {
 
         check(handle, serHandle);
         check([handle], [serHandle]);
-        check({handle}, {handle: serHandle});
-        check([{handle}, {handle}], [{handle: serHandle}, {handle: serHandle}]);
+        check({ handle }, { handle: serHandle });
+        check([{ handle }, { handle }], [{ handle: serHandle }, { handle: serHandle }]);
 
         it(`sizable json tree`, () => {
             const input: any = makeJson(

--- a/packages/runtime/sequence/package.json
+++ b/packages/runtime/sequence/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-gitresources": "^0.1004.1-0",
     "@microsoft/fluid-server-services-client": "^0.1004.1-0",

--- a/packages/runtime/sequence/src/intervalCollection.ts
+++ b/packages/runtime/sequence/src/intervalCollection.ts
@@ -186,7 +186,6 @@ export class SequenceInterval implements ISerializableInterval {
             console.log(`be ${MergeTree.ordinalToArray(b.end.segment.ordinal)}@${b.end.offset}`);
             console.log(this.checkMergeTree.nodeToString(b.start.segment.parent, ""));
         }
-
     }
 }
 
@@ -272,7 +271,6 @@ export class LocalIntervalCollection<TInterval extends ISerializableInterval> {
         private readonly client: MergeTree.Client,
         private readonly label: string,
         private readonly helpers: IIntervalHelpers<TInterval>) {
-
         this.endIntervalTree =
             // eslint-disable-next-line @typescript-eslint/unbound-method
             new MergeTree.RedBlackTree<TInterval, TInterval>(helpers.compareEnds);
@@ -347,7 +345,6 @@ export class LocalIntervalCollection<TInterval extends ISerializableInterval> {
         end: number,
         intervalType: MergeTree.IntervalType,
         props?: MergeTree.PropertySet) {
-
         const interval = this.createInterval(start, end, intervalType);
         if (interval) {
             interval.addProperties(props);
@@ -631,7 +628,6 @@ export class IntervalCollectionView<TInterval extends ISerializableInterval> ext
     }
 
     public deleteInterval(serializedInterval: ISerializedInterval, local: boolean, op: ISequencedDocumentMessage) {
-
         const interval = this.localCollection.removeInterval(serializedInterval.start, serializedInterval.end);
 
         if (interval) {
@@ -743,7 +739,6 @@ export class IntervalCollection<TInterval extends ISerializableInterval> {
         serializedInterval: ISerializedInterval,
         local: boolean,
         op: ISequencedDocumentMessage) {
-
         if (!this.view) {
             throw new Error("attachSequence must be called");
         }

--- a/packages/runtime/sequence/src/sequence.ts
+++ b/packages/runtime/sequence/src/sequence.ts
@@ -38,7 +38,6 @@ const cloneDeep = require("lodash/cloneDeep");
 const snapshotFileName = "header";
 const contentPath = "content";
 
-
 export interface ISharedSegmentSequenceEvents
     extends ISharedObjectEvents {
 

--- a/packages/runtime/sequence/src/sequence.ts
+++ b/packages/runtime/sequence/src/sequence.ts
@@ -50,7 +50,6 @@ export interface ISharedSegmentSequenceEvents
 export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
     extends SharedObject<ISharedSegmentSequenceEvents>
     implements ISharedIntervalCollection<SequenceInterval> {
-
     get loaded(): Promise<void> {
         return this.loadedDeferred.promise;
     }
@@ -214,7 +213,6 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
      * @param register - The name of the register to store the range in
      */
     public copy(start: number, end: number, register: string) {
-
         const insertOp = this.client.copyLocal(start, end, register);
         if (insertOp) {
             this.submitSequenceMessage(insertOp);
@@ -224,7 +222,6 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
     public groupOperation(groupOp: MergeTree.IMergeTreeGroupMsg) {
         this.client.localTransaction(groupOp);
         this.submitSequenceMessage(groupOp);
-
     }
 
     public getContainingSegment(pos: number) {
@@ -256,7 +253,6 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
         end: number,
         props: MergeTree.PropertySet,
         combiningOp?: MergeTree.ICombiningOp) {
-
         const annotateOp =
             this.client.annotateRangeLocal(start, end, props, combiningOp);
         if (annotateOp) {
@@ -307,7 +303,6 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
             remoteClientPosition,
             remoteClientRefSeq,
             remoteClientId);
-
     }
 
     public submitSequenceMessage(message: MergeTree.IMergeTreeOp) {
@@ -353,7 +348,6 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
         handler: MergeTree.ISegmentAction<TClientData>,
         start?: number, end?: number, accum?: TClientData,
         splitRange: boolean = false) {
-
         return this.client.walkSegments<TClientData>(handler, start, end, accum, splitRange);
     }
 
@@ -450,7 +444,6 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
     }
 
     protected onConnect(pending: any[]) {
-
         for (const message of pending) {
             this.intervalMapKernel.trySubmitMessage(message);
         }
@@ -470,7 +463,6 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
     protected async loadCore(
         branchId: string,
         storage: IObjectStorageService) {
-
         const header = await storage.read(snapshotFileName);
 
         const data: string = header ? fromBase64ToUtf8(header) : undefined;
@@ -563,7 +555,6 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
             && this.messagesSinceMSNChange[20].sequenceNumber < message.minimumSequenceNumber) {
             this.processMinSequenceNumberChanged(message.minimumSequenceNumber);
         }
-
     }
 
     private getIntervalCollectionPath(label: string) {
@@ -595,7 +586,6 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
     }
 
     private initializeIntervalCollections() {
-
         // Listen and initialize new SharedIntervalCollections
         this.intervalMapKernel.eventEmitter.on("valueChanged", (ev: IValueChanged) => {
             const intervalCollection = this.intervalMapKernel.get<IntervalCollection<SequenceInterval>>(ev.key);

--- a/packages/runtime/sequence/src/sequenceFactory.ts
+++ b/packages/runtime/sequence/src/sequenceFactory.ts
@@ -45,7 +45,6 @@ export class SharedStringFactory implements ISharedObjectFactory {
         services: ISharedObjectServices,
         branchId: string,
         attributes: IChannelAttributes): Promise<ISharedObject> {
-
         const sharedString = new SharedString(runtime, id, attributes);
         await sharedString.load(branchId, services);
         return sharedString;
@@ -92,7 +91,6 @@ export class SharedObjectSequenceFactory implements ISharedObjectFactory {
         services: ISharedObjectServices,
         branchId: string,
         attributes: IChannelAttributes): Promise<ISharedObject> {
-
         const sharedSeq = new SharedObjectSequence<object>(runtime, id, attributes);
         await sharedSeq.load(branchId, services);
         return sharedSeq;
@@ -139,7 +137,6 @@ export class SharedNumberSequenceFactory implements ISharedObjectFactory {
         services: ISharedObjectServices,
         branchId: string,
         attributes: IChannelAttributes): Promise<ISharedObject> {
-
         const sharedSeq = new SharedNumberSequence(runtime, id, attributes);
         await sharedSeq.load(branchId, services);
         return sharedSeq;

--- a/packages/runtime/sequence/src/sharedIntervalCollection.ts
+++ b/packages/runtime/sequence/src/sharedIntervalCollection.ts
@@ -56,7 +56,6 @@ export class SharedIntervalCollectionFactory implements ISharedObjectFactory {
         services: ISharedObjectServices,
         branchId: string,
         attributes: IChannelAttributes): Promise<SharedIntervalCollection> {
-
         const map = new SharedIntervalCollection(id, runtime, attributes);
         await map.load(branchId, services);
 
@@ -81,7 +80,6 @@ export interface ISharedIntervalCollection<TInterval extends ISerializableInterv
 
 export class SharedIntervalCollection<TInterval extends ISerializableInterval = Interval>
     extends SharedObject implements ISharedIntervalCollection<TInterval> {
-
     /**
      * Create a SharedIntervalCollection
      *
@@ -170,7 +168,6 @@ export class SharedIntervalCollection<TInterval extends ISerializableInterval = 
         for (const message of pending) {
             this.intervalMapKernel.trySubmitMessage(message);
         }
-
     }
 
     protected onDisconnect() {
@@ -180,7 +177,6 @@ export class SharedIntervalCollection<TInterval extends ISerializableInterval = 
     protected async loadCore(
         branchId: string,
         storage: IObjectStorageService) {
-
         const header = await storage.read(snapshotFileName);
 
         const data: string = header ? fromBase64ToUtf8(header) : undefined;

--- a/packages/runtime/sequence/src/sharedSequence.ts
+++ b/packages/runtime/sequence/src/sharedSequence.ts
@@ -97,7 +97,6 @@ export class SubSequence<T> extends BaseSegment {
             return leafSegment;
         }
     }
-
 }
 
 export class SharedSequence<T> extends SharedSegmentSequence<SubSequence<T>> {
@@ -116,7 +115,6 @@ export class SharedSequence<T> extends SharedSegmentSequence<SubSequence<T>> {
      * @param props - Optional. Properties to set on the inserted items.
      */
     public insert(pos: number, items: T[], props?: PropertySet) {
-
         const segment = new SubSequence<T>(items);
         if (props) {
             segment.addProperties(props);

--- a/packages/runtime/sequence/src/sharedString.ts
+++ b/packages/runtime/sequence/src/sharedString.ts
@@ -77,7 +77,6 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
         relativePos1: MergeTree.IRelativePosition,
         refType: MergeTree.ReferenceType,
         props?: MergeTree.PropertySet) {
-
         const segment = new MergeTree.Marker(refType);
         if (props) {
             segment.addProperties(props);
@@ -101,7 +100,6 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
         pos: number,
         refType: MergeTree.ReferenceType,
         props?: MergeTree.PropertySet) {
-
         const segment = new MergeTree.Marker(refType);
         if (props) {
             segment.addProperties(props);
@@ -180,7 +178,6 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
         marker: MergeTree.Marker,
         props: MergeTree.PropertySet,
         callback: (m: MergeTree.Marker) => void) {
-
         const annotateOp = this.client.annotateMarkerNotifyConsensus(marker, props, callback);
         if (annotateOp) {
             this.submitSequenceMessage(annotateOp);

--- a/packages/runtime/sequence/src/test/marshalling.spec.ts
+++ b/packages/runtime/sequence/src/test/marshalling.spec.ts
@@ -26,7 +26,7 @@ const segmentTypes = [
 ];
 
 describe("Segment Marshalling", () => {
-    for (const {name, ctor, fromJSON} of segmentTypes) {
+    for (const { name, ctor, fromJSON } of segmentTypes) {
         describe(name, () => {
             describe("to/from spec", () => {
                 // Ensure that a segment w/no 'props' correctly round-trips

--- a/packages/runtime/sequence/src/test/sequenceDeltaEvent.spec.ts
+++ b/packages/runtime/sequence/src/test/sequenceDeltaEvent.spec.ts
@@ -128,7 +128,6 @@ describe("non-collab", () => {
         });
 
         it("add property over separate range", () => {
-
             annotateText(0, 3, { foo1: "bar1" },
                 [{ offset: 0, numChar: 3, props: { foo1: "bar1" }, propDeltas: { foo1: null } }]);
 
@@ -140,7 +139,6 @@ describe("non-collab", () => {
         });
 
         it("add property over overlapping runs", () => {
-
             annotateText(2, 10, { foo: "bar" },
                 [
                     { offset: 2, numChar: 1, props: { foo: "bar", foo1: "bar1" }, propDeltas: { foo: null } },
@@ -150,7 +148,6 @@ describe("non-collab", () => {
         });
 
         it("nullify all properties", () => {
-
             annotateText(2, 10, { foo: undefined },
                 [
                     { offset: 2, numChar: 1, props: { foo: undefined, foo1: "bar1" }, propDeltas: { foo: "bar" } },
@@ -1612,7 +1609,6 @@ describe("collab", () => {
         });
 
         it("overlapping ranges, same properties, different values", () => {
-
             // initialize as following:
             // - second word has property foo1=bar1
             // - third word has property foo2=bar2
@@ -1913,7 +1909,6 @@ describe("collab", () => {
             end: number,
             expected: IExpectedSegmentInfo[],
         ): void {
-
             assert(event.isLocal === isLocal);
             assert(event.isEmpty === isEmpty);
             if (isEmpty) {
@@ -3001,7 +2996,6 @@ describe("collab", () => {
 });
 
 describe("SequenceDeltaEvent", () => {
-
     const localUserLongId = "localUser";
     let client: TestClient;
 

--- a/packages/runtime/sequence/src/test/sharedString.spec.ts
+++ b/packages/runtime/sequence/src/test/sharedString.spec.ts
@@ -11,7 +11,6 @@ import { SharedString } from "../sharedString";
 import { SharedStringFactory } from "../sequenceFactory";
 
 describe("SharedString", () => {
-
     const documentId = "fakeId";
     let deltaConnectionFactory: MockDeltaConnectionFactory;
     let sharedString: SharedString;
@@ -27,7 +26,6 @@ describe("SharedString", () => {
     });
 
     describe(".snapshot", () => {
-
         it("Create and compare snapshot", async () => {
             const insertText = "text";
             const segmentCount = 1000;
@@ -68,7 +66,6 @@ describe("SharedString", () => {
         });
 
         async function CreateStringAndCompare(tree: ITree): Promise<void> {
-
             const runtime = new MockRuntime();
             const services: ISharedObjectServices = {
                 deltaConnection: deltaConnectionFactory.createDeltaConnection(runtime),
@@ -77,7 +74,7 @@ describe("SharedString", () => {
 
             const sharedString2 = new SharedString(runtime, documentId, SharedStringFactory.Attributes);
             // eslint-disable-next-line no-null/no-null
-            await sharedString2.load(null/*branchId*/, services);
+            await sharedString2.load(null/* branchId */, services);
             await sharedString2.loaded;
 
             assert(sharedString.getText() === sharedString2.getText());

--- a/packages/runtime/sequence/src/test/snapshotVersion.spec.ts
+++ b/packages/runtime/sequence/src/test/snapshotVersion.spec.ts
@@ -49,7 +49,7 @@ describe("SharedString Snapshot Version", () => {
             };
             const sharedString = new SharedString(runtime, documentId, SharedStringFactory.Attributes);
             // eslint-disable-next-line no-null/no-null
-            await sharedString.load(null/*branchId*/, services);
+            await sharedString.load(null/* branchId */, services);
             await sharedString.loaded;
 
             // test rebuilt sharedString

--- a/packages/runtime/sequence/src/test/testFarm.ts
+++ b/packages/runtime/sequence/src/test/testFarm.ts
@@ -318,7 +318,7 @@ export function TestPack(verbose = true) {
         }
 
         function checkTextMatch() {
-            //Console.log(`checking text match @${server.getCurrentSeq()}`);
+            // Console.log(`checking text match @${server.getCurrentSeq()}`);
             let clockStart = clock();
             const serverText = server.getText();
             getTextTime += elapsedMicroseconds(clockStart);
@@ -336,8 +336,8 @@ export function TestPack(verbose = true) {
                 const cliText = client.getText();
                 if (cliText !== serverText) {
                     console.log(`mismatch @${server.getCurrentSeq()} client @${client.getCurrentSeq()} id: ${client.getClientId()}`);
-                    //Console.log(serverText);
-                    //console.log(cliText);
+                    // Console.log(serverText);
+                    // console.log(cliText);
                     const diffParts = JsDiff.diffChars(serverText, cliText);
                     for (const diffPart of diffParts) {
                         let annotes = "";
@@ -474,7 +474,6 @@ export function TestPack(verbose = true) {
             }
         }
 
-
         let errorCount = 0;
 
         // Function asyncRoundStep(asyncInfo: AsyncRoundInfo, roundCount: number) {
@@ -595,12 +594,10 @@ export function TestPack(verbose = true) {
                                 ordSuccess++;
                                 // Console.log(`happy ordinals ${MergeTree.ordinalToArray(segoff1.segment.ordinal)} < ${MergeTree.ordinalToArray(segoff2.segment.ordinal)}`);
                             }
-
                         } else {
                             // Console.log(`no seg for [${b},${e}) with len ${len}`);
                         }
                     }
-
                 }
                 if (measureRanges) {
                     const mt = random.engines.mt19937();
@@ -743,8 +740,8 @@ export function TestPack(verbose = true) {
                 if (verbose) {
                     console.log(`total time ${(totalTime / 1000000.0).toFixed(1)} check time ${(checkTime / 1000000.0).toFixed(1)}`);
                 }
-                //Console.log(server.getText());
-                //console.log(server.mergeTree.toString());
+                // Console.log(server.getText());
+                // console.log(server.mergeTree.toString());
             }
             return errorCount;
         }
@@ -851,8 +848,8 @@ export function TestPack(verbose = true) {
         function tail() {
             reportTiming(server);
             reportTiming(clients[2]);
-            //Console.log(server.getText());
-            //console.log(server.mergeTree.toString());
+            // Console.log(server.getText());
+            // console.log(server.mergeTree.toString());
         }
         return errorCount;
     }
@@ -862,7 +859,6 @@ export function TestPack(verbose = true) {
         const clientCountB = 2;
         const fileSegCount = 0;
         const initString = "don't ask for whom the bell tolls; it tolls for thee";
-
 
         const serverA = new TestServer();
         serverA.measureOps = true;
@@ -934,7 +930,7 @@ export function TestPack(verbose = true) {
         }
 
         function checkTextMatch(clients: TestClient[], server: TestServer) {
-            //Console.log(`checking text match @${server.getCurrentSeq()}`);
+            // Console.log(`checking text match @${server.getCurrentSeq()}`);
             const clockStart = clock();
             const serverText = server.getText();
             getTextTime += elapsedMicroseconds(clockStart);
@@ -944,8 +940,8 @@ export function TestPack(verbose = true) {
                 const cliText = client.getText();
                 if (cliText !== serverText) {
                     console.log(`mismatch @${server.getCurrentSeq()} client @${client.getCurrentSeq()} id: ${client.getClientId()}`);
-                    //Console.log(serverText);
-                    //console.log(cliText);
+                    // Console.log(serverText);
+                    // console.log(cliText);
                     if (showDiff) {
                         const diffParts = JsDiff.diffChars(serverText, cliText);
                         for (const diffPart of diffParts) {
@@ -1118,8 +1114,8 @@ export function TestPack(verbose = true) {
                 if (verbose) {
                     console.log(`total time ${(totalTime / 1000000.0).toFixed(1)} check time ${(checkTime / 1000000.0).toFixed(1)}`);
                 }
-                //Console.log(server.getText());
-                //console.log(server.mergeTree.toString());
+                // Console.log(server.getText());
+                // console.log(server.mergeTree.toString());
             }
             return errorCount;
         }
@@ -1181,11 +1177,10 @@ export function TestPack(verbose = true) {
             reportTiming(serverA);
             reportTiming(clientsA[1]);
             reportTiming(clientsB[1]);
-            //Console.log(server.getText());
-            //console.log(server.mergeTree.toString());
+            // Console.log(server.getText());
+            // console.log(server.mergeTree.toString());
         }
         return errorCount;
-
     }
     const clientNames = ["Ed", "Ted", "Ned", "Harv", "Marv", "Glenda", "Susan"];
 
@@ -1573,7 +1568,6 @@ export function mergeTreeCheckedTest() {
                 errorCount++;
                 break;
             }
-
         }
         if ((i > 0) && (0 === (i % 1000))) {
             const perIter = (accumTime / (i + 1)).toFixed(3);
@@ -1628,7 +1622,6 @@ export function mergeTreeCheckedTest() {
                 errorCount++;
                 break;
             }
-
         }
         if ((i > 0) && (0 === (i % 1000))) {
             const perIter = (accumTime / (i + 1)).toFixed(3);
@@ -1894,7 +1887,6 @@ export class DocumentTree {
                 const row = DocumentTree.generateRow(rowProbability);
                 items.push(row);
             }
-
         }
         return items;
     }

--- a/packages/runtime/shared-object-common/package.json
+++ b/packages/runtime/shared-object-common/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@typescript-eslint/eslint-plugin": "~2.17.0",
     "@typescript-eslint/parser": "~2.17.0",

--- a/packages/runtime/shared-object-common/src/sharedObject.ts
+++ b/packages/runtime/shared-object-common/src/sharedObject.ts
@@ -90,7 +90,6 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
         public id: string,
         protected runtime: IComponentRuntime,
         public readonly attributes: IChannelAttributes) {
-
         super();
 
         this.handle = new SharedObjectComponentHandle(
@@ -126,7 +125,6 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
     public async load(
         branchId: string,
         services: ISharedObjectServices): Promise<void> {
-
         this.services = services;
 
         await this.loadCore(

--- a/packages/runtime/shared-summary-block/package.json
+++ b/packages/runtime/shared-summary-block/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-test-runtime-utils": "^0.16.0",
     "@types/benchmark": "^1.0.31",

--- a/packages/runtime/shared-summary-block/src/sharedSummaryBlock.ts
+++ b/packages/runtime/shared-summary-block/src/sharedSummaryBlock.ts
@@ -129,7 +129,6 @@ export class SharedSummaryBlock extends SharedObject implements ISharedSummaryBl
     protected async loadCore(
         branchId: string,
         storage: IObjectStorageService): Promise<void> {
-
         const rawContent = await storage.read(snapshotFileName);
         const contents = JSON.parse(fromBase64ToUtf8(rawContent)) as ISharedSummaryBlockDataSerializable;
 

--- a/packages/runtime/shared-summary-block/src/sharedSummaryBlockFactory.ts
+++ b/packages/runtime/shared-summary-block/src/sharedSummaryBlockFactory.ts
@@ -15,7 +15,6 @@ import {
 import { pkgVersion } from "./packageVersion";
 import { SharedSummaryBlock } from "./sharedSummaryBlock";
 
-
 /**
  * The factory that defines the shared summary block.
  * @sealed
@@ -58,7 +57,6 @@ export class SharedSummaryBlockFactory implements ISharedObjectFactory {
         services: ISharedObjectServices,
         branchId: string,
         attributes: IChannelAttributes): Promise<ISharedObject> {
-
         const sharedSummaryBlock = new SharedSummaryBlock(id, runtime, attributes);
         await sharedSummaryBlock.load(branchId, services);
 

--- a/packages/server/local-test-utils/package.json
+++ b/packages/server/local-test-utils/package.json
@@ -61,7 +61,7 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/debug": "^0.0.31",
     "@types/mocha": "^5.2.5",

--- a/packages/server/local-test-utils/src/sessionStorageTestDb.ts
+++ b/packages/server/local-test-utils/src/sessionStorageTestDb.ts
@@ -18,7 +18,6 @@ export class SessionStorageDbFactory implements ITestDbFactory {
     public async connect(): Promise<IDb> {
         return Promise.resolve(this.testDatabase);
     }
-
 }
 
 /**

--- a/packages/server/tools-core/package.json
+++ b/packages/server/tools-core/package.json
@@ -35,7 +35,7 @@
     "lodash": "^4.17.11"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/async": "^2.0.50",
     "@types/debug": "^0.0.31",

--- a/packages/server/tools-core/src/author.ts
+++ b/packages/server/tools-core/src/author.ts
@@ -104,7 +104,6 @@ export async function typeFile(
     writers: number,
     scribeCallback: ScribeMetricsCallback,
 ): Promise<IScribeMetrics> {
-
     const metricsArray: IScribeMetrics[] = [];
     let q: any;
 
@@ -242,7 +241,6 @@ export async function typeChunk(
     intervalTime: number,
     scribeCallback: ScribeMetricsCallback,
     queueCallback: QueueCallback): Promise<IScribeMetrics> {
-
     return new Promise<IScribeMetrics>((resolve, reject) => {
         let readPosition = 0;
         let totalOps = 0;
@@ -270,7 +268,6 @@ export async function typeChunk(
                 message.clientSequenceNumber &&
                 message.clientSequenceNumber > 100 &&
                 local) {
-
                 ackCounter.increment(1);
                 // Wait for at least one cycle
                 if (ackCounter.elapsed() > samplingRate) {

--- a/packages/server/tools-core/src/scribe.ts
+++ b/packages/server/tools-core/src/scribe.ts
@@ -101,7 +101,6 @@ export async function type(
     callback: author.ScribeMetricsCallback,
     distributed = false,
 ): Promise<author.IScribeMetrics> {
-
     if (distributed) {
         console.log("distributed");
     }

--- a/packages/server/tools-core/src/spellingStats.ts
+++ b/packages/server/tools-core/src/spellingStats.ts
@@ -16,7 +16,6 @@ function shuffle<T>(a: T[]) {
 
     // While there remain elements to shuffle...
     while (0 !== currentIndex) {
-
         // Pick a remaining element...
         randomIndex = Math.floor(Math.random() * currentIndex);
         currentIndex--;

--- a/packages/test/end-to-end/package.json
+++ b/packages/test/end-to-end/package.json
@@ -47,7 +47,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-agent-scheduler": "^0.16.0",
     "@microsoft/fluid-aqueduct": "^0.16.0",
     "@microsoft/fluid-build-common": "^0.14.0",

--- a/packages/test/end-to-end/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
+++ b/packages/test/end-to-end/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
@@ -32,7 +32,6 @@ interface ISharedObjectConstructor<T> {
 function generate(
     name: string, ctor: ISharedObjectConstructor<IConsensusOrderedCollection>,
     input: any[], output: any[]) {
-
     describe(name, () => {
         const id = "fluid-test://localhost/consensusOrderedCollectionTest";
         const mapId = "mapKey";

--- a/packages/test/end-to-end/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/end-to-end/src/test/detachedContainerTests.spec.ts
@@ -78,7 +78,7 @@ describe("Detached Container", () => {
         // Create a sub component of type TestFluidComponent and verify that it is attached.
         const subCompId = uuid();
         await createAndAttachComponent(component.context, subCompId, "default");
-        const subResponse = await container.request({url: `/${subCompId}`});
+        const subResponse = await container.request({ url: `/${subCompId}` });
         if (subResponse.mimeType !== "fluid/component" && subResponse.status !== 200) {
             assert.fail("New components should be created in detached container");
         }
@@ -105,7 +105,7 @@ describe("Detached Container", () => {
         await container.attach(testRequest);
 
         // Get the sub component and verify that it is attached.
-        const testResponse = await container.request({url: `/${newComponentId}`});
+        const testResponse = await container.request({ url: `/${newComponentId}` });
         if (testResponse.mimeType !== "fluid/component" && testResponse.status !== 200) {
             assert.fail("New components should be created in detached container");
         }

--- a/packages/test/end-to-end/src/test/error.spec.ts
+++ b/packages/test/end-to-end/src/test/error.spec.ts
@@ -95,7 +95,7 @@ describe("Errors Types", () => {
     }
 
     it("GenericNetworkError Test_1", async () => {
-        const networkError = createNetworkError("Test Message", false /*canRetry*/);
+        const networkError = createNetworkError("Test Message", false /* canRetry */);
         assert.equal(networkError.errorType, ErrorType.genericNetworkError,
             "Error should be a genericNetworkError");
         assertCustomPropertySupport(networkError);
@@ -104,10 +104,10 @@ describe("Errors Types", () => {
     it("GenericNetworkError Test_2", async () => {
         const networkError = createNetworkError(
             "Test Message",
-            true /*canRetry*/,
-            400 /*statusCode*/,
-            undefined /*retryAfterSeconds*/,
-            "foo" /*online*/);
+            true /* canRetry */,
+            400 /* statusCode */,
+            undefined /* retryAfterSeconds */,
+            "foo" /* online */);
         if (networkError.errorType !== ErrorType.genericNetworkError) {
             assert.fail("Error should be a genericNetworkError");
         }
@@ -121,8 +121,8 @@ describe("Errors Types", () => {
     it("AccessDeniedError Test 401", async () => {
         const networkError = createNetworkError(
             "Test Message",
-            false /*canRetry*/,
-            401 /*statusCode*/);
+            false /* canRetry */,
+            401 /* statusCode */);
         assert.equal(networkError.errorType, ErrorType.accessDeniedError,
             "Error should be an accessDeniedError");
         assertCustomPropertySupport(networkError);
@@ -131,8 +131,8 @@ describe("Errors Types", () => {
     it("AccessDeniedError Test 403", async () => {
         const networkError = createNetworkError(
             "Test Message",
-            false /*canRetry*/,
-            403 /*statusCode*/);
+            false /* canRetry */,
+            403 /* statusCode */);
         if (networkError.errorType !== ErrorType.accessDeniedError) {
             assert.fail("Error should be an accessDeniedError");
         }
@@ -145,8 +145,8 @@ describe("Errors Types", () => {
     it("FileNotFoundError Test", async () => {
         const networkError = createNetworkError(
             "Test Message",
-            false /*canRetry*/,
-            404 /*statusCode*/);
+            false /* canRetry */,
+            404 /* statusCode */);
         assertCustomPropertySupport(networkError);
         if (networkError.errorType !== ErrorType.fileNotFoundError) {
             assert.fail("Error should be a fileNotFoundError");
@@ -160,8 +160,8 @@ describe("Errors Types", () => {
     it("FatalError Test", async () => {
         const networkError = createNetworkError(
             "Test Message",
-            false /*canRetry*/,
-            500 /*statusCode*/);
+            false /* canRetry */,
+            500 /* statusCode */);
         assertCustomPropertySupport(networkError);
         if (networkError.errorType !== ErrorType.fatalError) {
             assert.fail("Error should be a fatalError");
@@ -174,9 +174,9 @@ describe("Errors Types", () => {
     it("ThrottlingError Test", async () => {
         const networkError = createNetworkError(
             "Test Message",
-            false /*canRetry*/,
-            400 /*statusCode*/,
-            100 /*retryAfterSeconds*/);
+            false /* canRetry */,
+            400 /* statusCode */,
+            100 /* retryAfterSeconds */);
         assertCustomPropertySupport(networkError);
         if (networkError.errorType !== ErrorType.throttlingError) {
             assert.fail("Error should be a throttlingError");
@@ -194,7 +194,7 @@ describe("Errors Types", () => {
     });
 
     it("Check double conversion of network error", async () => {
-        const networkError = createNetworkError("Test Error", true /*canRetry*/);
+        const networkError = createNetworkError("Test Error", true /* canRetry */);
         const error1 = createIError(networkError, true);
         const error2 = createIError(error1, false);
         assert.equal(error1, error2, "Both errors should be same!!");
@@ -221,5 +221,4 @@ describe("Errors Types", () => {
         assert.equal(error1.critical, false, "Error should contain critical property.");
         assert.equal(error2.critical, undefined, "Error should not contain critical property.");
     });
-
 });

--- a/packages/test/end-to-end/src/test/localTestSignals.spec.ts
+++ b/packages/test/end-to-end/src/test/localTestSignals.spec.ts
@@ -81,7 +81,6 @@ describe("TestSignals", () => {
             await containerDeltaEventManager.process();
             assert.equal(user1SignalReceivedCount, 2, "client 1 did not received signal");
             assert.equal(user2SignalReceivedCount, 2, "client 2 did not received signal");
-
         });
 
         it("Validate host runtime signals", async () => {

--- a/packages/test/end-to-end/src/test/mapEndToEndTests.spec.ts
+++ b/packages/test/end-to-end/src/test/mapEndToEndTests.spec.ts
@@ -216,7 +216,6 @@ describe("Map", () => {
         await containerDeltaEventManager.process();
 
         expectAllAfterValues("testKey2", "value2.2");
-
     });
 
     it("Simultaneous set/delete should reach eventual consistency with the same value", async () => {

--- a/packages/test/end-to-end/src/test/primedComponent.spec.ts
+++ b/packages/test/end-to-end/src/test/primedComponent.spec.ts
@@ -8,7 +8,7 @@ import { PrimedComponent, PrimedComponentFactory } from "@microsoft/fluid-aquedu
 import { IComponentHandle } from "@microsoft/fluid-component-core-interfaces";
 import { IFluidCodeDetails, ILoader } from "@microsoft/fluid-container-definitions";
 import { Container } from "@microsoft/fluid-container-loader";
-//import { DocumentDeltaEventManager } from "@microsoft/fluid-local-driver";
+// import { DocumentDeltaEventManager } from "@microsoft/fluid-local-driver";
 import { ISharedDirectory } from "@microsoft/fluid-map";
 import { LocalDeltaConnectionServer, ILocalDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
 import { createLocalLoader, initializeLocalContainer } from "@microsoft/fluid-test-utils";
@@ -28,7 +28,6 @@ class Component extends PrimedComponent {
 }
 
 describe("PrimedComponent", () => {
-
     describe("Blob support", () => {
         const id = "fluid-test://localhost/primedComponentTest";
         const codeDetails: IFluidCodeDetails = {

--- a/packages/test/functional/package.json
+++ b/packages/test/functional/package.json
@@ -47,7 +47,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-container-loader": "^0.16.0",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -49,7 +49,7 @@
     "@microsoft/fluid-replay-tool": "^0.16.0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.14.6",

--- a/packages/test/snapshots/src/replayMultipleFiles.ts
+++ b/packages/test/snapshots/src/replayMultipleFiles.ts
@@ -110,7 +110,6 @@ export async function processContent(mode: Mode, concurrently = true) {
         });
 
         promises.push(work);
-
     }
 
     return Promise.all(promises);

--- a/packages/test/utils/package.json
+++ b/packages/test/utils/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/debug": "^0.0.31",
     "@types/diff": "^3.5.1",

--- a/packages/test/utils/src/localLoader.ts
+++ b/packages/test/utils/src/localLoader.ts
@@ -30,7 +30,6 @@ export function createLocalLoader(
     ]>,
     deltaConnectionServer: ILocalDeltaConnectionServer,
 ): ILoader {
-
     const urlResolver = new TestResolver(deltaConnectionServer);
     const documentServiceFactory = new TestDocumentServiceFactory(deltaConnectionServer);
     const codeLoader: ICodeLoader = new LocalCodeLoader(packageEntries);
@@ -55,7 +54,6 @@ export async function initializeLocalContainer(
     loader: ILoader,
     codeDetails: IFluidCodeDetails,
 ): Promise<Container> {
-
     const container = await loader.resolve({ url: documentId }) as unknown as Container;
 
     await initializeContainerCode(container, codeDetails);

--- a/packages/test/utils/src/testFluidComponent.ts
+++ b/packages/test/utils/src/testFluidComponent.ts
@@ -20,7 +20,6 @@ export class TestFluidComponent implements ITestFluidComponent {
         runtime: IComponentRuntime,
         context: IComponentContext,
         factoryEntries: Map<string, ISharedObjectFactory>) {
-
         const component = new TestFluidComponent(runtime, context, factoryEntries);
         await component.initialize();
 

--- a/packages/tools/fluid-fetch/package.json
+++ b/packages/tools/fluid-fetch/package.json
@@ -35,7 +35,7 @@
     "@microsoft/fluid-tool-utils": "^0.16.0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/node": "^10.14.6",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/packages/tools/fluid-fetch/src/fluidAnalyzeMessages.ts
+++ b/packages/tools/fluid-fetch/src/fluidAnalyzeMessages.ts
@@ -476,7 +476,6 @@ function processOp(
     if (message.type === MessageType.Attach) {
         const attachMessage = message.contents as IAttachMessage;
         processComponentAttachOp(attachMessage, dataType);
-
     } else if (message.type === MessageType.Operation) {
         let envelop = message.contents as IEnvelope;
         // TODO: Legacy?

--- a/packages/tools/fluid-fetch/src/fluidFetchInit.ts
+++ b/packages/tools/fluid-fetch/src/fluidFetchInit.ts
@@ -34,7 +34,6 @@ async function initializeODSPCore(
     server: string,
     clientConfig: IClientConfig,
 ) {
-
     const { driveId, itemId } = odspResolvedUrl;
 
     connectionInfo = {
@@ -115,7 +114,6 @@ async function initializeR11s(server: string, pathname: string, r11sResolvedUrl:
 }
 
 async function resolveUrl(url: string): Promise<IResolvedUrl | undefined> {
-
     const resolversList: IUrlResolver[] = [
         new OdspUrlResolver(),
         new FluidAppOdspUrlResolver(),

--- a/packages/tools/fluid-fetch/src/fluidFetchMessages.ts
+++ b/packages/tools/fluid-fetch/src/fluidFetchMessages.ts
@@ -210,5 +210,4 @@ export async function fluidFetchMessages(documentService?: IDocumentService, sav
         let item;
         for await (item of generator) { }
     }
-
 }

--- a/packages/tools/merge-tree-client-replay/package.json
+++ b/packages/tools/merge-tree-client-replay/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/node": "^10.14.6",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/packages/tools/merge-tree-client-replay/src/clientReplayTool.ts
+++ b/packages/tools/merge-tree-client-replay/src/clientReplayTool.ts
@@ -120,7 +120,6 @@ export class ClientReplayTool {
         const mergeTreeMessages = new Array<IFullPathSequencedDocumentMessage>();
         const chunkMap = new Map<string, string[]>();
         for (const message of this.deltaStorageService.getFromWebSocket(0, this.args.to)) {
-
             if (message.type === MessageType.ChunkedOp) {
                 const chunk = JSON.parse(message.contents as string) as IChunkedOp;
                 if (!chunkMap.has(message.clientId)) {

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/node": "^10.14.6",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/packages/tools/replay-tool/src/replayMessages.ts
+++ b/packages/tools/replay-tool/src/replayMessages.ts
@@ -232,7 +232,7 @@ class Document {
     public snapshot() {
         return this.container.snapshot(
             `ReplayTool Snapshot: op ${this.currentOp}, ${this.getFileName()}`,
-            !this.args.incremental /*generateFullTreeNoOtimizations*/);
+            !this.args.incremental /* generateFullTreeNoOtimizations */);
     }
 
     public extractContent(): ContainerContent {
@@ -520,7 +520,6 @@ export class ReplayTool {
                 this.compareSnapshots(
                     content,
                     `${dir}/${this.mainDocument.getFileName()}`);
-
             } else if (this.args.write) {
                 fs.mkdirSync(dir, { recursive: true });
                 this.expandForReadabilityAndWriteOut(
@@ -589,7 +588,6 @@ export class ReplayTool {
                     this.documentPriorSnapshot = undefined;
                 });
         }
-
     }
 
     private async validateSaveAndLoad(content: ContainerContent, dir: string, final: boolean) {

--- a/packages/tools/replay-tool/src/replayTool.ts
+++ b/packages/tools/replay-tool/src/replayTool.ts
@@ -35,7 +35,6 @@ const optionsArray = [
  * This is the main class used to take user input to replay ops for debugging purposes.
  */
 class ReplayProcessArgs extends ReplayArgs {
-
     constructor() {
         super();
         this.parseArguments();

--- a/packages/tools/webpack-component-loader/package.json
+++ b/packages/tools/webpack-component-loader/package.json
@@ -78,7 +78,7 @@
     "webpack-dev-server": "^3.8.0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/express": "^4.11.0",
     "@types/mocha": "^5.2.5",

--- a/packages/tools/webpack-component-loader/src/loader.ts
+++ b/packages/tools/webpack-component-loader/src/loader.ts
@@ -169,32 +169,31 @@ function makeSideBySideDiv(divId?: string) {
 }
 
 class WebpackCodeResolver implements IFluidCodeResolver {
-    constructor(private readonly options: IBaseRouteOptions){}
+    constructor(private readonly options: IBaseRouteOptions) {}
     async resolveCodeDetails(details: IFluidCodeDetails): Promise<IResolvedFluidCodeDetails> {
         const baseUrl = details.config.cdn ?? `http://localhost:${this.options.port}`;
         let pkg = details.package;
-        if(typeof pkg === "string"){
+        if (typeof pkg === "string") {
             const resp = await fetch(`${baseUrl}/package.json`);
             pkg = await resp.json() as IFluidPackage;
         }
-        if(!isFluidPackage(pkg)){
+        if (!isFluidPackage(pkg)) {
             throw new Error("Not a fluid package");
         }
         const files = pkg.fluid.browser.umd.files;
-        for(let i=0;i<pkg.fluid.browser.umd.files.length;i++){
-            if(!files[i].startsWith("http")){
+        for (let i = 0; i < pkg.fluid.browser.umd.files.length; i++) {
+            if (!files[i].startsWith("http")) {
                 files[i] = `${baseUrl}/${files[i]}`;
             }
         }
         const parse = extractPackageIdentifierDetails(details.package);
-        return{
+        return {
             config:details.config,
             package: details.package,
             resolvedPackage: pkg,
             resolvedPackageCacheId: parse.fullId,
         };
     }
-
 }
 
 function getDocumentServiceFactory(documentId: string, options: RouteOptions) {
@@ -231,7 +230,7 @@ function getDocumentServiceFactory(documentId: string, options: RouteOptions) {
             );
         }
     }
-    return {documentServiceFactory, connection: deltaConn};
+    return { documentServiceFactory, connection: deltaConn };
 }
 
 export async function start(
@@ -249,14 +248,14 @@ export async function start(
         textArea.style.display = "none";
     }
 
-    const {documentServiceFactory, connection} = getDocumentServiceFactory(documentId, options);
+    const { documentServiceFactory, connection } = getDocumentServiceFactory(documentId, options);
 
     const urlResolver = getUrlResolver(options, connection);
 
     // Construct a request
     const url = window.location.href;
 
-    const codeDetails: IFluidCodeDetails ={
+    const codeDetails: IFluidCodeDetails = {
         package:packageJson,
         config:{},
     };
@@ -330,7 +329,7 @@ export async function start(
     }
     if (!attached) {
         attachButton.onclick = async () => {
-            await container1.attach({url: window.location.href})
+            await container1.attach({ url: window.location.href })
                 .then(() => {
                     const text = window.location.href.replace("create", container1.id);
                     textArea.innerText = text;

--- a/packages/tools/webpack-component-loader/src/routes.ts
+++ b/packages/tools/webpack-component-loader/src/routes.ts
@@ -75,7 +75,6 @@ export const after = (app: express.Application, server: WebpackDevServer, baseDi
                 };
             });
             try {
-
                 const originalUrl = `${getThisOrigin(options)}${req.url}`;
                 if (odspAuthStage >= 2) {
                     if (!options.odspAccessToken || !options.pushAccessToken) {
@@ -184,7 +183,6 @@ export const after = (app: express.Application, server: WebpackDevServer, baseDi
 };
 
 const fluid = (req: express.Request, res: express.Response, baseDir: string, options: RouteOptions) => {
-
     const documentId = req.params.id;
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const packageJson = require(path.join(baseDir, "./package.json")) as IFluidPackage;

--- a/packages/utils/fluid-tool-utils/package.json
+++ b/packages/utils/fluid-tool-utils/package.json
@@ -25,7 +25,7 @@
     "@microsoft/fluid-odsp-utils": "^0.16.0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@types/node": "^10.14.6",
     "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/packages/utils/fluid-tool-utils/src/httpHelpers.ts
+++ b/packages/utils/fluid-tool-utils/src/httpHelpers.ts
@@ -23,7 +23,7 @@ export function createTrackedServer(port: number, requestListener: http.RequestL
     return { server, sockets, fullyClose() {
         server.close();
         sockets.forEach((socket) => socket.destroy());
-    }};
+    } };
 }
 export type OnceListenerHandler<T> = (req: http.IncomingMessage, res: http.ServerResponse) => Promise<T>;
 export type OnceListenerResult<T> = Promise<() => Promise<T>>;

--- a/packages/utils/odsp-utils/package.json
+++ b/packages/utils/odsp-utils/package.json
@@ -26,7 +26,7 @@
     "axios": "^0.18.0"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-fluid": "^0.15.0",
+    "@microsoft/eslint-config-fluid": "^0.16.0-0",
     "@microsoft/fluid-build-common": "^0.14.0",
     "@typescript-eslint/eslint-plugin": "~2.17.0",
     "@typescript-eslint/parser": "~2.17.0",

--- a/packages/utils/odsp-utils/src/odspRequest.ts
+++ b/packages/utils/odsp-utils/src/odspRequest.ts
@@ -1,4 +1,3 @@
-
 /*!
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.

--- a/packages/utils/odsp-utils/src/odspUtils.ts
+++ b/packages/utils/odsp-utils/src/odspUtils.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-
 const odspTenants = new Map<string, string>([
     ["spo", "microsoft-my.sharepoint.com"],
     ["spo-df", "microsoft-my.sharepoint-df.com"],


### PR DESCRIPTION
Updating the eslint-config-fluid version and fixing up whitespace errors for the client packages and examples.  Will follow up subsequently with server packages