### PR TITLE
isRegistered() for dds should be true if it is attached to component. It should not depend on whether the container is attached/detached.

### DIFF
--- a/packages/runtime/shared-object-common/src/sharedObject.ts
+++ b/packages/runtime/shared-object-common/src/sharedObject.ts
@@ -185,7 +185,7 @@ export abstract class SharedObject extends EventEmitterWithErrorHandling impleme
      * {@inheritDoc ISharedObject.isRegistered}
      */
     public isRegistered(): boolean {
-        return (!this.isLocal() || this.registered);
+        return (!!this.services || this.registered);
     }
 
     /**

--- a/packages/runtime/shared-object-common/src/sharedObject.ts
+++ b/packages/runtime/shared-object-common/src/sharedObject.ts
@@ -185,6 +185,11 @@ export abstract class SharedObject extends EventEmitterWithErrorHandling impleme
      * {@inheritDoc ISharedObject.isRegistered}
      */
     public isRegistered(): boolean {
+        // If the dds is attached to the component then it should be registered irrespective of
+        // whether the container is attached/detached. If it is attached to its component, it will
+        // have its services. This will lead to get the dds summarized. It should also be registered
+        // if somebody called register on dds explicitly without attaching it which will set
+        // this.registered to be true.
         return (!!this.services || this.registered);
     }
 


### PR DESCRIPTION
Problem: Scriptor expected the some dds to have content which it didnt have.
Findings from debugging session:
1.) We started with finding the id of dds missing its sharedstring. We checked that whether we upload that dds and get back in getLatest call.
    So the getLatest response was fine. We did get back what we uploaded but the uploaded dds was not fine. It just had a handle and was
    missing its content.

2.) Then we looked at whether the root component and its dds was getting summarized properly. We found out that the root component is attached and we start summarizing it because we dont summarize unattached components.

3.) While summarizing the attached root component, we found out that dds was not summarized because it was not registered to its component.
    The problem that we found out is that the missing sharedstring dds component handle got created after the component is attached so the logic where we attach all children when we attach ourself did not attach the dds was correct. So the dds never got registered to its component because we only do that when we attach the handle. On summarization logic we skip all the dds that are not registered which caused the problem.
   
    This was never a problem previously because isRegistered() always returns true is the component is attached. However now it was returning false because the container is not attached.