### PR TITLE
Add backwards compatibility for the ops on reconnect change #2235

### DIFF
--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -40,7 +40,7 @@ import {
     IEnvelope,
     IInboundSignalMessage,
 } from "@fluidframework/runtime-definitions";
-import { SummaryTracker } from "@fluidframework/runtime-utils";
+import { SummaryTracker, strongAssert } from "@fluidframework/runtime-utils";
 import { v4 as uuid } from "uuid";
 
 // Snapshot Format Version to be used in component attributes.
@@ -564,8 +564,12 @@ export abstract class ComponentContext extends EventEmitter implements
     }
 
     public reSubmit(type: MessageType, content: any, localOpMetadata: unknown) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.componentRuntime!.reSubmit(type, content, localOpMetadata);
+        strongAssert(this.componentRuntime, "ComponentRuntime must exist when resubmitting ops");
+
+        // back-compat: supporting <= 0.18 components
+        if (this.componentRuntime.reSubmit) {
+            this.componentRuntime.reSubmit(type, content, localOpMetadata);
+        }
     }
 
     private verifyNotClosed() {

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -566,7 +566,7 @@ export abstract class ComponentContext extends EventEmitter implements
     public reSubmit(type: MessageType, content: any, localOpMetadata: unknown) {
         strongAssert(this.componentRuntime, "ComponentRuntime must exist when resubmitting ops");
 
-        // back-compat: supporting <= 0.18 components
+        // back-compat: 0.18 components
         if (this.componentRuntime.reSubmit) {
             this.componentRuntime.reSubmit(type, content, localOpMetadata);
         }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1053,9 +1053,9 @@ export class ContainerRuntime extends EventEmitter implements IContainerRuntime,
     }
 
     /**
-     * back-compat: supporting <= 0.18 components
      * Called by IComponentRuntime (on behalf of distributed data structure) in disconnected state to notify about
      * local changes. All pending changes are automatically flushed by shared objects on connection.
+     * back-compat: 0.18 components
      */
     public notifyPendingMessages(): void {
         assert(!this.connected);

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1053,6 +1053,16 @@ export class ContainerRuntime extends EventEmitter implements IContainerRuntime,
     }
 
     /**
+     * back-compat: supporting <= 0.18 components
+     * Called by IComponentRuntime (on behalf of distributed data structure) in disconnected state to notify about
+     * local changes. All pending changes are automatically flushed by shared objects on connection.
+     */
+    public notifyPendingMessages(): void {
+        assert(!this.connected);
+        this.updateDocumentDirtyState(true);
+    }
+
+    /**
      * Returns true of document is dirty, i.e. there are some pending local changes that
      * either were not sent out to delta stream or were not yet acknowledged.
      */

--- a/packages/test/end-to-end/src/test/compat.spec.ts
+++ b/packages/test/end-to-end/src/test/compat.spec.ts
@@ -118,9 +118,6 @@ describe("loader/runtime compatibility", () => {
                 createContainerWithOldLoader( // old loader, new container/component runtimes
                     { fluidExport: createRuntimeFactory(TestComponent.type, createComponentFactory()) },
                     this.deltaConnectionServer),
-                createContainerWithOldLoader( // old loader/container runtime, new component runtime
-                    { fluidExport: createOldRuntimeFactory(TestComponent.type, createComponentFactory()) },
-                    this.deltaConnectionServer),
                 createContainerWithOldLoader( // old everything
                     { fluidExport: createOldRuntimeFactory(TestComponent.type, createOldComponentFactory()) },
                     this.deltaConnectionServer),
@@ -175,26 +172,6 @@ describe("loader/runtime compatibility", () => {
             this.containerDeltaEventManager = new DocumentDeltaEventManager(this.deltaConnectionServer);
             this.container = await createContainer(
                 { fluidExport: createOldRuntimeFactory(OldTestComponent.type, createOldComponentFactory()) },
-                this.deltaConnectionServer,
-            );
-
-            this.component = await getComponent<OldTestComponent>("default", this.container);
-            this.containerDeltaEventManager.registerDocuments(this.component._runtime);
-        });
-
-        tests();
-
-        afterEach(async function() {
-            await this.deltaConnectionServer.webSocketServer.close();
-        });
-    });
-
-    describe("old ContainerRuntime, new ComponentRuntime", function() {
-        beforeEach(async function() {
-            this.deltaConnectionServer = LocalDeltaConnectionServer.create();
-            this.containerDeltaEventManager = new DocumentDeltaEventManager(this.deltaConnectionServer);
-            this.container = await createContainerWithOldLoader(
-                { fluidExport: createOldRuntimeFactory(TestComponent.type, createComponentFactory()) },
                 this.deltaConnectionServer,
             );
 


### PR DESCRIPTION
#2235 changed the model of ops resubmission of reconnect. However, this broke backward compatibility between the Container / Component runtime layers.

This change adds backward compatibility when using a new Container Runtime and old Component Runtime.

Also, remove the old Container Runtime / new Component Runtime case from the compat tests as we are not supporting that for the time being at least. We can add it back if we decide to support it.