### PR TITLE
Dont add dds to pending attach if container detached and change isAttached for handles.

### DIFF
--- a/packages/runtime/component-runtime/src/componentRuntime.ts
+++ b/packages/runtime/component-runtime/src/componentRuntime.ts
@@ -590,17 +590,23 @@ export class ComponentRuntime extends EventEmitter implements IComponentRuntime,
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         channel.handle!.attach();
 
-        // Get the object snapshot and include it in the initial attach
-        const snapshot = snapshotChannel(channel);
+        assert(this.isAttached, "Component should be attached to attach the channel.");
+        // If the container is detached, we don't need to send OP or add to pending attach because
+        // we will summarize it while uploading the create new summary and make it known to other
+        // clients. If the container is attached and component is not attached we will never reach here.
+        if (!this.isLocal()) {
+            // Get the object snapshot and include it in the initial attach
+            const snapshot = snapshotChannel(channel);
 
-        const message: IAttachMessage = {
-            id: channel.id,
-            snapshot,
-            type: channel.attributes.type,
-        };
-        this.pendingAttach.set(channel.id, message);
-        if (this.connected) {
-            this.submit(MessageType.Attach, message);
+            const message: IAttachMessage = {
+                id: channel.id,
+                snapshot,
+                type: channel.attributes.type,
+            };
+            this.pendingAttach.set(channel.id, message);
+            if (this.connected) {
+                this.submit(MessageType.Attach, message);
+            }
         }
 
         const context = this.contexts.get(channel.id) as LocalChannelContext;

--- a/packages/runtime/shared-object-common/src/handle.ts
+++ b/packages/runtime/shared-object-common/src/handle.ts
@@ -33,7 +33,9 @@ export class SharedObjectComponentHandle implements IComponentHandle {
      * Whether services have been attached for the associated shared object.
      */
     public get isAttached(): boolean {
-        return !this.value.isLocal();
+        // This change is due to the change in meaning of isLocal. Because a shared object is still local
+        // if it is attached and container is detached. So isLocal cann't tell that it is attached or not.
+        return this.value.isRegistered();
     }
 
     /**


### PR DESCRIPTION
1.) Don't add to pending attach because for create new we will take its summary with create new and it will get known to other clients at that time.
2.) isLocal doesn't represent whether the shared object is attached or not because it could be attached even if it is Local.