### PR TITLE
referenceSequenceNumber -> currentSequenceNumber

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2213,57 +2213,57 @@
 			}
 		},
 		"@microsoft/fluid-agent-scheduler": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-agent-scheduler/-/fluid-agent-scheduler-0.18.3.tgz",
-			"integrity": "sha1-g+UZaolaPZaghyRYebmJCtRRor4=",
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-agent-scheduler/-/fluid-agent-scheduler-0.18.4.tgz",
+			"integrity": "sha1-vOQW94on/kJ6jy8VRiXZVzKZF30=",
 			"requires": {
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
-				"@microsoft/fluid-component-runtime": "^0.18.3",
-				"@microsoft/fluid-component-runtime-definitions": "^0.18.3",
-				"@microsoft/fluid-container-definitions": "^0.18.3",
-				"@microsoft/fluid-map": "^0.18.3",
-				"@microsoft/fluid-register-collection": "^0.18.3",
-				"@microsoft/fluid-runtime-definitions": "^0.18.3",
-				"@microsoft/fluid-shared-object-base": "^0.18.3",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4",
+				"@microsoft/fluid-component-runtime": "^0.18.4",
+				"@microsoft/fluid-component-runtime-definitions": "^0.18.4",
+				"@microsoft/fluid-container-definitions": "^0.18.4",
+				"@microsoft/fluid-map": "^0.18.4",
+				"@microsoft/fluid-register-collection": "^0.18.4",
+				"@microsoft/fluid-runtime-definitions": "^0.18.4",
+				"@microsoft/fluid-shared-object-base": "^0.18.4",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
 			}
 		},
 		"@microsoft/fluid-aqueduct": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-aqueduct/-/fluid-aqueduct-0.18.3.tgz",
-			"integrity": "sha1-KVLfYQ2IK6yAZXwI/Kjf/zyvfGc=",
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-aqueduct/-/fluid-aqueduct-0.18.4.tgz",
+			"integrity": "sha1-yxqy04RTM5gsrzHXrQsXznX7lHw=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
-				"@microsoft/fluid-component-runtime": "^0.18.3",
-				"@microsoft/fluid-component-runtime-definitions": "^0.18.3",
-				"@microsoft/fluid-container-definitions": "^0.18.3",
-				"@microsoft/fluid-container-runtime": "^0.18.3",
-				"@microsoft/fluid-container-runtime-definitions": "^0.18.3",
-				"@microsoft/fluid-framework-interfaces": "^0.18.3",
-				"@microsoft/fluid-map": "^0.18.3",
-				"@microsoft/fluid-runtime-definitions": "^0.18.3",
-				"@microsoft/fluid-shared-object-base": "^0.18.3",
-				"@microsoft/fluid-synthesize": "^0.18.3",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4",
+				"@microsoft/fluid-component-runtime": "^0.18.4",
+				"@microsoft/fluid-component-runtime-definitions": "^0.18.4",
+				"@microsoft/fluid-container-definitions": "^0.18.4",
+				"@microsoft/fluid-container-runtime": "^0.18.4",
+				"@microsoft/fluid-container-runtime-definitions": "^0.18.4",
+				"@microsoft/fluid-framework-interfaces": "^0.18.4",
+				"@microsoft/fluid-map": "^0.18.4",
+				"@microsoft/fluid-runtime-definitions": "^0.18.4",
+				"@microsoft/fluid-shared-object-base": "^0.18.4",
+				"@microsoft/fluid-synthesize": "^0.18.4",
 				"uuid": "^3.3.2"
 			}
 		},
 		"@microsoft/fluid-base-host": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-base-host/-/fluid-base-host-0.18.3.tgz",
-			"integrity": "sha1-w4ShZ9xw34RG6rb5VCNfclMXHMM=",
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-base-host/-/fluid-base-host-0.18.4.tgz",
+			"integrity": "sha1-KEOZHUOnx2uPu1qo7cDjYpSINRY=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
-				"@microsoft/fluid-container-definitions": "^0.18.3",
-				"@microsoft/fluid-container-loader": "^0.18.3",
-				"@microsoft/fluid-driver-definitions": "^0.18.3",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4",
+				"@microsoft/fluid-container-definitions": "^0.18.4",
+				"@microsoft/fluid-container-loader": "^0.18.4",
+				"@microsoft/fluid-driver-definitions": "^0.18.4",
 				"@microsoft/fluid-protocol-base": "^0.1005.1",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
-				"@microsoft/fluid-web-code-loader": "^0.18.3"
+				"@microsoft/fluid-web-code-loader": "^0.18.4"
 			}
 		},
 		"@microsoft/fluid-common-definitions": {
@@ -2284,65 +2284,65 @@
 			}
 		},
 		"@microsoft/fluid-component-core-interfaces": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-component-core-interfaces/-/fluid-component-core-interfaces-0.18.3.tgz",
-			"integrity": "sha1-nSTKuYLhVc/seGJZxfDMJe4GL3w="
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-component-core-interfaces/-/fluid-component-core-interfaces-0.18.4.tgz",
+			"integrity": "sha1-yHJWFy9nCl7It+dODX6WGT3tJzM="
 		},
 		"@microsoft/fluid-component-runtime": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-component-runtime/-/fluid-component-runtime-0.18.3.tgz",
-			"integrity": "sha1-yWsxtTnNNrjZMvkp+xfrYvrQgVc=",
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-component-runtime/-/fluid-component-runtime-0.18.4.tgz",
+			"integrity": "sha1-DJhJWB1WtLcTSvgtAT2IZ1Qa5Cs=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
-				"@microsoft/fluid-component-runtime-definitions": "^0.18.3",
-				"@microsoft/fluid-container-definitions": "^0.18.3",
-				"@microsoft/fluid-driver-definitions": "^0.18.3",
-				"@microsoft/fluid-driver-utils": "^0.18.3",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4",
+				"@microsoft/fluid-component-runtime-definitions": "^0.18.4",
+				"@microsoft/fluid-container-definitions": "^0.18.4",
+				"@microsoft/fluid-driver-definitions": "^0.18.4",
+				"@microsoft/fluid-driver-utils": "^0.18.4",
 				"@microsoft/fluid-protocol-base": "^0.1005.1",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
-				"@microsoft/fluid-runtime-definitions": "^0.18.3",
-				"@microsoft/fluid-shared-object-base": "^0.18.3",
+				"@microsoft/fluid-runtime-definitions": "^0.18.4",
+				"@microsoft/fluid-shared-object-base": "^0.18.4",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
 			}
 		},
 		"@microsoft/fluid-component-runtime-definitions": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-component-runtime-definitions/-/fluid-component-runtime-definitions-0.18.3.tgz",
-			"integrity": "sha1-e9qjPsMMt6mOtfoP5+U43K+FGyQ=",
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-component-runtime-definitions/-/fluid-component-runtime-definitions-0.18.4.tgz",
+			"integrity": "sha1-hA7096D89tXP+j+2a8JTQ30loNg=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
-				"@microsoft/fluid-container-definitions": "^0.18.3",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4",
+				"@microsoft/fluid-container-definitions": "^0.18.4",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
-				"@microsoft/fluid-runtime-definitions": "^0.18.3",
+				"@microsoft/fluid-runtime-definitions": "^0.18.4",
 				"@types/node": "^10.14.6"
 			}
 		},
 		"@microsoft/fluid-container-definitions": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-definitions/-/fluid-container-definitions-0.18.3.tgz",
-			"integrity": "sha1-5oVP+HGt2FlfB6sTF2Cg329gSvM=",
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-definitions/-/fluid-container-definitions-0.18.4.tgz",
+			"integrity": "sha1-DsjhyqE4CUw4WrgX3nzHhdZm3io=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
-				"@microsoft/fluid-driver-definitions": "^0.18.3",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4",
+				"@microsoft/fluid-driver-definitions": "^0.18.4",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1"
 			}
 		},
 		"@microsoft/fluid-container-loader": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-loader/-/fluid-container-loader-0.18.3.tgz",
-			"integrity": "sha1-3RGxVdc+LU6JD7007RDCWDmefTI=",
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-loader/-/fluid-container-loader-0.18.4.tgz",
+			"integrity": "sha1-W5rGuZdY8yDS6Dzt6QaGeoxJTYc=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
-				"@microsoft/fluid-container-definitions": "^0.18.3",
-				"@microsoft/fluid-driver-definitions": "^0.18.3",
-				"@microsoft/fluid-driver-utils": "^0.18.3",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4",
+				"@microsoft/fluid-container-definitions": "^0.18.4",
+				"@microsoft/fluid-driver-definitions": "^0.18.4",
+				"@microsoft/fluid-driver-utils": "^0.18.4",
 				"@microsoft/fluid-protocol-base": "^0.1005.1",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
 				"@types/double-ended-queue": "^2.1.0",
@@ -2355,22 +2355,22 @@
 			}
 		},
 		"@microsoft/fluid-container-runtime": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-runtime/-/fluid-container-runtime-0.18.3.tgz",
-			"integrity": "sha1-symuiUxTg3PKj7YJwf7s8Sk5Nkg=",
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-runtime/-/fluid-container-runtime-0.18.4.tgz",
+			"integrity": "sha1-G7kqlmqSVT1/RyWpb0APMoGoWs4=",
 			"requires": {
-				"@microsoft/fluid-agent-scheduler": "^0.18.3",
+				"@microsoft/fluid-agent-scheduler": "^0.18.4",
 				"@microsoft/fluid-common-definitions": "^0.17.0",
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
-				"@microsoft/fluid-container-definitions": "^0.18.3",
-				"@microsoft/fluid-container-runtime-definitions": "^0.18.3",
-				"@microsoft/fluid-driver-definitions": "^0.18.3",
-				"@microsoft/fluid-driver-utils": "^0.18.3",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4",
+				"@microsoft/fluid-container-definitions": "^0.18.4",
+				"@microsoft/fluid-container-runtime-definitions": "^0.18.4",
+				"@microsoft/fluid-driver-definitions": "^0.18.4",
+				"@microsoft/fluid-driver-utils": "^0.18.4",
 				"@microsoft/fluid-protocol-base": "^0.1005.1",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
-				"@microsoft/fluid-runtime-definitions": "^0.18.3",
-				"@microsoft/fluid-runtime-utils": "^0.18.3",
+				"@microsoft/fluid-runtime-definitions": "^0.18.4",
+				"@microsoft/fluid-runtime-utils": "^0.18.4",
 				"@types/debug": "^0.0.31",
 				"@types/node": "^10.14.6",
 				"@types/uuid": "^3.4.4",
@@ -2387,26 +2387,26 @@
 			}
 		},
 		"@microsoft/fluid-container-runtime-definitions": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-runtime-definitions/-/fluid-container-runtime-definitions-0.18.3.tgz",
-			"integrity": "sha1-PsBo1Tuy1nYcfGAZ3GT/sGx2c8o=",
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-runtime-definitions/-/fluid-container-runtime-definitions-0.18.4.tgz",
+			"integrity": "sha1-9x77ZWW6X3ha02B56jNS3mhD1CI=",
 			"requires": {
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
-				"@microsoft/fluid-container-definitions": "^0.18.3",
-				"@microsoft/fluid-driver-definitions": "^0.18.3",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4",
+				"@microsoft/fluid-container-definitions": "^0.18.4",
+				"@microsoft/fluid-driver-definitions": "^0.18.4",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
-				"@microsoft/fluid-runtime-definitions": "^0.18.3",
+				"@microsoft/fluid-runtime-definitions": "^0.18.4",
 				"@types/node": "^10.14.6"
 			}
 		},
 		"@microsoft/fluid-driver-base": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-driver-base/-/fluid-driver-base-0.18.3.tgz",
-			"integrity": "sha1-+CLL45un8VsX9CP8ocqN712Gdhk=",
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-driver-base/-/fluid-driver-base-0.18.4.tgz",
+			"integrity": "sha1-hQ8YmtazIqfVy9JuSo4tDPmVzMs=",
 			"requires": {
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-driver-definitions": "^0.18.3",
-				"@microsoft/fluid-driver-utils": "^0.18.3",
+				"@microsoft/fluid-driver-definitions": "^0.18.4",
+				"@microsoft/fluid-driver-utils": "^0.18.4",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
 				"@types/debug": "^0.0.31",
 				"@types/node": "^10.14.6",
@@ -2422,32 +2422,32 @@
 			}
 		},
 		"@microsoft/fluid-driver-definitions": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-driver-definitions/-/fluid-driver-definitions-0.18.3.tgz",
-			"integrity": "sha1-mRFoYpTrP0Xnu7vIXCmQjAl9eIo=",
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-driver-definitions/-/fluid-driver-definitions-0.18.4.tgz",
+			"integrity": "sha1-9mI18asQfU4vQt9gYMgRV4lXZGA=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1"
 			}
 		},
 		"@microsoft/fluid-driver-utils": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-driver-utils/-/fluid-driver-utils-0.18.3.tgz",
-			"integrity": "sha1-sbqOKgvjtMLl0odZAA4oatM2T+w=",
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-driver-utils/-/fluid-driver-utils-0.18.4.tgz",
+			"integrity": "sha1-aeTbQ0OBPwR7uTD5WIn9JvzZG5A=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
-				"@microsoft/fluid-driver-definitions": "^0.18.3",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4",
+				"@microsoft/fluid-driver-definitions": "^0.18.4",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1"
 			}
 		},
 		"@microsoft/fluid-framework-interfaces": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-framework-interfaces/-/fluid-framework-interfaces-0.18.3.tgz",
-			"integrity": "sha1-BNqsX9/LjPXey4qR0FJDDPXo37Y=",
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-framework-interfaces/-/fluid-framework-interfaces-0.18.4.tgz",
+			"integrity": "sha1-cP783Oc/ADcl//yL9P1/Pz0tVoo=",
 			"requires": {
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3"
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4"
 			}
 		},
 		"@microsoft/fluid-gitresources": {
@@ -2456,18 +2456,18 @@
 			"integrity": "sha1-WVO1ox1/sSeTSct9g4AT930j++s="
 		},
 		"@microsoft/fluid-local-driver": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-local-driver/-/fluid-local-driver-0.18.3.tgz",
-			"integrity": "sha1-4/iQ6DbSZF10qLC7fSRZ6qxZGLE=",
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-local-driver/-/fluid-local-driver-0.18.4.tgz",
+			"integrity": "sha1-Dnvudm4xAxeyX/Hx16IEnZOH5vw=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
-				"@microsoft/fluid-container-definitions": "^0.18.3",
-				"@microsoft/fluid-driver-definitions": "^0.18.3",
-				"@microsoft/fluid-driver-utils": "^0.18.3",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4",
+				"@microsoft/fluid-container-definitions": "^0.18.4",
+				"@microsoft/fluid-driver-definitions": "^0.18.4",
+				"@microsoft/fluid-driver-utils": "^0.18.4",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
-				"@microsoft/fluid-routerlicious-driver": "^0.18.3",
+				"@microsoft/fluid-routerlicious-driver": "^0.18.4",
 				"@microsoft/fluid-server-local-server": "^0.1005.1",
 				"@microsoft/fluid-server-services-client": "^0.1005.1",
 				"@microsoft/fluid-server-services-core": "^0.1005.1",
@@ -2476,17 +2476,17 @@
 			}
 		},
 		"@microsoft/fluid-map": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-map/-/fluid-map-0.18.3.tgz",
-			"integrity": "sha1-OCsPN4Y7VKUSr+mtxq6dh4JuvAk=",
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-map/-/fluid-map-0.18.4.tgz",
+			"integrity": "sha1-DMEABNEVPv7X3lv5yGF2ZHkUkI0=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
-				"@microsoft/fluid-component-runtime-definitions": "^0.18.3",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4",
+				"@microsoft/fluid-component-runtime-definitions": "^0.18.4",
 				"@microsoft/fluid-protocol-base": "^0.1005.1",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
-				"@microsoft/fluid-shared-object-base": "^0.18.3",
+				"@microsoft/fluid-shared-object-base": "^0.18.4",
 				"debug": "^4.1.1"
 			}
 		},
@@ -2517,28 +2517,28 @@
 			}
 		},
 		"@microsoft/fluid-register-collection": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-register-collection/-/fluid-register-collection-0.18.3.tgz",
-			"integrity": "sha1-Dr16qZyyEvN5A0XNWpq4z/BPaOY=",
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-register-collection/-/fluid-register-collection-0.18.4.tgz",
+			"integrity": "sha1-5If0jzQURwREcgPLneOPf+W0hUo=",
 			"requires": {
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-component-runtime-definitions": "^0.18.3",
+				"@microsoft/fluid-component-runtime-definitions": "^0.18.4",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
-				"@microsoft/fluid-runtime-utils": "^0.18.3",
-				"@microsoft/fluid-shared-object-base": "^0.18.3",
+				"@microsoft/fluid-runtime-utils": "^0.18.4",
+				"@microsoft/fluid-shared-object-base": "^0.18.4",
 				"debug": "^4.1.1"
 			}
 		},
 		"@microsoft/fluid-routerlicious-driver": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-routerlicious-driver/-/fluid-routerlicious-driver-0.18.3.tgz",
-			"integrity": "sha1-Q0Urlx3zRu8Kaja1j2osAz04DG8=",
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-routerlicious-driver/-/fluid-routerlicious-driver-0.18.4.tgz",
+			"integrity": "sha1-7xGMPlerwvh3cB9VY1jYLKuWFvE=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-driver-base": "^0.18.3",
-				"@microsoft/fluid-driver-definitions": "^0.18.3",
-				"@microsoft/fluid-driver-utils": "^0.18.3",
+				"@microsoft/fluid-driver-base": "^0.18.4",
+				"@microsoft/fluid-driver-definitions": "^0.18.4",
+				"@microsoft/fluid-driver-utils": "^0.18.4",
 				"@microsoft/fluid-gitresources": "^0.1005.1",
 				"@microsoft/fluid-protocol-base": "^0.1005.1",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
@@ -2559,27 +2559,27 @@
 			}
 		},
 		"@microsoft/fluid-runtime-definitions": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-runtime-definitions/-/fluid-runtime-definitions-0.18.3.tgz",
-			"integrity": "sha1-U90lJfsjh84tyaupVqiCUdpDnwo=",
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-runtime-definitions/-/fluid-runtime-definitions-0.18.4.tgz",
+			"integrity": "sha1-vGyFGGi4EDlzARsmL3vobWtM4Hk=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
-				"@microsoft/fluid-container-definitions": "^0.18.3",
-				"@microsoft/fluid-driver-definitions": "^0.18.3",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4",
+				"@microsoft/fluid-container-definitions": "^0.18.4",
+				"@microsoft/fluid-driver-definitions": "^0.18.4",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
 				"@types/node": "^10.14.6"
 			}
 		},
 		"@microsoft/fluid-runtime-utils": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-runtime-utils/-/fluid-runtime-utils-0.18.3.tgz",
-			"integrity": "sha1-oSaKI9Po6XCnVKF2bp3TQ+c/U1g=",
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-runtime-utils/-/fluid-runtime-utils-0.18.4.tgz",
+			"integrity": "sha1-iKxJAxMcQMLIF0WAGgyfOC8EqI4=",
 			"requires": {
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
-				"@microsoft/fluid-component-runtime-definitions": "^0.18.3",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4",
+				"@microsoft/fluid-component-runtime-definitions": "^0.18.4",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
-				"@microsoft/fluid-runtime-definitions": "^0.18.3"
+				"@microsoft/fluid-runtime-definitions": "^0.18.4"
 			}
 		},
 		"@microsoft/fluid-server-lambdas": {
@@ -2733,15 +2733,15 @@
 			}
 		},
 		"@microsoft/fluid-shared-object-base": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-shared-object-base/-/fluid-shared-object-base-0.18.3.tgz",
-			"integrity": "sha1-+dVhvUggD5y+2uEtX8rt/bQhfcA=",
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-shared-object-base/-/fluid-shared-object-base-0.18.4.tgz",
+			"integrity": "sha1-XFrdWIJVq0ywlahioYc67cc1Wy0=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
-				"@microsoft/fluid-component-runtime-definitions": "^0.18.3",
-				"@microsoft/fluid-container-definitions": "^0.18.3",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4",
+				"@microsoft/fluid-component-runtime-definitions": "^0.18.4",
+				"@microsoft/fluid-container-definitions": "^0.18.4",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
 				"@types/debug": "^0.0.31",
 				"@types/double-ended-queue": "^2.1.0",
@@ -2758,19 +2758,19 @@
 			}
 		},
 		"@microsoft/fluid-synthesize": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-synthesize/-/fluid-synthesize-0.18.3.tgz",
-			"integrity": "sha1-FPqHQPSeLI/irT5Ch1EGwvTzZZM=",
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-synthesize/-/fluid-synthesize-0.18.4.tgz",
+			"integrity": "sha1-e71NTjj00+bFmdLqvTosjNPJE4w=",
 			"requires": {
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3"
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4"
 			}
 		},
 		"@microsoft/fluid-web-code-loader": {
-			"version": "0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-web-code-loader/-/fluid-web-code-loader-0.18.3.tgz",
-			"integrity": "sha1-IXbaP3UCv6tdnSvm+AUn+IEtnkM=",
+			"version": "0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-web-code-loader/-/fluid-web-code-loader-0.18.4.tgz",
+			"integrity": "sha1-6OLvROh1aTBbiWTELr3rK7XawUs=",
 			"requires": {
-				"@microsoft/fluid-container-definitions": "^0.18.3",
+				"@microsoft/fluid-container-definitions": "^0.18.4",
 				"@types/node": "^10.14.6",
 				"isomorphic-fetch": "^2.2.1"
 			}
@@ -14901,48 +14901,48 @@
 			}
 		},
 		"old-aqueduct": {
-			"version": "npm:@microsoft/fluid-aqueduct@0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-aqueduct/-/fluid-aqueduct-0.18.3.tgz",
-			"integrity": "sha1-KVLfYQ2IK6yAZXwI/Kjf/zyvfGc=",
+			"version": "npm:@microsoft/fluid-aqueduct@0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-aqueduct/-/fluid-aqueduct-0.18.4.tgz",
+			"integrity": "sha1-yxqy04RTM5gsrzHXrQsXznX7lHw=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
-				"@microsoft/fluid-component-runtime": "^0.18.3",
-				"@microsoft/fluid-component-runtime-definitions": "^0.18.3",
-				"@microsoft/fluid-container-definitions": "^0.18.3",
-				"@microsoft/fluid-container-runtime": "^0.18.3",
-				"@microsoft/fluid-container-runtime-definitions": "^0.18.3",
-				"@microsoft/fluid-framework-interfaces": "^0.18.3",
-				"@microsoft/fluid-map": "^0.18.3",
-				"@microsoft/fluid-runtime-definitions": "^0.18.3",
-				"@microsoft/fluid-shared-object-base": "^0.18.3",
-				"@microsoft/fluid-synthesize": "^0.18.3",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4",
+				"@microsoft/fluid-component-runtime": "^0.18.4",
+				"@microsoft/fluid-component-runtime-definitions": "^0.18.4",
+				"@microsoft/fluid-container-definitions": "^0.18.4",
+				"@microsoft/fluid-container-runtime": "^0.18.4",
+				"@microsoft/fluid-container-runtime-definitions": "^0.18.4",
+				"@microsoft/fluid-framework-interfaces": "^0.18.4",
+				"@microsoft/fluid-map": "^0.18.4",
+				"@microsoft/fluid-runtime-definitions": "^0.18.4",
+				"@microsoft/fluid-shared-object-base": "^0.18.4",
+				"@microsoft/fluid-synthesize": "^0.18.4",
 				"uuid": "^3.3.2"
 			}
 		},
 		"old-container-definitions": {
-			"version": "npm:@microsoft/fluid-container-definitions@0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-definitions/-/fluid-container-definitions-0.18.3.tgz",
-			"integrity": "sha1-5oVP+HGt2FlfB6sTF2Cg329gSvM=",
+			"version": "npm:@microsoft/fluid-container-definitions@0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-definitions/-/fluid-container-definitions-0.18.4.tgz",
+			"integrity": "sha1-DsjhyqE4CUw4WrgX3nzHhdZm3io=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
-				"@microsoft/fluid-driver-definitions": "^0.18.3",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4",
+				"@microsoft/fluid-driver-definitions": "^0.18.4",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1"
 			}
 		},
 		"old-container-loader": {
-			"version": "npm:@microsoft/fluid-container-loader@0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-loader/-/fluid-container-loader-0.18.3.tgz",
-			"integrity": "sha1-3RGxVdc+LU6JD7007RDCWDmefTI=",
+			"version": "npm:@microsoft/fluid-container-loader@0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-container-loader/-/fluid-container-loader-0.18.4.tgz",
+			"integrity": "sha1-W5rGuZdY8yDS6Dzt6QaGeoxJTYc=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
 				"@microsoft/fluid-common-utils": "^0.18.2",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
-				"@microsoft/fluid-container-definitions": "^0.18.3",
-				"@microsoft/fluid-driver-definitions": "^0.18.3",
-				"@microsoft/fluid-driver-utils": "^0.18.3",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4",
+				"@microsoft/fluid-container-definitions": "^0.18.4",
+				"@microsoft/fluid-driver-definitions": "^0.18.4",
+				"@microsoft/fluid-driver-utils": "^0.18.4",
 				"@microsoft/fluid-protocol-base": "^0.1005.1",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
 				"@types/double-ended-queue": "^2.1.0",
@@ -14955,35 +14955,35 @@
 			}
 		},
 		"old-runtime-definitions": {
-			"version": "npm:@microsoft/fluid-runtime-definitions@0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-runtime-definitions/-/fluid-runtime-definitions-0.18.3.tgz",
-			"integrity": "sha1-U90lJfsjh84tyaupVqiCUdpDnwo=",
+			"version": "npm:@microsoft/fluid-runtime-definitions@0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-runtime-definitions/-/fluid-runtime-definitions-0.18.4.tgz",
+			"integrity": "sha1-vGyFGGi4EDlzARsmL3vobWtM4Hk=",
 			"requires": {
 				"@microsoft/fluid-common-definitions": "^0.17.0",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
-				"@microsoft/fluid-container-definitions": "^0.18.3",
-				"@microsoft/fluid-driver-definitions": "^0.18.3",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4",
+				"@microsoft/fluid-container-definitions": "^0.18.4",
+				"@microsoft/fluid-driver-definitions": "^0.18.4",
 				"@microsoft/fluid-protocol-definitions": "^0.1005.1",
 				"@types/node": "^10.14.6"
 			}
 		},
 		"old-test-utils": {
-			"version": "npm:@microsoft/fluid-test-utils@0.18.3",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-test-utils/-/fluid-test-utils-0.18.3.tgz",
-			"integrity": "sha1-jIt4FcYTM+1Fh5unFAFnnm336I4=",
+			"version": "npm:@microsoft/fluid-test-utils@0.18.4",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/fluid-test-utils/-/fluid-test-utils-0.18.4.tgz",
+			"integrity": "sha1-1jHiUY83iiz/1mXqIcNRpycPHjo=",
 			"requires": {
-				"@microsoft/fluid-aqueduct": "^0.18.3",
-				"@microsoft/fluid-base-host": "^0.18.3",
-				"@microsoft/fluid-component-core-interfaces": "^0.18.3",
-				"@microsoft/fluid-component-runtime": "^0.18.3",
-				"@microsoft/fluid-component-runtime-definitions": "^0.18.3",
-				"@microsoft/fluid-container-definitions": "^0.18.3",
-				"@microsoft/fluid-container-loader": "^0.18.3",
-				"@microsoft/fluid-local-driver": "^0.18.3",
-				"@microsoft/fluid-map": "^0.18.3",
-				"@microsoft/fluid-runtime-definitions": "^0.18.3",
+				"@microsoft/fluid-aqueduct": "^0.18.4",
+				"@microsoft/fluid-base-host": "^0.18.4",
+				"@microsoft/fluid-component-core-interfaces": "^0.18.4",
+				"@microsoft/fluid-component-runtime": "^0.18.4",
+				"@microsoft/fluid-component-runtime-definitions": "^0.18.4",
+				"@microsoft/fluid-container-definitions": "^0.18.4",
+				"@microsoft/fluid-container-loader": "^0.18.4",
+				"@microsoft/fluid-local-driver": "^0.18.4",
+				"@microsoft/fluid-map": "^0.18.4",
+				"@microsoft/fluid-runtime-definitions": "^0.18.4",
 				"@microsoft/fluid-server-local-server": "^0.1005.1",
-				"@microsoft/fluid-shared-object-base": "^0.18.3"
+				"@microsoft/fluid-shared-object-base": "^0.18.4"
 			}
 		},
 		"on-finished": {

--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -101,7 +101,7 @@ export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>
     minimumSequenceNumber: number;
 
     // The last sequence number processed by the delta manager
-    referenceSequenceNumber: number;
+    currentSequenceNumber: number;
 
     // The initial sequence number set when attaching the op handler
     initialSequenceNumber: number;

--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -101,7 +101,7 @@ export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>
     minimumSequenceNumber: number;
 
     // The last sequence number processed by the delta manager
-    currentSequenceNumber: number;
+    lastSequenceNumber: number;
 
     // The initial sequence number set when attaching the op handler
     initialSequenceNumber: number;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -445,7 +445,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 {
                     eventName: "ContainerClose",
                     // record sequence number for easier debugging
-                    sequenceNumber: this._deltaManager.referenceSequenceNumber,
+                    sequenceNumber: this._deltaManager.currentSequenceNumber,
                 },
                 error,
             );
@@ -705,7 +705,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         const attributes: IDocumentAttributes = {
             branch: this.id,
             minimumSequenceNumber: this._deltaManager.minimumSequenceNumber,
-            sequenceNumber: this._deltaManager.referenceSequenceNumber,
+            sequenceNumber: this._deltaManager.currentSequenceNumber,
             term: this._deltaManager.referenceTerm,
         };
 
@@ -729,7 +729,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         // Generate base snapshot message
         const deltaDetails =
-            `${this._deltaManager.referenceSequenceNumber}:${this._deltaManager.minimumSequenceNumber}`;
+            `${this._deltaManager.currentSequenceNumber}:${this._deltaManager.minimumSequenceNumber}`;
         const message = `Commit @${deltaDetails} ${tagMessage}`;
 
         // Pull in the prior version and snapshot tree to store against
@@ -788,7 +788,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         const documentAttributes = {
             branch: this.id,
             minimumSequenceNumber: this._deltaManager.minimumSequenceNumber,
-            sequenceNumber: this._deltaManager.referenceSequenceNumber,
+            sequenceNumber: this._deltaManager.currentSequenceNumber,
             term: this._deltaManager.referenceTerm,
         };
         entries.push({

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -448,7 +448,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             this.logger.sendErrorEvent(
                 {
                     eventName: "ContainerClose",
-                    sequenceNumber: error.sequenceNumber ?? this._deltaManager.currentSequenceNumber,
+                    sequenceNumber: error.sequenceNumber ?? this._deltaManager.lastSequenceNumber,
                 },
                 error,
             );
@@ -708,7 +708,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         const attributes: IDocumentAttributes = {
             branch: this.id,
             minimumSequenceNumber: this._deltaManager.minimumSequenceNumber,
-            sequenceNumber: this._deltaManager.currentSequenceNumber,
+            sequenceNumber: this._deltaManager.lastSequenceNumber,
             term: this._deltaManager.referenceTerm,
         };
 
@@ -732,7 +732,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         // Generate base snapshot message
         const deltaDetails =
-            `${this._deltaManager.currentSequenceNumber}:${this._deltaManager.minimumSequenceNumber}`;
+            `${this._deltaManager.lastSequenceNumber}:${this._deltaManager.minimumSequenceNumber}`;
         const message = `Commit @${deltaDetails} ${tagMessage}`;
 
         // Pull in the prior version and snapshot tree to store against
@@ -791,7 +791,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         const documentAttributes = {
             branch: this.id,
             minimumSequenceNumber: this._deltaManager.minimumSequenceNumber,
-            sequenceNumber: this._deltaManager.currentSequenceNumber,
+            sequenceNumber: this._deltaManager.lastSequenceNumber,
             term: this._deltaManager.referenceTerm,
         };
         entries.push({

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -135,7 +135,7 @@ export class DeltaManager
     // There are three numbers we track
     // * lastQueuedSequenceNumber is the last queued sequence number
     private lastQueuedSequenceNumber: number = 0;
-    private _currentSequenceNumber: number = 0;
+    private _lastSequenceNumber: number = 0;
     private baseTerm: number = 0;
 
     // The sequence number we initially loaded from
@@ -182,8 +182,8 @@ export class DeltaManager
         return this.initSequenceNumber;
     }
 
-    public get currentSequenceNumber(): number {
-        return this._currentSequenceNumber;
+    public get lastSequenceNumber(): number {
+        return this._lastSequenceNumber;
     }
 
     public get referenceTerm(): number {
@@ -378,7 +378,7 @@ export class DeltaManager
         debug("Attached op handler", sequenceNumber);
 
         this.initSequenceNumber = sequenceNumber;
-        this._currentSequenceNumber = sequenceNumber;
+        this._lastSequenceNumber = sequenceNumber;
         this.baseTerm = term;
         this.minSequenceNumber = minSequenceNumber;
         this.lastQueuedSequenceNumber = sequenceNumber;
@@ -581,7 +581,7 @@ export class DeltaManager
             clientSequenceNumber: ++this.clientSequenceNumber,
             contents: JSON.stringify(contents),
             metadata,
-            referenceSequenceNumber: this._currentSequenceNumber,
+            referenceSequenceNumber: this._lastSequenceNumber,
             traces,
             type,
         };
@@ -1088,7 +1088,7 @@ export class DeltaManager
             // We did not setup handler yet.
             // This happens when we connect to web socket faster than we get attributes for container
             // and thus faster than attachOpHandler() is called
-            // this._currentSequenceNumber is still zero, so we can't rely on this.fetchMissingDeltas()
+            // this._lastSequenceNumber is still zero, so we can't rely on this.fetchMissingDeltas()
             // to do the right thing.
             this.pending = this.pending.concat(messages);
             return;
@@ -1172,8 +1172,8 @@ export class DeltaManager
         assert(this.minSequenceNumber <= message.minimumSequenceNumber, "msn moves backwards");
         this.minSequenceNumber = message.minimumSequenceNumber;
 
-        assert.equal(message.sequenceNumber, this._currentSequenceNumber + 1, "non-seq seq#");
-        this._currentSequenceNumber = message.sequenceNumber;
+        assert.equal(message.sequenceNumber, this._lastSequenceNumber + 1, "non-seq seq#");
+        this._lastSequenceNumber = message.sequenceNumber;
 
         // Back-compat for older server with no term
         this.baseTerm = message.term === undefined ? 1 : message.term;

--- a/packages/loader/container-loader/src/deltaManagerProxy.ts
+++ b/packages/loader/container-loader/src/deltaManagerProxy.ts
@@ -96,13 +96,13 @@ export class DeltaManagerProxy
         return this.deltaManager.minimumSequenceNumber;
     }
 
-    public get currentSequenceNumber(): number {
-        return this.deltaManager.currentSequenceNumber;
+    public get lastSequenceNumber(): number {
+        return this.deltaManager.lastSequenceNumber;
     }
 
     // Back-compat: <= 0.18
     public get referenceSequenceNumber(): number {
-        return this.currentSequenceNumber;
+        return this.lastSequenceNumber;
     }
 
     public get initialSequenceNumber(): number {

--- a/packages/loader/container-loader/src/deltaManagerProxy.ts
+++ b/packages/loader/container-loader/src/deltaManagerProxy.ts
@@ -96,8 +96,13 @@ export class DeltaManagerProxy
         return this.deltaManager.minimumSequenceNumber;
     }
 
+    public get currentSequenceNumber(): number {
+        return this.deltaManager.currentSequenceNumber;
+    }
+
+    // Back-compat: <= 0.18
     public get referenceSequenceNumber(): number {
-        return this.deltaManager.referenceSequenceNumber;
+        return this.currentSequenceNumber;
     }
 
     public get initialSequenceNumber(): number {

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -269,7 +269,7 @@ export class Loader extends EventEmitter implements ILoader {
                     this.logger);
         }
 
-        if (container.deltaManager.referenceSequenceNumber <= fromSequenceNumber) {
+        if (container.deltaManager.currentSequenceNumber <= fromSequenceNumber) {
             await new Promise((resolve, reject) => {
                 function opHandler(message: ISequencedDocumentMessage) {
                     if (message.sequenceNumber > fromSequenceNumber) {

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -269,7 +269,7 @@ export class Loader extends EventEmitter implements ILoader {
                     this.logger);
         }
 
-        if (container.deltaManager.currentSequenceNumber <= fromSequenceNumber) {
+        if (container.deltaManager.lastSequenceNumber <= fromSequenceNumber) {
             await new Promise((resolve, reject) => {
                 function opHandler(message: ISequencedDocumentMessage) {
                     if (message.sequenceNumber > fromSequenceNumber) {

--- a/packages/runtime/agent-scheduler/src/scheduler.ts
+++ b/packages/runtime/agent-scheduler/src/scheduler.ts
@@ -443,7 +443,7 @@ export class TaskManager implements ITaskManager {
                     type: "agent",
                 },
                 [LoaderHeader.reconnect]: false,
-                [LoaderHeader.sequenceNumber]: this.context.deltaManager.referenceSequenceNumber,
+                [LoaderHeader.sequenceNumber]: this.context.deltaManager.currentSequenceNumber,
                 [LoaderHeader.executionContext]: worker ? "worker" : undefined,
             },
             url,

--- a/packages/runtime/agent-scheduler/src/scheduler.ts
+++ b/packages/runtime/agent-scheduler/src/scheduler.ts
@@ -443,7 +443,7 @@ export class TaskManager implements ITaskManager {
                     type: "agent",
                 },
                 [LoaderHeader.reconnect]: false,
-                [LoaderHeader.sequenceNumber]: this.context.deltaManager.currentSequenceNumber,
+                [LoaderHeader.sequenceNumber]: this.context.deltaManager.lastSequenceNumber,
                 [LoaderHeader.executionContext]: worker ? "worker" : undefined,
             },
             url,

--- a/packages/runtime/component-runtime/src/componentRuntime.ts
+++ b/packages/runtime/component-runtime/src/componentRuntime.ts
@@ -183,7 +183,7 @@ export class ComponentRuntime extends EventEmitter implements IComponentRuntimeC
                     componentContext.branch,
                     this.componentContext.summaryTracker.createOrGetChild(
                         path,
-                        this.deltaManager.referenceSequenceNumber,
+                        this.deltaManager.currentSequenceNumber,
                     ));
                 const deferred = new Deferred<IChannelContext>();
                 deferred.resolve(channelContext);

--- a/packages/runtime/component-runtime/src/componentRuntime.ts
+++ b/packages/runtime/component-runtime/src/componentRuntime.ts
@@ -183,7 +183,7 @@ export class ComponentRuntime extends EventEmitter implements IComponentRuntimeC
                     componentContext.branch,
                     this.componentContext.summaryTracker.createOrGetChild(
                         path,
-                        this.deltaManager.currentSequenceNumber,
+                        this.deltaManager.lastSequenceNumber,
                     ));
                 const deferred = new Deferred<IChannelContext>();
                 deferred.resolve(channelContext);

--- a/packages/runtime/consensus-register-collection/src/consensusRegisterCollection.ts
+++ b/packages/runtime/consensus-register-collection/src/consensusRegisterCollection.ts
@@ -161,7 +161,7 @@ export class ConsensusRegisterCollection<T>
             key,
             type: "write",
             serializedValue,
-            refSeq: this.runtime.deltaManager.currentSequenceNumber,
+            refSeq: this.runtime.deltaManager.lastSequenceNumber,
         };
 
         const clientSequenceNumber = this.submitLocalMessage(message);

--- a/packages/runtime/consensus-register-collection/src/consensusRegisterCollection.ts
+++ b/packages/runtime/consensus-register-collection/src/consensusRegisterCollection.ts
@@ -161,7 +161,7 @@ export class ConsensusRegisterCollection<T>
             key,
             type: "write",
             serializedValue,
-            refSeq: this.runtime.deltaManager.referenceSequenceNumber,
+            refSeq: this.runtime.deltaManager.currentSequenceNumber,
         };
 
         const clientSequenceNumber = this.submitLocalMessage(message);

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -427,7 +427,7 @@ export abstract class ComponentContext extends EventEmitter implements
         this.verifyNotClosed();
 
         // Get the latest sequence number.
-        const latestSequenceNumber = this.deltaManager.currentSequenceNumber;
+        const latestSequenceNumber = this.deltaManager.lastSequenceNumber;
 
         // Update our summary tracker's latestSequenceNumber.
         this.summaryTracker.updateLatestSequenceNumber(latestSequenceNumber);

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -427,7 +427,7 @@ export abstract class ComponentContext extends EventEmitter implements
         this.verifyNotClosed();
 
         // Get the latest sequence number.
-        const latestSequenceNumber = this.deltaManager.referenceSequenceNumber;
+        const latestSequenceNumber = this.deltaManager.currentSequenceNumber;
 
         // Update our summary tracker's latestSequenceNumber.
         this.summaryTracker.updateLatestSequenceNumber(latestSequenceNumber);

--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -64,7 +64,7 @@ class ConnectionTelemetry {
                 this.logger.sendTelemetryEvent({
                     eventName: "MsnStatistics",
                     sequenceNumber: message.sequenceNumber,
-                    msnDistance: this.deltaManager.currentSequenceNumber - this.deltaManager.minimumSequenceNumber,
+                    msnDistance: this.deltaManager.lastSequenceNumber - this.deltaManager.minimumSequenceNumber,
                     timeDelta: message.timestamp - this.opSendTimeForLatencyStatisticsForMsnStatistics,
                 });
             }

--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -64,7 +64,7 @@ class ConnectionTelemetry {
                 this.logger.sendTelemetryEvent({
                     eventName: "MsnStatistics",
                     sequenceNumber: message.sequenceNumber,
-                    msnDistance: this.deltaManager.referenceSequenceNumber - this.deltaManager.minimumSequenceNumber,
+                    msnDistance: this.deltaManager.currentSequenceNumber - this.deltaManager.minimumSequenceNumber,
                     timeDelta: message.timestamp - this.opSendTimeForLatencyStatisticsForMsnStatistics,
                 });
             }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -233,7 +233,7 @@ export class ScheduleManager {
         }
 
         // Based on track pending update the pause state
-        this.updatePauseState(this.deltaManager.referenceSequenceNumber);
+        this.updatePauseState(this.deltaManager.currentSequenceNumber);
     }
 
     public beginOperation(message: ISequencedDocumentMessage) {
@@ -989,7 +989,7 @@ export class ContainerRuntime extends EventEmitter implements IContainerRuntime,
             this,
             this.storage,
             this.containerScope,
-            this.summaryTracker.createOrGetChild(id, this.deltaManager.referenceSequenceNumber),
+            this.summaryTracker.createOrGetChild(id, this.deltaManager.currentSequenceNumber),
             (cr: IComponentRuntimeChannel) => this.attachComponent(cr),
             props);
 
@@ -1014,7 +1014,7 @@ export class ContainerRuntime extends EventEmitter implements IContainerRuntime,
             this,
             this.storage,
             this.containerScope,
-            this.summaryTracker.createOrGetChild(id, this.deltaManager.referenceSequenceNumber),
+            this.summaryTracker.createOrGetChild(id, this.deltaManager.currentSequenceNumber),
             (cr: IComponentRuntimeChannel) => this.attachComponent(cr),
             undefined /* #1635: Remove LocalComponentContext createProps */);
 
@@ -1296,7 +1296,7 @@ export class ContainerRuntime extends EventEmitter implements IContainerRuntime,
         safe: boolean = false,
     ): Promise<GenerateSummaryData | undefined> {
         const message =
-            `Summary @${this.deltaManager.referenceSequenceNumber}:${this.deltaManager.minimumSequenceNumber}`;
+            `Summary @${this.deltaManager.currentSequenceNumber}:${this.deltaManager.minimumSequenceNumber}`;
 
         // TODO: Issue-2171 Support for Branch Snapshots
         if (this.parentBranch) {
@@ -1311,7 +1311,7 @@ export class ContainerRuntime extends EventEmitter implements IContainerRuntime,
             await this.scheduleManager.pause();
 
             const attemptData: IUnsubmittedSummaryData = {
-                referenceSequenceNumber: this.deltaManager.referenceSequenceNumber,
+                referenceSequenceNumber: this.deltaManager.currentSequenceNumber,
                 submitted: false,
             };
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -233,7 +233,7 @@ export class ScheduleManager {
         }
 
         // Based on track pending update the pause state
-        this.updatePauseState(this.deltaManager.currentSequenceNumber);
+        this.updatePauseState(this.deltaManager.lastSequenceNumber);
     }
 
     public beginOperation(message: ISequencedDocumentMessage) {
@@ -989,7 +989,7 @@ export class ContainerRuntime extends EventEmitter implements IContainerRuntime,
             this,
             this.storage,
             this.containerScope,
-            this.summaryTracker.createOrGetChild(id, this.deltaManager.currentSequenceNumber),
+            this.summaryTracker.createOrGetChild(id, this.deltaManager.lastSequenceNumber),
             (cr: IComponentRuntimeChannel) => this.attachComponent(cr),
             props);
 
@@ -1014,7 +1014,7 @@ export class ContainerRuntime extends EventEmitter implements IContainerRuntime,
             this,
             this.storage,
             this.containerScope,
-            this.summaryTracker.createOrGetChild(id, this.deltaManager.currentSequenceNumber),
+            this.summaryTracker.createOrGetChild(id, this.deltaManager.lastSequenceNumber),
             (cr: IComponentRuntimeChannel) => this.attachComponent(cr),
             undefined /* #1635: Remove LocalComponentContext createProps */);
 
@@ -1296,7 +1296,7 @@ export class ContainerRuntime extends EventEmitter implements IContainerRuntime,
         safe: boolean = false,
     ): Promise<GenerateSummaryData | undefined> {
         const message =
-            `Summary @${this.deltaManager.currentSequenceNumber}:${this.deltaManager.minimumSequenceNumber}`;
+            `Summary @${this.deltaManager.lastSequenceNumber}:${this.deltaManager.minimumSequenceNumber}`;
 
         // TODO: Issue-2171 Support for Branch Snapshots
         if (this.parentBranch) {
@@ -1311,7 +1311,7 @@ export class ContainerRuntime extends EventEmitter implements IContainerRuntime,
             await this.scheduleManager.pause();
 
             const attemptData: IUnsubmittedSummaryData = {
-                referenceSequenceNumber: this.deltaManager.currentSequenceNumber,
+                referenceSequenceNumber: this.deltaManager.lastSequenceNumber,
                 submitted: false,
             };
 

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -672,7 +672,7 @@ export class Summarizer extends EventEmitter implements ISummarizer {
             this.summaryCollection.createWatcher(startResult.clientId),
             this.configurationGetter(),
             async (full: boolean, safe: boolean) => this.generateSummary(full, safe),
-            this.runtime.deltaManager.currentSequenceNumber,
+            this.runtime.deltaManager.lastSequenceNumber,
             initialAttempt,
             this.immediateSummary,
             (description: string) =>

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -672,7 +672,7 @@ export class Summarizer extends EventEmitter implements ISummarizer {
             this.summaryCollection.createWatcher(startResult.clientId),
             this.configurationGetter(),
             async (full: boolean, safe: boolean) => this.generateSummary(full, safe),
-            this.runtime.deltaManager.referenceSequenceNumber,
+            this.runtime.deltaManager.currentSequenceNumber,
             initialAttempt,
             this.immediateSummary,
             (description: string) =>

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -424,7 +424,7 @@ export class SummaryManager extends EventEmitter implements IDisposable {
                     type: "summarizer",
                 },
                 [LoaderHeader.reconnect]: false,
-                [LoaderHeader.sequenceNumber]: this.context.deltaManager.referenceSequenceNumber,
+                [LoaderHeader.sequenceNumber]: this.context.deltaManager.currentSequenceNumber,
                 [LoaderHeader.executionContext]: this.enableWorker ? "worker" : undefined,
             },
             url: "/_summarizer",

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -424,7 +424,7 @@ export class SummaryManager extends EventEmitter implements IDisposable {
                     type: "summarizer",
                 },
                 [LoaderHeader.reconnect]: false,
-                [LoaderHeader.sequenceNumber]: this.context.deltaManager.currentSequenceNumber,
+                [LoaderHeader.sequenceNumber]: this.context.deltaManager.lastSequenceNumber,
                 [LoaderHeader.executionContext]: this.enableWorker ? "worker" : undefined,
             },
             url: "/_summarizer",

--- a/packages/runtime/merge-tree/src/client.ts
+++ b/packages/runtime/merge-tree/src/client.ts
@@ -892,7 +892,7 @@ export class Client {
         // Required for case where ComponentRuntime.attachChannel() generates snapshot right after loading component.
         // Note that we mock runtime in tests and mock does not have deltamanager implementation.
         if (deltaManager) {
-            this.updateSeqNumbers(minSeq, deltaManager.referenceSequenceNumber);
+            this.updateSeqNumbers(minSeq, deltaManager.currentSequenceNumber);
 
             // One of the snapshots (from SPO) I observed to have chunk.chunkSequenceNumber > minSeq!
             // Not sure why - need to catch it sooner

--- a/packages/runtime/merge-tree/src/client.ts
+++ b/packages/runtime/merge-tree/src/client.ts
@@ -892,7 +892,7 @@ export class Client {
         // Required for case where ComponentRuntime.attachChannel() generates snapshot right after loading component.
         // Note that we mock runtime in tests and mock does not have deltamanager implementation.
         if (deltaManager) {
-            this.updateSeqNumbers(minSeq, deltaManager.currentSequenceNumber);
+            this.updateSeqNumbers(minSeq, deltaManager.lastSequenceNumber);
 
             // One of the snapshots (from SPO) I observed to have chunk.chunkSequenceNumber > minSeq!
             // Not sure why - need to catch it sooner

--- a/packages/runtime/runtime-test-utils/src/mockDeltas.ts
+++ b/packages/runtime/runtime-test-utils/src/mockDeltas.ts
@@ -97,7 +97,7 @@ export class MockDeltaManager extends EventEmitter
         return 0;
     }
 
-    public get referenceSequenceNumber(): number {
+    public get currentSequenceNumber(): number {
         return 0;
     }
 

--- a/packages/runtime/runtime-test-utils/src/mockDeltas.ts
+++ b/packages/runtime/runtime-test-utils/src/mockDeltas.ts
@@ -97,7 +97,7 @@ export class MockDeltaManager extends EventEmitter
         return 0;
     }
 
-    public get currentSequenceNumber(): number {
+    public get lastSequenceNumber(): number {
         return 0;
     }
 

--- a/packages/tools/replay-tool/src/replayMessages.ts
+++ b/packages/tools/replay-tool/src/replayMessages.ts
@@ -209,7 +209,7 @@ class Document {
             this.containerDescription,
             errorHandler);
 
-        this.from = this.container.deltaManager.currentSequenceNumber;
+        this.from = this.container.deltaManager.lastSequenceNumber;
         this.replayer = deltaConnection.getReplayer();
 
         this.replayer.currentReplayedOp = this.from;

--- a/packages/tools/replay-tool/src/replayMessages.ts
+++ b/packages/tools/replay-tool/src/replayMessages.ts
@@ -209,7 +209,7 @@ class Document {
             this.containerDescription,
             errorHandler);
 
-        this.from = this.container.deltaManager.referenceSequenceNumber;
+        this.from = this.container.deltaManager.currentSequenceNumber;
         this.replayer = deltaConnection.getReplayer();
 
         this.replayer.currentReplayedOp = this.from;

--- a/server/gateway/src/controllers/workerLoader.ts
+++ b/server/gateway/src/controllers/workerLoader.ts
@@ -77,7 +77,7 @@ class WorkerLoader implements ILoader, IComponentRunnable {
             new BaseTelemetryNullLogger());
         this.container = container;
 
-        if (this.container.deltaManager.referenceSequenceNumber <= this.fromSequenceNumber) {
+        if (this.container.deltaManager.currentSequenceNumber <= this.fromSequenceNumber) {
             await new Promise((resolve, reject) => {
                 const opHandler = (message: ISequencedDocumentMessage) => {
                     if (message.sequenceNumber > this.fromSequenceNumber) {

--- a/server/gateway/src/controllers/workerLoader.ts
+++ b/server/gateway/src/controllers/workerLoader.ts
@@ -77,7 +77,8 @@ class WorkerLoader implements ILoader, IComponentRunnable {
             new BaseTelemetryNullLogger());
         this.container = container;
 
-        if (this.container.deltaManager.currentSequenceNumber <= this.fromSequenceNumber) {
+        // TODO: referenceSequenceNumber -> lastSequenceNumber (when latest loader is picked up)
+        if (this.container.deltaManager.referenceSequenceNumber <= this.fromSequenceNumber) {
             await new Promise((resolve, reject) => {
                 const opHandler = (message: ISequencedDocumentMessage) => {
                     if (message.sequenceNumber > this.fromSequenceNumber) {


### PR DESCRIPTION
Leaving "referenceSequenceNumber" to be used only in context of sequenced message (and not use that wording on API anywhere not to cause confusion).

My only doubt is if we want to use "current" in here, or just use plain "sequenceNumber" to be consistent with nominclature on messages.
I feel like "current" is a bit more descriptive on what this API returns.