### PR TITLE
Fix state SummaryManager state machine and handle NotStarted scenarios [0.15]

### DIFF
--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -9,5 +9,6 @@ export * from "./summaryTreeConverter";
 export * from "./requestHandlers";
 export * from "./requestParser";
 export * from "./componentRegistry";
+export * from "./runWhileConnectedCoordinator";
 export * from "./summarizer";
 export * from "./summaryCollection";

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
 import { IDisposable, ITelemetryLogger } from "@microsoft/fluid-common-definitions";
 import {
     IComponentLoadable,
@@ -18,10 +17,12 @@ import {
     ISequencedDocumentSystemMessage,
     ISummaryConfiguration,
     MessageType,
+    IDocumentMessage,
 } from "@microsoft/fluid-protocol-definitions";
 import { ISummaryContext } from "@microsoft/fluid-driver-definitions";
-import { ContainerRuntime, GenerateSummaryData } from "./containerRuntime";
-import { RunWhileConnectedCoordinator } from "./runWhileConnectedCoordinator";
+import { IDeltaManager } from "@microsoft/fluid-container-definitions";
+import { GenerateSummaryData, IPreviousState } from "./containerRuntime";
+import { RunWhileConnectedCoordinator, IStartedResult, IConnectableRuntime } from "./runWhileConnectedCoordinator";
 import { IClientSummaryWatcher, SummaryCollection } from "./summaryCollection";
 
 // Send some telemetry if generate summary takes too long
@@ -47,6 +48,18 @@ export interface ISummarizer extends IComponentRouter, IComponentRunnable, IComp
     stop(reason?: string): void;
 }
 
+export interface ISummarizerRuntime extends IConnectableRuntime {
+    readonly logger: ITelemetryLogger;
+    readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
+    readonly previousState: IPreviousState;
+    readonly summarizerClientId: string;
+    nextSummarizerD?: Deferred<Summarizer>;
+    closeFn(reason?: string): void;
+    on(event: "batchEnd", listener: (error: any, op: ISequencedDocumentMessage) => void): this;
+    on(event: "disconnected", listener: () => void): this;
+    removeListener(event: "batchEnd", listener: (error: any, op: ISequencedDocumentMessage) => void): this;
+}
+
 /**
  * Summarizer is responsible for coordinating when to send generate and send summaries.
  * It is the main entry point for summary work.
@@ -66,10 +79,11 @@ export class Summarizer implements ISummarizer {
     private immediateSummary: boolean = false;
     public readonly summaryCollection: SummaryCollection;
     private stopReason?: string;
+    private readonly stopDeferred = new Deferred<IStartedResult>();
 
     constructor(
         public readonly url: string,
-        private readonly runtime: ContainerRuntime,
+        private readonly runtime: ISummarizerRuntime,
         private readonly configurationGetter: () => ISummaryConfiguration,
         private readonly generateSummaryCore: (full: boolean, safe: boolean) => Promise<GenerateSummaryData>,
         private readonly refreshLatestAck: (context: ISummaryContext, referenceSequenceNumber: number) => Promise<void>,
@@ -97,17 +111,7 @@ export class Summarizer implements ISummarizer {
             // Cleanup after running
             if (this.runtime.connected) {
                 if (this.runningSummarizer) {
-                    // Let running summarizer finish if no other summarizer client in quorum
-                    let hasOtherSummarizerClient = false;
-                    for (const [clientId, member] of this.runtime.getQuorum().getMembers()) {
-                        if (clientId !== this.runtime.clientId && member.client.details?.type === "summarizer") {
-                            hasOtherSummarizerClient = true;
-                            break;
-                        }
-                    }
-                    if (hasOtherSummarizerClient === false) {
-                        await this.runningSummarizer.waitStop();
-                    }
+                    await this.runningSummarizer.waitStop();
                 }
                 this.runtime.closeFn(`Summarizer: ${this.stopReason ?? "runEnded"}`);
             }
@@ -125,13 +129,13 @@ export class Summarizer implements ISummarizer {
             // already stopping
             return;
         }
-        this.stopReason = reason;
+        this.stopReason = reason ?? "Unspecified";
         this.logger.sendTelemetryEvent({
             eventName: "StoppingSummarizer",
             onBehalfOf: this.onBehalfOfClientId,
             reason,
         });
-        this.runCoordinator.stop();
+        this.stopDeferred.resolve();
     }
 
     public async request(request: IRequest): Promise<IResponse> {
@@ -142,28 +146,36 @@ export class Summarizer implements ISummarizer {
         };
     }
 
-    private async runCore(onBehalfOf: string): Promise<void> {
+    private async runCore(onBehalfOf: string): Promise<boolean> {
         this.onBehalfOfClientId = onBehalfOf;
 
         const startResult = await this.runCoordinator.waitStart();
         if (startResult.started === false) {
             this.logger.sendTelemetryEvent({
                 eventName: "NotStarted",
-                error: startResult.message,
+                reason: startResult.message,
                 onBehalfOf,
             });
-            return;
+            return false;
         }
 
-        if (this.runtime.summarizerClientId !== this.onBehalfOfClientId) {
-            // This calculated summarizer differs from parent
-            // parent SummaryManager should prevent this from happening
-            this.logger.sendErrorEvent({
-                eventName: "ParentIsNotSummarizer",
-                expectedSummarizer: this.runtime.summarizerClientId,
+        if (this.runtime.summarizerClientId !== this.onBehalfOfClientId
+            && this.runtime.summarizerClientId !== this.runtime.clientId) {
+            // Verify that this client's computed summarizer matches the client this was spawned
+            // on behalf of.  If not, fallback on the following logic before stopping:
+            // If we are not oldest client in quorum, another client will take over as summarizer.
+            // We want to make sure we at least try to summarize in case server is rejecting ops,
+            // so if we are the oldest client, we will still go through and try to summarize at least once.
+            // We also don't want to end up with two summarizer clients running at the same time,
+            // so we bypass running altogether if this client isn't the oldest.
+            this.logger.sendTelemetryEvent({
+                eventName: "NotStarted",
+                reason: "DifferentComputedSummarizer",
+                computedSummarizer: this.runtime.summarizerClientId,
                 onBehalfOf,
+                clientId: this.runtime.clientId,
             });
-            return;
+            return false;
         }
 
         // Initialize values and first ack (time is not exact)
@@ -178,17 +190,11 @@ export class Summarizer implements ISummarizer {
             summaryTime: Date.now(),
         };
 
-        // this.runCoordinator.waitStart in the beginning guaranteed that we are connected and has a clientId
-        // eslint-disable-next-line max-len
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion
-        const clientId = this.runtime.clientId!;
-        assert(clientId);
-
         const runningSummarizer = await RunningSummarizer.start(
-            clientId,
+            startResult.clientId,
             onBehalfOf,
             this.logger,
-            this.summaryCollection.createWatcher(clientId),
+            this.summaryCollection.createWatcher(startResult.clientId),
             this.configurationGetter(),
             async (full: boolean, safe: boolean) => this.generateSummary(full, safe),
             this.runtime.deltaManager.referenceSequenceNumber,
@@ -212,7 +218,10 @@ export class Summarizer implements ISummarizer {
         this.opListener = (error: any, op: ISequencedDocumentMessage) => runningSummarizer.handleOp(error, op);
         this.runtime.on("batchEnd", this.opListener);
 
-        await this.runCoordinator.waitStopped();
+        await Promise.race([
+            this.runCoordinator.waitStopped(),
+            this.stopDeferred.promise,
+        ]);
     }
 
     /**

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -304,7 +304,7 @@ export class SummaryManager extends EventEmitter implements IDisposable {
             this.runningSummarizer.stop(reason);
         } else {
             // Should not be possible to hit this case
-            this.logger.sendErrorEvent({ eventName: "StopCalledWithoutRunningSummarizer" });
+            this.logger.sendErrorEvent({ eventName: "StopCalledWithoutRunningSummarizer", reason });
             this.state = SummaryManagerState.Off;
         }
     }

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -311,7 +311,7 @@ export class SummaryManager extends EventEmitter implements IDisposable {
 
     private async createSummarizer(delayMs: number): Promise<ISummarizer | undefined> {
         const shouldDelay = delayMs > 0;
-        const shouldInitialDelay = this.opsUntilFirstConnect >= opsToBypassInitialDelay;
+        const shouldInitialDelay = this.opsUntilFirstConnect < opsToBypassInitialDelay;
         if (shouldDelay || shouldInitialDelay) {
             await Promise.all([
                 shouldInitialDelay ? this.initialDelayP : Promise.resolve(),


### PR DESCRIPTION
The following changes are intended to help docs automatically recover by having better defined rules around summarizers.

1. Fix `SummaryManager` state machine
    1. Move check for other running summarizer clients from `start` to `getShouldSummarizeState()` which now gives `shouldSummarize` if elected summarizer, `shouldStart` if safe to start, and `stopReason` if it should stop.
    2. Always call `run` on created summarizer client, thus removing checks for `shouldSummarize` in the between steps; so now `start` always leads to `run`, but after calling `run`, now it will check `shouldSummarize` and if not it will call `stop`.
    3. Add `Stopping` state to prevent excessive calls to stop for running summarizer.
    4. Add `Disabled` state to more clearly define the state when summaries are disabled, or the client itself is a summarizer client, either way this client should never spawn a summarizer.
2. Fix Summarizer transitions for cleaning up docs with too many ops
    1. Now calling `stop` on `Summarizer` will use a separate `Deferred` than the `RunWhileConnectedCoordinator`, to prevent premature closing of the summarizer client.  The intention is that now it will always wait to be connected before deciding to end or not.
    2. Added check to bypass `run` if neither this summarizer's clientId nor its parent clientId is the oldest client in quorum.  See comment in code for more details.  This is now one of the `NotStarted` cases which basically indicates that it bypasses running.  This can also happen if the client manages to disconnect before `run` is called.
3. Miscellaneous cleanup:
    1. Add `ISummarizerRuntime` to make a contract for `ContainerRuntime` needs within `Summarizer`
    2. Add `IConnectableRuntime` to make a contract for `ContainerRuntime` needs within `RunWhileConnectedCoordinator`.
    3. Return `clientId` from `RunWhileConnectedCoordinator` if connected.
    4. Add `StopReason` type to restrict stop reasons within `SummaryManager`.
