### PR TITLE
Move throttled and closed events off IDeltaManager interface

### DIFF
--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -17,7 +17,6 @@ import {
     ITokenClaims,
     MessageType,
 } from "@fluidframework/protocol-definitions";
-import { CriticalContainerError, IThrottlingWarning } from "./error";
 
 export interface IConnectionDetails {
     clientId: string;
@@ -75,12 +74,10 @@ export interface IDeltaSender extends IProvideDeltaSender {
 }
 
 export interface IDeltaManagerEvents extends IEvent {
-    (event: "throttled", listener: (error: IThrottlingWarning) => void);
     (event: "prepareSend", listener: (messageBuffer: any[]) => void);
     (event: "submitOp", listener: (message: IDocumentMessage) => void);
     (event: "beforeOpProcessing", listener: (message: ISequencedDocumentMessage) => void);
     (event: "allSentOpsAckd" | "caughtUp", listener: () => void);
-    (event: "closed", listener: (error?: CriticalContainerError) => void);
     (event: "pong" | "processTime", listener: (latency: number) => void);
     (event: "connect", listener: (details: IConnectionDetails) => void);
     (event: "disconnect", listener: (reason: string) => void);

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -99,7 +99,7 @@ export enum ReconnectMode {
  * Includes events emitted by the concrete implementation DeltaManager
  * but not exposed on the public interface IDeltaManager
  */
-interface IDeltaManagerInternalEvents extends IDeltaManagerEvents {
+export interface IDeltaManagerInternalEvents extends IDeltaManagerEvents {
     (event: "throttled", listener: (error: IThrottlingWarning) => void);
     (event: "closed", listener: (error?: CriticalContainerError) => void);
 }

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from "assert";
-import { ITelemetryLogger, IEvent, IEventProvider } from "@fluidframework/common-definitions";
+import { ITelemetryLogger, IEventProvider } from "@fluidframework/common-definitions";
 import {
     IConnectionDetails,
     IDeltaHandlerStrategy,
@@ -96,10 +96,10 @@ export enum ReconnectMode {
 }
 
 /**
- * Events emitted by the concrete implementation DeltaManager
+ * Includes events emitted by the concrete implementation DeltaManager
  * but not exposed on the public interface IDeltaManager
  */
-interface IDeltaManagerInternalEvents extends IEvent {
+interface IDeltaManagerInternalEvents extends IDeltaManagerEvents {
     (event: "throttled", listener: (error: IThrottlingWarning) => void);
     (event: "closed", listener: (error?: CriticalContainerError) => void);
 }
@@ -109,7 +109,7 @@ interface IDeltaManagerInternalEvents extends IEvent {
  * messages in order regardless of possible network conditions or timings causing out of order delivery.
  */
 export class DeltaManager
-    extends TypedEventEmitter<IDeltaManagerEvents & IDeltaManagerInternalEvents>
+    extends TypedEventEmitter<IDeltaManagerInternalEvents>
     implements
         IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
         IEventProvider<IDeltaManagerInternalEvents>


### PR DESCRIPTION
Fixes #2002 by moving `closed` to a separate event list from the rest of what's exposed on `IDeltaManager`, instead only adding it to `DeltaManager`

Also moves `throttling` to the same list, as it was before #1820.

@anthony-murphy - One observation about how this works, is that `IDeltaManager`'s `on` function supports _only exactly_ the list of 8 events on `IDeltaManagerEvents`, but `DeltaManager`'s `on` function also includes the `string | symbol` signature, so you don't get a build error if you misspell the event name (whereas you do for `IDeltaManager`).  Is this expected? Any way to tighten this up? I'm assuming this is from extending `TypedEventEmitter` or something? I can't quite piece it together.