### PR TITLE
Update orderer connection methods to return promises

### DIFF
--- a/server/routerlicious/packages/kafka-orderer/src/kafkaOrderer.ts
+++ b/server/routerlicious/packages/kafka-orderer/src/kafkaOrderer.ts
@@ -94,10 +94,6 @@ export class KafkaOrdererConnection implements core.IOrdererConnection {
         return this.submitRawOperation([message]);
     }
 
-    public once(event: "error", listener: (...args: any[]) => void) {
-        this.producer.once(event, listener);
-    }
-
     public async order(messages: IDocumentMessage[]): Promise<void> {
         const rawMessages = messages.map((message) => {
             const rawMessage: core.IRawOperationMessage = {
@@ -134,6 +130,10 @@ export class KafkaOrdererConnection implements core.IOrdererConnection {
         };
 
         return this.submitRawOperation([message]);
+    }
+
+    public once(event: "error", listener: (...args: any[]) => void) {
+        this.producer.once(event, listener);
     }
 
     private async submitRawOperation(messages: core.IRawOperationMessage[]): Promise<void> {

--- a/server/routerlicious/packages/kafka-orderer/src/kafkaOrderer.ts
+++ b/server/routerlicious/packages/kafka-orderer/src/kafkaOrderer.ts
@@ -64,7 +64,7 @@ export class KafkaOrdererConnection implements core.IOrdererConnection {
     /**
      * Sends the client join op for this connection
      */
-    public async initialize() {
+    public async connect() {
         const clientDetail: IClientJoin = {
             clientId: this.clientId,
             detail: this.client,

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -323,6 +323,7 @@ export function configureWebSocketServices(
                             .map((message) => sanitizeMessage(message));
 
                         if (sanitized.length > 0) {
+                            // eslint-disable-next-line @typescript-eslint/no-floating-promises
                             connection.order(sanitized);
                         }
                     });
@@ -406,6 +407,7 @@ export function configureWebSocketServices(
             // Send notification messages for all client IDs in the connection map
             for (const [clientId, connection] of connectionsMap) {
                 logger.info(`Disconnect of ${clientId}`);
+                // eslint-disable-next-line @typescript-eslint/no-floating-promises
                 connection.disconnect();
             }
             // Send notification messages for all client IDs in the room map

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -224,7 +224,7 @@ export function configureWebSocketServices(
                 const orderer = await orderManager.getOrderer(claims.tenantId, claims.documentId);
                 const connection = await orderer.connect(socket, clientId, messageClient as IClient, details);
                 // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                connection.initialize();
+                connection.connect();
 
                 connectionsMap.set(clientId, connection);
 

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -223,6 +223,9 @@ export function configureWebSocketServices(
             if (isWriter(messageClient.scopes, details.existing, message.mode)) {
                 const orderer = await orderManager.getOrderer(claims.tenantId, claims.documentId);
                 const connection = await orderer.connect(socket, clientId, messageClient as IClient, details);
+                // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                connection.initialize();
+
                 connectionsMap.set(clientId, connection);
 
                 // Eventually we will send disconnect reason as headers to client.

--- a/server/routerlicious/packages/memory-orderer/src/localNode.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localNode.ts
@@ -210,6 +210,7 @@ export class LocalNode extends EventEmitter implements IConcreteNode {
                     case "disconnect": {
                         const connection = this.connectionMap.get(message.cid);
                         assert(connection);
+                        // eslint-disable-next-line @typescript-eslint/no-floating-promises
                         connection.disconnect();
                         this.connectionMap.delete(message.cid);
 
@@ -220,6 +221,7 @@ export class LocalNode extends EventEmitter implements IConcreteNode {
                         const orderMessage = message.payload as IDocumentMessage;
                         const connection = this.connectionMap.get(message.cid);
                         assert(connection);
+                        // eslint-disable-next-line @typescript-eslint/no-floating-promises
                         connection.order([orderMessage]);
                         break;
                     }

--- a/server/routerlicious/packages/memory-orderer/src/localNode.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localNode.ts
@@ -190,6 +190,9 @@ export class LocalNode extends EventEmitter implements IConcreteNode {
                             moniker.choose(),
                             connectMessage.client);
 
+                        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                        connection.initialize();
+
                         // Need to subscribe to both channels. Then broadcast subscription across pipe
                         // on receiving a message
                         this.connectionMap.set(message.cid, connection);

--- a/server/routerlicious/packages/memory-orderer/src/localNode.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localNode.ts
@@ -191,7 +191,7 @@ export class LocalNode extends EventEmitter implements IConcreteNode {
                             connectMessage.client);
 
                         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                        connection.initialize();
+                        connection.connect();
 
                         // Need to subscribe to both channels. Then broadcast subscription across pipe
                         // on receiving a message

--- a/server/routerlicious/packages/memory-orderer/src/localOrdererConnection.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrdererConnection.ts
@@ -42,7 +42,7 @@ export class LocalOrdererConnection implements IOrdererConnection {
         this.parentBranch = document.parent ? document.parent.documentId : null;
     }
 
-    public async initialize() {
+    public async connect() {
         // Subscribe to the message channels
         // Todo: We probably don't need this.
         this.pubsub.subscribe(`${this.tenantId}/${this.documentId}`, this.socket);
@@ -74,8 +74,6 @@ export class LocalOrdererConnection implements IOrdererConnection {
 
         // Submit on next tick to sequence behind connect response
         this.submitRawOperation([message]);
-
-        return Promise.resolve();
     }
 
     public async order(messages: IDocumentMessage[]) {
@@ -93,8 +91,6 @@ export class LocalOrdererConnection implements IOrdererConnection {
         });
 
         this.submitRawOperation(rawMessages);
-
-        return Promise.resolve();
     }
 
     public async disconnect() {
@@ -119,8 +115,6 @@ export class LocalOrdererConnection implements IOrdererConnection {
         // Todo: We probably don't need this either.
         this.pubsub.unsubscribe(`${this.tenantId}/${this.documentId}`, this.socket);
         this.pubsub.unsubscribe(`client#${this.clientId}`, this.socket);
-
-        return Promise.resolve();
     }
 
     public once(event: "error", listener: (...args: any[]) => void) {

--- a/server/routerlicious/packages/memory-orderer/src/localOrdererConnection.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrdererConnection.ts
@@ -74,7 +74,7 @@ export class LocalOrdererConnection implements IOrdererConnection {
         this.submitRawOperation([message]);
     }
 
-    public order(messages: IDocumentMessage[]): void {
+    public async order(messages: IDocumentMessage[]) {
         const rawMessages = messages.map((message) => {
             const rawMessage: IRawOperationMessage = {
                 clientId: this.clientId,
@@ -89,9 +89,11 @@ export class LocalOrdererConnection implements IOrdererConnection {
         });
 
         this.submitRawOperation(rawMessages);
+
+        return Promise.resolve();
     }
 
-    public disconnect() {
+    public async disconnect() {
         const operation: IDocumentSystemMessage = {
             clientSequenceNumber: -1,
             contents: null,
@@ -113,6 +115,8 @@ export class LocalOrdererConnection implements IOrdererConnection {
         // Todo: We probably don't need this either.
         this.pubsub.unsubscribe(`${this.tenantId}/${this.documentId}`, this.socket);
         this.pubsub.unsubscribe(`client#${this.clientId}`, this.socket);
+
+        return Promise.resolve();
     }
 
     public once(event: "error", listener: (...args: any[]) => void) {

--- a/server/routerlicious/packages/memory-orderer/src/localOrdererConnection.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrdererConnection.ts
@@ -40,7 +40,9 @@ export class LocalOrdererConnection implements IOrdererConnection {
         public readonly serviceConfiguration: IServiceConfiguration,
     ) {
         this.parentBranch = document.parent ? document.parent.documentId : null;
+    }
 
+    public async initialize() {
         // Subscribe to the message channels
         // Todo: We probably don't need this.
         this.pubsub.subscribe(`${this.tenantId}/${this.documentId}`, this.socket);
@@ -72,6 +74,8 @@ export class LocalOrdererConnection implements IOrdererConnection {
 
         // Submit on next tick to sequence behind connect response
         this.submitRawOperation([message]);
+
+        return Promise.resolve();
     }
 
     public async order(messages: IDocumentMessage[]) {

--- a/server/routerlicious/packages/memory-orderer/src/remoteNode.ts
+++ b/server/routerlicious/packages/memory-orderer/src/remoteNode.ts
@@ -43,6 +43,10 @@ class ProxySocketConnection implements IOrdererConnection {
         private readonly details: IConnectedMessage) {
     }
 
+    public async initialize() {
+        return Promise.resolve();
+    }
+
     public async order(messages: IDocumentMessage[]) {
         this.node.send(this.cid, "order", messages);
         return Promise.resolve();

--- a/server/routerlicious/packages/memory-orderer/src/remoteNode.ts
+++ b/server/routerlicious/packages/memory-orderer/src/remoteNode.ts
@@ -43,12 +43,14 @@ class ProxySocketConnection implements IOrdererConnection {
         private readonly details: IConnectedMessage) {
     }
 
-    public order(messages: IDocumentMessage[]): void {
+    public async order(messages: IDocumentMessage[]) {
         this.node.send(this.cid, "order", messages);
+        return Promise.resolve();
     }
 
-    public disconnect(): void {
+    public async disconnect() {
         this.node.send(this.cid, "disconnect", null);
+        return Promise.resolve();
     }
 
     public emit(op: string, id: string, ...data: any[]) {

--- a/server/routerlicious/packages/memory-orderer/src/remoteNode.ts
+++ b/server/routerlicious/packages/memory-orderer/src/remoteNode.ts
@@ -43,18 +43,16 @@ class ProxySocketConnection implements IOrdererConnection {
         private readonly details: IConnectedMessage) {
     }
 
-    public async initialize() {
-        return Promise.resolve();
+    public async connect() {
+        return;
     }
 
     public async order(messages: IDocumentMessage[]) {
         this.node.send(this.cid, "order", messages);
-        return Promise.resolve();
     }
 
     public async disconnect() {
         this.node.send(this.cid, "disconnect", null);
-        return Promise.resolve();
     }
 
     public emit(op: string, id: string, ...data: any[]) {

--- a/server/routerlicious/packages/services-core/src/orderer.ts
+++ b/server/routerlicious/packages/services-core/src/orderer.ts
@@ -43,6 +43,11 @@ export interface IOrdererConnection {
     readonly serviceConfiguration: IServiceConfiguration;
 
     /**
+     * Sends the client join op for this connection
+     */
+    initialize(): Promise<void>;
+
+    /**
      * Orders the provided list of messages. The messages in the array are guaranteed to be ordered sequentially
      * so long as their total size fits under the maxMessageSize.
      */
@@ -53,6 +58,9 @@ export interface IOrdererConnection {
      */
     once(event: "error", listener: (...args: any[]) => void): void;
 
+    /**
+     * Sends the client leave op for this connection
+     */
     disconnect(): Promise<void>;
 }
 

--- a/server/routerlicious/packages/services-core/src/orderer.ts
+++ b/server/routerlicious/packages/services-core/src/orderer.ts
@@ -45,7 +45,7 @@ export interface IOrdererConnection {
     /**
      * Sends the client join op for this connection
      */
-    initialize(): Promise<void>;
+    connect(): Promise<void>;
 
     /**
      * Orders the provided list of messages. The messages in the array are guaranteed to be ordered sequentially

--- a/server/routerlicious/packages/services-core/src/orderer.ts
+++ b/server/routerlicious/packages/services-core/src/orderer.ts
@@ -46,14 +46,14 @@ export interface IOrdererConnection {
      * Orders the provided list of messages. The messages in the array are guaranteed to be ordered sequentially
      * so long as their total size fits under the maxMessageSize.
      */
-    order(message: IDocumentMessage[]): void;
+    order(message: IDocumentMessage[]): Promise<void>;
 
     /**
      * Error event Handler.
      */
     once(event: "error", listener: (...args: any[]) => void): void;
 
-    disconnect(): void;
+    disconnect(): Promise<void>;
 }
 
 export interface IOrderer {

--- a/server/routerlicious/packages/services-core/src/queue.ts
+++ b/server/routerlicious/packages/services-core/src/queue.ts
@@ -72,7 +72,7 @@ export interface IProducer {
     /**
      * Sends the message to a queue
      */
-    send(messages: object[], tenantId: string, documentId: string): Promise<any>;
+    send(messages: object[], tenantId: string, documentId: string): Promise<void>;
 
     /**
      * Closes the underlying connection


### PR DESCRIPTION
Return the `producer.send` promise for the `order` and `disconnect` methods. Also add a new `initialize` method so that we can return a promise for the client join message.

This will allow the frontend to optionally await these operations. For example the frontend could use these for telemetry purposes. They could also decide to disconnect the clients websocket if the `order` method throws.

Due to how socket.io's event handler works, awaiting `order` will not slow down the ordering of ops. socket.io will not wait for the handler to complete before sending subsequent events.
Also the frontend should likely not await the `initialize` method because doing so would slow down sending the `connect_document` response. It's still useful for telemetry/error handling purposes.