### PR TITLE
Remove component creation from Spaces dataModel and other refactoring for view/model

### DIFF
--- a/examples/components/external-component-loader/src/index.ts
+++ b/examples/components/external-component-loader/src/index.ts
@@ -7,7 +7,6 @@ import { SpacesComponentName, Spaces } from "@fluid-example/spaces";
 import { WaterParkLoaderInstantiationFactory, WaterParkLoaderName } from "./waterParkLoader";
 import { WaterParkModuleInstantiationFactory } from "./waterParkModuleInstantiationFactory";
 
-// TODO: Why does ComponentToolbar need to be added here
 export const fluidExport = new WaterParkModuleInstantiationFactory(
     new Map([
         [WaterParkLoaderName, Promise.resolve(WaterParkLoaderInstantiationFactory)],

--- a/examples/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
+++ b/examples/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
@@ -197,9 +197,8 @@ export class ExternalComponentLoader extends PrimedComponent
                 component = component.IComponentCollection.createCollectionItem();
             }
             viewComponent.IComponentCollection.createCollectionItem<IComponentOptions>({
-                handle: component.IComponentHandle,
+                component: component as IComponent & IComponentLoadable,
                 type: value,
-                url: component.IComponentLoadable?.url,
             });
         } catch (error) {
             this.error = error;

--- a/examples/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
+++ b/examples/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
@@ -20,10 +20,12 @@ import { IComponentCallable, IComponentCallbacks, IComponentOptions } from "@flu
 const pkg = require("../../package.json") as IPackage;
 export const WaterParkLoaderName = `${pkg.name}-loader`;
 
-const extraComponents = [
-    "http://localhost:8080/file/C:\\git\\FluidFramework\\examples\\components\\todo",
-    "http://localhost:8080/file/C:\\git\\FluidFramework\\examples\\components\\clicker",
-];
+// extraComponents facilitates local component development.  Make sure the path points to a directory containing
+// the package.json for the package, and also make sure you've run webpack there first.
+// const extraComponents = [
+//     "http://localhost:8080/file/C:\\git\\FluidFramework\\examples\\components\\todo",
+//     "http://localhost:8080/file/C:\\git\\FluidFramework\\examples\\components\\clicker",
+// ];
 
 /**
  * Component that loads extneral components via their url
@@ -90,11 +92,11 @@ export class ExternalComponentLoader extends PrimedComponent
                 option.value = `${url}@${defaultVersionToLoad}`;
                 dataList.append(option);
             });
-            extraComponents.forEach((url) => {
-                const option = document.createElement("option");
-                option.value = `${url}`;
-                dataList.append(option);
-            });
+            // extraComponents.forEach((url) => {
+            //     const option = document.createElement("option");
+            //     option.value = `${url}`;
+            //     dataList.append(option);
+            // });
 
             const input = document.createElement("input");
             inputDiv.append(input);

--- a/examples/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
+++ b/examples/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
@@ -20,12 +20,13 @@ import { IComponentCallable, IComponentCallbacks, IComponentOptions } from "@flu
 const pkg = require("../../package.json") as IPackage;
 export const WaterParkLoaderName = `${pkg.name}-loader`;
 
-// extraComponents facilitates local component development.  Make sure the path points to a directory containing
-// the package.json for the package, and also make sure you've run webpack there first.
-// const extraComponents = [
-//     "http://localhost:8080/file/C:\\git\\FluidFramework\\examples\\components\\todo",
-//     "http://localhost:8080/file/C:\\git\\FluidFramework\\examples\\components\\clicker",
-// ];
+// localComponents facilitates local component development.  Make sure the path points to a directory containing
+// the package.json for the package, and also make sure you've run webpack there first.  These will only be
+// available when running on localhost.
+const localComponents = [
+    // "http://localhost:8080/file/C:\\git\\FluidFramework\\examples\\components\\todo",
+    // "http://localhost:8080/file/C:\\git\\FluidFramework\\examples\\components\\clicker",
+];
 
 /**
  * Component that loads extneral components via their url
@@ -92,11 +93,14 @@ export class ExternalComponentLoader extends PrimedComponent
                 option.value = `${url}@${defaultVersionToLoad}`;
                 dataList.append(option);
             });
-            // extraComponents.forEach((url) => {
-            //     const option = document.createElement("option");
-            //     option.value = `${url}`;
-            //     dataList.append(option);
-            // });
+            // When running on localhost, add entries for local component development.
+            if (window.location.hostname === "localhost") {
+                localComponents.forEach((url) => {
+                    const option = document.createElement("option");
+                    option.value = `${url}`;
+                    dataList.append(option);
+                });
+            }
 
             const input = document.createElement("input");
             inputDiv.append(input);

--- a/examples/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
+++ b/examples/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
@@ -14,7 +14,7 @@ import { IPackage } from "@microsoft/fluid-container-definitions";
 import { IComponentRuntime } from "@microsoft/fluid-runtime-definitions";
 import { IComponentHTMLView } from "@microsoft/fluid-view-interfaces";
 import * as uuid from "uuid";
-import { IComponentCallable, IComponentCallbacks, IComponentOptions } from "@fluid-example/spaces";
+import { IComponentCallbacks, IComponentOptions, SpacesCompatibleToolbar } from "@fluid-example/spaces";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const pkg = require("../../package.json") as IPackage;
@@ -32,7 +32,7 @@ const localComponents = [
  * Component that loads extneral components via their url
  */
 export class ExternalComponentLoader extends PrimedComponent
-    implements IComponentHTMLView, IComponentCallable<IComponentCallbacks> {
+    implements IComponentHTMLView, SpacesCompatibleToolbar {
     private static readonly defaultComponents = [
         "@fluid-example/todo",
         "@fluid-example/math",

--- a/examples/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
+++ b/examples/components/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
@@ -20,6 +20,11 @@ import { IComponentCallable, IComponentCallbacks, IComponentOptions } from "@flu
 const pkg = require("../../package.json") as IPackage;
 export const WaterParkLoaderName = `${pkg.name}-loader`;
 
+const extraComponents = [
+    "http://localhost:8080/file/C:\\git\\FluidFramework\\examples\\components\\todo",
+    "http://localhost:8080/file/C:\\git\\FluidFramework\\examples\\components\\clicker",
+];
+
 /**
  * Component that loads extneral components via their url
  */
@@ -83,6 +88,11 @@ export class ExternalComponentLoader extends PrimedComponent
             ExternalComponentLoader.defaultComponents.forEach((url) => {
                 const option = document.createElement("option");
                 option.value = `${url}@${defaultVersionToLoad}`;
+                dataList.append(option);
+            });
+            extraComponents.forEach((url) => {
+                const option = document.createElement("option");
+                option.value = `${url}`;
                 dataList.append(option);
             });
 

--- a/examples/components/external-component-loader/src/waterParkModuleInstantiationFactory.ts
+++ b/examples/components/external-component-loader/src/waterParkModuleInstantiationFactory.ts
@@ -57,7 +57,7 @@ export class WaterParkModuleInstantiationFactory extends ContainerRuntimeFactory
         // Only add the component toolbar if the view component supports it
         if (viewComponent.IComponentToolbarConsumer !== undefined) {
             await viewComponent.IComponentToolbarConsumer
-                .setComponentToolbar(loaderComponent.id, this.loaderComponentName, loaderComponent.handle);
+                .setComponentToolbar(loaderComponent.id, this.loaderComponentName, loaderComponent);
         }
         loaderComponent.setViewComponent(viewComponent);
     }

--- a/examples/components/external-component-loader/src/waterParkModuleInstantiationFactory.ts
+++ b/examples/components/external-component-loader/src/waterParkModuleInstantiationFactory.ts
@@ -56,7 +56,7 @@ export class WaterParkModuleInstantiationFactory extends ContainerRuntimeFactory
 
         // Only add the component toolbar if the view component supports it
         if (viewComponent.IComponentToolbarConsumer !== undefined) {
-            await viewComponent.IComponentToolbarConsumer
+            viewComponent.IComponentToolbarConsumer
                 .setComponentToolbar(loaderComponent.id, this.loaderComponentName, loaderComponent);
         }
         loaderComponent.setViewComponent(viewComponent);

--- a/examples/components/spaces/src/dataModel.ts
+++ b/examples/components/spaces/src/dataModel.ts
@@ -85,7 +85,6 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
         let componentUrl: string;
         if (instance.IComponentLoadable) {
             componentUrl = instance.IComponentLoadable.url;
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             this.removeComponent(componentUrl);
         }
     }
@@ -119,7 +118,7 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
         url: string,
         type: string,
         handle: IComponentHandle): Promise<IComponent> {
-        await this.removeComponent(this.componentToolbarUrl);
+        this.removeComponent(this.componentToolbarUrl);
         const component = await handle.get();
         const defaultModel: ISpacesModel = {
             type,
@@ -168,7 +167,7 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
         return this.addComponentInternal<T>(type, defaultLayout);
     }
 
-    public async removeComponent(id: string) {
+    public removeComponent(id: string) {
         this.componentSubDirectory.delete(id);
     }
 

--- a/examples/components/spaces/src/dataModel.ts
+++ b/examples/components/spaces/src/dataModel.ts
@@ -104,7 +104,8 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
     public setComponentToolbar(
         url: string,
         type: string,
-        toolbarComponent: IComponent & IComponentLoadable): void {
+        toolbarComponent: IComponent & IComponentLoadable,
+    ): void {
         this.removeComponent(this.componentToolbarUrl);
         this.addComponent(toolbarComponent, type, { x: 0, y: 0, w: 6, h: 2 });
         this.root.set(ComponentToolbarUrlKey, url);

--- a/examples/components/spaces/src/dataModel.ts
+++ b/examples/components/spaces/src/dataModel.ts
@@ -22,9 +22,7 @@ export interface ISpacesDataModel extends EventEmitter {
     setComponentToolbar(id: string, type: string, toolbarComponent: IComponent & IComponentLoadable): void;
     getComponentToolbar(): Promise<IComponent>;
     updateGridItem(id: string, newLayout: Layout): void;
-    getLayout(id: string): Layout;
-    saveLayout(): void;
-    setTemplate(): Promise<void>;
+    getModels(): ISpacesModel[]
     readonly componentToolbarUrl: string;
     IComponentCollection: IComponentCollection;
     createCollectionItem<ISpacesCollectionOptions>(options: ISpacesCollectionOptions): IComponent;
@@ -39,9 +37,6 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
 
     constructor(
         private readonly root: ISharedDirectory,
-        private readonly createAndAttachComponent: <T extends IComponent & IComponentLoadable>(
-            pkg: string,
-            props?: any) => Promise<T>,
     ) {
         super();
 
@@ -150,38 +145,12 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
         return this.componentSubDirectory.get<ISpacesModel>(id)?.handle.get() as Promise<T>;
     }
 
-    public getLayout(id: string): Layout {
-        const entry = this.componentSubDirectory.get<ISpacesModel>(id);
-        return entry.layout;
-    }
-
-    public saveLayout(): void {
-        const value = this.componentSubDirectory.values();
-        localStorage.setItem("spacesTemplate", JSON.stringify([...value]));
-    }
-
-    public async setTemplate(): Promise<void> {
-        const size = this.componentSubDirectory.size;
-        if (size > 0) {
-            console.log("Can't set template because there is already components");
-            return;
-        }
-
-        const templateString = localStorage.getItem("spacesTemplate");
-        if (templateString) {
-            const templateItems = JSON.parse(templateString) as ISpacesModel[];
-            const promises = templateItems.map(async (templateItem) => {
-                const component = await this.createAndAttachComponent(templateItem.type);
-                this.addComponent(component, templateItem.type, templateItem.layout);
-                return component;
-            });
-
-            await Promise.all(promises);
-        }
+    public getModels(): ISpacesModel[] {
+        return [...this.componentSubDirectory.values()];
     }
 }
 
-interface ISpacesModel {
+export interface ISpacesModel {
     type: string;
     layout: Layout;
     handle: IComponentHandle;

--- a/examples/components/spaces/src/dataModel.ts
+++ b/examples/components/spaces/src/dataModel.ts
@@ -15,7 +15,7 @@ import { IComponentOptions } from "./interfaces";
 const ComponentToolbarUrlKey = "component-toolbar-url";
 export interface ISpacesDataModel extends EventEmitter {
     readonly componentList: Map<string, Layout>;
-    setComponentToolbar(id: string, type: string, handle: IComponentHandle): void;
+    setComponentToolbar(id: string, type: string, toolbarComponent: IComponent & IComponentLoadable): void;
     setComponent(component: IComponent & IComponentLoadable, type: string): void;
     getComponentToolbar(): Promise<IComponent>;
     addComponent<T extends IComponent & IComponentLoadable>(
@@ -108,15 +108,18 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
     public setComponentToolbar(
         url: string,
         type: string,
-        handle: IComponentHandle): void {
+        toolbarComponent: IComponent & IComponentLoadable): void {
+        if (toolbarComponent.handle === undefined) {
+            throw new Error(`Component must have a handle: ${type}`);
+        }
         this.removeComponent(this.componentToolbarUrl);
+        this.root.set(ComponentToolbarUrlKey, url);
+
         const model: ISpacesModel = {
             type,
             layout: { x: 0, y: 0, w: 6, h: 2 },
-            handle,
+            handle: toolbarComponent.handle,
         };
-
-        this.root.set(ComponentToolbarUrlKey, url);
         this.componentSubDirectory.set(url, model);
     }
 

--- a/examples/components/spaces/src/dataModel.ts
+++ b/examples/components/spaces/src/dataModel.ts
@@ -204,10 +204,9 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
 
         const templateString = localStorage.getItem("spacesTemplate");
         if (templateString) {
-            const template = JSON.parse(templateString) as ISpacesModel[];
-            const promises: Promise<IComponent>[] = [];
-            template.forEach((value) => {
-                promises.push(this.addComponentInternal(value.type, value.layout));
+            const templateItems = JSON.parse(templateString) as ISpacesModel[];
+            const promises = templateItems.map(async (templateItem) => {
+                return this.addComponentInternal(templateItem.type, templateItem.layout);
             });
 
             await Promise.all(promises);

--- a/examples/components/spaces/src/dataModel.ts
+++ b/examples/components/spaces/src/dataModel.ts
@@ -14,7 +14,7 @@ import { Layout } from "react-grid-layout";
 const ComponentToolbarUrlKey = "component-toolbar-url";
 export interface ISpacesDataModel extends EventEmitter {
     readonly componentList: Map<string, Layout>;
-    setComponentToolbar(id: string, type: string, handle: IComponentHandle): Promise<void>;
+    setComponentToolbar(id: string, type: string, handle: IComponentHandle): void;
     setComponent(id: string, handle: IComponentHandle, url: string): Promise<IComponent>;
     getComponentToolbar(): Promise<IComponent>;
     addComponent<T extends IComponent & IComponentLoadable>(
@@ -114,20 +114,16 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
         return this.root.get<string>(ComponentToolbarUrlKey);
     }
 
-    public async setComponentToolbar(
+    public setComponentToolbar(
         url: string,
         type: string,
-        handle: IComponentHandle): Promise<void> {
+        handle: IComponentHandle): void {
         this.removeComponent(this.componentToolbarUrl);
-        const component = await handle.get();
         const defaultModel: ISpacesModel = {
             type,
             layout: { x: 0, y: 0, w: 6, h: 2 },
             handle,
         };
-        if (component === undefined) {
-            throw new Error(`Runtime does not contain component with url: ${url}`);
-        }
 
         this.root.set(ComponentToolbarUrlKey, url);
         this.componentSubDirectory.set(url, defaultModel);

--- a/examples/components/spaces/src/dataModel.ts
+++ b/examples/components/spaces/src/dataModel.ts
@@ -17,6 +17,7 @@ export interface ISpacesDataModel extends EventEmitter {
     readonly componentList: Map<string, Layout>;
     setComponentToolbar(id: string, type: string, toolbarComponent: IComponent & IComponentLoadable): void;
     setComponent(component: IComponent & IComponentLoadable, type: string): void;
+    setComponentWithLayout(component: IComponent & IComponentLoadable, type: string, layout: Layout): void;
     getComponentToolbar(): Promise<IComponent>;
     addComponent<T extends IComponent & IComponentLoadable>(
         type: string,

--- a/examples/components/spaces/src/dataModel.ts
+++ b/examples/components/spaces/src/dataModel.ts
@@ -14,7 +14,7 @@ import { Layout } from "react-grid-layout";
 const ComponentToolbarUrlKey = "component-toolbar-url";
 export interface ISpacesDataModel extends EventEmitter {
     readonly componentList: Map<string, Layout>;
-    setComponentToolbar(id: string, type: string, handle: IComponentHandle): Promise<IComponent>;
+    setComponentToolbar(id: string, type: string, handle: IComponentHandle): Promise<void>;
     setComponent(id: string, handle: IComponentHandle, url: string): Promise<IComponent>;
     getComponentToolbar(): Promise<IComponent>;
     addComponent<T extends IComponent & IComponentLoadable>(
@@ -117,7 +117,7 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
     public async setComponentToolbar(
         url: string,
         type: string,
-        handle: IComponentHandle): Promise<IComponent> {
+        handle: IComponentHandle): Promise<void> {
         this.removeComponent(this.componentToolbarUrl);
         const component = await handle.get();
         const defaultModel: ISpacesModel = {
@@ -131,7 +131,6 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
 
         this.root.set(ComponentToolbarUrlKey, url);
         this.componentSubDirectory.set(url, defaultModel);
-        return component;
     }
 
     public async getComponentToolbar(): Promise<IComponent> {
@@ -163,8 +162,8 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
         x: number = 0,
         y: number = 0,
     ): Promise<T> {
-        const defaultLayout = { x, y, w, h };
-        return this.addComponentInternal<T>(type, defaultLayout);
+        const layout = { x, y, w, h };
+        return this.addComponentInternal<T>(type, layout);
     }
 
     public removeComponent(id: string) {

--- a/examples/components/spaces/src/dataModel.ts
+++ b/examples/components/spaces/src/dataModel.ts
@@ -13,7 +13,7 @@ import { Layout } from "react-grid-layout";
 
 export const ComponentToolbarUrlKey = "component-toolbar-url";
 export interface ISpacesDataModel extends EventEmitter {
-    componentList: Map<string, Layout>;
+    readonly componentList: Map<string, Layout>;
     setComponentToolbar(id: string, type: string, handle: IComponentHandle): Promise<IComponent>;
     setComponent(id: string, handle: IComponentHandle, url: string): Promise<IComponent>;
     getComponentToolbar(): Promise<IComponent>;

--- a/examples/components/spaces/src/dataModel.ts
+++ b/examples/components/spaces/src/dataModel.ts
@@ -11,7 +11,7 @@ import {
 import { IComponentCollection } from "@microsoft/fluid-framework-interfaces";
 import { Layout } from "react-grid-layout";
 
-export const ComponentToolbarUrlKey = "component-toolbar-url";
+const ComponentToolbarUrlKey = "component-toolbar-url";
 export interface ISpacesDataModel extends EventEmitter {
     readonly componentList: Map<string, Layout>;
     setComponentToolbar(id: string, type: string, handle: IComponentHandle): Promise<IComponent>;
@@ -53,7 +53,6 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
         private readonly createAndAttachComponent: <T extends IComponent & IComponentLoadable>(
             pkg: string,
             props?: any) => Promise<T>,
-        private _componentToolbarUrl: string,
     ) {
         super();
 
@@ -113,7 +112,7 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
     }
 
     public get componentToolbarUrl(): string {
-        return this._componentToolbarUrl;
+        return this.root.get<string>(ComponentToolbarUrlKey);
     }
 
     public async setComponentToolbar(
@@ -121,7 +120,6 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
         type: string,
         handle: IComponentHandle): Promise<IComponent> {
         return this.removeComponent(this.componentToolbarUrl).then(async () => {
-            this._componentToolbarUrl = url;
             const component = await handle.get();
             const defaultModel: ISpacesModel = {
                 type,

--- a/examples/components/spaces/src/dataModel.ts
+++ b/examples/components/spaces/src/dataModel.ts
@@ -31,7 +31,7 @@ export interface ISpacesDataModel extends EventEmitter {
     getLayout(id: string): Layout;
     saveLayout(): void;
     setTemplate(): Promise<void>;
-    componentToolbarUrl: string;
+    readonly componentToolbarUrl: string;
     IComponentCollection: IComponentCollection;
     createCollectionItem<ISpacesCollectionOptions>(options: ISpacesCollectionOptions): IComponent;
     removeCollectionItem(item: IComponent): void;
@@ -59,7 +59,7 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
             directory: IDirectory,
             getObjectFromDirectory: (id: string, directory: IDirectory) => string | IComponentHandle | undefined) =>
         Promise<T | undefined>,
-        public componentToolbarUrl: string,
+        private _componentToolbarUrl: string,
     ) {
         super();
 
@@ -118,6 +118,10 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
         return response;
     }
 
+    public get componentToolbarUrl(): string {
+        return this._componentToolbarUrl;
+    }
+
     public async addFormattedComponents(componentsToAdd: ISpacesModel[]): Promise<void> {
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         componentsToAdd.forEach(async (componentTemplate) => {
@@ -131,7 +135,7 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
         type: string,
         handle: IComponentHandle): Promise<IComponent> {
         return this.removeComponent(this.componentToolbarUrl).then(async () => {
-            this.componentToolbarUrl = url;
+            this._componentToolbarUrl = url;
             const component = await handle.get();
             const defaultModel: ISpacesModel = {
                 type,

--- a/examples/components/spaces/src/dataModel.ts
+++ b/examples/components/spaces/src/dataModel.ts
@@ -24,7 +24,6 @@ export interface ISpacesDataModel extends EventEmitter {
         x?: number,
         y?: number,
     ): Promise<T>;
-    addFormattedComponents(componentsToAdd: ISpacesModel[]): Promise<void>;
     getComponent<T extends IComponent & IComponentLoadable>(id: string): Promise<T | undefined>;
     removeComponent(id: string): void;
     updateGridItem(id: string, newLayout: Layout): void;
@@ -115,14 +114,6 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
 
     public get componentToolbarUrl(): string {
         return this._componentToolbarUrl;
-    }
-
-    public async addFormattedComponents(componentsToAdd: ISpacesModel[]): Promise<void> {
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        componentsToAdd.forEach(async (componentTemplate) => {
-            await this.addComponent(componentTemplate.type, componentTemplate.layout.w,
-                componentTemplate.layout.h, componentTemplate.layout.x, componentTemplate.layout.y);
-        });
     }
 
     public async setComponentToolbar(

--- a/examples/components/spaces/src/dataModel.ts
+++ b/examples/components/spaces/src/dataModel.ts
@@ -18,6 +18,7 @@ export interface ISpacesDataModel extends EventEmitter {
     addComponent(component: IComponent & IComponentLoadable, type: string, layout: Layout): void;
     getComponent<T extends IComponent & IComponentLoadable>(id: string): Promise<T | undefined>;
     removeComponent(id: string): void;
+    addFormattedComponents(componentModels: ISpacesModel[]): Promise<void>;
     setComponentToolbar(id: string, type: string, toolbarComponent: IComponent & IComponentLoadable): void;
     getComponentToolbar(): Promise<IComponent>;
     updateGridItem(id: string, newLayout: Layout): void;
@@ -96,6 +97,13 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
 
     public get componentToolbarUrl(): string {
         return this.root.get<string>(ComponentToolbarUrlKey);
+    }
+
+    public async addFormattedComponents(componentModels: ISpacesModel[]): Promise<void> {
+        const components = await Promise.all(componentModels.map(async (model) => model.handle.get()));
+        components.forEach((component, index) => {
+            this.addComponent(component, componentModels[index].type, componentModels[index].layout);
+        });
     }
 
     public setComponentToolbar(

--- a/examples/components/spaces/src/dataModel.ts
+++ b/examples/components/spaces/src/dataModel.ts
@@ -10,17 +10,18 @@ import {
 } from "@microsoft/fluid-component-core-interfaces";
 import { IComponentCollection } from "@microsoft/fluid-framework-interfaces";
 import { Layout } from "react-grid-layout";
-import { IComponentOptions } from "./interfaces";
+import { IComponentOptions, SpacesCompatibleToolbar } from "./interfaces";
 
 const ComponentToolbarUrlKey = "component-toolbar-url";
+
 export interface ISpacesDataModel extends EventEmitter {
     readonly componentList: Map<string, Layout>;
     addComponent(component: IComponent & IComponentLoadable, type: string, layout: Layout): void;
     getComponent<T extends IComponent & IComponentLoadable>(id: string): Promise<T | undefined>;
     removeComponent(id: string): void;
     addFormattedComponents(componentModels: ISpacesModel[]): Promise<void>;
-    setComponentToolbar(id: string, type: string, toolbarComponent: IComponent & IComponentLoadable): void;
-    getComponentToolbar(): Promise<IComponent>;
+    setComponentToolbar(id: string, type: string, toolbarComponent: SpacesCompatibleToolbar): void;
+    getComponentToolbar(): Promise<SpacesCompatibleToolbar | undefined>;
     updateGridItem(id: string, newLayout: Layout): void;
     getModels(): ISpacesModel[]
     readonly componentToolbarUrl: string;
@@ -104,16 +105,16 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
     public setComponentToolbar(
         url: string,
         type: string,
-        toolbarComponent: IComponent & IComponentLoadable,
+        toolbarComponent: SpacesCompatibleToolbar,
     ): void {
         this.removeComponent(this.componentToolbarUrl);
         this.addComponent(toolbarComponent, type, { x: 0, y: 0, w: 6, h: 2 });
         this.root.set(ComponentToolbarUrlKey, url);
     }
 
-    public async getComponentToolbar(): Promise<IComponent> {
-        const component = await this.getComponent(this.componentToolbarUrl);
-        return component as IComponent;
+    public async getComponentToolbar(): Promise<SpacesCompatibleToolbar | undefined> {
+        const component = await this.getComponent<SpacesCompatibleToolbar>(this.componentToolbarUrl);
+        return component;
     }
 
     public addComponent(component: IComponent & IComponentLoadable, type: string, layout: Layout): void {

--- a/examples/components/spaces/src/dataModel.ts
+++ b/examples/components/spaces/src/dataModel.ts
@@ -109,18 +109,9 @@ export class SpacesDataModel extends EventEmitter implements ISpacesDataModel, I
         url: string,
         type: string,
         toolbarComponent: IComponent & IComponentLoadable): void {
-        if (toolbarComponent.handle === undefined) {
-            throw new Error(`Component must have a handle: ${type}`);
-        }
         this.removeComponent(this.componentToolbarUrl);
+        this.setComponent(toolbarComponent, type);
         this.root.set(ComponentToolbarUrlKey, url);
-
-        const model: ISpacesModel = {
-            type,
-            layout: { x: 0, y: 0, w: 6, h: 2 },
-            handle: toolbarComponent.handle,
-        };
-        this.componentSubDirectory.set(url, model);
     }
 
     public async getComponentToolbar(): Promise<IComponent> {

--- a/examples/components/spaces/src/interfaces/componentCallable.ts
+++ b/examples/components/spaces/src/interfaces/componentCallable.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IComponentHandle } from "@microsoft/fluid-component-core-interfaces";
+import { IComponent, IComponentLoadable } from "@microsoft/fluid-component-core-interfaces";
 import { Templates } from "..";
 
 declare module "@microsoft/fluid-component-core-interfaces" {
@@ -34,7 +34,6 @@ export interface IComponentCallable<T> extends IProvideComponentCallable {
 }
 
 export interface IComponentOptions {
-    url?: string;
-    handle?: IComponentHandle;
+    component?: IComponent & IComponentLoadable;
     type?: string;
 }

--- a/examples/components/spaces/src/interfaces/componentCallable.ts
+++ b/examples/components/spaces/src/interfaces/componentCallable.ts
@@ -33,6 +33,8 @@ export interface IComponentCallable<T> extends IProvideComponentCallable {
     setComponentCallbacks(callbacks: T): void;
 }
 
+export type SpacesCompatibleToolbar = IComponent & IComponentLoadable & IComponentCallable<IComponentCallbacks>;
+
 export interface IComponentOptions {
     component?: IComponent & IComponentLoadable;
     type?: string;

--- a/examples/components/spaces/src/interfaces/componentToolbarConsumer.ts
+++ b/examples/components/spaces/src/interfaces/componentToolbarConsumer.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IComponentHandle } from "@microsoft/fluid-component-core-interfaces";
+import { IComponent, IComponentLoadable } from "@microsoft/fluid-component-core-interfaces";
 
 declare module "@microsoft/fluid-component-core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -20,5 +20,5 @@ export interface IProvideComponentToolbarConsumer {
  * An IComponentCallable is a component that has a roster of functions defined by T that other components can use
  */
 export interface IComponentToolbarConsumer extends IProvideComponentToolbarConsumer {
-    setComponentToolbar(id: string, type: string, handle: IComponentHandle): Promise<void>;
+    setComponentToolbar(id: string, type: string, toolbarComponent: IComponent & IComponentLoadable): Promise<void>;
 }

--- a/examples/components/spaces/src/interfaces/componentToolbarConsumer.ts
+++ b/examples/components/spaces/src/interfaces/componentToolbarConsumer.ts
@@ -17,7 +17,8 @@ export interface IProvideComponentToolbarConsumer {
 }
 
 /**
- * An IComponentCallable is a component that has a roster of functions defined by T that other components can use
+ * An IComponentToolbarConsumer is a component that takes another to use as a toolbar.  That toolbar may implement
+ * other interfaces such as IComponentToolbar or IComponentCallable.
  */
 export interface IComponentToolbarConsumer extends IProvideComponentToolbarConsumer {
     setComponentToolbar(id: string, type: string, toolbarComponent: IComponent & IComponentLoadable): void;

--- a/examples/components/spaces/src/interfaces/componentToolbarConsumer.ts
+++ b/examples/components/spaces/src/interfaces/componentToolbarConsumer.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IComponent, IComponentLoadable } from "@microsoft/fluid-component-core-interfaces";
+import { SpacesCompatibleToolbar } from ".";
 
 declare module "@microsoft/fluid-component-core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -21,5 +21,5 @@ export interface IProvideComponentToolbarConsumer {
  * other interfaces such as IComponentToolbar or IComponentCallable.
  */
 export interface IComponentToolbarConsumer extends IProvideComponentToolbarConsumer {
-    setComponentToolbar(id: string, type: string, toolbarComponent: IComponent & IComponentLoadable): void;
+    setComponentToolbar(id: string, type: string, toolbarComponent: SpacesCompatibleToolbar): void;
 }

--- a/examples/components/spaces/src/interfaces/componentToolbarConsumer.ts
+++ b/examples/components/spaces/src/interfaces/componentToolbarConsumer.ts
@@ -20,5 +20,5 @@ export interface IProvideComponentToolbarConsumer {
  * An IComponentCallable is a component that has a roster of functions defined by T that other components can use
  */
 export interface IComponentToolbarConsumer extends IProvideComponentToolbarConsumer {
-    setComponentToolbar(id: string, type: string, toolbarComponent: IComponent & IComponentLoadable): Promise<void>;
+    setComponentToolbar(id: string, type: string, toolbarComponent: IComponent & IComponentLoadable): void;
 }

--- a/examples/components/spaces/src/spaces.tsx
+++ b/examples/components/spaces/src/spaces.tsx
@@ -75,7 +75,6 @@ export class Spaces extends PrimedComponent
 
     protected async componentInitializingFirstTime() {
         this.root.createSubDirectory("component-list");
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.initializeDataModel();
         const componentToolbar =
             await this.dataModel.addComponent<ComponentToolbar>(
@@ -98,7 +97,6 @@ export class Spaces extends PrimedComponent
     }
 
     protected async componentInitializingFromExisting() {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.initializeDataModel();
         this.componentToolbar = await this.dataModel.getComponentToolbar();
     }
@@ -133,7 +131,7 @@ export class Spaces extends PrimedComponent
         }
     }
 
-    private async initializeDataModel() {
+    private initializeDataModel() {
         this.dataModelInternal =
             new SpacesDataModel(
                 this.root,

--- a/examples/components/spaces/src/spaces.tsx
+++ b/examples/components/spaces/src/spaces.tsx
@@ -114,8 +114,13 @@ export class Spaces extends PrimedComponent
         if (this.componentToolbar && this.componentToolbar.IComponentCallable) {
             this.componentToolbar.IComponentCallable.setComponentCallbacks({
                 addComponent: (type: string, w?: number, h?: number) => {
-                    /* eslint-disable-next-line @typescript-eslint/no-floating-promises */
-                    this.dataModel.addComponent(type, w, h);
+                    this.createAndAttachComponent(type)
+                        .then((component) => {
+                            this.dataModel.setComponentWithLayout(component, type, { w, h });
+                        })
+                        .catch((error) => {
+                            console.error(`Error while creating component: ${type}`, error);
+                        });
                 },
                 addTemplate: this.addTemplateFromRegistry.bind(this),
                 saveLayout: () => this.dataModel.saveLayout(),

--- a/examples/components/spaces/src/spaces.tsx
+++ b/examples/components/spaces/src/spaces.tsx
@@ -12,7 +12,7 @@ import {
 } from "@microsoft/fluid-aqueduct";
 import {
     IComponent,
-    IComponentHandle,
+    IComponentLoadable,
 } from "@microsoft/fluid-component-core-interfaces";
 import { IProvideComponentCollection } from "@microsoft/fluid-framework-interfaces";
 import { SharedObjectSequence } from "@microsoft/fluid-sequence";
@@ -60,10 +60,9 @@ export class Spaces extends PrimedComponent
     public get IComponentCollection() { return this.dataModel; }
     public get IComponentToolbarConsumer() { return this; }
 
-    public async setComponentToolbar(id: string, type: string, handle: IComponentHandle) {
-        this.dataModel.setComponentToolbar(id, type, handle);
-        const componentToolbar = await this.dataModel.getComponentToolbar();
-        this.componentToolbar = componentToolbar;
+    public async setComponentToolbar(id: string, type: string, toolbarComponent: IComponent & IComponentLoadable) {
+        this.dataModel.setComponentToolbar(id, type, toolbarComponent);
+        this.componentToolbar = toolbarComponent;
         this.addToolbarListeners();
     }
 
@@ -92,7 +91,7 @@ export class Spaces extends PrimedComponent
         await this.setComponentToolbar(
             componentToolbar.url,
             ComponentToolbarName,
-            componentToolbar.handle);
+            componentToolbar);
         // Set the saved template if there is a template query param
         const urlParams = new URLSearchParams(window.location.search);
         if (urlParams.has("template")) {

--- a/examples/components/spaces/src/spaces.tsx
+++ b/examples/components/spaces/src/spaces.tsx
@@ -116,7 +116,7 @@ export class Spaces extends PrimedComponent
                 addComponent: (type: string, w?: number, h?: number) => {
                     this.createAndAttachComponent(type)
                         .then((component) => {
-                            this.dataModel.setComponentWithLayout(component, type, { w, h });
+                            this.dataModel.setComponentWithLayout(component, type, { w, h, x: 0, y: 0 });
                         })
                         .catch((error) => {
                             console.error(`Error while creating component: ${type}`, error);
@@ -146,13 +146,8 @@ export class Spaces extends PrimedComponent
                 const templateLayouts: Layout[] = componentRegistryEntry.templates[template];
                 // eslint-disable-next-line @typescript-eslint/no-misused-promises
                 templateLayouts.forEach(async (templateLayout: Layout) => {
-                    await this.dataModel.addComponent(
-                        componentRegistryEntry.type,
-                        templateLayout.w,
-                        templateLayout.h,
-                        templateLayout.x,
-                        templateLayout.y,
-                    );
+                    const component = await this.createAndAttachComponent(componentRegistryEntry.type);
+                    this.dataModel.setComponentWithLayout(component, componentRegistryEntry.type, templateLayout);
                 });
             });
         }

--- a/examples/components/spaces/src/spaces.tsx
+++ b/examples/components/spaces/src/spaces.tsx
@@ -18,7 +18,7 @@ import { IProvideComponentCollection } from "@microsoft/fluid-framework-interfac
 import { SharedObjectSequence } from "@microsoft/fluid-sequence";
 import { IComponentHTMLView } from "@microsoft/fluid-view-interfaces";
 
-import { ISpacesDataModel, SpacesDataModel, ComponentToolbarUrlKey } from "./dataModel";
+import { ISpacesDataModel, SpacesDataModel } from "./dataModel";
 import { SpacesGridView } from "./view";
 import { ComponentToolbar, ComponentToolbarName } from "./components";
 import { IComponentToolbarConsumer } from "./interfaces";
@@ -87,11 +87,11 @@ export class Spaces extends PrimedComponent
                 0,
                 0,
             );
+        componentToolbar.changeEditState(true);
         await this.setComponentToolbar(
             componentToolbar.url,
             ComponentToolbarName,
             componentToolbar.handle);
-        (this.componentToolbar as ComponentToolbar).changeEditState(true);
         // Set the saved template if there is a template query param
         const urlParams = new URLSearchParams(window.location.search);
         if (urlParams.has("template")) {
@@ -102,8 +102,7 @@ export class Spaces extends PrimedComponent
     protected async componentInitializingFromExisting() {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.initializeDataModel();
-        this.componentToolbar = await this.dataModel.getComponent<ComponentToolbar>(
-            this.root.get(ComponentToolbarUrlKey));
+        this.componentToolbar = await this.dataModel.getComponentToolbar();
     }
 
     protected async componentHasInitialized() {
@@ -141,7 +140,6 @@ export class Spaces extends PrimedComponent
             new SpacesDataModel(
                 this.root,
                 this.createAndAttachComponent.bind(this),
-                this.root.get(ComponentToolbarUrlKey),
             );
     }
 

--- a/examples/components/spaces/src/spaces.tsx
+++ b/examples/components/spaces/src/spaces.tsx
@@ -116,7 +116,7 @@ export class Spaces extends PrimedComponent
                 addComponent: (type: string, w?: number, h?: number) => {
                     this.createAndAttachComponent(type)
                         .then((component) => {
-                            this.dataModel.setComponentWithLayout(component, type, { w, h, x: 0, y: 0 });
+                            this.dataModel.addComponent(component, type, { w, h, x: 0, y: 0 });
                         })
                         .catch((error) => {
                             console.error(`Error while creating component: ${type}`, error);
@@ -147,7 +147,7 @@ export class Spaces extends PrimedComponent
                 // eslint-disable-next-line @typescript-eslint/no-misused-promises
                 templateLayouts.forEach(async (templateLayout: Layout) => {
                     const component = await this.createAndAttachComponent(componentRegistryEntry.type);
-                    this.dataModel.setComponentWithLayout(component, componentRegistryEntry.type, templateLayout);
+                    this.dataModel.addComponent(component, componentRegistryEntry.type, templateLayout);
                 });
             });
         }

--- a/examples/components/spaces/src/spaces.tsx
+++ b/examples/components/spaces/src/spaces.tsx
@@ -76,14 +76,7 @@ export class Spaces extends PrimedComponent
     protected async componentInitializingFirstTime() {
         this.root.createSubDirectory("component-list");
         this.initializeDataModel();
-        const componentToolbar =
-            await this.dataModel.addComponent<ComponentToolbar>(
-                ComponentToolbarName,
-                4,
-                4,
-                0,
-                0,
-            );
+        const componentToolbar = await this.createAndAttachComponent<ComponentToolbar>(ComponentToolbarName);
         componentToolbar.changeEditState(true);
         this.setComponentToolbar(
             componentToolbar.url,

--- a/examples/components/spaces/src/spaces.tsx
+++ b/examples/components/spaces/src/spaces.tsx
@@ -12,7 +12,6 @@ import {
 } from "@microsoft/fluid-aqueduct";
 import {
     IComponent,
-    IComponentLoadable,
 } from "@microsoft/fluid-component-core-interfaces";
 import { IProvideComponentCollection } from "@microsoft/fluid-framework-interfaces";
 import { SharedObjectSequence } from "@microsoft/fluid-sequence";
@@ -21,7 +20,7 @@ import { IComponentHTMLView } from "@microsoft/fluid-view-interfaces";
 import { ISpacesDataModel, ISpacesModel, SpacesDataModel } from "./dataModel";
 import { SpacesGridView } from "./view";
 import { ComponentToolbar, ComponentToolbarName } from "./components";
-import { IComponentToolbarConsumer } from "./interfaces";
+import { IComponentToolbarConsumer, SpacesCompatibleToolbar } from "./interfaces";
 import { SpacesComponentName, Templates } from ".";
 
 /**
@@ -30,7 +29,7 @@ import { SpacesComponentName, Templates } from ".";
 export class Spaces extends PrimedComponent
     implements IComponentHTMLView, IProvideComponentCollection, IComponentToolbarConsumer {
     private dataModelInternal: ISpacesDataModel | undefined;
-    private componentToolbar: IComponent | undefined;
+    private componentToolbar: SpacesCompatibleToolbar | undefined;
     private registryDetails: IComponent | undefined;
 
     // TODO #1188 - Component registry should automatically add ComponentToolbar
@@ -60,7 +59,7 @@ export class Spaces extends PrimedComponent
     public get IComponentCollection() { return this.dataModel; }
     public get IComponentToolbarConsumer() { return this; }
 
-    public setComponentToolbar(id: string, type: string, toolbarComponent: IComponent & IComponentLoadable) {
+    public setComponentToolbar(id: string, type: string, toolbarComponent: SpacesCompatibleToolbar) {
         this.dataModel.setComponentToolbar(id, type, toolbarComponent);
         this.componentToolbar = toolbarComponent;
         this.addToolbarListeners();
@@ -111,7 +110,7 @@ export class Spaces extends PrimedComponent
     }
 
     private addToolbarListeners() {
-        if (this.componentToolbar && this.componentToolbar.IComponentCallable) {
+        if (this.componentToolbar) {
             this.componentToolbar.IComponentCallable.setComponentCallbacks({
                 addComponent: (type: string, w?: number, h?: number) => {
                     this.createAndAttachComponent(type)

--- a/examples/components/spaces/src/spaces.tsx
+++ b/examples/components/spaces/src/spaces.tsx
@@ -141,7 +141,6 @@ export class Spaces extends PrimedComponent
             new SpacesDataModel(
                 this.root,
                 this.createAndAttachComponent.bind(this),
-                this.getComponentFromDirectory.bind(this),
                 this.root.get(ComponentToolbarUrlKey),
             );
     }

--- a/examples/components/spaces/src/spaces.tsx
+++ b/examples/components/spaces/src/spaces.tsx
@@ -70,9 +70,7 @@ export class Spaces extends PrimedComponent
      * Will return a new Spaces View
      */
     public render(div: HTMLElement) {
-        ReactDOM.render(
-            <SpacesGridView dataModel={this.dataModel}/>,
-            div);
+        ReactDOM.render(<SpacesGridView dataModel={this.dataModel}/>, div);
     }
 
     protected async componentInitializingFirstTime() {

--- a/examples/components/spaces/src/spaces.tsx
+++ b/examples/components/spaces/src/spaces.tsx
@@ -61,7 +61,7 @@ export class Spaces extends PrimedComponent
     public get IComponentToolbarConsumer() { return this; }
 
     public async setComponentToolbar(id: string, type: string, handle: IComponentHandle) {
-        await this.dataModel.setComponentToolbar(id, type, handle);
+        this.dataModel.setComponentToolbar(id, type, handle);
         const componentToolbar = await this.dataModel.getComponentToolbar();
         this.componentToolbar = componentToolbar;
         this.addToolbarListeners();

--- a/examples/components/spaces/src/spaces.tsx
+++ b/examples/components/spaces/src/spaces.tsx
@@ -60,7 +60,7 @@ export class Spaces extends PrimedComponent
     public get IComponentCollection() { return this.dataModel; }
     public get IComponentToolbarConsumer() { return this; }
 
-    public async setComponentToolbar(id: string, type: string, toolbarComponent: IComponent & IComponentLoadable) {
+    public setComponentToolbar(id: string, type: string, toolbarComponent: IComponent & IComponentLoadable) {
         this.dataModel.setComponentToolbar(id, type, toolbarComponent);
         this.componentToolbar = toolbarComponent;
         this.addToolbarListeners();
@@ -88,7 +88,7 @@ export class Spaces extends PrimedComponent
                 0,
             );
         componentToolbar.changeEditState(true);
-        await this.setComponentToolbar(
+        this.setComponentToolbar(
             componentToolbar.url,
             ComponentToolbarName,
             componentToolbar);

--- a/examples/components/spaces/src/spaces.tsx
+++ b/examples/components/spaces/src/spaces.tsx
@@ -61,7 +61,8 @@ export class Spaces extends PrimedComponent
     public get IComponentToolbarConsumer() { return this; }
 
     public async setComponentToolbar(id: string, type: string, handle: IComponentHandle) {
-        const componentToolbar = await this.dataModel.setComponentToolbar(id, type, handle);
+        await this.dataModel.setComponentToolbar(id, type, handle);
+        const componentToolbar = await this.dataModel.getComponentToolbar();
         this.componentToolbar = componentToolbar;
         this.addToolbarListeners();
     }


### PR DESCRIPTION
This change is primarily just refactoring, but with the main goal of lifting component creation out of the dataModel.

For view/model separation, I'll want the caller of `addComponent()` (probably with somewhat different signature then) to be in more control of how the model is instantiated and bound to a view before being stored in the data model, so pulling that process up out of the data model makes that more straightforward.  It has some added benefits of making more methods synchronous and also unifying a few similar methods, plus simplifying the members of the dataModel now that it has fewer responsibilities.

I took the approach here of just passing the component itself through, as opposed to the component's handle.  Passing the handle through to the Spaces component and `.get()` it there would also be fine, though this clashes with the `IComponentCollection` interface expecting a synchronous `IComponent` to be returned from `createCollectionItem()` -- we'd need to continue floating the promise.  Ultimately, we shouldn't be using the `IComponentCollection` interface here, but I didn't try to make that change yet.