### PR TITLE
Update package locks for latest ESLint rules

### DIFF
--- a/common/lib/common-definitions/package-lock.json
+++ b/common/lib/common-definitions/package-lock.json
@@ -52,9 +52,9 @@
       }
     },
     "@microsoft/eslint-config-fluid": {
-      "version": "0.16.0-24425",
-      "resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2feslint-config-fluid/-/eslint-config-fluid-0.16.0-24425.tgz",
-      "integrity": "sha512-E9HqI9ivVk/8qFMVLnWGnHvh8Os4iWvdPrvHEUzZbTP7wBib599ivGTYFmH7OIJ5wrLYvQBW3hO9qqI/rWiBjA==",
+      "version": "0.16.0-24490",
+      "resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2feslint-config-fluid/-/eslint-config-fluid-0.16.0-24490.tgz",
+      "integrity": "sha512-knD/3bNs2DNqhmzvQooEabvIDEbbkppOC+gZzB8erByazFt444bOQoPK5gUnSugbbqTW0fMvLwUXIHfU/iyCaA==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -277,9 +277,9 @@
       }
     },
     "@microsoft/eslint-config-fluid": {
-      "version": "0.16.0-24425",
-      "resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2feslint-config-fluid/-/eslint-config-fluid-0.16.0-24425.tgz",
-      "integrity": "sha512-E9HqI9ivVk/8qFMVLnWGnHvh8Os4iWvdPrvHEUzZbTP7wBib599ivGTYFmH7OIJ5wrLYvQBW3hO9qqI/rWiBjA==",
+      "version": "0.16.0-24490",
+      "resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2feslint-config-fluid/-/eslint-config-fluid-0.16.0-24490.tgz",
+      "integrity": "sha512-knD/3bNs2DNqhmzvQooEabvIDEbbkppOC+gZzB8erByazFt444bOQoPK5gUnSugbbqTW0fMvLwUXIHfU/iyCaA==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "~2.17.0",

--- a/examples/components/client-ui-lib/src/controls/overlayCanvas.ts
+++ b/examples/components/client-ui-lib/src/controls/overlayCanvas.ts
@@ -464,5 +464,5 @@ export class OverlayCanvas extends ui.Component {
         stroke = stroke.slice(0, -2);
         stroke += "]";
         return stroke;
-    }*/
+    } */
 }

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2159,9 +2159,9 @@
 			}
 		},
 		"@microsoft/eslint-config-fluid": {
-			"version": "0.16.0-24425",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2feslint-config-fluid/-/eslint-config-fluid-0.16.0-24425.tgz",
-			"integrity": "sha512-E9HqI9ivVk/8qFMVLnWGnHvh8Os4iWvdPrvHEUzZbTP7wBib599ivGTYFmH7OIJ5wrLYvQBW3hO9qqI/rWiBjA==",
+			"version": "0.16.0-24490",
+			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2feslint-config-fluid/-/eslint-config-fluid-0.16.0-24490.tgz",
+			"integrity": "sha512-knD/3bNs2DNqhmzvQooEabvIDEbbkppOC+gZzB8erByazFt444bOQoPK5gUnSugbbqTW0fMvLwUXIHfU/iyCaA==",
 			"requires": {
 				"@typescript-eslint/eslint-plugin": "~2.17.0",
 				"@typescript-eslint/parser": "~2.17.0",

--- a/packages/agents/flow-intel/src/analytics/resumeAnalytics.ts
+++ b/packages/agents/flow-intel/src/analytics/resumeAnalytics.ts
@@ -74,7 +74,7 @@ class ResumeAnalyticsIntelligentService implements IIntelligentService {
                     return resolve(body);
                 });
         });
-    }*/
+    } */
 }
 
 export class ResumeAnalyticsFactory implements IIntelligentServiceFactory {

--- a/packages/agents/intelligence-runner/src/analytics/resumeAnalytics.ts
+++ b/packages/agents/intelligence-runner/src/analytics/resumeAnalytics.ts
@@ -74,7 +74,7 @@ class ResumeAnalyticsIntelligentService implements IIntelligentService {
                     return resolve(body);
                 });
         });
-    }*/
+    } */
 }
 
 export class ResumeAnalyticsFactory implements IIntelligentServiceFactory {

--- a/packages/drivers/odsp-socket-storage/src/test/odspError.spec.ts
+++ b/packages/drivers/odsp-socket-storage/src/test/odspError.spec.ts
@@ -62,13 +62,13 @@ describe("Odsp Error", () => {
     });
 
     it("throwOdspNetworkError sprequestguid exist", async () => {
-        const error1: any = createOdspNetworkError("Error", 400, true /* canRetry*/, true /* includeResponse */);
+        const error1: any = createOdspNetworkError("Error", 400, true /* canRetry */, true /* includeResponse */);
         const errorBag = { ...error1.getCustomProperties() };
         assert.equal("xxx-xxx", errorBag.sprequestguid, "sprequestguid should be 'xxx-xxx'");
     });
 
     it("throwOdspNetworkError sprequestguid undefined", async () => {
-        const error1: any = createOdspNetworkError("Error", 400, true /* canRetry*/, false /* includeResponse */);
+        const error1: any = createOdspNetworkError("Error", 400, true /* canRetry */, false /* includeResponse */);
         const errorBag = { ...error1.getCustomProperties() };
         assert.equal(undefined, errorBag.sprequestguid, "sprequestguid should not be defined");
     });

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -1641,9 +1641,9 @@
 			}
 		},
 		"@microsoft/eslint-config-fluid": {
-			"version": "0.16.0-24425",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2feslint-config-fluid/-/eslint-config-fluid-0.16.0-24425.tgz",
-			"integrity": "sha512-E9HqI9ivVk/8qFMVLnWGnHvh8Os4iWvdPrvHEUzZbTP7wBib599ivGTYFmH7OIJ5wrLYvQBW3hO9qqI/rWiBjA==",
+			"version": "0.16.0-24490",
+			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2feslint-config-fluid/-/eslint-config-fluid-0.16.0-24490.tgz",
+			"integrity": "sha512-knD/3bNs2DNqhmzvQooEabvIDEbbkppOC+gZzB8erByazFt444bOQoPK5gUnSugbbqTW0fMvLwUXIHfU/iyCaA==",
 			"requires": {
 				"@typescript-eslint/eslint-plugin": "~2.17.0",
 				"@typescript-eslint/parser": "~2.17.0",


### PR DESCRIPTION
Current ones include the bulk of the rules, but not the balance inline block comments rule.