### PR TITLE
Add asserts for duplciate component creation.

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -976,6 +976,8 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
     public createComponentContext(pkg: string[], props?: any, id = uuid()) {
         this.verifyNotClosed();
 
+        assert(!this.contexts.has(id), "Creating component with existing ID");
+
         const context = new LocalComponentContext(
             id,
             pkg,
@@ -1001,6 +1003,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
 
         // tslint:disable-next-line: no-unsafe-any
         const id: string = uuid();
+        assert(!this.contexts.has(id)); // there should be no collisions!
         const context = new LocalComponentContext(
             id,
             pkg,
@@ -1180,6 +1183,8 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
                     assert(this.pendingAttach.has(attachMessage.id));
                     this.pendingAttach.delete(attachMessage.id);
                 } else {
+                    assert(!this.contexts.has(attachMessage.id), "Component created with existing ID");
+
                     // Resolve pending gets and store off any new ones
                     const deferred = this.ensureContextDeferred(attachMessage.id);
                     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1003,7 +1003,6 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
 
         // tslint:disable-next-line: no-unsafe-any
         const id: string = uuid();
-        assert(!this.contexts.has(id)); // there should be no collisions!
         const context = new LocalComponentContext(
             id,
             pkg,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1183,7 +1183,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
                     assert(this.pendingAttach.has(attachMessage.id));
                     this.pendingAttach.delete(attachMessage.id);
                 } else {
-                    assert(!this.contexts.has(attachMessage.id), "Component created with existing ID");
+                    assert(!this.contexts.has(attachMessage.id), "Component attached with existing ID");
 
                     // Resolve pending gets and store off any new ones
                     const deferred = this.ensureContextDeferred(attachMessage.id);

--- a/server/routerlicious/packages/protocol-base/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-base/src/protocol.ts
@@ -34,6 +34,7 @@ export function isSystemMessage(message: ISequencedDocumentMessage) {
         case MessageType.Propose:
         case MessageType.Reject:
         case MessageType.NoOp:
+        case MessageType.NoClient:
         case MessageType.Summarize:
         case MessageType.SummaryAck:
         case MessageType.SummaryNack:


### PR DESCRIPTION
I've added similar asserts / better messages to detect DDS duplicates - that's where we usually catch duplicate components. Raising asserts up the stack to catch issues earlier.

Also adding noClient to system messages. I hit an issue where (due to my failed experiment) connection was nacked and noClient op was delivered to NullRuntime, causing failure.
This is mostly noop, fix for the future correctness