### PR TITLE
Assign id to loader and container instance and log it in telemetry

### DIFF
--- a/common/lib/common-definitions/src/logger.ts
+++ b/common/lib/common-definitions/src/logger.ts
@@ -84,7 +84,7 @@ export interface ITelemetryLogger extends ITelemetryBaseLogger {
     sendErrorEvent(event: ITelemetryErrorEvent, error?: any): void;
 
     /**
-     * Send error telemetry event
+     * Send performance telemetry event
      * @param event - Event to send
      */
     sendPerformanceEvent(event: ITelemetryPerformanceEvent, error?: any): void;

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -62,7 +62,8 @@
     "double-ended-queue": "^2.1.0-0",
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.11",
-    "performance-now": "^2.1.0"
+    "performance-now": "^2.1.0",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -4,6 +4,7 @@
  */
 
 import * as assert from "assert";
+import * as uuid from "uuid";
 import {
     ITelemetryBaseLogger,
     ITelemetryLogger,
@@ -25,7 +26,6 @@ import {
 } from "@microsoft/fluid-container-definitions";
 import {
     ChildLogger,
-    DebugLogger,
     EventEmitterWithErrorHandling,
     PerformanceEvent,
     TelemetryLogger,
@@ -368,9 +368,9 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         const clientType = `${interactive ? "interactive" : "noninteractive"}${type ? `/${type}` : ""}`;
         // Need to use the property getter for docId because for detached flow we don't have the docId initially.
         // We assign the id later so property getter is used.
-        this.subLogger = DebugLogger.mixinDebugLogger(
-            "fluid:telemetry",
+        this.subLogger = ChildLogger.create(
             logger,
+            undefined,
             {
                 clientType, // Differentiating summarizer container from main container
                 loaderVersion: pkgVersion,
@@ -380,7 +380,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             });
 
         // Prefix all events in this file with container-loader
-        this.logger = ChildLogger.create(this.subLogger, "Container");
+        this.logger = ChildLogger.create(this.subLogger, "Container", { containerId: uuid() });
 
         this.on("error", (error: any) => {
             this.logContainerError(error);
@@ -594,7 +594,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         // Ensure connection to web socket
         // All errors are reported through events ("error" / "disconnected") and telemetry in DeltaManager
-        this.connectToDeltaStream().catch(() => {});
+        this.connectToDeltaStream().catch(() => { });
     }
 
     public get storage(): IDocumentStorageService | null | undefined {
@@ -788,7 +788,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         // DeltaManager is resilient to this and will wait to start processing ops until after it is attached.
         if (!pause) {
             startConnectionP = this.connectToDeltaStream(connectionArgs);
-            startConnectionP.catch((error) => {});
+            startConnectionP.catch((error) => { });
         }
 
         this.storageService = await this.getDocumentStorageService();

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -17,6 +17,7 @@ import {
     IContainerEvents,
     IDeltaManager,
     IFluidCodeDetails,
+    IFluidModule,
     IGenericBlob,
     IRuntimeFactory,
     LoaderHeader,
@@ -1036,7 +1037,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
      * Loads the runtime factory for the provided package
      */
     private async loadRuntimeFactory(pkg: IFluidCodeDetails): Promise<IRuntimeFactory> {
-        let component;
+        let component: IFluidModule;
         const perfEvent = PerformanceEvent.start(this.logger, { eventName: "CodeLoad" });
         try {
             component = await this.codeLoader.load(pkg);

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -374,13 +374,14 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             {
                 clientType, // Differentiating summarizer container from main container
                 loaderVersion: pkgVersion,
+                containerId: uuid(),
             },
             {
                 docId: () => this.id,
             });
 
         // Prefix all events in this file with container-loader
-        this.logger = ChildLogger.create(this.subLogger, "Container", { containerId: uuid() });
+        this.logger = ChildLogger.create(this.subLogger, "Container");
 
         this.on("error", (error: any) => {
             this.logContainerError(error);

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -12,7 +12,7 @@ import {
     IDeltaManager,
     IDeltaQueue,
 } from "@microsoft/fluid-container-definitions";
-import { PerformanceEvent } from "@microsoft/fluid-common-utils";
+import { PerformanceEvent, TelemetryLogger } from "@microsoft/fluid-common-utils";
 import {
     IDocumentDeltaStorageService,
     IDocumentService,
@@ -513,7 +513,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
             if (connectRepeatCount > 1) {
                 this.logger.sendTelemetryEvent({
                     attempts: connectRepeatCount,
-                    duration: (performanceNow() - connectStartTime).toFixed(0),
+                    duration: TelemetryLogger.formatTick(performanceNow() - connectStartTime),
                     eventName: "MultipleDeltaConnectionFailures",
                 });
             }

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -4,6 +4,7 @@
  */
 
 import { EventEmitter } from "events";
+import * as uuid from "uuid";
 import { ITelemetryBaseLogger } from "@microsoft/fluid-common-definitions";
 import {
     IComponent,
@@ -17,7 +18,7 @@ import {
     LoaderHeader,
     IFluidCodeDetails,
 } from "@microsoft/fluid-container-definitions";
-import { Deferred } from "@microsoft/fluid-common-utils";
+import { DebugLogger, Deferred } from "@microsoft/fluid-common-utils";
 import {
     IDocumentServiceFactory,
     IFluidResolvedUrl,
@@ -137,6 +138,7 @@ export class Loader extends EventEmitter implements ILoader {
     private readonly containers = new Map<string, Promise<Container>>();
     private readonly resolver: IUrlResolver;
     private readonly documentServiceFactory: IDocumentServiceFactory;
+    private readonly logger?: ITelemetryBaseLogger;
 
     constructor(
         resolver: IUrlResolver | IUrlResolver[],
@@ -145,9 +147,11 @@ export class Loader extends EventEmitter implements ILoader {
         private readonly options: any,
         private readonly scope: IComponent,
         private readonly proxyLoaderFactories: Map<string, IProxyLoaderFactory>,
-        private readonly logger?: ITelemetryBaseLogger,
+        logger?: ITelemetryBaseLogger,
     ) {
         super();
+
+        this.logger = DebugLogger.mixinDebugLogger("fluid:telemetry", logger, { loaderId: uuid() });
 
         if (!resolver) {
             throw new Error("An IUrlResolver must be provided");


### PR DESCRIPTION
Assign id to loader and container instance and log it in telemetry so that we can associate events with instance.

Also change MultipleDeltaconnectionFailures to use formatTick instead of toFixed

