### PR TITLE
Add test-tools package for shared test support code

### DIFF
--- a/tools/test-tools/README.md
+++ b/tools/test-tools/README.md
@@ -1,0 +1,7 @@
+# Test Tools
+
+Tools to help with testing
+
+## AssignTestPorts.ts
+
+Used to assign unique ports to jest/puppeteer tests so that they do not need to be hardcoded into config files, and so writers of new tests do not need to manually find the next available port.  This is an issue because all jest tests are run concurrently for performance, so ports may not be re-used.

--- a/tools/test-tools/bin/assign-test-ports
+++ b/tools/test-tools/bin/assign-test-ports
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require("../dist/assignTestPorts.js");

--- a/tools/test-tools/package-lock.json
+++ b/tools/test-tools/package-lock.json
@@ -1,0 +1,20 @@
+{
+  "name": "@fluidframework/test-tools",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/node": {
+      "version": "11.15.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.14.tgz",
+      "integrity": "sha512-5R/ADTMiAxv+4GAwzsupaUO51T1e0UYdPc8StO/t6a+Fv1o2sbY9MWgmP2QxtKGwge8HqTjq058L360ai5RDug==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
+      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
+      "dev": true
+    }
+  }
+}

--- a/tools/test-tools/package.json
+++ b/tools/test-tools/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {},
   "devDependencies": {

--- a/tools/test-tools/package.json
+++ b/tools/test-tools/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@fluidframework/test-tools",
+  "version": "0.1.0",
+  "description": "Fluid test tools",
+  "license": "MIT",
+  "author": "Microsoft",
+  "main": "dist/getTestPort.js",
+  "bin": {
+    "assign-test-ports": "bin/assign-test-ports"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "test": "echo \"Error: no test specified\" && exit 1",
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^11.9.4",
+    "typescript": "^3.7.4"
+  }
+}

--- a/tools/test-tools/src/assignTestPorts.ts
+++ b/tools/test-tools/src/assignTestPorts.ts
@@ -1,0 +1,40 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as child_process from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+function main() {
+    // Get the lerna output
+    let lernaOutput;
+    try {
+        lernaOutput = JSON.parse(child_process.execSync("npx lerna list --all --json").toString());
+        if (!Array.isArray(lernaOutput)) {
+            throw new Error("stdin input was not package array");
+        }
+    } catch (e) {
+        console.error(e.toString());
+        process.exit(-1);
+    }
+
+    // Assign a unique port to each package
+    const portMap: { [pkgName: string]: number } = {};
+    let port = 8081;
+    lernaOutput.forEach((pkg: {name: string}) => {
+        if (pkg.name === undefined) {
+            console.error("missing name in lerna package entry");
+            process.exit(-1);
+        }
+        portMap[pkg.name] = port++;
+    });
+
+    // Write the mappings to a temporary file as kv pairs
+    const portMapPath = path.join(os.tmpdir(), "testportmap.json");
+    fs.writeFileSync(portMapPath, JSON.stringify(portMap));
+}
+
+main();

--- a/tools/test-tools/src/getTestPort.ts
+++ b/tools/test-tools/src/getTestPort.ts
@@ -1,0 +1,23 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+// Get the port for the pkg from the mapping.  Use a default if the file or the
+// entry doesn't exist (e.g. an individual test is being run and the file was
+// never generated), which should presumably not lead to collisions
+export function getTestPort(pkgName: string): string {
+    let mappedPort = undefined;
+    try {
+        const testPortsJson = JSON.parse(fs.readFileSync(path.join(os.tmpdir(), "testportmap.json"), "utf-8"));
+        mappedPort = testPortsJson[pkgName];
+    } catch (e) { }
+    if (mappedPort === undefined) {
+        mappedPort = "8081";
+    }
+    return mappedPort;
+}

--- a/tools/test-tools/tsconfig.json
+++ b/tools/test-tools/tsconfig.json
@@ -1,0 +1,58 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "es2018", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "./dist",                        /* Redirect output structure to the directory. */
+    "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+    /* Strict Type-Checking Options */
+    "strict": true, /* Enable all strict type-checking options. */
+    "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    "strictNullChecks": true,              /* Enable strict null checks. */
+    "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    "types": ["node"],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+}


### PR DESCRIPTION
Pt1 of fixing #1341 

Add test-tools package to hold shared test support code, such as port management for jest tests (and maybe other things in the future?).

For jest ports, the issue is that they're currently hardcoded in the test configs, and all tests are run in parallel.  Meaning that anyone adding a new test needs to find the next available port and hardcode that as well.  This change adds a script that sets up a mapping of unique ports so that packages running tests will not see collisions when run under lerna (and new test writers do not need to futz around with port values).

Updating consumers coming in a followup after this new package becomes available for import (couldn't test some things such as the binary availability due to this)