### PR TITLE
Implement cache policy contract for ODSP driver

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/odspCache.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspCache.ts
@@ -3,19 +3,44 @@
  * Licensed under the MIT License.
  */
 
+/**
+  * A configuration that defines caching behavior.
+  */
+export interface ICachePolicy {
+    /**
+     * Defines how long (in milliseconds) user content should be cached. Making this number larger increases the
+     * probability of a cache hit and also increases the probability that the user will see noticeably stale content.
+     */
+    userContentCacheExpiry: number;
+}
+
+export const defaultCachePolicy: ICachePolicy = {
+    // By default, we only cache user content for 10 seconds
+    userContentCacheExpiry: 10 * 1000,
+};
+
+/**
+  * A generic caching interface that can be used to save values, like network calls, that are expensive to obtain.
+  */
 export interface ICache {
     /**
-     * Get the cache value of the key
+     * Called when a value is being requested from the cache.
+     * @param key - The key of the data that is being requested.
+     * @returns A promise that resolves to cached data or undefined if the item is not in the cache or is expired.
      */
     get(key: string): Promise<any>;
 
     /**
-     * Deletes value in storage
+     * Called when a value should be removed from the cache.
+     * @param key - The key of the item to remove from the cache
      */
     remove(key: string);
 
     /**
-     * puts value into cache
+     * Called when a value should be inserted in the cache.
+     * @param key - A unique key that is associated with this data. Will be used later for fetching.
+     * @param value - The value of the data that should be stored.
+     * @param expiryTime - The number of milliseconds from the current time that this data should be safe to cache.
      */
     put(key: string, value: any, expiryTime?: number);
 }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
@@ -29,7 +29,7 @@ import { IOdspResolvedUrl, ISocketStorageDiscovery } from "./contracts";
 import { createNewFluidFile } from "./createFile";
 import { debug } from "./debug";
 import { IFetchWrapper } from "./fetchWrapper";
-import { IOdspCache } from "./odspCache";
+import { IOdspCache, ICachePolicy } from "./odspCache";
 import { OdspDeltaStorageService } from "./odspDeltaStorageService";
 import { OdspDocumentDeltaConnection } from "./odspDocumentDeltaConnection";
 import { OdspDocumentStorageManager } from "./odspDocumentStorageManager";
@@ -68,6 +68,7 @@ export class OdspDocumentService implements IDocumentService {
         deltasFetchWrapper: IFetchWrapper,
         socketIOClientP: Promise<SocketIOClientStatic>,
         cache: IOdspCache,
+        cachePolicy: ICachePolicy,
         isFirstTimeDocumentOpened = true,
     ): Promise<IDocumentService> {
         let odspResolvedUrl: IOdspResolvedUrl = resolvedUrl as IOdspResolvedUrl;
@@ -102,6 +103,7 @@ export class OdspDocumentService implements IDocumentService {
             deltasFetchWrapper,
             socketIOClientP,
             cache,
+            cachePolicy,
             isFirstTimeDocumentOpened,
         );
     }
@@ -190,6 +192,7 @@ export class OdspDocumentService implements IDocumentService {
         private readonly deltasFetchWrapper: IFetchWrapper,
         private readonly socketIOClientP: Promise<SocketIOClientStatic>,
         private readonly cache: IOdspCache,
+        private readonly cachePolicy: ICachePolicy,
         private readonly isFirstTimeDocumentOpened = true,
     ) {
         this.joinSessionKey = `${this.odspResolvedUrl.hashedDocumentId}/joinsession`;
@@ -258,6 +261,7 @@ export class OdspDocumentService implements IDocumentService {
             this.logger,
             true,
             this.cache,
+            this.cachePolicy,
             this.isFirstTimeDocumentOpened,
         );
 

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactory.ts
@@ -13,7 +13,7 @@ import { ISummaryTree } from "@fluidframework/protocol-definitions";
 import { IOdspResolvedUrl } from "./contracts";
 import { FetchWrapper, IFetchWrapper } from "./fetchWrapper";
 import { getSocketIo } from "./getSocketIo";
-import { ICache, IOdspCache, OdspCache } from "./odspCache";
+import { ICache, IOdspCache, OdspCache, ICachePolicy, defaultCachePolicy } from "./odspCache";
 import { OdspDocumentService } from "./odspDocumentService";
 
 /**
@@ -50,7 +50,8 @@ export class OdspDocumentServiceFactory implements IDocumentServiceFactory {
      * referred to as the "Push" token in SPO.
      * @param storageFetchWrapper - if not provided FetchWrapper will be used
      * @param deltasFetchWrapper - if not provided FetchWrapper will be used
-     * @param odspCache - This caches response for joinSession.
+     * @param odspCache - A generic cache that can be used to store network requests to improve performance.
+     * @param cachePolicy - A configuration that defines how the cache should be leveraged by the driver.
      */
     constructor(
         private readonly getStorageToken: (siteUrl: string, refresh: boolean) => Promise<string | null>,
@@ -58,6 +59,7 @@ export class OdspDocumentServiceFactory implements IDocumentServiceFactory {
         private readonly storageFetchWrapper: IFetchWrapper = new FetchWrapper(),
         private readonly deltasFetchWrapper: IFetchWrapper = new FetchWrapper(),
         permanentCache?: ICache,
+        private readonly cachePolicy: ICachePolicy = defaultCachePolicy,
     ) {
         this.cache = new OdspCache(permanentCache);
     }
@@ -88,6 +90,7 @@ export class OdspDocumentServiceFactory implements IDocumentServiceFactory {
             this.deltasFetchWrapper,
             Promise.resolve(getSocketIo()),
             this.cache,
+            this.cachePolicy,
             isFirstTimeDocumentOpened,
         );
     }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryWithCodeSplit.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryWithCodeSplit.ts
@@ -12,7 +12,7 @@ import {
 import { ISummaryTree } from "@fluidframework/protocol-definitions";
 import { IOdspResolvedUrl } from "./contracts";
 import { FetchWrapper, IFetchWrapper } from "./fetchWrapper";
-import { ICache, IOdspCache, OdspCache } from "./odspCache";
+import { ICache, IOdspCache, OdspCache, ICachePolicy, defaultCachePolicy } from "./odspCache";
 import { OdspDocumentService } from "./odspDocumentService";
 
 /**
@@ -46,15 +46,16 @@ export class OdspDocumentServiceFactoryWithCodeSplit implements IDocumentService
     }
 
     /**
-   * @param getStorageToken - function that can provide the storage token for a given site. This is
-   * is also referred to as the "VROOM" token in SPO.
-   * @param getWebsocketToken - function that can provide a token for accessing the web socket. This is also
-   * referred to as the "Push" token in SPO.
-   * @param logger - a logger that can capture performance and diagnostic information
-   * @param storageFetchWrapper - if not provided FetchWrapper will be used
-   * @param deltasFetchWrapper - if not provided FetchWrapper will be used
-   * @param odspCache - This caches response for joinSession.
-   */
+     * @param getStorageToken - function that can provide the storage token for a given site. This is
+     * is also referred to as the "VROOM" token in SPO.
+     * @param getWebsocketToken - function that can provide a token for accessing the web socket. This is also
+     * referred to as the "Push" token in SPO.
+     * @param logger - a logger that can capture performance and diagnostic information
+     * @param storageFetchWrapper - if not provided FetchWrapper will be used
+     * @param deltasFetchWrapper - if not provided FetchWrapper will be used
+     * @param odspCache - A generic cache that can be used to store network requests to improve performance.
+     * @param cachePolicy - A configuration that defines how the cache should be leveraged by the driver.
+     */
     constructor(
         private readonly getStorageToken: (siteUrl: string, refresh: boolean) => Promise<string | null>,
         private readonly getWebsocketToken: (refresh: boolean) => Promise<string | null>,
@@ -62,6 +63,7 @@ export class OdspDocumentServiceFactoryWithCodeSplit implements IDocumentService
         private readonly storageFetchWrapper: IFetchWrapper = new FetchWrapper(),
         private readonly deltasFetchWrapper: IFetchWrapper = new FetchWrapper(),
         permanentCache?: ICache,
+        private readonly cachePolicy: ICachePolicy = defaultCachePolicy,
     ) {
         this.cache = new OdspCache(permanentCache);
     }
@@ -86,6 +88,7 @@ export class OdspDocumentServiceFactoryWithCodeSplit implements IDocumentService
             this.deltasFetchWrapper,
             import("./getSocketIo").then((m) => m.getSocketIo()),
             this.cache,
+            this.cachePolicy,
             isFirstTimeDocumentOpened,
         );
     }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
@@ -35,7 +35,7 @@ import { fetchSnapshot } from "./fetchSnapshot";
 import { IFetchWrapper } from "./fetchWrapper";
 import { getQueryString } from "./getQueryString";
 import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth";
-import { IOdspCache } from "./odspCache";
+import { IOdspCache, ICachePolicy } from "./odspCache";
 import { getWithRetryForTokenRefresh, throwOdspNetworkError } from "./odspUtils";
 
 /* eslint-disable max-len */
@@ -87,6 +87,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
         private readonly logger: ITelemetryLogger,
         private readonly fetchFullSnapshot: boolean,
         private readonly cache: IOdspCache,
+        private readonly cachePolicy: ICachePolicy,
         private readonly isFirstTimeDocumentOpened: boolean,
     ) {
     }
@@ -307,10 +308,8 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
                         throw error;
                     }
 
-                    // We are storing the getLatest response in cache for 10s so that other containers initializing in the same timeframe can use this
-                    // result. We are choosing a small time period as the summarizes are generated frequently and if that is the case then we don't
-                    // want to use the same getLatest result.
-                    this.cache.localStorage.put(odspCacheKey, odspSnapshot, 10000);
+                    // We let the host app define how long user content is cached
+                    this.cache.localStorage.put(odspCacheKey, odspSnapshot, this.cachePolicy.userContentCacheExpiry);
                 }
                 const { trees, tree, blobs, ops, sha } = odspSnapshot;
                 const blobsIdToPathMap: Map<string, string> = new Map();


### PR DESCRIPTION
As we start looking into improving performance for boot scenarios via snapshot caching, it's become clear that the host app is going to need to provide input on how the cache is used, since each host may have different scenarios or preferences.

Principles: 
* Cache remains agnostic to host app. Host app should have a simple contract to implement and is mostly in the business of storing the data in a secure and compliant manner.
* The host app is given settings it can use to customize caching behavior. The host app is in the best position to understand usage patterns and make the trade off between cache hit rate and staleness of content shown to the user.