### PR TITLE
Make clicker component work with detach container flow

### DIFF
--- a/components/examples/clicker/src/index.tsx
+++ b/components/examples/clicker/src/index.tsx
@@ -26,9 +26,6 @@ export class Clicker extends PrimedComponent implements IComponentHTMLView {
      */
     protected async componentInitializingFirstTime() {
         this.root.createValueType("clicks", CounterValueType.Name, 0);
-        if (!this.runtime.connected) {
-            await new Promise<void>((resolve) => this.runtime.on("connected", () => resolve()));
-        }
         this.setupAgent();
     }
 


### PR DESCRIPTION
So we were waiting for connected event in initializingFirstTime before setting up agent. In detach container flow, we don't get connected event until we attach, so we were waiting here forever.
Removing this work fine for both normal flow and detach flow.
Also I don't know what was the purpose of this. So please review once.