### PR TITLE
Use .app/ackHandle to refer to previous blobs for odsp.

### DIFF
--- a/packages/components/todo/package.json
+++ b/packages/components/todo/package.json
@@ -25,7 +25,7 @@
     "start:docker": "webpack-dev-server --config webpack.config.js --package package.json --env.mode docker",
     "start:r11s": "webpack-dev-server --config webpack.config.js --package package.json --env.mode r11s",
     "start:spo": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo",
-    "start:spo-df": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo-df --env.driveId b!iSFu-Bz89kWuhzkOQKCZi0ccZIMBFPBNpwEtylvzMqDbs6AUFApoTp-aORnjmZ3N --env.openMode detached",
+    "start:spo-df": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo-df",
     "start:tinylicious": "webpack-dev-server --config webpack.config.js --package package.json --env.mode tinylicious",
     "test:jest": "jest",
     "tsc": "tsc",

--- a/packages/components/todo/package.json
+++ b/packages/components/todo/package.json
@@ -25,7 +25,7 @@
     "start:docker": "webpack-dev-server --config webpack.config.js --package package.json --env.mode docker",
     "start:r11s": "webpack-dev-server --config webpack.config.js --package package.json --env.mode r11s",
     "start:spo": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo",
-    "start:spo-df": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo-df",
+    "start:spo-df": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo-df --env.driveId b!iSFu-Bz89kWuhzkOQKCZi0ccZIMBFPBNpwEtylvzMqDbs6AUFApoTp-aORnjmZ3N --env.openMode detached",
     "start:tinylicious": "webpack-dev-server --config webpack.config.js --package package.json --env.mode tinylicious",
     "test:jest": "jest",
     "tsc": "tsc",

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
@@ -70,7 +70,6 @@ export class OdspDocumentService implements IDocumentService, IExperimentalDocum
         socketIOClientP: Promise<SocketIOClientStatic>,
         cache: IOdspCache,
         isFirstTimeDocumentOpened = true,
-        createNewFlag: boolean,
     ): Promise<IDocumentService> {
         let odspResolvedUrl: IOdspResolvedUrl = resolvedUrl as IOdspResolvedUrl;
         const templogger: ITelemetryLogger = DebugLogger.mixinDebugLogger(
@@ -109,7 +108,6 @@ export class OdspDocumentService implements IDocumentService, IExperimentalDocum
             socketIOClientP,
             cache,
             isFirstTimeDocumentOpened,
-            createNewFlag,
         );
     }
 
@@ -197,7 +195,6 @@ export class OdspDocumentService implements IDocumentService, IExperimentalDocum
         private readonly socketIOClientP: Promise<SocketIOClientStatic>,
         private readonly cache: IOdspCache,
         private readonly isFirstTimeDocumentOpened = true,
-        private readonly createNewFlag: boolean,
     ) {
 
         this.joinSessionKey = `${this.odspResolvedUrl.hashedDocumentId}/joinsession`;
@@ -270,7 +267,6 @@ export class OdspDocumentService implements IDocumentService, IExperimentalDocum
             true,
             this.cache,
             this.isFirstTimeDocumentOpened,
-            this.createNewFlag,
         );
 
         return new OdspDocumentStorageService(this.storageManager);

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactory.ts
@@ -63,7 +63,6 @@ export class OdspDocumentServiceFactory implements IDocumentServiceFactory, IExp
         private readonly storageFetchWrapper: IFetchWrapper = new FetchWrapper(),
         private readonly deltasFetchWrapper: IFetchWrapper = new FetchWrapper(),
         permanentCache?: ICache,
-        private readonly createNewFlag: boolean = false,
     ) {
         this.cache = new OdspCache(permanentCache);
     }
@@ -87,7 +86,6 @@ export class OdspDocumentServiceFactory implements IDocumentServiceFactory, IExp
             Promise.resolve(getSocketIo()),
             this.cache,
             isFirstTimeDocumentOpened,
-            this.createNewFlag,
         );
     }
 }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryWithCodeSplit.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryWithCodeSplit.ts
@@ -66,7 +66,6 @@ export class OdspDocumentServiceFactoryWithCodeSplit implements IDocumentService
         private readonly storageFetchWrapper: IFetchWrapper = new FetchWrapper(),
         private readonly deltasFetchWrapper: IFetchWrapper = new FetchWrapper(),
         permanentCache?: ICache,
-        private readonly createNewFlag: boolean = false,
     ) {
         this.cache = new OdspCache(permanentCache);
     }
@@ -90,7 +89,6 @@ export class OdspDocumentServiceFactoryWithCodeSplit implements IDocumentService
             import("./getSocketIo").then((m) => m.getSocketIo()),
             this.cache,
             isFirstTimeDocumentOpened,
-            this.createNewFlag,
         );
     }
 }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
@@ -89,7 +89,6 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
         private readonly fetchFullSnapshot: boolean,
         private readonly cache: IOdspCache,
         private readonly isFirstTimeDocumentOpened: boolean,
-        private createNewFlag: boolean,
     ) {
         this.queryString = getQueryString(queryParams);
         this.appId = queryParams.app_id;
@@ -436,12 +435,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
     public async uploadSummaryWithContext(summary: api.ISummaryTree, context: ISummaryContext): Promise<string> {
         this.checkSnapshotUrl();
 
-        if (this.createNewFlag) {
-            this.lastSummaryHandle = `${context.ackHandle}/.app`;
-            this.createNewFlag = false;
-        } else {
-            this.lastSummaryHandle = context.proposalHandle;
-        }
+        this.lastSummaryHandle = `${context.ackHandle}/.app`;
         const { result, blobsShaToPathCacheLatest } = await this.writeSummaryTree({
             useContext: true,
             parentHandle: this.lastSummaryHandle,

--- a/packages/tools/webpack-component-loader/src/multiDocumentServiceFactory.ts
+++ b/packages/tools/webpack-component-loader/src/multiDocumentServiceFactory.ts
@@ -29,7 +29,6 @@ export function getDocumentServiceFactory(documentId: string, options: RouteOpti
             undefined,
             undefined,
             undefined,
-            options.openMode === "detached" ? true : false,
         ),
         new RouterliciousDocumentServiceFactory(
             false,


### PR DESCRIPTION
1.) Remove temporary fix merged with this PR: https://github.com/microsoft/FluidFramework/pull/1709
This temp fix was put until server side changes were not there. Now the server side changes are in prod, we should remove this.
2.) Now start using .app/ackHandle to refer to previous blobs.