### PR TITLE
Update containerRuntime.ts

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -994,7 +994,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
             pkg,
             this,
             this.storage,
-            this.context.scope,
+            this.containerScope,
             this.summaryTracker.createOrGetChild(id, this.deltaManager.referenceSequenceNumber),
             (cr: IComponentRuntime) => this.attachComponent(cr),
             undefined /* #1635: Remove LocalComponentContext createProps */);


### PR DESCRIPTION
ComponentContext should be created with the containerScope instead of the runtime's context's scope.

(Note this now matches the call to create a new LocalComponentContext in the above method)