### PR TITLE
Add support for client specific nacks in ODSP driver

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentDeltaConnection.ts
@@ -259,10 +259,9 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
 
         // when possible emit nacks only when it targets this specific client/document
         super.addTrackedListener("nack", (clientIdOrDocumentId: string, message: INack[]) => {
-            if (!clientIdOrDocumentId ||
-                clientIdOrDocumentId.length === 0 ||
+            if (clientIdOrDocumentId.length === 0 ||
                 clientIdOrDocumentId === documentId ||
-                clientIdOrDocumentId === this.clientId) {
+                (this.hasDetails && clientIdOrDocumentId === this.clientId)) {
                 this.emit("nack", clientIdOrDocumentId, message);
             }
         });

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentDeltaConnection.ts
@@ -261,8 +261,8 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
         super.addTrackedListener("nack", (clientIdOrDocumentId: string, message: INack[]) => {
             if (!clientIdOrDocumentId ||
                 clientIdOrDocumentId.length === 0 ||
-                clientIdOrDocumentId == documentId ||
-                clientIdOrDocumentId == this.clientId) {
+                clientIdOrDocumentId === documentId ||
+                clientIdOrDocumentId === this.clientId) {
                 this.emit("nack", clientIdOrDocumentId, message);
             }
         });

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentDeltaConnection.ts
@@ -258,7 +258,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
         super(socket, documentId);
 
         // when possible emit nacks only when it targets this specific client/document
-        this.on("nack", (clientIdOrDocumentId: string, message: INack[]) => {
+        super.addTrackedListener("nack", (clientIdOrDocumentId: string, message: INack[]) => {
             if (!clientIdOrDocumentId ||
                 clientIdOrDocumentId.length === 0 ||
                 clientIdOrDocumentId == documentId ||
@@ -271,6 +271,10 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
     protected addTrackedListener(event: string, listener: (...args: any[]) => void) {
         if (!this.nonForwardEvents.includes(event)) {
             super.addTrackedListener(event, listener);
+        } else {
+            // this is a "nonforward" event
+            // don't directly link up this socket event to the listener
+            // we will handle the event from a listener in the constructor
         }
     }
 

--- a/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
+++ b/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
@@ -470,7 +470,7 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
         this.trackedListeners.push({ event, connectionListener: true, listener });
     }
 
-    private addTrackedListener(event: string, listener: (...args: any[]) => void) {
+    protected addTrackedListener(event: string, listener: (...args: any[]) => void) {
         this.socket.on(event, listener);
         this.trackedListeners.push({ event, connectionListener: true, listener });
     }

--- a/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
+++ b/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
@@ -114,6 +114,10 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
 
     private trackedListeners: IEventListener[] = [];
 
+    protected get hasDetails(): boolean {
+        return !!this._details;
+    }
+
     private get details(): IConnected {
         if (!this._details) {
             throw new Error("Internal error: calling method before _details is initialized!");
@@ -472,7 +476,7 @@ export class DocumentDeltaConnection extends EventEmitter implements IDocumentDe
 
     protected addTrackedListener(event: string, listener: (...args: any[]) => void) {
         this.socket.on(event, listener);
-        this.trackedListeners.push({ event, connectionListener: true, listener });
+        this.trackedListeners.push({ event, connectionListener: false, listener });
     }
 
     private removeTrackedListeners(connectionListenerOnly) {


### PR DESCRIPTION
Fixes #1930

Push will set the first parameter to the clientid when emitting nacks.