### PR TITLE
pass through scope in the baseContainerRuntimeFactory

### DIFF
--- a/packages/framework/aqueduct/src/containerRuntimeFactories/baseContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/containerRuntimeFactories/baseContainerRuntimeFactory.ts
@@ -55,6 +55,16 @@ export class BaseContainerRuntimeFactory implements
             dc.register(entry.type, entry.provider);
         }
 
+        // Create a scope object that passes through everything except for IComponentDependencySynthesizer
+        // which we will replace with the new one we just created.
+        const scope: any = {};
+        for (const key of Object.keys(context.scope)) {
+            if (key !== "IComponentDependencySynthesizer") {
+                scope[key] = context.scope[key];
+            }
+        }
+        scope.IComponentDependencySynthesizer = dc;
+
         const runtime = await ContainerRuntime.load(
             context,
             this.registryEntries,
@@ -63,7 +73,7 @@ export class BaseContainerRuntimeFactory implements
                 componentRuntimeRequestHandler,
             ],
             undefined,
-            dc);
+            scope);
 
         // we register the runtime so developers of providers can use it in the factory pattern.
         dc.register(IContainerRuntime, runtime);

--- a/packages/framework/aqueduct/src/containerRuntimeFactories/baseContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/containerRuntimeFactories/baseContainerRuntimeFactory.ts
@@ -57,12 +57,7 @@ export class BaseContainerRuntimeFactory implements
 
         // Create a scope object that passes through everything except for IComponentDependencySynthesizer
         // which we will replace with the new one we just created.
-        const scope: any = {};
-        for (const key of Object.keys(context.scope)) {
-            if (key !== "IComponentDependencySynthesizer") {
-                scope[key] = context.scope[key];
-            }
-        }
+        const scope: any = context.scope;
         scope.IComponentDependencySynthesizer = dc;
 
         const runtime = await ContainerRuntime.load(


### PR DESCRIPTION
We will pass through the scope and augment the `IComponentDependencySynthesizer` to be the one we just create.