### PR TITLE
Stabalize jest test exec times

### DIFF
--- a/components/experimental/canvas/test/canvas.test.ts
+++ b/components/experimental/canvas/test/canvas.test.ts
@@ -7,7 +7,12 @@ import { ElementHandle } from "puppeteer";
 import { globals } from "../jest.config";
 
 describe("canvas", () => {
-    jest.setTimeout(10000);
+    beforeAll(async () => {
+        // Wait for the page to load first before running any tests
+        // so this time isn't attributed to the first test
+        await page.goto(globals.PATH, { waitUntil: "load" });
+    }, 45000);
+
     beforeEach(async () => {
         await page.goto(globals.PATH, { waitUntil: "load" });
         await page.waitFor(() => window["fluidStarted"]);

--- a/components/experimental/clicker/tests/clicker.test.ts
+++ b/components/experimental/clicker/tests/clicker.test.ts
@@ -6,8 +6,6 @@
 import { globals } from "../jest.config";
 
 describe("clicker", () => {
-    jest.setTimeout(10000);
-
     const getValue = async (index: number) => {
         return page.evaluate((i: number) => {
             const clickerElements = document.getElementsByClassName("clicker-value-class");
@@ -19,6 +17,12 @@ describe("clicker", () => {
             return "";
         }, index);
     };
+
+    beforeAll(async () => {
+        // Wait for the page to load first before running any tests
+        // so this time isn't attributed to the first test
+        await page.goto(globals.PATH, { waitUntil: "load" });
+    }, 45000);
 
     beforeEach(async () => {
         await page.goto(globals.PATH, { waitUntil: "load" });

--- a/components/experimental/collaborative-textarea/tests/collaborativetext.test.ts
+++ b/components/experimental/collaborative-textarea/tests/collaborativetext.test.ts
@@ -6,8 +6,6 @@
 import { globals } from "../jest.config";
 
 describe("collaborativetext", () => {
-    jest.setTimeout(10000);
-
     const getValue = async (index: number) => {
         return page.evaluate((i: number) => {
             const divs = document.getElementsByClassName("text-area");
@@ -39,6 +37,12 @@ describe("collaborativetext", () => {
             }
         }, index, text);
     };
+
+    beforeAll(async () => {
+        // Wait for the page to load first before running any tests
+        // so this time isn't attributed to the first test
+        await page.goto(globals.PATH, { waitUntil: "load" });
+    }, 45000);
 
     beforeEach(async () => {
         await page.goto(globals.PATH, { waitUntil: "load" });

--- a/components/experimental/dice-roller/tests/diceRoller.test.ts
+++ b/components/experimental/dice-roller/tests/diceRoller.test.ts
@@ -6,7 +6,11 @@
 import { globals } from "../jest.config";
 
 describe("diceRoller", () => {
-    jest.setTimeout(10000);
+    beforeAll(async () => {
+        // Wait for the page to load first before running any tests
+        // so this time isn't attributed to the first test
+        await page.goto(globals.PATH, { waitUntil: "load" });
+    }, 45000);
 
     beforeEach(async () => {
         await page.goto(globals.PATH, { waitUntil: "load" });

--- a/components/experimental/external-component-loader/test/external-component-loader.test.ts
+++ b/components/experimental/external-component-loader/test/external-component-loader.test.ts
@@ -7,7 +7,11 @@ import * as path from "path";
 import { globals } from "../jest.config";
 
 describe("external-component-loader", () => {
-    jest.setTimeout(20000);
+    beforeAll(async () => {
+        // Wait for the page to load first before running any tests
+        // so this time isn't attributed to the first test
+        await page.goto(globals.PATH, { waitUntil: "load" });
+    }, 45000);
 
     beforeEach(async () => {
         await page.goto(globals.PATH, { waitUntil: "load" });

--- a/components/experimental/pond/tests/pond.test.ts
+++ b/components/experimental/pond/tests/pond.test.ts
@@ -6,7 +6,11 @@
 import { globals } from "../jest.config";
 
 describe("pond", () => {
-    jest.setTimeout(10000);
+    beforeAll(async () => {
+        // Wait for the page to load first before running any tests
+        // so this time isn't attributed to the first test
+        await page.goto(globals.PATH, { waitUntil: "load" });
+    }, 45000);
 
     beforeEach(async () => {
         await page.goto(globals.PATH, { waitUntil: "load" });

--- a/components/experimental/shared-text/tests/sharedText.test.ts
+++ b/components/experimental/shared-text/tests/sharedText.test.ts
@@ -6,7 +6,11 @@
 import { globals } from "../jest.config";
 
 describe("sharedText", () => {
-    jest.setTimeout(30000);
+    beforeAll(async () => {
+        // Wait for the page to load first before running any tests
+        // so this time isn't attributed to the first test
+        await page.goto(globals.PATH, { waitUntil: "load" });
+    }, 45000);
 
     beforeEach(async () => {
         await page.goto(globals.PATH, { waitUntil: "load" });

--- a/components/experimental/spaces/tests/spaces.test.ts
+++ b/components/experimental/spaces/tests/spaces.test.ts
@@ -6,7 +6,12 @@
 import { globals } from "../jest.config";
 
 describe("spaces", () => {
-    jest.setTimeout(40000);
+    beforeAll(async () => {
+        // Wait for the page to load first before running any tests
+        // so this time isn't attributed to the first test
+        await page.goto(globals.PATH, { waitUntil: "load" });
+    }, 45000);
+
     beforeEach(async () => {
         await page.goto(globals.PATH, { waitUntil: "load" });
         await page.waitFor(() => window["fluidStarted"]);

--- a/components/experimental/todo/tests/todo.test.ts
+++ b/components/experimental/todo/tests/todo.test.ts
@@ -6,7 +6,11 @@
 import { globals } from "../jest.config";
 
 describe("ToDo", () => {
-    jest.setTimeout(15000);
+    beforeAll(async () => {
+        // Wait for the page to load first before running any tests
+        // so this time isn't attributed to the first test
+        await page.goto(globals.PATH, { waitUntil: "load" });
+    }, 45000);
 
     beforeEach(async () => {
         await page.goto(globals.PATH, { waitUntil: "load" });

--- a/components/experimental/vltava/tests/vltava.test.ts
+++ b/components/experimental/vltava/tests/vltava.test.ts
@@ -6,7 +6,12 @@
 import { globals } from "../jest.config";
 
 describe("vltava", () => {
-    jest.setTimeout(10000);
+    beforeAll(async () => {
+        // Wait for the page to load first before running any tests
+        // so this time isn't attributed to the first test
+        await page.goto(globals.PATH, { waitUntil: "load" });
+    }, 45000);
+
     beforeEach(async () => {
         await page.goto(globals.PATH, { waitUntil: "load" });
         await page.waitFor(() => window["fluidStarted"]);

--- a/packages/test/context-reload/tests/contextReload.test.ts
+++ b/packages/test/context-reload/tests/contextReload.test.ts
@@ -7,7 +7,12 @@ import { Deferred } from "@microsoft/fluid-common-utils";
 import { globals } from "../jest.config";
 
 describe("context reload", () => {
-    jest.setTimeout(10000);
+    beforeAll(async () => {
+        // Wait for the page to load first before running any tests
+        // so this time isn't attributed to the first test
+        await page.goto(globals.PATH, { waitUntil: "load" });
+    }, 45000);
+
     beforeEach(async () => {
         await page.goto(globals.PATH, { waitUntil: "load" });
         await page.waitFor(() => window["fluidStarted"]);


### PR DESCRIPTION
Fixes #2093 
Jest tests kick off webpack-dev-server asynchronously at start, which takes a while to be ready, and is even slower when run under lerna. The wait for page load at the beginning of each jest test gets attributed to the first test run, which then leads to intermittent (or consistent on slower machines) timeouts.  It's not clear that webpack-dev-server can reuse previously built products because of how it runs in-memory, but we can move the initial wait for page load out from the first test and give it a larger timeout to stabilize the actual test runs.  Initial page load aside, the actual tests show very little variance in their run times, and we can also revert their timeouts to the default 5s.  Certain projects like sharedtext and spaces that had very large timeouts set previously needed them because their ordinal positioning usually put them at the end of the first batch of runs by lerna, causing them to take the longest to finish the webpack step.