### PR TITLE
Incorporate term in client

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -157,6 +157,7 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
     // * lastQueuedSequenceNumber is the last queued sequence number
     private lastQueuedSequenceNumber: number = 0;
     private baseSequenceNumber: number = 0;
+    private baseTerm: number = 0;
 
     // The sequence number we initially loaded from
     private initSequenceNumber: number = 0;
@@ -204,6 +205,10 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
 
     public get referenceSequenceNumber(): number {
         return this.baseSequenceNumber;
+    }
+
+    public get referenceTerm(): number {
+        return this.baseTerm;
     }
 
     public get minimumSequenceNumber(): number {
@@ -403,12 +408,14 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
     public attachOpHandler(
         minSequenceNumber: number,
         sequenceNumber: number,
+        term: number,
         handler: IDeltaHandlerStrategy,
     ) {
         debug("Attached op handler", sequenceNumber);
 
         this.initSequenceNumber = sequenceNumber;
         this.baseSequenceNumber = sequenceNumber;
+        this.baseTerm = term;
         this.minSequenceNumber = minSequenceNumber;
         this.lastQueuedSequenceNumber = sequenceNumber;
 
@@ -1209,6 +1216,9 @@ export class DeltaManager extends EventEmitter implements IDeltaManager<ISequenc
 
         assert.equal(message.sequenceNumber, this.baseSequenceNumber + 1, "non-seq seq#");
         this.baseSequenceNumber = message.sequenceNumber;
+
+        // Back-compat for older server with no term
+        this.baseTerm = message.term === undefined ? 1 : message.term;
 
         this.emit("beforeOpProcessing", message);
 

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -90,7 +90,7 @@ describe("Loader", () => {
                     logger,
                     false,
                 );
-                deltaManager.attachOpHandler(0, 0, {
+                deltaManager.attachOpHandler(0, 0, 1, {
                     process: (message) => intendedResult,
                     processSignal() {},
                 });

--- a/packages/test/functional/src/test/containerRuntime.spec.ts
+++ b/packages/test/functional/src/test/containerRuntime.spec.ts
@@ -117,7 +117,7 @@ describe("Container Runtime", () => {
                 assert.strictEqual(batchBegin, batchEnd, "Received batchEnd without corresponding batchBegin");
             });
 
-            deltaManager.attachOpHandler(0, 0, {
+            deltaManager.attachOpHandler(0, 0, 1, {
                 process(message: ISequencedDocumentMessage) {
                     processOp(message);
                     return {};


### PR DESCRIPTION
Recently we added term in protocol (sequenced messages and attributes inside summaries). This PR handles the incorporation along with back-compatiblity for older servers and documents.