### PR TITLE
Send and verify a nonce on connect

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -210,38 +210,16 @@
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.9.5.tgz",
-			"integrity": "sha512-IipaxGaQmW4TfWoXdqjY0TzoXQ1HRS0kPpEgvjosb3u7Uedcq297xFqDQiCcQtRRwzIMif+N1MLVI8C5a4/PAA==",
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.8.6.tgz",
+			"integrity": "sha512-klTBDdsr+VFFqaDHm5rR69OpEQtO2Qv8ECxHS1mNhJJvaHArR6a1xTf5K/eZW7eZpJbhCx3NW1Yt/sKsLXLblg==",
 			"requires": {
-				"@babel/helper-function-name": "^7.9.5",
+				"@babel/helper-function-name": "^7.8.3",
 				"@babel/helper-member-expression-to-functions": "^7.8.3",
 				"@babel/helper-optimise-call-expression": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3",
 				"@babel/helper-replace-supers": "^7.8.6",
 				"@babel/helper-split-export-declaration": "^7.8.3"
-			},
-			"dependencies": {
-				"@babel/helper-function-name": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
-					"integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
-					"requires": {
-						"@babel/helper-get-function-arity": "^7.8.3",
-						"@babel/template": "^7.8.3",
-						"@babel/types": "^7.9.5"
-					}
-				},
-				"@babel/types": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
-					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.5",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
 			}
 		},
 		"@babel/helper-function-name": {
@@ -303,53 +281,43 @@
 			},
 			"dependencies": {
 				"@babel/generator": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
-					"integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
+					"version": "7.8.8",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.8.tgz",
+					"integrity": "sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==",
 					"requires": {
-						"@babel/types": "^7.9.5",
+						"@babel/types": "^7.8.7",
 						"jsesc": "^2.5.1",
 						"lodash": "^4.17.13",
 						"source-map": "^0.5.0"
 					}
 				},
-				"@babel/helper-function-name": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
-					"integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
-					"requires": {
-						"@babel/helper-get-function-arity": "^7.8.3",
-						"@babel/template": "^7.8.3",
-						"@babel/types": "^7.9.5"
-					}
-				},
 				"@babel/parser": {
-					"version": "7.9.4",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-					"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
+					"version": "7.8.8",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
+					"integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
 				},
 				"@babel/traverse": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
-					"integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
+					"integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
-						"@babel/generator": "^7.9.5",
-						"@babel/helper-function-name": "^7.9.5",
+						"@babel/generator": "^7.8.6",
+						"@babel/helper-function-name": "^7.8.3",
 						"@babel/helper-split-export-declaration": "^7.8.3",
-						"@babel/parser": "^7.9.0",
-						"@babel/types": "^7.9.5",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.13"
 					}
 				},
 				"@babel/types": {
-					"version": "7.9.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
-					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+					"version": "7.8.7",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
+					"integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.5",
+						"esutils": "^2.0.2",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -368,11 +336,6 @@
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
-		},
-		"@babel/helper-validator-identifier": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-			"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
 		},
 		"@babel/helpers": {
 			"version": "7.8.4",
@@ -417,9 +380,9 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+			"version": "7.8.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
+			"integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
@@ -498,11 +461,6 @@
 			"version": "0.7.4",
 			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
 			"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
-		},
-		"@emotion/stylis": {
-			"version": "0.8.5",
-			"resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-			"integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
 		},
 		"@emotion/unitless": {
 			"version": "0.7.5",
@@ -628,32 +586,21 @@
 			}
 		},
 		"@fluentui/react-focus": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.7.0.tgz",
-			"integrity": "sha512-HG7rWibSEgWJXEJKTQhZ9IK3oBBv/05KIngVihQB2kDoy0GDvgleoacMwAgBBBhCdtm1/wHItIz/EVPJzeXCJA==",
+			"version": "7.1.8",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.1.8.tgz",
+			"integrity": "sha512-SIjBYGVF88D5TNf00HdMaVYDqUp4UaI5pGx8jpzp/aDQfj7YsWpFoVzOrq9p1LXPJ9UkpMYh6SpXStPDO7t8FQ==",
 			"requires": {
-				"@uifabric/merge-styles": "^7.11.1",
-				"@uifabric/set-version": "^7.0.11",
-				"@uifabric/styling": "^7.11.9",
-				"@uifabric/utilities": "^7.16.0",
-				"tslib": "^1.10.0"
-			}
-		},
-		"@fluentui/react-icons": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-0.1.7.tgz",
-			"integrity": "sha512-bseI3dRnmX7blvAtnkM/eNSTR2g3qlatXjAA8wXr8q3d8xLWTIyWBKIXSETweUG4Yiz8d54VYg06GKqOTSrHlg==",
-			"requires": {
-				"@uifabric/set-version": "^7.0.11",
-				"@uifabric/styling": "^7.11.9",
-				"@uifabric/utilities": "^7.16.0",
+				"@uifabric/merge-styles": "^7.8.8",
+				"@uifabric/set-version": "^7.0.7",
+				"@uifabric/styling": "^7.10.21",
+				"@uifabric/utilities": "^7.15.1",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@fortawesome/fontawesome-free": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.13.0.tgz",
-			"integrity": "sha512-xKOeQEl5O47GPZYIMToj6uuA2syyFlq9EMSl2ui0uytjY9xbe8XS0pexNWmxrdcCyNGyDmLyYw5FtKsalBUeOg=="
+			"version": "5.12.1",
+			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.12.1.tgz",
+			"integrity": "sha512-ZtjIIFplxncqxvogq148C3hBLQE+W3iJ8E4UvJ09zIJUgzwLcROsWwFDErVSXY2Plzao5J9KUYNHKHMEUYDMKw=="
 		},
 		"@hapi/address": {
 			"version": "2.1.4",
@@ -2159,9 +2106,9 @@
 			}
 		},
 		"@microsoft/eslint-config-fluid": {
-			"version": "0.15.22637",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2feslint-config-fluid/-/eslint-config-fluid-0.15.22637.tgz",
-			"integrity": "sha512-WSqvZgK8lAorQR2egur3HDwOpaXLP53LFL8XO8S8kVyCwUsw5vhSRYLrv7QihRoZ+w8N4f3LMh/0ffBQaZSS8w==",
+			"version": "0.15.22492",
+			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2feslint-config-fluid/-/eslint-config-fluid-0.15.22492.tgz",
+			"integrity": "sha512-PXe5BJyonSkTGuJmru52VgwFaS/VL5pKhgF1pOwGLb3X4F8wq4xB8YKSGh3qWo2XmT2dbTXOaOZV2HPijZktkw==",
 			"requires": {
 				"@typescript-eslint/eslint-plugin": "~2.17.0",
 				"@typescript-eslint/parser": "~2.17.0",
@@ -2329,9 +2276,9 @@
 			}
 		},
 		"@microsoft/load-themed-styles": {
-			"version": "1.10.43",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2fload-themed-styles/-/load-themed-styles-1.10.43.tgz",
-			"integrity": "sha512-9RUeBMXPHbT/qHTRIQi9oQs3bw5JkQGBQ8ayjycq95q+1OUI9jBJPiJi2d8btpGdJWisVb3ZXxRsUx5u6f5dRA=="
+			"version": "1.10.39",
+			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2fload-themed-styles/-/load-themed-styles-1.10.39.tgz",
+			"integrity": "sha512-KKeQSM0FMTR7VtvkVF+D488zUmO3YoImxJ3O2xyLDEu9GqxqthF3Zvv1GddC2Jyoj2vuAJ0RGGgrI/T+MxLLDg=="
 		},
 		"@microsoft/node-core-library": {
 			"version": "3.19.3",
@@ -2589,9 +2536,9 @@
 			}
 		},
 		"@sinonjs/commons": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
-			"integrity": "sha512-+DUO6pnp3udV/v2VfUWgaY5BIE1IfT7lLfeDzPVeMT1XKkaAp9LgSI9x5RtrFQoZ9Oi0PgXQQHPaoKu7dCjVxw==",
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
+			"integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
 			"requires": {
 				"type-detect": "4.0.8"
 			}
@@ -2672,9 +2619,9 @@
 			"integrity": "sha512-bWBbC7VG2jdjbgZMX0qpds8U/3h3anfIqE81L8jmVrgFZw/urEDnBA78ymGGKTTK6ciBXmmJ/xlok+Re41S8ww=="
 		},
 		"@types/babel__core": {
-			"version": "7.1.7",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",
-			"integrity": "sha512-RL62NqSFPCDK2FM1pSDH0scHpJvsXtZNiYlMB73DgPBaG1E38ZYVL+ei5EkWRbr+KC4YNiAUNBnRj+bgwpgjMw==",
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.6.tgz",
+			"integrity": "sha512-tTnhWszAqvXnhW7m5jQU9PomXSiKXk2sFxpahXvI20SZKu9ylPi8WtIxueZ6ehDWikPT0jeFujMj3X4ZHuf3Tg==",
 			"requires": {
 				"@babel/parser": "^7.1.0",
 				"@babel/types": "^7.0.0",
@@ -2701,9 +2648,9 @@
 			}
 		},
 		"@types/babel__traverse": {
-			"version": "7.0.11",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.11.tgz",
-			"integrity": "sha512-ddHK5icION5U6q11+tV2f9Mo6CZVuT8GJKld2q9LqHSZbvLbH34Kcu2yFGckZut453+eQU6btIA3RihmnRgI+Q==",
+			"version": "7.0.9",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.9.tgz",
+			"integrity": "sha512-jEFQ8L1tuvPjOI8lnpaf73oCJe+aoxL6ygqSy6c8LcW98zaC+4mzWuQIRCEvKeCOu+lbqdXcg4Uqmm1S8AP1tw==",
 			"requires": {
 				"@babel/types": "^7.3.0"
 			}
@@ -2764,9 +2711,9 @@
 			"integrity": "sha512-O2+umEIlHBVyi+ePmucPjpINqTvSnsz+hAok0D4IpvrOsIsDr6c34B0AbNXW2UDVYuxbv51z5dxnrRt23ohgWg=="
 		},
 		"@types/draft-js": {
-			"version": "0.10.40",
-			"resolved": "https://registry.npmjs.org/@types/draft-js/-/draft-js-0.10.40.tgz",
-			"integrity": "sha512-XMkk8pamH/XwSOpEk/B6wFB0Y6LvMFWQZZaIVjzQUH2GCpFxbugo8gYpETsNMkJrGb3yb7hhFjjT1SyJ8AbXjA==",
+			"version": "0.10.38",
+			"resolved": "https://registry.npmjs.org/@types/draft-js/-/draft-js-0.10.38.tgz",
+			"integrity": "sha512-iDg8fJATjGVfQVv/dysAMMcPwORyJix2AyAm8OdwseteYh1jV+Xwlz+1HddoCWxQWqzWf/MDkNQH5sLYG47e0w==",
 			"requires": {
 				"@types/react": "*",
 				"immutable": "~3.7.4"
@@ -2778,9 +2725,9 @@
 			"integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag=="
 		},
 		"@types/estree": {
-			"version": "0.0.44",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.44.tgz",
-			"integrity": "sha512-iaIVzr+w2ZJ5HkidlZ3EJM8VTZb2MJLCjw3V+505yVts0gRC4UMvjw0d1HPtGqI/HQC/KdsYtayfzl+AXY2R8g=="
+			"version": "0.0.43",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.43.tgz",
+			"integrity": "sha512-WfOySUnBpyKXbkC9QuZguwOGhGnugDXT2f2P6X8EIis7qlnd5NI1Nr4kRi357NtguxezyizIcaFlQe0wx23XnA=="
 		},
 		"@types/events": {
 			"version": "3.0.0",
@@ -2797,20 +2744,19 @@
 			}
 		},
 		"@types/express": {
-			"version": "4.17.6",
-			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
-			"integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
+			"version": "4.17.3",
+			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.3.tgz",
+			"integrity": "sha512-I8cGRJj3pyOLs/HndoP+25vOqhqWkAZsWMEmq1qXy/b/M3ppufecUwaK2/TVDVxcV61/iSdhykUjQQ2DLSrTdg==",
 			"requires": {
 				"@types/body-parser": "*",
 				"@types/express-serve-static-core": "*",
-				"@types/qs": "*",
 				"@types/serve-static": "*"
 			}
 		},
 		"@types/express-serve-static-core": {
-			"version": "4.17.5",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.5.tgz",
-			"integrity": "sha512-578YH5Lt88AKoADy0b2jQGwJtrBxezXtVe/MBqWXKZpqx91SnC0pVkVCcxcytz3lWW+cHBYDi3Ysh0WXc+rAYw==",
+			"version": "4.17.2",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.2.tgz",
+			"integrity": "sha512-El9yMpctM6tORDAiBwZVLMcxoTMcqqRO9dVyYcn7ycLWbvR8klrDn8CAOwRfZujZtWD7yS/mshTdz43jMOejbg==",
 			"requires": {
 				"@types/node": "*",
 				"@types/range-parser": "*"
@@ -2867,9 +2813,9 @@
 			}
 		},
 		"@types/jquery": {
-			"version": "3.3.36",
-			"resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.36.tgz",
-			"integrity": "sha512-jHL8J5y5fJ0+C9zCTkeOvX4zqRnPug3r6JhAqAYl2YyBCYHiXTbZSH0MRCpayZADed5TigPjH92dEKczUFT2TQ==",
+			"version": "3.3.33",
+			"resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.33.tgz",
+			"integrity": "sha512-U6IdXYGkfUI42SR79vB2Spj+h1Ly3J3UZjpd8mi943lh126TK7CB+HZOxGh2nM3IySor7wqVQdemD/xtydsBKA==",
 			"requires": {
 				"@types/sizzle": "*"
 			}
@@ -2901,9 +2847,9 @@
 			"integrity": "sha512-aWw2YTtAdT7CskFyxEX2K21/zSDStuf/ikI3yBqmwpwJF0pS+/IX5DWv+1UFffZIbruP6cnT9/LAJV1gFwAT1A=="
 		},
 		"@types/lodash": {
-			"version": "4.14.150",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.150.tgz",
-			"integrity": "sha512-kMNLM5JBcasgYscD9x/Gvr6lTAv2NVgsKtet/hm93qMyf/D1pt+7jeEZklKJKxMVmXjxbRVQQGfqDSfipYCO6w=="
+			"version": "4.14.149",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+			"integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
 		},
 		"@types/mime": {
 			"version": "2.0.1",
@@ -2990,9 +2936,9 @@
 			}
 		},
 		"@types/prosemirror-view": {
-			"version": "1.11.4",
-			"resolved": "https://registry.npmjs.org/@types/prosemirror-view/-/prosemirror-view-1.11.4.tgz",
-			"integrity": "sha512-Hh8v2tpCEMaIesQuw7Y7Pz6imoC1T/bR5OlNGVtp944PZvctXiBvFRkQIb0YvZpt7vVkFzeq2kmR+7mnUfvWiw==",
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/@types/prosemirror-view/-/prosemirror-view-1.11.2.tgz",
+			"integrity": "sha512-EKcQmR4KdkFZU13wS5pWrkSojRCPGqz/l/uzpZFfW5cgdr7fQsftf2/ttvIjpk1a94ISifEY4UZwflVJ+uL4Rg==",
 			"requires": {
 				"@types/prosemirror-model": "*",
 				"@types/prosemirror-state": "*",
@@ -3008,11 +2954,6 @@
 				"@types/node": "*"
 			}
 		},
-		"@types/qs": {
-			"version": "6.9.1",
-			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.1.tgz",
-			"integrity": "sha512-lhbQXx9HKZAPgBkISrBcmAcMpZsmpe/Cd/hY7LGZS5OfkySUBItnPZHgQPssWYUET8elF+yCFBbP1Q0RZPTdaw=="
-		},
 		"@types/random-js": {
 			"version": "1.0.31",
 			"resolved": "https://registry.npmjs.org/@types/random-js/-/random-js-1.0.31.tgz",
@@ -3024,18 +2965,18 @@
 			"integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
 		},
 		"@types/react": {
-			"version": "16.9.34",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.34.tgz",
-			"integrity": "sha512-8AJlYMOfPe1KGLKyHpflCg5z46n0b5DbRfqDksxBLBTUpB75ypDBAO9eCUcjNwE6LCUslwTz00yyG/X9gaVtow==",
+			"version": "16.9.23",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.23.tgz",
+			"integrity": "sha512-SsGVT4E7L2wLN3tPYLiF20hmZTPGuzaayVunfgXzUn1x4uHVsKH6QDJQ/TdpHqwsTLd4CwrmQ2vOgxN7gE24gw==",
 			"requires": {
 				"@types/prop-types": "*",
 				"csstype": "^2.2.0"
 			}
 		},
 		"@types/react-dom": {
-			"version": "16.9.7",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.7.tgz",
-			"integrity": "sha512-GHTYhM8/OwUCf254WO5xqR/aqD3gC9kSTLpopWGpQLpnw23jk44RvMHsyUSEplvRJZdHxhJGMMLF0kCPYHPhQA==",
+			"version": "16.9.5",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.5.tgz",
+			"integrity": "sha512-BX6RQ8s9D+2/gDhxrj8OW+YD4R+8hj7FEM/OJHGNR0KipE1h1mSsf39YeyC81qafkq+N3rU3h3RFbLSwE5VqUg==",
 			"requires": {
 				"@types/react": "*"
 			}
@@ -3132,9 +3073,9 @@
 			}
 		},
 		"@types/tough-cookie": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
-			"integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.6.tgz",
+			"integrity": "sha512-wHNBMnkoEBiRAd3s8KTKwIuO9biFtTf0LehITzBhSco+HQI0xkXZbLOD55SW3Aqw3oUkHstkm5SPv58yaAdFPQ=="
 		},
 		"@types/unist": {
 			"version": "2.0.3",
@@ -3142,9 +3083,9 @@
 			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
 		},
 		"@types/uuid": {
-			"version": "3.4.9",
-			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.9.tgz",
-			"integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ=="
+			"version": "3.4.8",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.8.tgz",
+			"integrity": "sha512-zHWce3allXWSmRx6/AGXKCtSOA7JjeWd2L3t4aHfysNk8mouQnWCocveaT7a4IEIlPVHp81jzlnknqTgCjCLXA=="
 		},
 		"@types/ws": {
 			"version": "6.0.4",
@@ -3255,254 +3196,255 @@
 			}
 		},
 		"@uifabric/fluent-theme": {
-			"version": "7.1.63",
-			"resolved": "https://registry.npmjs.org/@uifabric/fluent-theme/-/fluent-theme-7.1.63.tgz",
-			"integrity": "sha512-d4n1tPfdlf9mtlcGUegUJbvDJbhGA1VS0/I9pBS6+6BT41teVpXcDZoDZdE9uCBKJ3KbXqNXX4GWEuv5xMXCOQ==",
+			"version": "7.1.41",
+			"resolved": "https://registry.npmjs.org/@uifabric/fluent-theme/-/fluent-theme-7.1.41.tgz",
+			"integrity": "sha512-qsoDlsA1iAz5pwMmWEQy2VJD0Tpz8+cRjlrwc+QwH92mVH96M2WrhCIiZ/Io7/iFu7XZqn38ESN20VRkOB5zMQ==",
 			"requires": {
-				"@uifabric/merge-styles": "^7.11.1",
-				"@uifabric/set-version": "^7.0.11",
-				"@uifabric/styling": "^7.11.9",
-				"@uifabric/variants": "^7.1.52",
-				"office-ui-fabric-react": "^7.108.0",
+				"@uifabric/merge-styles": "^7.8.8",
+				"@uifabric/set-version": "^7.0.7",
+				"@uifabric/styling": "^7.10.21",
+				"@uifabric/variants": "^7.1.32",
+				"office-ui-fabric-react": "^7.105.1",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/foundation": {
-			"version": "7.7.6",
-			"resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.7.6.tgz",
-			"integrity": "sha512-xw91u6TlQKdDIKnOFXEdc8xWpKjQ0Aw/5kY2s12Mwnw57hhQ5ieKNio/h7QXzoJfJNIs2O7f7W5R11f1MOHT6Q==",
+			"version": "7.5.21",
+			"resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.5.21.tgz",
+			"integrity": "sha512-jrvb6Hzoc9nmLvFicPyZSbqCPvHh7ki61GngZRJ4DzhDR6YEgGANtbd+r9qsnim+S55gxyVkyzcRTFWxuK400g==",
 			"requires": {
-				"@uifabric/merge-styles": "^7.11.1",
-				"@uifabric/set-version": "^7.0.11",
-				"@uifabric/styling": "^7.11.9",
-				"@uifabric/utilities": "^7.16.0",
+				"@uifabric/merge-styles": "^7.8.8",
+				"@uifabric/set-version": "^7.0.7",
+				"@uifabric/styling": "^7.10.21",
+				"@uifabric/utilities": "^7.15.1",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/icons": {
-			"version": "7.3.32",
-			"resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.3.32.tgz",
-			"integrity": "sha512-l0EaVlbursTBwqwloE1/DOUtXOmb6cKvpUR90BC0CwOSgEHfqrFwi7kKcpH0CLEdw+o5h0DyDN8P8p1RHSPXrQ==",
+			"version": "7.3.20",
+			"resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.3.20.tgz",
+			"integrity": "sha512-V4r3qEt0VNYMg1BcE03z2g+T0jYDomqiLrdclH57NgoCBVrhmEYHPYATh/3D3YzKtupzvhokjEi3Wvjr0uzEyw==",
 			"requires": {
-				"@uifabric/set-version": "^7.0.11",
-				"@uifabric/styling": "^7.11.9",
+				"@uifabric/set-version": "^7.0.7",
+				"@uifabric/styling": "^7.10.21",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/merge-styles": {
-			"version": "7.11.1",
-			"resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-7.11.1.tgz",
-			"integrity": "sha512-r3T+xOo36qr0lrA+RRN1Ie6eI6Uzo7Gf8AplFkIGeaNczC2m3k5xY+oUa1WmOc6yRCJdMnn18fTYljOXAV4Tpw==",
+			"version": "7.8.8",
+			"resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-7.8.8.tgz",
+			"integrity": "sha512-8jsol90sFZ/mt69SsdxvQAYXBFDnmFtBVfFRn+jvtlaT7XdSDfV8GxFlouKMwpsZEYVDKuuUZXs78sTI92LhYg==",
 			"requires": {
-				"@uifabric/set-version": "^7.0.11",
+				"@uifabric/set-version": "^7.0.7",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/react-hooks": {
-			"version": "7.2.1",
-			"resolved": "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.2.1.tgz",
-			"integrity": "sha512-iXnLZYO7W8FYuthy/lwXZxzwIx14OqpN0xJdDqwnKTZ67n8c0lgD/BP7NWK4iubXOl6CzsyScPrTxNI/h6WX3g==",
+			"version": "7.0.22",
+			"resolved": "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.0.22.tgz",
+			"integrity": "sha512-RiIJIaEpK/uM0qotpB4Ea6wRiDcMaUETZSJaEONKZqUrgYK8hZq4e1ALVBba+kMfw95mB1NqJFI2jZEzNcju+Q==",
 			"requires": {
-				"@uifabric/set-version": "^7.0.11",
-				"@uifabric/utilities": "^7.16.0",
+				"@uifabric/set-version": "^7.0.7",
+				"@uifabric/utilities": "^7.15.1",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/set-version": {
-			"version": "7.0.11",
-			"resolved": "https://registry.npmjs.org/@uifabric/set-version/-/set-version-7.0.11.tgz",
-			"integrity": "sha512-QAwgQa/Pik/q4Io8SGAjiAjiSHT5JIdhHxFw9Ytct/daagZl40Kt/Et+3U01geMLSD5TOAUATvRN7xAFFgkD9A==",
+			"version": "7.0.7",
+			"resolved": "https://registry.npmjs.org/@uifabric/set-version/-/set-version-7.0.7.tgz",
+			"integrity": "sha512-NBmLJ7h+t1XS3MmOwOEeYVrmcxWiDyDoV1g0W87iuy5Qis+9Kqz3OZy6muNzcsLU6mALe/hP8DE+KgiZY06LLQ==",
 			"requires": {
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/styling": {
-			"version": "7.11.9",
-			"resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.11.9.tgz",
-			"integrity": "sha512-xjnm8nMDG6CS3WNGtyM7bv9q+CxG7kynagl5nenXh/hiTMvHRZpJPIlI1x6dBgx7G/f4+yp4qvmaKd+JPwiNcQ==",
+			"version": "7.10.21",
+			"resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.10.21.tgz",
+			"integrity": "sha512-Hl+3LH2XZ/q13K54uEXrmgNoZt/1dITZQLl3Vkvl42TX4Pp0vAdK7U8Ka5ai5gJLmKjucWvv+hFV0FMbPlGHtQ==",
 			"requires": {
 				"@microsoft/load-themed-styles": "^1.10.26",
-				"@uifabric/merge-styles": "^7.11.1",
-				"@uifabric/set-version": "^7.0.11",
-				"@uifabric/utilities": "^7.16.0",
+				"@uifabric/merge-styles": "^7.8.8",
+				"@uifabric/set-version": "^7.0.7",
+				"@uifabric/utilities": "^7.15.1",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/utilities": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.16.0.tgz",
-			"integrity": "sha512-dJazpicc8b72T768eB+PcL6aZS1IzKFsgUnG8b5bTIK6QYWIarrvH/hP/+gRZEWT0mB5C4eCLSRHqZOxPRcpFw==",
+			"version": "7.15.1",
+			"resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.15.1.tgz",
+			"integrity": "sha512-HuD82wV76JbyrM+N4ek8qVHOEB7YTmLpThylhB5mFSNxHxiCmUpo5d4xwUogu8c2M0ik3BrrJkrwMXXtAeuRbg==",
 			"requires": {
-				"@uifabric/merge-styles": "^7.11.1",
-				"@uifabric/set-version": "^7.0.11",
+				"@uifabric/merge-styles": "^7.8.8",
+				"@uifabric/set-version": "^7.0.7",
 				"prop-types": "^15.7.2",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/variants": {
-			"version": "7.1.52",
-			"resolved": "https://registry.npmjs.org/@uifabric/variants/-/variants-7.1.52.tgz",
-			"integrity": "sha512-/H4dbHODOkdSH6iZi12D35WfQiu/8UnioFnQ9kv6QfDnp1Isb46UrWE+BbXIAANBTqaZi8/PafJWw23Af6PxYA==",
+			"version": "7.1.32",
+			"resolved": "https://registry.npmjs.org/@uifabric/variants/-/variants-7.1.32.tgz",
+			"integrity": "sha512-yg3M+/CRc1jgh1QNQtsyrGZqwPJzVm8fSdFAIk55P/ZXdq6hcaUalVzbnDhNGy9cgyPuHdFxmLPGNZCNuTAv3g==",
 			"requires": {
-				"@uifabric/set-version": "^7.0.11",
-				"office-ui-fabric-react": "^7.108.0",
+				"@uifabric/set-version": "^7.0.7",
+				"office-ui-fabric-react": "^7.105.1",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@webassemblyjs/ast": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
-			"integrity": "sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
+			"integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
 			"requires": {
-				"@webassemblyjs/helper-module-context": "1.9.0",
-				"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-				"@webassemblyjs/wast-parser": "1.9.0"
+				"@webassemblyjs/helper-module-context": "1.8.5",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+				"@webassemblyjs/wast-parser": "1.8.5"
 			}
 		},
 		"@webassemblyjs/floating-point-hex-parser": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz",
-			"integrity": "sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA=="
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
+			"integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ=="
 		},
 		"@webassemblyjs/helper-api-error": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
-			"integrity": "sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw=="
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
+			"integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA=="
 		},
 		"@webassemblyjs/helper-buffer": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
-			"integrity": "sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA=="
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
+			"integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q=="
 		},
 		"@webassemblyjs/helper-code-frame": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz",
-			"integrity": "sha512-ERCYdJBkD9Vu4vtjUYe8LZruWuNIToYq/ME22igL+2vj2dQ2OOujIZr3MEFvfEaqKoVqpsFKAGsRdBSBjrIvZA==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
+			"integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
 			"requires": {
-				"@webassemblyjs/wast-printer": "1.9.0"
+				"@webassemblyjs/wast-printer": "1.8.5"
 			}
 		},
 		"@webassemblyjs/helper-fsm": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.0.tgz",
-			"integrity": "sha512-OPRowhGbshCb5PxJ8LocpdX9Kl0uB4XsAjl6jH/dWKlk/mzsANvhwbiULsaiqT5GZGT9qinTICdj6PLuM5gslw=="
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
+			"integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow=="
 		},
 		"@webassemblyjs/helper-module-context": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz",
-			"integrity": "sha512-MJCW8iGC08tMk2enck1aPW+BE5Cw8/7ph/VGZxwyvGbJwjktKkDK7vy7gAmMDx88D7mhDTCNKAW5tED+gZ0W8g==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
+			"integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
 			"requires": {
-				"@webassemblyjs/ast": "1.9.0"
+				"@webassemblyjs/ast": "1.8.5",
+				"mamacro": "^0.0.3"
 			}
 		},
 		"@webassemblyjs/helper-wasm-bytecode": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
-			"integrity": "sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw=="
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
+			"integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ=="
 		},
 		"@webassemblyjs/helper-wasm-section": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
-			"integrity": "sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
+			"integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
 			"requires": {
-				"@webassemblyjs/ast": "1.9.0",
-				"@webassemblyjs/helper-buffer": "1.9.0",
-				"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-				"@webassemblyjs/wasm-gen": "1.9.0"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-buffer": "1.8.5",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+				"@webassemblyjs/wasm-gen": "1.8.5"
 			}
 		},
 		"@webassemblyjs/ieee754": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz",
-			"integrity": "sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
+			"integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
 			"requires": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
 		},
 		"@webassemblyjs/leb128": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.0.tgz",
-			"integrity": "sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
+			"integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
 			"requires": {
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/utf8": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.9.0.tgz",
-			"integrity": "sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w=="
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
+			"integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw=="
 		},
 		"@webassemblyjs/wasm-edit": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
-			"integrity": "sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
+			"integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
 			"requires": {
-				"@webassemblyjs/ast": "1.9.0",
-				"@webassemblyjs/helper-buffer": "1.9.0",
-				"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-				"@webassemblyjs/helper-wasm-section": "1.9.0",
-				"@webassemblyjs/wasm-gen": "1.9.0",
-				"@webassemblyjs/wasm-opt": "1.9.0",
-				"@webassemblyjs/wasm-parser": "1.9.0",
-				"@webassemblyjs/wast-printer": "1.9.0"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-buffer": "1.8.5",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+				"@webassemblyjs/helper-wasm-section": "1.8.5",
+				"@webassemblyjs/wasm-gen": "1.8.5",
+				"@webassemblyjs/wasm-opt": "1.8.5",
+				"@webassemblyjs/wasm-parser": "1.8.5",
+				"@webassemblyjs/wast-printer": "1.8.5"
 			}
 		},
 		"@webassemblyjs/wasm-gen": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz",
-			"integrity": "sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
+			"integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
 			"requires": {
-				"@webassemblyjs/ast": "1.9.0",
-				"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-				"@webassemblyjs/ieee754": "1.9.0",
-				"@webassemblyjs/leb128": "1.9.0",
-				"@webassemblyjs/utf8": "1.9.0"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+				"@webassemblyjs/ieee754": "1.8.5",
+				"@webassemblyjs/leb128": "1.8.5",
+				"@webassemblyjs/utf8": "1.8.5"
 			}
 		},
 		"@webassemblyjs/wasm-opt": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz",
-			"integrity": "sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
+			"integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
 			"requires": {
-				"@webassemblyjs/ast": "1.9.0",
-				"@webassemblyjs/helper-buffer": "1.9.0",
-				"@webassemblyjs/wasm-gen": "1.9.0",
-				"@webassemblyjs/wasm-parser": "1.9.0"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-buffer": "1.8.5",
+				"@webassemblyjs/wasm-gen": "1.8.5",
+				"@webassemblyjs/wasm-parser": "1.8.5"
 			}
 		},
 		"@webassemblyjs/wasm-parser": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
-			"integrity": "sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
+			"integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
 			"requires": {
-				"@webassemblyjs/ast": "1.9.0",
-				"@webassemblyjs/helper-api-error": "1.9.0",
-				"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-				"@webassemblyjs/ieee754": "1.9.0",
-				"@webassemblyjs/leb128": "1.9.0",
-				"@webassemblyjs/utf8": "1.9.0"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-api-error": "1.8.5",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+				"@webassemblyjs/ieee754": "1.8.5",
+				"@webassemblyjs/leb128": "1.8.5",
+				"@webassemblyjs/utf8": "1.8.5"
 			}
 		},
 		"@webassemblyjs/wast-parser": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.9.0.tgz",
-			"integrity": "sha512-qsqSAP3QQ3LyZjNC/0jBJ/ToSxfYJ8kYyuiGvtn/8MK89VrNEfwj7BPQzJVHi0jGTRK2dGdJ5PRqhtjzoww+bw==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
+			"integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
 			"requires": {
-				"@webassemblyjs/ast": "1.9.0",
-				"@webassemblyjs/floating-point-hex-parser": "1.9.0",
-				"@webassemblyjs/helper-api-error": "1.9.0",
-				"@webassemblyjs/helper-code-frame": "1.9.0",
-				"@webassemblyjs/helper-fsm": "1.9.0",
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/floating-point-hex-parser": "1.8.5",
+				"@webassemblyjs/helper-api-error": "1.8.5",
+				"@webassemblyjs/helper-code-frame": "1.8.5",
+				"@webassemblyjs/helper-fsm": "1.8.5",
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/wast-printer": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
-			"integrity": "sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
+			"integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
 			"requires": {
-				"@webassemblyjs/ast": "1.9.0",
-				"@webassemblyjs/wast-parser": "1.9.0",
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/wast-parser": "1.8.5",
 				"@xtuc/long": "4.2.2"
 			}
 		},
@@ -4149,30 +4091,16 @@
 			}
 		},
 		"babel-loader": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.1.0.tgz",
-			"integrity": "sha512-7q7nC1tYOrqvUrN3LQK4GwSk/TQorZSOlO9C+RZDZpODgyN4ZlCqE5q9cDsyWOliN+aU9B4JX01xK9eJXowJLw==",
+			"version": "8.0.6",
+			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.6.tgz",
+			"integrity": "sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==",
 			"requires": {
-				"find-cache-dir": "^2.1.0",
-				"loader-utils": "^1.4.0",
-				"mkdirp": "^0.5.3",
-				"pify": "^4.0.1",
-				"schema-utils": "^2.6.5"
+				"find-cache-dir": "^2.0.0",
+				"loader-utils": "^1.0.2",
+				"mkdirp": "^0.5.1",
+				"pify": "^4.0.1"
 			},
 			"dependencies": {
-				"minimist": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-				},
-				"mkdirp": {
-					"version": "0.5.5",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-					"requires": {
-						"minimist": "^1.2.5"
-					}
-				},
 				"pify": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -4644,11 +4572,6 @@
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				}
 			}
-		},
-		"buffer-crc32": {
-			"version": "0.2.13",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
 		},
 		"buffer-equal-constant-time": {
 			"version": "1.0.1",
@@ -5126,9 +5049,9 @@
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
 		"codemirror": {
-			"version": "5.53.2",
-			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.53.2.tgz",
-			"integrity": "sha512-wvSQKS4E+P8Fxn/AQ+tQtJnF1qH5UOlxtugFLpubEZ5jcdH2iXTVinb+Xc/4QjshuOxRm4fUsU2QPF1JJKiyXA=="
+			"version": "5.52.0",
+			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.52.0.tgz",
+			"integrity": "sha512-K2UB6zjscrfME03HeRe/IuOmCeqNpw7PLKGHThYpLbZEuKf+ZoujJPhxZN4hHJS1O7QyzEsV7JJZGxuQWVaFCg=="
 		},
 		"codemirror-graphql": {
 			"version": "0.8.3",
@@ -5221,9 +5144,9 @@
 			}
 		},
 		"comlink": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/comlink/-/comlink-4.3.0.tgz",
-			"integrity": "sha512-mu4KKKNuW8TvkfpW/H88HBPeILubBS6T94BdD1VWBXNXfiyqVtwUCVNO1GeNOBTsIswzsMjWlycYr+77F5b84g=="
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/comlink/-/comlink-4.2.0.tgz",
+			"integrity": "sha512-33hF3yYzZicIWLREuvluTGSZkbAXYwRmrA9IYQo0/P+0O45qgvzR0FHX4tRZztObFMTs/RhnN0G0UBNDAZSiCg=="
 		},
 		"commander": {
 			"version": "2.20.3",
@@ -5949,16 +5872,6 @@
 					"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
 					"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
 				},
-				"schema-utils": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-errors": "^1.0.0",
-						"ajv-keywords": "^3.1.0"
-					}
-				},
 				"slash": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -6352,20 +6265,13 @@
 			}
 		},
 		"css-to-react-native": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
-			"integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.2.tgz",
+			"integrity": "sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==",
 			"requires": {
 				"camelize": "^1.0.0",
 				"css-color-keywords": "^1.0.0",
-				"postcss-value-parser": "^4.0.2"
-			},
-			"dependencies": {
-				"postcss-value-parser": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
-					"integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
-				}
+				"postcss-value-parser": "^3.3.0"
 			}
 		},
 		"cssesc": {
@@ -6387,9 +6293,9 @@
 			}
 		},
 		"csstype": {
-			"version": "2.6.10",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.10.tgz",
-			"integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w=="
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz",
+			"integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q=="
 		},
 		"currently-unhandled": {
 			"version": "0.4.1",
@@ -6863,9 +6769,9 @@
 			}
 		},
 		"draft-js": {
-			"version": "0.11.5",
-			"resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.11.5.tgz",
-			"integrity": "sha512-RlHcoDtblwCD6Bw2ay3D0dTLA6lH8862OcdJrHGnYrY5JjlitzSzGvGQwqqumVvbGUNDSZLD3FyNpSs4z5WIUg==",
+			"version": "0.11.4",
+			"resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.11.4.tgz",
+			"integrity": "sha512-BLZ59s0vkDj/zI8UPo9Nit/hPsl11ztDejxDCQlVbvEXJSWrTXqO6ZYgdw3hXLtuojq/URqq3wTrpnb3dvzvLA==",
 			"requires": {
 				"fbjs": "^1.0.0",
 				"immutable": "~3.7.4",
@@ -7007,9 +6913,9 @@
 			}
 		},
 		"engine.io-client": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.1.tgz",
-			"integrity": "sha512-RJNmA+A9Js+8Aoq815xpGAsgWH1VoSYM//2VgIiu9lNOaHFfLpTjH4tOzktBpjIs5lvOfiNY1dwf+NuU6D38Mw==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.0.tgz",
+			"integrity": "sha512-a4J5QO2k99CM2a0b12IznnyQndoEvtA4UAldhGzKqnHf42I3Qs2W5SPnDvatZRcMaNZs4IevVicBPayxYt6FwA==",
 			"requires": {
 				"component-emitter": "1.2.1",
 				"component-inherit": "0.0.3",
@@ -7411,9 +7317,12 @@
 					}
 				},
 				"run-async": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-					"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
+					"integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
+					"requires": {
+						"is-promise": "^2.1.0"
+					}
 				},
 				"string-width": {
 					"version": "4.2.0",
@@ -7475,9 +7384,9 @@
 			}
 		},
 		"eslint-config-prettier": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
-			"integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
+			"integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
 			"requires": {
 				"get-stdin": "^6.0.0"
 			},
@@ -7512,9 +7421,9 @@
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				},
 				"resolve": {
-					"version": "1.17.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+					"version": "1.15.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+					"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
 					"requires": {
 						"path-parse": "^1.0.6"
 					}
@@ -7522,9 +7431,9 @@
 			}
 		},
 		"eslint-module-utils": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
-			"integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.2.tgz",
+			"integrity": "sha512-LGScZ/JSlqGKiT8OC+cYRxseMjyqt6QO54nl281CK93unD89ijSeRV6An8Ci/2nvWVKe8K/Tqdm75RQoIOCr+Q==",
 			"requires": {
 				"debug": "^2.6.9",
 				"pkg-dir": "^2.0.0"
@@ -7743,9 +7652,9 @@
 					}
 				},
 				"resolve": {
-					"version": "1.17.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+					"version": "1.15.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+					"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
 					"requires": {
 						"path-parse": "^1.0.6"
 					}
@@ -7771,9 +7680,9 @@
 			"integrity": "sha512-epsA4g804mRovlOHSbeO1xxW7REGeUjULRME9MJTJDOVscNIA01AkR66TP4cmHDfD+w72EQ9cPhf37MbZiFI2w=="
 		},
 		"eslint-plugin-prettier": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.3.tgz",
-			"integrity": "sha512-+HG5jmu/dN3ZV3T6eCD7a4BlAySdN7mLIbJYo0z1cFQuI+r2DiTJEFeF68ots93PsnrMxbzIZ2S/ieX+mkrBeQ==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
+			"integrity": "sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==",
 			"requires": {
 				"prettier-linter-helpers": "^1.0.0"
 			}
@@ -7804,9 +7713,9 @@
 					}
 				},
 				"resolve": {
-					"version": "1.17.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+					"version": "1.15.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+					"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
 					"requires": {
 						"path-parse": "^1.0.6"
 					}
@@ -7973,18 +7882,11 @@
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"esquery": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
-			"integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
+			"integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
 			"requires": {
-				"estraverse": "^5.1.0"
-			},
-			"dependencies": {
-				"estraverse": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
-					"integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw=="
-				}
+				"estraverse": "^4.0.0"
 			}
 		},
 		"esrecurse": {
@@ -8326,14 +8228,14 @@
 			}
 		},
 		"extract-zip": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
-			"integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+			"integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
 			"requires": {
-				"concat-stream": "^1.6.2",
-				"debug": "^2.6.9",
-				"mkdirp": "^0.5.4",
-				"yauzl": "^2.10.0"
+				"concat-stream": "1.6.2",
+				"debug": "2.6.9",
+				"mkdirp": "0.5.1",
+				"yauzl": "2.4.1"
 			},
 			"dependencies": {
 				"debug": {
@@ -8342,19 +8244,6 @@
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"requires": {
 						"ms": "2.0.0"
-					}
-				},
-				"minimist": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-				},
-				"mkdirp": {
-					"version": "0.5.5",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-					"requires": {
-						"minimist": "^1.2.5"
 					}
 				},
 				"ms": {
@@ -8483,9 +8372,9 @@
 			"integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
 		},
 		"fd-slicer": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-			"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+			"integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
 			"requires": {
 				"pend": "~1.2.0"
 			}
@@ -8632,18 +8521,6 @@
 			"requires": {
 				"loader-utils": "^1.0.2",
 				"schema-utils": "^1.0.0"
-			},
-			"dependencies": {
-				"schema-utils": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-errors": "^1.0.0",
-						"ajv-keywords": "^3.1.0"
-					}
-				}
 			}
 		},
 		"file-uri-to-path": {
@@ -8861,9 +8738,9 @@
 			}
 		},
 		"flatted": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-			"integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+			"integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg=="
 		},
 		"flush-write-stream": {
 			"version": "1.1.1",
@@ -10320,9 +10197,9 @@
 			}
 		},
 		"handle-thing": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
-			"integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
+			"integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
 		},
 		"handlebars": {
 			"version": "4.7.3",
@@ -10577,9 +10454,9 @@
 			}
 		},
 		"html-entities": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
-			"integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA=="
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+			"integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
 		},
 		"html-escaper": {
 			"version": "2.0.0",
@@ -11273,8 +11150,7 @@
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-			"dev": true
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
 		},
 		"is-regex": {
 			"version": "1.0.5",
@@ -11325,6 +11201,11 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
 			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+		},
+		"is-what": {
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/is-what/-/is-what-3.7.1.tgz",
+			"integrity": "sha512-IAoapxlqyLSqt0Zr/7ZMT/fjEw9nwxxmz/TlBH+TJjvcXxmmAdRvo41W74uw3XJMGFpbeft97cpkPmLK89lJWw=="
 		},
 		"is-whitespace-character": {
 			"version": "1.0.4",
@@ -12376,9 +12257,9 @@
 			"dev": true
 		},
 		"jquery": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-			"integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+			"integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
 		},
 		"js-base64": {
 			"version": "2.5.2",
@@ -13019,9 +12900,9 @@
 			}
 		},
 		"loglevel": {
-			"version": "1.6.8",
-			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
-			"integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA=="
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",
+			"integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A=="
 		},
 		"loglevelnext": {
 			"version": "1.0.5",
@@ -13124,6 +13005,11 @@
 				"tmpl": "1.0.x"
 			}
 		},
+		"mamacro": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
+			"integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA=="
+		},
 		"map-age-cleaner": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
@@ -13174,9 +13060,9 @@
 			"integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q=="
 		},
 		"marked": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-			"integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw=="
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-0.8.1.tgz",
+			"integrity": "sha512-tZfJS8uE0zpo7xpTffwFwYRfW9AzNcdo04Qcjs+C9+oCy8MSRD2reD5iDVtYx8mtLaqsGughw/YLlcwNxAHA1g=="
 		},
 		"md5": {
 			"version": "2.2.1",
@@ -13225,6 +13111,11 @@
 				"mimic-fn": "^2.0.0",
 				"p-is-promise": "^2.0.0"
 			}
+		},
+		"memoize-one": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+			"integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
 		},
 		"memory-fs": {
 			"version": "0.5.0",
@@ -13416,6 +13307,14 @@
 				}
 			}
 		},
+		"merge-anything": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-2.4.4.tgz",
+			"integrity": "sha512-l5XlriUDJKQT12bH+rVhAHjwIuXWdAIecGwsYjv2LJo+dA1AeRTmeQS+3QBpO6lEthBMDi2IUMpLC1yyRvGlwQ==",
+			"requires": {
+				"is-what": "^3.3.1"
+			}
+		},
 		"merge-deep": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
@@ -13539,16 +13438,6 @@
 						"prepend-http": "^1.0.0",
 						"query-string": "^4.1.0",
 						"sort-keys": "^1.0.0"
-					}
-				},
-				"schema-utils": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-errors": "^1.0.0",
-						"ajv-keywords": "^3.1.0"
 					}
 				},
 				"sort-keys": {
@@ -13869,9 +13758,9 @@
 			}
 		},
 		"nan": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -14265,9 +14154,9 @@
 			}
 		},
 		"node-sass": {
-			"version": "4.14.0",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.0.tgz",
-			"integrity": "sha512-AxqU+DFpk0lEz95sI6jO0hU0Rwyw7BXVEv6o9OItoXLyeygPeaSpiV4rwQb10JiTghHaa0gZeD21sz+OsQluaw==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
+			"integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
 			"requires": {
 				"async-foreach": "^0.1.3",
 				"chalk": "^1.1.1",
@@ -14926,33 +14815,9 @@
 			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
 		},
 		"object-is": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
-			"integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.17.5",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-					"integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
-					"requires": {
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.1",
-						"is-callable": "^1.1.5",
-						"is-regex": "^1.0.5",
-						"object-inspect": "^1.7.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.0",
-						"string.prototype.trimleft": "^2.1.1",
-						"string.prototype.trimright": "^2.1.1"
-					}
-				}
-			}
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+			"integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
 		},
 		"object-keys": {
 			"version": "1.1.1",
@@ -15040,20 +14905,19 @@
 			"dev": true
 		},
 		"office-ui-fabric-react": {
-			"version": "7.108.0",
-			"resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.108.0.tgz",
-			"integrity": "sha512-xfKpXIBcU3smOLSH9j3a9GEpMp8FUxtsM3+HMGRxGWP7ask2nSWnBHnBSLT6liN+RfLHGt1PvKLUEuv1ZF3O0Q==",
+			"version": "7.105.1",
+			"resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.105.1.tgz",
+			"integrity": "sha512-xSwnPiYbOvbL8tOMaevt/sUWQaP9e7Wcbk4WHsUxydEBBDgVdYshbFM8E2FYwkky3ATKEVN1sCHz+AA7CXkPXg==",
 			"requires": {
-				"@fluentui/react-focus": "^7.7.0",
-				"@fluentui/react-icons": "^0.1.7",
+				"@fluentui/react-focus": "^7.1.8",
 				"@microsoft/load-themed-styles": "^1.10.26",
-				"@uifabric/foundation": "^7.7.6",
-				"@uifabric/icons": "^7.3.32",
-				"@uifabric/merge-styles": "^7.11.1",
-				"@uifabric/react-hooks": "^7.2.1",
-				"@uifabric/set-version": "^7.0.11",
-				"@uifabric/styling": "^7.11.9",
-				"@uifabric/utilities": "^7.16.0",
+				"@uifabric/foundation": "^7.5.21",
+				"@uifabric/icons": "^7.3.20",
+				"@uifabric/merge-styles": "^7.8.8",
+				"@uifabric/react-hooks": "^7.0.22",
+				"@uifabric/set-version": "^7.0.7",
+				"@uifabric/styling": "^7.10.21",
+				"@uifabric/utilities": "^7.15.1",
 				"prop-types": "^15.7.2",
 				"tslib": "^1.10.0"
 			}
@@ -15819,9 +15683,9 @@
 			"integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk="
 		},
 		"prosemirror-commands": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.1.4.tgz",
-			"integrity": "sha512-kj4Qi+8h3EpJtZuuEDwZ9h2/QNGWDsIX/CzjmClxi9GhxWyBUMVUvIFk0mgdqHyX20lLeGmOpc0TLA5aPzgpWg==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.1.3.tgz",
+			"integrity": "sha512-YVbKwTR4likoyhuwIUC9egbzHvnFrFUNbiesB0DB/HZ8hBcopQ42Tb4KGlYrS3n+pNDTFObN73CLFY6mYLN2IQ==",
 			"requires": {
 				"prosemirror-model": "^1.0.0",
 				"prosemirror-state": "^1.0.0",
@@ -15855,9 +15719,9 @@
 			}
 		},
 		"prosemirror-gapcursor": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.1.5.tgz",
-			"integrity": "sha512-SjbUZq5pgsBDuV3hu8GqgIpZR5eZvGLM+gPQTqjVVYSMUCfKW3EGXTEYaLHEl1bGduwqNC95O3bZflgtAb4L6w==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.1.3.tgz",
+			"integrity": "sha512-/lgWvt2AdHjsM6oEsF65z0lhdQJGl6sQSfXSOX8/xjpd8ycfOolhgKZd4TPYpikwnh85JF4l5eIyiFZsl/RQQA==",
 			"requires": {
 				"prosemirror-keymap": "^1.0.0",
 				"prosemirror-model": "^1.0.0",
@@ -15931,17 +15795,17 @@
 			}
 		},
 		"prosemirror-transform": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.2.5.tgz",
-			"integrity": "sha512-eqeIaxWtUfOnpA1ERrXCuSIMzqIJtL9Qrs5uJMCjY5RMSaH5o4pc390SAjn/IDPeIlw6auh0hCCXs3wRvGnQug==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.2.4.tgz",
+			"integrity": "sha512-0A668uf0EN89L9O9brE05kHcqp7FHmT5YN7Tom58Kj926QqOBs7iNRHDLWxrSaQB5MNZtzDOD9T3EyJ88YDcBg==",
 			"requires": {
 				"prosemirror-model": "^1.0.0"
 			}
 		},
 		"prosemirror-view": {
-			"version": "1.14.7",
-			"resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.14.7.tgz",
-			"integrity": "sha512-ZCRbGAmJa0ORIY4xrDvOpxS/oAnph3egDauvQEI7SX4eex0zovUfC61I5X4AtPCaNN4JpLWEk60voCWi0cE2vA==",
+			"version": "1.14.4",
+			"resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.14.4.tgz",
+			"integrity": "sha512-qPlKWigymKio7Ed52E+mwZEn2TJE28u8Masj0ygGHYZRhY/abB/s0XEGLwx2FTsvt92gIqfRRezhUzTk3eE2rQ==",
 			"requires": {
 				"prosemirror-model": "^1.1.0",
 				"prosemirror-state": "^1.0.0",
@@ -16166,9 +16030,9 @@
 			}
 		},
 		"rc-animate": {
-			"version": "2.11.1",
-			"resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.11.1.tgz",
-			"integrity": "sha512-1NyuCGFJG/0Y+9RKh5y/i/AalUCA51opyyS/jO2seELpgymZm2u9QV3xwODwEuzkmeQ1BDPxMLmYLcTJedPlkQ==",
+			"version": "2.10.3",
+			"resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.10.3.tgz",
+			"integrity": "sha512-A9qQ5Y8BLlM7EhuCO3fWb/dChndlbWtY/P5QvPqBU7h4r5Q2QsvsbpTGgdYZATRDZbTRnJXXfVk9UtlyS7MBLg==",
 			"requires": {
 				"babel-runtime": "6.x",
 				"classnames": "^2.2.6",
@@ -16219,11 +16083,12 @@
 			}
 		},
 		"rc-util": {
-			"version": "4.20.5",
-			"resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.20.5.tgz",
-			"integrity": "sha512-f67s4Dt1quBYhrVPq5QMKmK3eS2hN1NNIAyhaiG0HmvqiGYAXMQ7SP2AlGqv750vnzhJs38JklbkWT1/wjhFPg==",
+			"version": "4.20.1",
+			"resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.20.1.tgz",
+			"integrity": "sha512-EGlDg9KPN0POzmAR2hk9ZyFc3DmJIrXwlC8NoDxJguX2LTINnVqwadLIVauLfYgYISMiFYFrSHiFW+cqUhZ5dA==",
 			"requires": {
 				"add-dom-event-listener": "^1.1.0",
+				"babel-runtime": "6.x",
 				"prop-types": "^15.5.10",
 				"react-is": "^16.12.0",
 				"react-lifecycles-compat": "^3.0.4",
@@ -16231,9 +16096,9 @@
 			}
 		},
 		"react": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-			"integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+			"version": "16.13.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.13.0.tgz",
+			"integrity": "sha512-TSavZz2iSLkq5/oiE7gnFzmURKZMltmi193rm5HEoUDAXpzT9Kzw6oNZnGoai/4+fUnm7FqS5dwgUL34TujcWQ==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -16259,23 +16124,23 @@
 			}
 		},
 		"react-countdown360": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/react-countdown360/-/react-countdown360-1.3.2.tgz",
-			"integrity": "sha512-tS9BncwpalPxobaK1tEZdkycr+om1XAG+oTDnHrCrEDuMJcda2gLtFKFZXzbTWvU4GPTdfEBB0fHTwbvVqJ1GA==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/react-countdown360/-/react-countdown360-1.3.1.tgz",
+			"integrity": "sha512-CrZzLB27hQIxnFpQe70bEVJWFEvcSnJ3J7bYym9tucG9HpJJ2zL4ReUElaB/4QHu5KuAWp5s1yT/cgiP+8yinA==",
 			"requires": {
 				"prop-types": "^15.7.2",
-				"styled-components": "^5.1.0"
+				"styled-components": "^4.4.0"
 			}
 		},
 		"react-dom": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
-			"integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
+			"version": "16.13.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.0.tgz",
+			"integrity": "sha512-y09d2c4cG220DzdlFkPTnVvGTszVvNpC73v+AaLGLHbkpy3SSgvYq8x0rNwPJ/Rk/CicTNgk0hbHNw1gMEZAXg==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
-				"scheduler": "^0.19.1"
+				"scheduler": "^0.19.0"
 			}
 		},
 		"react-draggable": {
@@ -16322,9 +16187,9 @@
 			}
 		},
 		"react-is": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+			"version": "16.13.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
+			"integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA=="
 		},
 		"react-lifecycles-compat": {
 			"version": "3.0.4",
@@ -16366,9 +16231,9 @@
 			},
 			"dependencies": {
 				"react-draggable": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.3.1.tgz",
-					"integrity": "sha512-m8QeV+eIi7LhD5mXoLqDzLbokc6Ncwa0T34fF6uJzWSs4vc4fdZI/XGqHYoEn91T8S6qO+BSXslONh7Jz9VPQQ==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.2.0.tgz",
+					"integrity": "sha512-5wFq//gEoeTYprnd4ze8GrFc+Rbnx+9RkOMR3vk4EbWxj02U6L6T3yrlKeiw4X5CtjD2ma2+b3WujghcXNRzkw==",
 					"requires": {
 						"classnames": "^2.2.5",
 						"prop-types": "^15.6.0"
@@ -16757,9 +16622,9 @@
 			}
 		},
 		"regexpp": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q=="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
+			"integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g=="
 		},
 		"regexpu-core": {
 			"version": "4.7.0",
@@ -17399,21 +17264,22 @@
 			}
 		},
 		"scheduler": {
-			"version": "0.19.1",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-			"integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.0.tgz",
+			"integrity": "sha512-xowbVaTPe9r7y7RUejcK73/j8tt2jfiyTednOvHbA8JoClvMYCp+r8QegLwK/n8zWQAtZb1fFnER4XLBZXrCxA==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
 			}
 		},
 		"schema-utils": {
-			"version": "2.6.6",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.6.tgz",
-			"integrity": "sha512-wHutF/WPSbIi9x6ctjGGk2Hvl0VOz5l3EKEuKbjPlB30mKZUzb9A5k9yEXRX3pwyqVLPvpfZZEllaFq/M718hA==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+			"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
 			"requires": {
-				"ajv": "^6.12.0",
-				"ajv-keywords": "^3.4.1"
+				"ajv": "^6.1.0",
+				"ajv-errors": "^1.0.0",
+				"ajv-keywords": "^3.1.0"
 			}
 		},
 		"scss-tokenizer": {
@@ -18194,9 +18060,9 @@
 			}
 		},
 		"source-map-support": {
-			"version": "0.5.19",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-			"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+			"integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -18296,9 +18162,9 @@
 			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
 		},
 		"spdy": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
-			"integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.1.tgz",
+			"integrity": "sha512-HeZS3PBdMA+sZSu0qwpCxl3DeALD5ASx8pAX0jZdKXSpPWbQ6SYGnlg3BBmYLx5LtiZrmkAZfErCm2oECBcioA==",
 			"requires": {
 				"debug": "^4.1.0",
 				"handle-thing": "^2.0.0",
@@ -18675,9 +18541,9 @@
 			"dev": true
 		},
 		"strip-json-comments": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
-			"integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w=="
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+			"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
 		},
 		"strong-log-transformer": {
 			"version": "2.1.0",
@@ -18699,53 +18565,42 @@
 			}
 		},
 		"style-loader": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.2.1.tgz",
-			"integrity": "sha512-ByHSTQvHLkWE9Ir5+lGbVOXhxX10fbprhLvdg96wedFZb4NDekDPxVKv5Fwmio+QcMlkkNfuK+5W1peQ5CUhZg==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.1.3.tgz",
+			"integrity": "sha512-rlkH7X/22yuwFYK357fMN/BxYOorfnfq0eD7+vqlemSK4wEcejFF1dg4zxP0euBW8NrYx2WZzZ8PPFevr7D+Kw==",
 			"requires": {
-				"loader-utils": "^2.0.0",
-				"schema-utils": "^2.6.6"
+				"loader-utils": "^1.2.3",
+				"schema-utils": "^2.6.4"
 			},
 			"dependencies": {
-				"json5": {
-					"version": "2.1.3",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-					"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+				"schema-utils": {
+					"version": "2.6.5",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.5.tgz",
+					"integrity": "sha512-5KXuwKziQrTVHh8j/Uxz+QUbxkaLW9X/86NBlx/gnKgtsZA2GIVMUn17qWhRFwF8jdYb3Dig5hRO/W5mZqy6SQ==",
 					"requires": {
-						"minimist": "^1.2.5"
+						"ajv": "^6.12.0",
+						"ajv-keywords": "^3.4.1"
 					}
-				},
-				"loader-utils": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-					"integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-					"requires": {
-						"big.js": "^5.2.2",
-						"emojis-list": "^3.0.0",
-						"json5": "^2.1.2"
-					}
-				},
-				"minimist": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 				}
 			}
 		},
 		"styled-components": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.1.0.tgz",
-			"integrity": "sha512-0Qs2wEkFBXHFlysz6CV831VG6HedcrFUwChjnWylNivsx14MtmqQsohi21rMHZxzuTba063dEyoe/SR6VGJI7Q==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.4.1.tgz",
+			"integrity": "sha512-RNqj14kYzw++6Sr38n7197xG33ipEOktGElty4I70IKzQF1jzaD1U4xQ+Ny/i03UUhHlC5NWEO+d8olRCDji6g==",
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
-				"@babel/traverse": "^7.4.5",
-				"@emotion/is-prop-valid": "^0.8.8",
-				"@emotion/stylis": "^0.8.4",
-				"@emotion/unitless": "^0.7.4",
+				"@babel/traverse": "^7.0.0",
+				"@emotion/is-prop-valid": "^0.8.1",
+				"@emotion/unitless": "^0.7.0",
 				"babel-plugin-styled-components": ">= 1",
-				"css-to-react-native": "^3.0.0",
-				"hoist-non-react-statics": "^3.0.0",
-				"shallowequal": "^1.1.0",
+				"css-to-react-native": "^2.2.2",
+				"memoize-one": "^5.0.0",
+				"merge-anything": "^2.2.4",
+				"prop-types": "^15.5.4",
+				"react-is": "^16.6.0",
+				"stylis": "^3.5.0",
+				"stylis-rule-sheet": "^0.0.10",
 				"supports-color": "^5.5.0"
 			},
 			"dependencies": {
@@ -18758,6 +18613,16 @@
 					}
 				}
 			}
+		},
+		"stylis": {
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
+			"integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q=="
+		},
+		"stylis-rule-sheet": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
+			"integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
 		},
 		"sudokus": {
 			"version": "1.0.2",
@@ -19155,9 +19020,9 @@
 			}
 		},
 		"terser": {
-			"version": "4.6.12",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-4.6.12.tgz",
-			"integrity": "sha512-fnIwuaKjFPANG6MAixC/k1TDtnl1YlPLUlLVIxxGZUn1gfUx2+l3/zGNB72wya+lgsb50QBi2tUV75RiODwnww==",
+			"version": "4.6.7",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.6.7.tgz",
+			"integrity": "sha512-fmr7M1f7DBly5cX2+rFDvmGBAaaZyPrHYK4mMdHEDAdNTqXSZgSOfqsfGq2HqPGT/1V0foZZuCZFx8CHKgAk3g==",
 			"requires": {
 				"commander": "^2.20.0",
 				"source-map": "~0.6.1",
@@ -19178,18 +19043,6 @@
 				"terser": "^4.1.2",
 				"webpack-sources": "^1.4.0",
 				"worker-farm": "^1.7.0"
-			},
-			"dependencies": {
-				"schema-utils": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-errors": "^1.0.0",
-						"ajv-keywords": "^3.1.0"
-					}
-				}
 			}
 		},
 		"test-exclude": {
@@ -19509,9 +19362,9 @@
 					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"json5": {
-					"version": "2.1.3",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-					"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
+					"integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
 					"requires": {
 						"minimist": "^1.2.5"
 					}
@@ -19537,9 +19390,9 @@
 			}
 		},
 		"ts-loader": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.2.tgz",
-			"integrity": "sha512-HDo5kXZCBml3EUPcc7RlZOV/JGlLHwppTLEHb3SHnr5V7NXD4klMEkrhJe5wgRbaWsSXi+Y1SIBN/K9B6zWGWQ==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.1.tgz",
+			"integrity": "sha512-Dd9FekWuABGgjE1g0TlQJ+4dFUfYGbYcs52/HQObE0ZmUNjQlmLAS7xXsSzy23AMaMwipsx5sNHvoEpT2CZq1g==",
 			"requires": {
 				"chalk": "^2.3.0",
 				"enhanced-resolve": "^4.0.0",
@@ -20318,6 +20171,15 @@
 					"version": "2.4.4",
 					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
 					"integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+				},
+				"schema-utils": {
+					"version": "2.6.5",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.5.tgz",
+					"integrity": "sha512-5KXuwKziQrTVHh8j/Uxz+QUbxkaLW9X/86NBlx/gnKgtsZA2GIVMUn17qWhRFwF8jdYb3Dig5hRO/W5mZqy6SQ==",
+					"requires": {
+						"ajv": "^6.12.0",
+						"ajv-keywords": "^3.4.1"
+					}
 				}
 			}
 		},
@@ -20435,9 +20297,9 @@
 			}
 		},
 		"vfile": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/vfile/-/vfile-4.1.0.tgz",
-			"integrity": "sha512-BaTPalregj++64xbGK6uIlsurN3BCRNM/P2Pg8HezlGzKd1O9PrwIac6bd9Pdx2uTb0QHoioZ+rXKolbVXEgJg==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.3.tgz",
+			"integrity": "sha512-lREgT5sF05TQk68LO6APy0In+TkFGnFEgKChK2+PHIaTrFQ9oHCKXznZ7VILwgYVBcl0gv4lGATFZBLhi2kVQg==",
 			"requires": {
 				"@types/unist": "^2.0.0",
 				"is-buffer": "^2.0.0",
@@ -20459,9 +20321,9 @@
 			"integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
 		},
 		"vfile-message": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
-			"integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.3.tgz",
+			"integrity": "sha512-qQg/2z8qnnBHL0psXyF72kCjb9YioIynvyltuNKFaUhRtqTIcIMP3xnBaPzirVZNuBrUe1qwFciSx2yApa4byw==",
 			"requires": {
 				"@types/unist": "^2.0.0",
 				"unist-util-stringify-position": "^2.0.0"
@@ -20481,9 +20343,9 @@
 			}
 		},
 		"w3c-keyname": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.4.tgz",
-			"integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw=="
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.2.tgz",
+			"integrity": "sha512-8Vs/aVwcy0IJACaPm4tyzh1fzehZE70bGSjEl3dDms5UXtWnaBElrSHC8lDDeak0Gk5jxKOFstL64/65o7Ge2A=="
 		},
 		"wait-on": {
 			"version": "3.3.0",
@@ -20538,11 +20400,11 @@
 			}
 		},
 		"watchpack": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.1.tgz",
-			"integrity": "sha512-+IF9hfUFOrYOOaKyfaI7h7dquUIOgyEMoQMLA7OP5FxegKA2+XdXThAZ9TU2kucfhDH7rfMHs1oPYziVGWRnZA==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
+			"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
 			"requires": {
-				"chokidar": "^2.1.8",
+				"chokidar": "^2.0.2",
 				"graceful-fs": "^4.1.2",
 				"neo-async": "^2.5.0"
 			}
@@ -20570,15 +20432,15 @@
 			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
 		},
 		"webpack": {
-			"version": "4.43.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.43.0.tgz",
-			"integrity": "sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==",
+			"version": "4.42.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.42.0.tgz",
+			"integrity": "sha512-EzJRHvwQyBiYrYqhyjW9AqM90dE4+s1/XtCfn7uWg6cS72zH+2VPFAlsnW0+W0cDi0XRjNKUMoJtpSi50+Ph6w==",
 			"requires": {
-				"@webassemblyjs/ast": "1.9.0",
-				"@webassemblyjs/helper-module-context": "1.9.0",
-				"@webassemblyjs/wasm-edit": "1.9.0",
-				"@webassemblyjs/wasm-parser": "1.9.0",
-				"acorn": "^6.4.1",
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-module-context": "1.8.5",
+				"@webassemblyjs/wasm-edit": "1.8.5",
+				"@webassemblyjs/wasm-parser": "1.8.5",
+				"acorn": "^6.2.1",
 				"ajv": "^6.10.2",
 				"ajv-keywords": "^3.4.1",
 				"chrome-trace-event": "^1.0.2",
@@ -20589,13 +20451,13 @@
 				"loader-utils": "^1.2.3",
 				"memory-fs": "^0.4.1",
 				"micromatch": "^3.1.10",
-				"mkdirp": "^0.5.3",
+				"mkdirp": "^0.5.1",
 				"neo-async": "^2.6.1",
 				"node-libs-browser": "^2.2.1",
 				"schema-utils": "^1.0.0",
 				"tapable": "^1.1.3",
 				"terser-webpack-plugin": "^1.4.3",
-				"watchpack": "^1.6.1",
+				"watchpack": "^1.6.0",
 				"webpack-sources": "^1.4.1"
 			},
 			"dependencies": {
@@ -20627,19 +20489,6 @@
 						"readable-stream": "^2.0.1"
 					}
 				},
-				"minimist": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-				},
-				"mkdirp": {
-					"version": "0.5.5",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-					"requires": {
-						"minimist": "^1.2.5"
-					}
-				},
 				"readable-stream": {
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -20652,16 +20501,6 @@
 						"safe-buffer": "~5.1.1",
 						"string_decoder": "~1.1.1",
 						"util-deprecate": "~1.0.1"
-					}
-				},
-				"schema-utils": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-errors": "^1.0.0",
-						"ajv-keywords": "^3.1.0"
 					}
 				},
 				"string_decoder": {
@@ -21009,16 +20848,6 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"schema-utils": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-errors": "^1.0.0",
-						"ajv-keywords": "^3.1.0"
-					}
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
@@ -21431,12 +21260,11 @@
 			}
 		},
 		"yauzl": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-			"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+			"integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
 			"requires": {
-				"buffer-crc32": "~0.2.3",
-				"fd-slicer": "~1.1.0"
+				"fd-slicer": "~1.0.1"
 			}
 		},
 		"yeast": {

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -210,16 +210,38 @@
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.8.6.tgz",
-			"integrity": "sha512-klTBDdsr+VFFqaDHm5rR69OpEQtO2Qv8ECxHS1mNhJJvaHArR6a1xTf5K/eZW7eZpJbhCx3NW1Yt/sKsLXLblg==",
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.9.5.tgz",
+			"integrity": "sha512-IipaxGaQmW4TfWoXdqjY0TzoXQ1HRS0kPpEgvjosb3u7Uedcq297xFqDQiCcQtRRwzIMif+N1MLVI8C5a4/PAA==",
 			"requires": {
-				"@babel/helper-function-name": "^7.8.3",
+				"@babel/helper-function-name": "^7.9.5",
 				"@babel/helper-member-expression-to-functions": "^7.8.3",
 				"@babel/helper-optimise-call-expression": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3",
 				"@babel/helper-replace-supers": "^7.8.6",
 				"@babel/helper-split-export-declaration": "^7.8.3"
+			},
+			"dependencies": {
+				"@babel/helper-function-name": {
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+					"integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.3",
+						"@babel/template": "^7.8.3",
+						"@babel/types": "^7.9.5"
+					}
+				},
+				"@babel/types": {
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.9.5",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-function-name": {
@@ -281,43 +303,53 @@
 			},
 			"dependencies": {
 				"@babel/generator": {
-					"version": "7.8.8",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.8.tgz",
-					"integrity": "sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==",
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
+					"integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
 					"requires": {
-						"@babel/types": "^7.8.7",
+						"@babel/types": "^7.9.5",
 						"jsesc": "^2.5.1",
 						"lodash": "^4.17.13",
 						"source-map": "^0.5.0"
 					}
 				},
+				"@babel/helper-function-name": {
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+					"integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.3",
+						"@babel/template": "^7.8.3",
+						"@babel/types": "^7.9.5"
+					}
+				},
 				"@babel/parser": {
-					"version": "7.8.8",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
-					"integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
+					"version": "7.9.4",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+					"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
 				},
 				"@babel/traverse": {
-					"version": "7.8.6",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
-					"integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
+					"integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
 					"requires": {
 						"@babel/code-frame": "^7.8.3",
-						"@babel/generator": "^7.8.6",
-						"@babel/helper-function-name": "^7.8.3",
+						"@babel/generator": "^7.9.5",
+						"@babel/helper-function-name": "^7.9.5",
 						"@babel/helper-split-export-declaration": "^7.8.3",
-						"@babel/parser": "^7.8.6",
-						"@babel/types": "^7.8.6",
+						"@babel/parser": "^7.9.0",
+						"@babel/types": "^7.9.5",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.13"
 					}
 				},
 				"@babel/types": {
-					"version": "7.8.7",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-					"integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+					"version": "7.9.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+					"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
 					"requires": {
-						"esutils": "^2.0.2",
+						"@babel/helper-validator-identifier": "^7.9.5",
 						"lodash": "^4.17.13",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -336,6 +368,11 @@
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
+		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+			"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
 		},
 		"@babel/helpers": {
 			"version": "7.8.4",
@@ -380,9 +417,9 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.8.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-			"integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+			"version": "7.9.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
@@ -461,6 +498,11 @@
 			"version": "0.7.4",
 			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
 			"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+		},
+		"@emotion/stylis": {
+			"version": "0.8.5",
+			"resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+			"integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
 		},
 		"@emotion/unitless": {
 			"version": "0.7.5",
@@ -586,21 +628,32 @@
 			}
 		},
 		"@fluentui/react-focus": {
-			"version": "7.1.8",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.1.8.tgz",
-			"integrity": "sha512-SIjBYGVF88D5TNf00HdMaVYDqUp4UaI5pGx8jpzp/aDQfj7YsWpFoVzOrq9p1LXPJ9UkpMYh6SpXStPDO7t8FQ==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.7.0.tgz",
+			"integrity": "sha512-HG7rWibSEgWJXEJKTQhZ9IK3oBBv/05KIngVihQB2kDoy0GDvgleoacMwAgBBBhCdtm1/wHItIz/EVPJzeXCJA==",
 			"requires": {
-				"@uifabric/merge-styles": "^7.8.8",
-				"@uifabric/set-version": "^7.0.7",
-				"@uifabric/styling": "^7.10.21",
-				"@uifabric/utilities": "^7.15.1",
+				"@uifabric/merge-styles": "^7.11.1",
+				"@uifabric/set-version": "^7.0.11",
+				"@uifabric/styling": "^7.11.9",
+				"@uifabric/utilities": "^7.16.0",
+				"tslib": "^1.10.0"
+			}
+		},
+		"@fluentui/react-icons": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-0.1.7.tgz",
+			"integrity": "sha512-bseI3dRnmX7blvAtnkM/eNSTR2g3qlatXjAA8wXr8q3d8xLWTIyWBKIXSETweUG4Yiz8d54VYg06GKqOTSrHlg==",
+			"requires": {
+				"@uifabric/set-version": "^7.0.11",
+				"@uifabric/styling": "^7.11.9",
+				"@uifabric/utilities": "^7.16.0",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@fortawesome/fontawesome-free": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.12.1.tgz",
-			"integrity": "sha512-ZtjIIFplxncqxvogq148C3hBLQE+W3iJ8E4UvJ09zIJUgzwLcROsWwFDErVSXY2Plzao5J9KUYNHKHMEUYDMKw=="
+			"version": "5.13.0",
+			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.13.0.tgz",
+			"integrity": "sha512-xKOeQEl5O47GPZYIMToj6uuA2syyFlq9EMSl2ui0uytjY9xbe8XS0pexNWmxrdcCyNGyDmLyYw5FtKsalBUeOg=="
 		},
 		"@hapi/address": {
 			"version": "2.1.4",
@@ -2106,9 +2159,9 @@
 			}
 		},
 		"@microsoft/eslint-config-fluid": {
-			"version": "0.15.22492",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2feslint-config-fluid/-/eslint-config-fluid-0.15.22492.tgz",
-			"integrity": "sha512-PXe5BJyonSkTGuJmru52VgwFaS/VL5pKhgF1pOwGLb3X4F8wq4xB8YKSGh3qWo2XmT2dbTXOaOZV2HPijZktkw==",
+			"version": "0.15.22637",
+			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2feslint-config-fluid/-/eslint-config-fluid-0.15.22637.tgz",
+			"integrity": "sha512-WSqvZgK8lAorQR2egur3HDwOpaXLP53LFL8XO8S8kVyCwUsw5vhSRYLrv7QihRoZ+w8N4f3LMh/0ffBQaZSS8w==",
 			"requires": {
 				"@typescript-eslint/eslint-plugin": "~2.17.0",
 				"@typescript-eslint/parser": "~2.17.0",
@@ -2145,74 +2198,73 @@
 			}
 		},
 		"@microsoft/fluid-gitresources": {
-			"version": "0.1003.22488",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-gitresources/-/fluid-gitresources-0.1003.22488.tgz",
-			"integrity": "sha512-BJcfgI/5SK9CfoGpko22zrzvrgZxvwX7+K2T+Wr5WzcLkel38mH1BFbWYwyGgfRY3rsc6W+Ka+77PUNUpZGinQ=="
+			"version": "0.1003.25082",
+			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-gitresources/-/fluid-gitresources-0.1003.25082.tgz",
+			"integrity": "sha512-c2hHJWXite1Nmq+cA8cNacR9+w2fKsQ5qkUbJFfN1P0VuLJ6+Q1tG4tI8xlaVkQWnvipZh1v3rRorDBFiTidnw=="
 		},
 		"@microsoft/fluid-protocol-base": {
-			"version": "0.1003.22488",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-protocol-base/-/fluid-protocol-base-0.1003.22488.tgz",
-			"integrity": "sha512-BlR+ZmcYAzARxsmJasuui3HObt52O2UY9tS05pmim0o+CpB7MnWrEw85NVMSwUN2ZvSraZusFWbT94W1YQMzLw==",
+			"version": "0.1003.25082",
+			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-protocol-base/-/fluid-protocol-base-0.1003.25082.tgz",
+			"integrity": "sha512-6zkV6bjttTm6auMEN0NAP0AhyGr4B2YsjK3VUldlefhVlsVk41EVtuUzOUFGAnQcdWV378nuq5paT5/sDL1Hww==",
 			"requires": {
 				"@microsoft/fluid-common-utils": "^0.14.0",
-				"@microsoft/fluid-gitresources": "^0.1003.22488",
-				"@microsoft/fluid-protocol-definitions": "^0.1003.22488",
+				"@microsoft/fluid-gitresources": "^0.1003.25082",
+				"@microsoft/fluid-protocol-definitions": "^0.1003.25082",
 				"lodash": "^4.17.11"
 			}
 		},
 		"@microsoft/fluid-protocol-definitions": {
-			"version": "0.1003.22488",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-protocol-definitions/-/fluid-protocol-definitions-0.1003.22488.tgz",
-			"integrity": "sha512-2ZaYm6jVqHWGyjnGFnGFJQPEpoqmOQVssKtRTBQDmiEtDfAljESQ/cO25BohVMrA4t0lKkakcy4qoAYWjSmnEw==",
+			"version": "0.1003.25082",
+			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-protocol-definitions/-/fluid-protocol-definitions-0.1003.25082.tgz",
+			"integrity": "sha512-II8ksufv90axO5SkySduAHIBviuuH986dY9BvOAzNcoOT8eJGaYuNP87FJmNw9LNZclHg3cIwlyozlKBr4ZbGg==",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.13.0"
 			}
 		},
 		"@microsoft/fluid-server-lambdas": {
-			"version": "0.1003.22488",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-server-lambdas/-/fluid-server-lambdas-0.1003.22488.tgz",
-			"integrity": "sha512-i9vjm+HnOWAc+gqoSIMtfVZi3fc97jjzXS7umWZY4MeRRx/c9pvSfq5857WoTLVLJ1lOwW/yAkq1Ouzl0gOzbg==",
+			"version": "0.1003.25082",
+			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-server-lambdas/-/fluid-server-lambdas-0.1003.25082.tgz",
+			"integrity": "sha512-mQa8x7Z++7PioVTortY6tVgnsCKJTD+1zm3RfbWtDU7Pqp9RoOnD4eu/pZ0CCG5I5820tJAOVW3kQsbDkR4qUw==",
 			"requires": {
 				"@microsoft/fluid-common-utils": "^0.14.0",
-				"@microsoft/fluid-gitresources": "^0.1003.22488",
-				"@microsoft/fluid-protocol-base": "^0.1003.22488",
-				"@microsoft/fluid-protocol-definitions": "^0.1003.22488",
-				"@microsoft/fluid-server-services-client": "^0.1003.22488",
-				"@microsoft/fluid-server-services-core": "^0.1003.22488",
+				"@microsoft/fluid-gitresources": "^0.1003.25082",
+				"@microsoft/fluid-protocol-base": "^0.1003.25082",
+				"@microsoft/fluid-protocol-definitions": "^0.1003.25082",
+				"@microsoft/fluid-server-services-client": "^0.1003.25082",
+				"@microsoft/fluid-server-services-core": "^0.1003.25082",
 				"@types/semver": "^6.0.1",
 				"async": "^2.6.1",
 				"double-ended-queue": "^2.1.0-0",
 				"jsonwebtoken": "^8.4.0",
 				"lodash": "^4.17.11",
-				"moniker": "^0.1.2",
 				"nconf": "^0.10.0",
 				"semver": "^6.3.0",
 				"uuid": "^3.3.2"
 			}
 		},
 		"@microsoft/fluid-server-local-server": {
-			"version": "0.1003.22488",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-server-local-server/-/fluid-server-local-server-0.1003.22488.tgz",
-			"integrity": "sha512-05kl95evzr9MPi8LEqyiVrWRxMaDPhKP4Bvk7Xg4DHNHvjOPgN54/rQydR3CbgHGK93FgFIzXSgZs4/Hv92RFA==",
+			"version": "0.1003.25082",
+			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-server-local-server/-/fluid-server-local-server-0.1003.25082.tgz",
+			"integrity": "sha512-KmzLhIbOWTOzll1oH8zDWdEL66rpdFy/4uxdOppISHaoktfgrPJAyCsCISQPhZ8z6GOctMGH5ypzmBMlTg4cfw==",
 			"requires": {
-				"@microsoft/fluid-server-lambdas": "^0.1003.22488",
-				"@microsoft/fluid-server-memory-orderer": "^0.1003.22488",
-				"@microsoft/fluid-server-services-core": "^0.1003.22488",
-				"@microsoft/fluid-server-test-utils": "^0.1003.22488"
+				"@microsoft/fluid-server-lambdas": "^0.1003.25082",
+				"@microsoft/fluid-server-memory-orderer": "^0.1003.25082",
+				"@microsoft/fluid-server-services-core": "^0.1003.25082",
+				"@microsoft/fluid-server-test-utils": "^0.1003.25082"
 			}
 		},
 		"@microsoft/fluid-server-memory-orderer": {
-			"version": "0.1003.22488",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-server-memory-orderer/-/fluid-server-memory-orderer-0.1003.22488.tgz",
-			"integrity": "sha512-M+tjORwZYnubpbGbfw1IQVdeDfePP+glnAr31xUO//RlC+r3oN8qdFyQ3oESiw9uDcFSpPVFP8lggfKvACYJiQ==",
+			"version": "0.1003.25082",
+			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-server-memory-orderer/-/fluid-server-memory-orderer-0.1003.25082.tgz",
+			"integrity": "sha512-NCCQFmV9VgfKxno8nSuNa0mBVCtU3nLqfCHoTaCJV1qGaB9tuFyqF/GErMgubHnjgm2uCP1ZYFW+J/uYNidCVA==",
 			"requires": {
 				"@microsoft/fluid-common-utils": "^0.14.0",
-				"@microsoft/fluid-protocol-base": "^0.1003.22488",
-				"@microsoft/fluid-protocol-definitions": "^0.1003.22488",
-				"@microsoft/fluid-server-lambdas": "^0.1003.22488",
-				"@microsoft/fluid-server-services-client": "^0.1003.22488",
-				"@microsoft/fluid-server-services-core": "^0.1003.22488",
-				"@microsoft/fluid-server-test-utils": "^0.1003.22488",
+				"@microsoft/fluid-protocol-base": "^0.1003.25082",
+				"@microsoft/fluid-protocol-definitions": "^0.1003.25082",
+				"@microsoft/fluid-server-lambdas": "^0.1003.25082",
+				"@microsoft/fluid-server-services-client": "^0.1003.25082",
+				"@microsoft/fluid-server-services-core": "^0.1003.25082",
+				"@microsoft/fluid-server-test-utils": "^0.1003.25082",
 				"@types/debug": "^0.0.31",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/lodash": "^4.14.118",
@@ -2228,14 +2280,14 @@
 			}
 		},
 		"@microsoft/fluid-server-services-client": {
-			"version": "0.1003.22488",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-server-services-client/-/fluid-server-services-client-0.1003.22488.tgz",
-			"integrity": "sha512-6YCtM4oHroqESMWvO8q0FPtJ1cZ1e8T6MKDVmwue3ll4XxcDHxZTweugBa6QNs5SF8Yw/QDslm1yXlxlRQ+Jug==",
+			"version": "0.1003.25082",
+			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-server-services-client/-/fluid-server-services-client-0.1003.25082.tgz",
+			"integrity": "sha512-J/JrmwcJcTWmgUKHyy+1rnFBTB9FbNR13xfy8DpKAq4GL/2YwpZ/eac6pWDfo9bfhgATgT8c68hK9Yi02zUqEg==",
 			"requires": {
 				"@microsoft/fluid-common-utils": "^0.14.0",
-				"@microsoft/fluid-gitresources": "^0.1003.22488",
-				"@microsoft/fluid-protocol-base": "^0.1003.22488",
-				"@microsoft/fluid-protocol-definitions": "^0.1003.22488",
+				"@microsoft/fluid-gitresources": "^0.1003.25082",
+				"@microsoft/fluid-protocol-base": "^0.1003.25082",
+				"@microsoft/fluid-protocol-definitions": "^0.1003.25082",
 				"@types/node": "^10.14.6",
 				"axios": "^0.18.0",
 				"debug": "^4.1.1",
@@ -2244,14 +2296,14 @@
 			}
 		},
 		"@microsoft/fluid-server-services-core": {
-			"version": "0.1003.22488",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-server-services-core/-/fluid-server-services-core-0.1003.22488.tgz",
-			"integrity": "sha512-ebzXDLI2/dO2lU7e7j03EwD4OEtPQb6SfQ3Bq5B25ffKOa7YFVhhTN+WD02iImlcw4lxqkIcCf2nKd+WnpaEKw==",
+			"version": "0.1003.25082",
+			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-server-services-core/-/fluid-server-services-core-0.1003.25082.tgz",
+			"integrity": "sha512-Vh9nRbC+iW9lc73kQtrVfAwb+A4mABniBJ+JJkDAoXQpZ7OzuLvkLejVQZ/PZ4rJkENJRRES9/I9J7JX7sI2ow==",
 			"requires": {
 				"@microsoft/fluid-common-utils": "^0.14.0",
-				"@microsoft/fluid-gitresources": "^0.1003.22488",
-				"@microsoft/fluid-protocol-definitions": "^0.1003.22488",
-				"@microsoft/fluid-server-services-client": "^0.1003.22488",
+				"@microsoft/fluid-gitresources": "^0.1003.25082",
+				"@microsoft/fluid-protocol-definitions": "^0.1003.25082",
+				"@microsoft/fluid-server-services-client": "^0.1003.25082",
 				"@types/nconf": "^0.0.37",
 				"@types/node": "^10.14.6",
 				"debug": "^4.1.1",
@@ -2259,16 +2311,16 @@
 			}
 		},
 		"@microsoft/fluid-server-test-utils": {
-			"version": "0.1003.22488",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-server-test-utils/-/fluid-server-test-utils-0.1003.22488.tgz",
-			"integrity": "sha512-enLtO6+kPgqi3gIQJuL9NT8YU5tJfvghxu1zYRrRklPY7plycidloWPz4h4JGXYyropRg0auZaANbkgYSnZI6g==",
+			"version": "0.1003.25082",
+			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-server-test-utils/-/fluid-server-test-utils-0.1003.25082.tgz",
+			"integrity": "sha512-kQNbR6fTFaFdJfA4C0LhMUAezJyl3oSkLsI+RIZagLanfqk6c0kU5f+i0BnrsQscvEL0jq0TTVrXxVhOXqfX8g==",
 			"requires": {
 				"@microsoft/fluid-common-utils": "^0.14.0",
-				"@microsoft/fluid-gitresources": "^0.1003.22488",
-				"@microsoft/fluid-protocol-base": "^0.1003.22488",
-				"@microsoft/fluid-protocol-definitions": "^0.1003.22488",
-				"@microsoft/fluid-server-services-client": "^0.1003.22488",
-				"@microsoft/fluid-server-services-core": "^0.1003.22488",
+				"@microsoft/fluid-gitresources": "^0.1003.25082",
+				"@microsoft/fluid-protocol-base": "^0.1003.25082",
+				"@microsoft/fluid-protocol-definitions": "^0.1003.25082",
+				"@microsoft/fluid-server-services-client": "^0.1003.25082",
+				"@microsoft/fluid-server-services-core": "^0.1003.25082",
 				"debug": "^4.1.1",
 				"lodash": "^4.17.11",
 				"moniker": "^0.1.2",
@@ -2277,9 +2329,9 @@
 			}
 		},
 		"@microsoft/load-themed-styles": {
-			"version": "1.10.39",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2fload-themed-styles/-/load-themed-styles-1.10.39.tgz",
-			"integrity": "sha512-KKeQSM0FMTR7VtvkVF+D488zUmO3YoImxJ3O2xyLDEu9GqxqthF3Zvv1GddC2Jyoj2vuAJ0RGGgrI/T+MxLLDg=="
+			"version": "1.10.43",
+			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2fload-themed-styles/-/load-themed-styles-1.10.43.tgz",
+			"integrity": "sha512-9RUeBMXPHbT/qHTRIQi9oQs3bw5JkQGBQ8ayjycq95q+1OUI9jBJPiJi2d8btpGdJWisVb3ZXxRsUx5u6f5dRA=="
 		},
 		"@microsoft/node-core-library": {
 			"version": "3.19.3",
@@ -2537,9 +2589,9 @@
 			}
 		},
 		"@sinonjs/commons": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
-			"integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
+			"integrity": "sha512-+DUO6pnp3udV/v2VfUWgaY5BIE1IfT7lLfeDzPVeMT1XKkaAp9LgSI9x5RtrFQoZ9Oi0PgXQQHPaoKu7dCjVxw==",
 			"requires": {
 				"type-detect": "4.0.8"
 			}
@@ -2620,9 +2672,9 @@
 			"integrity": "sha512-bWBbC7VG2jdjbgZMX0qpds8U/3h3anfIqE81L8jmVrgFZw/urEDnBA78ymGGKTTK6ciBXmmJ/xlok+Re41S8ww=="
 		},
 		"@types/babel__core": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.6.tgz",
-			"integrity": "sha512-tTnhWszAqvXnhW7m5jQU9PomXSiKXk2sFxpahXvI20SZKu9ylPi8WtIxueZ6ehDWikPT0jeFujMj3X4ZHuf3Tg==",
+			"version": "7.1.7",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",
+			"integrity": "sha512-RL62NqSFPCDK2FM1pSDH0scHpJvsXtZNiYlMB73DgPBaG1E38ZYVL+ei5EkWRbr+KC4YNiAUNBnRj+bgwpgjMw==",
 			"requires": {
 				"@babel/parser": "^7.1.0",
 				"@babel/types": "^7.0.0",
@@ -2649,9 +2701,9 @@
 			}
 		},
 		"@types/babel__traverse": {
-			"version": "7.0.9",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.9.tgz",
-			"integrity": "sha512-jEFQ8L1tuvPjOI8lnpaf73oCJe+aoxL6ygqSy6c8LcW98zaC+4mzWuQIRCEvKeCOu+lbqdXcg4Uqmm1S8AP1tw==",
+			"version": "7.0.11",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.11.tgz",
+			"integrity": "sha512-ddHK5icION5U6q11+tV2f9Mo6CZVuT8GJKld2q9LqHSZbvLbH34Kcu2yFGckZut453+eQU6btIA3RihmnRgI+Q==",
 			"requires": {
 				"@babel/types": "^7.3.0"
 			}
@@ -2712,9 +2764,9 @@
 			"integrity": "sha512-O2+umEIlHBVyi+ePmucPjpINqTvSnsz+hAok0D4IpvrOsIsDr6c34B0AbNXW2UDVYuxbv51z5dxnrRt23ohgWg=="
 		},
 		"@types/draft-js": {
-			"version": "0.10.38",
-			"resolved": "https://registry.npmjs.org/@types/draft-js/-/draft-js-0.10.38.tgz",
-			"integrity": "sha512-iDg8fJATjGVfQVv/dysAMMcPwORyJix2AyAm8OdwseteYh1jV+Xwlz+1HddoCWxQWqzWf/MDkNQH5sLYG47e0w==",
+			"version": "0.10.40",
+			"resolved": "https://registry.npmjs.org/@types/draft-js/-/draft-js-0.10.40.tgz",
+			"integrity": "sha512-XMkk8pamH/XwSOpEk/B6wFB0Y6LvMFWQZZaIVjzQUH2GCpFxbugo8gYpETsNMkJrGb3yb7hhFjjT1SyJ8AbXjA==",
 			"requires": {
 				"@types/react": "*",
 				"immutable": "~3.7.4"
@@ -2726,9 +2778,9 @@
 			"integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag=="
 		},
 		"@types/estree": {
-			"version": "0.0.43",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.43.tgz",
-			"integrity": "sha512-WfOySUnBpyKXbkC9QuZguwOGhGnugDXT2f2P6X8EIis7qlnd5NI1Nr4kRi357NtguxezyizIcaFlQe0wx23XnA=="
+			"version": "0.0.44",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.44.tgz",
+			"integrity": "sha512-iaIVzr+w2ZJ5HkidlZ3EJM8VTZb2MJLCjw3V+505yVts0gRC4UMvjw0d1HPtGqI/HQC/KdsYtayfzl+AXY2R8g=="
 		},
 		"@types/events": {
 			"version": "3.0.0",
@@ -2745,19 +2797,20 @@
 			}
 		},
 		"@types/express": {
-			"version": "4.17.3",
-			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.3.tgz",
-			"integrity": "sha512-I8cGRJj3pyOLs/HndoP+25vOqhqWkAZsWMEmq1qXy/b/M3ppufecUwaK2/TVDVxcV61/iSdhykUjQQ2DLSrTdg==",
+			"version": "4.17.6",
+			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
+			"integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
 			"requires": {
 				"@types/body-parser": "*",
 				"@types/express-serve-static-core": "*",
+				"@types/qs": "*",
 				"@types/serve-static": "*"
 			}
 		},
 		"@types/express-serve-static-core": {
-			"version": "4.17.2",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.2.tgz",
-			"integrity": "sha512-El9yMpctM6tORDAiBwZVLMcxoTMcqqRO9dVyYcn7ycLWbvR8klrDn8CAOwRfZujZtWD7yS/mshTdz43jMOejbg==",
+			"version": "4.17.5",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.5.tgz",
+			"integrity": "sha512-578YH5Lt88AKoADy0b2jQGwJtrBxezXtVe/MBqWXKZpqx91SnC0pVkVCcxcytz3lWW+cHBYDi3Ysh0WXc+rAYw==",
 			"requires": {
 				"@types/node": "*",
 				"@types/range-parser": "*"
@@ -2814,9 +2867,9 @@
 			}
 		},
 		"@types/jquery": {
-			"version": "3.3.33",
-			"resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.33.tgz",
-			"integrity": "sha512-U6IdXYGkfUI42SR79vB2Spj+h1Ly3J3UZjpd8mi943lh126TK7CB+HZOxGh2nM3IySor7wqVQdemD/xtydsBKA==",
+			"version": "3.3.36",
+			"resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.36.tgz",
+			"integrity": "sha512-jHL8J5y5fJ0+C9zCTkeOvX4zqRnPug3r6JhAqAYl2YyBCYHiXTbZSH0MRCpayZADed5TigPjH92dEKczUFT2TQ==",
 			"requires": {
 				"@types/sizzle": "*"
 			}
@@ -2848,9 +2901,9 @@
 			"integrity": "sha512-aWw2YTtAdT7CskFyxEX2K21/zSDStuf/ikI3yBqmwpwJF0pS+/IX5DWv+1UFffZIbruP6cnT9/LAJV1gFwAT1A=="
 		},
 		"@types/lodash": {
-			"version": "4.14.149",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
-			"integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
+			"version": "4.14.150",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.150.tgz",
+			"integrity": "sha512-kMNLM5JBcasgYscD9x/Gvr6lTAv2NVgsKtet/hm93qMyf/D1pt+7jeEZklKJKxMVmXjxbRVQQGfqDSfipYCO6w=="
 		},
 		"@types/mime": {
 			"version": "2.0.1",
@@ -2937,9 +2990,9 @@
 			}
 		},
 		"@types/prosemirror-view": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/@types/prosemirror-view/-/prosemirror-view-1.11.2.tgz",
-			"integrity": "sha512-EKcQmR4KdkFZU13wS5pWrkSojRCPGqz/l/uzpZFfW5cgdr7fQsftf2/ttvIjpk1a94ISifEY4UZwflVJ+uL4Rg==",
+			"version": "1.11.4",
+			"resolved": "https://registry.npmjs.org/@types/prosemirror-view/-/prosemirror-view-1.11.4.tgz",
+			"integrity": "sha512-Hh8v2tpCEMaIesQuw7Y7Pz6imoC1T/bR5OlNGVtp944PZvctXiBvFRkQIb0YvZpt7vVkFzeq2kmR+7mnUfvWiw==",
 			"requires": {
 				"@types/prosemirror-model": "*",
 				"@types/prosemirror-state": "*",
@@ -2955,6 +3008,11 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/qs": {
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.1.tgz",
+			"integrity": "sha512-lhbQXx9HKZAPgBkISrBcmAcMpZsmpe/Cd/hY7LGZS5OfkySUBItnPZHgQPssWYUET8elF+yCFBbP1Q0RZPTdaw=="
+		},
 		"@types/random-js": {
 			"version": "1.0.31",
 			"resolved": "https://registry.npmjs.org/@types/random-js/-/random-js-1.0.31.tgz",
@@ -2966,18 +3024,18 @@
 			"integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
 		},
 		"@types/react": {
-			"version": "16.9.23",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.23.tgz",
-			"integrity": "sha512-SsGVT4E7L2wLN3tPYLiF20hmZTPGuzaayVunfgXzUn1x4uHVsKH6QDJQ/TdpHqwsTLd4CwrmQ2vOgxN7gE24gw==",
+			"version": "16.9.34",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.34.tgz",
+			"integrity": "sha512-8AJlYMOfPe1KGLKyHpflCg5z46n0b5DbRfqDksxBLBTUpB75ypDBAO9eCUcjNwE6LCUslwTz00yyG/X9gaVtow==",
 			"requires": {
 				"@types/prop-types": "*",
 				"csstype": "^2.2.0"
 			}
 		},
 		"@types/react-dom": {
-			"version": "16.9.5",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.5.tgz",
-			"integrity": "sha512-BX6RQ8s9D+2/gDhxrj8OW+YD4R+8hj7FEM/OJHGNR0KipE1h1mSsf39YeyC81qafkq+N3rU3h3RFbLSwE5VqUg==",
+			"version": "16.9.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.7.tgz",
+			"integrity": "sha512-GHTYhM8/OwUCf254WO5xqR/aqD3gC9kSTLpopWGpQLpnw23jk44RvMHsyUSEplvRJZdHxhJGMMLF0kCPYHPhQA==",
 			"requires": {
 				"@types/react": "*"
 			}
@@ -3074,9 +3132,9 @@
 			}
 		},
 		"@types/tough-cookie": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.6.tgz",
-			"integrity": "sha512-wHNBMnkoEBiRAd3s8KTKwIuO9biFtTf0LehITzBhSco+HQI0xkXZbLOD55SW3Aqw3oUkHstkm5SPv58yaAdFPQ=="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
+			"integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
 		},
 		"@types/unist": {
 			"version": "2.0.3",
@@ -3084,9 +3142,9 @@
 			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
 		},
 		"@types/uuid": {
-			"version": "3.4.8",
-			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.8.tgz",
-			"integrity": "sha512-zHWce3allXWSmRx6/AGXKCtSOA7JjeWd2L3t4aHfysNk8mouQnWCocveaT7a4IEIlPVHp81jzlnknqTgCjCLXA=="
+			"version": "3.4.9",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.9.tgz",
+			"integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ=="
 		},
 		"@types/ws": {
 			"version": "6.0.4",
@@ -3197,255 +3255,254 @@
 			}
 		},
 		"@uifabric/fluent-theme": {
-			"version": "7.1.41",
-			"resolved": "https://registry.npmjs.org/@uifabric/fluent-theme/-/fluent-theme-7.1.41.tgz",
-			"integrity": "sha512-qsoDlsA1iAz5pwMmWEQy2VJD0Tpz8+cRjlrwc+QwH92mVH96M2WrhCIiZ/Io7/iFu7XZqn38ESN20VRkOB5zMQ==",
+			"version": "7.1.63",
+			"resolved": "https://registry.npmjs.org/@uifabric/fluent-theme/-/fluent-theme-7.1.63.tgz",
+			"integrity": "sha512-d4n1tPfdlf9mtlcGUegUJbvDJbhGA1VS0/I9pBS6+6BT41teVpXcDZoDZdE9uCBKJ3KbXqNXX4GWEuv5xMXCOQ==",
 			"requires": {
-				"@uifabric/merge-styles": "^7.8.8",
-				"@uifabric/set-version": "^7.0.7",
-				"@uifabric/styling": "^7.10.21",
-				"@uifabric/variants": "^7.1.32",
-				"office-ui-fabric-react": "^7.105.1",
+				"@uifabric/merge-styles": "^7.11.1",
+				"@uifabric/set-version": "^7.0.11",
+				"@uifabric/styling": "^7.11.9",
+				"@uifabric/variants": "^7.1.52",
+				"office-ui-fabric-react": "^7.108.0",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/foundation": {
-			"version": "7.5.21",
-			"resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.5.21.tgz",
-			"integrity": "sha512-jrvb6Hzoc9nmLvFicPyZSbqCPvHh7ki61GngZRJ4DzhDR6YEgGANtbd+r9qsnim+S55gxyVkyzcRTFWxuK400g==",
+			"version": "7.7.6",
+			"resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.7.6.tgz",
+			"integrity": "sha512-xw91u6TlQKdDIKnOFXEdc8xWpKjQ0Aw/5kY2s12Mwnw57hhQ5ieKNio/h7QXzoJfJNIs2O7f7W5R11f1MOHT6Q==",
 			"requires": {
-				"@uifabric/merge-styles": "^7.8.8",
-				"@uifabric/set-version": "^7.0.7",
-				"@uifabric/styling": "^7.10.21",
-				"@uifabric/utilities": "^7.15.1",
+				"@uifabric/merge-styles": "^7.11.1",
+				"@uifabric/set-version": "^7.0.11",
+				"@uifabric/styling": "^7.11.9",
+				"@uifabric/utilities": "^7.16.0",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/icons": {
-			"version": "7.3.20",
-			"resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.3.20.tgz",
-			"integrity": "sha512-V4r3qEt0VNYMg1BcE03z2g+T0jYDomqiLrdclH57NgoCBVrhmEYHPYATh/3D3YzKtupzvhokjEi3Wvjr0uzEyw==",
+			"version": "7.3.32",
+			"resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.3.32.tgz",
+			"integrity": "sha512-l0EaVlbursTBwqwloE1/DOUtXOmb6cKvpUR90BC0CwOSgEHfqrFwi7kKcpH0CLEdw+o5h0DyDN8P8p1RHSPXrQ==",
 			"requires": {
-				"@uifabric/set-version": "^7.0.7",
-				"@uifabric/styling": "^7.10.21",
+				"@uifabric/set-version": "^7.0.11",
+				"@uifabric/styling": "^7.11.9",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/merge-styles": {
-			"version": "7.8.8",
-			"resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-7.8.8.tgz",
-			"integrity": "sha512-8jsol90sFZ/mt69SsdxvQAYXBFDnmFtBVfFRn+jvtlaT7XdSDfV8GxFlouKMwpsZEYVDKuuUZXs78sTI92LhYg==",
+			"version": "7.11.1",
+			"resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-7.11.1.tgz",
+			"integrity": "sha512-r3T+xOo36qr0lrA+RRN1Ie6eI6Uzo7Gf8AplFkIGeaNczC2m3k5xY+oUa1WmOc6yRCJdMnn18fTYljOXAV4Tpw==",
 			"requires": {
-				"@uifabric/set-version": "^7.0.7",
+				"@uifabric/set-version": "^7.0.11",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/react-hooks": {
-			"version": "7.0.22",
-			"resolved": "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.0.22.tgz",
-			"integrity": "sha512-RiIJIaEpK/uM0qotpB4Ea6wRiDcMaUETZSJaEONKZqUrgYK8hZq4e1ALVBba+kMfw95mB1NqJFI2jZEzNcju+Q==",
+			"version": "7.2.1",
+			"resolved": "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.2.1.tgz",
+			"integrity": "sha512-iXnLZYO7W8FYuthy/lwXZxzwIx14OqpN0xJdDqwnKTZ67n8c0lgD/BP7NWK4iubXOl6CzsyScPrTxNI/h6WX3g==",
 			"requires": {
-				"@uifabric/set-version": "^7.0.7",
-				"@uifabric/utilities": "^7.15.1",
+				"@uifabric/set-version": "^7.0.11",
+				"@uifabric/utilities": "^7.16.0",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/set-version": {
-			"version": "7.0.7",
-			"resolved": "https://registry.npmjs.org/@uifabric/set-version/-/set-version-7.0.7.tgz",
-			"integrity": "sha512-NBmLJ7h+t1XS3MmOwOEeYVrmcxWiDyDoV1g0W87iuy5Qis+9Kqz3OZy6muNzcsLU6mALe/hP8DE+KgiZY06LLQ==",
+			"version": "7.0.11",
+			"resolved": "https://registry.npmjs.org/@uifabric/set-version/-/set-version-7.0.11.tgz",
+			"integrity": "sha512-QAwgQa/Pik/q4Io8SGAjiAjiSHT5JIdhHxFw9Ytct/daagZl40Kt/Et+3U01geMLSD5TOAUATvRN7xAFFgkD9A==",
 			"requires": {
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/styling": {
-			"version": "7.10.21",
-			"resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.10.21.tgz",
-			"integrity": "sha512-Hl+3LH2XZ/q13K54uEXrmgNoZt/1dITZQLl3Vkvl42TX4Pp0vAdK7U8Ka5ai5gJLmKjucWvv+hFV0FMbPlGHtQ==",
+			"version": "7.11.9",
+			"resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.11.9.tgz",
+			"integrity": "sha512-xjnm8nMDG6CS3WNGtyM7bv9q+CxG7kynagl5nenXh/hiTMvHRZpJPIlI1x6dBgx7G/f4+yp4qvmaKd+JPwiNcQ==",
 			"requires": {
 				"@microsoft/load-themed-styles": "^1.10.26",
-				"@uifabric/merge-styles": "^7.8.8",
-				"@uifabric/set-version": "^7.0.7",
-				"@uifabric/utilities": "^7.15.1",
+				"@uifabric/merge-styles": "^7.11.1",
+				"@uifabric/set-version": "^7.0.11",
+				"@uifabric/utilities": "^7.16.0",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/utilities": {
-			"version": "7.15.1",
-			"resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.15.1.tgz",
-			"integrity": "sha512-HuD82wV76JbyrM+N4ek8qVHOEB7YTmLpThylhB5mFSNxHxiCmUpo5d4xwUogu8c2M0ik3BrrJkrwMXXtAeuRbg==",
+			"version": "7.16.0",
+			"resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.16.0.tgz",
+			"integrity": "sha512-dJazpicc8b72T768eB+PcL6aZS1IzKFsgUnG8b5bTIK6QYWIarrvH/hP/+gRZEWT0mB5C4eCLSRHqZOxPRcpFw==",
 			"requires": {
-				"@uifabric/merge-styles": "^7.8.8",
-				"@uifabric/set-version": "^7.0.7",
+				"@uifabric/merge-styles": "^7.11.1",
+				"@uifabric/set-version": "^7.0.11",
 				"prop-types": "^15.7.2",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/variants": {
-			"version": "7.1.32",
-			"resolved": "https://registry.npmjs.org/@uifabric/variants/-/variants-7.1.32.tgz",
-			"integrity": "sha512-yg3M+/CRc1jgh1QNQtsyrGZqwPJzVm8fSdFAIk55P/ZXdq6hcaUalVzbnDhNGy9cgyPuHdFxmLPGNZCNuTAv3g==",
+			"version": "7.1.52",
+			"resolved": "https://registry.npmjs.org/@uifabric/variants/-/variants-7.1.52.tgz",
+			"integrity": "sha512-/H4dbHODOkdSH6iZi12D35WfQiu/8UnioFnQ9kv6QfDnp1Isb46UrWE+BbXIAANBTqaZi8/PafJWw23Af6PxYA==",
 			"requires": {
-				"@uifabric/set-version": "^7.0.7",
-				"office-ui-fabric-react": "^7.105.1",
+				"@uifabric/set-version": "^7.0.11",
+				"office-ui-fabric-react": "^7.108.0",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@webassemblyjs/ast": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
-			"integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
+			"integrity": "sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==",
 			"requires": {
-				"@webassemblyjs/helper-module-context": "1.8.5",
-				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-				"@webassemblyjs/wast-parser": "1.8.5"
+				"@webassemblyjs/helper-module-context": "1.9.0",
+				"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+				"@webassemblyjs/wast-parser": "1.9.0"
 			}
 		},
 		"@webassemblyjs/floating-point-hex-parser": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
-			"integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ=="
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz",
+			"integrity": "sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA=="
 		},
 		"@webassemblyjs/helper-api-error": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
-			"integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA=="
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
+			"integrity": "sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw=="
 		},
 		"@webassemblyjs/helper-buffer": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
-			"integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q=="
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
+			"integrity": "sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA=="
 		},
 		"@webassemblyjs/helper-code-frame": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
-			"integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz",
+			"integrity": "sha512-ERCYdJBkD9Vu4vtjUYe8LZruWuNIToYq/ME22igL+2vj2dQ2OOujIZr3MEFvfEaqKoVqpsFKAGsRdBSBjrIvZA==",
 			"requires": {
-				"@webassemblyjs/wast-printer": "1.8.5"
+				"@webassemblyjs/wast-printer": "1.9.0"
 			}
 		},
 		"@webassemblyjs/helper-fsm": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
-			"integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow=="
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.0.tgz",
+			"integrity": "sha512-OPRowhGbshCb5PxJ8LocpdX9Kl0uB4XsAjl6jH/dWKlk/mzsANvhwbiULsaiqT5GZGT9qinTICdj6PLuM5gslw=="
 		},
 		"@webassemblyjs/helper-module-context": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
-			"integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz",
+			"integrity": "sha512-MJCW8iGC08tMk2enck1aPW+BE5Cw8/7ph/VGZxwyvGbJwjktKkDK7vy7gAmMDx88D7mhDTCNKAW5tED+gZ0W8g==",
 			"requires": {
-				"@webassemblyjs/ast": "1.8.5",
-				"mamacro": "^0.0.3"
+				"@webassemblyjs/ast": "1.9.0"
 			}
 		},
 		"@webassemblyjs/helper-wasm-bytecode": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
-			"integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ=="
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
+			"integrity": "sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw=="
 		},
 		"@webassemblyjs/helper-wasm-section": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
-			"integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
+			"integrity": "sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==",
 			"requires": {
-				"@webassemblyjs/ast": "1.8.5",
-				"@webassemblyjs/helper-buffer": "1.8.5",
-				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-				"@webassemblyjs/wasm-gen": "1.8.5"
+				"@webassemblyjs/ast": "1.9.0",
+				"@webassemblyjs/helper-buffer": "1.9.0",
+				"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+				"@webassemblyjs/wasm-gen": "1.9.0"
 			}
 		},
 		"@webassemblyjs/ieee754": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
-			"integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz",
+			"integrity": "sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==",
 			"requires": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
 		},
 		"@webassemblyjs/leb128": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
-			"integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.0.tgz",
+			"integrity": "sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==",
 			"requires": {
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/utf8": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
-			"integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw=="
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.9.0.tgz",
+			"integrity": "sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w=="
 		},
 		"@webassemblyjs/wasm-edit": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
-			"integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
+			"integrity": "sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==",
 			"requires": {
-				"@webassemblyjs/ast": "1.8.5",
-				"@webassemblyjs/helper-buffer": "1.8.5",
-				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-				"@webassemblyjs/helper-wasm-section": "1.8.5",
-				"@webassemblyjs/wasm-gen": "1.8.5",
-				"@webassemblyjs/wasm-opt": "1.8.5",
-				"@webassemblyjs/wasm-parser": "1.8.5",
-				"@webassemblyjs/wast-printer": "1.8.5"
+				"@webassemblyjs/ast": "1.9.0",
+				"@webassemblyjs/helper-buffer": "1.9.0",
+				"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+				"@webassemblyjs/helper-wasm-section": "1.9.0",
+				"@webassemblyjs/wasm-gen": "1.9.0",
+				"@webassemblyjs/wasm-opt": "1.9.0",
+				"@webassemblyjs/wasm-parser": "1.9.0",
+				"@webassemblyjs/wast-printer": "1.9.0"
 			}
 		},
 		"@webassemblyjs/wasm-gen": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
-			"integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz",
+			"integrity": "sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==",
 			"requires": {
-				"@webassemblyjs/ast": "1.8.5",
-				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-				"@webassemblyjs/ieee754": "1.8.5",
-				"@webassemblyjs/leb128": "1.8.5",
-				"@webassemblyjs/utf8": "1.8.5"
+				"@webassemblyjs/ast": "1.9.0",
+				"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+				"@webassemblyjs/ieee754": "1.9.0",
+				"@webassemblyjs/leb128": "1.9.0",
+				"@webassemblyjs/utf8": "1.9.0"
 			}
 		},
 		"@webassemblyjs/wasm-opt": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
-			"integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz",
+			"integrity": "sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==",
 			"requires": {
-				"@webassemblyjs/ast": "1.8.5",
-				"@webassemblyjs/helper-buffer": "1.8.5",
-				"@webassemblyjs/wasm-gen": "1.8.5",
-				"@webassemblyjs/wasm-parser": "1.8.5"
+				"@webassemblyjs/ast": "1.9.0",
+				"@webassemblyjs/helper-buffer": "1.9.0",
+				"@webassemblyjs/wasm-gen": "1.9.0",
+				"@webassemblyjs/wasm-parser": "1.9.0"
 			}
 		},
 		"@webassemblyjs/wasm-parser": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
-			"integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
+			"integrity": "sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==",
 			"requires": {
-				"@webassemblyjs/ast": "1.8.5",
-				"@webassemblyjs/helper-api-error": "1.8.5",
-				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-				"@webassemblyjs/ieee754": "1.8.5",
-				"@webassemblyjs/leb128": "1.8.5",
-				"@webassemblyjs/utf8": "1.8.5"
+				"@webassemblyjs/ast": "1.9.0",
+				"@webassemblyjs/helper-api-error": "1.9.0",
+				"@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+				"@webassemblyjs/ieee754": "1.9.0",
+				"@webassemblyjs/leb128": "1.9.0",
+				"@webassemblyjs/utf8": "1.9.0"
 			}
 		},
 		"@webassemblyjs/wast-parser": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
-			"integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.9.0.tgz",
+			"integrity": "sha512-qsqSAP3QQ3LyZjNC/0jBJ/ToSxfYJ8kYyuiGvtn/8MK89VrNEfwj7BPQzJVHi0jGTRK2dGdJ5PRqhtjzoww+bw==",
 			"requires": {
-				"@webassemblyjs/ast": "1.8.5",
-				"@webassemblyjs/floating-point-hex-parser": "1.8.5",
-				"@webassemblyjs/helper-api-error": "1.8.5",
-				"@webassemblyjs/helper-code-frame": "1.8.5",
-				"@webassemblyjs/helper-fsm": "1.8.5",
+				"@webassemblyjs/ast": "1.9.0",
+				"@webassemblyjs/floating-point-hex-parser": "1.9.0",
+				"@webassemblyjs/helper-api-error": "1.9.0",
+				"@webassemblyjs/helper-code-frame": "1.9.0",
+				"@webassemblyjs/helper-fsm": "1.9.0",
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/wast-printer": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
-			"integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
+			"integrity": "sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==",
 			"requires": {
-				"@webassemblyjs/ast": "1.8.5",
-				"@webassemblyjs/wast-parser": "1.8.5",
+				"@webassemblyjs/ast": "1.9.0",
+				"@webassemblyjs/wast-parser": "1.9.0",
 				"@xtuc/long": "4.2.2"
 			}
 		},
@@ -4092,16 +4149,30 @@
 			}
 		},
 		"babel-loader": {
-			"version": "8.0.6",
-			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.6.tgz",
-			"integrity": "sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.1.0.tgz",
+			"integrity": "sha512-7q7nC1tYOrqvUrN3LQK4GwSk/TQorZSOlO9C+RZDZpODgyN4ZlCqE5q9cDsyWOliN+aU9B4JX01xK9eJXowJLw==",
 			"requires": {
-				"find-cache-dir": "^2.0.0",
-				"loader-utils": "^1.0.2",
-				"mkdirp": "^0.5.1",
-				"pify": "^4.0.1"
+				"find-cache-dir": "^2.1.0",
+				"loader-utils": "^1.4.0",
+				"mkdirp": "^0.5.3",
+				"pify": "^4.0.1",
+				"schema-utils": "^2.6.5"
 			},
 			"dependencies": {
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+				},
+				"mkdirp": {
+					"version": "0.5.5",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+					"requires": {
+						"minimist": "^1.2.5"
+					}
+				},
 				"pify": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -4573,6 +4644,11 @@
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				}
 			}
+		},
+		"buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
 		},
 		"buffer-equal-constant-time": {
 			"version": "1.0.1",
@@ -5050,9 +5126,9 @@
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
 		"codemirror": {
-			"version": "5.52.0",
-			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.52.0.tgz",
-			"integrity": "sha512-K2UB6zjscrfME03HeRe/IuOmCeqNpw7PLKGHThYpLbZEuKf+ZoujJPhxZN4hHJS1O7QyzEsV7JJZGxuQWVaFCg=="
+			"version": "5.53.2",
+			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.53.2.tgz",
+			"integrity": "sha512-wvSQKS4E+P8Fxn/AQ+tQtJnF1qH5UOlxtugFLpubEZ5jcdH2iXTVinb+Xc/4QjshuOxRm4fUsU2QPF1JJKiyXA=="
 		},
 		"codemirror-graphql": {
 			"version": "0.8.3",
@@ -5145,9 +5221,9 @@
 			}
 		},
 		"comlink": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/comlink/-/comlink-4.2.0.tgz",
-			"integrity": "sha512-33hF3yYzZicIWLREuvluTGSZkbAXYwRmrA9IYQo0/P+0O45qgvzR0FHX4tRZztObFMTs/RhnN0G0UBNDAZSiCg=="
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/comlink/-/comlink-4.3.0.tgz",
+			"integrity": "sha512-mu4KKKNuW8TvkfpW/H88HBPeILubBS6T94BdD1VWBXNXfiyqVtwUCVNO1GeNOBTsIswzsMjWlycYr+77F5b84g=="
 		},
 		"commander": {
 			"version": "2.20.3",
@@ -5873,6 +5949,16 @@
 					"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
 					"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
 				},
+				"schema-utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"requires": {
+						"ajv": "^6.1.0",
+						"ajv-errors": "^1.0.0",
+						"ajv-keywords": "^3.1.0"
+					}
+				},
 				"slash": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -6266,13 +6352,20 @@
 			}
 		},
 		"css-to-react-native": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.2.tgz",
-			"integrity": "sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
+			"integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
 			"requires": {
 				"camelize": "^1.0.0",
 				"css-color-keywords": "^1.0.0",
-				"postcss-value-parser": "^3.3.0"
+				"postcss-value-parser": "^4.0.2"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+					"integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
+				}
 			}
 		},
 		"cssesc": {
@@ -6294,9 +6387,9 @@
 			}
 		},
 		"csstype": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz",
-			"integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q=="
+			"version": "2.6.10",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.10.tgz",
+			"integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w=="
 		},
 		"currently-unhandled": {
 			"version": "0.4.1",
@@ -6770,9 +6863,9 @@
 			}
 		},
 		"draft-js": {
-			"version": "0.11.4",
-			"resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.11.4.tgz",
-			"integrity": "sha512-BLZ59s0vkDj/zI8UPo9Nit/hPsl11ztDejxDCQlVbvEXJSWrTXqO6ZYgdw3hXLtuojq/URqq3wTrpnb3dvzvLA==",
+			"version": "0.11.5",
+			"resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.11.5.tgz",
+			"integrity": "sha512-RlHcoDtblwCD6Bw2ay3D0dTLA6lH8862OcdJrHGnYrY5JjlitzSzGvGQwqqumVvbGUNDSZLD3FyNpSs4z5WIUg==",
 			"requires": {
 				"fbjs": "^1.0.0",
 				"immutable": "~3.7.4",
@@ -6914,9 +7007,9 @@
 			}
 		},
 		"engine.io-client": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.0.tgz",
-			"integrity": "sha512-a4J5QO2k99CM2a0b12IznnyQndoEvtA4UAldhGzKqnHf42I3Qs2W5SPnDvatZRcMaNZs4IevVicBPayxYt6FwA==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.1.tgz",
+			"integrity": "sha512-RJNmA+A9Js+8Aoq815xpGAsgWH1VoSYM//2VgIiu9lNOaHFfLpTjH4tOzktBpjIs5lvOfiNY1dwf+NuU6D38Mw==",
 			"requires": {
 				"component-emitter": "1.2.1",
 				"component-inherit": "0.0.3",
@@ -7318,12 +7411,9 @@
 					}
 				},
 				"run-async": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
-					"integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
-					"requires": {
-						"is-promise": "^2.1.0"
-					}
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+					"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
 				},
 				"string-width": {
 					"version": "4.2.0",
@@ -7385,9 +7475,9 @@
 			}
 		},
 		"eslint-config-prettier": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-			"integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
+			"integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
 			"requires": {
 				"get-stdin": "^6.0.0"
 			},
@@ -7422,9 +7512,9 @@
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				},
 				"resolve": {
-					"version": "1.15.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-					"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+					"version": "1.17.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
 					"requires": {
 						"path-parse": "^1.0.6"
 					}
@@ -7432,9 +7522,9 @@
 			}
 		},
 		"eslint-module-utils": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.2.tgz",
-			"integrity": "sha512-LGScZ/JSlqGKiT8OC+cYRxseMjyqt6QO54nl281CK93unD89ijSeRV6An8Ci/2nvWVKe8K/Tqdm75RQoIOCr+Q==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
+			"integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
 			"requires": {
 				"debug": "^2.6.9",
 				"pkg-dir": "^2.0.0"
@@ -7653,9 +7743,9 @@
 					}
 				},
 				"resolve": {
-					"version": "1.15.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-					"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+					"version": "1.17.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
 					"requires": {
 						"path-parse": "^1.0.6"
 					}
@@ -7681,9 +7771,9 @@
 			"integrity": "sha512-epsA4g804mRovlOHSbeO1xxW7REGeUjULRME9MJTJDOVscNIA01AkR66TP4cmHDfD+w72EQ9cPhf37MbZiFI2w=="
 		},
 		"eslint-plugin-prettier": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
-			"integrity": "sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.3.tgz",
+			"integrity": "sha512-+HG5jmu/dN3ZV3T6eCD7a4BlAySdN7mLIbJYo0z1cFQuI+r2DiTJEFeF68ots93PsnrMxbzIZ2S/ieX+mkrBeQ==",
 			"requires": {
 				"prettier-linter-helpers": "^1.0.0"
 			}
@@ -7714,9 +7804,9 @@
 					}
 				},
 				"resolve": {
-					"version": "1.15.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-					"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+					"version": "1.17.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
 					"requires": {
 						"path-parse": "^1.0.6"
 					}
@@ -7883,11 +7973,18 @@
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"esquery": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
-			"integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+			"integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
 			"requires": {
-				"estraverse": "^4.0.0"
+				"estraverse": "^5.1.0"
+			},
+			"dependencies": {
+				"estraverse": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
+					"integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw=="
+				}
 			}
 		},
 		"esrecurse": {
@@ -8229,14 +8326,14 @@
 			}
 		},
 		"extract-zip": {
-			"version": "1.6.7",
-			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-			"integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+			"integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
 			"requires": {
-				"concat-stream": "1.6.2",
-				"debug": "2.6.9",
-				"mkdirp": "0.5.1",
-				"yauzl": "2.4.1"
+				"concat-stream": "^1.6.2",
+				"debug": "^2.6.9",
+				"mkdirp": "^0.5.4",
+				"yauzl": "^2.10.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -8245,6 +8342,19 @@
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"requires": {
 						"ms": "2.0.0"
+					}
+				},
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+				},
+				"mkdirp": {
+					"version": "0.5.5",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+					"requires": {
+						"minimist": "^1.2.5"
 					}
 				},
 				"ms": {
@@ -8373,9 +8483,9 @@
 			"integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
 		},
 		"fd-slicer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-			"integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+			"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
 			"requires": {
 				"pend": "~1.2.0"
 			}
@@ -8522,6 +8632,18 @@
 			"requires": {
 				"loader-utils": "^1.0.2",
 				"schema-utils": "^1.0.0"
+			},
+			"dependencies": {
+				"schema-utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"requires": {
+						"ajv": "^6.1.0",
+						"ajv-errors": "^1.0.0",
+						"ajv-keywords": "^3.1.0"
+					}
+				}
 			}
 		},
 		"file-uri-to-path": {
@@ -8739,9 +8861,9 @@
 			}
 		},
 		"flatted": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-			"integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg=="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+			"integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
 		},
 		"flush-write-stream": {
 			"version": "1.1.1",
@@ -10198,9 +10320,9 @@
 			}
 		},
 		"handle-thing": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
-			"integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
+			"integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg=="
 		},
 		"handlebars": {
 			"version": "4.7.3",
@@ -10455,9 +10577,9 @@
 			}
 		},
 		"html-entities": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
-			"integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
+			"integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA=="
 		},
 		"html-escaper": {
 			"version": "2.0.0",
@@ -11151,7 +11273,8 @@
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
 		},
 		"is-regex": {
 			"version": "1.0.5",
@@ -11202,11 +11325,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
 			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-		},
-		"is-what": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/is-what/-/is-what-3.7.1.tgz",
-			"integrity": "sha512-IAoapxlqyLSqt0Zr/7ZMT/fjEw9nwxxmz/TlBH+TJjvcXxmmAdRvo41W74uw3XJMGFpbeft97cpkPmLK89lJWw=="
 		},
 		"is-whitespace-character": {
 			"version": "1.0.4",
@@ -12258,9 +12376,9 @@
 			"dev": true
 		},
 		"jquery": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-			"integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
+			"integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
 		},
 		"js-base64": {
 			"version": "2.5.2",
@@ -12901,9 +13019,9 @@
 			}
 		},
 		"loglevel": {
-			"version": "1.6.7",
-			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",
-			"integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A=="
+			"version": "1.6.8",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
+			"integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA=="
 		},
 		"loglevelnext": {
 			"version": "1.0.5",
@@ -13006,11 +13124,6 @@
 				"tmpl": "1.0.x"
 			}
 		},
-		"mamacro": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
-			"integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA=="
-		},
 		"map-age-cleaner": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
@@ -13061,9 +13174,9 @@
 			"integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q=="
 		},
 		"marked": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-0.8.1.tgz",
-			"integrity": "sha512-tZfJS8uE0zpo7xpTffwFwYRfW9AzNcdo04Qcjs+C9+oCy8MSRD2reD5iDVtYx8mtLaqsGughw/YLlcwNxAHA1g=="
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
+			"integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw=="
 		},
 		"md5": {
 			"version": "2.2.1",
@@ -13112,11 +13225,6 @@
 				"mimic-fn": "^2.0.0",
 				"p-is-promise": "^2.0.0"
 			}
-		},
-		"memoize-one": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
-			"integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
 		},
 		"memory-fs": {
 			"version": "0.5.0",
@@ -13308,14 +13416,6 @@
 				}
 			}
 		},
-		"merge-anything": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-2.4.4.tgz",
-			"integrity": "sha512-l5XlriUDJKQT12bH+rVhAHjwIuXWdAIecGwsYjv2LJo+dA1AeRTmeQS+3QBpO6lEthBMDi2IUMpLC1yyRvGlwQ==",
-			"requires": {
-				"is-what": "^3.3.1"
-			}
-		},
 		"merge-deep": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
@@ -13439,6 +13539,16 @@
 						"prepend-http": "^1.0.0",
 						"query-string": "^4.1.0",
 						"sort-keys": "^1.0.0"
+					}
+				},
+				"schema-utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"requires": {
+						"ajv": "^6.1.0",
+						"ajv-errors": "^1.0.0",
+						"ajv-keywords": "^3.1.0"
 					}
 				},
 				"sort-keys": {
@@ -13759,9 +13869,9 @@
 			}
 		},
 		"nan": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -14155,9 +14265,9 @@
 			}
 		},
 		"node-sass": {
-			"version": "4.13.1",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
-			"integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
+			"version": "4.14.0",
+			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.0.tgz",
+			"integrity": "sha512-AxqU+DFpk0lEz95sI6jO0hU0Rwyw7BXVEv6o9OItoXLyeygPeaSpiV4rwQb10JiTghHaa0gZeD21sz+OsQluaw==",
 			"requires": {
 				"async-foreach": "^0.1.3",
 				"chalk": "^1.1.1",
@@ -14816,9 +14926,33 @@
 			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
 		},
 		"object-is": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
-			"integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
+			"integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.5"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.17.5",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+					"integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.1.5",
+						"is-regex": "^1.0.5",
+						"object-inspect": "^1.7.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimleft": "^2.1.1",
+						"string.prototype.trimright": "^2.1.1"
+					}
+				}
+			}
 		},
 		"object-keys": {
 			"version": "1.1.1",
@@ -14906,19 +15040,20 @@
 			"dev": true
 		},
 		"office-ui-fabric-react": {
-			"version": "7.105.1",
-			"resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.105.1.tgz",
-			"integrity": "sha512-xSwnPiYbOvbL8tOMaevt/sUWQaP9e7Wcbk4WHsUxydEBBDgVdYshbFM8E2FYwkky3ATKEVN1sCHz+AA7CXkPXg==",
+			"version": "7.108.0",
+			"resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.108.0.tgz",
+			"integrity": "sha512-xfKpXIBcU3smOLSH9j3a9GEpMp8FUxtsM3+HMGRxGWP7ask2nSWnBHnBSLT6liN+RfLHGt1PvKLUEuv1ZF3O0Q==",
 			"requires": {
-				"@fluentui/react-focus": "^7.1.8",
+				"@fluentui/react-focus": "^7.7.0",
+				"@fluentui/react-icons": "^0.1.7",
 				"@microsoft/load-themed-styles": "^1.10.26",
-				"@uifabric/foundation": "^7.5.21",
-				"@uifabric/icons": "^7.3.20",
-				"@uifabric/merge-styles": "^7.8.8",
-				"@uifabric/react-hooks": "^7.0.22",
-				"@uifabric/set-version": "^7.0.7",
-				"@uifabric/styling": "^7.10.21",
-				"@uifabric/utilities": "^7.15.1",
+				"@uifabric/foundation": "^7.7.6",
+				"@uifabric/icons": "^7.3.32",
+				"@uifabric/merge-styles": "^7.11.1",
+				"@uifabric/react-hooks": "^7.2.1",
+				"@uifabric/set-version": "^7.0.11",
+				"@uifabric/styling": "^7.11.9",
+				"@uifabric/utilities": "^7.16.0",
 				"prop-types": "^15.7.2",
 				"tslib": "^1.10.0"
 			}
@@ -15684,9 +15819,9 @@
 			"integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk="
 		},
 		"prosemirror-commands": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.1.3.tgz",
-			"integrity": "sha512-YVbKwTR4likoyhuwIUC9egbzHvnFrFUNbiesB0DB/HZ8hBcopQ42Tb4KGlYrS3n+pNDTFObN73CLFY6mYLN2IQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.1.4.tgz",
+			"integrity": "sha512-kj4Qi+8h3EpJtZuuEDwZ9h2/QNGWDsIX/CzjmClxi9GhxWyBUMVUvIFk0mgdqHyX20lLeGmOpc0TLA5aPzgpWg==",
 			"requires": {
 				"prosemirror-model": "^1.0.0",
 				"prosemirror-state": "^1.0.0",
@@ -15720,9 +15855,9 @@
 			}
 		},
 		"prosemirror-gapcursor": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.1.3.tgz",
-			"integrity": "sha512-/lgWvt2AdHjsM6oEsF65z0lhdQJGl6sQSfXSOX8/xjpd8ycfOolhgKZd4TPYpikwnh85JF4l5eIyiFZsl/RQQA==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.1.5.tgz",
+			"integrity": "sha512-SjbUZq5pgsBDuV3hu8GqgIpZR5eZvGLM+gPQTqjVVYSMUCfKW3EGXTEYaLHEl1bGduwqNC95O3bZflgtAb4L6w==",
 			"requires": {
 				"prosemirror-keymap": "^1.0.0",
 				"prosemirror-model": "^1.0.0",
@@ -15796,17 +15931,17 @@
 			}
 		},
 		"prosemirror-transform": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.2.4.tgz",
-			"integrity": "sha512-0A668uf0EN89L9O9brE05kHcqp7FHmT5YN7Tom58Kj926QqOBs7iNRHDLWxrSaQB5MNZtzDOD9T3EyJ88YDcBg==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.2.5.tgz",
+			"integrity": "sha512-eqeIaxWtUfOnpA1ERrXCuSIMzqIJtL9Qrs5uJMCjY5RMSaH5o4pc390SAjn/IDPeIlw6auh0hCCXs3wRvGnQug==",
 			"requires": {
 				"prosemirror-model": "^1.0.0"
 			}
 		},
 		"prosemirror-view": {
-			"version": "1.14.4",
-			"resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.14.4.tgz",
-			"integrity": "sha512-qPlKWigymKio7Ed52E+mwZEn2TJE28u8Masj0ygGHYZRhY/abB/s0XEGLwx2FTsvt92gIqfRRezhUzTk3eE2rQ==",
+			"version": "1.14.7",
+			"resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.14.7.tgz",
+			"integrity": "sha512-ZCRbGAmJa0ORIY4xrDvOpxS/oAnph3egDauvQEI7SX4eex0zovUfC61I5X4AtPCaNN4JpLWEk60voCWi0cE2vA==",
 			"requires": {
 				"prosemirror-model": "^1.1.0",
 				"prosemirror-state": "^1.0.0",
@@ -16031,9 +16166,9 @@
 			}
 		},
 		"rc-animate": {
-			"version": "2.10.3",
-			"resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.10.3.tgz",
-			"integrity": "sha512-A9qQ5Y8BLlM7EhuCO3fWb/dChndlbWtY/P5QvPqBU7h4r5Q2QsvsbpTGgdYZATRDZbTRnJXXfVk9UtlyS7MBLg==",
+			"version": "2.11.1",
+			"resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.11.1.tgz",
+			"integrity": "sha512-1NyuCGFJG/0Y+9RKh5y/i/AalUCA51opyyS/jO2seELpgymZm2u9QV3xwODwEuzkmeQ1BDPxMLmYLcTJedPlkQ==",
 			"requires": {
 				"babel-runtime": "6.x",
 				"classnames": "^2.2.6",
@@ -16084,12 +16219,11 @@
 			}
 		},
 		"rc-util": {
-			"version": "4.20.1",
-			"resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.20.1.tgz",
-			"integrity": "sha512-EGlDg9KPN0POzmAR2hk9ZyFc3DmJIrXwlC8NoDxJguX2LTINnVqwadLIVauLfYgYISMiFYFrSHiFW+cqUhZ5dA==",
+			"version": "4.20.5",
+			"resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.20.5.tgz",
+			"integrity": "sha512-f67s4Dt1quBYhrVPq5QMKmK3eS2hN1NNIAyhaiG0HmvqiGYAXMQ7SP2AlGqv750vnzhJs38JklbkWT1/wjhFPg==",
 			"requires": {
 				"add-dom-event-listener": "^1.1.0",
-				"babel-runtime": "6.x",
 				"prop-types": "^15.5.10",
 				"react-is": "^16.12.0",
 				"react-lifecycles-compat": "^3.0.4",
@@ -16097,9 +16231,9 @@
 			}
 		},
 		"react": {
-			"version": "16.13.0",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.13.0.tgz",
-			"integrity": "sha512-TSavZz2iSLkq5/oiE7gnFzmURKZMltmi193rm5HEoUDAXpzT9Kzw6oNZnGoai/4+fUnm7FqS5dwgUL34TujcWQ==",
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
+			"integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -16125,23 +16259,23 @@
 			}
 		},
 		"react-countdown360": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/react-countdown360/-/react-countdown360-1.3.1.tgz",
-			"integrity": "sha512-CrZzLB27hQIxnFpQe70bEVJWFEvcSnJ3J7bYym9tucG9HpJJ2zL4ReUElaB/4QHu5KuAWp5s1yT/cgiP+8yinA==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/react-countdown360/-/react-countdown360-1.3.2.tgz",
+			"integrity": "sha512-tS9BncwpalPxobaK1tEZdkycr+om1XAG+oTDnHrCrEDuMJcda2gLtFKFZXzbTWvU4GPTdfEBB0fHTwbvVqJ1GA==",
 			"requires": {
 				"prop-types": "^15.7.2",
-				"styled-components": "^4.4.0"
+				"styled-components": "^5.1.0"
 			}
 		},
 		"react-dom": {
-			"version": "16.13.0",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.0.tgz",
-			"integrity": "sha512-y09d2c4cG220DzdlFkPTnVvGTszVvNpC73v+AaLGLHbkpy3SSgvYq8x0rNwPJ/Rk/CicTNgk0hbHNw1gMEZAXg==",
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+			"integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
-				"scheduler": "^0.19.0"
+				"scheduler": "^0.19.1"
 			}
 		},
 		"react-draggable": {
@@ -16188,9 +16322,9 @@
 			}
 		},
 		"react-is": {
-			"version": "16.13.0",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
-			"integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA=="
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"react-lifecycles-compat": {
 			"version": "3.0.4",
@@ -16232,9 +16366,9 @@
 			},
 			"dependencies": {
 				"react-draggable": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.2.0.tgz",
-					"integrity": "sha512-5wFq//gEoeTYprnd4ze8GrFc+Rbnx+9RkOMR3vk4EbWxj02U6L6T3yrlKeiw4X5CtjD2ma2+b3WujghcXNRzkw==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.3.1.tgz",
+					"integrity": "sha512-m8QeV+eIi7LhD5mXoLqDzLbokc6Ncwa0T34fF6uJzWSs4vc4fdZI/XGqHYoEn91T8S6qO+BSXslONh7Jz9VPQQ==",
 					"requires": {
 						"classnames": "^2.2.5",
 						"prop-types": "^15.6.0"
@@ -16623,9 +16757,9 @@
 			}
 		},
 		"regexpp": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
-			"integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g=="
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q=="
 		},
 		"regexpu-core": {
 			"version": "4.7.0",
@@ -17265,22 +17399,21 @@
 			}
 		},
 		"scheduler": {
-			"version": "0.19.0",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.0.tgz",
-			"integrity": "sha512-xowbVaTPe9r7y7RUejcK73/j8tt2jfiyTednOvHbA8JoClvMYCp+r8QegLwK/n8zWQAtZb1fFnER4XLBZXrCxA==",
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+			"integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
 			}
 		},
 		"schema-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-			"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+			"version": "2.6.6",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.6.tgz",
+			"integrity": "sha512-wHutF/WPSbIi9x6ctjGGk2Hvl0VOz5l3EKEuKbjPlB30mKZUzb9A5k9yEXRX3pwyqVLPvpfZZEllaFq/M718hA==",
 			"requires": {
-				"ajv": "^6.1.0",
-				"ajv-errors": "^1.0.0",
-				"ajv-keywords": "^3.1.0"
+				"ajv": "^6.12.0",
+				"ajv-keywords": "^3.4.1"
 			}
 		},
 		"scss-tokenizer": {
@@ -18061,9 +18194,9 @@
 			}
 		},
 		"source-map-support": {
-			"version": "0.5.16",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-			"integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+			"version": "0.5.19",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+			"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -18163,9 +18296,9 @@
 			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
 		},
 		"spdy": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.1.tgz",
-			"integrity": "sha512-HeZS3PBdMA+sZSu0qwpCxl3DeALD5ASx8pAX0jZdKXSpPWbQ6SYGnlg3BBmYLx5LtiZrmkAZfErCm2oECBcioA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
+			"integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
 			"requires": {
 				"debug": "^4.1.0",
 				"handle-thing": "^2.0.0",
@@ -18542,9 +18675,9 @@
 			"dev": true
 		},
 		"strip-json-comments": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-			"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+			"integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w=="
 		},
 		"strong-log-transformer": {
 			"version": "2.1.0",
@@ -18566,42 +18699,53 @@
 			}
 		},
 		"style-loader": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.1.3.tgz",
-			"integrity": "sha512-rlkH7X/22yuwFYK357fMN/BxYOorfnfq0eD7+vqlemSK4wEcejFF1dg4zxP0euBW8NrYx2WZzZ8PPFevr7D+Kw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.2.1.tgz",
+			"integrity": "sha512-ByHSTQvHLkWE9Ir5+lGbVOXhxX10fbprhLvdg96wedFZb4NDekDPxVKv5Fwmio+QcMlkkNfuK+5W1peQ5CUhZg==",
 			"requires": {
-				"loader-utils": "^1.2.3",
-				"schema-utils": "^2.6.4"
+				"loader-utils": "^2.0.0",
+				"schema-utils": "^2.6.6"
 			},
 			"dependencies": {
-				"schema-utils": {
-					"version": "2.6.5",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.5.tgz",
-					"integrity": "sha512-5KXuwKziQrTVHh8j/Uxz+QUbxkaLW9X/86NBlx/gnKgtsZA2GIVMUn17qWhRFwF8jdYb3Dig5hRO/W5mZqy6SQ==",
+				"json5": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+					"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
 					"requires": {
-						"ajv": "^6.12.0",
-						"ajv-keywords": "^3.4.1"
+						"minimist": "^1.2.5"
 					}
+				},
+				"loader-utils": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+					"integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^2.1.2"
+					}
+				},
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 				}
 			}
 		},
 		"styled-components": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.4.1.tgz",
-			"integrity": "sha512-RNqj14kYzw++6Sr38n7197xG33ipEOktGElty4I70IKzQF1jzaD1U4xQ+Ny/i03UUhHlC5NWEO+d8olRCDji6g==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.1.0.tgz",
+			"integrity": "sha512-0Qs2wEkFBXHFlysz6CV831VG6HedcrFUwChjnWylNivsx14MtmqQsohi21rMHZxzuTba063dEyoe/SR6VGJI7Q==",
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
-				"@babel/traverse": "^7.0.0",
-				"@emotion/is-prop-valid": "^0.8.1",
-				"@emotion/unitless": "^0.7.0",
+				"@babel/traverse": "^7.4.5",
+				"@emotion/is-prop-valid": "^0.8.8",
+				"@emotion/stylis": "^0.8.4",
+				"@emotion/unitless": "^0.7.4",
 				"babel-plugin-styled-components": ">= 1",
-				"css-to-react-native": "^2.2.2",
-				"memoize-one": "^5.0.0",
-				"merge-anything": "^2.2.4",
-				"prop-types": "^15.5.4",
-				"react-is": "^16.6.0",
-				"stylis": "^3.5.0",
-				"stylis-rule-sheet": "^0.0.10",
+				"css-to-react-native": "^3.0.0",
+				"hoist-non-react-statics": "^3.0.0",
+				"shallowequal": "^1.1.0",
 				"supports-color": "^5.5.0"
 			},
 			"dependencies": {
@@ -18614,16 +18758,6 @@
 					}
 				}
 			}
-		},
-		"stylis": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
-			"integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q=="
-		},
-		"stylis-rule-sheet": {
-			"version": "0.0.10",
-			"resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
-			"integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
 		},
 		"sudokus": {
 			"version": "1.0.2",
@@ -19021,9 +19155,9 @@
 			}
 		},
 		"terser": {
-			"version": "4.6.7",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-4.6.7.tgz",
-			"integrity": "sha512-fmr7M1f7DBly5cX2+rFDvmGBAaaZyPrHYK4mMdHEDAdNTqXSZgSOfqsfGq2HqPGT/1V0foZZuCZFx8CHKgAk3g==",
+			"version": "4.6.12",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.6.12.tgz",
+			"integrity": "sha512-fnIwuaKjFPANG6MAixC/k1TDtnl1YlPLUlLVIxxGZUn1gfUx2+l3/zGNB72wya+lgsb50QBi2tUV75RiODwnww==",
 			"requires": {
 				"commander": "^2.20.0",
 				"source-map": "~0.6.1",
@@ -19044,6 +19178,18 @@
 				"terser": "^4.1.2",
 				"webpack-sources": "^1.4.0",
 				"worker-farm": "^1.7.0"
+			},
+			"dependencies": {
+				"schema-utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"requires": {
+						"ajv": "^6.1.0",
+						"ajv-errors": "^1.0.0",
+						"ajv-keywords": "^3.1.0"
+					}
+				}
 			}
 		},
 		"test-exclude": {
@@ -19363,9 +19509,9 @@
 					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"json5": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
-					"integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+					"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
 					"requires": {
 						"minimist": "^1.2.5"
 					}
@@ -19391,9 +19537,9 @@
 			}
 		},
 		"ts-loader": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.1.tgz",
-			"integrity": "sha512-Dd9FekWuABGgjE1g0TlQJ+4dFUfYGbYcs52/HQObE0ZmUNjQlmLAS7xXsSzy23AMaMwipsx5sNHvoEpT2CZq1g==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.2.tgz",
+			"integrity": "sha512-HDo5kXZCBml3EUPcc7RlZOV/JGlLHwppTLEHb3SHnr5V7NXD4klMEkrhJe5wgRbaWsSXi+Y1SIBN/K9B6zWGWQ==",
 			"requires": {
 				"chalk": "^2.3.0",
 				"enhanced-resolve": "^4.0.0",
@@ -20172,15 +20318,6 @@
 					"version": "2.4.4",
 					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
 					"integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
-				},
-				"schema-utils": {
-					"version": "2.6.5",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.5.tgz",
-					"integrity": "sha512-5KXuwKziQrTVHh8j/Uxz+QUbxkaLW9X/86NBlx/gnKgtsZA2GIVMUn17qWhRFwF8jdYb3Dig5hRO/W5mZqy6SQ==",
-					"requires": {
-						"ajv": "^6.12.0",
-						"ajv-keywords": "^3.4.1"
-					}
 				}
 			}
 		},
@@ -20298,9 +20435,9 @@
 			}
 		},
 		"vfile": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.3.tgz",
-			"integrity": "sha512-lREgT5sF05TQk68LO6APy0In+TkFGnFEgKChK2+PHIaTrFQ9oHCKXznZ7VILwgYVBcl0gv4lGATFZBLhi2kVQg==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-4.1.0.tgz",
+			"integrity": "sha512-BaTPalregj++64xbGK6uIlsurN3BCRNM/P2Pg8HezlGzKd1O9PrwIac6bd9Pdx2uTb0QHoioZ+rXKolbVXEgJg==",
 			"requires": {
 				"@types/unist": "^2.0.0",
 				"is-buffer": "^2.0.0",
@@ -20322,9 +20459,9 @@
 			"integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
 		},
 		"vfile-message": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.3.tgz",
-			"integrity": "sha512-qQg/2z8qnnBHL0psXyF72kCjb9YioIynvyltuNKFaUhRtqTIcIMP3xnBaPzirVZNuBrUe1qwFciSx2yApa4byw==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+			"integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
 			"requires": {
 				"@types/unist": "^2.0.0",
 				"unist-util-stringify-position": "^2.0.0"
@@ -20344,9 +20481,9 @@
 			}
 		},
 		"w3c-keyname": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.2.tgz",
-			"integrity": "sha512-8Vs/aVwcy0IJACaPm4tyzh1fzehZE70bGSjEl3dDms5UXtWnaBElrSHC8lDDeak0Gk5jxKOFstL64/65o7Ge2A=="
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.4.tgz",
+			"integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw=="
 		},
 		"wait-on": {
 			"version": "3.3.0",
@@ -20401,11 +20538,11 @@
 			}
 		},
 		"watchpack": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
-			"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.1.tgz",
+			"integrity": "sha512-+IF9hfUFOrYOOaKyfaI7h7dquUIOgyEMoQMLA7OP5FxegKA2+XdXThAZ9TU2kucfhDH7rfMHs1oPYziVGWRnZA==",
 			"requires": {
-				"chokidar": "^2.0.2",
+				"chokidar": "^2.1.8",
 				"graceful-fs": "^4.1.2",
 				"neo-async": "^2.5.0"
 			}
@@ -20433,15 +20570,15 @@
 			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
 		},
 		"webpack": {
-			"version": "4.42.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.42.0.tgz",
-			"integrity": "sha512-EzJRHvwQyBiYrYqhyjW9AqM90dE4+s1/XtCfn7uWg6cS72zH+2VPFAlsnW0+W0cDi0XRjNKUMoJtpSi50+Ph6w==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.43.0.tgz",
+			"integrity": "sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==",
 			"requires": {
-				"@webassemblyjs/ast": "1.8.5",
-				"@webassemblyjs/helper-module-context": "1.8.5",
-				"@webassemblyjs/wasm-edit": "1.8.5",
-				"@webassemblyjs/wasm-parser": "1.8.5",
-				"acorn": "^6.2.1",
+				"@webassemblyjs/ast": "1.9.0",
+				"@webassemblyjs/helper-module-context": "1.9.0",
+				"@webassemblyjs/wasm-edit": "1.9.0",
+				"@webassemblyjs/wasm-parser": "1.9.0",
+				"acorn": "^6.4.1",
 				"ajv": "^6.10.2",
 				"ajv-keywords": "^3.4.1",
 				"chrome-trace-event": "^1.0.2",
@@ -20452,13 +20589,13 @@
 				"loader-utils": "^1.2.3",
 				"memory-fs": "^0.4.1",
 				"micromatch": "^3.1.10",
-				"mkdirp": "^0.5.1",
+				"mkdirp": "^0.5.3",
 				"neo-async": "^2.6.1",
 				"node-libs-browser": "^2.2.1",
 				"schema-utils": "^1.0.0",
 				"tapable": "^1.1.3",
 				"terser-webpack-plugin": "^1.4.3",
-				"watchpack": "^1.6.0",
+				"watchpack": "^1.6.1",
 				"webpack-sources": "^1.4.1"
 			},
 			"dependencies": {
@@ -20490,6 +20627,19 @@
 						"readable-stream": "^2.0.1"
 					}
 				},
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+				},
+				"mkdirp": {
+					"version": "0.5.5",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+					"requires": {
+						"minimist": "^1.2.5"
+					}
+				},
 				"readable-stream": {
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -20502,6 +20652,16 @@
 						"safe-buffer": "~5.1.1",
 						"string_decoder": "~1.1.1",
 						"util-deprecate": "~1.0.1"
+					}
+				},
+				"schema-utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"requires": {
+						"ajv": "^6.1.0",
+						"ajv-errors": "^1.0.0",
+						"ajv-keywords": "^3.1.0"
 					}
 				},
 				"string_decoder": {
@@ -20849,6 +21009,16 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
+				"schema-utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"requires": {
+						"ajv": "^6.1.0",
+						"ajv-errors": "^1.0.0",
+						"ajv-keywords": "^3.1.0"
+					}
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
@@ -21261,11 +21431,12 @@
 			}
 		},
 		"yauzl": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-			"integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
 			"requires": {
-				"fd-slicer": "~1.0.1"
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
 			}
 		},
 		"yeast": {

--- a/packages/drivers/odsp-socket-storage/package.json
+++ b/packages/drivers/odsp-socket-storage/package.json
@@ -61,7 +61,8 @@
     "node-fetch": "^2.2.1",
     "performance-now": "^2.1.0",
     "sha.js": "^2.4.11",
-    "socket.io-client": "^2.1.1"
+    "socket.io-client": "^2.1.1",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentDeltaConnection.ts
@@ -18,6 +18,7 @@ import { FatalError, ThrottlingError } from "@microsoft/fluid-driver-utils";
 import { IOdspSocketError } from "./contracts";
 import { debug } from "./debug";
 import { errorObjectFromOdspError, OdspNetworkError, socketErrorRetryFilter } from "./odspUtils";
+import uuid from 'uuid/v4';
 
 const protocolVersions = ["^0.3.0", "^0.2.0", "^0.1.0"];
 
@@ -97,6 +98,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
             tenantId,
             token,  // Token is going to indicate tenant level information, etc...
             versions: protocolVersions,
+            nonce: uuid(),
         };
 
         const deltaConnection = new OdspDocumentDeltaConnection(socket, webSocketId, socketReferenceKey);

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentDeltaConnection.ts
@@ -15,10 +15,11 @@ import {
     INack,
 } from "@microsoft/fluid-protocol-definitions";
 import { FatalError, ThrottlingError } from "@microsoft/fluid-driver-utils";
+// eslint-disable-next-line import/no-internal-modules
+import * as uuid from "uuid/v4";
 import { IOdspSocketError } from "./contracts";
 import { debug } from "./debug";
 import { errorObjectFromOdspError, OdspNetworkError, socketErrorRetryFilter } from "./odspUtils";
-import uuid from 'uuid/v4';
 
 const protocolVersions = ["^0.3.0", "^0.2.0", "^0.1.0"];
 
@@ -54,7 +55,6 @@ class SocketReference {
  * Represents a connection to a stream of delta updates
  */
 export class OdspDocumentDeltaConnection extends DocumentDeltaConnection implements IDocumentDeltaConnection {
-
     private readonly nonForwardEvents = ["nack"];
 
     /**
@@ -80,7 +80,6 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
         url: string,
         timeoutMs: number = 20000,
         telemetryLogger: ITelemetryLogger = new TelemetryNullLogger()): Promise<IDocumentDeltaConnection> {
-
         const socketReferenceKey = `${url},${tenantId},${webSocketId}`;
 
         const socketReference = OdspDocumentDeltaConnection.getOrCreateSocketIoReference(
@@ -159,7 +158,6 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
             socketReference.clearTimer();
 
             debug(`Using existing socketio reference for ${key} (${socketReference.references})`);
-
         } else {
             const socket = io(
                 url,
@@ -185,7 +183,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
                 // The server always closes the socket after sending this message
                 // fully remove the socket reference now
                 // This raises "disconnect" event with proper error object.
-                OdspDocumentDeltaConnection.removeSocketIoReference(key, true /*socketProtocolError*/, error);
+                OdspDocumentDeltaConnection.removeSocketIoReference(key, true /* socketProtocolError */, error);
             });
 
             socketReference = new SocketReference(socket);

--- a/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
+++ b/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
@@ -379,7 +379,10 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
         this._details = await new Promise<IConnected>((resolve, reject) => {
             // Listen for connection issues
             this.addConnectionListener("connect_error", (error) => {
-                if (connectMessage.nonce !== undefined && error.nonce !== undefined && error.nonce !== connectMessage.nonce) {
+                // If we sent a nonce and the server supports nonces, check that the nonces match
+                if (connectMessage.nonce !== undefined &&
+                    error.nonce !== undefined &&
+                    error.nonce !== connectMessage.nonce) {
                     return;
                 }
 
@@ -402,7 +405,10 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
             });
 
             this.addConnectionListener("connect_document_success", (response: IConnected) => {
-                if (connectMessage.nonce !== undefined && response.nonce !== undefined && response.nonce !== connectMessage.nonce) {
+                // If we sent a nonce and the server supports nonces, check that the nonces match
+                if (connectMessage.nonce !== undefined &&
+                    response.nonce !== undefined &&
+                    response.nonce !== connectMessage.nonce) {
                     return;
                 }
 

--- a/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
+++ b/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
@@ -379,7 +379,7 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
         this._details = await new Promise<IConnected>((resolve, reject) => {
             // Listen for connection issues
             this.addConnectionListener("connect_error", (error) => {
-                if (connectMessage.nonce && error.nonce && error.nonce !== connectMessage.nonce) {
+                if (connectMessage.nonce !== undefined && error.nonce !== undefined && error.nonce !== connectMessage.nonce) {
                     return;
                 }
 
@@ -402,7 +402,7 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
             });
 
             this.addConnectionListener("connect_document_success", (response: IConnected) => {
-                if (connectMessage.nonce && response.nonce && response.nonce !== connectMessage.nonce) {
+                if (connectMessage.nonce !== undefined && response.nonce !== undefined && response.nonce !== connectMessage.nonce) {
                     return;
                 }
 

--- a/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
+++ b/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
@@ -379,6 +379,10 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
         this._details = await new Promise<IConnected>((resolve, reject) => {
             // Listen for connection issues
             this.addConnectionListener("connect_error", (error) => {
+                if (connectMessage.nonce && error.nonce && error.nonce !== connectMessage.nonce) {
+                    return;
+                }
+
                 debug(`Socket connection error: [${error}]`);
                 this.disconnect(true);
                 reject(createErrorObject("connect_error", error));
@@ -398,6 +402,10 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
             });
 
             this.addConnectionListener("connect_document_success", (response: IConnected) => {
+                if (connectMessage.nonce && response.nonce && response.nonce !== connectMessage.nonce) {
+                    return;
+                }
+
                 this.removeTrackedListeners(true);
                 resolve(response);
             });


### PR DESCRIPTION
If more than one client tries sending connect_document on the multiplexed websocket before a connection handshake finishes, they can get confused by another client's message. This adds a UUID nonce to the request, and the given document will ignore responses that don't have a matching nonce (support for this on the Push side is ready to go when this is approved)

Backwards compatibility is maintained via not performing the check if the client or the server don't have a nonce.

@GaryWilber @vladsud 