### PR TITLE
Fix for getComponent in TestHost failing intermittently after cloning

### DIFF
--- a/packages/server/local-test-utils/src/testHost.ts
+++ b/packages/server/local-test-utils/src/testHost.ts
@@ -62,7 +62,8 @@ export class TestRootComponent extends PrimedComponent implements IComponentRunn
     }
 
     public async getComponent<T extends IComponentLoadable>(id: string): Promise<T> {
-        return this.root.get<IComponentHandle<T>>(id).get();
+        const handle = await this.root.wait<IComponentHandle<T>>(id);
+        return handle.get();
     }
 
     /**
@@ -196,7 +197,7 @@ export class TestHost {
             new TestDocumentServiceFactory(this.deltaConnectionServer),
             new TestResolver());
 
-        this.root = store.open<TestRootComponent>("test-root-component", TestRootComponent.codeProposal, "", scope);
+        this.root = store.open<TestRootComponent>("testHostContainer", TestRootComponent.codeProposal, "", scope);
     }
 
     /**


### PR DESCRIPTION
In `TestHost::createAndAttachComponent`, the handle of the component that is created is stored in the default component's root DDS by calling `set`.

When this TestHost is cloned and `getComponent` is called, it retrieves the id from the default component's root DDS. However, the op for the `set` may not have arrived yet, resulting in failure to get the component.

The fix here is to call `wait` on the root DDS instead of `set`.

Fixes #2061.