### PR TITLE
Can reconnect false [0.16]

### DIFF
--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -591,6 +591,15 @@ export class Summarizer implements ISummarizer {
             return;
         }
 
+        if (this.runtime.deltaManager.active === false) {
+            this.logger.sendTelemetryEvent({
+                eventName: "NotStarted",
+                reason: "CannotWrite",
+                onBehalfOf,
+            });
+            return;
+        }
+
         if (this.runtime.summarizerClientId !== this.onBehalfOfClientId
             && this.runtime.summarizerClientId !== this.runtime.clientId) {
             // Verify that this client's computed summarizer matches the client this was spawned


### PR DESCRIPTION
Port #1988 to 0.16.  Although I haven't seen this cause issues on its own, it complicates telemetry and interacts poorly with other issues (such as the reconnect sending ops issue and reuse clientId issue).

Fixes #1986 by adding IContainerConfig to constructor.

Also distinguish NotStarted event with reason CannotWrite when deltaManager.active is false.