### PR TITLE
Fix `TreeEntry` type

### DIFF
--- a/server/routerlicious/packages/protocol-definitions/src/storage.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/storage.ts
@@ -71,9 +71,9 @@ export interface ITreeEntry {
  * Type of entries that can be stored in a tree
  */
 export enum TreeEntry {
-    Blob,
-    Commit,
-    Tree,
+    Blob = "Blob",
+    Commit = "Commit",
+    Tree = "Tree",
 }
 
 export interface ITree {


### PR DESCRIPTION
(Resurrecting this old PR)

Defines TreeEntry enum values to match their corresponding names.

Once this lands, we can use the enum's value instead of looking up the enum's value name on each access:
```ts
Old:  type: TreeEntry[TreeEntry.Blob]
New:  type: TreeEntry.Blob
```
