### PR TITLE
We do not clear properly event handlers in ODSP driver on disconnect

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentDeltaConnection.ts
@@ -346,5 +346,8 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
             // If it's not critical error, we want to raise event on this object only.
             this.emit("disconnect", reason);
         }
+
+        // Remove all listeners after "disconnect" event was raised.
+        super.removeTrackedListeners(false);
     }
 }

--- a/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
+++ b/packages/drivers/socket-storage-shared/src/documentDeltaConnection.ts
@@ -336,8 +336,8 @@ export class DocumentDeltaConnection
      *  (not on Fluid protocol level)
      */
     public disconnect(socketProtocolError: boolean = false) {
-        this.removeTrackedListeners(false);
         this.socket.disconnect();
+        this.removeTrackedListeners(false);
     }
 
     protected async initialize(connectMessage: IConnect, timeout: number) {
@@ -479,7 +479,7 @@ export class DocumentDeltaConnection
         this.trackedListeners.push({ event, connectionListener: false, listener });
     }
 
-    private removeTrackedListeners(connectionListenerOnly) {
+    protected removeTrackedListeners(connectionListenerOnly) {
         const remaining: IEventListener[] = [];
         for (const { event, connectionListener, listener } of this.trackedListeners) {
             if (!connectionListenerOnly || connectionListener) {


### PR DESCRIPTION
Noticed by doing code inspection.

@tanviraumi, looking over your earlier change in disconnect(), I think it was wrong - if we remove listeners before raising "disconnect" event, then we would never deliver it. Maybe I'm missing something, but on second look, original code that was there looks correct.