### PR TITLE
Keep Summarizer up to date with latest defined SummaryManager clientId [0.15]

### DIFF
--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -46,6 +46,8 @@ export interface ISummarizer extends IComponentRouter, IComponentRunnable, IComp
      */
     setSummarizer(): Promise<Summarizer>;
     stop(reason?: string): void;
+    run(onBehalfOf: string): Promise<void>;
+    updateOnBehalfOf(onBehalfOf: string): void;
 }
 
 export interface ISummarizerRuntime extends IConnectableRuntime {
@@ -136,6 +138,10 @@ export class Summarizer implements ISummarizer {
             reason,
         });
         this.stopDeferred.resolve();
+    }
+
+    public updateOnBehalfOf(onBehalfOf: string): void {
+        this.onBehalfOfClientId = onBehalfOf;
     }
 
     public async request(request: IRequest): Promise<IResponse> {

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -92,6 +92,7 @@ export class SummaryManager extends EventEmitter implements IDisposable {
     private readonly initialDelayTimer?: PromiseTimer;
     private summarizerClientId?: string;
     private clientId?: string;
+    private latestClientId?: string;
     private connected = false;
     private state = SummaryManagerState.Off;
     private runningSummarizer?: ISummarizer;
@@ -123,7 +124,7 @@ export class SummaryManager extends EventEmitter implements IDisposable {
 
         this.connected = context.connected;
         if (this.connected) {
-            this.clientId = context.clientId;
+            this.setClientId(context.clientId);
         }
 
         const members = context.quorum.getMembers();
@@ -159,6 +160,16 @@ export class SummaryManager extends EventEmitter implements IDisposable {
         this.updateConnected(false);
     }
 
+    private setClientId(clientId: string | undefined): void {
+        this.clientId = clientId;
+        if (clientId !== undefined) {
+            this.latestClientId = this.clientId;
+            if (this.runningSummarizer !== undefined) {
+                this.runningSummarizer.updateOnBehalfOf(this.latestClientId);
+            }
+        }
+    }
+
     public on(event: "summarizer", listener: (clientId: string) => void): this;
     public on(event: string | symbol, listener: (...args: any[]) => void): this {
         return super.on(event, listener);
@@ -170,7 +181,7 @@ export class SummaryManager extends EventEmitter implements IDisposable {
         }
 
         this.connected = connected;
-        this.clientId = connected ? clientId : undefined;
+        this.setClientId(clientId);
         this.refreshSummarizer();
     }
 
@@ -275,7 +286,7 @@ export class SummaryManager extends EventEmitter implements IDisposable {
         const runningSummarizerEvent = PerformanceEvent.start(this.logger, { eventName: "RunningSummarizer" });
         this.runningSummarizer = summarizer;
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.runningSummarizer.run(this.clientId).then(() => {
+        this.runningSummarizer.run(this.latestClientId).then(() => {
             runningSummarizerEvent.end();
         }, (error) => {
             runningSummarizerEvent.cancel({}, error);


### PR DESCRIPTION
Problem:
[A] client connected with clientId: A, tries to spawn summarizer client
[B] same client disconnects and reconnects with clientId: B, while summarizer client is still connecting
[B, S] summarizer client connects, but sees B instead of A (or undefined) as oldest client

This causes Summarizer to raise "NotStarted" event and stop itself.

Now parent client synchronously keeps the summarizer client up-to-date with its new clientId whenever it changes.
It also makes sure to never send undefined for clientId by tracking its latest clientId.