### PR TITLE
Add fallback for hashFilefor 0.15

### DIFF
--- a/common/lib/common-utils/src/hashFile.ts
+++ b/common/lib/common-utils/src/hashFile.ts
@@ -7,6 +7,21 @@
 import * as sha1 from "sha.js/sha1";
 
 /**
+ * Create Hash (Github hashes the string with blob and size)
+ *
+ * @param file - The contents of the file in a buffer
+ * @returns The sha1 hash of the content of the buffer with the `blob` prefix and size
+ */
+export function gitHashFile(file: Buffer): string {
+    const size = file.byteLength;
+    const filePrefix = `blob ${size.toString()}${String.fromCharCode(0)}`;
+    const engine = new sha1();
+    return engine.update(filePrefix)
+        .update(file)
+        .digest("hex");
+}
+
+/**
  * Hash a file. Consistent within a session, but should not be persisted and
  * is not consistent with git.
  *
@@ -22,28 +37,17 @@ export async function hashFile(file: Buffer): Promise<string> {
         return engine.update(file).digest("hex");
     }
 
-    const hash = await crypto.subtle.digest("SHA-1", file);
-    const hashArray = new Uint8Array(hash);
-    const hashHex = Array.prototype.map.call(hashArray, function(byte) {
-        return byte.toString(16).padStart(2, "0");
-    }).join("");
+    // Fallback to sha.js library if subtlecrypto fails for whatever reason
+    return Promise.resolve(crypto.subtle.digest("SHA-1", file)).then((hash) => {
+        const hashArray = new Uint8Array(hash);
+        const hashHex = Array.prototype.map.call(hashArray, function(byte) {
+            return byte.toString(16).padStart(2, "0");
+        }).join("");
 
-    return hashHex;
-}
-
-/**
- * Create Hash (Github hashes the string with blob and size)
- *
- * @param file - The contents of the file in a buffer
- * @returns The sha1 hash of the content of the buffer with the `blob` prefix and size
- */
-export function gitHashFile(file: Buffer): string {
-    const size = file.byteLength;
-    const filePrefix = `blob ${size.toString()}${String.fromCharCode(0)}`;
-    const engine = new sha1();
-    return engine.update(filePrefix)
-        .update(file)
-        .digest("hex");
+        return hashHex;
+    }).catch((error) => {
+        return gitHashFile(file);
+    });
 }
 
 /**

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2154,7 +2154,7 @@
 			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-protocol-base/-/fluid-protocol-base-0.1003.22488.tgz",
 			"integrity": "sha512-BlR+ZmcYAzARxsmJasuui3HObt52O2UY9tS05pmim0o+CpB7MnWrEw85NVMSwUN2ZvSraZusFWbT94W1YQMzLw==",
 			"requires": {
-				"@microsoft/fluid-common-utils": "^0.14.0",
+				"@microsoft/fluid-common-utils": "^0.15.0",
 				"@microsoft/fluid-gitresources": "^0.1003.22488",
 				"@microsoft/fluid-protocol-definitions": "^0.1003.22488",
 				"lodash": "^4.17.11"
@@ -2173,7 +2173,7 @@
 			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-server-lambdas/-/fluid-server-lambdas-0.1003.22488.tgz",
 			"integrity": "sha512-i9vjm+HnOWAc+gqoSIMtfVZi3fc97jjzXS7umWZY4MeRRx/c9pvSfq5857WoTLVLJ1lOwW/yAkq1Ouzl0gOzbg==",
 			"requires": {
-				"@microsoft/fluid-common-utils": "^0.14.0",
+				"@microsoft/fluid-common-utils": "^0.15.0",
 				"@microsoft/fluid-gitresources": "^0.1003.22488",
 				"@microsoft/fluid-protocol-base": "^0.1003.22488",
 				"@microsoft/fluid-protocol-definitions": "^0.1003.22488",
@@ -2206,7 +2206,7 @@
 			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-server-memory-orderer/-/fluid-server-memory-orderer-0.1003.22488.tgz",
 			"integrity": "sha512-M+tjORwZYnubpbGbfw1IQVdeDfePP+glnAr31xUO//RlC+r3oN8qdFyQ3oESiw9uDcFSpPVFP8lggfKvACYJiQ==",
 			"requires": {
-				"@microsoft/fluid-common-utils": "^0.14.0",
+				"@microsoft/fluid-common-utils": "^0.15.0",
 				"@microsoft/fluid-protocol-base": "^0.1003.22488",
 				"@microsoft/fluid-protocol-definitions": "^0.1003.22488",
 				"@microsoft/fluid-server-lambdas": "^0.1003.22488",
@@ -2232,7 +2232,7 @@
 			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-server-services-client/-/fluid-server-services-client-0.1003.22488.tgz",
 			"integrity": "sha512-6YCtM4oHroqESMWvO8q0FPtJ1cZ1e8T6MKDVmwue3ll4XxcDHxZTweugBa6QNs5SF8Yw/QDslm1yXlxlRQ+Jug==",
 			"requires": {
-				"@microsoft/fluid-common-utils": "^0.14.0",
+				"@microsoft/fluid-common-utils": "^0.15.0",
 				"@microsoft/fluid-gitresources": "^0.1003.22488",
 				"@microsoft/fluid-protocol-base": "^0.1003.22488",
 				"@microsoft/fluid-protocol-definitions": "^0.1003.22488",
@@ -2248,7 +2248,7 @@
 			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-server-services-core/-/fluid-server-services-core-0.1003.22488.tgz",
 			"integrity": "sha512-ebzXDLI2/dO2lU7e7j03EwD4OEtPQb6SfQ3Bq5B25ffKOa7YFVhhTN+WD02iImlcw4lxqkIcCf2nKd+WnpaEKw==",
 			"requires": {
-				"@microsoft/fluid-common-utils": "^0.14.0",
+				"@microsoft/fluid-common-utils": "^0.15.0",
 				"@microsoft/fluid-gitresources": "^0.1003.22488",
 				"@microsoft/fluid-protocol-definitions": "^0.1003.22488",
 				"@microsoft/fluid-server-services-client": "^0.1003.22488",
@@ -2263,7 +2263,7 @@
 			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-server-test-utils/-/fluid-server-test-utils-0.1003.22488.tgz",
 			"integrity": "sha512-enLtO6+kPgqi3gIQJuL9NT8YU5tJfvghxu1zYRrRklPY7plycidloWPz4h4JGXYyropRg0auZaANbkgYSnZI6g==",
 			"requires": {
-				"@microsoft/fluid-common-utils": "^0.14.0",
+				"@microsoft/fluid-common-utils": "^0.15.0",
 				"@microsoft/fluid-gitresources": "^0.1003.22488",
 				"@microsoft/fluid-protocol-base": "^0.1003.22488",
 				"@microsoft/fluid-protocol-definitions": "^0.1003.22488",

--- a/packages/components/client-ui-lib/package.json
+++ b/packages/components/client-ui-lib/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@fluid-example/search-menu": "^0.15.0",
     "@fluid-internal/client-api": "^0.15.0",
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-container-definitions": "^0.15.0",
     "@microsoft/fluid-framework-experimental": "^0.15.0",

--- a/packages/components/external-component-loader/package.json
+++ b/packages/components/external-component-loader/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@microsoft/fluid-aqueduct": "^0.15.0",
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-container-definitions": "^0.15.0",
     "@microsoft/fluid-framework-interfaces": "^0.15.0",

--- a/packages/components/owned-map/package.json
+++ b/packages/components/owned-map/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@microsoft/fluid-aqueduct": "^0.15.0",
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-map": "^0.15.0",
     "@microsoft/fluid-protocol-definitions": "^0.1003.0",

--- a/packages/components/pond/package-lock.json
+++ b/packages/components/pond/package-lock.json
@@ -529,7 +529,7 @@
 			"integrity": "sha512-Ax1WJO9aS05RkQA0z7Ccka5zOQOBgsjYOCpdr2eX2nd/+msELDW2nidr4F+Dr6Os16iPa17f+UmFEBFjz+noMQ==",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.13.0",
-				"@microsoft/fluid-common-utils": "^0.14.0",
+				"@microsoft/fluid-common-utils": "^0.15.0",
 				"@microsoft/fluid-component-core-interfaces": "^0.15.21539",
 				"@microsoft/fluid-container-definitions": "^0.15.21539",
 				"@microsoft/fluid-driver-definitions": "^0.15.21539",
@@ -561,7 +561,7 @@
 			"dev": true,
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.13.0",
-				"@microsoft/fluid-common-utils": "^0.14.0",
+				"@microsoft/fluid-common-utils": "^0.15.0",
 				"@microsoft/fluid-component-core-interfaces": "^0.15.21539",
 				"@microsoft/fluid-container-definitions": "^0.15.21539",
 				"@microsoft/fluid-driver-definitions": "^0.15.21539",
@@ -583,7 +583,7 @@
 			"requires": {
 				"@microsoft/fluid-agent-scheduler": "^0.15.21539",
 				"@microsoft/fluid-common-definitions": "^0.13.0",
-				"@microsoft/fluid-common-utils": "^0.14.0",
+				"@microsoft/fluid-common-utils": "^0.15.0",
 				"@microsoft/fluid-component-core-interfaces": "^0.15.21539",
 				"@microsoft/fluid-container-definitions": "^0.15.21539",
 				"@microsoft/fluid-driver-definitions": "^0.15.21539",
@@ -606,7 +606,7 @@
 			"integrity": "sha512-vEZ3Du0njTLUAT+H0ZNTb43/fuXyfGI9rGVng+86Q5Ig3DQDA+DBBp1Vz+2haXLWZLMyMH4AhcBVTpfKEaFddw==",
 			"dev": true,
 			"requires": {
-				"@microsoft/fluid-common-utils": "^0.14.0",
+				"@microsoft/fluid-common-utils": "^0.15.0",
 				"@microsoft/fluid-driver-definitions": "^0.15.21539",
 				"@microsoft/fluid-driver-utils": "^0.15.21539",
 				"@microsoft/fluid-protocol-definitions": "^0.1002.0",
@@ -655,7 +655,7 @@
 			"integrity": "sha512-aYp48rwCloiv+hpzgQ3L+GqARIxpkDzK/JShXKb66sQLHGiXakeKjmh+DEtpV/pz6SvxQjPGkC8QVRsA0Xg9BA==",
 			"dev": true,
 			"requires": {
-				"@microsoft/fluid-common-utils": "^0.14.0",
+				"@microsoft/fluid-common-utils": "^0.15.0",
 				"@microsoft/fluid-component-core-interfaces": "^0.15.21539",
 				"@microsoft/fluid-container-definitions": "^0.15.21539",
 				"@microsoft/fluid-driver-definitions": "^0.15.21539",
@@ -694,7 +694,7 @@
 			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-map/-/fluid-map-0.15.21539.tgz",
 			"integrity": "sha512-d2zwcwuBPp8Hclt4zwdkFf5rNByTrI3FJ3tOgNt/XsUWvIxTUOlKYhkpNE6TKjAxra/q/JnL+DzfwyqjqQr0Vw==",
 			"requires": {
-				"@microsoft/fluid-common-utils": "^0.14.0",
+				"@microsoft/fluid-common-utils": "^0.15.0",
 				"@microsoft/fluid-component-core-interfaces": "^0.15.21539",
 				"@microsoft/fluid-protocol-base": "^0.1002.0",
 				"@microsoft/fluid-protocol-definitions": "^0.1002.0",
@@ -710,7 +710,7 @@
 			"dev": true,
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.13.0",
-				"@microsoft/fluid-common-utils": "^0.14.0",
+				"@microsoft/fluid-common-utils": "^0.15.0",
 				"@microsoft/fluid-component-core-interfaces": "^0.15.21539",
 				"@microsoft/fluid-driver-base": "^0.15.21539",
 				"@microsoft/fluid-driver-definitions": "^0.15.21539",
@@ -747,7 +747,7 @@
 			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-protocol-base/-/fluid-protocol-base-0.1002.21380.tgz",
 			"integrity": "sha512-drsDlEaJVLMhRdsGMgHB1ely3Bgwg9FBbJ82/M64QQ9a1CUyRbOPtBHvDkSwY/JgQ9D/8XQddWbTGsvnc9lEtw==",
 			"requires": {
-				"@microsoft/fluid-common-utils": "^0.14.0",
+				"@microsoft/fluid-common-utils": "^0.15.0",
 				"@microsoft/fluid-gitresources": "^0.1002.21380",
 				"@microsoft/fluid-protocol-definitions": "^0.1002.21380",
 				"lodash": "^4.17.11"
@@ -766,7 +766,7 @@
 			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-register-collection/-/fluid-register-collection-0.15.21539.tgz",
 			"integrity": "sha512-wiIznfAEHXebIXbLjBAyk1nHDZ2L8Tvi8VXWYawPzqMaJlToh/Pzl9PjRAK/Dp+MRO+RnsmlS/KjQN4rc3Xtqw==",
 			"requires": {
-				"@microsoft/fluid-common-utils": "^0.14.0",
+				"@microsoft/fluid-common-utils": "^0.15.0",
 				"@microsoft/fluid-protocol-definitions": "^0.1002.0",
 				"@microsoft/fluid-runtime-definitions": "^0.15.21539",
 				"@microsoft/fluid-shared-object-base": "^0.15.21539",
@@ -779,7 +779,7 @@
 			"integrity": "sha512-oOzb4qoNmLt56udJ5oYazBopZLOqo96s2Q5meWVV6ICc44RhvHj4PY1/EbhoKveL7jTeCKq7T/IiV2Y0MpHL2g==",
 			"dev": true,
 			"requires": {
-				"@microsoft/fluid-common-utils": "^0.14.0",
+				"@microsoft/fluid-common-utils": "^0.15.0",
 				"@microsoft/fluid-driver-base": "^0.15.21539",
 				"@microsoft/fluid-driver-definitions": "^0.15.21539",
 				"@microsoft/fluid-gitresources": "^0.1002.0",
@@ -823,7 +823,7 @@
 			"integrity": "sha512-FgqLeXo4axR8DYe/CwMVTnhBS6c9m7TL1wjUE2KsLI0kOhmtbevdxZiqhTecwn3WYF6+ciQMRNbLQ5DOYT6Wog==",
 			"dev": true,
 			"requires": {
-				"@microsoft/fluid-common-utils": "^0.14.0",
+				"@microsoft/fluid-common-utils": "^0.15.0",
 				"@microsoft/fluid-gitresources": "^0.1002.21380",
 				"@microsoft/fluid-protocol-base": "^0.1002.21380",
 				"@microsoft/fluid-protocol-definitions": "^0.1002.21380",
@@ -858,7 +858,7 @@
 			"integrity": "sha512-QRdqTabFd/ffzBLr4dl2ZyAtDVA3FiHFhg0zEoVI8PFbv33S5RWzjQOQrV/1q70zRa9cjtpTgneSwJA7NMhYGA==",
 			"dev": true,
 			"requires": {
-				"@microsoft/fluid-common-utils": "^0.14.0",
+				"@microsoft/fluid-common-utils": "^0.15.0",
 				"@microsoft/fluid-protocol-base": "^0.1002.21380",
 				"@microsoft/fluid-protocol-definitions": "^0.1002.21380",
 				"@microsoft/fluid-server-lambdas": "^0.1002.21380",
@@ -885,7 +885,7 @@
 			"integrity": "sha512-8i8Vrt3h0XTtwld63YVmbkGi1XAaWc1OWPqj8xgyS9NNeMfY+KFvccV1/BaNxbTyY7sWk9wrBRSjVe5sJfPEyQ==",
 			"dev": true,
 			"requires": {
-				"@microsoft/fluid-common-utils": "^0.14.0",
+				"@microsoft/fluid-common-utils": "^0.15.0",
 				"@microsoft/fluid-gitresources": "^0.1002.21380",
 				"@microsoft/fluid-protocol-base": "^0.1002.21380",
 				"@microsoft/fluid-protocol-definitions": "^0.1002.21380",
@@ -902,7 +902,7 @@
 			"integrity": "sha512-rEFOVhJJRpKIXVpvYNS/4vyioHcf15FMXq+cLDS4fHAWruMWwpuBEgH2fHG35Ki1nptvoY1TCHwZgbSRo4Mdew==",
 			"dev": true,
 			"requires": {
-				"@microsoft/fluid-common-utils": "^0.14.0",
+				"@microsoft/fluid-common-utils": "^0.15.0",
 				"@microsoft/fluid-gitresources": "^0.1002.21380",
 				"@microsoft/fluid-protocol-definitions": "^0.1002.21380",
 				"@microsoft/fluid-server-services-client": "^0.1002.21380",
@@ -918,7 +918,7 @@
 			"integrity": "sha512-+VMO67FLoz8bNpOM7YU9vUiTcAWvC+5U38w+RAVLV6cBYIHSPTzHrBKc+ygenjKTtH74P4+HpAo66Dg/hr0/pg==",
 			"dev": true,
 			"requires": {
-				"@microsoft/fluid-common-utils": "^0.14.0",
+				"@microsoft/fluid-common-utils": "^0.15.0",
 				"@microsoft/fluid-gitresources": "^0.1002.21380",
 				"@microsoft/fluid-protocol-definitions": "^0.1002.21380",
 				"@microsoft/fluid-server-services-client": "^0.1002.21380",
@@ -936,7 +936,7 @@
 			"integrity": "sha512-+BKIYC4465liDmi8z8RcH891N1OOBfudBtOFPtWHa8h3bc0RDBSPtAFxW+aLgOHmlMfrHh6wnlztlfb5/uWGUA==",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.13.0",
-				"@microsoft/fluid-common-utils": "^0.14.0",
+				"@microsoft/fluid-common-utils": "^0.15.0",
 				"@microsoft/fluid-component-core-interfaces": "^0.15.21539",
 				"@microsoft/fluid-container-definitions": "^0.15.21539",
 				"@microsoft/fluid-protocol-definitions": "^0.1002.0",

--- a/packages/drivers/create-new-driver/package.json
+++ b/packages/drivers/create-new-driver/package.json
@@ -49,7 +49,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-driver-definitions": "^0.15.0",
     "@microsoft/fluid-driver-utils": "^0.15.0",

--- a/packages/drivers/file-socket-storage/package.json
+++ b/packages/drivers/file-socket-storage/package.json
@@ -24,7 +24,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-driver-definitions": "^0.15.0",
     "@microsoft/fluid-protocol-base": "^0.1003.0",
     "@microsoft/fluid-protocol-definitions": "^0.1003.0",

--- a/packages/drivers/fluid-debugger/package.json
+++ b/packages/drivers/fluid-debugger/package.json
@@ -24,7 +24,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-driver-definitions": "^0.15.0",
     "@microsoft/fluid-driver-utils": "^0.15.0",
     "@microsoft/fluid-protocol-definitions": "^0.1003.0",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -26,7 +26,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-driver-definitions": "^0.15.0",
     "@microsoft/fluid-odsp-driver": "^0.15.0"

--- a/packages/drivers/iframe-socket-storage/package.json
+++ b/packages/drivers/iframe-socket-storage/package.json
@@ -25,7 +25,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-driver-definitions": "^0.15.0",
     "@microsoft/fluid-driver-utils": "^0.15.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -24,7 +24,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-container-definitions": "^0.15.0",
     "@microsoft/fluid-driver-definitions": "^0.15.0",

--- a/packages/drivers/odsp-socket-storage/package.json
+++ b/packages/drivers/odsp-socket-storage/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@microsoft/fluid-common-definitions": "^0.13.0",
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-driver-base": "^0.15.0",
     "@microsoft/fluid-driver-definitions": "^0.15.0",

--- a/packages/drivers/routerlicious-socket-storage/package.json
+++ b/packages/drivers/routerlicious-socket-storage/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@microsoft/fluid-common-definitions": "^0.13.0",
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-driver-base": "^0.15.0",
     "@microsoft/fluid-driver-definitions": "^0.15.0",
     "@microsoft/fluid-driver-utils": "^0.15.0",

--- a/packages/drivers/socket-storage-shared/package.json
+++ b/packages/drivers/socket-storage-shared/package.json
@@ -25,7 +25,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-driver-definitions": "^0.15.0",
     "@microsoft/fluid-driver-utils": "^0.15.0",
     "@microsoft/fluid-protocol-definitions": "^0.1003.0",

--- a/packages/framework/component-base/package.json
+++ b/packages/framework/component-base/package.json
@@ -50,7 +50,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-component-runtime": "^0.15.0",
     "@microsoft/fluid-container-definitions": "^0.15.0",

--- a/packages/hosts/tiny-web-host/package.json
+++ b/packages/hosts/tiny-web-host/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@microsoft/fluid-base-host": "^0.15.0",
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-container-definitions": "^0.15.0",
     "@microsoft/fluid-container-loader": "^0.15.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@microsoft/fluid-common-definitions": "^0.13.0",
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-container-definitions": "^0.15.0",
     "@microsoft/fluid-driver-definitions": "^0.15.0",

--- a/packages/runtime/cell/package.json
+++ b/packages/runtime/cell/package.json
@@ -48,7 +48,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-protocol-definitions": "^0.1003.0",
     "@microsoft/fluid-runtime-definitions": "^0.15.0",

--- a/packages/runtime/client-api/package.json
+++ b/packages/runtime/client-api/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@microsoft/fluid-cell": "^0.15.0",
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-component-runtime": "^0.15.0",
     "@microsoft/fluid-container-definitions": "^0.15.0",

--- a/packages/runtime/component-runtime/package.json
+++ b/packages/runtime/component-runtime/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@microsoft/fluid-common-definitions": "^0.13.0",
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-container-definitions": "^0.15.0",
     "@microsoft/fluid-driver-definitions": "^0.15.0",

--- a/packages/runtime/consensus-ordered-collection/package.json
+++ b/packages/runtime/consensus-ordered-collection/package.json
@@ -48,7 +48,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-protocol-definitions": "^0.1003.0",
     "@microsoft/fluid-runtime-definitions": "^0.15.0",
     "@microsoft/fluid-shared-object-base": "^0.15.0",

--- a/packages/runtime/consensus-register-collection/package.json
+++ b/packages/runtime/consensus-register-collection/package.json
@@ -48,7 +48,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-protocol-definitions": "^0.1003.0",
     "@microsoft/fluid-runtime-definitions": "^0.15.0",
     "@microsoft/fluid-shared-object-base": "^0.15.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@microsoft/fluid-agent-scheduler": "^0.15.0",
     "@microsoft/fluid-common-definitions": "^0.13.0",
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-container-definitions": "^0.15.0",
     "@microsoft/fluid-driver-definitions": "^0.15.0",

--- a/packages/runtime/ink/package.json
+++ b/packages/runtime/ink/package.json
@@ -25,7 +25,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-protocol-definitions": "^0.1003.0",
     "@microsoft/fluid-runtime-definitions": "^0.15.0",
     "@microsoft/fluid-shared-object-base": "^0.15.0",

--- a/packages/runtime/map/package.json
+++ b/packages/runtime/map/package.json
@@ -48,7 +48,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-protocol-base": "^0.1003.0",
     "@microsoft/fluid-protocol-definitions": "^0.1003.0",

--- a/packages/runtime/matrix/package.json
+++ b/packages/runtime/matrix/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@microsoft/fluid-common-definitions": "^0.13.0",
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-merge-tree": "^0.15.0",
     "@microsoft/fluid-protocol-definitions": "^0.1003.0",

--- a/packages/runtime/merge-tree/package.json
+++ b/packages/runtime/merge-tree/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@microsoft/fluid-common-definitions": "^0.13.0",
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-protocol-definitions": "^0.1003.0",
     "@microsoft/fluid-runtime-definitions": "^0.15.0"

--- a/packages/runtime/runtime-test-utils/package.json
+++ b/packages/runtime/runtime-test-utils/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@microsoft/fluid-common-definitions": "^0.13.0",
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-container-definitions": "^0.15.0",
     "@microsoft/fluid-driver-definitions": "^0.15.0",

--- a/packages/runtime/sequence/package.json
+++ b/packages/runtime/sequence/package.json
@@ -50,7 +50,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-map": "^0.15.0",
     "@microsoft/fluid-merge-tree": "^0.15.0",

--- a/packages/runtime/shared-object-common/package.json
+++ b/packages/runtime/shared-object-common/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@microsoft/fluid-common-definitions": "^0.13.0",
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-container-definitions": "^0.15.0",
     "@microsoft/fluid-protocol-definitions": "^0.1003.0",

--- a/packages/runtime/summarizable-object/package.json
+++ b/packages/runtime/summarizable-object/package.json
@@ -50,7 +50,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-protocol-definitions": "^0.1003.0",
     "@microsoft/fluid-runtime-definitions": "0.15.0",
     "@microsoft/fluid-shared-object-base": "^0.15.0"

--- a/packages/test/context-reload/package.json
+++ b/packages/test/context-reload/package.json
@@ -34,7 +34,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-webpack-component-loader": "^0.15.0",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/packages/test/functional/package.json
+++ b/packages/test/functional/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@microsoft/eslint-config-fluid": "^0.15.0",
     "@microsoft/fluid-build-common": "^0.14.0",
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-container-loader": "^0.15.0",
     "@microsoft/fluid-container-runtime": "^0.15.0",
     "@microsoft/fluid-protocol-definitions": "^0.1003.0",

--- a/packages/tools/fluid-fetch/package.json
+++ b/packages/tools/fluid-fetch/package.json
@@ -21,7 +21,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-driver-definitions": "^0.15.0",
     "@microsoft/fluid-driver-utils": "^0.15.0",
     "@microsoft/fluid-fluidapp-odsp-urlresolver": "^0.15.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@fluid-internal/client-api": "^0.15.0",
     "@microsoft/fluid-common-definitions": "^0.13.0",
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-container-definitions": "^0.15.0",
     "@microsoft/fluid-container-loader": "^0.15.0",

--- a/packages/tools/webpack-component-loader/package.json
+++ b/packages/tools/webpack-component-loader/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@microsoft/fluid-aqueduct": "^0.15.0",
     "@microsoft/fluid-base-host": "^0.15.0",
-    "@microsoft/fluid-common-utils": "^0.14.0",
+    "@microsoft/fluid-common-utils": "^0.15.0",
     "@microsoft/fluid-component-core-interfaces": "^0.15.0",
     "@microsoft/fluid-container-definitions": "^0.15.0",
     "@microsoft/fluid-container-loader": "^0.15.0",


### PR DESCRIPTION
Fixes #1922
SHA1 hash in subtle crypto fails on edge classic.  Add a fallback for sublte crypto if it fails, then update to use version 0.15
The affected API is hashFile, which is only used in packages projects.  Server only uses gitHashFile.

Will merge to 0.16 as well after