### PR TITLE
Allow for read-only client limit to be different than write-enabled clients limit

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -54,7 +54,8 @@ data:
         "alfred": {
             "kafkaClientId": "{{ template "alfred.fullname" . }}",
             "maxMessageSize": "16KB",
-            "maxNumberOfClientsPerDocument": {{ .Values.alfred.maxNumberOfClientsPerDocument }},
+            "maxNumberOfWriteClientsPerDocument": {{ .Values.alfred.maxNumberOfWriteClientsPerDocument }},
+            "maxNumberOfReadClientsPerDocument": {{ .Values.alfred.maxNumberOfReadClientsPerDocument }},
             "topic": "{{ .Values.kafka.topics.rawdeltas }}",
             "bucket": "snapshots",
             "restJsonSize": "50mb",

--- a/server/routerlicious/kubernetes/tools/generateChart.js
+++ b/server/routerlicious/kubernetes/tools/generateChart.js
@@ -45,7 +45,8 @@ alfred:
   cert: wu2-tls-certificate
   tenants: []
   key: VBQyoGpEYrTn3XQPtXW3K8fFDd
-  maxNumberOfClientsPerDocument: 1000000
+  maxNumberOfWriteClientsPerDocument: 1000000
+  maxNumberOfReadClientsPerDocument: 1000000
 
 login:
   microsoft:

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -36,7 +36,8 @@
     "alfred": {
         "kafkaClientId": "alfred",
         "maxMessageSize": "16KB",
-        "maxNumberOfClientsPerDocument": 1000000,
+        "maxNumberOfWriteClientsPerDocument": 1000000,
+        "maxNumberOfReadClientsPerDocument": 1000000,
         "topic": "rawdeltas",
         "bucket": "snapshots",
         "restJsonSize": "50mb",

--- a/server/routerlicious/packages/routerlicious/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious/src/alfred/runner.ts
@@ -60,7 +60,8 @@ export class AlfredRunner implements utils.IRunner {
 
         const httpServer = this.server.httpServer;
 
-        const maxNumberOfClientsPerDocument = this.config.get("alfred:maxNumberOfClientsPerDocument");
+        const maxNumberOfWriteClientsPerDocument = this.config.get("alfred:maxNumberOfWriteClientsPerDocument");
+        const maxNumberOfReadClientsPerDocument = this.config.get("alfred:maxNumberOfReadClientsPerDocument");
         // Register all the socket.io stuff
         configureWebSocketServices(
             this.server.webSocketServer,
@@ -71,7 +72,8 @@ export class AlfredRunner implements utils.IRunner {
             this.clientManager,
             createMetricClient(this.metricClientConfig),
             winston,
-            maxNumberOfClientsPerDocument);
+            maxNumberOfReadClientsPerDocument,
+            maxNumberOfWriteClientsPerDocument);
 
         // Listen on provided port, on all network interfaces.
         httpServer.listen(this.port);


### PR DESCRIPTION
When stress-testing our app before //build we realized read-only clients are much cheaper on the service than write-enabled once and we can support orders of magnitude more of them for a given Fluid document. This change will enable the client limits to be set differently for read-only and write-enabled clients.