### PR TITLE
0.15: Assert Invalid Tardis Ops in Summary

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,31 +1,20 @@
 registry=https://registry.npmjs.org/
 always-auth=false
 
-//packages.wu2.prague.office-int.com/:_authToken="mQ12JIgL/OVL2fiPinbqIA=="
-//packages.wu2.prague.office-int.com/:always-auth=true
-@prague:registry=https://packages.wu2.prague.office-int.com
-@prague:always-auth=true
-
-@chaincode:registry=https://packages.wu2.prague.office-int.com
-@chaincode:always-auth=true
-
-@component:registry=https://packages.wu2.prague.office-int.com
-@component:always-auth=true
-
-@ms:registry=https://packages.wu2.prague.office-int.com
-@ms:always-auth=true
-
-@tiny-calc:registry=https://packages.wu2.prague.office-int.com
+@tiny-calc:registry=https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/
 @tiny-calc:always-auth=true
 
-@tiny:registry=https://packages.wu2.prague.office-int.com
+@tiny:registry=https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/
 @tiny:always-auth=true
 
-@microsoft:registry=https://packages.wu2.prague.office-int.com
+@microsoft:registry=https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/
 @microsoft:always-auth=true
 
-@fluid-internal:registry=https://packages.wu2.prague.office-int.com
+@fluid-internal:registry=https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/
 @fluid-internal:always-auth=true
 
-@fluid-example:registry=https://packages.wu2.prague.office-int.com
+@fluid-example:registry=https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/
 @fluid-example:always-auth=true
+
+@fluidframework:registry=https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/
+@fluidframework:always-auth=true

--- a/packages/drivers/file-socket-storage/src/fileDocumentDeltaConnection.ts
+++ b/packages/drivers/file-socket-storage/src/fileDocumentDeltaConnection.ts
@@ -15,6 +15,7 @@ import {
     ISignalClient,
     ISignalMessage,
     ITokenClaims,
+    ScopeType,
 } from "@microsoft/fluid-protocol-definitions";
 import { debug } from "./debug";
 import { FileDeltaStorageService } from "./fileDeltaStorageService";
@@ -30,7 +31,7 @@ const replayDocumentId = "replayDocId";
 
 const Claims: ITokenClaims = {
     documentId: replayDocumentId,
-    scopes: [],
+    scopes: [ScopeType.DocWrite],
     tenantId: "",
     user: {
         id: "",

--- a/packages/runtime/sequence/src/test/generateSharedStrings.ts
+++ b/packages/runtime/sequence/src/test/generateSharedStrings.ts
@@ -12,6 +12,9 @@ import { SharedStringFactory } from "../sequenceFactory";
 export function* generateStrings() {
     const documentId = "fakeId";
     const runtime: mocks.MockRuntime = new mocks.MockRuntime();
+    const deltaConnectionFactory = new mocks.MockDeltaConnectionFactory();
+    deltaConnectionFactory.createDeltaConnection(runtime);
+
     const insertText = "text";
 
     let sharedString = new SharedString(runtime, documentId, SharedStringFactory.Attributes);

--- a/packages/tools/replay-tool/.gitignore
+++ b/packages/tools/replay-tool/.gitignore
@@ -53,3 +53,5 @@ temp_modules/
 
 # Generated Snapshot diffs
 **/snapshot*_extended.json
+
+output

--- a/packages/tools/replay-tool/src/replayMessages.ts
+++ b/packages/tools/replay-tool/src/replayMessages.ts
@@ -285,6 +285,11 @@ class Document {
                 ["@ms/undo-stack", Promise.resolve(chaincode)],
                 ["@ms/commanding-surface", Promise.resolve(chaincode)],
                 ["@ms/dias", Promise.resolve(chaincode)],
+                ["@ms/scriptor/Titulo", Promise.resolve(chaincode)],
+                ["@fluidx/tasks", Promise.resolve(chaincode)],
+                ["@ms/tablero/TableroView", Promise.resolve(chaincode)],
+                ["@ms/tablero/TableroDocument", Promise.resolve(chaincode)],
+                ["@fluid-example/table-document/TableDocument", Promise.resolve(chaincode)],
             ]);
         const options = {};
 


### PR DESCRIPTION
I'm seeing some summaries that have tardis ops below the sequence number of the summary, and the shared string segments. The shared string segments should always be summarizing at the min sequence number, and the tardis ops should bring it forward, so have ops below that is invalid. I haven't been able to figure out the root cause, but this will make the failure more explicit when the issue is hit

related to #2139 