### PR TITLE
api extractor fix given updated path of r11s builds

### DIFF
--- a/server/routerlicious/.npmrc
+++ b/server/routerlicious/.npmrc
@@ -1,4 +1,7 @@
 ; begin auth token
+; The lines between begin and end auth may be stripped by the build server in cases where the NPM_TOKEN
+; cannot be provided. In its place the build server will updated the npmrc with the required connection
+; strings.
 //offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/:username=offnet
 //offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/:_password=${NPM_TOKEN}
 //offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/:username=offnet

--- a/server/routerlicious/.npmrc.vsts
+++ b/server/routerlicious/.npmrc.vsts
@@ -1,5 +1,0 @@
-# registry=https://registry.npmjs.org/
-# always-auth=false
-
-@microsoft:registry=https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/
-@microsoft:always-auth=true

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "npm run build:genver && concurrently npm:build:compile npm:lint",
     "build:compile": "concurrently npm:tsc npm:build:esnext",
-    "build:docs": "api-extractor run --local && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../../../_api-extractor-temp/",
+    "build:docs": "api-extractor run --local && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../_api-extractor-temp/",
     "build:esnext": "tsc --project ./tsconfig.esnext.json",
     "build:full": "npm run build",
     "build:full:compile": "npm run build:compile",

--- a/server/routerlicious/packages/protocol-definitions/package.json
+++ b/server/routerlicious/packages/protocol-definitions/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "concurrently npm:build:compile npm:lint",
     "build:compile": "concurrently npm:tsc npm:build:esnext",
-    "build:docs": "api-extractor run --local && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../../../_api-extractor-temp/",
+    "build:docs": "api-extractor run --local && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../_api-extractor-temp/",
     "build:esnext": "tsc --project ./tsconfig.esnext.json",
     "build:full": "npm run build",
     "build:full:compile": "npm run build:compile",


### PR DESCRIPTION
Also removes the vsts auth npmrc which isn't needed thanks to the use of sed on the build server.