### PR TITLE
Add messages to asserts in SharedSegmentSequence and Client.

### DIFF
--- a/packages/runtime/merge-tree/src/client.ts
+++ b/packages/runtime/merge-tree/src/client.ts
@@ -844,7 +844,7 @@ export class Client {
         // Equal is fine here due to SharedSegmentSequence<>.snapshotContent() potentially updating with same #
         assert(collabWindow.currentSeq <= seq, "Incoming op sequence# < local collabWindow's currentSequence#");
         collabWindow.currentSeq = seq;
-        assert(min <= seq, "Incoming op minSequence# > sequence#");
+        assert(min <= seq, "Incoming op sequence# < minSequence#");
         this.updateMinSeq(min);
     }
 

--- a/packages/runtime/merge-tree/src/client.ts
+++ b/packages/runtime/merge-tree/src/client.ts
@@ -449,8 +449,10 @@ export class Client {
                 this.localOps++;
             }
         } else {
-            assert(this.mergeTree.getCollabWindow().currentSeq < clientArgs.sequenceNumber);
-            assert(this.mergeTree.getCollabWindow().minSeq <= opArgs.sequencedMessage.minimumSequenceNumber);
+            assert(this.mergeTree.getCollabWindow().currentSeq < clientArgs.sequenceNumber,
+                "Incoming remote op sequence# <= local collabWindow's currentSequence#");
+            assert(this.mergeTree.getCollabWindow().minSeq <= opArgs.sequencedMessage.minimumSequenceNumber,
+                "Incoming remote op minSequence# < local collabWindow's minSequence#");
             if (clockStart) {
                 this.accumTime += elapsedMicroseconds(clockStart);
                 this.accumOps++;
@@ -840,9 +842,9 @@ export class Client {
     public updateSeqNumbers(min: number, seq: number) {
         const collabWindow = this.mergeTree.getCollabWindow();
         // Equal is fine here due to SharedSegmentSequence<>.snapshotContent() potentially updating with same #
-        assert(collabWindow.currentSeq <= seq);
+        assert(collabWindow.currentSeq <= seq, "Incoming op sequence# < local collabWindow's currentSequence#");
         collabWindow.currentSeq = seq;
-        assert(min <= seq);
+        assert(min <= seq, "Incoming op minSequence# > sequence#");
         this.updateMinSeq(min);
     }
 

--- a/packages/runtime/sequence/src/sequence.ts
+++ b/packages/runtime/sequence/src/sequence.ts
@@ -511,7 +511,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
 
     private snapshotMergeTree(): ITree {
         // Are we fully loaded? If not, things will go south
-        assert(this.isLoaded);
+        assert(this.isLoaded, "Snapshot called when not fully loaded");
 
         const minSeq = this.runtime.deltaManager
             ? this.runtime.deltaManager.minimumSequenceNumber


### PR DESCRIPTION
Fixes #1947.

There were a couple of asserts in telemetry as documented in #1948 and #1949. Adding messages to these asserts so it's easier to debug.