### PR TITLE
Add telemetry event for summaries disabled

### DIFF
--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -160,7 +160,11 @@ export class SummaryManager extends EventEmitter implements IDisposable {
     ) {
         super();
 
-        this.logger = ChildLogger.create(parentLogger, "SummaryManager");
+        this.logger = ChildLogger.create(
+            parentLogger,
+            "SummaryManager",
+            undefined,
+            { clientId: () => this.latestClientId });
 
         this.connected = context.connected;
         if (this.connected) {
@@ -292,6 +296,7 @@ export class SummaryManager extends EventEmitter implements IDisposable {
     private start() {
         if (!this.summariesEnabled) {
             // If we should never summarize, lock in disabled state
+            this.logger.sendTelemetryEvent({ eventName: "SummariesDisabled" });
             this.state = SummaryManagerState.Disabled;
             return;
         }


### PR DESCRIPTION
The event should only fire once per container/client.  Since generally disabling summaries is bad/dangerous, it would be nice to see in telemetry more easily if they are disabled.  Otherwise we don't get any SummaryManager events and it is tricky to debug.

fixes #1917

Also add clientId to all SummaryManager events, because it is useful.