### PR TITLE
Ensure ConsensusOrderedCollection promises reject when ComponentRuntime disposes

### DIFF
--- a/packages/components/agent-scheduler/src/scheduler.ts
+++ b/packages/components/agent-scheduler/src/scheduler.ts
@@ -479,6 +479,7 @@ export class AgentSchedulerFactory implements IComponentFactory {
             dataTypes,
         );
 
+        // Warning: This promise is unhandled in this scope, and can result in unhandled promise rejection error
         const taskManagerP = TaskManager.load(runtime, context);
         runtime.registerRequestHandler(async (request: IRequest) => {
             const taskManager = await taskManagerP;

--- a/packages/components/agent-scheduler/src/scheduler.ts
+++ b/packages/components/agent-scheduler/src/scheduler.ts
@@ -479,7 +479,8 @@ export class AgentSchedulerFactory implements IComponentFactory {
             dataTypes,
         );
 
-        // Warning: This promise is unhandled in this scope, and can result in unhandled promise rejection error
+        // Warning: This promise is unhandled in this scope, and can result in unhandled promise rejection error,
+        // similar to cases where the no-floating-promise eslint rule applies.
         const taskManagerP = TaskManager.load(runtime, context);
         runtime.registerRequestHandler(async (request: IRequest) => {
             const taskManager = await taskManagerP;

--- a/packages/runtime/consensus-ordered-collection/src/consensusOrderedCollection.ts
+++ b/packages/runtime/consensus-ordered-collection/src/consensusOrderedCollection.ts
@@ -373,6 +373,10 @@ export class ConsensusOrderedCollection<T = any>
     ): Promise<IConsensusOrderedCollectionValue<T> | undefined> {
         assert(!this.isLocal());
 
+        if (this.runtime.disposed) {
+            throw new Error("Attempting to submit an op on a disposed ComponentRuntime");
+        }
+
         const clientSequenceNumber = this.submitLocalMessage(message);
         return new Promise((resolve) => {
             // Note that clientSequenceNumber and message is only used for asserts and isn't strictly necessary.

--- a/packages/runtime/consensus-ordered-collection/src/consensusOrderedCollection.ts
+++ b/packages/runtime/consensus-ordered-collection/src/consensusOrderedCollection.ts
@@ -190,12 +190,8 @@ export class ConsensusOrderedCollection<T = any>
         do {
             if (this.data.size() === 0) {
                 // Wait for new entry before trying to acquire again
-                await new Promise((resolve, reject) => {
+                await this.newAckBasedPromise((resolve, reject) => {
                     this.once("add", resolve);
-                    //* todo: figure out the right event that's available or fix the proxy
-                    (this.runtime.deltaManager as any).deltaManager.on(
-                        "closed",
-                        () => reject(new Error("Delta Manager closed while waiting")));
                 });
             }
         } while (!(await this.acquire(callback)));

--- a/packages/runtime/consensus-ordered-collection/src/consensusOrderedCollection.ts
+++ b/packages/runtime/consensus-ordered-collection/src/consensusOrderedCollection.ts
@@ -192,11 +192,10 @@ export class ConsensusOrderedCollection<T = any>
                 // Wait for new entry before trying to acquire again
                 await new Promise((resolve, reject) => {
                     this.once("add", resolve);
-                    //* todo: get rid of "as any" (i.e. figure out the right event that's available or fix the proxy)
-                    //* todo: Deal with the UnhandledPromiseRejectionWarning showing up in the test
-                    (this.runtime.deltaManager as any).deltaManager.on("closed", () => {
-                        reject(new Error("Delta Manager closed while waiting"));
-                    });
+                    //* todo: figure out the right event that's available or fix the proxy
+                    (this.runtime.deltaManager as any).deltaManager.on(
+                        "closed",
+                        () => reject(new Error("Delta Manager closed while waiting")));
                 });
             }
         } while (!(await this.acquire(callback)));

--- a/packages/runtime/consensus-ordered-collection/src/consensusOrderedCollection.ts
+++ b/packages/runtime/consensus-ordered-collection/src/consensusOrderedCollection.ts
@@ -183,18 +183,19 @@ export class ConsensusOrderedCollection<T = any>
      * Wait for a value to be available and acquire it from the consensus collection
      */
     public async waitAndAcquire(callback: ConsensusCallback<T>): Promise<void> {
-        this.runtime.deltaManager.once("closed", () => {
-            throw new Error("deltaManager closed");
-        });
-
-        while (!(await this.acquire(callback))) {
+        do {
             if (this.data.size() === 0) {
                 // Wait for new entry before trying to acquire again
-                await new Promise((resolve) => {
+                await new Promise((resolve, reject) => {
                     this.once("add", resolve);
+                    //* todo: get rid of "as any" (i.e. figure out the right event that's available or fix the proxy)
+                    //* todo: Deal with the UnhandledPromiseRejectionWarning showing up in the test
+                    (this.runtime.deltaManager as any).deltaManager.on("closed", () => {
+                        reject(new Error("Delta Manager closed while waiting"));
+                    });
                 });
             }
-        }
+        } while (!(await this.acquire(callback)));
     }
 
     public snapshot(): ITree {

--- a/packages/runtime/consensus-ordered-collection/src/consensusOrderedCollection.ts
+++ b/packages/runtime/consensus-ordered-collection/src/consensusOrderedCollection.ts
@@ -373,12 +373,8 @@ export class ConsensusOrderedCollection<T = any>
     ): Promise<IConsensusOrderedCollectionValue<T> | undefined> {
         assert(!this.isLocal());
 
-        if (this.runtime.disposed) {
-            throw new Error("Attempting to submit an op on a disposed ComponentRuntime");
-        }
-
         const clientSequenceNumber = this.submitLocalMessage(message);
-        return new Promise((resolve) => {
+        return this.newAckBasedPromise((resolve) => {
             // Note that clientSequenceNumber and message is only used for asserts and isn't strictly necessary.
             this.pendingLocalMessages.push({ resolve, clientSequenceNumber, message });
         });

--- a/packages/runtime/consensus-ordered-collection/src/interfaces.ts
+++ b/packages/runtime/consensus-ordered-collection/src/interfaces.ts
@@ -74,19 +74,23 @@ export interface IConsensusOrderedCollectionEvents<T> extends ISharedObjectEvent
  * Consensus Ordered Collection interface
  *
  * An consensus ordered collection is a distributed data structure, which
- * holds a collection of JSON-able or shared objects, and have a
+ * holds a collection of JSON-able or handles, and has a
  * deterministic add/remove order.
  *
  * @remarks
  * The order the server receive the add/remove operation determines the
  * order those operation are applied to the collection. Different clients
- * issuing `add` or `remove` operations at the same time will be sequenced.
+ * issuing `add` or `acquire` operations at the same time will be sequenced.
  * The order dictates which `add` is done first, thus determining the order
  * in which it appears in the collection.  It also determines which client
  * will get the first removed item, etc. All operations are asynchronous.
- * A function `wait` is provided to wait for and remove an entry in the collection.
+ * A function `waitAndAcquire` is provided to wait for and remove an entry in the collection.
  *
- * All non-shared objects added to the collection will be cloned (via JSON).
+ * As a client acquires an item, it processes it and then returns a value (via callback)
+ * indicating whether it has completed processing the item, or whether the item should be
+ * released back to the collection for another client to process.
+ *
+ * All objects added to the collection will be cloned (via JSON).
  * They will not be references to the original input object.  Thus changed to
  * the input object will not reflect the object in the collection.
  */

--- a/packages/runtime/shared-object-common/src/sharedObject.ts
+++ b/packages/runtime/shared-object-common/src/sharedObject.ts
@@ -303,6 +303,10 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
         executor: (resolve: (value?: T | PromiseLike<T> | undefined) => void, reject: (reason?: any) => void) => void,
     ): Promise<T> {
         return new Promise((resolve, reject) => {
+            if (this.runtime.disposed) {
+                reject("Preparing to wait for an op to be acked with a disposed ComponentRuntime");
+            }
+
             (this.runtime).on(
                 "dispose",
                 () => reject(new Error("ComponentRuntime disposed while this ack-based Promise was pending")));

--- a/packages/runtime/shared-object-common/src/sharedObject.ts
+++ b/packages/runtime/shared-object-common/src/sharedObject.ts
@@ -304,11 +304,10 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
     ): Promise<T> {
         return new Promise((resolve, reject) => {
             if (this.runtime.disposed) {
-                reject("Preparing to wait for an op to be acked with a disposed ComponentRuntime");
+                reject("Preparing to wait for an op to be acked but ComponentRuntime has been disposed");
             }
 
-            (this.runtime).on(
-                "dispose",
+            this.runtime.on("dispose",
                 () => reject(new Error("ComponentRuntime disposed while this ack-based Promise was pending")));
 
             executor(resolve, reject);

--- a/packages/runtime/shared-object-common/src/sharedObject.ts
+++ b/packages/runtime/shared-object-common/src/sharedObject.ts
@@ -307,7 +307,7 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
                 reject("Preparing to wait for an op to be acked but ComponentRuntime has been disposed");
             }
 
-            this.runtime.on("dispose",
+            this.runtime.once("dispose",
                 () => reject(new Error("ComponentRuntime disposed while this ack-based Promise was pending")));
 
             executor(resolve, reject);

--- a/packages/test/end-to-end/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
+++ b/packages/test/end-to-end/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
@@ -272,8 +272,7 @@ function generate(
             await collection1.add("testValue");
 
             assert(rejected, "Closing the runtime while waiting should cause promise reject");
-            //* todo: This deadlocks, since it's waiting for the op to come back...
-            // assert.equal(await acquireAndComplete(collection2), undefined);
+            await assert.rejects(acquireAndComplete(collection2), "Acquiring when the runtime is disposed should fail");
             assert.equal(await acquireAndComplete(collection1), "testValue", "testValue should still be there");
         });
 

--- a/packages/test/end-to-end/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
+++ b/packages/test/end-to-end/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
@@ -254,7 +254,7 @@ function generate(
             assert.equal(await acquireAndComplete(collection2), undefined);
         });
 
-        it.only("cancel wait on close", async () => {
+        it.only("cancel on close", async () => {
             const collection1 = ctor.create(component1.runtime);
             sharedMap1.set("collection", collection1.handle);
 
@@ -262,16 +262,16 @@ function generate(
                 await sharedMap2.wait<IComponentHandle<IConsensusOrderedCollection>>("collection");
             const collection2 = await collection2Handle.get();
 
-            let rejected = false;
+            let waitRejected = false;
             waitAcquireAndComplete(collection2)
-                .catch(() => { rejected = true; });
+                .catch(() => { waitRejected = true; });
             component2.runtime.deltaManager.close();
             //* todo: this fails badly too:
             // component1.runtime.deltaManager.close();
 
             await collection1.add("testValue");
 
-            assert(rejected, "Closing the runtime while waiting should cause promise reject");
+            assert(waitRejected, "Closing the runtime while waiting should cause promise reject");
             await assert.rejects(acquireAndComplete(collection2), "Acquiring when the runtime is disposed should fail");
             assert.equal(await acquireAndComplete(collection1), "testValue", "testValue should still be there");
         });

--- a/packages/test/end-to-end/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
+++ b/packages/test/end-to-end/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
@@ -254,7 +254,7 @@ function generate(
             assert.equal(await acquireAndComplete(collection2), undefined);
         });
 
-        it.only("cancel on close", async () => {
+        it("cancel on close", async () => {
             const collection1 = ctor.create(component1.runtime);
             sharedMap1.set("collection", collection1.handle);
 
@@ -266,13 +266,12 @@ function generate(
             waitAcquireAndComplete(collection2)
                 .catch(() => { waitRejected = true; });
             component2.runtime.deltaManager.close();
-            //* todo: this fails badly too:
-            // component1.runtime.deltaManager.close();
 
             await collection1.add("testValue");
 
             assert(waitRejected, "Closing the runtime while waiting should cause promise reject");
             await assert.rejects(acquireAndComplete(collection2), "Acquiring when the runtime is disposed should fail");
+            await assert.rejects(collection2.add("anotherValue"), "Adding when the runtime is disposed should fail");
             assert.equal(await acquireAndComplete(collection1), "testValue", "testValue should still be there");
         });
 

--- a/packages/test/end-to-end/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
+++ b/packages/test/end-to-end/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
@@ -242,12 +242,14 @@ function generate(
             const collection2 = await collection2Handle.get();
 
             await collection1.add("testValue");
-            await collection1.acquire(async (value) => {
+            const acquireReleaseP = collection1.acquire(async (value) => {
                 assert.strictEqual(value, "testValue");
                 return ConsensusResult.Release;
             });
+            const waitAcquireCompleteP = waitAcquireAndComplete(collection2);
 
-            assert.equal(await waitAcquireAndComplete(collection2), "testValue");
+            assert.equal(await acquireReleaseP, true);
+            assert.equal(await waitAcquireCompleteP, "testValue");
             assert.equal(await acquireAndComplete(collection1), undefined);
             assert.equal(await acquireAndComplete(collection2), undefined);
         });
@@ -260,17 +262,19 @@ function generate(
                 await sharedMap2.wait<IComponentHandle<IConsensusOrderedCollection>>("collection");
             const collection2 = await collection2Handle.get();
 
-            const p2 = waitAcquireAndComplete(collection2);
-            // await new Promise((res) => setImmediate(res));
+            let rejected = false;
+            myWaitAcquireAndComplete(collection2)
+                .catch(() => { rejected = true; });
             component2.runtime.deltaManager.close();
             //* todo: this fails badly too:
             // component1.runtime.deltaManager.close();
 
             await collection1.add("testValue");
-            await collection1.acquire(async (value) => {
-                assert.strictEqual(value, "testValue");
-                return ConsensusResult.Release;
-            });
+
+            assert(rejected, "Closing the runtime while waiting should cause promise reject");
+            //* todo: This deadlocks, since it's waiting for the op to come back...
+            // assert.equal(await acquireAndComplete(collection2), undefined);
+            assert.equal(await acquireAndComplete(collection1), "testValue", "testValue should still be there");
 
             await assert.rejects(p2, "Closing the runtime while waiting should cause promise reject");
             assert.equal(await acquireAndComplete(collection1), undefined);

--- a/packages/test/end-to-end/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
+++ b/packages/test/end-to-end/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
@@ -261,6 +261,7 @@ function generate(
             const collection2 = await collection2Handle.get();
 
             const p2 = waitAcquireAndComplete(collection2);
+            // await new Promise((res) => setImmediate(res));
             component2.runtime.deltaManager.close();
             //* todo: this fails badly too:
             // component1.runtime.deltaManager.close();
@@ -271,7 +272,7 @@ function generate(
                 return ConsensusResult.Release;
             });
 
-            assert.equal(await p2, "testValue");
+            await assert.rejects(p2, "Closing the runtime while waiting should cause promise reject");
             assert.equal(await acquireAndComplete(collection1), undefined);
             assert.equal(await acquireAndComplete(collection2), undefined);
         });

--- a/packages/test/end-to-end/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
+++ b/packages/test/end-to-end/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
@@ -263,7 +263,7 @@ function generate(
             const collection2 = await collection2Handle.get();
 
             let rejected = false;
-            myWaitAcquireAndComplete(collection2)
+            waitAcquireAndComplete(collection2)
                 .catch(() => { rejected = true; });
             component2.runtime.deltaManager.close();
             //* todo: this fails badly too:
@@ -275,10 +275,6 @@ function generate(
             //* todo: This deadlocks, since it's waiting for the op to come back...
             // assert.equal(await acquireAndComplete(collection2), undefined);
             assert.equal(await acquireAndComplete(collection1), "testValue", "testValue should still be there");
-
-            await assert.rejects(p2, "Closing the runtime while waiting should cause promise reject");
-            assert.equal(await acquireAndComplete(collection1), undefined);
-            assert.equal(await acquireAndComplete(collection2), undefined);
         });
 
         it("Events", async () => {

--- a/packages/test/end-to-end/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
+++ b/packages/test/end-to-end/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
@@ -43,6 +43,7 @@ function generate(
         let deltaConnectionServer: ILocalDeltaConnectionServer;
         let containerDeltaEventManager: DocumentDeltaEventManager;
         let component1: ITestFluidComponent;
+        let component2: ITestFluidComponent;
         let sharedMap1: ISharedMap;
         let sharedMap2: ISharedMap;
         let sharedMap3: ISharedMap;
@@ -72,7 +73,7 @@ function generate(
             sharedMap1 = await component1.getSharedObject<SharedMap>(mapId);
 
             const container2 = await createContainer();
-            const component2 = await getComponent("default", container2);
+            component2 = await getComponent("default", container2);
             sharedMap2 = await component2.getSharedObject<SharedMap>(mapId);
 
             const container3 = await createContainer();
@@ -247,6 +248,30 @@ function generate(
             });
 
             assert.equal(await waitAcquireAndComplete(collection2), "testValue");
+            assert.equal(await acquireAndComplete(collection1), undefined);
+            assert.equal(await acquireAndComplete(collection2), undefined);
+        });
+
+        it.only("cancel wait on close", async () => {
+            const collection1 = ctor.create(component1.runtime);
+            sharedMap1.set("collection", collection1.handle);
+
+            const collection2Handle =
+                await sharedMap2.wait<IComponentHandle<IConsensusOrderedCollection>>("collection");
+            const collection2 = await collection2Handle.get();
+
+            const p2 = waitAcquireAndComplete(collection2);
+            component2.runtime.deltaManager.close();
+            //* todo: this fails badly too:
+            // component1.runtime.deltaManager.close();
+
+            await collection1.add("testValue");
+            await collection1.acquire(async (value) => {
+                assert.strictEqual(value, "testValue");
+                return ConsensusResult.Release;
+            });
+
+            assert.equal(await p2, "testValue");
             assert.equal(await acquireAndComplete(collection1), undefined);
             assert.equal(await acquireAndComplete(collection2), undefined);
         });


### PR DESCRIPTION
Fixes #1420, and provides an API to fix similar issues in other DDS's.

The idea is that any Promise created in a DDS that doesn't resolve until after an op has been ack'd will hang if the ComponentRuntime is disposed before the ack comes back.  So I added a `newAckBasedPromise` protected function to `SharedObject` that will ensure the promise is rejected when the ComponentRuntime disposes.

I also did some editorial work in `ConsensusOrderedCollection` based on what made sense to me after digesting it.