### PR TITLE
Fix layer data

### DIFF
--- a/tools/fluid-build-tools/data/layerInfo.json
+++ b/tools/fluid-build-tools/data/layerInfo.json
@@ -63,7 +63,8 @@
                 ],
                 "deps": [
                     "Protocol-Utils",
-                    "Driver-Definitions"
+                    "Driver-Definitions",
+                    "@fluidframework/container-definitions"
                 ]
             },
             "Framework-Utils": {
@@ -122,7 +123,8 @@
                 ],
                 "deps": [
                     "Driver-Utils",
-                    "@fluidframework/component-core-interfaces"
+                    "@fluidframework/component-core-interfaces",
+                    "@fluidframework/container-definitions"
                 ]
             },
             "Loader": {
@@ -225,7 +227,8 @@
                 ],
                 "deps": [
                     "Driver",
-                    "Server-Shared-Utils"
+                    "Server-Shared-Utils",
+                    "@fluidframework/container-definitions"
                 ]
             },
             "Routerlicious-Server": {

--- a/tools/fluid-build-tools/data/layerInfo.json
+++ b/tools/fluid-build-tools/data/layerInfo.json
@@ -184,7 +184,6 @@
                 "dev": true,
                 "packages": [
                     "@fluidframework/build-common",
-                    "@fluidframework/build-common",
                     "@fluidframework/eslint-config-fluid"
                 ]
             },
@@ -234,7 +233,6 @@
                     "@fluidframework/server-routerlicious"
                 ],
                 "deps": [
-                    "Routerlicious-Host",
                     "Server-Libs"
                 ]
             }


### PR DESCRIPTION
The layer check as disable temporary in the CI to facilitate package rename.
This is the remaining fix to make it mostly running again.
There were violation creeped in already, so those will need to be fixed before we turn it back on in the CI.

