### PR TITLE
Add error param for dispose

### DIFF
--- a/common/lib/common-definitions/src/disposable.ts
+++ b/common/lib/common-definitions/src/disposable.ts
@@ -5,5 +5,5 @@
 
 export interface IDisposable {
     readonly disposed: boolean;
-    dispose(): void;
+    dispose(error?: Error): void;
 }


### PR DESCRIPTION
Add optional error parameter for dispose.  General idea is an object may want to do something differently if disposing in an error case.  More specific reason for this is because we are getting a not insignificant number of "Runtime is closed" unhandled promise rejections in telemetry that are a result of the Container closing (and thus disposing the ContainerRuntime) due to some other error.  By disposing with the error in these cases (Container's close already takes an error), we can then fail silently in ContainerRuntime instead of throwing an unhandled rejection and not add to the telemetry.

Pt1 of #1835; next part will update the package versions and consumers