### PR TITLE
Do not increment latest acked summary ref seq in safe mode [0.16]

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1337,7 +1337,7 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
                 const parents = versions.map((version) => version.id);
                 await this.refreshLatestSummaryAck(
                     { proposalHandle: undefined, ackHandle: parents[0] },
-                    this.deltaManager.referenceSequenceNumber);
+                    this.summaryTracker.referenceSequenceNumber);
             }
 
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -432,6 +432,7 @@ export class RunningSummarizer implements IDisposable {
             summarizeCount: ++this.summarizeCount,
             timeSinceLastAttempt: Date.now() - this.heuristics.lastSent.summaryTime,
             timeSinceLastSummary: Date.now() - this.heuristics.lastAcked.summaryTime,
+            safe: safe || undefined,
         });
 
         // Wait for generate/send summary


### PR DESCRIPTION
Part of fixing #1900 - the latest acked summary ref seq number should not be incremented during safe mode.  To get the exact number, we would have to fetch the snapshot from storage and parse it.  However, using an older number is fine as well, since it just means we may not reuse where possible, but since it always happens in the context of a safe summary currently, that should be fine (safe summaries imply fullTree true).