### PR TITLE
401 when using fluid-fetch: Tokens are never refreshed

### DIFF
--- a/packages/tools/fluid-fetch/src/fluidFetchArgs.ts
+++ b/packages/tools/fluid-fetch/src/fluidFetchArgs.ts
@@ -14,7 +14,14 @@ export let dumpSnapshotVersions = false;
 export let paramSnapshotVersionIndex: number | undefined;
 export let paramNumSnapshotVersions = 10;
 
-export let paramForceTokenReauth = false;
+let paramForceTokenReauth = false;
+
+// Only return true once, to reauth on first call.
+export function getForceTokenReauth() {
+    const result = paramForceTokenReauth;
+    paramForceTokenReauth = false;
+    return result;
+}
 
 export let paramSaveDir: string | undefined;
 export const messageTypeFilter = new Set<string>();

--- a/packages/tools/fluid-fetch/src/fluidFetchInit.ts
+++ b/packages/tools/fluid-fetch/src/fluidFetchInit.ts
@@ -10,11 +10,12 @@ import { configurableUrlResolver } from "@microsoft/fluid-driver-utils";
 import { FluidAppOdspUrlResolver } from "@microsoft/fluid-fluidapp-odsp-urlresolver";
 import * as odsp from "@microsoft/fluid-odsp-driver";
 import { OdspUrlResolver } from "@microsoft/fluid-odsp-urlresolver";
-import { IClientConfig, refreshAccessToken, getOdspScope } from "@microsoft/fluid-odsp-utils";
+import { IClientConfig, IOdspAuthRequestInfo } from "@microsoft/fluid-odsp-utils";
 import * as r11s from "@microsoft/fluid-routerlicious-driver";
 import { RouterliciousUrlResolver } from "@microsoft/fluid-routerlicious-urlresolver";
-import { OdspTokenManager, odspTokensCache, getMicrosoftConfiguration } from "@microsoft/fluid-tool-utils";
+import { getMicrosoftConfiguration } from "@microsoft/fluid-tool-utils";
 import { localDataOnly, paramJWT } from "./fluidFetchArgs";
+import { resolveWrapper } from "./fluidFetchSharePoint";
 
 export let latestVersionsId: string = "";
 export let connectionInfo: any;
@@ -53,18 +54,17 @@ async function initializeODSPCore(
   item:   ${itemId}
   docId:  ${docId}`);
 
-    const odspTokenManager = new OdspTokenManager(odspTokensCache);
     const getStorageTokenStub = async (siteUrl: string, refresh: boolean) => {
-        const tokens = await odspTokenManager.getOdspTokens(
+        return resolveWrapper(
+            async (authRequestInfo: IOdspAuthRequestInfo) => {
+                if ((refresh || !authRequestInfo.accessToken) && authRequestInfo.refreshTokenFn) {
+                    return authRequestInfo.refreshTokenFn();
+                }
+                return authRequestInfo.accessToken;
+            },
             server,
             clientConfig,
-            fluidFetchWebNavigator,
         );
-        if (refresh || !tokens.accessToken) {
-            // TODO: might want to handle if refresh failed and we want to reauth here.
-            await refreshAccessToken(getOdspScope(server), server, clientConfig, tokens);
-        }
-        return tokens.accessToken;
     };
     // eslint-disable-next-line @typescript-eslint/promise-function-async
     const getWebsocketTokenStub = () => Promise.resolve("");

--- a/packages/tools/fluid-fetch/src/fluidFetchSharePoint.ts
+++ b/packages/tools/fluid-fetch/src/fluidFetchSharePoint.ts
@@ -13,8 +13,9 @@ import {
 } from "@microsoft/fluid-odsp-utils";
 import { getMicrosoftConfiguration, OdspTokenManager, odspTokensCache } from "@microsoft/fluid-tool-utils";
 import { fluidFetchWebNavigator } from "./fluidFetchInit";
+import { getForceTokenReauth } from "./fluidFetchArgs";
 
-async function resolveWrapper<T>(
+export async function resolveWrapper<T>(
     callback: (authRequestInfo: IOdspAuthRequestInfo) => Promise<T>,
     server: string,
     clientConfig: IClientConfig,
@@ -28,7 +29,7 @@ async function resolveWrapper<T>(
             fluidFetchWebNavigator,
             undefined,
             undefined,
-            forceTokenReauth,
+            forceTokenReauth || getForceTokenReauth(),
         );
 
         return callback({


### PR DESCRIPTION
paramForceTokenReauth is never used in code.
resolveWrapper() already handles retries, but it is not used on first call, resulting in failures.