### PR TITLE
Make view-only connection always catch up on latest changes (remove race condition).

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -931,10 +931,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         // if we have some op on the wire (or will have a "join" op for ourselves for r/w connection), then client
         // can detect it has a gap and fetch missing ops. However if we are connecting as view-only, then there
         // is no good signal to realize if client is behind. Thus we have to hit storage to see if any ops are there.
-        // Note that doing this request all the time will add substantial amount of traffic to storage.
-        // Doing it only if connection took long. Need to reevaluate in the future.
         if (this.handler && connection.details.mode !== "write" &&
-            performanceNow() - this.connectionStartingTime > 15000 &&
             (connection.details.initialMessages === undefined || connection.details.initialMessages.length === 0)) {
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
             this.fetchMissingDeltas("Reconnect", this.lastQueuedSequenceNumber);

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -131,7 +131,6 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
     private clientSequenceNumber = 0;
     private clientSequenceNumberObserved = 0;
     private closed = false;
-    private connectionStartingTime: number = 0;
 
     // track clientId used last time when we sent any ops
     private lastSubmittedClientId: string | undefined;
@@ -403,8 +402,6 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         if (!docService) {
             throw new Error("Container is not attached");
         }
-
-        this.connectionStartingTime = performanceNow();
 
         // The promise returned from connectCore will settle with a resolved DeltaConnection or reject with error
         const connectCore = async () => {


### PR DESCRIPTION
There is no other reliable signal from server on "current" seq#, so the only way to solve problem is to ask storage for latest ops after we are connected.

This is follow up to a discussion we had in email.