### PR TITLE
Updated LastEditedTracker to store an IUser object instead of clientId

### DIFF
--- a/packages/framework/last-edited/README.md
+++ b/packages/framework/last-edited/README.md
@@ -2,13 +2,14 @@
 
 LastEditedTracker tracks the last edit to a document, such as the client who last edited the document and the time it happened.
 
-It is created by passing a `SharedSummaryBlock`:
+It is created by passing a `SharedSummaryBlock` and an `IQuorum`:
 ```
 constructor(
     private readonly sharedSummaryBlock: SharedSummaryBlock,
+    private readonly quorum: IQuorum,
 );
 ```
-It uses the SharedSummaryBlock to store the last edit details.
+It uses the SharedSummaryBlock to store the last edit details. The quorum is used to get the user details.
 
 ## API
 
@@ -23,14 +24,7 @@ The update should always be called in response to a remote op because:
 1. It updates its state from the remote op.
 2. It uses a SharedSummaryBlock as storage which must be set in response to a remote op.
 
-The details returned in getLastEditDetails contain the `clientId` and the `timestamp` of the last edit.
-
-## Events
-
-It emits an `"lastEditedChanged"` event with ILastEditDetails whenever the details are updated:
-```
-public on(event: "lastEditedChanged", listener: (lastEditDetails: ILastEditDetails) => void): this;
-```
+The details returned in getLastEditDetails contain the `IUser` object and the `timestamp` of the last edit.
 
 # Last Edited Tracker Component
 
@@ -95,13 +89,9 @@ public async instantiateRuntime(context: IContainerContext): Promise<IRuntime> {
 
 This will make sure that the root component loads before any other component and it tracks every op in the Container.
 
-The IComponentLastEditedTracker can be retrieved from the root component. Registering for "lastEditedChanged" event on the IComponentLastEditedTracker will give the last edited details everytime it changes. For example:
+The IComponentLastEditedTracker can be retrieved from the root component:
 ```
 const response = await containerRuntime.request({ url: "/" });
 const rootComponent = response.value;
 const lastEditedTracker = rootComponent.IComponentLastEditedTracker;
-
-lastEditedTracker.on("lastEditedChanged", (lastEditDetails: ILastEditDetails) => {
-    // Do something cool.
-});
 ```

--- a/packages/framework/last-edited/README.md
+++ b/packages/framework/last-edited/README.md
@@ -2,14 +2,11 @@
 
 LastEditedTracker tracks the last edit to a document, such as the client who last edited the document and the time it happened.
 
-It is created by passing a `SharedSummaryBlock` and an `IQuorum`:
+It is created by passing a `SharedSummaryBlock`:
 ```
-constructor(
-    private readonly sharedSummaryBlock: SharedSummaryBlock,
-    private readonly quorum: IQuorum,
-);
+constructor(private readonly sharedSummaryBlock: SharedSummaryBlock);
 ```
-It uses the SharedSummaryBlock to store the last edit details. The quorum is used to get the user details.
+It uses the SharedSummaryBlock to store the last edit details.
 
 ## API
 
@@ -34,20 +31,20 @@ It implements IProvideComponentLastEditedTracker and returns an IComponentLastEd
 
 # Setup
 
-This package also provides a `setupLastEditedTrackerForContainer` method that can be used to set up a root component that provides IComponentLastEditedTracker to track last edited in a Container:
+This package also provides a `setupLastEditedTrackerForContainer` method that can be used to set up a component that provides IComponentLastEditedTracker to track last edited in a Container:
 ```
 async function setupLastEditedTrackerForContainer(
-    rootComponentId: string,
+    componentId: string,
     runtime: IHostRuntime,
     shouldDiscardMessageFn: (message: ISequencedDocumentMessage) => boolean = shouldDiscardMessageDefault,
 )
 ```
 
-- The root component with id "rootComponentId" must implement an IComponentLastEditedTracker.
+- The component with id "componentId" must implement an IComponentLastEditedTracker.
 - This setup function should be called during container instantiation so that ops are not missed.
 - Requests the root component from the runtime and waits for it to load.
-- Registers an "op" listener on the runtime. On each message, it calls the shouldDiscardMessageFn to check if the message should be discarded. It also discards all scheduler message. If a message is not discarded, it is passed to the IComponentLastEditedTracker in the root component.
-- The last message received before the component is loaded is stored and passed to the tracker once the component loads.
+- Registers an "op" listener on the runtime. On each message, it calls the shouldDiscardMessageFn to check if the message should be discarded. It also discards all scheduler message. If a message is not discarded, it passes the last edited information from the message to the last edited tracker in the component.
+- The last edited information from the last message received before the component is loaded is stored and passed to the tracker once the component loads.
 
 Note:
 - By default, message that are not of `"Attach"` and `"Operation"` type are discarded as per the `shouldDiscardMessageDefault` function:
@@ -65,20 +62,20 @@ function shouldDiscardMessageDefault(message: ISequencedDocumentMessage) {
 
 ## For tracking the last edit on a Container:
 
-In instantiateRuntime, create a root component that implements IComponentLastEditedTracker. Then call `setupLastEditedTrackerForContainer` with the component id of the root component:
+In instantiateRuntime, create a component that implements IComponentLastEditedTracker. Then call `setupLastEditedTrackerForContainer` with the id of the component:
 ```
 public async instantiateRuntime(context: IContainerContext): Promise<IRuntime> {
-    const rootComponentId = "root";
+    const componentId = "root";
 
     // Create the ContainerRuntime
     const runtime = await ContainerRuntime.load(...);
 
     if (!runtime.existing) {
-        // On first boot create the root component with rootComponentId.
-        await runtime.createComponent(rootComponentId, "rootComponent");
+        // On first boot create the root component with id `componentId`.
+        await runtime.createComponent(componentId, "lastEditedTracker");
     }
 
-    setupLastEditedTrackerForContainer(rootComponentId, runtime)
+    setupLastEditedTrackerForContainer(componentId, runtime)
         .catch((error) => {
             throw error;
         });

--- a/packages/framework/last-edited/src/interfaces.ts
+++ b/packages/framework/last-edited/src/interfaces.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ISequencedDocumentMessage, IUser } from "@microsoft/fluid-protocol-definitions";
+import { IUser } from "@microsoft/fluid-protocol-definitions";
 
 declare module "@microsoft/fluid-component-core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -23,10 +23,9 @@ export interface IComponentLastEditedTracker extends IProvideComponentLastEdited
     getLastEditDetails(): ILastEditDetails | undefined;
 
     /**
-     * Updates the last edit details based on the information in the message. This should be called only in response
-     * to a remote op because it uses a shared summary block as storage.
+     * Updates the details of last edit to the container.
      */
-    updateLastEditDetails(message: ISequencedDocumentMessage): void;
+    updateLastEditDetails(lastEditDetails: ILastEditDetails): void;
 }
 
 export interface ILastEditDetails {

--- a/packages/framework/last-edited/src/interfaces.ts
+++ b/packages/framework/last-edited/src/interfaces.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ISequencedDocumentMessage } from "@microsoft/fluid-protocol-definitions";
+import { ISequencedDocumentMessage, IUser } from "@microsoft/fluid-protocol-definitions";
 
 declare module "@microsoft/fluid-component-core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -30,6 +30,6 @@ export interface IComponentLastEditedTracker extends IProvideComponentLastEdited
 }
 
 export interface ILastEditDetails {
-    clientId: string;
+    user: IUser;
     timestamp: number;
 }

--- a/packages/framework/last-edited/src/lastEditedTracker.ts
+++ b/packages/framework/last-edited/src/lastEditedTracker.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { IQuorum, ISequencedDocumentMessage } from "@microsoft/fluid-protocol-definitions";
 import { Jsonable } from "@microsoft/fluid-runtime-definitions";
 import { SharedSummaryBlock } from "@microsoft/fluid-shared-summary-block";
 import { IComponentLastEditedTracker, ILastEditDetails } from "./interfaces";
@@ -19,12 +18,8 @@ export class LastEditedTracker implements IComponentLastEditedTracker {
     /**
      * Creates a LastEditedTracker object.
      * @param sharedSummaryBlock - The shared summary block where the details will be stored.
-     * @param quorum - The quorum to get the user details from.
      */
-    constructor(
-        private readonly sharedSummaryBlock: SharedSummaryBlock,
-        private readonly quorum: IQuorum,
-    ) {}
+    constructor(private readonly sharedSummaryBlock: SharedSummaryBlock) {}
 
     public get IComponentLastEditedTracker() {
         return this;
@@ -40,15 +35,7 @@ export class LastEditedTracker implements IComponentLastEditedTracker {
     /**
      * {@inheritDoc ILastEditedTracker.updateLastEditDetails}
      */
-    public updateLastEditDetails(message: ISequencedDocumentMessage) {
-        const sequencedClient = this.quorum.getMember(message.clientId);
-        const user = sequencedClient?.client.user;
-        if (user !== undefined) {
-            const lastEditDetails: ILastEditDetails = {
-                user,
-                timestamp: message.timestamp,
-            };
-            this.sharedSummaryBlock.set(this.lastEditedDetailsKey, lastEditDetails as unknown as Jsonable);
-        }
+    public updateLastEditDetails(lastEditDetails: ILastEditDetails) {
+        this.sharedSummaryBlock.set(this.lastEditedDetailsKey, lastEditDetails as unknown as Jsonable);
     }
 }

--- a/packages/framework/last-edited/src/lastEditedTrackerComponent.ts
+++ b/packages/framework/last-edited/src/lastEditedTrackerComponent.ts
@@ -51,6 +51,6 @@ export class LastEditedTrackerComponent extends PrimedComponent implements IProv
     protected async componentHasInitialized() {
         const sharedSummaryBlock =
             await this.root.get<IComponentHandle<SharedSummaryBlock>>(this.sharedSummaryBlockId).get();
-        this._lastEditedTracker = new LastEditedTracker(sharedSummaryBlock);
+        this._lastEditedTracker = new LastEditedTracker(sharedSummaryBlock, this.context.getQuorum());
     }
 }

--- a/packages/framework/last-edited/src/lastEditedTrackerComponent.ts
+++ b/packages/framework/last-edited/src/lastEditedTrackerComponent.ts
@@ -51,6 +51,6 @@ export class LastEditedTrackerComponent extends PrimedComponent implements IProv
     protected async componentHasInitialized() {
         const sharedSummaryBlock =
             await this.root.get<IComponentHandle<SharedSummaryBlock>>(this.sharedSummaryBlockId).get();
-        this._lastEditedTracker = new LastEditedTracker(sharedSummaryBlock, this.context.getQuorum());
+        this._lastEditedTracker = new LastEditedTracker(sharedSummaryBlock);
     }
 }

--- a/packages/framework/last-edited/src/setup.ts
+++ b/packages/framework/last-edited/src/setup.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { ISequencedDocumentMessage, MessageType } from "@microsoft/fluid-protocol-definitions";
+import { ISequencedDocumentMessage, MessageType, IQuorum } from "@microsoft/fluid-protocol-definitions";
 import { IAttachMessage, IEnvelope, IHostRuntime } from "@microsoft/fluid-runtime-definitions";
-import { IComponentLastEditedTracker } from "./interfaces";
+import { IComponentLastEditedTracker, ILastEditDetails } from "./interfaces";
 
 const schedulerId = "_schdeuler";
 
@@ -34,57 +34,85 @@ function shouldDiscardMessageDefault(message: ISequencedDocumentMessage) {
     return true;
 }
 
+// Extracts the user information and timestamp from a message. Returns undefined if the user information for the
+// client who sent the message doesn't exist in the quorum.
+function getLastEditDetailsFromMessage(
+    message: ISequencedDocumentMessage,
+    quorum: IQuorum,
+): ILastEditDetails | undefined {
+    const sequencedClient = quorum.getMember(message.clientId);
+    const user = sequencedClient?.client.user;
+    if (user !== undefined) {
+        const lastEditDetails: ILastEditDetails = {
+            user,
+            timestamp: message.timestamp,
+        };
+        return lastEditDetails;
+    }
+    return undefined;
+}
+
 /**
- * Helper function to set up a root component that provides IComponentLastEditedTracker to track last edited in a.
- * Container. The component with id "rootrootComponentId" must implement an IComponentLastEditedTracker and this setup
- * should be called during container instantiatiion so that it does not miss ops. It does the following:
+ * Helper function to set up a component that provides IComponentLastEditedTracker to track last edited in a Container.
+ * The component with id "componentId" must implement an IComponentLastEditedTracker and this setup should be called
+ * during container instantiatiion so that it does not miss ops. It does the following:
  * - Requests the component with the given id from the runtime and waits for it to load.
  * - Registers an "op" listener on the runtime. On each message, it calls the shouldDiscardMessageFn to check
  *   if the message should be discarded. It also discards all scheduler message. If a message is not discarded,
- *   it is passed to the last edited tracker in the component.
- * - The last message received before the component is loaded is stored and passed to the tracker once the component
- *   loads.
- * @param rootComponentId - The id of the root component whose last edited tracker is to be set up.
+ *   it passes the last edited information from the message to the last edited tracker in the component.
+ * - The last edited information from the last message received before the component is loaded is stored and passed to
+ *   the tracker once the component loads.
+ * @param componentId - The id of the component whose last edited tracker is to be set up.
  * @param runtime - The container runtime whose messages are to be tracked.
  * @param shouldDiscardMessageFn - Function that tells if a message should not be considered in computing last edited.
  */
 export async function setupLastEditedTrackerForContainer(
-    rootComponentId: string,
+    componentId: string,
     runtime: IHostRuntime,
     shouldDiscardMessageFn: (message: ISequencedDocumentMessage) => boolean = shouldDiscardMessageDefault,
 ) {
     // eslint-disable-next-line prefer-const
     let lastEditedTracker: IComponentLastEditedTracker;
-    // Stores messages until the component has loaded.
-    let pendingMessage: ISequencedDocumentMessage | undefined;
+    // Stores the last edit details until the component has loaded.
+    let pendingLastEditDetails: ILastEditDetails | undefined;
 
-    // Register an op listener on the runtime. If the component has loaded, it passes the message to its last
-    // edited tracker. If the component hasn't loaded, store the message temporarily.
+    // Register an op listener on the runtime. If the component has loaded, it passes the last edited information to its
+    // last edited tracker. If the component hasn't loaded, store the last edited information temporarily.
     runtime.on("op", (message: ISequencedDocumentMessage) => {
-        // Discard scheduler messages and other messages as per shouldDiscardMessageFn.
-        if (!shouldDiscardMessageFn(message) && !isSchedulerMessage(message)) {
-            if (lastEditedTracker !== undefined) {
-                lastEditedTracker.updateLastEditDetails(message);
-            } else {
-                pendingMessage = message;
-            }
+        // If this is a scheduler messages or it should be discarded as per shouldDiscardMessageFn, return.
+        if (shouldDiscardMessageFn(message) || isSchedulerMessage(message)) {
+            return;
+        }
+
+        // Get the last edited details from the message. If it doesn't exist, return.
+        const lastEditDetails = getLastEditDetailsFromMessage(message, runtime.getQuorum());
+        if (lastEditDetails === undefined) {
+            return;
+        }
+
+        if (lastEditedTracker !== undefined) {
+            // Update the last edited tracker if the component has loaded.
+            lastEditedTracker.updateLastEditDetails(lastEditDetails);
+        } else {
+            // If the component hasn't loaded, store the last edited details temporarily.
+            pendingLastEditDetails = lastEditDetails;
         }
     });
 
-    const response = await runtime.request({ url: rootComponentId });
+    const response = await runtime.request({ url: componentId });
     if (response.status !== 200 || response.mimeType !== "fluid/component") {
-        throw new Error(`Component with id ${rootComponentId} does not exist.`);
+        throw new Error(`Component with id ${componentId} does not exist.`);
     }
 
     // Get the last edited tracker from the component.
     const component = response.value;
     lastEditedTracker = component.IComponentLastEditedTracker;
     if (lastEditedTracker === undefined) {
-        throw new Error(`Component with id ${rootComponentId} does not have IComponentLastEditedTracker.`);
+        throw new Error(`Component with id ${componentId} does not have IComponentLastEditedTracker.`);
     }
 
-    // Now that the component has loaded, pass any pending message to its last edited tracker.
-    if (pendingMessage !== undefined) {
-        lastEditedTracker.updateLastEditDetails(pendingMessage);
+    // Now that the component has loaded, pass any pending last edit details to its last edited tracker.
+    if (pendingLastEditDetails !== undefined) {
+        lastEditedTracker.updateLastEditDetails(pendingLastEditDetails);
     }
 }


### PR DESCRIPTION
LastEditedTracker stores the clientId and the expectation is that the consumer can get the user information from the quorum. However, if the client who last edited the document disconnects, then the user info cannot be retrieved from the clientId.
So, updating the LastEditedTracker to store the IUser object instead.

Also, removed the event generated by the LastEditedTracker because this will be generated for every op in the system making it too noisy.