### PR TITLE
Add optional serverMetadata property to messages

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -545,6 +545,7 @@ export class DeliLambda implements IPartitionLambda {
             clientSequenceNumber: message.operation.clientSequenceNumber,
             contents: message.operation.contents,
             metadata: message.operation.metadata,
+            serverMetadata: message.operation.serverMetadata,
             minimumSequenceNumber: this.minimumSequenceNumber,
             origin,
             referenceSequenceNumber: message.operation.referenceSequenceNumber,

--- a/server/routerlicious/packages/protocol-definitions/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/protocol.ts
@@ -119,6 +119,9 @@ export interface IDocumentMessage {
     // App provided metadata about the operation
     metadata?: any;
 
+    // Server provided metadata about the operation
+    serverMetadata?: any;
+
     // Traces related to the packet.
     traces?: ITrace[];
 }

--- a/server/routerlicious/packages/protocol-definitions/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/protocol.ts
@@ -173,6 +173,9 @@ export interface ISequencedDocumentMessage {
     // App provided metadata about the operation
     metadata?: any;
 
+    // Server provided metadata about the operation
+    serverMetadata?: any;
+
     // Origin branch information for the message. Can be marked undefined if the current
     // message is also the origin.
     origin?: IBranchOrigin;


### PR DESCRIPTION
This allows the server to add additional information to messages. This is similar to the `metadata` field, except that only the server can fill out `serverMetadata`. Alfred sanitizes messages, which prevents the client from filling out this new field.

I will use this to pass some metadata from my frontend to the backend lambdas (scribe / broadcaster).