### PR TITLE
Fix localDeltaConnectionServer test hang for 5 mins after passing

### DIFF
--- a/server/routerlicious/packages/local-server/src/test/localDeltaConnectionServer.spec.ts
+++ b/server/routerlicious/packages/local-server/src/test/localDeltaConnectionServer.spec.ts
@@ -83,5 +83,8 @@ describe("LocalDeltaConnectionServer", ()=>{
         const join2 = await join2P.promise;
         assert.equal(connected2.clientId, join2.clientId);
         assert.notEqual(connected2.clientId, connected1.clientId);
+
+        socket1.disconnect();
+        socket2.disconnect();
     });
 });

--- a/server/routerlicious/packages/test-utils/src/testWebServer.ts
+++ b/server/routerlicious/packages/test-utils/src/testWebServer.ts
@@ -63,6 +63,7 @@ export class TestWebSocket implements core.IWebSocket {
         for (const room of this.rooms) {
             this.server.rooms.get(room).delete(this);
         }
+        this.emit("disconnect");
     }
 }
 


### PR DESCRIPTION
The socket need to close and the TestWebSocket needs to emit the "disconnect even to tell Alfred and Deli to remove the client and cancel the timer.