### PR TITLE
Recommend the eslint vscode plugin

### DIFF
--- a/docs/.vscode/extensions.json
+++ b/docs/.vscode/extensions.json
@@ -5,7 +5,8 @@
   "recommendations": [
     // "docsmsft.docs-authoring-pack",
     "davidanson.vscode-markdownlint",
-    "stkb.rewrap"
+    "stkb.rewrap",
+    "dbaeumer.vscode-eslint"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []


### PR DESCRIPTION
Add the eslint vscode plugin to the set of recommended plugins. Most developers should have this installed.