### PR TITLE
Spaces toolbar cleanup

### DIFF
--- a/components/experimental/spaces/src/spaces.tsx
+++ b/components/experimental/spaces/src/spaces.tsx
@@ -29,9 +29,9 @@ const SpacesStorageKey = "spaces-storage";
  * ISpacesProps are the public interface that SpacesView will use to communicate with Spaces.
  */
 export interface ISpacesProps {
-    addComponent?(type: string): void;
-    templatesAvailable?: boolean;
-    applyTemplate?(template: Templates): void;
+    addComponent(type: string): void;
+    templatesAvailable: boolean;
+    applyTemplate(template: Templates): void;
 }
 
 /**

--- a/components/experimental/spaces/src/spaces.tsx
+++ b/components/experimental/spaces/src/spaces.tsx
@@ -66,21 +66,20 @@ export class Spaces extends PrimedComponent implements IComponentHTMLView {
             throw new Error("Spaces can't render, storage not found");
         }
 
-        const spacesProps: ISpacesProps = {
-            addComponent: (type: string) => {
-                this.createAndStoreComponent(type, { w: 20, h: 5, x: 0, y: 0 })
-                    .catch((error) => {
-                        console.error(`Error while creating component: ${type}`, error);
-                    });
-            },
-            templatesAvailable: this.internalRegistry?.IComponentRegistryTemplates !== undefined,
-            applyTemplate: this.applyTemplateFromRegistry.bind(this),
+        const addComponent = (type: string) => {
+            this.createAndStoreComponent(type, { w: 20, h: 5, x: 0, y: 0 })
+                .catch((error) => {
+                    console.error(`Error while creating component: ${type}`, error);
+                });
         };
+
         ReactDOM.render(
             <SpacesView
                 supportedComponents={this.supportedComponents}
                 storage={ this.storageComponent }
-                spacesProps={ spacesProps }
+                addComponent={ addComponent }
+                templatesAvailable={ this.internalRegistry?.IComponentRegistryTemplates !== undefined }
+                applyTemplate={ this.applyTemplateFromRegistry.bind(this) }
             />,
             div,
         );

--- a/components/experimental/spaces/src/spaces.tsx
+++ b/components/experimental/spaces/src/spaces.tsx
@@ -26,15 +26,6 @@ import { Templates } from ".";
 const SpacesStorageKey = "spaces-storage";
 
 /**
- * ISpacesProps are the public interface that SpacesView will use to communicate with Spaces.
- */
-export interface ISpacesProps {
-    addComponent(type: string): void;
-    templatesAvailable: boolean;
-    applyTemplate(template: Templates): void;
-}
-
-/**
  * Spaces is the main component, which composes a SpacesToolbar with a SpacesStorage.
  */
 export class Spaces extends PrimedComponent implements IComponentHTMLView {

--- a/components/experimental/spaces/src/spacesToolbar.tsx
+++ b/components/experimental/spaces/src/spacesToolbar.tsx
@@ -18,7 +18,7 @@ import "./spacesToolbarStyle.css";
 initializeIcons();
 
 interface ISpacesToolbarComponentItemProps {
-    components: IInternalRegistryEntry[];
+    supportedComponents: IInternalRegistryEntry[];
     addComponent(type: string): void;
 }
 
@@ -35,7 +35,7 @@ const SpacesToolbarComponentItem: React.FC<ISpacesToolbarComponentItemProps> =
                 {"Add Components"}
             </Button>
         );
-        const componentButtonList = props.components.map((supportedComponent) => {
+        const componentButtonList = props.supportedComponents.map((supportedComponent) => {
             return (
                 <Button
                     className="spaces-toolbar-option-button"
@@ -57,8 +57,8 @@ const SpacesToolbarComponentItem: React.FC<ISpacesToolbarComponentItemProps> =
             <Collapsible
                 open={open}
                 trigger={componentsButton}
-                className="spaces-toolbar-item"
-                openedClassName="spaces-toolbar-item"
+                className="spaces-toolbar-tool"
+                openedClassName="spaces-toolbar-tool"
             >
                 {componentButtonList}
             </Collapsible>
@@ -103,8 +103,8 @@ const SpacesToolbarTemplateItem: React.FC<ISpacesToolbarTemplateItemProps> =
             <Collapsible
                 open={open}
                 trigger={templateButton}
-                className="spaces-toolbar-item"
-                openedClassName="spaces-toolbar-item"
+                className="spaces-toolbar-tool"
+                openedClassName="spaces-toolbar-tool"
             >
                 {templateButtonList}
             </Collapsible>
@@ -126,7 +126,7 @@ export const SpacesToolbar: React.FC<ISpacesToolbarProps> =
 
         // Add the edit button
         toolbarItems.push(
-            <div key="edit" className="spaces-toolbar-item">
+            <div key="edit" className="spaces-toolbar-tool">
                 <Button
                     id="edit"
                     className="spaces-toolbar-top-level-button"
@@ -145,7 +145,7 @@ export const SpacesToolbar: React.FC<ISpacesToolbarProps> =
             toolbarItems.push(
                 <SpacesToolbarComponentItem
                     key="component"
-                    components={props.components}
+                    supportedComponents={props.components}
                     addComponent={props.addComponent}
                 />,
             );

--- a/components/experimental/spaces/src/spacesToolbar.tsx
+++ b/components/experimental/spaces/src/spacesToolbar.tsx
@@ -14,19 +14,7 @@ import {
     ISpacesProps,
     Templates,
 } from ".";
-
-const componentToolbarStyle: React.CSSProperties = { position: "absolute", top: 10, left: 10, zIndex: 1000 };
-const dropDownButtonStyle: React.CSSProperties = { width: "20vh" };
-const menuButtonStyle: React.CSSProperties = { width: "20vh", height: "5vh" };
-const editableButtonStyle: React.CSSProperties = {
-    width: "20vh", height: "5vh", position: "absolute", left: 0, top: 0, margin: "1vh",
-};
-const templateButtonStyle: React.CSSProperties = {
-    width: "20vh", height: "5vh", position: "absolute", left: "40vh", top: 0, margin: "1vh", zIndex: -1,
-};
-const componentButtonStyle: React.CSSProperties = {
-    width: "20vh", height: "5vh", position: "absolute", left: "20vh", top: 0, margin: "1vh", zIndex: -1,
-};
+import "./spacesToolbarStyle.css";
 
 initializeIcons();
 
@@ -47,7 +35,7 @@ export const SpacesToolbar: React.FC<ISpacesToolbarProps> =
         const componentsButton = (
             <Button
                 iconProps={{ iconName: componentListOpen ? "ChevronUpEnd6" : "ChevronDownEnd6" }}
-                style={menuButtonStyle}
+                className="spaces-toolbar-top-level-button"
                 onClick={() => setComponentListOpen(!componentListOpen)}
             >
                 {"Add Components"}
@@ -58,7 +46,7 @@ export const SpacesToolbar: React.FC<ISpacesToolbarProps> =
             props.components.forEach(((supportedComponent: IInternalRegistryEntry) => {
                 componentButtonList.push(
                     <Button
-                        style={dropDownButtonStyle}
+                        className="spaces-toolbar-option-button"
                         key={`componentToolbarButton-${supportedComponent.type}`}
                         iconProps={{ iconName: supportedComponent.fabricIconName }}
                         onClick={() => {
@@ -79,7 +67,7 @@ export const SpacesToolbar: React.FC<ISpacesToolbarProps> =
             const templateButton = (
                 <Button
                     iconProps={{ iconName: templateListOpen ? "ChevronUpEnd6" : "ChevronDownEnd6" }}
-                    style={menuButtonStyle}
+                    className="spaces-toolbar-top-level-button"
                     onClick={() => setTemplateListOpen(!templateListOpen)}
                 >
                     {"Add Templates"}
@@ -91,7 +79,7 @@ export const SpacesToolbar: React.FC<ISpacesToolbarProps> =
                     if (template) {
                         templateButtonList.push(
                             <Button
-                                style={dropDownButtonStyle}
+                                className="spaces-toolbar-option-button"
                                 key={`componentToolbarButton-${template}`}
                                 onClick={() => {
                                     if (props.spacesProps.applyTemplate) {
@@ -101,48 +89,49 @@ export const SpacesToolbar: React.FC<ISpacesToolbarProps> =
                                 }}
                             >
                                 {Templates[template]}
-                            </Button>
-                            ,
+                            </Button>,
                         );
                     }
                 }
             }
             templateCollapsible = (
-                <div style={templateButtonStyle}>
-                    <Collapsible
-                        open={templateListOpen}
-                        trigger={templateButton}
-                    >
-                        {templateButtonList}
-                    </Collapsible>
-                </div>
+                <Collapsible
+                    open={templateListOpen}
+                    trigger={templateButton}
+                    className="spaces-toolbar-item"
+                    openedClassName="spaces-toolbar-item"
+                >
+                    {templateButtonList}
+                </Collapsible>
             );
         }
         return (
-            <div style={componentToolbarStyle}>
-                <Button
-                    id="edit"
-                    style={editableButtonStyle}
-                    iconProps={{ iconName: "BullseyeTargetEdit" }}
-                    onClick={() => {
-                        const newEditableState = !props.editable;
-                        props.setEditable(newEditableState);
-                    }}
-                >
-                    {`Edit: ${props.editable}`}
-                </Button>
+            <div className="spaces-toolbar">
+                <div className="spaces-toolbar-item">
+                    <Button
+                        id="edit"
+                        className="spaces-toolbar-top-level-button"
+                        iconProps={{ iconName: "BullseyeTargetEdit" }}
+                        onClick={() => {
+                            const newEditableState = !props.editable;
+                            props.setEditable(newEditableState);
+                        }}
+                    >
+                        {`Edit: ${props.editable}`}
+                    </Button>
+                </div>
                 {props.editable ?
-                    <div>
-                        <div style={componentButtonStyle}>
-                            <Collapsible
-                                open={componentListOpen}
-                                trigger={componentsButton}
-                            >
-                                {componentButtonList}
-                            </Collapsible>
-                        </div>
+                    <>
+                        <Collapsible
+                            open={componentListOpen}
+                            trigger={componentsButton}
+                            className="spaces-toolbar-item"
+                            openedClassName="spaces-toolbar-item"
+                        >
+                            {componentButtonList}
+                        </Collapsible>
                         {templateCollapsible}
-                    </div>
+                    </>
                     : undefined}
             </div>
         );

--- a/components/experimental/spaces/src/spacesToolbar.tsx
+++ b/components/experimental/spaces/src/spacesToolbar.tsx
@@ -11,7 +11,6 @@ import {
 } from "office-ui-fabric-react";
 import {
     IInternalRegistryEntry,
-    ISpacesProps,
     Templates,
 } from ".";
 import "./spacesToolbarStyle.css";
@@ -113,10 +112,12 @@ const SpacesToolbarTemplateItem: React.FC<ISpacesToolbarTemplateItemProps> =
     };
 
 interface ISpacesToolbarProps {
-    spacesProps: ISpacesProps;
     components: IInternalRegistryEntry[];
     editable: boolean;
     setEditable: (editable: boolean) => void;
+    addComponent(type: string): void;
+    templatesAvailable: boolean;
+    applyTemplate(template: Templates): void;
 }
 
 export const SpacesToolbar: React.FC<ISpacesToolbarProps> =
@@ -145,15 +146,15 @@ export const SpacesToolbar: React.FC<ISpacesToolbarProps> =
                 <SpacesToolbarComponentItem
                     key="component"
                     components={props.components}
-                    addComponent={props.spacesProps.addComponent}
+                    addComponent={props.addComponent}
                 />,
             );
 
-            if (props.spacesProps.templatesAvailable) {
+            if (props.templatesAvailable) {
                 toolbarItems.push(
                     <SpacesToolbarTemplateItem
                         key="template"
-                        applyTemplate={props.spacesProps.applyTemplate}
+                        applyTemplate={props.applyTemplate}
                     />,
                 );
             }

--- a/components/experimental/spaces/src/spacesToolbarStyle.css
+++ b/components/experimental/spaces/src/spacesToolbarStyle.css
@@ -1,16 +1,17 @@
 .spaces-toolbar {
     position: relative;
+    height: 45px;
     margin: 10px;
     display: flex;
 }
 
-.spaces-toolbar-item {
+.spaces-toolbar-tool {
     width: 180px;
 }
 
 .spaces-toolbar-top-level-button {
     width: 100%;
-    height: 45px;
+    height: 100%;
 }
 
 .spaces-toolbar-option-button {

--- a/components/experimental/spaces/src/spacesToolbarStyle.css
+++ b/components/experimental/spaces/src/spacesToolbarStyle.css
@@ -3,6 +3,7 @@
     height: 45px;
     margin: 10px;
     display: flex;
+    z-index: 1000;
 }
 
 .spaces-toolbar-tool {

--- a/components/experimental/spaces/src/spacesToolbarStyle.css
+++ b/components/experimental/spaces/src/spacesToolbarStyle.css
@@ -1,0 +1,18 @@
+.spaces-toolbar {
+    position: relative;
+    margin: 10px;
+    display: flex;
+}
+
+.spaces-toolbar-item {
+    width: 180px;
+}
+
+.spaces-toolbar-top-level-button {
+    width: 100%;
+    height: 45px;
+}
+
+.spaces-toolbar-option-button {
+    width: 100%;
+}

--- a/components/experimental/spaces/src/spacesView.tsx
+++ b/components/experimental/spaces/src/spacesView.tsx
@@ -5,15 +5,16 @@
 
 import React from "react";
 import "react-grid-layout/css/styles.css";
-import { IInternalRegistryEntry } from "./interfaces";
-import { ISpacesProps } from "./spaces";
+import { IInternalRegistryEntry, Templates } from "./interfaces";
 import { ISpacesStorage, SpacesStorageView } from "./storage";
 import { SpacesToolbar } from "./spacesToolbar";
 
 interface ISpacesViewProps {
     supportedComponents: IInternalRegistryEntry[];
     storage: ISpacesStorage;
-    spacesProps: ISpacesProps;
+    addComponent(type: string): void;
+    templatesAvailable: boolean;
+    applyTemplate(template: Templates): void;
 }
 
 /**
@@ -27,10 +28,12 @@ export const SpacesView: React.FC<ISpacesViewProps> =
         return (
             <div className="spaces-view">
                 <SpacesToolbar
-                    spacesProps={props.spacesProps}
                     editable={editable}
                     setEditable={setEditable}
                     components={props.supportedComponents}
+                    addComponent={props.addComponent}
+                    templatesAvailable={props.templatesAvailable}
+                    applyTemplate={props.applyTemplate}
                 />
                 <SpacesStorageView storage={props.storage} editable={editable} />
             </div>

--- a/components/experimental/spaces/src/storage/spacesStorageStyle.css
+++ b/components/experimental/spaces/src/storage/spacesStorageStyle.css
@@ -1,11 +1,8 @@
 .spaces-storage-view {
-    padding-top: 7rem;
-    min-height: 3000px;
     width: 100%;
 }
 
 .spaces-component-view-wrapper {
-    padding: 2px;
     overflow: scroll;
 }
 


### PR DESCRIPTION
This PR is from breaking out some chunks of changes from my prototype branch into individual PRs.

This change does the following:

1. Moves the `SpacesToolbar`'s styles into a separate file
2. Breaks the toolbar into subcomponents, which I find easier to read through
3. Flattens the `ISpacesProps` onto the `ISpacesViewProps` and makes them mandatory
4. Some small simplifications in the view's html/css (e.g. less absolute positioning, viewport units, and wrapper divs).