### PR TITLE
Recommend editorconfig and eslint plugins

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,9 @@ yarn.lock                    merge=binary
 *.jpg -text
 *.gif -text
 *.pdf -text
+
+# Set the language for these files to json5 to ensure GitHub doesn't show the comments as errors
+/.vscode/*.json              linguist-language=JSON5
+
+# Hide docs from GitHub's language detection
+/docs/**                     linguist-documentation

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+    // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+    // List of extensions which should be recommended for users of this workspace.
+    "recommendations": [
+        "dbaeumer.vscode-eslint",
+        "editorconfig.editorconfig"
+    ],
+    // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+    "unwantedRecommendations": []
+}

--- a/docs/.vscode/extensions.json
+++ b/docs/.vscode/extensions.json
@@ -5,8 +5,7 @@
   "recommendations": [
     // "docsmsft.docs-authoring-pack",
     "davidanson.vscode-markdownlint",
-    "stkb.rewrap",
-    "dbaeumer.vscode-eslint"
+    "stkb.rewrap"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []


### PR DESCRIPTION
Moved these recommendations into the top-level `.vscode` folder since they shouldn't be limited to the `docs/` folder. Also updated GitHub's lang detection for some files/folders.