### PR TITLE
Matrix: Test & stress enhancements

### DIFF
--- a/packages/runtime/matrix/.gitignore
+++ b/packages/runtime/matrix/.gitignore
@@ -50,3 +50,6 @@ nyc
 # Generated modeuls
 intel_modules/
 temp_modules/
+
+bench/dist/
+bench/profile.txt

--- a/packages/runtime/matrix/bench/src/profile.ts
+++ b/packages/runtime/matrix/bench/src/profile.ts
@@ -1,0 +1,30 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { createContiguousMatrix } from "./util";
+import { fill } from "./imports";
+
+const row = 0, col = 0, numRows = 256, numCols = 256, shouldFill = true;
+
+const rowSize = row + numRows;
+const colSize = col + numCols;
+
+const arr = createContiguousMatrix(rowSize, colSize);
+
+if (shouldFill) {
+    fill(arr);
+}
+
+let sum = 0;
+
+for (let i = 0; i < 1000; i++) {
+    for (let r = row; r < numRows; r++) {
+        for (let c = col; c < numCols; c++) {
+            sum += (arr.read(r, c) as any | 0);
+        }
+    }
+}
+
+console.log(sum);

--- a/packages/runtime/matrix/package.json
+++ b/packages/runtime/matrix/package.json
@@ -11,7 +11,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "bench": "cd bench && node --expose-gc -r ts-node/register src/index.ts",
-    "bench:profile": "cd bench && tsc && node --prof dist/profile && node --prof-process isolate-0x*-v8.log > profile.txt && rm isolate-0x*-v8.log && cat profile.txt",
+    "bench:profile": "cd bench && tsc && node --prof dist/bench/src/profile && node --prof-process isolate-0x*-v8.log > profile.txt && rm isolate-0x*-v8.log && cat profile.txt",
     "build": "npm run build:genver && concurrently npm:build:compile npm:lint",
     "build:compile": "concurrently npm:tsc npm:build:esnext",
     "build:docs": "api-extractor run --local && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../../_api-extractor-temp/",
@@ -19,7 +19,7 @@
     "build:full": "npm run build",
     "build:full:compile": "npm run build:compile",
     "build:genver": "gen-version",
-    "clean": "rimraf dist lib *.tsbuildinfo *.build.log",
+    "clean": "rimraf dist lib bench/dist *.tsbuildinfo *.build.log",
     "eslint": "eslint --ext=ts,tsx --format stylish src",
     "eslint:fix": "eslint --ext=ts,tsx --format stylish src --fix",
     "lint": "npm run eslint",

--- a/packages/runtime/matrix/test/matrix.spec.ts
+++ b/packages/runtime/matrix/test/matrix.spec.ts
@@ -190,6 +190,24 @@ describe("Matrix", () => {
             ]);
         });
 
+        // Vets that the matrix correctly handles noncontiguous handles when allocating a range
+        // of more than one handle.
+        it("remove 1 row, insert 2 rows", async () => {
+            matrix.insertRows(0,4);
+            matrix.insertCols(0,1);
+            matrix.setCells(/* row: */ 0, /* col: */ 0, /* numCols: */ 1, [0,1,2,3]);
+            matrix.removeRows(2,1);
+            matrix.insertRows(0,2);
+            matrix.setCells(/* row: */ 0, /* col: */ 0, /* numCols: */ 1, [84,45]);
+            await expect([
+                [84],
+                [45],
+                [0],
+                [1],
+                [3],
+            ]);
+        });
+
         describe("contiguous", () => {
             it("read/write 256x256", () => {
                 matrix.insertRows(0, 256);
@@ -319,7 +337,29 @@ describe("Matrix", () => {
                 ]);
             });
 
-            it("insert col", async () => {
+            it("insert and set in new row", async () => {
+                matrix1.insertCols(0,2);
+                await expect();
+                matrix1.insertRows(0,1);
+                matrix1.setCells(/* row: */ 0, /* col: */ 1, /* numCols: */ 1, ["x"]);
+                await expect([[undefined, "x"]]);
+            });
+
+            it("insert and set in new col", async () => {
+                matrix1.insertRows(0,2);
+                await expect([
+                    [],
+                    [],
+                ]);
+                matrix1.insertCols(0,1);
+                matrix1.setCells(/* row: */ 1, /* col: */ 0, /* numCols: */ 1, ["x"]);
+                await expect([
+                    [undefined],
+                    ["x"]
+                ]);
+            });
+
+            it("insert col conflict", async () => {
                 matrix1.insertRows(0, 1);
                 await expect([
                     []
@@ -336,7 +376,7 @@ describe("Matrix", () => {
                 ]);
             });
 
-            it("insert row", async () => {
+            it("insert row conflict", async () => {
                 matrix1.insertCols(0, 1);
                 await expect([]);
 
@@ -352,7 +392,7 @@ describe("Matrix", () => {
                 ]);
             });
 
-            it("remove col", async () => {
+            it("overlapping remove col", async () => {
                 matrix1.insertCols(0, 3);
                 matrix1.insertRows(0, 1);
                 matrix1.setCell(0, 0, "A");
@@ -370,7 +410,7 @@ describe("Matrix", () => {
                 ]);
             });
 
-            it("remove row", async () => {
+            it("overlapping remove row", async () => {
                 matrix1.insertCols(0, 1);
                 matrix1.insertRows(0, 3);
                 matrix1.setCell(0, 0, "A");

--- a/packages/runtime/matrix/test/matrix.stress.spec.ts
+++ b/packages/runtime/matrix/test/matrix.stress.spec.ts
@@ -21,30 +21,18 @@ describe("Matrix", () => {
          * Drains the queue of pending ops for each client and vets that all matrices converged on the same state.
          */
         const expect = async () => {
-            try {
-                await TestHost.sync(...hosts);
+            await TestHost.sync(...hosts);
 
-                const matrix0 = matrices[0];
-                const actual0 = extract(matrix0);
+            const matrix0 = matrices[0];
+            const actual0 = extract(matrix0);
 
-                for (let i = 1; i < matrices.length; i++) {
-                    const matrixN = matrices[i];
-                    const actualN = extract(matrixN);
-                    assert.deepEqual(actual0, actualN);
+            for (let i = 1; i < matrices.length; i++) {
+                const matrixN = matrices[i];
+                const actualN = extract(matrixN);
+                assert.deepEqual(actual0, actualN);
 
-                    // Vet that empty matrices have identical dimensions (see notes on `expectSize`).
-                    expectSize(matrixN, matrix0.numRows, matrix0.numCols);
-                }
-            } catch (error) {
-                for (const s of trace) {
-                    console.log(s);
-                }
-
-                for (const m of matrices) {
-                    console.log(m.toString());
-                }
-
-                throw error;
+                // Vet that empty matrices have identical dimensions (see notes on `expectSize`).
+                expectSize(matrixN, matrix0.numRows, matrix0.numCols);
             }
         };
 
@@ -84,24 +72,30 @@ describe("Matrix", () => {
                     .fill(0)
                     .map(() => int32(100));
 
+                // Invokes 'setCells()' on the matrix w/the given index and logs the command to the trace.
+                const setCells = (matrixIndex: number, row: number, col: number, numCols: number, values: any[]) => {
+                    const matrix = matrices[matrixIndex];
+                    trace?.push(`matrix${matrixIndex + 1}.setCells(/* row: */ ${row}, /* col: */ ${col}, /* numCols: */ ${numCols}, ${JSON.stringify(values)});    // numRows: ${matrix.numRows} numCols: ${matrix.numCols} stride: ${matrix.numCols} length: ${values.length}`);
+                    matrix.setCells(row, col, numCols, values);
+                }
+
                 // Initialize with [0..5] row and [0..5] cols, filling the cells.
                 {
                     const numRows = int32(5);
                     if (numRows > 0) {
-                        matrix0.insertRows(0, numRows);
                         trace?.push(`matrix1.insertRows(0,${numRows});    // numRows: ${matrix0.numRows}, numCols: ${matrix0.numCols}`);
+                        matrix0.insertRows(0, numRows);
                     }
 
                     const numCols = int32(5);
                     if (numCols > 0) {
-                        matrix0.insertCols(0, numCols);
                         trace?.push(`matrix1.insertCols(0,${numCols});    // numRows: ${matrix0.numRows}, numCols: ${matrix0.numCols}`);
+                        matrix0.insertCols(0, numCols);
                     }
 
                     if (numCols > 0 && numRows > 0) {
                         const v = new Array(numCols * numRows).fill(0).map((_, index) => index);
-                        matrix0.setCells(0, 0, numCols, v);
-                        trace?.push(`matrix1.setCells(0, 0, ${numCols}, ${JSON.stringify(v)});`);
+                        setCells(/* matrixIndex: */ 0, /* row: */ 0, /* col: */ 0, numCols, v);
                     }
                 }
 
@@ -132,8 +126,8 @@ describe("Matrix", () => {
                                     ? int32(numRows - row - 1) + 1
                                     : 1;
 
+                                trace?.push(`matrix${matrixIndex + 1}.removeRows(${row},${numRemoved});    // numRows: ${matrix.numRows - numRemoved}, numCols: ${matrix.numCols}`);
                                 matrix.removeRows(row, numRemoved);
-                                trace?.push(`matrix${matrixIndex + 1}.removeRows(${row},${numRemoved});    // numRows: ${matrix.numRows}, numCols: ${matrix.numCols}`);
                             }
                             break;
                         }
@@ -146,8 +140,8 @@ describe("Matrix", () => {
                                     ? int32(numCols - col - 1) + 1
                                     : 1;
 
+                                trace?.push(`matrix${matrixIndex + 1}.removeCols(${col},${numRemoved});    // numRows: ${matrix.numRows}, numCols: ${matrix.numCols - numRemoved}`);
                                 matrix.removeCols(col, numRemoved);
-                                trace?.push(`matrix${matrixIndex + 1}.removeCols(${col},${numRemoved});    // numRows: ${matrix.numRows}, numCols: ${matrix.numCols}`);
                             }
                             break;
                         }
@@ -158,15 +152,14 @@ describe("Matrix", () => {
                                 ? int32(3) + 1
                                 : 1;
 
+                            trace?.push(`matrix${matrixIndex + 1}.insertRows(${row},${numInserted});    // numRows: ${matrix.numRows + numInserted}, numCols: ${matrix.numCols}`);
                             matrix.insertRows(row, numInserted);
-                            trace?.push(`matrix${matrixIndex + 1}.insertRows(${row},${numInserted});    // numRows: ${matrix.numRows}, numCols: ${matrix.numCols}`);
 
                             // 90% probability of filling the newly inserted row with values.
                             if (float64() < 0.9) {
                                 if (numCols > 0) {
                                     const v = values(matrix.numCols * numInserted);
-                                    matrix.setCells(row, 0, matrix.numCols, v);
-                                    trace?.push(`matrix${matrixIndex + 1}.setCells(/* row: */ ${row}, /* col: */ 0, /* numCols: */ ${matrix.numCols}, ${JSON.stringify(v)});`);
+                                    setCells(matrixIndex, row, /* col: */ 0, matrix.numCols, v);
                                 }
                             }
                             break;
@@ -178,15 +171,14 @@ describe("Matrix", () => {
                                 ? int32(3) + 1
                                 : 1;
 
+                            trace?.push(`matrix${matrixIndex + 1}.insertCols(${col},${numInserted});    // numRows: ${matrix.numRows}, numCols: ${matrix.numCols + numInserted}`);
                             matrix.insertCols(col, numInserted);
-                            trace?.push(`matrix${matrixIndex + 1}.insertCols(${col},${numInserted});    // numRows: ${matrix.numRows}, numCols: ${matrix.numCols}`);
 
                             // 90% probability of filling the newly inserted col with values.
                             if (float64() < 0.9) {
                                 if (numRows > 0) {
                                     const v = values(matrix.numRows * numInserted);
-                                    matrix.setCells(0, col, numInserted, v);
-                                    trace?.push(`matrix${matrixIndex + 1}.setCells(/* row: */ 0, /* col: */ ${col}, /* numCols: */ 1, ${JSON.stringify(v)});`);
+                                    setCells(matrixIndex, /* row: */ 0, col, numInserted, v);
                                 }
                             }
                             break;
@@ -198,8 +190,7 @@ describe("Matrix", () => {
                                 const stride = int32(numCols - col - 1) + 1;
                                 const length = (int32(numRows - row - 1) + 1) * stride;
                                 const v = values(length);
-                                matrix.setCells(row, col, stride, v);
-                                trace?.push(`matrix${matrixIndex + 1}.setCells(/* row: */ ${row}, /* col: */ ${col}, /* numCols: */ ${stride}, ${JSON.stringify(v)});`);
+                                setCells(matrixIndex, row, col, stride, v);
                             }
                             break;
                         }
@@ -208,13 +199,29 @@ describe("Matrix", () => {
                     // Clients periodically exchanging ops, at which point we verify they have converged
                     // on the same state.
                     if (float64() < syncProbability) {
+                        trace?.push("await expect();");
                         await expect();
-                        trace?.push("await expect()");
                     }
                 }
 
                 // Test is finished.  Drain pending ops and vet that clients converged.
                 await expect();
+            } catch (error) {
+                // If an error occurs, dump the repro instructions.
+                for (const s of trace) {
+                    console.log(s);
+                }
+
+                // Append an 'await expect();' to the log.
+                console.log("await expect();");
+
+                // Also dump the current state of the matrices.
+                for (const m of matrices) {
+                    console.log(m.toString());
+                }
+
+                // Finally, rethrow the original error.
+                throw error;
             } finally {
                 for (const host of hosts) {
                     await host.close();

--- a/packages/runtime/matrix/test/matrix.stress.spec.ts
+++ b/packages/runtime/matrix/test/matrix.stress.spec.ts
@@ -94,8 +94,8 @@ describe("Matrix", () => {
                     }
 
                     if (numCols > 0 && numRows > 0) {
-                        const v = new Array(numCols * numRows).fill(0).map((_, index) => index);
-                        setCells(/* matrixIndex: */ 0, /* row: */ 0, /* col: */ 0, numCols, v);
+                        setCells(/* matrixIndex: */ 0, /* row: */ 0, /* col: */ 0, numCols,
+                            new Array(numCols * numRows).fill(0).map((_, index) => index));
                     }
                 }
 
@@ -158,8 +158,8 @@ describe("Matrix", () => {
                             // 90% probability of filling the newly inserted row with values.
                             if (float64() < 0.9) {
                                 if (numCols > 0) {
-                                    const v = values(matrix.numCols * numInserted);
-                                    setCells(matrixIndex, row, /* col: */ 0, matrix.numCols, v);
+                                    setCells(matrixIndex, row, /* col: */ 0, matrix.numCols,
+                                        values(matrix.numCols * numInserted));
                                 }
                             }
                             break;
@@ -177,8 +177,8 @@ describe("Matrix", () => {
                             // 90% probability of filling the newly inserted col with values.
                             if (float64() < 0.9) {
                                 if (numRows > 0) {
-                                    const v = values(matrix.numRows * numInserted);
-                                    setCells(matrixIndex, /* row: */ 0, col, numInserted, v);
+                                    setCells(matrixIndex, /* row: */ 0, col, numInserted,
+                                        values(matrix.numRows * numInserted));
                                 }
                             }
                             break;
@@ -189,8 +189,7 @@ describe("Matrix", () => {
                             if (numRows > 0 && numCols > 0) {
                                 const stride = int32(numCols - col - 1) + 1;
                                 const length = (int32(numRows - row - 1) + 1) * stride;
-                                const v = values(length);
-                                setCells(matrixIndex, row, col, stride, v);
+                                setCells(matrixIndex, row, col, stride, values(length));
                             }
                             break;
                         }


### PR DESCRIPTION
* A few additional test cases
* Stress trace now emits matrix ops before executing them
* Stress now replays trace on any exception
* Add NPM script to profile the matrix read benchmark