### PR TITLE
Hotfix testhost to store components on its own root

### DIFF
--- a/examples/components/markflow/test/segmentspan.spec.ts
+++ b/examples/components/markflow/test/segmentspan.spec.ts
@@ -21,7 +21,7 @@ describe("SegmentSpan", () => {
             [FlowDocumentType, Promise.resolve(flowDocumentFactory)],
         ]);
 
-        doc = await host.createAndAttachComponent(FlowDocumentType);
+        doc = await host.createAndAttachComponent("test-doc", FlowDocumentType);
     });
 
     after(async () => {

--- a/examples/components/webflow/test/flowdocument.spec.ts
+++ b/examples/components/webflow/test/flowdocument.spec.ts
@@ -27,7 +27,7 @@ describe("FlowDocument", () => {
     });
 
     beforeEach(async () => {
-        doc = await host.createAndAttachComponent(flowDocumentFactory.type);
+        doc = await host.createAndAttachComponent("test-doc", flowDocumentFactory.type);
     });
 
     function expect(expected: string) {

--- a/examples/components/webflow/test/layout.spec.ts
+++ b/examples/components/webflow/test/layout.spec.ts
@@ -50,7 +50,7 @@ describe("Layout", () => {
             [flowDocumentFactory.type, Promise.resolve(flowDocumentFactory)],
         ]);
 
-        doc = await host.createAndAttachComponent("test-doc" flowDocumentFactory.type);
+        doc = await host.createAndAttachComponent("test-doc", flowDocumentFactory.type);
     });
 
     after(async () => {

--- a/examples/components/webflow/test/layout.spec.ts
+++ b/examples/components/webflow/test/layout.spec.ts
@@ -50,7 +50,7 @@ describe("Layout", () => {
             [flowDocumentFactory.type, Promise.resolve(flowDocumentFactory)],
         ]);
 
-        doc = await host.createAndAttachComponent(flowDocumentFactory.type);
+        doc = await host.createAndAttachComponent("test-doc" flowDocumentFactory.type);
     });
 
     after(async () => {

--- a/examples/components/webflow/test/segmentspan.spec.ts
+++ b/examples/components/webflow/test/segmentspan.spec.ts
@@ -21,7 +21,7 @@ describe("SegmentSpan", () => {
             [flowDocumentFactory.type, Promise.resolve(flowDocumentFactory)],
         ]);
 
-        doc = await host.createAndAttachComponent(flowDocumentFactory.type);
+        doc = await host.createAndAttachComponent("test-doc", flowDocumentFactory.type);
     });
 
     after(async () => {

--- a/packages/components/table-document/src/test/table.spec.ts
+++ b/packages/components/table-document/src/test/table.spec.ts
@@ -30,7 +30,7 @@ describe("TableDocument", () => {
         return id;
     }
 
-    const createTable = async () => host.createAndAttachComponent("test-tabel", TableDocumentType);
+    const createTable = async () => host.createAndAttachComponent(makeId(TableDocumentType), TableDocumentType);
 
     let table: TableDocument;
     beforeEach(async () => {

--- a/packages/components/table-document/src/test/table.spec.ts
+++ b/packages/components/table-document/src/test/table.spec.ts
@@ -30,7 +30,7 @@ describe("TableDocument", () => {
         return id;
     }
 
-    const createTable = async () => host.createAndAttachComponent("testTabel", TableDocumentType);
+    const createTable = async () => host.createAndAttachComponent("test-tabel", TableDocumentType);
 
     let table: TableDocument;
     beforeEach(async () => {

--- a/packages/components/table-document/src/test/table.spec.ts
+++ b/packages/components/table-document/src/test/table.spec.ts
@@ -30,7 +30,7 @@ describe("TableDocument", () => {
         return id;
     }
 
-    const createTable = async () => host.createAndAttachComponent(TableDocumentType);
+    const createTable = async () => host.createAndAttachComponent("testTabel", TableDocumentType);
 
     let table: TableDocument;
     beforeEach(async () => {

--- a/packages/server/local-test-utils/src/testHost.ts
+++ b/packages/server/local-test-utils/src/testHost.ts
@@ -54,14 +54,16 @@ export class TestRootComponent extends PrimedComponent implements IComponentRunn
 
     // Make this function public so TestHost can use them
     public async createAndAttachComponent<T extends IComponentLoadable>(
-        type: string, props?: any,
+        id: string, type: string, props?: any,
     ): Promise<T> {
-        return super.createAndAttachComponent<T>(type, props);
+        const component = await super.createAndAttachComponent<T>(type, props);
+        this.root.set(id, component.handle);
+        return component;
     }
 
     // Make this function public so TestHost can use them
-    public async getComponent_UNSAFE<T>(id: string): Promise<T> {
-        return super.getComponent_UNSAFE<T>(id);
+    public async getComponent<T>(id: string): Promise<T> {
+        return this.root.get<IComponentHandle<T>>(id).get();
     }
 
     /**
@@ -230,9 +232,9 @@ export class TestHost {
      * @param id component Id
      * @returns Component object
      */
-    public async getComponent_UNSAFE<T>(id: string): Promise<T> {
+    public async getComponent<T>(id: string): Promise<T> {
         const root = await this.root;
-        return root.getComponent_UNSAFE<T>(id);
+        return root.getComponent<T>(id);
     }
 
     /**

--- a/packages/server/local-test-utils/src/testHost.ts
+++ b/packages/server/local-test-utils/src/testHost.ts
@@ -52,7 +52,6 @@ export class TestRootComponent extends PrimedComponent implements IComponentRunn
         return;
     }
 
-    // Make this function public so TestHost can use them
     public async createAndAttachComponent<T extends IComponentLoadable>(
         id: string, type: string, props?: any,
     ): Promise<T> {
@@ -61,8 +60,7 @@ export class TestRootComponent extends PrimedComponent implements IComponentRunn
         return component;
     }
 
-    // Make this function public so TestHost can use them
-    public async getComponent<T>(id: string): Promise<T> {
+    public async getComponent<T extends IComponentLoadable>(id: string): Promise<T> {
         return this.root.get<IComponentHandle<T>>(id).get();
     }
 
@@ -217,22 +215,23 @@ export class TestHost {
      * Runs createComponent followed by openComponent
      * @param id component id
      * @param type component type
-     * @param services component services for query interface
+     * @param props optional props to be passed to the component on creation
      * @returns Component object
      */
     public async createAndAttachComponent<T extends IComponentLoadable>(
+        id: string,
         type: string,
         props?: any,
     ): Promise<T> {
         const root = await this.root;
-        return root.createAndAttachComponent<T>(type, props);
+        return root.createAndAttachComponent<T>(id, type, props);
     }
 
     /* Wait and get the component with the id.
      * @param id component Id
      * @returns Component object
      */
-    public async getComponent<T>(id: string): Promise<T> {
+    public async getComponent<T extends IComponentLoadable>(id: string): Promise<T> {
         const root = await this.root;
         return root.getComponent<T>(id);
     }

--- a/packages/server/local-test-utils/src/testHost.ts
+++ b/packages/server/local-test-utils/src/testHost.ts
@@ -55,9 +55,10 @@ export class TestRootComponent extends PrimedComponent implements IComponentRunn
     public async createAndAttachComponent<T extends IComponentLoadable>(
         id: string, type: string, props?: any,
     ): Promise<T> {
-        const component = await super.createAndAttachComponent<T>(type, props);
-        this.root.set(id, component.handle);
-        return component;
+        return super.createAndAttachComponent<T>(type, props).then((component: T) => {
+            this.root.set(id, component.handle);
+            return component;
+        });
     }
 
     public async getComponent<T extends IComponentLoadable>(id: string): Promise<T> {


### PR DESCRIPTION
Bohemia doesnt have a DDS to store the handles on. As such, it needs to have the test root handle storing and retrieving its components.

ScriptorPad is using TestHost and they don't have a DDS of their own. This is a workaround for ScriptorPad still using ID while we have removed IDs in 0.16. Ultimately, we should migrate ScriptorPad off of using TestHost as they are treating it as a container but that is a bigger change and should be isolated from the version migration.

fixes #1962 and #1628 