### PR TITLE
Make RequestParser query public

### DIFF
--- a/packages/runtime/container-runtime/src/requestParser.ts
+++ b/packages/runtime/container-runtime/src/requestParser.ts
@@ -28,7 +28,7 @@ export class RequestParser implements IRequest {
     }
 
     private requestPathParts: readonly string[] | undefined;
-    private readonly query: string;
+    public readonly query: string;
     constructor(private readonly request: Readonly<IRequest>) {
         const queryStartIndex = this.request.url.indexOf("?");
         if (queryStartIndex >= 0) {


### PR DESCRIPTION
Make query public on RequestParser so that consumers can use any query parameters