### PR TITLE
Documenting expectations from host around overlap of various events

### DIFF
--- a/packages/loader/container-loader/README.md
+++ b/packages/loader/container-loader/README.md
@@ -8,21 +8,25 @@
 - [ClientID and client identification](#ClientId-and-client-identification)
 - [Error Handling](#Error-handling)
 - [Connectivity events](#Connectivity-events)
-- [Readonly states](#Readonly-states)
+- [Read-only states](#Read-only-states)
 - [Proposal Lifetime](#Proposal-lifetime)
 
 ## Expectations from host implementers
 It's expected that host will listen to various events described in other sections of the document and conveys correctly (in some form) information to the user to ensure that user is aware of various situations and is not going to lose data.
 Please see specific sections for more details on these states and events - this section only serves as a summary and does not go into details
-1. ["disconnected" and "connected"](#Connectivity-events) event: Host can either notify user about no connectivity (and potential data loss if container is closed) or disallow edits via `Container.forceReadonly(true)`
-2. ["closed"](#Closure) event: If raised with error, host is responsible for conveying error in some form to the user. Container is left in disconnected & readonly state when it is closed (because of error or not).
-3. ["readonly"](#Readonly-states) event: Host should have some indication to user that document is not editable. User permissions can change over lifetime of Container, but they can't change per conneciton session (in other words, change in permissions causes disconnect and reconnect). Hosts are advised to recheck this property on every reconnect.
+1. ["readonly"](#Read-only-states) event: Host should have some indication to user that document is not editable. User permissions can change over lifetime of Container, but they can't change per conneciton session (in other words, change in permissions causes disconnect and reconnect). Hosts are advised to recheck this property on every reconnect.
+2. ["disconnected" and "connected"](#Connectivity-events) event: Host can either notify user about no connectivity (and potential data loss if container is closed) or disallow edits via `Container.forceReadonly(true)`
+3. ["closed"](#Closure) event: If raised with error, host is responsible for conveying error in some form to the user. Container is left in disconnected & read-only state when it is closed (because of error or not).
+
+Please note that container can be in multiple "modes" at the same time:
+- It can be both read-only and disconnected at the same time. User likely needs to be notified about both of those conditions - document can't be edited, and remote changes are not being reflected in document
+- When container is closed (for example, due to error), it is disconnected & read-only at the same time. Host likely does not want to expose later two states to user as distinct errors, and instead have one unified message about container error state.
 
 ## Expectations from container runtime and components implementers
-1. Respect ["readonly" state](#Readonly-states). In this state container runtime (and components) should not allow changes to local state, as these changes will be lost on container being closed.
-2. Maintain Ops in flight until observed they are acknowledged by server. Resubmit any lost Ops on reconnection. This is done by DDSs in stock implementations of container & component runtimes provided by Fluid Framework
-3. Respect "["disconnected" and "connected"](#Connectivity-events) states and do not not submit Ops when disconnected.
-4. Respect ["dispose"](#Closure) event and treat it as combination of "readonly" and "disconnected" states. I.e. it should be fully operatable (render content), but not allow edits. This is equivalent to "closed" event on container for hosts, but is broader (includes document's code version upgrades).
+1. Respect ["readonly" state](#Read-only-states). In this state container runtime (and components) should not allow changes to local state, as these changes will be lost on container being closed.
+2. Respect "["disconnected" and "connected"](#Connectivity-events) states and do not not submit Ops when disconnected.
+3. Respect ["dispose"](#Closure) event and treat it as combination of "`readonly"` and `"disconnected"` states (both these states are true in disposed state). I.e. it should be fully operatable (render content), but not allow edits. This is equivalent to "closed" event on container for hosts, but is broader (includes document's code version upgrades, when old instance of runtime is disconnected form storage and is abandoned).
+4. Maintain Ops in flight until observed they are acknowledged by server. Resubmit any lost Ops on reconnection. This is done by DDSs in stock implementations of container & component runtimes provided by Fluid Framework
 
 ## Fluid Loader
 
@@ -113,15 +117,15 @@ In normal circumstances, container will attempt to reconnect back to ordering se
 
 Container will also not attempt to reconnect on lost connection if `Container.setAutoReconnect(false)` was called prior to loss of connection. This might be useful if hosting application implements "user away" type of experience to reduce cost on both client and server of maintaining connection while user is away. Calling setAutoReconnect(true) will reenable automatic reconnections, but host might need to allow extra time for reconnection as it likely involves token fetch and processing of a lot of Ops generated by other clients while this client was not connected.
 
-Components should almost never listen to these events (see more on [Readonly states](#Readonly-states), and should use consensus DDSs if they need to synchronize activity across clients. DDSs listen for these events to know when to resubmit pending Ops.
+Components should almost never listen to these events (see more on [Read-only states](#Read-only-states), and should use consensus DDSs if they need to synchronize activity across clients. DDSs listen for these events to know when to resubmit pending Ops.
 
 Hosting application can use these events in order to indicate to user when user changes are not propagating through the system, and thus can be lost (on browser tab being closed). It's advised to use some delay (like 5 seconds) before showing such UI, as network connectivity might be intermittent.  Also if container was offline for very long period of time due to `Container.setAutoReconnect(false)` being called, it might take a while to get connected and current.
 
-Please note that hosts can implement various strategies on how to handle disconnections. Some may decide to show some UX letting user know about potential loss of data if document is closed while disconnected. Others can force container to disallow user edits while offline (see [Readonly states](#Readonly-states)).
+Please note that hosts can implement various strategies on how to handle disconnections. Some may decide to show some UX letting user know about potential loss of data if document is closed while disconnected. Others can force container to disallow user edits while offline (see [Read-only states](#Read-only-states)).
 
 It's worth pointing out that being connected does not mean all user edits are preserved on container closure. There is latency in the system, and loader layer does not provide any guarantees here. Not every implementation needs a solution here (games likely do not care), and thus solving this problem is pushed to framework level (i.e. having a component that can expose `'dirtyDocument'` signal from ContainerRuntime and request route that can return such component).
 
-## Readonly states
+## Read-only states
 `Container.readonlyPermissions` (and `DeltaManager.readonlyPermissions`) indicates to host if file is writable or not. There are two cases when it's true:
 
 1. User has no write permissions to to modify this container (which usually maps to file in storage, and lack of write permissions by a given user)
@@ -131,9 +135,9 @@ Please note that this property (as well as `readonly` property discussed below) 
 
 User permissions can change over lifetime of Container. They can't change during single connection session (in other words, change in permissions causes disconnect and reconnect). Hosts are advised to recheck this property on every reconnect.
 
-This value is not affected by `Container.forceReadonly` calls discussed below and can be used by hosts to indicate to users if it's possible to edit a file in the absence of readonly state being overridden via `Container.forceReadonly`.
+This value is not affected by `Container.forceReadonly` calls discussed below and can be used by hosts to indicate to users if it's possible to edit a file in the absence of read-only state being overridden via `Container.forceReadonly`.
 
-Hosts can also force readonly-mode for a container via calling `Container.forceReadonly(true)`. This can be useful in scenarios like
+Hosts can also force read-only mode for a container via calling `Container.forceReadonly(true)`. This can be useful in scenarios like
    - Loss of connectivity, in scenarios where host choses method od preventing user edits over (or in addition to) showing disconnected UX and warning user of potential data loss on closure of document (container)
    - Special view-only mode in host. For example can be used by hosts for previewing container content in-place with other host content, and leveraging full-screen / separate window experience for editing.
 
@@ -145,7 +149,7 @@ Container and DeltaManager expose `"readonly"` event and property. It can have 3
 - **false**: None of the above (Container.forceReadonly was never called or last call was with false), plus it's none that user has write permissions to a file (see below for more details)
 - **undefined**: Same as above, but we do not know yet if current user has write access to a file (because there were no successful connection to ordering service yet).
 
-Readonly events are accessible by components and DDSs (through ContainerRuntime.deltaManager). It's expected that components adhere to requirements and expose read-only (or rather 'no edit') experiences.
+Read-only state and event are accessible by components and DDSs (through ContainerRuntime.deltaManager). It's expected that components adhere to requirements and expose read-only (or rather 'no edit') experiences.
 
 ## Proposal lifetime
 

--- a/packages/loader/container-loader/README.md
+++ b/packages/loader/container-loader/README.md
@@ -13,19 +13,17 @@
 
 ## Expectations from host implementers
 It's expected that host will listen to various events described in other sections of the document and conveys correctly (in some form) information to the user to ensure that user is aware of various situations and is not going to lose data.
-Please see specific sections for more details on these states and events - this section only serves as a summary and does not go into details
-1. ["readonly"](#Read-only-states) event: Host should have some indication to user that document is not editable. User permissions can change over lifetime of Container, but they can't change per conneciton session (in other words, change in permissions causes disconnect and reconnect). Hosts are advised to recheck this property on every reconnect.
+Please see specific sections for more details on these states and events - this section only serves as a summary and does not go into details.
+1. ["readonly"](#Read-only-states) event: Host should have some indication to user that document is not editable. User permissions can change over lifetime of Container, but they can't change per connection session (in other words, change in permissions causes disconnect and reconnect). Hosts are advised to recheck this property on every reconnect.
 2. ["disconnected" and "connected"](#Connectivity-events) event: Host can either notify user about no connectivity (and potential data loss if container is closed) or disallow edits via `Container.forceReadonly(true)`
-3. ["closed"](#Closure) event: If raised with error, host is responsible for conveying error in some form to the user. Container is left in disconnected & read-only state when it is closed (because of error or not).
+3. ["closed"](#Closure) event: Raised when container is closed. Container is left in both the disconnected and read-only states when closed. If the event is raised with an error, host is responsible for informing the user about the error.
 
-Please note that container can be in multiple "modes" at the same time:
-- It can be both read-only and disconnected at the same time. User likely needs to be notified about both of those conditions - document can't be edited, and remote changes are not being reflected in document
-- When container is closed (for example, due to error), it is disconnected & read-only at the same time. Host likely does not want to expose later two states to user as distinct errors, and instead have one unified message about container error state.
+Overlap of "readonly" and "disconnected" means document can't be edited and remote changes are not being reflected in document.
 
 ## Expectations from container runtime and components implementers
 1. Respect ["readonly" state](#Read-only-states). In this state container runtime (and components) should not allow changes to local state, as these changes will be lost on container being closed.
 2. Respect "["disconnected" and "connected"](#Connectivity-events) states and do not not submit Ops when disconnected.
-3. Respect ["dispose"](#Closure) event and treat it as combination of "`readonly"` and `"disconnected"` states (both these states are true in disposed state). I.e. it should be fully operatable (render content), but not allow edits. This is equivalent to "closed" event on container for hosts, but is broader (includes document's code version upgrades, when old instance of runtime is disconnected form storage and is abandoned).
+3. Respect ["dispose"](#Closure) event and treat it as combination of "`readonly"` and `"disconnected"` states (both these states are true in disposed state). I.e. it should be fully operatable (render content), but not allow edits. This is similar to "closed" event on container for hosts, but is broader (includes document's code version upgrades, when old instance of runtime is disconnected from storage and is abandoned).
 4. Maintain Ops in flight until observed they are acknowledged by server. Resubmit any lost Ops on reconnection. This is done by DDSs in stock implementations of container & component runtimes provided by Fluid Framework
 
 ## Fluid Loader


### PR DESCRIPTION
Documenting expectations from host around overlap of disconnected / read-only and closed events.
readonly -> read-only