### PR TITLE
Stop throwing in ContainerRuntime verifyNotClosed

### DIFF
--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -323,8 +323,6 @@ export abstract class ComponentContext extends EventEmitter implements
      * it's new client ID when we are connecting or connected.
      */
     public changeConnectionState(value: ConnectionState, clientId?: string) {
-        this.verifyNotClosed();
-
         // Connection events are ignored if the component is not yet loaded
         if (!this.loaded) {
             return;
@@ -337,8 +335,6 @@ export abstract class ComponentContext extends EventEmitter implements
     }
 
     public process(message: ISequencedDocumentMessage, local: boolean): void {
-        this.verifyNotClosed();
-
         this.summaryTracker.updateLatestSequenceNumber(message.sequenceNumber);
 
         if (this.loaded) {
@@ -352,8 +348,6 @@ export abstract class ComponentContext extends EventEmitter implements
     }
 
     public processSignal(message: IInboundSignalMessage, local: boolean): void {
-        this.verifyNotClosed();
-
         // Signals are ignored if the component is not yet loaded
         if (!this.loaded) {
             return;
@@ -364,12 +358,10 @@ export abstract class ComponentContext extends EventEmitter implements
     }
 
     public getQuorum(): IQuorum {
-        this.verifyNotClosed();
         return this._containerRuntime.getQuorum();
     }
 
     public getAudience(): IAudience {
-        this.verifyNotClosed();
         return this._containerRuntime.getAudience();
     }
 
@@ -414,7 +406,6 @@ export abstract class ComponentContext extends EventEmitter implements
     }
 
     public submitMessage(type: MessageType, content: any): number {
-        this.verifyNotClosed();
         assert(this.componentRuntime);
         return this.submitOp(type, content);
     }
@@ -428,8 +419,6 @@ export abstract class ComponentContext extends EventEmitter implements
      *
      */
     public setChannelDirty(address: string): void {
-        this.verifyNotClosed();
-
         // Get the latest sequence number.
         const latestSequenceNumber = this.deltaManager.referenceSequenceNumber;
 
@@ -444,7 +433,6 @@ export abstract class ComponentContext extends EventEmitter implements
     }
 
     public submitSignal(type: string, content: any) {
-        this.verifyNotClosed();
         assert(this.componentRuntime);
         const envelope: IEnvelope = {
             address: this.id,
@@ -552,7 +540,6 @@ export abstract class ComponentContext extends EventEmitter implements
     protected abstract getInitialSnapshotDetails(): Promise<ISnapshotDetails>;
 
     private submitOp(type: MessageType, content: any): number {
-        this.verifyNotClosed();
         const envelope: IEnvelope = {
             address: this.id,
             contents: {
@@ -561,12 +548,6 @@ export abstract class ComponentContext extends EventEmitter implements
             },
         };
         return this._containerRuntime.submitFn(MessageType.Operation, envelope);
-    }
-
-    private verifyNotClosed() {
-        if (this._disposed) {
-            throw new Error("Runtime is closed");
-        }
     }
 }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -553,7 +553,6 @@ export class ContainerRuntime extends EventEmitter implements IContainerRuntime,
 
     private _disposed = false;
     public get disposed() { return this._disposed; }
-    private disposedWithError = false;
 
     // Components tracked by the Domain
     private readonly pendingAttach = new Map<string, IAttachMessage>();
@@ -697,15 +696,11 @@ export class ContainerRuntime extends EventEmitter implements IContainerRuntime,
         ReportConnectionTelemetry(this.context.clientId, this.deltaManager, this.logger);
     }
 
-    public dispose(error?: Error): void {
+    public dispose(): void {
         if (this._disposed) {
             return;
         }
         this._disposed = true;
-
-        if (error) {
-            this.disposedWithError = true;
-        }
 
         this.summaryManager.dispose();
         this.summarizer.dispose();
@@ -894,8 +889,6 @@ export class ContainerRuntime extends EventEmitter implements IContainerRuntime,
     }
 
     public async getComponentRuntime(id: string, wait = true): Promise<IComponentRuntimeChannel> {
-        this.verifyNotClosed();
-
         // Ensure deferred if it doesn't exist which will resolve once the process ID arrives
         const deferredContext = this.ensureContextDeferred(id);
 
@@ -991,8 +984,6 @@ export class ContainerRuntime extends EventEmitter implements IContainerRuntime,
     }
 
     private _createComponentContext(pkg: string[], props?: any, id = uuid()) {
-        this.verifyNotClosed();
-
         assert(!this.contexts.has(id), "Creating component with existing ID");
 
         const context = new LocalComponentContext(
@@ -1016,8 +1007,6 @@ export class ContainerRuntime extends EventEmitter implements IContainerRuntime,
         pkg: string[],
         realizationFn?: (context: IComponentContext) => void,
     ): Promise<IComponentRuntimeChannel> {
-        this.verifyNotClosed();
-
         // tslint:disable-next-line: no-unsafe-any
         const id: string = uuid();
         const context = new LocalComponentContext(
@@ -1221,8 +1210,6 @@ export class ContainerRuntime extends EventEmitter implements IContainerRuntime,
     }
 
     private attachComponent(componentRuntime: IComponentRuntimeChannel): void {
-        this.verifyNotClosed();
-
         const context = this.getContext(componentRuntime.id);
         // If storage is not available then we are not yet fully attached and so will defer to the initial snapshot
         if (!this.isLocal()) {
@@ -1492,16 +1479,13 @@ export class ContainerRuntime extends EventEmitter implements IContainerRuntime,
         return clientSequenceNumber;
     }
 
+    /**
+     * Throw an error if the runtime is closed.  Methods that are expected to potentially
+     * be called after dispose due to asynchrony should not call this.
+     */
     private verifyNotClosed() {
-        // Don't log another error here if the runtime was disposed due to an error,
-        // because the disposer should be responsible for reporting it.  Check this
-        // instead of stopping calls to the runtime because not all runtime consumers
-        // may be aware of the error.
-        if (this._disposed && !this.disposedWithError) {
-            this.logger.sendErrorEvent(
-                { eventName: "ContainerRuntime_verifyNotClosed" },
-                new Error("Runtime is closed"),
-            );
+        if (this._disposed) {
+            throw new Error("Runtime is closed");
         }
     }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1493,12 +1493,15 @@ export class ContainerRuntime extends EventEmitter implements IContainerRuntime,
     }
 
     private verifyNotClosed() {
-        // Don't throw another error here if the runtime was disposed due to an error,
+        // Don't log another error here if the runtime was disposed due to an error,
         // because the disposer should be responsible for reporting it.  Check this
         // instead of stopping calls to the runtime because not all runtime consumers
         // may be aware of the error.
         if (this._disposed && !this.disposedWithError) {
-            throw new Error("Runtime is closed");
+            this.logger.sendErrorEvent({
+                eventName: "ContainerRuntime_verifyNotClosed",
+                error: new Error("Runtime is closed"),
+            });
         }
     }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -984,6 +984,8 @@ export class ContainerRuntime extends EventEmitter implements IContainerRuntime,
     }
 
     private _createComponentContext(pkg: string[], props?: any, id = uuid()) {
+        this.verifyNotClosed();
+
         assert(!this.contexts.has(id), "Creating component with existing ID");
 
         const context = new LocalComponentContext(
@@ -1007,6 +1009,8 @@ export class ContainerRuntime extends EventEmitter implements IContainerRuntime,
         pkg: string[],
         realizationFn?: (context: IComponentContext) => void,
     ): Promise<IComponentRuntimeChannel> {
+        this.verifyNotClosed();
+
         // tslint:disable-next-line: no-unsafe-any
         const id: string = uuid();
         const context = new LocalComponentContext(
@@ -1210,6 +1214,8 @@ export class ContainerRuntime extends EventEmitter implements IContainerRuntime,
     }
 
     private attachComponent(componentRuntime: IComponentRuntimeChannel): void {
+        this.verifyNotClosed();
+
         const context = this.getContext(componentRuntime.id);
         // If storage is not available then we are not yet fully attached and so will defer to the initial snapshot
         if (!this.isLocal()) {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1498,10 +1498,10 @@ export class ContainerRuntime extends EventEmitter implements IContainerRuntime,
         // instead of stopping calls to the runtime because not all runtime consumers
         // may be aware of the error.
         if (this._disposed && !this.disposedWithError) {
-            this.logger.sendErrorEvent({
-                eventName: "ContainerRuntime_verifyNotClosed",
-                error: new Error("Runtime is closed"),
-            });
+            this.logger.sendErrorEvent(
+                { eventName: "ContainerRuntime_verifyNotClosed" },
+                new Error("Runtime is closed"),
+            );
         }
     }
 


### PR DESCRIPTION
#1835 

Previous change incorrectly changed the control flow of verifyNotClosed depending on dispose with error condition.  This changes it back so we do not consider any error condition, and instead removes the check from methods that may legitimately be called after dispose due to asynchrony.

In addition, do the same for ComponentRuntime and ComponentContext - remove the verifyNotClosed check for getting the quorum and audience, but keep it for methods that interface with the loader. For ComponentRuntime, also remove the stop() method and migrate it to use the disposed flag instead.