### PR TITLE
Fixes TestResolver inconsistencies and adds a unit test.

### DIFF
--- a/packages/drivers/local-driver/src/test/testResolverTest.spec.ts
+++ b/packages/drivers/local-driver/src/test/testResolverTest.spec.ts
@@ -9,37 +9,53 @@ import { IRequest } from "@microsoft/fluid-component-core-interfaces";
 import { TestResolver } from "../testResolver";
 
 describe("Local Driver Resolver", () => {
-    const tenantId = "tenantId";
-    const fileName = "fileName";
+    const documentId = "testResolverTest";
     let resolver: TestResolver;
-    let request: IRequest;
 
-    beforeEach(() => {
-        resolver = new TestResolver();
-        request = resolver.createCreateNewRequest(fileName);
+    describe("CreateNew Flow", () => {
+        let request: IRequest;
+
+        beforeEach(() => {
+            resolver = new TestResolver();
+            request = resolver.createCreateNewRequest(documentId);
+        });
+
+        it("should successfully create a creatNewRequest", async () => {
+            assert(!!request.headers?.[CreateNewHeader.createNew],
+                "Request should contain create new header");
+            const expectedUrl = `http://localhost:3000/${documentId}`;
+            assert.equal(request.url, expectedUrl, "The url in createNewRequest should match");
+        });
+
+        it("should successfully resolve a createNewRequest", async () => {
+            const resolvedUrl = await resolver.resolve(request) as IFluidResolvedUrl;
+            const expectedUrl = `fluid-test://localhost:3000/tenantId/${documentId}`;
+            assert.equal(resolvedUrl.url, expectedUrl, "The resolved url should match");
+        });
+
+        it("should successfully create requestUrl for a component from resolvedUrl", async () => {
+            const resolvedUrl = await resolver.resolve(request);
+            const componentId = "component";
+            const response = await resolver.requestUrl(resolvedUrl, { url: componentId });
+
+            assert.equal(response.status, "200", "Status code should be 200");
+            assert.equal(response.mimeType, "text/plain", "Mime type should be text/plain");
+
+            const expectedUrl = `http://localhost:3000/${documentId}/${componentId}`;
+            assert.equal(response.value, expectedUrl, "The requestUrl should match");
+        });
     });
 
-    it("Create New Request", async () => {
-        assert(!!request.headers?.[CreateNewHeader.createNew],
-            "Request should contain create new header");
-        const url = `http://localhost:3000/${tenantId}/${fileName}`;
-        assert.equal(request.url, url, "Request url should match");
-    });
+    describe("Container Request Resolution", () => {
+        beforeEach(() => {
+            resolver = new TestResolver();
+        });
 
-    it("Resolved CreateNew Request", async () => {
-        const resolvedUrl = await resolver.resolve(request);
-        const url = `fluid-test://localhost:3000/${tenantId}/${fileName}`;
-        assert.equal((resolvedUrl as IFluidResolvedUrl).url, url, "url should match");
-    });
-
-    it("Test RequestUrl for a component", async () => {
-        const resolvedUrl = await resolver.resolve(request);
-        const componentId = "component";
-        const response = await resolver.requestUrl(resolvedUrl, { url: componentId });
-
-        assert.equal(response.status, "200", "Status code should ve 200");
-        assert.equal(response.mimeType, "text/plain", "Mime type should be text/plain");
-        const [url] = response.value.split("?");
-        assert.equal(url, `https://localhost:3000/${tenantId}/${fileName}/${componentId}`, "Url should match");
+        it("should successfully resolve request for a container url", async () => {
+            const url = `http://localhost/${documentId}`;
+            const resolvedUrl = await resolver.resolve({ url }) as IFluidResolvedUrl;
+            const expectedUrl = `fluid-test://localhost:3000/tenantId/${documentId}`;
+            assert.equal(resolvedUrl.url, expectedUrl, "The resolved container url should match");
+        });
     });
 });

--- a/packages/drivers/local-driver/src/testResolver.ts
+++ b/packages/drivers/local-driver/src/testResolver.ts
@@ -35,12 +35,7 @@ export class TestResolver implements IUrlResolver, IExperimentalUrlResolver {
      */
     public async resolve(request: IRequest): Promise<IResolvedUrl> {
         const parsedUrl = new URL(request.url);
-        let documentId;
-        if (request.headers?.[CreateNewHeader.createNew]) {
-            documentId = parsedUrl.pathname.substr(1).split("/")[1];
-            return this.resolveHelper(documentId);
-        }
-        documentId = parsedUrl.pathname.substr(1).split("/")[0];
+        const documentId = parsedUrl.pathname.substr(1).split("/")[0];
         return this.resolveHelper(documentId);
     }
 
@@ -71,19 +66,20 @@ export class TestResolver implements IUrlResolver, IExperimentalUrlResolver {
         if (parsedUrl.pathname === undefined) {
             throw new Error("Url should contain tenant and docId!!");
         }
-        const [, , documentId] = parsedUrl.pathname.split("/");
-        assert(documentId);
+        const [, , documentId] = parsedUrl.pathname?.split("/");
+        assert(documentId, "The resolvedUrl must have a documentId");
+
         const response: IResponse = {
             mimeType: "text/plain",
-            value: `https://localhost:3000/${this.tenantId}/${documentId}/${url}`,
+            value: `http://localhost:3000/${documentId}/${url}`,
             status: 200,
         };
         return response;
     }
 
-    public createCreateNewRequest(id: string): IRequest {
+    public createCreateNewRequest(documentId: string): IRequest {
         const createNewRequest: IRequest = {
-            url: `http://localhost:3000/${this.tenantId}/${id}`,
+            url: `http://localhost:3000/${documentId}`,
             headers: {
                 [CreateNewHeader.createNew]: true,
             },

--- a/packages/drivers/local-driver/src/testResolver.ts
+++ b/packages/drivers/local-driver/src/testResolver.ts
@@ -66,7 +66,7 @@ export class TestResolver implements IUrlResolver, IExperimentalUrlResolver {
         if (parsedUrl.pathname === undefined) {
             throw new Error("Url should contain tenant and docId!!");
         }
-        const [, , documentId] = parsedUrl.pathname?.split("/");
+        const [, , documentId] = parsedUrl.pathname.split("/");
         assert(documentId, "The resolvedUrl must have a documentId");
 
         const response: IResponse = {


### PR DESCRIPTION
TestResolver has some inconsistencies after some conflicting changes and merges. 
This changes fixes the inconsistencies and adds a unit test to test the regular container request resolution.

Fixes #1967.