### PR TITLE
Reduce styling in webpack-component-loader and fix layout in single mode

### DIFF
--- a/components/experimental/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
+++ b/components/experimental/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
@@ -29,7 +29,7 @@ export const WaterParkLoaderName = `${pkg.name}-loader`;
 // available when running on localhost.
 const localComponents = [
     // "http://localhost:8080/file/C:\\git\\FluidFramework\\components\\experimental\\todo",
-    // "http://localhost:8080/file/C:\\git\\FluidFramework\\components\\experimental\\clicker",
+    "http://localhost:8080/file/C:\\git\\FluidFramework\\components\\experimental\\clicker",
 ];
 
 /**

--- a/components/experimental/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
+++ b/components/experimental/external-component-loader/src/waterParkLoader/externalComponentLoader.ts
@@ -29,7 +29,7 @@ export const WaterParkLoaderName = `${pkg.name}-loader`;
 // available when running on localhost.
 const localComponents = [
     // "http://localhost:8080/file/C:\\git\\FluidFramework\\components\\experimental\\todo",
-    "http://localhost:8080/file/C:\\git\\FluidFramework\\components\\experimental\\clicker",
+    // "http://localhost:8080/file/C:\\git\\FluidFramework\\components\\experimental\\clicker",
 ];
 
 /**

--- a/components/experimental/flow-util-lib/src/resizeobserver/index.css
+++ b/components/experimental/flow-util-lib/src/resizeobserver/index.css
@@ -1,4 +1,13 @@
 /*
+ * shared-text expects to fill the space provided to it.  When loading in webpack-component-loader, we need to force
+ * the larger size on the #content div or we'll render at 0 height.  shared-text should probably enforce a minimum
+ * functional size if the provided space is too small.
+ */
+#content {
+    height: 100vh;
+}
+
+/*
  * Based on 'ResizeSensor' from Marc J. Schmidt's 'CSS Element Queries':
  * https://github.com/marcj/css-element-queries/blob/09d4cf12a2bf2c143274bbe4e4bc04060e55880f/src/ResizeSensor.js
  */

--- a/components/experimental/markflow/src/host/index.css
+++ b/components/experimental/markflow/src/host/index.css
@@ -13,6 +13,7 @@ html, body {
 }
 
 .host {
+    min-height: 300px;
     bottom: 0;
     margin: 0;
     padding: 0;

--- a/packages/tools/webpack-component-loader/src/loader.ts
+++ b/packages/tools/webpack-component-loader/src/loader.ts
@@ -148,6 +148,11 @@ export async function start(
     textArea: HTMLTextAreaElement,
     attached: boolean,
 ): Promise<void> {
+    div.style.width = "100%";
+    div.style.minHeight = "100vh";
+    div.style.display = "flex";
+    div.style.position = "relative";
+
     let finalDocId = documentId;
     if (attached) {
         attachButton.style.display = "none";

--- a/packages/tools/webpack-component-loader/src/loader.ts
+++ b/packages/tools/webpack-component-loader/src/loader.ts
@@ -100,10 +100,10 @@ function wrapIfComponentPackage(packageJson: IFluidPackage, fluidModule: IFluidM
 function makeSideBySideDiv(divId?: string) {
     const div = document.createElement("div");
     div.style.flexGrow = "1";
-    div.style.width = "50vw"; // ensure the divs don't encroach on each other
+    div.style.width = "50%"; // ensure the divs don't encroach on each other
     div.style.border = "1px solid lightgray";
     div.style.boxSizing = "border-box";
-    div.style.position = "relative";                // Make the new <div> a CSS stacking context.
+    div.style.position = "relative"; // Make the new <div> a CSS containing block.
     if (divId) {
         div.id = divId;
     }
@@ -148,11 +148,6 @@ export async function start(
     textArea: HTMLTextAreaElement,
     attached: boolean,
 ): Promise<void> {
-    div.style.width = "100%";
-    div.style.minHeight = "100vh";
-    div.style.display = "flex";
-    div.style.position = "relative";
-
     let finalDocId = documentId;
     if (attached) {
         attachButton.style.display = "none";
@@ -203,6 +198,7 @@ export async function start(
     const urlDeferred = new Deferred<string>();
     // Side-by-side mode
     if (options.mode === "local" && !options.single) {
+        div.style.display = "flex";
         const leftDiv = makeSideBySideDiv("sbs-left");
         const rightDiv = makeSideBySideDiv("sbs-right");
         div.append(leftDiv, rightDiv);

--- a/packages/tools/webpack-component-loader/src/routes.ts
+++ b/packages/tools/webpack-component-loader/src/routes.ts
@@ -195,14 +195,14 @@ const fluid = (req: express.Request, res: express.Response, baseDir: string, opt
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>${documentId}</title>
 </head>
-<body style="margin: 0; padding: 0">
+<body style="margin: 0;">
     <div>
         <button id="attach-button" disabled>Attach!</button>
     </div>
     <div>
         <textarea id="text" rows="1" cols="60" wrap="hard">Url will appear here!!</textarea>
     </div>
-    <div id="content" style="width: 100%; min-height: 100vh; display: flex; position: relative">
+    <div id="content">
     </div>
 
     <script src="/node_modules/@microsoft/fluid-webpack-component-loader/dist/fluid-loader.bundle.js"></script>


### PR DESCRIPTION
We currently have bugs that component layout is inconsistent between single vs. side-by-side mode in webpack-component-loader.  This is because we were indiscriminately adding the flex style regardless of whether the side-by-side divs will be added or not, meaning that in single mode the component becomes a flex-item.  This alters component layout substantially in some cases.  Now we will only use flex layout in side-by-side mode.

This change also reduces the styling applied in webpack-component-loader in general, so that component developers are less affected by the specifics of loading in that environment.  This should be more representative of loading in other contexts.

I manually tested all components via `npm run start` and `npm run start:r11s`, and fixed up markflow and shared-text which both try to render at the size of their parent but lacked minimum sizing to protect themselves if the parent is too small.