### PR TITLE
Add class name and style properties to aqueduct react components

### DIFF
--- a/packages/framework/aqueduct-react/src/react/collaborativeCheckbox.tsx
+++ b/packages/framework/aqueduct-react/src/react/collaborativeCheckbox.tsx
@@ -10,7 +10,6 @@ interface IProps {
     id: string;
     className?: string;
     style?: React.CSSProperties;
-
 }
 
 interface IState {

--- a/packages/framework/aqueduct-react/src/react/collaborativeCheckbox.tsx
+++ b/packages/framework/aqueduct-react/src/react/collaborativeCheckbox.tsx
@@ -10,6 +10,7 @@ interface IProps {
     id: string;
     className?: string;
     style?: React.CSSProperties;
+
 }
 
 interface IState {

--- a/packages/framework/aqueduct-react/src/react/collaborativeCheckbox.tsx
+++ b/packages/framework/aqueduct-react/src/react/collaborativeCheckbox.tsx
@@ -8,6 +8,8 @@ import * as React from "react";
 interface IProps {
     counter: Counter;
     id: string;
+    className?: string;
+    style?: React.CSSProperties;
 }
 
 interface IState {
@@ -46,9 +48,11 @@ export class CollaborativeCheckbox extends React.Component<IProps, IState> {
         return (
             <input
                 type="checkbox"
+                className={this.props.className}
+                style={this.props.style}
                 aria-checked={this.state.checked}
-                name= {this.props.id}
-                checked = {this.state.checked}
+                name={this.props.id}
+                checked={this.state.checked}
                 onChange={this.updateCheckbox} />
         );
     }

--- a/packages/framework/aqueduct-react/src/react/collaborativeInput.tsx
+++ b/packages/framework/aqueduct-react/src/react/collaborativeInput.tsx
@@ -7,9 +7,9 @@ import * as React from "react";
 
 interface IProps {
     sharedString: SharedString;
-    style?: React.CSSProperties;
     spellCheck?: boolean;
     className?: string;
+    style?: React.CSSProperties;
 }
 
 interface IState {
@@ -72,7 +72,7 @@ export class CollaborativeInput extends React.Component<IProps, IState> {
                 onKeyDown={this.updateSelection}
                 onClick={this.updateSelection}
                 onContextMenu={this.updateSelection}
-                onInput={this.handleInput}/>
+                onInput={this.handleInput} />
         );
     }
 

--- a/packages/framework/aqueduct-react/src/react/collaborativeTextArea.tsx
+++ b/packages/framework/aqueduct-react/src/react/collaborativeTextArea.tsx
@@ -144,8 +144,6 @@ export class CollaborativeTextArea extends React.Component<IProps, IState> {
                 onContextMenu={this.updateSelection}
                 onInput={this.handleChange}
                 value={this.state.text} />
-
-
         );
     }
 

--- a/packages/framework/aqueduct-react/src/react/collaborativeTextArea.tsx
+++ b/packages/framework/aqueduct-react/src/react/collaborativeTextArea.tsx
@@ -144,6 +144,8 @@ export class CollaborativeTextArea extends React.Component<IProps, IState> {
                 onContextMenu={this.updateSelection}
                 onInput={this.handleChange}
                 value={this.state.text} />
+
+
         );
     }
 

--- a/packages/framework/aqueduct-react/src/react/collaborativeTextArea.tsx
+++ b/packages/framework/aqueduct-react/src/react/collaborativeTextArea.tsx
@@ -8,6 +8,7 @@ import * as React from "react";
 interface IProps {
     sharedString: SharedString;
     spellCheck?: boolean;
+    className?: string;
     style?: React.CSSProperties;
 }
 
@@ -134,6 +135,7 @@ export class CollaborativeTextArea extends React.Component<IProps, IState> {
                 rows={20}
                 cols={50}
                 ref={this.ref}
+                className={this.props.className}
                 style={this.props.style}
                 spellCheck={this.props.spellCheck ? this.props.spellCheck : false}
                 onBeforeInput={this.updateSelection}
@@ -141,7 +143,7 @@ export class CollaborativeTextArea extends React.Component<IProps, IState> {
                 onClick={this.updateSelection}
                 onContextMenu={this.updateSelection}
                 onInput={this.handleChange}
-                value={this.state.text}/>
+                value={this.state.text} />
         );
     }
 


### PR DESCRIPTION
Add `className` and `style` to props for each component. It wasn't consistent before.