### PR TITLE
Fluid-Build: work around the NPM_TOKEN environment variable

### DIFF
--- a/tools/fluid-build-tools/src/common/monoRepo.ts
+++ b/tools/fluid-build-tools/src/common/monoRepo.ts
@@ -5,7 +5,7 @@
 
 import { Package, Packages } from "./npmPackage";
 import * as path from "path";
-import { execWithErrorAsync, rimrafWithErrorAsync, existsSync, readJsonSync } from "./utils";
+import { execWithErrorAsync, rimrafWithErrorAsync, existsSync, readJsonSync, readFileAsync, ExecAsyncResult, writeFileAsync} from "./utils";
 
 export enum MonoRepoKind {
     Client,
@@ -36,9 +36,11 @@ export class MonoRepo {
     }
 
     public async install() {
+        // TODO: Remove env once publish to the public feed.
+        const env = process.env["NPM_TOKEN"]? process.env : { ...process.env, "NPM_TOKEN": "" };
         console.log(`${MonoRepoKind[this.kind]}: Installing - npm i`);
         const installScript = "npm i";
-        return execWithErrorAsync(installScript, { cwd: this.repoPath }, this.repoPath);
+        return execWithErrorAsync(installScript, { cwd: this.repoPath, env }, this.repoPath);
     }
     public async uninstall() {
         return rimrafWithErrorAsync(this.getNodeModulePath(), this.repoPath);


### PR DESCRIPTION
server/routerlicious/.npmrc requires the NPM_TOKEN environment variable.
set it to empty if it is not already so that it can rely on the one in user profile (from vsts-npm-auth)