### PR TITLE
Add the ability to disconnect and nack a client in the test drivers.

### DIFF
--- a/packages/drivers/local-driver/src/testDocumentDeltaConnection.ts
+++ b/packages/drivers/local-driver/src/testDocumentDeltaConnection.ts
@@ -18,6 +18,7 @@ import {
     ISignalClient,
     ISignalMessage,
     ITokenClaims,
+    NackErrorType,
 } from "@microsoft/fluid-protocol-definitions";
 import * as core from "@microsoft/fluid-server-services-core";
 import { TestWebSocketServer } from "@microsoft/fluid-server-test-utils";
@@ -30,7 +31,7 @@ export class TestDocumentDeltaConnection extends EventEmitter implements IDocume
         id: string,
         token: string,
         client: IClient,
-        webSocketServer: core.IWebSocketServer): Promise<IDocumentDeltaConnection> {
+        webSocketServer: core.IWebSocketServer): Promise<TestDocumentDeltaConnection> {
         const socket = (webSocketServer as TestWebSocketServer).createConnection();
 
         const connectMessage: IConnect = {
@@ -250,5 +251,32 @@ export class TestDocumentDeltaConnection extends EventEmitter implements IDocume
 
     public disconnect() {
         // Do nothing
+    }
+
+    /**
+     * Send a "disconnect" message on the socket.
+     * @param disconnectReason - The reason of the disconnection.
+     */
+    public disconnectClient(disconnectReason: string) {
+        this.socket.emit("disconnect", disconnectReason);
+    }
+
+    /**
+     * * Sends a "nack" message on the socket.
+     * @param code - An error code number that represents the error. It will be a valid HTTP error code.
+     * @param type - Type of the Nack.
+     * @param message - A message about the nack for debugging/logging/telemetry purposes.
+     */
+    public nackClient(code: number = 400, type: NackErrorType = NackErrorType.ThrottlingError, message: any) {
+        const nackMessage = {
+            operation: undefined,
+            sequenceNumber: -1,
+            content: {
+                code,
+                type,
+                message,
+            },
+        };
+        this.socket.emit("nack", "", [nackMessage]);
     }
 }

--- a/packages/test/end-to-end/src/test/opsOnReconnectTest.spec.ts
+++ b/packages/test/end-to-end/src/test/opsOnReconnectTest.spec.ts
@@ -40,22 +40,10 @@ describe("Ops on Reconnect", () => {
     let firstContainerComp1Directory: SharedDirectory;
 
     /**
-     * Yields control in the JavaScript event loop.
-     */
-    async function yieldEventLoop(): Promise<void> {
-        await new Promise<void>((resolve) => {
-            setTimeout(resolve, 0);
-        });
-    }
-
-    /**
-     * Waits for the given Container to get reconnected. Yields the JS event loop until the Container
-     * gets to Connected state.
+     * Waits for the "connected" event from the given container.
      */
     async function waitForContainerReconnection(container: Container): Promise<void> {
-        do {
-            await yieldEventLoop();
-        } while (container.connectionState !== ConnectionState.Connected);
+        await new Promise((resolve) => container.once("connected", () => resolve()));
     }
 
     async function createContainer(): Promise<Container> {

--- a/packages/test/end-to-end/src/test/opsOnReconnectTest.spec.ts
+++ b/packages/test/end-to-end/src/test/opsOnReconnectTest.spec.ts
@@ -1,0 +1,160 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as assert from "assert";
+import { ContainerRuntimeFactoryWithDefaultComponent } from "@microsoft/fluid-aqueduct";
+import { IComponentLoadable } from "@microsoft/fluid-component-core-interfaces";
+import { IFluidCodeDetails, IProxyLoaderFactory } from "@microsoft/fluid-container-definitions";
+import { Container, Loader } from "@microsoft/fluid-container-loader";
+import { DocumentDeltaEventManager, TestDocumentServiceFactory, TestResolver } from "@microsoft/fluid-local-driver";
+import { SharedMap, SharedDirectory } from "@microsoft/fluid-map";
+import { MessageType, ISequencedDocumentMessage } from "@microsoft/fluid-protocol-definitions";
+import { IEnvelope } from "@microsoft/fluid-runtime-definitions";
+import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@microsoft/fluid-server-local-server";
+import {
+    LocalCodeLoader,
+    initializeLocalContainer,
+    ITestFluidComponent,
+    TestFluidComponentFactory,
+} from "@microsoft/fluid-test-utils";
+
+describe("Ops on Reconnect", () => {
+    const id = `fluid-test://localhost/opsOnReconnectTest`;
+    const map1Id = "map1Key";
+    const map2Id = "map2Key";
+    const directoryId = "directoryKey";
+    const codeDetails: IFluidCodeDetails = {
+        package: "opsOnReconnectTestPackage",
+        config: {},
+    };
+
+    let deltaConnectionServer: ILocalDeltaConnectionServer;
+    let documentServiceFactory: TestDocumentServiceFactory;
+    let containerDeltaEventManager: DocumentDeltaEventManager;
+    let firstContainer: Container;
+    let firstContainerComp1: ITestFluidComponent & IComponentLoadable;
+    let firstContainerComp1Map1: SharedMap;
+    let firstContainerComp1Map2: SharedMap;
+    let firstContainerComp1Directory: SharedDirectory;
+
+    async function createContainer(): Promise<Container> {
+        const factory: TestFluidComponentFactory = new TestFluidComponentFactory(
+            [
+                [ map1Id, SharedMap.getFactory() ],
+                [ map2Id, SharedMap.getFactory() ],
+                [ directoryId, SharedDirectory.getFactory() ],
+            ],
+        );
+
+        const runtimeFactory =
+            new ContainerRuntimeFactoryWithDefaultComponent(
+                "default",
+                [
+                    ["default", Promise.resolve(factory)],
+                ],
+            );
+
+        const urlResolver = new TestResolver();
+        const codeLoader = new LocalCodeLoader([[ codeDetails, runtimeFactory ]]);
+
+        const loader = new Loader(
+            urlResolver,
+            documentServiceFactory,
+            codeLoader,
+            {},
+            {},
+            new Map<string, IProxyLoaderFactory>());
+
+        return initializeLocalContainer(id, loader, codeDetails);
+    }
+
+    async function getComponent(componentId: string, fromContainer: Container):
+    Promise<ITestFluidComponent & IComponentLoadable> {
+        const response = await fromContainer.request({ url: componentId });
+        if (response.status !== 200 || response.mimeType !== "fluid/component") {
+            throw new Error(`Component with id: ${componentId} not found`);
+        }
+        return response.value as ITestFluidComponent & IComponentLoadable;
+    }
+
+    beforeEach(async () => {
+        deltaConnectionServer = LocalDeltaConnectionServer.create();
+        documentServiceFactory = new TestDocumentServiceFactory(deltaConnectionServer);
+
+        // Create the first container, component and DDSes.
+        firstContainer = await createContainer();
+        firstContainerComp1 = await getComponent("default", firstContainer);
+        firstContainerComp1Map1 = await firstContainerComp1.getSharedObject<SharedMap>(map1Id);
+        firstContainerComp1Map2 = await firstContainerComp1.getSharedObject<SharedMap>(map2Id);
+        firstContainerComp1Directory = await firstContainerComp1.getSharedObject<SharedDirectory>(directoryId);
+
+        containerDeltaEventManager = new DocumentDeltaEventManager(deltaConnectionServer);
+        containerDeltaEventManager.registerDocuments(firstContainerComp1.runtime);
+    });
+
+    it("can resend ops on reconnection that were sent in disconnected / Nack'd state", async () => {
+        // Create a second container and set up a listener to store the received map / directory values.
+        let receivedKeyValues: [string, string][] = [];
+        const secondContainer = await createContainer();
+        secondContainer.on("op", (message: ISequencedDocumentMessage) => {
+            if (message.type === MessageType.Operation) {
+                const envelope = message.contents as IEnvelope;
+                if (envelope.address !== "_scheduler") {
+                    const content = message.contents.contents.content.contents;
+                    const key = content.key;
+                    const value = content.value.value;
+                    receivedKeyValues.push([ key, value ]);
+                }
+            }
+        });
+
+        // Get component1 on the second container.
+        const secondContainerComp1 = await getComponent("default", secondContainer);
+        containerDeltaEventManager.registerDocuments(secondContainerComp1.runtime);
+
+        // Disconnect the client.
+        documentServiceFactory.disconnectClient(firstContainer.clientId, "Disconnected for testing");
+
+        // Set values in DDSes in disconnected state.
+        firstContainerComp1Map1.set("key1", "value1");
+        firstContainerComp1Map1.set("key2", "value2");
+        firstContainerComp1Map2.set("key3", "value3");
+        firstContainerComp1Map2.set("key4", "value4");
+
+        // Wait for the ops to get processed.
+        await containerDeltaEventManager.process();
+
+        const expectedKeyValues1: string[][] = [
+            [ "key1", "value1" ],
+            [ "key2", "value2" ],
+            [ "key3", "value3" ],
+            [ "key4", "value4" ],
+        ];
+        assert.deepStrictEqual(
+            expectedKeyValues1, receivedKeyValues, "Did not receive the ops that were sent in disconnected state");
+
+        // Nack the client.
+        documentServiceFactory.nackClient(firstContainer.clientId);
+        receivedKeyValues = [];
+
+        // Set values in DDSes in disconnected state.
+        firstContainerComp1Map1.set("key1", "value1");
+        firstContainerComp1Map1.set("key2", "value2");
+        firstContainerComp1Directory.set("key3", "value3");
+        firstContainerComp1Directory.set("key4", "value4");
+
+        // Wait for the ops to get processed.
+        await containerDeltaEventManager.process();
+
+        const expectedKeyValues2: string[][] = [
+            [ "key1", "value1" ],
+            [ "key2", "value2" ],
+            [ "key3", "value3" ],
+            [ "key4", "value4" ],
+        ];
+        assert.deepStrictEqual(
+            expectedKeyValues2, receivedKeyValues, "Did not receive the ops that were sent in Nack'd state");
+    });
+});

--- a/packages/test/utils/src/testFluidComponent.ts
+++ b/packages/test/utils/src/testFluidComponent.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { IRequest, IResponse, IComponentHandle } from "@microsoft/fluid-component-core-interfaces";
-import { ComponentRuntime } from "@microsoft/fluid-component-runtime";
+import { IRequest, IResponse, IComponentHandle, IComponentLoadable } from "@microsoft/fluid-component-core-interfaces";
+import { ComponentHandle, ComponentRuntime } from "@microsoft/fluid-component-runtime";
 import { SharedMap, ISharedMap } from "@microsoft/fluid-map";
 import { IComponentContext, IComponentFactory } from "@microsoft/fluid-runtime-definitions";
 import { IComponentRuntime } from "@microsoft/fluid-component-runtime-definitions";
@@ -16,7 +16,7 @@ import { ITestFluidComponent } from "./interfaces";
  * The shared objects can be retrieved by passing the key of the entry to getSharedObject.
  * It exposes the IComponentContext and IComponentRuntime.
  */
-export class TestFluidComponent implements ITestFluidComponent {
+export class TestFluidComponent implements ITestFluidComponent, IComponentLoadable {
     public static async load(
         runtime: IComponentRuntime,
         context: IComponentContext,
@@ -31,7 +31,15 @@ export class TestFluidComponent implements ITestFluidComponent {
         return this;
     }
 
+    public get IComponentLoadable() {
+        return this;
+    }
+
+    public get handle(): IComponentHandle<this> { return this.innerHandle; }
+
+    public url: string;
     private root!: ISharedMap;
+    private readonly innerHandle: IComponentHandle<this>;
 
     /**
      * Creates a new TestFluidComponent.
@@ -44,7 +52,10 @@ export class TestFluidComponent implements ITestFluidComponent {
         public readonly runtime: IComponentRuntime,
         public readonly context: IComponentContext,
         private readonly factoryEntriesMap: Map<string, ISharedObjectFactory>,
-    ) {}
+    ) {
+        this.url = context.id;
+        this.innerHandle = new ComponentHandle(this, this.url, runtime.IComponentHandleContext);
+    }
 
     /**
      * Retrieves a shared object with the given id.


### PR DESCRIPTION
Fixes #2190.

- Added a map in the TestDocumentServiceFactory to track a clientId and its corresponding TestDocumentService/TestDocumentDeltaConnection.
- Added a method to TestDocumentServiceFactory that can be called to disconnect a client with a clientId and the disconnectReason:
```
public disconnectClient(clientId: string, disconnectReason: string);
```
- Added a method to TestDocumentServiceFactory that can be called to disconnect a client with a clientId:
```
public nackClient(clientId: string, code?: number, type?: NackErrorType, message?: any);
```
The parameters code, type and message are optional and the TestDocumentDeltaConnection will use default values to create the INack message if these are not provided.
- Also added a couple of tests that disconnect / nack a client, send ops and then verify that the ops are sent and received on reconnection.
- The test is very basic now. I will add more complex scenarios once we have op ordering and batching on reconnect fixed.