### PR TITLE
Reconnect on error cleanup

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2272,11 +2272,6 @@
 				"sha.js": "^2.4.11"
 			}
 		},
-		"@microsoft/fluid-component-core-interfaces": {
-			"version": "0.17.0",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-component-core-interfaces/-/fluid-component-core-interfaces-0.17.0.tgz",
-			"integrity": "sha512-45yL+laKcEmpmkkSFjrWwnzRDPJJ0eONmFFIxozH69EbpSZdg+yK9gCbZdzHM/8AQGfhfuydzqgG6ST3SgO8IQ=="
-		},
 		"@microsoft/fluid-component-runtime": {
 			"version": "0.16.4",
 			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-component-runtime/-/fluid-component-runtime-0.16.4.tgz",
@@ -2358,17 +2353,6 @@
 						"@microsoft/fluid-runtime-definitions": "^0.16.4"
 					}
 				}
-			}
-		},
-		"@microsoft/fluid-container-definitions": {
-			"version": "0.17.0",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-container-definitions/-/fluid-container-definitions-0.17.0.tgz",
-			"integrity": "sha512-Y0HpYILdAlz41+RzUGdREC4fw3zPDDUMfx8H88gN3gLGvC0pgrQW3eKh9hUcrU20B5HDanruxsOm0yrAIJ43Rw==",
-			"requires": {
-				"@microsoft/fluid-common-definitions": "^0.16.0",
-				"@microsoft/fluid-component-core-interfaces": "^0.17.0",
-				"@microsoft/fluid-driver-definitions": "^0.17.0",
-				"@microsoft/fluid-protocol-definitions": "^0.1004.2"
 			}
 		},
 		"@microsoft/fluid-container-loader": {
@@ -2561,16 +2545,6 @@
 						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
 					}
 				}
-			}
-		},
-		"@microsoft/fluid-driver-definitions": {
-			"version": "0.17.0",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-driver-definitions/-/fluid-driver-definitions-0.17.0.tgz",
-			"integrity": "sha512-yZIwXfsPGPU9inIYt/0yb6b0N7Zk9/dlRNaO7XlsNPgifSQHgpMupWw7JSZWQzGVhiQZC4ia1qFzx/5fwyQfFw==",
-			"requires": {
-				"@microsoft/fluid-common-definitions": "^0.16.0",
-				"@microsoft/fluid-component-core-interfaces": "^0.17.0",
-				"@microsoft/fluid-protocol-definitions": "^0.1004.2"
 			}
 		},
 		"@microsoft/fluid-driver-utils": {
@@ -2931,29 +2905,6 @@
 						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
 					}
 				}
-			}
-		},
-		"@microsoft/fluid-runtime-definitions": {
-			"version": "0.17.0",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-runtime-definitions/-/fluid-runtime-definitions-0.17.0.tgz",
-			"integrity": "sha512-rErCHfJuEZsnXzizC4gxR1l7iVUP2SV7W9A5Hg0qGHoPr2bgwiaGXDjpZYSf1GVVvdNu41QWKLslqg75Ak/U1g==",
-			"requires": {
-				"@microsoft/fluid-common-definitions": "^0.16.0",
-				"@microsoft/fluid-component-core-interfaces": "^0.17.0",
-				"@microsoft/fluid-container-definitions": "^0.17.0",
-				"@microsoft/fluid-driver-definitions": "^0.17.0",
-				"@microsoft/fluid-protocol-definitions": "^0.1004.2",
-				"@types/node": "^10.14.6"
-			}
-		},
-		"@microsoft/fluid-runtime-utils": {
-			"version": "0.17.0",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-runtime-utils/-/fluid-runtime-utils-0.17.0.tgz",
-			"integrity": "sha512-hyM4OomhRxfhymazmToUMFDTuCFsq3nhGcTNYx2KtyJk9QJ++Ri39D2YKHTphsHubi5d5YuW7qCD/PhIBJjraA==",
-			"requires": {
-				"@microsoft/fluid-component-core-interfaces": "^0.17.0",
-				"@microsoft/fluid-protocol-definitions": "^0.1004.2",
-				"@microsoft/fluid-runtime-definitions": "^0.17.0"
 			}
 		},
 		"@microsoft/fluid-server-lambdas": {

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2079,47 +2079,6 @@
 				"@microsoft/fluid-shared-object-base": "^0.16.4",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
-			},
-			"dependencies": {
-				"@microsoft/fluid-component-core-interfaces": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-component-core-interfaces/-/fluid-component-core-interfaces-0.16.4.tgz",
-					"integrity": "sha512-YXviVxV4ce++/h64Xu0kExTWSIu7k+/5Pg7ppxkU5jUnXJy0lc1/p0kA/h2tfUhSvvWMrJrST2NnNOtKNxNrUw=="
-				},
-				"@microsoft/fluid-container-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-container-definitions/-/fluid-container-definitions-0.16.4.tgz",
-					"integrity": "sha512-ilwa514uSooqXmy5HO4X4fDFT1P0R9s1ur/HwFWe+fY4EFTQK+OfJiRcYGN/IzQHhIBhIcnTcVpBj/1uGZSxww==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-driver-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-driver-definitions/-/fluid-driver-definitions-0.16.4.tgz",
-					"integrity": "sha512-IkXrTecKJyTamDMRR+RbX+EVUgU1ow9WHBKnZHOu0X0tde6G/jEFOJwwAEjbdXQNe7JuQSAKDCYruaLeV7N85Q==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-runtime-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-runtime-definitions/-/fluid-runtime-definitions-0.16.4.tgz",
-					"integrity": "sha512-9AScqNB2E7zCX3e3drRC9bPgUr39JOXW6ndXif0iDBBM8K3tUyitGUpgjJPA56a/dRI/EkG7IsIHwYLLhAo9OQ==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-container-definitions": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2",
-						"@types/node": "^10.14.6"
-					}
-				}
 			}
 		},
 		"@microsoft/fluid-aqueduct": {
@@ -2152,45 +2111,6 @@
 						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
-				},
-				"@microsoft/fluid-component-core-interfaces": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-component-core-interfaces/-/fluid-component-core-interfaces-0.16.4.tgz",
-					"integrity": "sha512-YXviVxV4ce++/h64Xu0kExTWSIu7k+/5Pg7ppxkU5jUnXJy0lc1/p0kA/h2tfUhSvvWMrJrST2NnNOtKNxNrUw=="
-				},
-				"@microsoft/fluid-container-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-container-definitions/-/fluid-container-definitions-0.16.4.tgz",
-					"integrity": "sha512-ilwa514uSooqXmy5HO4X4fDFT1P0R9s1ur/HwFWe+fY4EFTQK+OfJiRcYGN/IzQHhIBhIcnTcVpBj/1uGZSxww==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-driver-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-driver-definitions/-/fluid-driver-definitions-0.16.4.tgz",
-					"integrity": "sha512-IkXrTecKJyTamDMRR+RbX+EVUgU1ow9WHBKnZHOu0X0tde6G/jEFOJwwAEjbdXQNe7JuQSAKDCYruaLeV7N85Q==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-runtime-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-runtime-definitions/-/fluid-runtime-definitions-0.16.4.tgz",
-					"integrity": "sha512-9AScqNB2E7zCX3e3drRC9bPgUr39JOXW6ndXif0iDBBM8K3tUyitGUpgjJPA56a/dRI/EkG7IsIHwYLLhAo9OQ==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-container-definitions": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2",
-						"@types/node": "^10.14.6"
-					}
 				}
 			}
 		},
@@ -2221,32 +2141,6 @@
 						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
-				},
-				"@microsoft/fluid-component-core-interfaces": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-component-core-interfaces/-/fluid-component-core-interfaces-0.16.4.tgz",
-					"integrity": "sha512-YXviVxV4ce++/h64Xu0kExTWSIu7k+/5Pg7ppxkU5jUnXJy0lc1/p0kA/h2tfUhSvvWMrJrST2NnNOtKNxNrUw=="
-				},
-				"@microsoft/fluid-container-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-container-definitions/-/fluid-container-definitions-0.16.4.tgz",
-					"integrity": "sha512-ilwa514uSooqXmy5HO4X4fDFT1P0R9s1ur/HwFWe+fY4EFTQK+OfJiRcYGN/IzQHhIBhIcnTcVpBj/1uGZSxww==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-driver-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-driver-definitions/-/fluid-driver-definitions-0.16.4.tgz",
-					"integrity": "sha512-IkXrTecKJyTamDMRR+RbX+EVUgU1ow9WHBKnZHOu0X0tde6G/jEFOJwwAEjbdXQNe7JuQSAKDCYruaLeV7N85Q==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
 				}
 			}
 		},
@@ -2271,6 +2165,11 @@
 				"performance-now": "^2.1.0",
 				"sha.js": "^2.4.11"
 			}
+		},
+		"@microsoft/fluid-component-core-interfaces": {
+			"version": "0.16.4",
+			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-component-core-interfaces/-/fluid-component-core-interfaces-0.16.4.tgz",
+			"integrity": "sha512-YXviVxV4ce++/h64Xu0kExTWSIu7k+/5Pg7ppxkU5jUnXJy0lc1/p0kA/h2tfUhSvvWMrJrST2NnNOtKNxNrUw=="
 		},
 		"@microsoft/fluid-component-runtime": {
 			"version": "0.16.4",
@@ -2303,56 +2202,18 @@
 						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
-				},
-				"@microsoft/fluid-component-core-interfaces": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-component-core-interfaces/-/fluid-component-core-interfaces-0.16.4.tgz",
-					"integrity": "sha512-YXviVxV4ce++/h64Xu0kExTWSIu7k+/5Pg7ppxkU5jUnXJy0lc1/p0kA/h2tfUhSvvWMrJrST2NnNOtKNxNrUw=="
-				},
-				"@microsoft/fluid-container-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-container-definitions/-/fluid-container-definitions-0.16.4.tgz",
-					"integrity": "sha512-ilwa514uSooqXmy5HO4X4fDFT1P0R9s1ur/HwFWe+fY4EFTQK+OfJiRcYGN/IzQHhIBhIcnTcVpBj/1uGZSxww==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-driver-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-driver-definitions/-/fluid-driver-definitions-0.16.4.tgz",
-					"integrity": "sha512-IkXrTecKJyTamDMRR+RbX+EVUgU1ow9WHBKnZHOu0X0tde6G/jEFOJwwAEjbdXQNe7JuQSAKDCYruaLeV7N85Q==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-runtime-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-runtime-definitions/-/fluid-runtime-definitions-0.16.4.tgz",
-					"integrity": "sha512-9AScqNB2E7zCX3e3drRC9bPgUr39JOXW6ndXif0iDBBM8K3tUyitGUpgjJPA56a/dRI/EkG7IsIHwYLLhAo9OQ==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-container-definitions": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2",
-						"@types/node": "^10.14.6"
-					}
-				},
-				"@microsoft/fluid-runtime-utils": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-runtime-utils/-/fluid-runtime-utils-0.16.4.tgz",
-					"integrity": "sha512-jaQdRCZel8yjHcRpiQWzAiTX5GPZLcW6x6QdFp2vnPDf4BSHtTbthxM4VF10BJuSXeXM1dMQfT9PtyEdVLTfrQ==",
-					"requires": {
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2",
-						"@microsoft/fluid-runtime-definitions": "^0.16.4"
-					}
 				}
+			}
+		},
+		"@microsoft/fluid-container-definitions": {
+			"version": "0.16.4",
+			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-container-definitions/-/fluid-container-definitions-0.16.4.tgz",
+			"integrity": "sha512-ilwa514uSooqXmy5HO4X4fDFT1P0R9s1ur/HwFWe+fY4EFTQK+OfJiRcYGN/IzQHhIBhIcnTcVpBj/1uGZSxww==",
+			"requires": {
+				"@microsoft/fluid-common-definitions": "^0.16.0",
+				"@microsoft/fluid-component-core-interfaces": "^0.16.4",
+				"@microsoft/fluid-driver-definitions": "^0.16.4",
+				"@microsoft/fluid-protocol-definitions": "^0.1004.2"
 			}
 		},
 		"@microsoft/fluid-container-loader": {
@@ -2386,32 +2247,6 @@
 						"lodash": "^4.17.11",
 						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
-					}
-				},
-				"@microsoft/fluid-component-core-interfaces": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-component-core-interfaces/-/fluid-component-core-interfaces-0.16.4.tgz",
-					"integrity": "sha512-YXviVxV4ce++/h64Xu0kExTWSIu7k+/5Pg7ppxkU5jUnXJy0lc1/p0kA/h2tfUhSvvWMrJrST2NnNOtKNxNrUw=="
-				},
-				"@microsoft/fluid-container-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-container-definitions/-/fluid-container-definitions-0.16.4.tgz",
-					"integrity": "sha512-ilwa514uSooqXmy5HO4X4fDFT1P0R9s1ur/HwFWe+fY4EFTQK+OfJiRcYGN/IzQHhIBhIcnTcVpBj/1uGZSxww==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-driver-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-driver-definitions/-/fluid-driver-definitions-0.16.4.tgz",
-					"integrity": "sha512-IkXrTecKJyTamDMRR+RbX+EVUgU1ow9WHBKnZHOu0X0tde6G/jEFOJwwAEjbdXQNe7JuQSAKDCYruaLeV7N85Q==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
 					}
 				}
 			}
@@ -2451,55 +2286,6 @@
 						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
-				},
-				"@microsoft/fluid-component-core-interfaces": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-component-core-interfaces/-/fluid-component-core-interfaces-0.16.4.tgz",
-					"integrity": "sha512-YXviVxV4ce++/h64Xu0kExTWSIu7k+/5Pg7ppxkU5jUnXJy0lc1/p0kA/h2tfUhSvvWMrJrST2NnNOtKNxNrUw=="
-				},
-				"@microsoft/fluid-container-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-container-definitions/-/fluid-container-definitions-0.16.4.tgz",
-					"integrity": "sha512-ilwa514uSooqXmy5HO4X4fDFT1P0R9s1ur/HwFWe+fY4EFTQK+OfJiRcYGN/IzQHhIBhIcnTcVpBj/1uGZSxww==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-driver-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-driver-definitions/-/fluid-driver-definitions-0.16.4.tgz",
-					"integrity": "sha512-IkXrTecKJyTamDMRR+RbX+EVUgU1ow9WHBKnZHOu0X0tde6G/jEFOJwwAEjbdXQNe7JuQSAKDCYruaLeV7N85Q==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-runtime-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-runtime-definitions/-/fluid-runtime-definitions-0.16.4.tgz",
-					"integrity": "sha512-9AScqNB2E7zCX3e3drRC9bPgUr39JOXW6ndXif0iDBBM8K3tUyitGUpgjJPA56a/dRI/EkG7IsIHwYLLhAo9OQ==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-container-definitions": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2",
-						"@types/node": "^10.14.6"
-					}
-				},
-				"@microsoft/fluid-runtime-utils": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-runtime-utils/-/fluid-runtime-utils-0.16.4.tgz",
-					"integrity": "sha512-jaQdRCZel8yjHcRpiQWzAiTX5GPZLcW6x6QdFp2vnPDf4BSHtTbthxM4VF10BJuSXeXM1dMQfT9PtyEdVLTfrQ==",
-					"requires": {
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2",
-						"@microsoft/fluid-runtime-definitions": "^0.16.4"
-					}
 				}
 			}
 		},
@@ -2529,22 +2315,17 @@
 						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
-				},
-				"@microsoft/fluid-component-core-interfaces": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-component-core-interfaces/-/fluid-component-core-interfaces-0.16.4.tgz",
-					"integrity": "sha512-YXviVxV4ce++/h64Xu0kExTWSIu7k+/5Pg7ppxkU5jUnXJy0lc1/p0kA/h2tfUhSvvWMrJrST2NnNOtKNxNrUw=="
-				},
-				"@microsoft/fluid-driver-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-driver-definitions/-/fluid-driver-definitions-0.16.4.tgz",
-					"integrity": "sha512-IkXrTecKJyTamDMRR+RbX+EVUgU1ow9WHBKnZHOu0X0tde6G/jEFOJwwAEjbdXQNe7JuQSAKDCYruaLeV7N85Q==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
 				}
+			}
+		},
+		"@microsoft/fluid-driver-definitions": {
+			"version": "0.16.4",
+			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-driver-definitions/-/fluid-driver-definitions-0.16.4.tgz",
+			"integrity": "sha512-IkXrTecKJyTamDMRR+RbX+EVUgU1ow9WHBKnZHOu0X0tde6G/jEFOJwwAEjbdXQNe7JuQSAKDCYruaLeV7N85Q==",
+			"requires": {
+				"@microsoft/fluid-common-definitions": "^0.16.0",
+				"@microsoft/fluid-component-core-interfaces": "^0.16.4",
+				"@microsoft/fluid-protocol-definitions": "^0.1004.2"
 			}
 		},
 		"@microsoft/fluid-driver-utils": {
@@ -2556,23 +2337,6 @@
 				"@microsoft/fluid-component-core-interfaces": "^0.16.4",
 				"@microsoft/fluid-driver-definitions": "^0.16.4",
 				"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-			},
-			"dependencies": {
-				"@microsoft/fluid-component-core-interfaces": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-component-core-interfaces/-/fluid-component-core-interfaces-0.16.4.tgz",
-					"integrity": "sha512-YXviVxV4ce++/h64Xu0kExTWSIu7k+/5Pg7ppxkU5jUnXJy0lc1/p0kA/h2tfUhSvvWMrJrST2NnNOtKNxNrUw=="
-				},
-				"@microsoft/fluid-driver-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-driver-definitions/-/fluid-driver-definitions-0.16.4.tgz",
-					"integrity": "sha512-IkXrTecKJyTamDMRR+RbX+EVUgU1ow9WHBKnZHOu0X0tde6G/jEFOJwwAEjbdXQNe7JuQSAKDCYruaLeV7N85Q==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				}
 			}
 		},
 		"@microsoft/fluid-framework-interfaces": {
@@ -2582,47 +2346,6 @@
 			"requires": {
 				"@microsoft/fluid-component-core-interfaces": "^0.16.4",
 				"@microsoft/fluid-runtime-definitions": "^0.16.4"
-			},
-			"dependencies": {
-				"@microsoft/fluid-component-core-interfaces": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-component-core-interfaces/-/fluid-component-core-interfaces-0.16.4.tgz",
-					"integrity": "sha512-YXviVxV4ce++/h64Xu0kExTWSIu7k+/5Pg7ppxkU5jUnXJy0lc1/p0kA/h2tfUhSvvWMrJrST2NnNOtKNxNrUw=="
-				},
-				"@microsoft/fluid-container-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-container-definitions/-/fluid-container-definitions-0.16.4.tgz",
-					"integrity": "sha512-ilwa514uSooqXmy5HO4X4fDFT1P0R9s1ur/HwFWe+fY4EFTQK+OfJiRcYGN/IzQHhIBhIcnTcVpBj/1uGZSxww==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-driver-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-driver-definitions/-/fluid-driver-definitions-0.16.4.tgz",
-					"integrity": "sha512-IkXrTecKJyTamDMRR+RbX+EVUgU1ow9WHBKnZHOu0X0tde6G/jEFOJwwAEjbdXQNe7JuQSAKDCYruaLeV7N85Q==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-runtime-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-runtime-definitions/-/fluid-runtime-definitions-0.16.4.tgz",
-					"integrity": "sha512-9AScqNB2E7zCX3e3drRC9bPgUr39JOXW6ndXif0iDBBM8K3tUyitGUpgjJPA56a/dRI/EkG7IsIHwYLLhAo9OQ==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-container-definitions": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2",
-						"@types/node": "^10.14.6"
-					}
-				}
 			}
 		},
 		"@microsoft/fluid-gitresources": {
@@ -2661,32 +2384,6 @@
 						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
-				},
-				"@microsoft/fluid-component-core-interfaces": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-component-core-interfaces/-/fluid-component-core-interfaces-0.16.4.tgz",
-					"integrity": "sha512-YXviVxV4ce++/h64Xu0kExTWSIu7k+/5Pg7ppxkU5jUnXJy0lc1/p0kA/h2tfUhSvvWMrJrST2NnNOtKNxNrUw=="
-				},
-				"@microsoft/fluid-container-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-container-definitions/-/fluid-container-definitions-0.16.4.tgz",
-					"integrity": "sha512-ilwa514uSooqXmy5HO4X4fDFT1P0R9s1ur/HwFWe+fY4EFTQK+OfJiRcYGN/IzQHhIBhIcnTcVpBj/1uGZSxww==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-driver-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-driver-definitions/-/fluid-driver-definitions-0.16.4.tgz",
-					"integrity": "sha512-IkXrTecKJyTamDMRR+RbX+EVUgU1ow9WHBKnZHOu0X0tde6G/jEFOJwwAEjbdXQNe7JuQSAKDCYruaLeV7N85Q==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
 				}
 			}
 		},
@@ -2715,45 +2412,6 @@
 						"lodash": "^4.17.11",
 						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
-					}
-				},
-				"@microsoft/fluid-component-core-interfaces": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-component-core-interfaces/-/fluid-component-core-interfaces-0.16.4.tgz",
-					"integrity": "sha512-YXviVxV4ce++/h64Xu0kExTWSIu7k+/5Pg7ppxkU5jUnXJy0lc1/p0kA/h2tfUhSvvWMrJrST2NnNOtKNxNrUw=="
-				},
-				"@microsoft/fluid-container-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-container-definitions/-/fluid-container-definitions-0.16.4.tgz",
-					"integrity": "sha512-ilwa514uSooqXmy5HO4X4fDFT1P0R9s1ur/HwFWe+fY4EFTQK+OfJiRcYGN/IzQHhIBhIcnTcVpBj/1uGZSxww==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-driver-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-driver-definitions/-/fluid-driver-definitions-0.16.4.tgz",
-					"integrity": "sha512-IkXrTecKJyTamDMRR+RbX+EVUgU1ow9WHBKnZHOu0X0tde6G/jEFOJwwAEjbdXQNe7JuQSAKDCYruaLeV7N85Q==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-runtime-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-runtime-definitions/-/fluid-runtime-definitions-0.16.4.tgz",
-					"integrity": "sha512-9AScqNB2E7zCX3e3drRC9bPgUr39JOXW6ndXif0iDBBM8K3tUyitGUpgjJPA56a/dRI/EkG7IsIHwYLLhAo9OQ==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-container-definitions": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2",
-						"@types/node": "^10.14.6"
 					}
 				}
 			}
@@ -2814,45 +2472,6 @@
 						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
-				},
-				"@microsoft/fluid-component-core-interfaces": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-component-core-interfaces/-/fluid-component-core-interfaces-0.16.4.tgz",
-					"integrity": "sha512-YXviVxV4ce++/h64Xu0kExTWSIu7k+/5Pg7ppxkU5jUnXJy0lc1/p0kA/h2tfUhSvvWMrJrST2NnNOtKNxNrUw=="
-				},
-				"@microsoft/fluid-container-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-container-definitions/-/fluid-container-definitions-0.16.4.tgz",
-					"integrity": "sha512-ilwa514uSooqXmy5HO4X4fDFT1P0R9s1ur/HwFWe+fY4EFTQK+OfJiRcYGN/IzQHhIBhIcnTcVpBj/1uGZSxww==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-driver-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-driver-definitions/-/fluid-driver-definitions-0.16.4.tgz",
-					"integrity": "sha512-IkXrTecKJyTamDMRR+RbX+EVUgU1ow9WHBKnZHOu0X0tde6G/jEFOJwwAEjbdXQNe7JuQSAKDCYruaLeV7N85Q==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-runtime-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-runtime-definitions/-/fluid-runtime-definitions-0.16.4.tgz",
-					"integrity": "sha512-9AScqNB2E7zCX3e3drRC9bPgUr39JOXW6ndXif0iDBBM8K3tUyitGUpgjJPA56a/dRI/EkG7IsIHwYLLhAo9OQ==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-container-definitions": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2",
-						"@types/node": "^10.14.6"
-					}
 				}
 			}
 		},
@@ -2889,22 +2508,30 @@
 						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
-				},
-				"@microsoft/fluid-component-core-interfaces": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-component-core-interfaces/-/fluid-component-core-interfaces-0.16.4.tgz",
-					"integrity": "sha512-YXviVxV4ce++/h64Xu0kExTWSIu7k+/5Pg7ppxkU5jUnXJy0lc1/p0kA/h2tfUhSvvWMrJrST2NnNOtKNxNrUw=="
-				},
-				"@microsoft/fluid-driver-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-driver-definitions/-/fluid-driver-definitions-0.16.4.tgz",
-					"integrity": "sha512-IkXrTecKJyTamDMRR+RbX+EVUgU1ow9WHBKnZHOu0X0tde6G/jEFOJwwAEjbdXQNe7JuQSAKDCYruaLeV7N85Q==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
 				}
+			}
+		},
+		"@microsoft/fluid-runtime-definitions": {
+			"version": "0.16.4",
+			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-runtime-definitions/-/fluid-runtime-definitions-0.16.4.tgz",
+			"integrity": "sha512-9AScqNB2E7zCX3e3drRC9bPgUr39JOXW6ndXif0iDBBM8K3tUyitGUpgjJPA56a/dRI/EkG7IsIHwYLLhAo9OQ==",
+			"requires": {
+				"@microsoft/fluid-common-definitions": "^0.16.0",
+				"@microsoft/fluid-component-core-interfaces": "^0.16.4",
+				"@microsoft/fluid-container-definitions": "^0.16.4",
+				"@microsoft/fluid-driver-definitions": "^0.16.4",
+				"@microsoft/fluid-protocol-definitions": "^0.1004.2",
+				"@types/node": "^10.14.6"
+			}
+		},
+		"@microsoft/fluid-runtime-utils": {
+			"version": "0.16.4",
+			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-runtime-utils/-/fluid-runtime-utils-0.16.4.tgz",
+			"integrity": "sha512-jaQdRCZel8yjHcRpiQWzAiTX5GPZLcW6x6QdFp2vnPDf4BSHtTbthxM4VF10BJuSXeXM1dMQfT9PtyEdVLTfrQ==",
+			"requires": {
+				"@microsoft/fluid-component-core-interfaces": "^0.16.4",
+				"@microsoft/fluid-protocol-definitions": "^0.1004.2",
+				"@microsoft/fluid-runtime-definitions": "^0.16.4"
 			}
 		},
 		"@microsoft/fluid-server-lambdas": {
@@ -3115,45 +2742,6 @@
 						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
-				},
-				"@microsoft/fluid-component-core-interfaces": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-component-core-interfaces/-/fluid-component-core-interfaces-0.16.4.tgz",
-					"integrity": "sha512-YXviVxV4ce++/h64Xu0kExTWSIu7k+/5Pg7ppxkU5jUnXJy0lc1/p0kA/h2tfUhSvvWMrJrST2NnNOtKNxNrUw=="
-				},
-				"@microsoft/fluid-container-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-container-definitions/-/fluid-container-definitions-0.16.4.tgz",
-					"integrity": "sha512-ilwa514uSooqXmy5HO4X4fDFT1P0R9s1ur/HwFWe+fY4EFTQK+OfJiRcYGN/IzQHhIBhIcnTcVpBj/1uGZSxww==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-driver-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-driver-definitions/-/fluid-driver-definitions-0.16.4.tgz",
-					"integrity": "sha512-IkXrTecKJyTamDMRR+RbX+EVUgU1ow9WHBKnZHOu0X0tde6G/jEFOJwwAEjbdXQNe7JuQSAKDCYruaLeV7N85Q==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-runtime-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-runtime-definitions/-/fluid-runtime-definitions-0.16.4.tgz",
-					"integrity": "sha512-9AScqNB2E7zCX3e3drRC9bPgUr39JOXW6ndXif0iDBBM8K3tUyitGUpgjJPA56a/dRI/EkG7IsIHwYLLhAo9OQ==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-container-definitions": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2",
-						"@types/node": "^10.14.6"
-					}
 				}
 			}
 		},
@@ -3171,47 +2759,6 @@
 				"@microsoft/fluid-runtime-definitions": "^0.16.4",
 				"@microsoft/fluid-shared-object-base": "^0.16.4",
 				"uuid": "^3.3.2"
-			},
-			"dependencies": {
-				"@microsoft/fluid-component-core-interfaces": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-component-core-interfaces/-/fluid-component-core-interfaces-0.16.4.tgz",
-					"integrity": "sha512-YXviVxV4ce++/h64Xu0kExTWSIu7k+/5Pg7ppxkU5jUnXJy0lc1/p0kA/h2tfUhSvvWMrJrST2NnNOtKNxNrUw=="
-				},
-				"@microsoft/fluid-container-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-container-definitions/-/fluid-container-definitions-0.16.4.tgz",
-					"integrity": "sha512-ilwa514uSooqXmy5HO4X4fDFT1P0R9s1ur/HwFWe+fY4EFTQK+OfJiRcYGN/IzQHhIBhIcnTcVpBj/1uGZSxww==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-driver-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-driver-definitions/-/fluid-driver-definitions-0.16.4.tgz",
-					"integrity": "sha512-IkXrTecKJyTamDMRR+RbX+EVUgU1ow9WHBKnZHOu0X0tde6G/jEFOJwwAEjbdXQNe7JuQSAKDCYruaLeV7N85Q==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-runtime-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-runtime-definitions/-/fluid-runtime-definitions-0.16.4.tgz",
-					"integrity": "sha512-9AScqNB2E7zCX3e3drRC9bPgUr39JOXW6ndXif0iDBBM8K3tUyitGUpgjJPA56a/dRI/EkG7IsIHwYLLhAo9OQ==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-container-definitions": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2",
-						"@types/node": "^10.14.6"
-					}
-				}
 			}
 		},
 		"@microsoft/fluid-web-code-loader": {
@@ -3222,34 +2769,6 @@
 				"@microsoft/fluid-container-definitions": "^0.16.4",
 				"@types/node": "^10.14.6",
 				"isomorphic-fetch": "^2.2.1"
-			},
-			"dependencies": {
-				"@microsoft/fluid-component-core-interfaces": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-component-core-interfaces/-/fluid-component-core-interfaces-0.16.4.tgz",
-					"integrity": "sha512-YXviVxV4ce++/h64Xu0kExTWSIu7k+/5Pg7ppxkU5jUnXJy0lc1/p0kA/h2tfUhSvvWMrJrST2NnNOtKNxNrUw=="
-				},
-				"@microsoft/fluid-container-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-container-definitions/-/fluid-container-definitions-0.16.4.tgz",
-					"integrity": "sha512-ilwa514uSooqXmy5HO4X4fDFT1P0R9s1ur/HwFWe+fY4EFTQK+OfJiRcYGN/IzQHhIBhIcnTcVpBj/1uGZSxww==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-driver-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-driver-definitions/-/fluid-driver-definitions-0.16.4.tgz",
-					"integrity": "sha512-IkXrTecKJyTamDMRR+RbX+EVUgU1ow9WHBKnZHOu0X0tde6G/jEFOJwwAEjbdXQNe7JuQSAKDCYruaLeV7N85Q==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				}
 			}
 		},
 		"@microsoft/load-themed-styles": {
@@ -15602,45 +15121,6 @@
 						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
-				},
-				"@microsoft/fluid-component-core-interfaces": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-component-core-interfaces/-/fluid-component-core-interfaces-0.16.4.tgz",
-					"integrity": "sha512-YXviVxV4ce++/h64Xu0kExTWSIu7k+/5Pg7ppxkU5jUnXJy0lc1/p0kA/h2tfUhSvvWMrJrST2NnNOtKNxNrUw=="
-				},
-				"@microsoft/fluid-container-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-container-definitions/-/fluid-container-definitions-0.16.4.tgz",
-					"integrity": "sha512-ilwa514uSooqXmy5HO4X4fDFT1P0R9s1ur/HwFWe+fY4EFTQK+OfJiRcYGN/IzQHhIBhIcnTcVpBj/1uGZSxww==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-driver-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-driver-definitions/-/fluid-driver-definitions-0.16.4.tgz",
-					"integrity": "sha512-IkXrTecKJyTamDMRR+RbX+EVUgU1ow9WHBKnZHOu0X0tde6G/jEFOJwwAEjbdXQNe7JuQSAKDCYruaLeV7N85Q==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-runtime-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-runtime-definitions/-/fluid-runtime-definitions-0.16.4.tgz",
-					"integrity": "sha512-9AScqNB2E7zCX3e3drRC9bPgUr39JOXW6ndXif0iDBBM8K3tUyitGUpgjJPA56a/dRI/EkG7IsIHwYLLhAo9OQ==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-container-definitions": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2",
-						"@types/node": "^10.14.6"
-					}
 				}
 			}
 		},
@@ -15676,32 +15156,6 @@
 						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
-				},
-				"@microsoft/fluid-component-core-interfaces": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-component-core-interfaces/-/fluid-component-core-interfaces-0.16.4.tgz",
-					"integrity": "sha512-YXviVxV4ce++/h64Xu0kExTWSIu7k+/5Pg7ppxkU5jUnXJy0lc1/p0kA/h2tfUhSvvWMrJrST2NnNOtKNxNrUw=="
-				},
-				"@microsoft/fluid-container-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-container-definitions/-/fluid-container-definitions-0.16.4.tgz",
-					"integrity": "sha512-ilwa514uSooqXmy5HO4X4fDFT1P0R9s1ur/HwFWe+fY4EFTQK+OfJiRcYGN/IzQHhIBhIcnTcVpBj/1uGZSxww==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-driver-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-driver-definitions/-/fluid-driver-definitions-0.16.4.tgz",
-					"integrity": "sha512-IkXrTecKJyTamDMRR+RbX+EVUgU1ow9WHBKnZHOu0X0tde6G/jEFOJwwAEjbdXQNe7JuQSAKDCYruaLeV7N85Q==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
 				}
 			}
 		},
@@ -15721,47 +15175,6 @@
 				"@microsoft/fluid-runtime-definitions": "^0.16.4",
 				"@microsoft/fluid-server-local-server": "^0.1004.2",
 				"@microsoft/fluid-shared-object-base": "^0.16.4"
-			},
-			"dependencies": {
-				"@microsoft/fluid-component-core-interfaces": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-component-core-interfaces/-/fluid-component-core-interfaces-0.16.4.tgz",
-					"integrity": "sha512-YXviVxV4ce++/h64Xu0kExTWSIu7k+/5Pg7ppxkU5jUnXJy0lc1/p0kA/h2tfUhSvvWMrJrST2NnNOtKNxNrUw=="
-				},
-				"@microsoft/fluid-container-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-container-definitions/-/fluid-container-definitions-0.16.4.tgz",
-					"integrity": "sha512-ilwa514uSooqXmy5HO4X4fDFT1P0R9s1ur/HwFWe+fY4EFTQK+OfJiRcYGN/IzQHhIBhIcnTcVpBj/1uGZSxww==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-driver-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-driver-definitions/-/fluid-driver-definitions-0.16.4.tgz",
-					"integrity": "sha512-IkXrTecKJyTamDMRR+RbX+EVUgU1ow9WHBKnZHOu0X0tde6G/jEFOJwwAEjbdXQNe7JuQSAKDCYruaLeV7N85Q==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2"
-					}
-				},
-				"@microsoft/fluid-runtime-definitions": {
-					"version": "0.16.4",
-					"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ffluid-runtime-definitions/-/fluid-runtime-definitions-0.16.4.tgz",
-					"integrity": "sha512-9AScqNB2E7zCX3e3drRC9bPgUr39JOXW6ndXif0iDBBM8K3tUyitGUpgjJPA56a/dRI/EkG7IsIHwYLLhAo9OQ==",
-					"requires": {
-						"@microsoft/fluid-common-definitions": "^0.16.0",
-						"@microsoft/fluid-component-core-interfaces": "^0.16.4",
-						"@microsoft/fluid-container-definitions": "^0.16.4",
-						"@microsoft/fluid-driver-definitions": "^0.16.4",
-						"@microsoft/fluid-protocol-definitions": "^0.1004.2",
-						"@types/node": "^10.14.6"
-					}
-				}
 			}
 		},
 		"on-finished": {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -88,7 +88,7 @@ import { Audience } from "./audience";
 import { BlobManager } from "./blobManager";
 import { ContainerContext } from "./containerContext";
 import { debug } from "./debug";
-import { IConnectionArgs, DeltaManager } from "./deltaManager";
+import { IConnectionArgs, DeltaManager, ReconnectMode } from "./deltaManager";
 import { DeltaManagerProxy } from "./deltaManagerProxy";
 import { Loader, RelativeLoader } from "./loader";
 import { NullChaincode } from "./nullRuntime";
@@ -564,7 +564,7 @@ export class Container
             throw new Error("Attempting to setAutoReconnect() a closed DeltaManager");
         }
 
-        this._deltaManager.autoReconnect = reconnect;
+        this._deltaManager.setReconnect(reconnect);
 
         this.logger.sendTelemetryEvent({
             eventName: reconnect ? "AutoReconnectEnabled" : "AutoReconnectDisabled",
@@ -1178,9 +1178,9 @@ export class Container
         let durationFromDisconnected: number | undefined;
         let connectionMode: string | undefined;
         let connectionInitiationReason: string | undefined;
-        let autoReconnect: boolean | undefined;
+        let autoReconnect: ReconnectMode | undefined;
         if (value === ConnectionState.Disconnected) {
-            autoReconnect = this._deltaManager.autoReconnect;
+            autoReconnect = this._deltaManager.reconnect;
         } else {
             connectionMode = this._deltaManager.connectionMode;
             if (value === ConnectionState.Connected) {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -564,7 +564,7 @@ export class Container
             throw new Error("Attempting to setAutoReconnect() a closed DeltaManager");
         }
 
-        this._deltaManager.setReconnect(reconnect);
+        this._deltaManager.setAutomaticReconnect(reconnect);
 
         this.logger.sendTelemetryEvent({
             eventName: reconnect ? "AutoReconnectEnabled" : "AutoReconnectDisabled",
@@ -1180,7 +1180,7 @@ export class Container
         let connectionInitiationReason: string | undefined;
         let autoReconnect: ReconnectMode | undefined;
         if (value === ConnectionState.Disconnected) {
-            autoReconnect = this._deltaManager.reconnect;
+            autoReconnect = this._deltaManager.reconnectMode;
         } else {
             connectionMode = this._deltaManager.connectionMode;
             if (value === ConnectionState.Connected) {

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -273,7 +273,9 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
      * Will throw an error if reconnectMode set to Never.
      */
     public setAutomaticReconnect(reconnect: boolean): void {
-        assert(this._reconnectMode !== ReconnectMode.Never, "Cannot toggle automatic reconnect if reconnect is set to Never.");
+        assert(
+            this._reconnectMode !== ReconnectMode.Never,
+            "Cannot toggle automatic reconnect if reconnect is set to Never.");
         this._reconnectMode = reconnect ? ReconnectMode.Enabled : ReconnectMode.Disabled;
     }
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -260,10 +260,18 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
         return this.readonlyPermissions || this._forceReadonly;
     }
 
+    /**
+     * Automatic reconnecting enabled or disabled.
+     * If set to Never, then reconnecting will never be allowed.
+     */
     public get reconnect(): ReconnectMode {
         return this._reconnect;
     }
 
+    /**
+     * Enables or disables automatic reconnecting.
+     * Will throw an error if attempting to enable when set to Never.
+     */
     public setReconnect(reconnect: boolean): void {
         if (reconnect) {
             assert(this._reconnect !== ReconnectMode.Never, "Cannot enable reconnect if reconnect is set to Never.");


### PR DESCRIPTION
Some small cleanup in DeltaManager following #2070.

1. Some renames, formatting, and refactors
1. Convert all delay times to seconds
1. Combine `reconnectOnError` flows from nack, error, and disconnect
1. Remove `reconnect` and `autoReconnect` and replace with 3-state enum

Tried to break up work into separate commits.
Added PR comments to known functional/telemetry changes that might be debatable.