### PR TITLE
Integrate bohemia intercept logic into webpack server

### DIFF
--- a/packages/tools/webpack-component-loader/src/bohemiaIntercept.ts
+++ b/packages/tools/webpack-component-loader/src/bohemiaIntercept.ts
@@ -1,0 +1,59 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import fs from "fs";
+
+async function getPackage() {
+    const executedDir = process.cwd();
+    const pkgString = fs.readFileSync(`${executedDir}/package.json`);
+    return JSON.parse(pkgString as any);
+}
+
+const localhostURL = "http://localhost:8080/";
+
+async function getFilePath() {
+    const pkg = await getPackage();
+    return pkg.fluid.browser.umd.files[0];
+}
+
+async function createManifest() {
+    const pkg = await getPackage();
+
+    const manifest = {
+        id: pkg.name,
+        experimentalData: {
+            fluid: true,
+        },
+        loaderConfig: {
+            entryModuleId: "main",
+            internalModuleBaseUrls: [
+                localhostURL,
+            ],
+            scriptResources: {
+                "fluid.main": {
+                    path: await getFilePath(),
+                },
+            },
+        },
+        preconfiguredEntries: [
+            {
+                title: {
+                    default: pkg.name,
+                },
+                description: {
+                    default: pkg.description,
+                },
+            },
+        ],
+    };
+    return {
+        Manifest: JSON.stringify(manifest),
+    };
+}
+
+export async function createManifestResponse() {
+    const response = { d: { GetClientSideWebParts: { results: [(await createManifest())] } } };
+    return response;
+}

--- a/packages/tools/webpack-component-loader/src/routes.ts
+++ b/packages/tools/webpack-component-loader/src/routes.ts
@@ -21,8 +21,8 @@ let odspAuthLock: Promise<void> | undefined;
 
 const getThisOrigin = (options: RouteOptions): string => `http://localhost:${options.port}`;
 
-export const before = (app: express.Application) => {
-    app.get("/getclientsidewebparts", async (req, res) => res.send(createManifestResponse()));
+export const before = async (app: express.Application) => {
+    app.get("/getclientsidewebparts", async (req, res) => res.send(await createManifestResponse()));
     app.get("/", (req, res) => res.redirect(`/${moniker.choose()}`));
 };
 

--- a/packages/tools/webpack-component-loader/src/routes.ts
+++ b/packages/tools/webpack-component-loader/src/routes.ts
@@ -13,6 +13,7 @@ import { IOdspTokens, getServer } from "@fluidframework/odsp-utils";
 import { getMicrosoftConfiguration, OdspTokenManager, odspTokensCache } from "@fluidframework/tool-utils";
 import { IFluidPackage } from "@fluidframework/container-definitions";
 import { RouteOptions } from "./loader";
+import { createManifestResponse } from "./bohemiaIntercept";
 
 const tokenManager = new OdspTokenManager(odspTokensCache);
 let odspAuthStage = 0;
@@ -21,6 +22,7 @@ let odspAuthLock: Promise<void> | undefined;
 const getThisOrigin = (options: RouteOptions): string => `http://localhost:${options.port}`;
 
 export const before = (app: express.Application) => {
+    app.get("/getclientsidewebparts", async (req, res) => res.send(createManifestResponse()));
     app.get("/", (req, res) => res.redirect(`/${moniker.choose()}`));
 };
 

--- a/tools/fluidpreview-intercept/README.MD
+++ b/tools/fluidpreview-intercept/README.MD
@@ -20,6 +20,8 @@ This is a chrome extension package that listen to requests fired by the Bohemia 
 
 2) reroute-server
 
+(NOTE: Only needed if your package was generated using yo-fluid with Fluid Framework version lower than v0.19.0)
+
 This is an npm package containing a lightweight express server. It will be run from the new Fluid component's package directory. It receives the redirected getclientsidewebparts call and returns a manifest file generated from details found in the new component's package.json. It then redirects Bohemia's main.bundle.js call to fetch the component to where the component itself is currently running at locally. At this point, Bohemia will load the component like any other.
 
 
@@ -47,12 +49,19 @@ Alternatively, you can also install the package from the fluidpreview-intercept/
     c) Observe the discolored Fluid waterdrop icon on the top right Extension bar to indicate that your extension was installed.
 
 
-
 NOTE: This step only needs to be run once for all of your components as it is just loading the Fluid intercept extension to your browser. The next two to be run from your component directory, and will need to be run again when loading a different component from its respective directory.
 
 
+3a) At this point, if you are running Fluid Framework v ^0.19.0, you can simply run your component locally using:
 
-3) Run the following commands in your new Fluid component's package directory:
+
+npm run start
+
+
+Skip to step 5 now
+
+
+3b) Run the following commands in your new Fluid component's package directory:
 
 npm i -g @microsoft/fluidpreview-intercept-reroute-server
 

--- a/tools/fluidpreview-intercept/chrome-extension/background.js
+++ b/tools/fluidpreview-intercept/chrome-extension/background.js
@@ -30,7 +30,7 @@ chrome.storage.onChanged.addListener(function(changes, namespace) {
 // Redirect the web parts request if the extension isn't disabled
 function webPartsHandler(req) {
     if (!isDisabled) {
-        return { redirectUrl: 'http://localhost:3000/getclientsidewebparts' };
+        return { redirectUrl: 'http://localhost:8080/getclientsidewebparts' };
     }
 }
 
@@ -44,6 +44,26 @@ function setListeners() {
         webPartsHandler, {
             urls: combinedUrls
         }, ['requestBody', 'blocking']
+    );
+    chrome.webRequest.onBeforeSendHeaders.addListener(
+        function(details) {
+            return {
+                requestHeaders: []
+            };
+        }, { urls: ["http://localhost:8080/getclientsidewebparts"] }, ['blocking', 'requestHeaders']
+    );
+    chrome.webRequest.onHeadersReceived.addListener(
+        function(details) {
+            const responseHeaders = [
+                { name: "Access-Control-Allow-Origin", value: "*" },
+                { name: "Access-Control-Allow-Credentials", value: "true" },
+                { name: "Access-Control-Allow-Methods", value: "GET,HEAD,OPTIONS,POST,PUT" },
+                { name: "Access-Control-Allow-Headers", value: "Access-Control-Allow-Headers, Origin,Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers, Authorization" },
+            ]
+            return { responseHeaders };
+        }, {
+            urls: ["http://localhost:8080/getclientsidewebparts"],
+        }, ["blocking", "responseHeaders", "extraHeaders"]
     );
 }
 setListeners();


### PR DESCRIPTION
Users no longer have to run a seperate intercept server!
Just load the extension, run your component locally, and open Bohemia. Your component is available!

fixes #2001 