### PR TITLE
fix throttler args in wrong order

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentDeltaConnection.ts
@@ -51,7 +51,6 @@ class SocketReference {
  * Represents a connection to a stream of delta updates
  */
 export class OdspDocumentDeltaConnection extends DocumentDeltaConnection implements IDocumentDeltaConnection {
-
     private readonly nonForwardEvents = ["nack"];
 
     /**

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -84,14 +84,14 @@ type ShouldSummarizeState = {
     stopReason: StopReason;
 };
 
-const defaultThrottleMaxDelayMs = 30 * 1000;
 const defaultThrottleDelayWindowMs = 60 * 1000;
+const defaultThrottleMaxDelayMs = 30 * 1000;
+// default throttling function increases exponentially (0ms, 20ms, 60ms, 140ms, etc)
 const defaultThrottleDelayFunction = (n: number) => 20 * (Math.pow(2, n) - 1);
 
 /**
  * Used to give increasing delay times for throttling a single functionality.
  * Delay is based on previous attempts within specified time window, ignoring actual delay time.
- * Default throttling function increases exponentially (0ms, 20ms, 60ms, 140ms, etc) up to max delay (default 30s)
  */
 class Throttler {
     private startTimes: number[] = [];
@@ -134,8 +134,8 @@ export class SummaryManager extends EventEmitter implements IDisposable {
     private runningSummarizer?: ISummarizer;
     private _disposed = false;
     private readonly startThrottler = new Throttler(
-        defaultThrottleMaxDelayMs,
         defaultThrottleDelayWindowMs,
+        defaultThrottleMaxDelayMs,
         defaultThrottleDelayFunction,
     );
     private opsUntilFirstConnect = -1;


### PR DESCRIPTION
I noticed I switched these on accident. No major impact, but obviously wrong