### PR TITLE
Update the resolvedUrl/originalRequest so that the summarizer could join to the same container. 

### DIFF
--- a/packages/drivers/create-new-driver/src/creationDocumentService.ts
+++ b/packages/drivers/create-new-driver/src/creationDocumentService.ts
@@ -16,6 +16,7 @@ import { CreationServerMessagesHandler } from "./creationDriverServer";
 export class CreationDocumentService implements api.IDocumentService {
     private readonly creationServer: CreationServerMessagesHandler;
     constructor(
+        private readonly _resolvedUrl: api.IResolvedUrl,
         private readonly documentId: string,
         private readonly tenantId: string) {
         this.creationServer = CreationServerMessagesHandler.getInstance(this.documentId);
@@ -23,7 +24,7 @@ export class CreationDocumentService implements api.IDocumentService {
 
     // TODO: Issue-2109 Implement detach container api or put appropriate comment.
     public get resolvedUrl(): api.IResolvedUrl {
-        throw new Error("Not implemented");
+        return this._resolvedUrl;
     }
 
     public async connectToStorage(): Promise<api.IDocumentStorageService> {

--- a/packages/drivers/create-new-driver/src/creationDocumentServiceFactory.ts
+++ b/packages/drivers/create-new-driver/src/creationDocumentServiceFactory.ts
@@ -33,6 +33,7 @@ export class CreationDocumentServiceFactory implements IDocumentServiceFactory {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const [, , documentId] = parsedUrl.pathname!.split("/");
         return new CreationDocumentService(
+            resolvedUrl,
             documentId,
             "createNewFileDocTenant");
     }

--- a/packages/drivers/create-new-driver/src/creationDriverUrlResolver.ts
+++ b/packages/drivers/create-new-driver/src/creationDriverUrlResolver.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import * as assert from "assert";
+import { parse } from "url";
 import { IRequest, IResponse } from "@microsoft/fluid-component-core-interfaces";
 import { IFluidResolvedUrl, IResolvedUrl, IUrlResolver } from "@microsoft/fluid-driver-definitions";
 
@@ -32,6 +34,24 @@ export class CreationDriverUrlResolver implements IUrlResolver {
         resolvedUrl: IResolvedUrl,
         request: IRequest,
     ): Promise<IResponse> {
-        throw new Error("Not implmented");
+        let url = request.url;
+        if (url.startsWith("/")) {
+            url = url.substr(1);
+        }
+        const fluidResolvedUrl = resolvedUrl as IFluidResolvedUrl;
+
+        const parsedUrl = parse(fluidResolvedUrl.url);
+        if (parsedUrl.pathname === undefined) {
+            throw new Error("Url should contain tenant and docId!!");
+        }
+        const [, , documentId] = parsedUrl.pathname.split("/");
+        assert(documentId, "The resolvedUrl must have a documentId");
+
+        const response: IResponse = {
+            mimeType: "text/plain",
+            value: `/${url}?uniqueId=${documentId}`,
+            status: 200,
+        };
+        return response;
     }
 }

--- a/packages/drivers/create-new-driver/src/creationDriverUrlResolver.ts
+++ b/packages/drivers/create-new-driver/src/creationDriverUrlResolver.ts
@@ -34,10 +34,6 @@ export class CreationDriverUrlResolver implements IUrlResolver {
         resolvedUrl: IResolvedUrl,
         request: IRequest,
     ): Promise<IResponse> {
-        let url = request.url;
-        if (url.startsWith("/")) {
-            url = url.substr(1);
-        }
         const fluidResolvedUrl = resolvedUrl as IFluidResolvedUrl;
 
         const parsedUrl = parse(fluidResolvedUrl.url);
@@ -49,7 +45,7 @@ export class CreationDriverUrlResolver implements IUrlResolver {
 
         const response: IResponse = {
             mimeType: "text/plain",
-            value: `/${url}?uniqueId=${documentId}`,
+            value: `/?uniqueId=${documentId}`,
             status: 200,
         };
         return response;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -865,25 +865,21 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         // Internal context is fully loaded at this point
         this.loaded = true;
-        try {
-            const resolvedUrl = this.service.resolvedUrl;
-            ensureFluidResolvedUrl(resolvedUrl);
-            this._resolvedUrl = resolvedUrl;
-            const response = await this.urlResolver.requestUrl(resolvedUrl, { url: "" });
-            if (response.status !== 200) {
-                throw new Error(`Not able to get requested Url: value: ${response.value} status: ${response.status}`);
-            }
-            this.originalRequest = { url: response.value };
-            const parsedUrl = parseUrl(resolvedUrl.url);
-            if (!parsedUrl) {
-                throw new Error("Unable to parse Url");
-            }
-            const [, docId] = parsedUrl.id.split("/");
-            this._id = decodeURI(docId);
-        } catch (error) {
-            this.close(createIError(error, true));
-            throw error;
+
+        const resolvedUrl = this.service.resolvedUrl;
+        ensureFluidResolvedUrl(resolvedUrl);
+        this._resolvedUrl = resolvedUrl;
+        const response = await this.urlResolver.requestUrl(resolvedUrl, { url: "" });
+        if (response.status !== 200) {
+            throw new Error(`Not able to get requested Url: value: ${response.value} status: ${response.status}`);
         }
+        this.originalRequest = { url: response.value };
+        const parsedUrl = parseUrl(resolvedUrl.url);
+        if (!parsedUrl) {
+            throw new Error("Unable to parse Url");
+        }
+        const [, docId] = parsedUrl.id.split("/");
+        this._id = decodeURI(docId);
 
         // Propagate current connection state through the system.
         const connected = this.connectionState === ConnectionState.Connected;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -865,6 +865,25 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         // Internal context is fully loaded at this point
         this.loaded = true;
+        try {
+            const resolvedUrl = this.service.resolvedUrl;
+            ensureFluidResolvedUrl(resolvedUrl);
+            this._resolvedUrl = resolvedUrl;
+            const response = await this.urlResolver.requestUrl(resolvedUrl, { url: "" });
+            if (response.status !== 200) {
+                throw new Error(`Not able to get requested Url: value: ${response.value} status: ${response.status}`);
+            }
+            this.originalRequest = { url: response.value };
+            const parsedUrl = parseUrl(resolvedUrl.url);
+            if (!parsedUrl) {
+                throw new Error("Unable to parse Url");
+            }
+            const [, docId] = parsedUrl.id.split("/");
+            this._id = decodeURI(docId);
+        } catch(error) {
+            this.close(createIError(error, true));
+            throw error;
+        }
 
         // Propagate current connection state through the system.
         const connected = this.connectionState === ConnectionState.Connected;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -880,7 +880,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             }
             const [, docId] = parsedUrl.id.split("/");
             this._id = decodeURI(docId);
-        } catch(error) {
+        } catch (error) {
             this.close(createIError(error, true));
             throw error;
         }

--- a/packages/test/end-to-end/src/test/container.spec.ts
+++ b/packages/test/end-to-end/src/test/container.spec.ts
@@ -288,7 +288,7 @@ describe("Container", () => {
             testRequest,
             testResolved,
             testResolver);
-        assert.strictEqual(container.id, "documentId", "Container's id should be set");
+        assert.strictEqual(container.id, "containerTest", "Container's id should be set");
         assert.strictEqual(container.clientDetails.capabilities.interactive, true,
             "Client details should be set with interactive as true");
     });

--- a/packages/test/end-to-end/src/test/container.spec.ts
+++ b/packages/test/end-to-end/src/test/container.spec.ts
@@ -52,7 +52,7 @@ describe("Container", () => {
         let success: boolean;
         try {
             await Container.load(
-                "tenantId/documentId",
+                "localhost/containerTest",
                 serviceFactory,
                 codeLoader,
                 {},
@@ -83,7 +83,7 @@ describe("Container", () => {
             };
 
             await Container.load(
-                "tenantId/documentId",
+                "localhost/containerTest",
                 mockFactory,
                 codeLoader,
                 {},
@@ -114,7 +114,7 @@ describe("Container", () => {
                 return service;
             };
             await Container.load(
-                "tenantId/documentId",
+                "localhost/containerTest",
                 mockFactory,
                 codeLoader,
                 {},
@@ -148,7 +148,7 @@ describe("Container", () => {
         };
 
         const container = await Container.load(
-            "tenantId/documentId",
+            "localhost/containerTest",
             mockFactory,
             codeLoader,
             {},
@@ -181,7 +181,7 @@ describe("Container", () => {
         };
 
         const container = await Container.load(
-            "tenantId/documentId",
+            "localhost/containerTest",
             mockFactory,
             codeLoader,
             {},
@@ -215,7 +215,7 @@ describe("Container", () => {
         };
         let errorRaised = false;
         const container = await Container.load(
-            "tenantId/documentId",
+            "localhost/containerTest",
             mockFactory,
             codeLoader,
             {},
@@ -256,7 +256,7 @@ describe("Container", () => {
             return service;
         };
         const container = await Container.load(
-            "tenantId/documentId",
+            "localhost/containerTest",
             mockFactory,
             codeLoader,
             {},
@@ -279,7 +279,7 @@ describe("Container", () => {
 
     it("Check client details and Id", async () => {
         const container = await Container.load(
-            "tenantId/documentId",
+            "localhost/containerTest",
             serviceFactory,
             codeLoader,
             {},


### PR DESCRIPTION
For odsp the file is created in driver even for non detached container. So the summarizer does not know which container to join. After creating the container we need to update the original request/resolved url to get the container url.
For master, after the implementation of getAbsolute Url we will replace this.
Big fix: https://github.com/microsoft/FluidFramework/issues/2270
This is reported by bohemia, so needed to go in release/0.18.x