### PR TITLE
Add strong error handling for create file and rename some errors

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -2,6 +2,8 @@
 
 ## 0.17 Breaking Changes
 
+### FileNotFoundError is now FileNotFoundOrAccessDeniedError and AccessDeniedError to AuthorizationError
+
 - [IHostRuntime is now IContainerRuntime](#IHostRuntime-is-now-IContainerRuntime)
 - [Updates to ContainerRuntime and LocalComponentContext createProps removal](#Updates-to-ContainerRuntime-and-LocalComponentContext-createProps-removal)
 - [SimpleContainerRuntimeFactory removed](#SimpleContainerRuntimeFactory-removed)

--- a/packages/drivers/odsp-socket-storage/src/createFile.ts
+++ b/packages/drivers/odsp-socket-storage/src/createFile.ts
@@ -6,7 +6,7 @@
 import * as assert from "assert";
 import { Deferred } from "@microsoft/fluid-common-utils";
 import { getGitType } from "@microsoft/fluid-protocol-base";
-import { getDocAttributesFromProtocolSummary } from "@microsoft/fluid-driver-utils";
+import { getDocAttributesFromProtocolSummary, invalidFileNameErrorCode } from "@microsoft/fluid-driver-utils";
 import { SummaryType, ISummaryTree, ISummaryBlob, MessageType } from "@microsoft/fluid-protocol-definitions";
 import {
     IOdspResolvedUrl,
@@ -63,7 +63,7 @@ export async function createNewFluidFile(
     }
     // Check for valid filename before the request to create file is actually made.
     if (isInvalidFileName(newFileInfo.filename)) {
-        throwOdspNetworkError("Invalid filename. Please try again.", 710, false);
+        throwOdspNetworkError("Invalid filename. Please try again.", invalidFileNameErrorCode, false);
     }
     let containerSnapshot: ISnapshotTree | undefined;
     if (createNewSummary) {

--- a/packages/drivers/odsp-socket-storage/src/createFile.ts
+++ b/packages/drivers/odsp-socket-storage/src/createFile.ts
@@ -63,7 +63,7 @@ export async function createNewFluidFile(
     }
     // Check for valid filename before the request to create file is actually made.
     if (isInvalidFileName(newFileInfo.filename)) {
-        throw new Error("Invalid filename. Please try again.");
+        throwOdspNetworkError("Invalid filename. Please try again.", 710, false);
     }
     let containerSnapshot: ISnapshotTree | undefined;
     if (createNewSummary) {

--- a/packages/loader/driver-definitions/src/error.ts
+++ b/packages/loader/driver-definitions/src/error.ts
@@ -7,8 +7,10 @@
 export enum ErrorType {
     generalError,
     genericNetworkError,
-    accessDeniedError,
-    fileNotFoundError,
+    authorizationError,
+    fileNotFoundOrAccessDeniedError,
+    outOfStorageError,
+    invalidFileNameError,
     throttlingError,
     serviceError,
     summarizingError,
@@ -16,8 +18,8 @@ export enum ErrorType {
     fatalError,
 }
 
-export type IError = IGeneralError | IThrottlingError |
-IGenericNetworkError | IAccessDeniedError | IFileNotFoundError |
+export type IError = IGeneralError | IThrottlingError | IOutOfStorageError | IInvalidFileNameError |
+IGenericNetworkError | IAuthorizationError | IFileNotFoundOrAccessDeniedError |
 IServiceError | ISummarizingError | IWriteError | IFatalError;
 
 export interface IGeneralError {
@@ -45,12 +47,20 @@ export interface IGenericNetworkError extends IBaseConnectionError {
     readonly errorType: ErrorType.genericNetworkError;
 }
 
-export interface IAccessDeniedError extends IBaseConnectionError {
-    readonly errorType: ErrorType.accessDeniedError;
+export interface IAuthorizationError extends IBaseConnectionError {
+    readonly errorType: ErrorType.authorizationError;
 }
 
-export interface IFileNotFoundError extends IBaseConnectionError {
-    readonly errorType: ErrorType.fileNotFoundError;
+export interface IFileNotFoundOrAccessDeniedError extends IBaseConnectionError {
+    readonly errorType: ErrorType.fileNotFoundOrAccessDeniedError;
+}
+
+export interface IOutOfStorageError extends IBaseConnectionError {
+    readonly errorType: ErrorType.outOfStorageError;
+}
+
+export interface IInvalidFileNameError extends IBaseConnectionError {
+    readonly errorType: ErrorType.invalidFileNameError;
 }
 
 export interface IServiceError {

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -34,6 +34,9 @@ export enum OnlineStatus {
     Unknown,
 }
 
+// Status code for invalid file name error in odsp driver.
+export const invalidFileNameErrorCode: number = 710;
+
 // It tells if we have local connection only - we might not have connection to web.
 // No solution for node.js (other than resolve dns names / ping specific sites)
 // Can also use window.addEventListener("online" / "offline")
@@ -62,8 +65,9 @@ class GenericNetworkError extends ErrorWithProps implements IGenericNetworkError
 }
 
 /**
- * AuthorizationError error class -
- * used to communicate Unauthorized/Forbidden error responses(maybe due to expired token) from the server
+ * AuthorizationError error class - used to communicate Unauthorized/Forbidden error responses
+ * (maybe due to expired token) from the server. Almost all of these cases is because user does
+ * not have permissions.
  */
 class AuthorizationError extends ErrorWithProps implements IAuthorizationError {
     readonly errorType: ErrorType.authorizationError = ErrorType.authorizationError;
@@ -184,7 +188,7 @@ export function createNetworkError(
     if (statusCode === 507) {
         return new OutOfStorageError(errorMessage, statusCode, canRetry, online);
     }
-    if (statusCode === 414 || statusCode === 710) {
+    if (statusCode === 414 || statusCode === invalidFileNameErrorCode) {
         return new InvalidFileNameError(errorMessage, statusCode, canRetry, online);
     }
     if (retryAfterSeconds !== undefined) {

--- a/packages/test/end-to-end/src/test/error.spec.ts
+++ b/packages/test/end-to-end/src/test/error.spec.ts
@@ -118,23 +118,23 @@ describe("Errors Types", () => {
         }
     });
 
-    it("AccessDeniedError Test 401", async () => {
+    it("AuthorizationError Test 401", async () => {
         const networkError = createNetworkError(
             "Test Message",
             false /* canRetry */,
             401 /* statusCode */);
-        assert.equal(networkError.errorType, ErrorType.accessDeniedError,
-            "Error should be an accessDeniedError");
+        assert.equal(networkError.errorType, ErrorType.authorizationError,
+            "Error should be an authorizationError");
         assertCustomPropertySupport(networkError);
     });
 
-    it("AccessDeniedError Test 403", async () => {
+    it("AuthorizationError Test 403", async () => {
         const networkError = createNetworkError(
             "Test Message",
             false /* canRetry */,
             403 /* statusCode */);
-        if (networkError.errorType !== ErrorType.accessDeniedError) {
-            assert.fail("Error should be an accessDeniedError");
+        if (networkError.errorType !== ErrorType.authorizationError) {
+            assert.fail("Error should be an authorizationError");
         }
         else {
             assert.equal(networkError.canRetry, false, "canRetry should be preserved");
@@ -142,19 +142,49 @@ describe("Errors Types", () => {
         }
     });
 
-    it("FileNotFoundError Test", async () => {
+    it("OutOfStorageError Test 507", async () => {
+        const networkError = createNetworkError(
+            "Test Message",
+            false /* canRetry */,
+            507 /* statusCode */);
+        assert.equal(networkError.errorType, ErrorType.outOfStorageError,
+            "Error should be an OutOfStorageError");
+        assertCustomPropertySupport(networkError);
+    });
+
+    it("FileNotFoundOrAccessDeniedError Test", async () => {
         const networkError = createNetworkError(
             "Test Message",
             false /* canRetry */,
             404 /* statusCode */);
         assertCustomPropertySupport(networkError);
-        if (networkError.errorType !== ErrorType.fileNotFoundError) {
-            assert.fail("Error should be a fileNotFoundError");
+        if (networkError.errorType !== ErrorType.fileNotFoundOrAccessDeniedError) {
+            assert.fail("Error should be a fileNotFoundOrAccessDeniedError");
         }
         else {
             assert.equal(networkError.canRetry, false, "canRetry should be preserved");
             assert.equal(networkError.statusCode, 404, "status code should be preserved");
         }
+    });
+
+    it("InvalidFileNameError Test 414", async () => {
+        const networkError = createNetworkError(
+            "Test Message",
+            false /* canRetry */,
+            414 /* statusCode */);
+        assert.equal(networkError.errorType, ErrorType.invalidFileNameError,
+            "Error should be an InvalidFileNameError");
+        assertCustomPropertySupport(networkError);
+    });
+
+    it("InvalidFileNameError Test 710", async () => {
+        const networkError = createNetworkError(
+            "Test Message",
+            false /* canRetry */,
+            710 /* statusCode */);
+        assert.equal(networkError.errorType, ErrorType.invalidFileNameError,
+            "Error should be an InvalidFileNameError");
+        assertCustomPropertySupport(networkError);
     });
 
     it("FatalError Test", async () => {


### PR DESCRIPTION
1.) Issue: https://github.com/microsoft/FluidFramework/issues/1999 : Rename error FileNotFound to FileNotFoundOrAccessDenied and AccessDenied to AuthorizationError.

2.) Issue https://github.com/microsoft/FluidFramework/issues/1725 and https://github.com/microsoft/FluidFramework/issues/1141: Add more error codes to provide strong error handling like OutOfStorageError and InvalidFileNameError.