### PR TITLE
Make the bundle requests root-relative

### DIFF
--- a/packages/tools/webpack-component-loader/src/routes.ts
+++ b/packages/tools/webpack-component-loader/src/routes.ts
@@ -206,7 +206,7 @@ const fluid = (req: express.Request, res: express.Response, baseDir: string, opt
     </div>
 
     <script src="/node_modules/@microsoft/fluid-webpack-component-loader/dist/fluid-loader.bundle.js"></script>
-    ${packageJson.fluid.browser.umd.files.map((file)=>`<script src="${file}"></script>\n`)}
+    ${packageJson.fluid.browser.umd.files.map((file)=>`<script src="/${file}"></script>\n`)}
     <script>
         var pkgJson = ${JSON.stringify(packageJson)};
         var options = ${JSON.stringify(options)};


### PR DESCRIPTION
When navigating to a deeper path than the doc ID, the bundle requests aren't getting routed correctly (this can be observed e.g. when navigating to a TodoItem).  Making the bundle requests root-relative resolves the issue.