### PR TITLE
Bump development version for @microsoft/fluid-common-utils to 0.16.2

### DIFF
--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fluid-common-utils",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fluid-common-utils",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Collection of utility functions for Fluid",
   "repository": "microsoft/FluidFramework",
   "license": "MIT",

--- a/common/lib/common-utils/src/packageVersion.ts
+++ b/common/lib/common-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@microsoft/fluid-common-utils";
-export const pkgVersion = "0.16.1";
+export const pkgVersion = "0.16.2";

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2118,7 +2118,7 @@
 		},
 		"@microsoft/api-documenter": {
 			"version": "7.7.12",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2fapi-documenter/-/api-documenter-7.7.12.tgz",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft%2fapi-documenter/-/api-documenter-7.7.12.tgz",
 			"integrity": "sha512-FVd0c+DEz+HntBmtRsTTslVvBagx0FqGC+rzF8jnVDJbiW6xkwjwfTj/VKqNNdz821sEPp+eAJgGh7s0Nyx3Iw==",
 			"dev": true,
 			"requires": {
@@ -2133,7 +2133,7 @@
 		},
 		"@microsoft/api-extractor": {
 			"version": "7.7.8",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2fapi-extractor/-/api-extractor-7.7.8.tgz",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft%2fapi-extractor/-/api-extractor-7.7.8.tgz",
 			"integrity": "sha512-XNO6Dk6ByfJq24Cn1/j0B0F16ZtwYnEC/sxgB/M0wTphBdBlHjRXZmxofmjirBBj9f7vG4UJ18IOIZRLbhGFPw==",
 			"dev": true,
 			"requires": {
@@ -2150,7 +2150,7 @@
 		},
 		"@microsoft/api-extractor-model": {
 			"version": "7.7.7",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2fapi-extractor-model/-/api-extractor-model-7.7.7.tgz",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft%2fapi-extractor-model/-/api-extractor-model-7.7.7.tgz",
 			"integrity": "sha512-822kyHMEx2sl+KnBioEiFoTIXuz/4pYBo94nQ4AMqb9BFvY9I1AZUPtC4HFh2zcXQqpFLpKKC55s/o8UOze2wQ==",
 			"dev": true,
 			"requires": {
@@ -2337,7 +2337,7 @@
 		},
 		"@microsoft/node-core-library": {
 			"version": "3.19.3",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2fnode-core-library/-/node-core-library-3.19.3.tgz",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft%2fnode-core-library/-/node-core-library-3.19.3.tgz",
 			"integrity": "sha512-rJ+hT6+XK5AESbhn31YBnHKpZSFKCmqHCRZyK9+jyWwav1HXv0qzuXnFvnyrO0MZyJ6rH0seWOZVWbU5KGv1tg==",
 			"dev": true,
 			"requires": {
@@ -2360,7 +2360,7 @@
 		},
 		"@microsoft/ts-command-line": {
 			"version": "4.3.10",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2fts-command-line/-/ts-command-line-4.3.10.tgz",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft%2fts-command-line/-/ts-command-line-4.3.10.tgz",
 			"integrity": "sha512-AgxArGqPt0H5WTo3fxNFP3Blm3obkCCopVG9kwIo+/mMdXaj6qMDn6+8Bv8+5Nke3CvvXpKAZtu3IaGY5cV1Hg==",
 			"dev": true,
 			"requires": {
@@ -2371,7 +2371,7 @@
 		},
 		"@microsoft/tsdoc": {
 			"version": "0.12.14",
-			"resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ftsdoc/-/tsdoc-0.12.14.tgz",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft%2ftsdoc/-/tsdoc-0.12.14.tgz",
 			"integrity": "sha512-518yewjSga1jLdiLrcmpMFlaba5P+50b0TWNFUpC+SL9Yzf0kMi57qw+bMl+rQ08cGqH1vLx4eg9YFUbZXgZ0Q==",
 			"dev": true
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1604,7 +1604,7 @@
     },
     "@microsoft/api-documenter": {
       "version": "7.7.12",
-      "resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2fapi-documenter/-/api-documenter-7.7.12.tgz",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft%2fapi-documenter/-/api-documenter-7.7.12.tgz",
       "integrity": "sha512-FVd0c+DEz+HntBmtRsTTslVvBagx0FqGC+rzF8jnVDJbiW6xkwjwfTj/VKqNNdz821sEPp+eAJgGh7s0Nyx3Iw==",
       "dev": true,
       "requires": {
@@ -1619,7 +1619,7 @@
     },
     "@microsoft/api-extractor": {
       "version": "7.7.8",
-      "resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2fapi-extractor/-/api-extractor-7.7.8.tgz",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft%2fapi-extractor/-/api-extractor-7.7.8.tgz",
       "integrity": "sha512-XNO6Dk6ByfJq24Cn1/j0B0F16ZtwYnEC/sxgB/M0wTphBdBlHjRXZmxofmjirBBj9f7vG4UJ18IOIZRLbhGFPw==",
       "dev": true,
       "requires": {
@@ -1636,7 +1636,7 @@
     },
     "@microsoft/api-extractor-model": {
       "version": "7.7.7",
-      "resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2fapi-extractor-model/-/api-extractor-model-7.7.7.tgz",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft%2fapi-extractor-model/-/api-extractor-model-7.7.7.tgz",
       "integrity": "sha512-822kyHMEx2sl+KnBioEiFoTIXuz/4pYBo94nQ4AMqb9BFvY9I1AZUPtC4HFh2zcXQqpFLpKKC55s/o8UOze2wQ==",
       "dev": true,
       "requires": {
@@ -1646,7 +1646,7 @@
     },
     "@microsoft/node-core-library": {
       "version": "3.19.3",
-      "resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2fnode-core-library/-/node-core-library-3.19.3.tgz",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft%2fnode-core-library/-/node-core-library-3.19.3.tgz",
       "integrity": "sha512-rJ+hT6+XK5AESbhn31YBnHKpZSFKCmqHCRZyK9+jyWwav1HXv0qzuXnFvnyrO0MZyJ6rH0seWOZVWbU5KGv1tg==",
       "dev": true,
       "requires": {
@@ -1669,7 +1669,7 @@
     },
     "@microsoft/ts-command-line": {
       "version": "4.3.10",
-      "resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2fts-command-line/-/ts-command-line-4.3.10.tgz",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft%2fts-command-line/-/ts-command-line-4.3.10.tgz",
       "integrity": "sha512-AgxArGqPt0H5WTo3fxNFP3Blm3obkCCopVG9kwIo+/mMdXaj6qMDn6+8Bv8+5Nke3CvvXpKAZtu3IaGY5cV1Hg==",
       "dev": true,
       "requires": {
@@ -1680,7 +1680,7 @@
     },
     "@microsoft/tsdoc": {
       "version": "0.12.14",
-      "resolved": "https://packages.wu2.prague.office-int.com/@microsoft%2ftsdoc/-/tsdoc-0.12.14.tgz",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft%2ftsdoc/-/tsdoc-0.12.14.tgz",
       "integrity": "sha512-518yewjSga1jLdiLrcmpMFlaba5P+50b0TWNFUpC+SL9Yzf0kMi57qw+bMl+rQ08cGqH1vLx4eg9YFUbZXgZ0Q==",
       "dev": true
     },


### PR DESCRIPTION
           @microsoft/fluid-build-common:     0.16.0 (unchanged)
          @microsoft/eslint-config-fluid:     0.16.1 (unchanged)
     @microsoft/fluid-common-definitions:     0.16.1 (unchanged)
           @microsoft/fluid-common-utils:     0.16.1 -> 0.16.2
                                  Server:   0.1004.4 (unchanged)
                                  Client:     0.16.6 (unchanged)
              @microsoft/generator-fluid:     0.16.6 (unchanged)
                   @yo-fluid/dice-roller:     0.16.6 (unchanged)