### PR TITLE
Revert changes to ConsensusRegisterCollection op format

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -7,7 +7,7 @@
 - [IHostRuntime is now IContainerRuntime](#IHostRuntime-is-now-IContainerRuntime)
 - [Updates to ContainerRuntime and LocalComponentContext createProps removal](#Updates-to-ContainerRuntime-and-LocalComponentContext-createProps-removal)
 - [SimpleContainerRuntimeFactory removed](#SimpleContainerRuntimeFactory-removed)
-- [ConsensusRegisterCollection able to store handles not SharedObjects](#ConsensusRegisterCollection-able-to-store-handles-not-SharedObjects)
+- [ConsensusRegisterCollection can no longer store SharedObjects](#ConsensusRegisterCollection-can-no-longer-store-SharedObjects)
 
 ### IHostRuntime is now IContainerRuntime, hostRuntime in IComponentContext is now containerRuntime
 
@@ -48,13 +48,12 @@ As with previous guidance, components should ensure that only strongly typed ini
 
 `SimpleContainerRuntimeFactory` was deprecated in 0.16, and has now been removed in 0.17.
 
-### ConsensusRegisterCollection prepped to store handles not SharedObjects
+### ConsensusRegisterCollection can no longer store SharedObjects
 
-`ConsensusRegisterCollection` can store handles, and will properly serialize/deserialize to/from summary files.
-Please take care to ensure 0.17 is fully deployed before incorporating any change that writes handles to this data structure to avoid n/n-1 issues.
-Also, note that storing a SharedObject directly is no longer supported,
+`ConsensusRegisterCollection` no longer supports storing SharedObjects directly,
 and files with SharedObjects serialized within a ConsensusRegisterCollection will no longer open.
 We don't believe it's ever been used this way so there should be no such files, but please reach out if you see errors.
+In a subsequent release, support will be added for storing handles but due to n/n-1 constraints, in 0.17 neither are supported.
 
 ## 0.16 Breaking Changes
 

--- a/packages/runtime/consensus-register-collection/src/test/consensusRegisterCollection.spec.ts
+++ b/packages/runtime/consensus-register-collection/src/test/consensusRegisterCollection.spec.ts
@@ -61,7 +61,8 @@ describe("ConsensusRegisterCollection", () => {
                 assert.strictEqual(writeResult, true, "No concurrency expected");
             });
 
-            it("Can add and remove a handle", async () => {
+            // Disabled temporarily due to n/n-1 issues (see https://github.com/microsoft/FluidFramework/issues/2130)
+            it.skip("Can add and remove a handle", async () => {
                 assert.strictEqual(crc.read("key1"), undefined);
                 const handle = crc.handle;
                 if (handle === undefined) { assert.fail("Need an actual handle to test this case"); }

--- a/packages/test/end-to-end/src/test/consensusRegisterCollectionEndToEndTests.spec.ts
+++ b/packages/test/end-to-end/src/test/consensusRegisterCollectionEndToEndTests.spec.ts
@@ -174,7 +174,8 @@ function generate(name: string, ctor: ISharedObjectConstructor<IConsensusRegiste
             assert.strictEqual(versions6[0], "value10", "Happened after value did not overwrite");
         });
 
-        it("Can store handles", async () => {
+        // Disabled temporarily due to n/n-1 issues (see https://github.com/microsoft/FluidFramework/issues/2130)
+        it.skip("Can store handles", async () => {
             // Set up the collection with two handles and add it to the map so other containers can find it
             const collection1 = ctor.create(component1.runtime);
             sharedMap1.set("test", "sampleValue");


### PR DESCRIPTION
Fixes version 0.17 blocker #2130

Also adds in a parallel write to the new/preferred format (which supports handles), and an attempt at reading the new format, so in a subsequent change we can remove support for the old format.