### PR TITLE
Add snapshot options - ability to overwrite existing options and specify new

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2213,57 +2213,57 @@
 			}
 		},
 		"@microsoft/fluid-agent-scheduler": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-agent-scheduler/-/fluid-agent-scheduler-0.18.2.tgz",
-			"integrity": "sha1-2qZq6WxUlviwHFc2SVK+z/TiJJ4=",
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-agent-scheduler/-/fluid-agent-scheduler-0.18.3.tgz",
+			"integrity": "sha1-g+UZaolaPZaghyRYebmJCtRRor4=",
 			"requires": {
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2",
-				"@microsoft/fluid-component-runtime": "^0.18.2",
-				"@microsoft/fluid-component-runtime-definitions": "^0.18.2",
-				"@microsoft/fluid-container-definitions": "^0.18.2",
-				"@microsoft/fluid-map": "^0.18.2",
-				"@microsoft/fluid-register-collection": "^0.18.2",
-				"@microsoft/fluid-runtime-definitions": "^0.18.2",
-				"@microsoft/fluid-shared-object-base": "^0.18.2",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
+				"@microsoft/fluid-component-runtime": "^0.18.3",
+				"@microsoft/fluid-component-runtime-definitions": "^0.18.3",
+				"@microsoft/fluid-container-definitions": "^0.18.3",
+				"@microsoft/fluid-map": "^0.18.3",
+				"@microsoft/fluid-register-collection": "^0.18.3",
+				"@microsoft/fluid-runtime-definitions": "^0.18.3",
+				"@microsoft/fluid-shared-object-base": "^0.18.3",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
 			}
 		},
 		"@microsoft/fluid-aqueduct": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-aqueduct/-/fluid-aqueduct-0.18.2.tgz",
-			"integrity": "sha1-5GPtcHc8ekYB8JraB8DUXD29s00=",
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-aqueduct/-/fluid-aqueduct-0.18.3.tgz",
+			"integrity": "sha1-KVLfYQ2IK6yAZXwI/Kjf/zyvfGc=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2",
-				"@microsoft/fluid-component-runtime": "^0.18.2",
-				"@microsoft/fluid-component-runtime-definitions": "^0.18.2",
-				"@microsoft/fluid-container-definitions": "^0.18.2",
-				"@microsoft/fluid-container-runtime": "^0.18.2",
-				"@microsoft/fluid-container-runtime-definitions": "^0.18.2",
-				"@microsoft/fluid-framework-interfaces": "^0.18.2",
-				"@microsoft/fluid-map": "^0.18.2",
-				"@microsoft/fluid-runtime-definitions": "^0.18.2",
-				"@microsoft/fluid-shared-object-base": "^0.18.2",
-				"@microsoft/fluid-synthesize": "^0.18.2",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
+				"@microsoft/fluid-component-runtime": "^0.18.3",
+				"@microsoft/fluid-component-runtime-definitions": "^0.18.3",
+				"@microsoft/fluid-container-definitions": "^0.18.3",
+				"@microsoft/fluid-container-runtime": "^0.18.3",
+				"@microsoft/fluid-container-runtime-definitions": "^0.18.3",
+				"@microsoft/fluid-framework-interfaces": "^0.18.3",
+				"@microsoft/fluid-map": "^0.18.3",
+				"@microsoft/fluid-runtime-definitions": "^0.18.3",
+				"@microsoft/fluid-shared-object-base": "^0.18.3",
+				"@microsoft/fluid-synthesize": "^0.18.3",
 				"uuid": "^3.3.2"
 			}
 		},
 		"@microsoft/fluid-base-host": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-base-host/-/fluid-base-host-0.18.2.tgz",
-			"integrity": "sha1-zpCUKmi/GKCJej2B7l085lLOnto=",
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-base-host/-/fluid-base-host-0.18.3.tgz",
+			"integrity": "sha1-w4ShZ9xw34RG6rb5VCNfclMXHMM=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2",
-				"@microsoft/fluid-container-definitions": "^0.18.2",
-				"@microsoft/fluid-container-loader": "^0.18.2",
-				"@microsoft/fluid-driver-definitions": "^0.18.2",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
+				"@microsoft/fluid-container-definitions": "^0.18.3",
+				"@microsoft/fluid-container-loader": "^0.18.3",
+				"@microsoft/fluid-driver-definitions": "^0.18.3",
 				"@microsoft/fluid-protocol-base": "^0.1005.1",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
-				"@microsoft/fluid-web-code-loader": "^0.18.2"
+				"@microsoft/fluid-web-code-loader": "^0.18.3"
 			}
 		},
 		"@microsoft/fluid-common-definitions": {
@@ -2284,65 +2284,65 @@
 			}
 		},
 		"@microsoft/fluid-component-core-interfaces": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-component-core-interfaces/-/fluid-component-core-interfaces-0.18.2.tgz",
-			"integrity": "sha1-hBClCTMQInMlLfMNsBwMbX2u7uU="
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-component-core-interfaces/-/fluid-component-core-interfaces-0.18.3.tgz",
+			"integrity": "sha1-nSTKuYLhVc/seGJZxfDMJe4GL3w="
 		},
 		"@microsoft/fluid-component-runtime": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-component-runtime/-/fluid-component-runtime-0.18.2.tgz",
-			"integrity": "sha1-wW2Sr6JViUHppgxfNDu+l93Hsg8=",
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-component-runtime/-/fluid-component-runtime-0.18.3.tgz",
+			"integrity": "sha1-yWsxtTnNNrjZMvkp+xfrYvrQgVc=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2",
-				"@microsoft/fluid-component-runtime-definitions": "^0.18.2",
-				"@microsoft/fluid-container-definitions": "^0.18.2",
-				"@microsoft/fluid-driver-definitions": "^0.18.2",
-				"@microsoft/fluid-driver-utils": "^0.18.2",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
+				"@microsoft/fluid-component-runtime-definitions": "^0.18.3",
+				"@microsoft/fluid-container-definitions": "^0.18.3",
+				"@microsoft/fluid-driver-definitions": "^0.18.3",
+				"@microsoft/fluid-driver-utils": "^0.18.3",
 				"@microsoft/fluid-protocol-base": "^0.1005.1",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
-				"@microsoft/fluid-runtime-definitions": "^0.18.2",
-				"@microsoft/fluid-shared-object-base": "^0.18.2",
+				"@microsoft/fluid-runtime-definitions": "^0.18.3",
+				"@microsoft/fluid-shared-object-base": "^0.18.3",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
 			}
 		},
 		"@microsoft/fluid-component-runtime-definitions": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-component-runtime-definitions/-/fluid-component-runtime-definitions-0.18.2.tgz",
-			"integrity": "sha1-JQM79DYt5r/DW6n/u5r6ab9IxGA=",
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-component-runtime-definitions/-/fluid-component-runtime-definitions-0.18.3.tgz",
+			"integrity": "sha1-e9qjPsMMt6mOtfoP5+U43K+FGyQ=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2",
-				"@microsoft/fluid-container-definitions": "^0.18.2",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
+				"@microsoft/fluid-container-definitions": "^0.18.3",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
-				"@microsoft/fluid-runtime-definitions": "^0.18.2",
+				"@microsoft/fluid-runtime-definitions": "^0.18.3",
 				"@types/node": "^10.14.6"
 			}
 		},
 		"@microsoft/fluid-container-definitions": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-definitions/-/fluid-container-definitions-0.18.2.tgz",
-			"integrity": "sha1-d6J3fjIoMihbpcIC3zmvD+4LeY0=",
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-definitions/-/fluid-container-definitions-0.18.3.tgz",
+			"integrity": "sha1-5oVP+HGt2FlfB6sTF2Cg329gSvM=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2",
-				"@microsoft/fluid-driver-definitions": "^0.18.2",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
+				"@microsoft/fluid-driver-definitions": "^0.18.3",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1"
 			}
 		},
 		"@microsoft/fluid-container-loader": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-loader/-/fluid-container-loader-0.18.2.tgz",
-			"integrity": "sha1-7Yx86yBWoNZEC1MF37nk/CqSO1I=",
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-loader/-/fluid-container-loader-0.18.3.tgz",
+			"integrity": "sha1-3RGxVdc+LU6JD7007RDCWDmefTI=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2",
-				"@microsoft/fluid-container-definitions": "^0.18.2",
-				"@microsoft/fluid-driver-definitions": "^0.18.2",
-				"@microsoft/fluid-driver-utils": "^0.18.2",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
+				"@microsoft/fluid-container-definitions": "^0.18.3",
+				"@microsoft/fluid-driver-definitions": "^0.18.3",
+				"@microsoft/fluid-driver-utils": "^0.18.3",
 				"@microsoft/fluid-protocol-base": "^0.1005.1",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
 				"@types/double-ended-queue": "^2.1.0",
@@ -2355,22 +2355,22 @@
 			}
 		},
 		"@microsoft/fluid-container-runtime": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-runtime/-/fluid-container-runtime-0.18.2.tgz",
-			"integrity": "sha1-l/MpvZwGiDFjygxJCTHSNS2XhGI=",
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-runtime/-/fluid-container-runtime-0.18.3.tgz",
+			"integrity": "sha1-symuiUxTg3PKj7YJwf7s8Sk5Nkg=",
 			"requires": {
-				"@microsoft/fluid-agent-scheduler": "^0.18.2",
+				"@microsoft/fluid-agent-scheduler": "^0.18.3",
 				"@microsoft/fluid-common-definitions": "^0.17.0",
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2",
-				"@microsoft/fluid-container-definitions": "^0.18.2",
-				"@microsoft/fluid-container-runtime-definitions": "^0.18.2",
-				"@microsoft/fluid-driver-definitions": "^0.18.2",
-				"@microsoft/fluid-driver-utils": "^0.18.2",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
+				"@microsoft/fluid-container-definitions": "^0.18.3",
+				"@microsoft/fluid-container-runtime-definitions": "^0.18.3",
+				"@microsoft/fluid-driver-definitions": "^0.18.3",
+				"@microsoft/fluid-driver-utils": "^0.18.3",
 				"@microsoft/fluid-protocol-base": "^0.1005.1",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
-				"@microsoft/fluid-runtime-definitions": "^0.18.2",
-				"@microsoft/fluid-runtime-utils": "^0.18.2",
+				"@microsoft/fluid-runtime-definitions": "^0.18.3",
+				"@microsoft/fluid-runtime-utils": "^0.18.3",
 				"@types/debug": "^0.0.31",
 				"@types/node": "^10.14.6",
 				"@types/uuid": "^3.4.4",
@@ -2387,26 +2387,26 @@
 			}
 		},
 		"@microsoft/fluid-container-runtime-definitions": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-runtime-definitions/-/fluid-container-runtime-definitions-0.18.2.tgz",
-			"integrity": "sha1-010+F/WeGZ0bfdHxhoYdlhXiuLA=",
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-runtime-definitions/-/fluid-container-runtime-definitions-0.18.3.tgz",
+			"integrity": "sha1-PsBo1Tuy1nYcfGAZ3GT/sGx2c8o=",
 			"requires": {
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2",
-				"@microsoft/fluid-container-definitions": "^0.18.2",
-				"@microsoft/fluid-driver-definitions": "^0.18.2",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
+				"@microsoft/fluid-container-definitions": "^0.18.3",
+				"@microsoft/fluid-driver-definitions": "^0.18.3",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
-				"@microsoft/fluid-runtime-definitions": "^0.18.2",
+				"@microsoft/fluid-runtime-definitions": "^0.18.3",
 				"@types/node": "^10.14.6"
 			}
 		},
 		"@microsoft/fluid-driver-base": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-driver-base/-/fluid-driver-base-0.18.2.tgz",
-			"integrity": "sha1-JaAr81vqE7zUlKDfpnnFqjXTI2M=",
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-driver-base/-/fluid-driver-base-0.18.3.tgz",
+			"integrity": "sha1-+CLL45un8VsX9CP8ocqN712Gdhk=",
 			"requires": {
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-driver-definitions": "^0.18.2",
-				"@microsoft/fluid-driver-utils": "^0.18.2",
+				"@microsoft/fluid-driver-definitions": "^0.18.3",
+				"@microsoft/fluid-driver-utils": "^0.18.3",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
 				"@types/debug": "^0.0.31",
 				"@types/node": "^10.14.6",
@@ -2422,32 +2422,32 @@
 			}
 		},
 		"@microsoft/fluid-driver-definitions": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-driver-definitions/-/fluid-driver-definitions-0.18.2.tgz",
-			"integrity": "sha1-UYXiBQtvDHoDjR2DQj0pLcLq2YA=",
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-driver-definitions/-/fluid-driver-definitions-0.18.3.tgz",
+			"integrity": "sha1-mRFoYpTrP0Xnu7vIXCmQjAl9eIo=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1"
 			}
 		},
 		"@microsoft/fluid-driver-utils": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-driver-utils/-/fluid-driver-utils-0.18.2.tgz",
-			"integrity": "sha1-wdf4dDzAPLKwCJalfg0DYvFvMLk=",
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-driver-utils/-/fluid-driver-utils-0.18.3.tgz",
+			"integrity": "sha1-sbqOKgvjtMLl0odZAA4oatM2T+w=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2",
-				"@microsoft/fluid-driver-definitions": "^0.18.2",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
+				"@microsoft/fluid-driver-definitions": "^0.18.3",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1"
 			}
 		},
 		"@microsoft/fluid-framework-interfaces": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-framework-interfaces/-/fluid-framework-interfaces-0.18.2.tgz",
-			"integrity": "sha1-DEWm4sk+kQvUhLG1BUtlTF8uYFo=",
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-framework-interfaces/-/fluid-framework-interfaces-0.18.3.tgz",
+			"integrity": "sha1-BNqsX9/LjPXey4qR0FJDDPXo37Y=",
 			"requires": {
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2"
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3"
 			}
 		},
 		"@microsoft/fluid-gitresources": {
@@ -2456,18 +2456,18 @@
 			"integrity": "sha1-WVO1ox1/sSeTSct9g4AT930j++s="
 		},
 		"@microsoft/fluid-local-driver": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-local-driver/-/fluid-local-driver-0.18.2.tgz",
-			"integrity": "sha1-BtQUL+bZbze0OuozmgmWg5RpGhw=",
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-local-driver/-/fluid-local-driver-0.18.3.tgz",
+			"integrity": "sha1-4/iQ6DbSZF10qLC7fSRZ6qxZGLE=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2",
-				"@microsoft/fluid-container-definitions": "^0.18.2",
-				"@microsoft/fluid-driver-definitions": "^0.18.2",
-				"@microsoft/fluid-driver-utils": "^0.18.2",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
+				"@microsoft/fluid-container-definitions": "^0.18.3",
+				"@microsoft/fluid-driver-definitions": "^0.18.3",
+				"@microsoft/fluid-driver-utils": "^0.18.3",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
-				"@microsoft/fluid-routerlicious-driver": "^0.18.2",
+				"@microsoft/fluid-routerlicious-driver": "^0.18.3",
 				"@microsoft/fluid-server-local-server": "^0.1005.1",
 				"@microsoft/fluid-server-services-client": "^0.1005.1",
 				"@microsoft/fluid-server-services-core": "^0.1005.1",
@@ -2476,17 +2476,17 @@
 			}
 		},
 		"@microsoft/fluid-map": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-map/-/fluid-map-0.18.2.tgz",
-			"integrity": "sha1-cXlG7SiyUsOev0PfvnofLmbUKdE=",
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-map/-/fluid-map-0.18.3.tgz",
+			"integrity": "sha1-OCsPN4Y7VKUSr+mtxq6dh4JuvAk=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2",
-				"@microsoft/fluid-component-runtime-definitions": "^0.18.2",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
+				"@microsoft/fluid-component-runtime-definitions": "^0.18.3",
 				"@microsoft/fluid-protocol-base": "^0.1005.1",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
-				"@microsoft/fluid-shared-object-base": "^0.18.2",
+				"@microsoft/fluid-shared-object-base": "^0.18.3",
 				"debug": "^4.1.1"
 			}
 		},
@@ -2517,28 +2517,28 @@
 			}
 		},
 		"@microsoft/fluid-register-collection": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-register-collection/-/fluid-register-collection-0.18.2.tgz",
-			"integrity": "sha1-NnvYwuKf0ML0ydC4XDdh3KjnFTg=",
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-register-collection/-/fluid-register-collection-0.18.3.tgz",
+			"integrity": "sha1-Dr16qZyyEvN5A0XNWpq4z/BPaOY=",
 			"requires": {
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-component-runtime-definitions": "^0.18.2",
+				"@microsoft/fluid-component-runtime-definitions": "^0.18.3",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
-				"@microsoft/fluid-runtime-utils": "^0.18.2",
-				"@microsoft/fluid-shared-object-base": "^0.18.2",
+				"@microsoft/fluid-runtime-utils": "^0.18.3",
+				"@microsoft/fluid-shared-object-base": "^0.18.3",
 				"debug": "^4.1.1"
 			}
 		},
 		"@microsoft/fluid-routerlicious-driver": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-routerlicious-driver/-/fluid-routerlicious-driver-0.18.2.tgz",
-			"integrity": "sha1-otFC1Zl4wUxFy9jTjZC2IRQ34C8=",
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-routerlicious-driver/-/fluid-routerlicious-driver-0.18.3.tgz",
+			"integrity": "sha1-Q0Urlx3zRu8Kaja1j2osAz04DG8=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-driver-base": "^0.18.2",
-				"@microsoft/fluid-driver-definitions": "^0.18.2",
-				"@microsoft/fluid-driver-utils": "^0.18.2",
+				"@microsoft/fluid-driver-base": "^0.18.3",
+				"@microsoft/fluid-driver-definitions": "^0.18.3",
+				"@microsoft/fluid-driver-utils": "^0.18.3",
 				"@microsoft/fluid-gitresources": "^0.1005.1",
 				"@microsoft/fluid-protocol-base": "^0.1005.1",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
@@ -2559,27 +2559,27 @@
 			}
 		},
 		"@microsoft/fluid-runtime-definitions": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-runtime-definitions/-/fluid-runtime-definitions-0.18.2.tgz",
-			"integrity": "sha1-YQjjSNNm3fV/xYPbfXH0YWi2Z70=",
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-runtime-definitions/-/fluid-runtime-definitions-0.18.3.tgz",
+			"integrity": "sha1-U90lJfsjh84tyaupVqiCUdpDnwo=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2",
-				"@microsoft/fluid-container-definitions": "^0.18.2",
-				"@microsoft/fluid-driver-definitions": "^0.18.2",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
+				"@microsoft/fluid-container-definitions": "^0.18.3",
+				"@microsoft/fluid-driver-definitions": "^0.18.3",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
 				"@types/node": "^10.14.6"
 			}
 		},
 		"@microsoft/fluid-runtime-utils": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-runtime-utils/-/fluid-runtime-utils-0.18.2.tgz",
-			"integrity": "sha1-dP9kFecGYQJ1UGGGbN30Wn0VwpQ=",
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-runtime-utils/-/fluid-runtime-utils-0.18.3.tgz",
+			"integrity": "sha1-oSaKI9Po6XCnVKF2bp3TQ+c/U1g=",
 			"requires": {
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2",
-				"@microsoft/fluid-component-runtime-definitions": "^0.18.2",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
+				"@microsoft/fluid-component-runtime-definitions": "^0.18.3",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
-				"@microsoft/fluid-runtime-definitions": "^0.18.2"
+				"@microsoft/fluid-runtime-definitions": "^0.18.3"
 			}
 		},
 		"@microsoft/fluid-server-lambdas": {
@@ -2733,15 +2733,15 @@
 			}
 		},
 		"@microsoft/fluid-shared-object-base": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-shared-object-base/-/fluid-shared-object-base-0.18.2.tgz",
-			"integrity": "sha1-y/5ZVN/RRmtXeqhuHtScM/fuf/Q=",
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-shared-object-base/-/fluid-shared-object-base-0.18.3.tgz",
+			"integrity": "sha1-+dVhvUggD5y+2uEtX8rt/bQhfcA=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2",
-				"@microsoft/fluid-component-runtime-definitions": "^0.18.2",
-				"@microsoft/fluid-container-definitions": "^0.18.2",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
+				"@microsoft/fluid-component-runtime-definitions": "^0.18.3",
+				"@microsoft/fluid-container-definitions": "^0.18.3",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
 				"@types/debug": "^0.0.31",
 				"@types/double-ended-queue": "^2.1.0",
@@ -2758,19 +2758,19 @@
 			}
 		},
 		"@microsoft/fluid-synthesize": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-synthesize/-/fluid-synthesize-0.18.2.tgz",
-			"integrity": "sha1-pREGtyugx+KUDhtCYGiNiX7OWMQ=",
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-synthesize/-/fluid-synthesize-0.18.3.tgz",
+			"integrity": "sha1-FPqHQPSeLI/irT5Ch1EGwvTzZZM=",
 			"requires": {
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2"
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3"
 			}
 		},
 		"@microsoft/fluid-web-code-loader": {
-			"version": "0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-web-code-loader/-/fluid-web-code-loader-0.18.2.tgz",
-			"integrity": "sha1-4kSAE+xkVkFMotg59BXG1bR58KA=",
+			"version": "0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-web-code-loader/-/fluid-web-code-loader-0.18.3.tgz",
+			"integrity": "sha1-IXbaP3UCv6tdnSvm+AUn+IEtnkM=",
 			"requires": {
-				"@microsoft/fluid-container-definitions": "^0.18.2",
+				"@microsoft/fluid-container-definitions": "^0.18.3",
 				"@types/node": "^10.14.6",
 				"isomorphic-fetch": "^2.2.1"
 			}
@@ -14901,48 +14901,48 @@
 			}
 		},
 		"old-aqueduct": {
-			"version": "npm:@microsoft/fluid-aqueduct@0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-aqueduct/-/fluid-aqueduct-0.18.2.tgz",
-			"integrity": "sha1-5GPtcHc8ekYB8JraB8DUXD29s00=",
+			"version": "npm:@microsoft/fluid-aqueduct@0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-aqueduct/-/fluid-aqueduct-0.18.3.tgz",
+			"integrity": "sha1-KVLfYQ2IK6yAZXwI/Kjf/zyvfGc=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2",
-				"@microsoft/fluid-component-runtime": "^0.18.2",
-				"@microsoft/fluid-component-runtime-definitions": "^0.18.2",
-				"@microsoft/fluid-container-definitions": "^0.18.2",
-				"@microsoft/fluid-container-runtime": "^0.18.2",
-				"@microsoft/fluid-container-runtime-definitions": "^0.18.2",
-				"@microsoft/fluid-framework-interfaces": "^0.18.2",
-				"@microsoft/fluid-map": "^0.18.2",
-				"@microsoft/fluid-runtime-definitions": "^0.18.2",
-				"@microsoft/fluid-shared-object-base": "^0.18.2",
-				"@microsoft/fluid-synthesize": "^0.18.2",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
+				"@microsoft/fluid-component-runtime": "^0.18.3",
+				"@microsoft/fluid-component-runtime-definitions": "^0.18.3",
+				"@microsoft/fluid-container-definitions": "^0.18.3",
+				"@microsoft/fluid-container-runtime": "^0.18.3",
+				"@microsoft/fluid-container-runtime-definitions": "^0.18.3",
+				"@microsoft/fluid-framework-interfaces": "^0.18.3",
+				"@microsoft/fluid-map": "^0.18.3",
+				"@microsoft/fluid-runtime-definitions": "^0.18.3",
+				"@microsoft/fluid-shared-object-base": "^0.18.3",
+				"@microsoft/fluid-synthesize": "^0.18.3",
 				"uuid": "^3.3.2"
 			}
 		},
 		"old-container-definitions": {
-			"version": "npm:@microsoft/fluid-container-definitions@0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-definitions/-/fluid-container-definitions-0.18.2.tgz",
-			"integrity": "sha1-d6J3fjIoMihbpcIC3zmvD+4LeY0=",
+			"version": "npm:@microsoft/fluid-container-definitions@0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-definitions/-/fluid-container-definitions-0.18.3.tgz",
+			"integrity": "sha1-5oVP+HGt2FlfB6sTF2Cg329gSvM=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2",
-				"@microsoft/fluid-driver-definitions": "^0.18.2",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
+				"@microsoft/fluid-driver-definitions": "^0.18.3",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1"
 			}
 		},
 		"old-container-loader": {
-			"version": "npm:@microsoft/fluid-container-loader@0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-loader/-/fluid-container-loader-0.18.2.tgz",
-			"integrity": "sha1-7Yx86yBWoNZEC1MF37nk/CqSO1I=",
+			"version": "npm:@microsoft/fluid-container-loader@0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-loader/-/fluid-container-loader-0.18.3.tgz",
+			"integrity": "sha1-3RGxVdc+LU6JD7007RDCWDmefTI=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2",
-				"@microsoft/fluid-container-definitions": "^0.18.2",
-				"@microsoft/fluid-driver-definitions": "^0.18.2",
-				"@microsoft/fluid-driver-utils": "^0.18.2",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
+				"@microsoft/fluid-container-definitions": "^0.18.3",
+				"@microsoft/fluid-driver-definitions": "^0.18.3",
+				"@microsoft/fluid-driver-utils": "^0.18.3",
 				"@microsoft/fluid-protocol-base": "^0.1005.1",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
 				"@types/double-ended-queue": "^2.1.0",
@@ -14955,35 +14955,35 @@
 			}
 		},
 		"old-runtime-definitions": {
-			"version": "npm:@microsoft/fluid-runtime-definitions@0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-runtime-definitions/-/fluid-runtime-definitions-0.18.2.tgz",
-			"integrity": "sha1-YQjjSNNm3fV/xYPbfXH0YWi2Z70=",
+			"version": "npm:@microsoft/fluid-runtime-definitions@0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-runtime-definitions/-/fluid-runtime-definitions-0.18.3.tgz",
+			"integrity": "sha1-U90lJfsjh84tyaupVqiCUdpDnwo=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2",
-				"@microsoft/fluid-container-definitions": "^0.18.2",
-				"@microsoft/fluid-driver-definitions": "^0.18.2",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
+				"@microsoft/fluid-container-definitions": "^0.18.3",
+				"@microsoft/fluid-driver-definitions": "^0.18.3",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
 				"@types/node": "^10.14.6"
 			}
 		},
 		"old-test-utils": {
-			"version": "npm:@microsoft/fluid-test-utils@0.18.2",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-test-utils/-/fluid-test-utils-0.18.2.tgz",
-			"integrity": "sha1-p75sbC0WlP75un55LfA+KQ8tjfA=",
+			"version": "npm:@microsoft/fluid-test-utils@0.18.3",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-test-utils/-/fluid-test-utils-0.18.3.tgz",
+			"integrity": "sha1-jIt4FcYTM+1Fh5unFAFnnm336I4=",
 			"requires": {
-				"@microsoft/fluid-aqueduct": "^0.18.2",
-				"@microsoft/fluid-base-host": "^0.18.2",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.2",
-				"@microsoft/fluid-component-runtime": "^0.18.2",
-				"@microsoft/fluid-component-runtime-definitions": "^0.18.2",
-				"@microsoft/fluid-container-definitions": "^0.18.2",
-				"@microsoft/fluid-container-loader": "^0.18.2",
-				"@microsoft/fluid-local-driver": "^0.18.2",
-				"@microsoft/fluid-map": "^0.18.2",
-				"@microsoft/fluid-runtime-definitions": "^0.18.2",
+				"@microsoft/fluid-aqueduct": "^0.18.3",
+				"@microsoft/fluid-base-host": "^0.18.3",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
+				"@microsoft/fluid-component-runtime": "^0.18.3",
+				"@microsoft/fluid-component-runtime-definitions": "^0.18.3",
+				"@microsoft/fluid-container-definitions": "^0.18.3",
+				"@microsoft/fluid-container-loader": "^0.18.3",
+				"@microsoft/fluid-local-driver": "^0.18.3",
+				"@microsoft/fluid-map": "^0.18.3",
+				"@microsoft/fluid-runtime-definitions": "^0.18.3",
 				"@microsoft/fluid-server-local-server": "^0.1005.1",
-				"@microsoft/fluid-shared-object-base": "^0.18.2"
+				"@microsoft/fluid-shared-object-base": "^0.18.3"
 			}
 		},
 		"on-finished": {

--- a/packages/drivers/odsp-socket-storage/src/contracts.ts
+++ b/packages/drivers/odsp-socket-storage/src/contracts.ts
@@ -245,6 +245,6 @@ export interface ISnapshotOptions {
     channels?: number;
 }
 
-export interface HostPolicy {
+export interface HostStoragePolicy {
     snapshotOptions?: ISnapshotOptions;
 }

--- a/packages/drivers/odsp-socket-storage/src/contracts.ts
+++ b/packages/drivers/odsp-socket-storage/src/contracts.ts
@@ -243,6 +243,12 @@ export interface ISnapshotOptions {
     blobs?: number;
     deltas?: number;
     channels?: number;
+    /*
+     * Maximum Data size (in bytes)
+     * If specified, SPO will fail snapshot request with 413 error (see ErrorType.snapshotTooBig)
+     * if snapshot is bigger in size than specified limit.
+     */
+    mds?: number;
 }
 
 export interface HostStoragePolicy {

--- a/packages/drivers/odsp-socket-storage/src/contracts.ts
+++ b/packages/drivers/odsp-socket-storage/src/contracts.ts
@@ -238,3 +238,13 @@ export interface IOdspUrlParts {
     drive: string;
     item: string;
 }
+
+export interface ISnapshotOptions {
+    blobs?: number;
+    deltas?: number;
+    channels?: number;
+}
+
+export interface HostPolicy {
+    snapshotOptions?: ISnapshotOptions;
+}

--- a/packages/drivers/odsp-socket-storage/src/index.ts
+++ b/packages/drivers/odsp-socket-storage/src/index.ts
@@ -15,6 +15,7 @@ export * from "./odspUtils";
 export * from "./createOdspUrl";
 export * from "./vroom";
 export * from "./odspDocumentServiceFactoryWithCodeSplit";
+export * from "./odspDocumentServiceFactoryCore";
 export * from "./odspDocumentDeltaConnection";
 export * from "./odspCache";
 export * from "./createFile";

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
@@ -22,7 +22,7 @@ import {
     IClient,
     IErrorTrackingService,
 } from "@fluidframework/protocol-definitions";
-import { IOdspResolvedUrl, ISocketStorageDiscovery } from "./contracts";
+import { IOdspResolvedUrl, HostPolicy, ISocketStorageDiscovery } from "./contracts";
 import { createNewFluidFile } from "./createFile";
 import { debug } from "./debug";
 import { IFetchWrapper } from "./fetchWrapper";
@@ -65,7 +65,7 @@ export class OdspDocumentService implements IDocumentService {
         deltasFetchWrapper: IFetchWrapper,
         socketIOClientP: Promise<SocketIOClientStatic>,
         cache: IOdspCache,
-        snapshotOptions: {[key: string]: number},
+        hostPolicy: HostPolicy,
         isFirstTimeDocumentOpened = true,
     ): Promise<IDocumentService> {
         let odspResolvedUrl: IOdspResolvedUrl = resolvedUrl as IOdspResolvedUrl;
@@ -100,7 +100,7 @@ export class OdspDocumentService implements IDocumentService {
             deltasFetchWrapper,
             socketIOClientP,
             cache,
-            snapshotOptions,
+            hostPolicy,
             isFirstTimeDocumentOpened,
         );
     }
@@ -137,7 +137,7 @@ export class OdspDocumentService implements IDocumentService {
         private readonly deltasFetchWrapper: IFetchWrapper,
         private readonly socketIOClientP: Promise<SocketIOClientStatic>,
         private readonly cache: IOdspCache,
-        private readonly snapshotOptions: {[key: string]: number},
+        private readonly hostPolicy: HostPolicy,
         private readonly isFirstTimeDocumentOpened = true,
     ) {
         this.joinSessionKey = `${this.odspResolvedUrl.hashedDocumentId}/joinsession`;
@@ -207,7 +207,7 @@ export class OdspDocumentService implements IDocumentService {
             true,
             this.cache,
             this.isFirstTimeDocumentOpened,
-            this.snapshotOptions,
+            this.hostPolicy,
         );
 
         return new OdspDocumentStorageService(this.storageManager);
@@ -319,7 +319,7 @@ export class OdspDocumentService implements IDocumentService {
     }
 
     /**
-     * Test if we deal with NetworkError object and if it has enough information to make a call
+     * Test if we deal with NetworkErrorBasic object and if it has enough information to make a call
      * If in doubt, allow retries
      *
      * @param error - error object

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentService.ts
@@ -22,7 +22,7 @@ import {
     IClient,
     IErrorTrackingService,
 } from "@fluidframework/protocol-definitions";
-import { IOdspResolvedUrl, HostPolicy, ISocketStorageDiscovery } from "./contracts";
+import { IOdspResolvedUrl, HostStoragePolicy, ISocketStorageDiscovery } from "./contracts";
 import { createNewFluidFile } from "./createFile";
 import { debug } from "./debug";
 import { IFetchWrapper } from "./fetchWrapper";
@@ -65,7 +65,7 @@ export class OdspDocumentService implements IDocumentService {
         deltasFetchWrapper: IFetchWrapper,
         socketIOClientP: Promise<SocketIOClientStatic>,
         cache: IOdspCache,
-        hostPolicy: HostPolicy,
+        hostPolicy: HostStoragePolicy,
         isFirstTimeDocumentOpened = true,
     ): Promise<IDocumentService> {
         let odspResolvedUrl: IOdspResolvedUrl = resolvedUrl as IOdspResolvedUrl;
@@ -137,7 +137,7 @@ export class OdspDocumentService implements IDocumentService {
         private readonly deltasFetchWrapper: IFetchWrapper,
         private readonly socketIOClientP: Promise<SocketIOClientStatic>,
         private readonly cache: IOdspCache,
-        private readonly hostPolicy: HostPolicy,
+        private readonly hostPolicy: HostStoragePolicy,
         private readonly isFirstTimeDocumentOpened = true,
     ) {
         this.joinSessionKey = `${this.odspResolvedUrl.hashedDocumentId}/joinsession`;

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactory.ts
@@ -4,6 +4,7 @@
  */
 
 import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
+import { HostPolicy } from "./contracts";
 import { FetchWrapper, IFetchWrapper } from "./fetchWrapper";
 import { IPersistedCache } from "./odspCache";
 import { OdspDocumentServiceFactoryCore } from "./odspDocumentServiceFactoryCore";
@@ -23,7 +24,7 @@ export class OdspDocumentServiceFactory
         storageFetchWrapper: IFetchWrapper = new FetchWrapper(),
         deltasFetchWrapper: IFetchWrapper = new FetchWrapper(),
         persistedCache?: IPersistedCache,
-        snapshotOptions?: {[key: string]: number},
+        hostPolicy?: HostPolicy,
     ) {
         super(
             getStorageToken,
@@ -32,7 +33,7 @@ export class OdspDocumentServiceFactory
             deltasFetchWrapper,
             async () => getSocketIo(),
             persistedCache,
-            snapshotOptions,
+            hostPolicy,
         );
     }
 }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactory.ts
@@ -4,7 +4,7 @@
  */
 
 import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
-import { HostPolicy } from "./contracts";
+import { HostStoragePolicy } from "./contracts";
 import { FetchWrapper, IFetchWrapper } from "./fetchWrapper";
 import { IPersistedCache } from "./odspCache";
 import { OdspDocumentServiceFactoryCore } from "./odspDocumentServiceFactoryCore";
@@ -24,7 +24,7 @@ export class OdspDocumentServiceFactory
         storageFetchWrapper: IFetchWrapper = new FetchWrapper(),
         deltasFetchWrapper: IFetchWrapper = new FetchWrapper(),
         persistedCache?: IPersistedCache,
-        hostPolicy?: HostPolicy,
+        hostPolicy?: HostStoragePolicy,
     ) {
         super(
             getStorageToken,

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryCore.ts
@@ -15,7 +15,7 @@ import {
     PerformanceEvent,
 } from "@fluidframework/common-utils";
 import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
-import { IOdspResolvedUrl, HostPolicy } from "./contracts";
+import { IOdspResolvedUrl, HostStoragePolicy } from "./contracts";
 import { FetchWrapper, IFetchWrapper } from "./fetchWrapper";
 import { IOdspCache, OdspCache, IPersistedCache } from "./odspCache";
 import { OdspDocumentService } from "./odspDocumentService";
@@ -101,7 +101,7 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
         private readonly deltasFetchWrapper: IFetchWrapper = new FetchWrapper(),
         private readonly getSocketIOClient: () => Promise<SocketIOClientStatic>,
         persistedCache?: IPersistedCache,
-        private readonly hostPolicy: HostPolicy = {},
+        private readonly hostPolicy: HostStoragePolicy = {},
     ) {
         this.cache = new OdspCache(persistedCache);
     }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryCore.ts
@@ -15,7 +15,7 @@ import {
     PerformanceEvent,
 } from "@fluidframework/common-utils";
 import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
-import { IOdspResolvedUrl } from "./contracts";
+import { IOdspResolvedUrl, HostPolicy } from "./contracts";
 import { FetchWrapper, IFetchWrapper } from "./fetchWrapper";
 import { IOdspCache, OdspCache, IPersistedCache } from "./odspCache";
 import { OdspDocumentService } from "./odspDocumentService";
@@ -101,7 +101,7 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
         private readonly deltasFetchWrapper: IFetchWrapper = new FetchWrapper(),
         private readonly getSocketIOClient: () => Promise<SocketIOClientStatic>,
         persistedCache?: IPersistedCache,
-        private readonly snapshotOptions: {[key: string]: number} = {},
+        private readonly hostPolicy: HostPolicy = {},
     ) {
         this.cache = new OdspCache(persistedCache);
     }
@@ -126,7 +126,7 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
             this.deltasFetchWrapper,
             this.getSocketIOClient(),
             this.cache,
-            this.snapshotOptions,
+            this.hostPolicy,
             isFirstTimeDocumentOpened,
         );
     }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryCore.ts
@@ -1,0 +1,133 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
+import {
+    IDocumentService,
+    IDocumentServiceFactory,
+    IResolvedUrl,
+} from "@fluidframework/driver-definitions";
+import { ISummaryTree } from "@fluidframework/protocol-definitions";
+import {
+    ChildLogger,
+    PerformanceEvent,
+} from "@fluidframework/common-utils";
+import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
+import { IOdspResolvedUrl } from "./contracts";
+import { FetchWrapper, IFetchWrapper } from "./fetchWrapper";
+import { IOdspCache, OdspCache, IPersistedCache } from "./odspCache";
+import { OdspDocumentService } from "./odspDocumentService";
+import { INewFileInfo } from "./odspUtils";
+import { createNewFluidFile } from "./createFile";
+
+/**
+ * Factory for creating the sharepoint document service. Use this if you want to
+ * use the sharepoint implementation.
+ *
+ * This constructor should be used by environments that support dynamic imports and that wish
+ * to leverage code splitting as a means to keep bundles as small as possible.
+ */
+export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
+    public readonly isExperimentalDocumentServiceFactory = true;
+    public readonly protocolName = "fluid-odsp:";
+
+    private readonly documentsOpened = new Set<string>();
+    private readonly cache: IOdspCache;
+
+    public async createContainer(
+        createNewSummary: ISummaryTree,
+        createNewResolvedUrl: IResolvedUrl,
+        logger?: ITelemetryBaseLogger,
+    ): Promise<IDocumentService> {
+        ensureFluidResolvedUrl(createNewResolvedUrl);
+
+        let odspResolvedUrl = createNewResolvedUrl as IOdspResolvedUrl;
+        const [, queryString] = odspResolvedUrl.url.split("?");
+
+        const searchParams = new URLSearchParams(queryString);
+        const filePath = searchParams.get("path");
+        if (!filePath) {
+            throw new Error("File path should be provided!!");
+        }
+        const newFileParams: INewFileInfo = {
+            driveId: odspResolvedUrl.driveId,
+            siteUrl: odspResolvedUrl.siteUrl,
+            filePath,
+            filename: odspResolvedUrl.fileName,
+        };
+
+        const event = PerformanceEvent.start(
+            ChildLogger.create(logger, "OdspDriver"),
+            {
+                eventName: "CreateNew",
+                isWithSummaryUpload: true,
+            });
+
+        try {
+            odspResolvedUrl = await createNewFluidFile(
+                this.getStorageToken,
+                newFileParams,
+                this.cache,
+                this.storageFetchWrapper,
+                createNewSummary);
+            const props = {
+                docId: odspResolvedUrl.hashedDocumentId,
+            };
+
+            const docService = this.createDocumentService(odspResolvedUrl, logger);
+            event.end(props);
+            return docService;
+        } catch (error) {
+            event.cancel(undefined, error);
+            throw error;
+        }
+    }
+
+    /**
+   * @param getStorageToken - function that can provide the storage token for a given site. This is
+   * is also referred to as the "VROOM" token in SPO.
+   * @param getWebsocketToken - function that can provide a token for accessing the web socket. This is also
+   * referred to as the "Push" token in SPO.
+   * @param storageFetchWrapper - if not provided FetchWrapper will be used
+   * @param deltasFetchWrapper - if not provided FetchWrapper will be used
+   * @param persistedCache - PersistedCache provided by host for use in this session.
+   */
+    constructor(
+        private readonly getStorageToken: (siteUrl: string, refresh: boolean) => Promise<string | null>,
+        private readonly getWebsocketToken: (refresh: boolean) => Promise<string | null>,
+        private readonly storageFetchWrapper: IFetchWrapper = new FetchWrapper(),
+        private readonly deltasFetchWrapper: IFetchWrapper = new FetchWrapper(),
+        private readonly getSocketIOClient: () => Promise<SocketIOClientStatic>,
+        persistedCache?: IPersistedCache,
+        private readonly snapshotOptions: {[key: string]: number} = {},
+    ) {
+        this.cache = new OdspCache(persistedCache);
+    }
+
+    public async createDocumentService(
+        resolvedUrl: IResolvedUrl,
+        logger?: ITelemetryBaseLogger,
+    ): Promise<IDocumentService> {
+        const odspResolvedUrl = resolvedUrl as IOdspResolvedUrl;
+
+        // A hint for driver if document was opened before by this factory
+        const docId = odspResolvedUrl.hashedDocumentId;
+        const isFirstTimeDocumentOpened = !this.documentsOpened.has(docId);
+        this.documentsOpened.add(docId);
+
+        return OdspDocumentService.create(
+            resolvedUrl,
+            this.getStorageToken,
+            this.getWebsocketToken,
+            ChildLogger.create(logger, "OdspDriver"),
+            this.storageFetchWrapper,
+            this.deltasFetchWrapper,
+            this.getSocketIOClient(),
+            this.cache,
+            this.snapshotOptions,
+            isFirstTimeDocumentOpened,
+        );
+    }
+}

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryWithCodeSplit.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryWithCodeSplit.ts
@@ -7,6 +7,7 @@ import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
 import { FetchWrapper, IFetchWrapper } from "./fetchWrapper";
 import { IPersistedCache } from "./odspCache";
 import { OdspDocumentServiceFactoryCore } from "./odspDocumentServiceFactoryCore";
+import { HostPolicy } from "./contracts";
 
 export class OdspDocumentServiceFactoryWithCodeSplit
     extends OdspDocumentServiceFactoryCore
@@ -18,7 +19,7 @@ export class OdspDocumentServiceFactoryWithCodeSplit
         storageFetchWrapper: IFetchWrapper = new FetchWrapper(),
         deltasFetchWrapper: IFetchWrapper = new FetchWrapper(),
         persistedCache?: IPersistedCache,
-        snapshotOptions?: {[key: string]: number},
+        hostPolicy?: HostPolicy,
     ) {
         super(
             getStorageToken,
@@ -27,7 +28,7 @@ export class OdspDocumentServiceFactoryWithCodeSplit
             deltasFetchWrapper,
             async () => import("./getSocketIo").then((m) => m.getSocketIo()),
             persistedCache,
-            snapshotOptions,
+            hostPolicy,
         );
     }
 }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryWithCodeSplit.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryWithCodeSplit.ts
@@ -7,7 +7,7 @@ import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
 import { FetchWrapper, IFetchWrapper } from "./fetchWrapper";
 import { IPersistedCache } from "./odspCache";
 import { OdspDocumentServiceFactoryCore } from "./odspDocumentServiceFactoryCore";
-import { HostPolicy } from "./contracts";
+import { HostStoragePolicy } from "./contracts";
 
 export class OdspDocumentServiceFactoryWithCodeSplit
     extends OdspDocumentServiceFactoryCore
@@ -19,7 +19,7 @@ export class OdspDocumentServiceFactoryWithCodeSplit
         storageFetchWrapper: IFetchWrapper = new FetchWrapper(),
         deltasFetchWrapper: IFetchWrapper = new FetchWrapper(),
         persistedCache?: IPersistedCache,
-        hostPolicy?: HostPolicy,
+        hostPolicy?: HostStoragePolicy,
     ) {
         super(
             getStorageToken,

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryWithCodeSplit.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentServiceFactoryWithCodeSplit.ts
@@ -3,90 +3,31 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
-import {
-    IDocumentService,
-    IDocumentServiceFactory,
-    IResolvedUrl,
-} from "@fluidframework/driver-definitions";
-import { ISummaryTree } from "@fluidframework/protocol-definitions";
-import { IOdspResolvedUrl } from "./contracts";
+import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
 import { FetchWrapper, IFetchWrapper } from "./fetchWrapper";
-import { IOdspCache, OdspCache, IPersistedCache } from "./odspCache";
-import { OdspDocumentService } from "./odspDocumentService";
+import { IPersistedCache } from "./odspCache";
+import { OdspDocumentServiceFactoryCore } from "./odspDocumentServiceFactoryCore";
 
-/**
- * Factory for creating the sharepoint document service. Use this if you want to
- * use the sharepoint implementation.
- *
- * This constructor should be used by environments that support dynamic imports and that wish
- * to leverage code splitting as a means to keep bundles as small as possible.
- */
-export class OdspDocumentServiceFactoryWithCodeSplit implements IDocumentServiceFactory {
-    public readonly isExperimentalDocumentServiceFactory = true;
-    public readonly protocolName = "fluid-odsp:";
-
-    private readonly documentsOpened = new Set<string>();
-    private readonly cache: IOdspCache;
-
-    public async createContainer(
-        createNewSummary: ISummaryTree,
-        createNewResolvedUrl: IResolvedUrl,
-        logger?: ITelemetryBaseLogger,
-    ): Promise<IDocumentService> {
-        return OdspDocumentService.createContainer(
-            createNewSummary,
-            createNewResolvedUrl,
-            logger ?? this.logger,
-            this.cache,
-            this.getStorageToken,
-            this,
-            this.storageFetchWrapper,
-        );
-    }
-
-    /**
-   * @param getStorageToken - function that can provide the storage token for a given site. This is
-   * is also referred to as the "VROOM" token in SPO.
-   * @param getWebsocketToken - function that can provide a token for accessing the web socket. This is also
-   * referred to as the "Push" token in SPO.
-   * @param logger - a logger that can capture performance and diagnostic information
-   * @param storageFetchWrapper - if not provided FetchWrapper will be used
-   * @param deltasFetchWrapper - if not provided FetchWrapper will be used
-   * @param persistedCache - PersistedCache provided by host for use in this session.
-   */
+export class OdspDocumentServiceFactoryWithCodeSplit
+    extends OdspDocumentServiceFactoryCore
+    implements IDocumentServiceFactory
+{
     constructor(
-        private readonly getStorageToken: (siteUrl: string, refresh: boolean) => Promise<string | null>,
-        private readonly getWebsocketToken: (refresh: boolean) => Promise<string | null>,
-        private readonly logger: ITelemetryBaseLogger,
-        private readonly storageFetchWrapper: IFetchWrapper = new FetchWrapper(),
-        private readonly deltasFetchWrapper: IFetchWrapper = new FetchWrapper(),
+        getStorageToken: (siteUrl: string, refresh: boolean) => Promise<string | null>,
+        getWebsocketToken: (refresh: boolean) => Promise<string | null>,
+        storageFetchWrapper: IFetchWrapper = new FetchWrapper(),
+        deltasFetchWrapper: IFetchWrapper = new FetchWrapper(),
         persistedCache?: IPersistedCache,
+        snapshotOptions?: {[key: string]: number},
     ) {
-        this.cache = new OdspCache(persistedCache);
-    }
-
-    public async createDocumentService(
-        resolvedUrl: IResolvedUrl,
-        logger?: ITelemetryBaseLogger,
-    ): Promise<IDocumentService> {
-        const odspResolvedUrl = resolvedUrl as IOdspResolvedUrl;
-
-        // A hint for driver if document was opened before by this factory
-        const docId = odspResolvedUrl.hashedDocumentId;
-        const isFirstTimeDocumentOpened = !this.documentsOpened.has(docId);
-        this.documentsOpened.add(docId);
-
-        return OdspDocumentService.create(
-            resolvedUrl,
-            this.getStorageToken,
-            this.getWebsocketToken,
-            logger ?? this.logger,
-            this.storageFetchWrapper,
-            this.deltasFetchWrapper,
-            import("./getSocketIo").then((m) => m.getSocketIo()),
-            this.cache,
-            isFirstTimeDocumentOpened,
+        super(
+            getStorageToken,
+            getWebsocketToken,
+            storageFetchWrapper,
+            deltasFetchWrapper,
+            async () => import("./getSocketIo").then((m) => m.getSocketIo()),
+            persistedCache,
+            snapshotOptions,
         );
     }
 }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
@@ -23,6 +23,7 @@ import {
     IDocumentStorageManager,
     IOdspSnapshot,
     ISequencedDeltaOpMessage,
+    HostPolicy,
     ISnapshotRequest,
     ISnapshotResponse,
     ISnapshotTree,
@@ -89,7 +90,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
         private readonly fetchFullSnapshot: boolean,
         private readonly cache: IOdspCache,
         private readonly isFirstTimeDocumentOpened: boolean,
-        private readonly snapshotOptions: {[key: string]: number},
+        private readonly hostPolicy: HostPolicy,
     ) {
     }
 
@@ -285,16 +286,16 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
                 if (cachedSnapshot === undefined) {
                     const storageToken = await this.getStorageToken(refresh, "TreesLatest");
 
-                    const snapshotOptions = {
+                    const hostPolicy = {
                         deltas: 1,
                         channels: 1,
                         blobs: 2,
-                        ...this.snapshotOptions,
+                        ...this.hostPolicy.snapshotOptions,
                     };
 
                     let delimiter = "?";
                     let options = "";
-                    for (const [key, value] of Object.entries(snapshotOptions)) {
+                    for (const [key, value] of Object.entries(hostPolicy)) {
                         options = `${options}${delimiter}${key}=${value}`;
                         delimiter = "&";
                     }

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
@@ -23,7 +23,7 @@ import {
     IDocumentStorageManager,
     IOdspSnapshot,
     ISequencedDeltaOpMessage,
-    HostPolicy,
+    HostStoragePolicy,
     ISnapshotRequest,
     ISnapshotResponse,
     ISnapshotTree,
@@ -90,7 +90,7 @@ export class OdspDocumentStorageManager implements IDocumentStorageManager {
         private readonly fetchFullSnapshot: boolean,
         private readonly cache: IOdspCache,
         private readonly isFirstTimeDocumentOpened: boolean,
-        private readonly hostPolicy: HostPolicy,
+        private readonly hostPolicy: HostStoragePolicy,
     ) {
     }
 

--- a/packages/drivers/odsp-socket-storage/src/odspUtils.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspUtils.ts
@@ -4,17 +4,14 @@
  */
 
 import {
-    AuthorizationError,
-    FileNotFoundOrAccessDeniedError,
+    NetworkErrorBasic,
     GenericNetworkError,
-    InvalidFileNameError,
-    OfflineError,
-    OutOfStorageError,
+    NonRetryableError,
     isOnline,
     createGenericNetworkError,
     OnlineStatus,
 } from "@fluidframework/driver-utils";
-import { CriticalContainerError } from "@fluidframework/container-definitions";
+import { CriticalContainerError, ErrorType } from "@fluidframework/container-definitions";
 import {
     default as fetch,
     RequestInfo as FetchRequestInfo,
@@ -41,23 +38,25 @@ export function createOdspNetworkError(
     switch (statusCode) {
         case 401:
         case 403:
-            error = new AuthorizationError(errorMessage, canRetry);
+            error = new NetworkErrorBasic(errorMessage, ErrorType.authorizationError, canRetry);
             break;
         case 404:
-            error = new FileNotFoundOrAccessDeniedError(errorMessage, canRetry);
+            error = new NetworkErrorBasic(errorMessage, ErrorType.fileNotFoundOrAccessDeniedError, canRetry);
             break;
         case 500:
             error = new GenericNetworkError(errorMessage, canRetry);
             break;
         case 507:
-            error = new OutOfStorageError(errorMessage, canRetry);
+            error = new NonRetryableError(errorMessage, ErrorType.outOfStorageError, canRetry);
             break;
+        case 413:
+            error = new NonRetryableError(errorMessage, ErrorType.snapshotTooBig, canRetry);
         case 414:
         case invalidFileNameStatusCode:
-            error = new InvalidFileNameError(errorMessage, canRetry);
+            error = new NonRetryableError(errorMessage, ErrorType.invalidFileNameError, canRetry);
             break;
         case offlineFetchFailureStatusCode:
-            error = new OfflineError(errorMessage, canRetry);
+            error = new NetworkErrorBasic(errorMessage, ErrorType.offlineError, canRetry);
             break;
 
         case fetchFailureStatusCode:

--- a/packages/drivers/routerlicious-socket-storage/src/documentDeltaConnection.ts
+++ b/packages/drivers/routerlicious-socket-storage/src/documentDeltaConnection.ts
@@ -3,12 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { CriticalContainerError } from "@fluidframework/container-definitions";
+import { CriticalContainerError, ErrorType } from "@fluidframework/container-definitions";
 import { DocumentDeltaConnection } from "@fluidframework/driver-base";
 import { IDocumentDeltaConnection } from "@fluidframework/driver-definitions";
 import {
-    AuthorizationError,
-    FileNotFoundOrAccessDeniedError,
+    NetworkErrorBasic,
     GenericNetworkError,
     createGenericNetworkError,
 } from "@fluidframework/driver-utils";
@@ -25,10 +24,10 @@ function createNetworkError(
     switch (statusCode) {
         case 401:
         case 403:
-            error = new AuthorizationError(errorMessage, canRetry);
+            error = new NetworkErrorBasic(errorMessage, ErrorType.authorizationError, canRetry);
             break;
         case 404:
-            error = new FileNotFoundOrAccessDeniedError(errorMessage, canRetry);
+            error = new NetworkErrorBasic(errorMessage, ErrorType.fileNotFoundOrAccessDeniedError, canRetry);
             break;
         case 500:
             error = new GenericNetworkError(errorMessage, canRetry);

--- a/packages/loader/container-definitions/src/error.ts
+++ b/packages/loader/container-definitions/src/error.ts
@@ -57,6 +57,13 @@ export enum ErrorType {
      * We can not reach server due to computer being offline.
      */
     offlineError,
+
+    /**
+     * Snapshot is too big. Host application specified limit for snapshot size, and snapshot was bigger
+     * that that limit, thus request failed. Hosting application is expected to have fall-back behavior for
+     * such case.
+     */
+    snapshotTooBig,
 }
 
 /**
@@ -75,10 +82,9 @@ export type ContainerErrorOrWarning = IThrottlingWarning;
  * delta connection are considered to be noncritical, ignoring 'canRetry' property.
  */
 export type CriticalContainerError =
-    IGenericError | ContainerErrorOrWarning |
-    IOutOfStorageError | IInvalidFileNameError |
-    IAuthorizationError | IFileNotFoundOrAccessDeniedError |
-    IWriteError | IGenericNetworkError | IOfflineError;
+    ContainerErrorOrWarning |
+    INetworkErrorBasic |
+    IGenericError | IGenericNetworkError;
 
 /**
  * List of warnings raised on container that are not critical.
@@ -113,20 +119,19 @@ export interface IGenericNetworkError extends IErrorBase {
     readonly statusCode?: number;
 }
 
-export interface IAuthorizationError extends IErrorBase {
-    readonly errorType: ErrorType.authorizationError;
-}
+/** Types of errors that do not contain any extra information other then error type */
+export type NetworkErrorBasicTypes =
+    ErrorType.authorizationError |
+    ErrorType.fileNotFoundOrAccessDeniedError |
+    ErrorType.outOfStorageError |
+    ErrorType.invalidFileNameError |
+    ErrorType.writeError |
+    ErrorType.offlineError |
+    ErrorType.snapshotTooBig;
 
-export interface IFileNotFoundOrAccessDeniedError extends IErrorBase {
-    readonly errorType: ErrorType.fileNotFoundOrAccessDeniedError;
-}
-
-export interface IOutOfStorageError extends IErrorBase {
-    readonly errorType: ErrorType.outOfStorageError;
-}
-
-export interface IInvalidFileNameError extends IErrorBase {
-    readonly errorType: ErrorType.invalidFileNameError;
+/** Types of errors that do not contain any extra information other then error type */
+export interface INetworkErrorBasic extends IErrorBase {
+    readonly errorType: NetworkErrorBasicTypes;
 }
 
 export interface ISummarizingWarning extends IErrorBase {
@@ -135,12 +140,4 @@ export interface ISummarizingWarning extends IErrorBase {
      * Whether this error has already been logged. Used to avoid logging errors twice.
      */
     readonly logged: boolean;
-}
-
-export interface IWriteError extends IErrorBase {
-    readonly errorType: ErrorType.writeError;
-}
-
-export interface IOfflineError extends IErrorBase {
-    readonly errorType: ErrorType.offlineError;
 }


### PR DESCRIPTION
Added functionality:
1) Most of PR is moving code around to reduce duplication of code between two driver factories - one with code split, and one without.
createContainer() is moved to factory - the only reason it was on driver itself (as static function) is to avoid code duplication. Now with single base class of factory, it can leave there.
2) Add host policy. For now this carries only snapshot options - ability to overwrite existing options and specify new
3) Streamlined error cases a bit, not to create individual interfaces and error objects for same-shaped error cases.