### PR TITLE
Call context.error when a document partition error occurs

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -47,6 +47,7 @@ export class DocumentPartition extends EventEmitter {
                     // TODO dead letter queue for bad messages, etc... when the lambda is throwing an exception
                     // for now we will simply continue on to keep the queue flowing
                     winston.error("Error processing partition message", error);
+                    context.error(error, false);
                     this.corrupt = true;
                 }
 

--- a/server/routerlicious/packages/lambdas-driver/src/test/document-router/documentLambda.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/document-router/documentLambda.spec.ts
@@ -119,6 +119,12 @@ describe("document-router", () => {
             });
 
             it("Should skip future messages after lambda exception (in future will dead letter queue)", async () => {
+                let contextErrored = false;
+
+                context.on("error", () => {
+                    contextErrored = true;
+                });
+
                 const totalMessages = 10;
 
                 for (let i = 0; i < totalMessages; i++) {
@@ -138,6 +144,8 @@ describe("document-router", () => {
                 }
                 await context.waitForOffset(kafkaMessageFactory.getHeadOffset("test"));
                 assert.equal(testModule.factories[0].lambdas[0].handleCalls, totalMessages + 1);
+
+                assert.ok(contextErrored);
             });
 
             it("Should emit an error on lambda creation exception", async () => {


### PR DESCRIPTION
I have telemetry logging for context.error calls. This will let me know when a document partition becomes corrupted.