### PR TITLE
Discard pending checkpoints when the term changes

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -126,10 +126,11 @@ export class ScribeLambda extends SequencedLambda {
                         this.pendingMessages = new Deque<ISequencedDocumentMessage>(
                             lastSummary.messages.filter(
                                 (op) => op.sequenceNumber > lastScribe.protocolState.sequenceNumber));
-                        // eslint-disable-next-line @typescript-eslint/no-misused-promises
-                        if (this.pendingP) {
-                            this.pendingP = undefined;
-                        }
+
+                        this.pendingP = undefined;
+                        this.pendingCheckpointScribe = undefined;
+                        this.pendingCheckpointOffset = undefined;
+
                         await this.deleteCheckpoint(lastScribe.sequenceNumber + 1, false);
                     }
                 }


### PR DESCRIPTION
This ensures that an old checkpoint is not created after we delete it.