### PR TITLE
make the generator-fluid policy exclusion more generic

### DIFF
--- a/tools/fluid-build-tools/data/exclusions.json
+++ b/tools/fluid-build-tools/data/exclusions.json
@@ -1,4 +1,4 @@
 [
     "server/routerlicious/packages/services-client/src/dockerNames.ts",
-    "tools/generator-fluid/app/"
+    "tools/generator-fluid/app/templates/"
 ]

--- a/tools/fluid-build-tools/data/exclusions.json
+++ b/tools/fluid-build-tools/data/exclusions.json
@@ -1,5 +1,4 @@
 [
     "server/routerlicious/packages/services-client/src/dockerNames.ts",
-    "tools/generator-fluid/app/templates/package.json",
-    "tools/generator-fluid/app/templates/src/"
+    "tools/generator-fluid/app/"
 ]


### PR DESCRIPTION
make the policy exclusion cover the entire fluid generator templating folder.