### PR TITLE
We may send same ops multiple times due to view-only connection

### DIFF
--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -19,6 +19,7 @@ describe("Loader", () => {
             let deltaManager: DeltaManager;
             let logger: ITelemetryLogger;
             let deltaConnection: MockDocumentDeltaConnection;
+            let clientSeqNumber = 0;
             let emitter: EventEmitter;
             let seq: number;
             let intendedResult: IProcessMessageResult;
@@ -44,6 +45,8 @@ describe("Loader", () => {
 
             async function emitSequentialOp(type: MessageType = MessageType.Operation) {
                 deltaConnection.emitOp(docId, [{
+                    clientId: "Some client ID",
+                    clientSequenceNumber: ++clientSeqNumber,
                     minimumSequenceNumber: 0,
                     sequenceNumber: seq++,
                     type,
@@ -74,6 +77,7 @@ describe("Loader", () => {
                     "test",
                     (messages) => emitter.emit(submitEvent, messages),
                 );
+                clientSeqNumber = 0;
                 const service = new MockDocumentService(
                     undefined,
                     () => deltaConnection,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -660,8 +660,9 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
 
         this.deltaManager.on("allSentOpsAckd", () => {
             // If we are not fully connected, then we have no clue if there are any pending ops
-            // to be resubmitted. wait for "connected" event to get that info.
-            // Not ideal, but it's better to have false negatives here then false positives
+            // to be resubmitted. Wait for "connected" event to get that info.
+            // Not ideal, but it's better to have false negatives then false positives.
+            // We will mark document clean on becoming "connected".
             if (this.connected) {
                 this.updateDocumentDirtyState(false);
             }
@@ -823,8 +824,8 @@ export class ContainerRuntime extends EventEmitter implements IHostRuntime, IRun
 
         if (value === ConnectionState.Connected) {
             // Once we are connected, all acks are accounted.
-            // If there are any pending ops, DDSs will resubmit them right away and we will
-            // switch back to dirty state.
+            // If there are any pending ops, DDSs will resubmit them right away (below) and
+            // we will switch back to dirty state in such case.
             this.updateDocumentDirtyState(false);
 
             // Resend all pending attach messages prior to notifying clients


### PR DESCRIPTION
Issue #2007: DeltaManager should not reconnect as view-only if there were any pending ops at the moment of last disconnect 

This is initial prototype, have not tested it yet.
All of this logic should likely move down to container runtime, and deltaManager ask it for reconnection mode instead. But that's left for another day.

Somewhat unrelated changes in containerRuntime.ts, based on a fact that code in processInboundMessage() was wrong regarding using connection clientId, which lead me to look at tracking of dirty state.