### PR TITLE
Record and log sequence number when we fail to load DDS

### DIFF
--- a/packages/loader/container-definitions/src/error.ts
+++ b/packages/loader/container-definitions/src/error.ts
@@ -96,6 +96,8 @@ export interface IErrorBase {
     readonly message: string;
     readonly canRetry: boolean;
     readonly online?: string;
+    /** Sequence number when error happened */
+    sequenceNumber?: number;
 }
 
 export interface IGenericError extends IErrorBase {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -448,7 +448,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             this.logger.sendErrorEvent(
                 {
                     eventName: "ContainerClose",
-                    sequenceNumber: (error as any)?.sequenceNumber ?? this._deltaManager.referenceSequenceNumber,
+                    sequenceNumber: error.sequenceNumber ?? this._deltaManager.referenceSequenceNumber,
                 },
                 error,
             );

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -441,11 +441,14 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         assert(this.connectionState === ConnectionState.Disconnected, "disconnect event was not raised!");
 
         if (error !== undefined) {
+            // Log current sequence number - useful if we have access to a file to understand better
+            // what op caused trouble (if it's related to op processing).
+            // Runtime may provide sequence number as part of error object - this may not match DeltaManager
+            // knowledge as old ops are processed when components / DDS are re-hydrated when delay-loaded
             this.logger.sendErrorEvent(
                 {
                     eventName: "ContainerClose",
-                    // record sequence number for easier debugging
-                    sequenceNumber: this._deltaManager.referenceSequenceNumber,
+                    sequenceNumber: (error as any)?.sequenceNumber ?? this._deltaManager.referenceSequenceNumber,
                 },
                 error,
             );

--- a/packages/runtime/component-runtime/src/remoteChannelContext.ts
+++ b/packages/runtime/component-runtime/src/remoteChannelContext.ts
@@ -167,7 +167,7 @@ export class RemoteChannelContext implements IChannelContext {
             } catch (err) {
                 // record sequence number for easier debugging
                 const error = CreateContainerError(err);
-                (error as any).sequenceNumber = message.sequenceNumber;
+                error.sequenceNumber = message.sequenceNumber;
                 throw error;
             }
         }


### PR DESCRIPTION
There is no easy way to guarantee that we raise critical error, and likely this should not be there (and be left to components).
But when it comes to agent scheduler, I've changed it (previous commit) to fail container if it failed to load, which would propagate this info.
Same for any other place that either does not do anything with exceptions (and let them propagate to container), or implements fail-fast strategy.