### PR TITLE
build-tools version bump

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -448,9 +448,9 @@
 			"integrity": "sha1-/r4fxBf1yVraARNHH6yU+5FYWPo="
 		},
 		"@fluidframework/build-tools": {
-			"version": "0.1.28674",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/build-tools/-/build-tools-0.1.28674.tgz",
-			"integrity": "sha1-ktlv3apS6Tsb53S4kV49dU+X8Vo=",
+			"version": "0.1.28700",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/build-tools/-/build-tools-0.1.28700.tgz",
+			"integrity": "sha1-2Mjn9ff2rE1izYxIkoAfUL7PZAU=",
 			"dev": true,
 			"requires": {
 				"async": "^2.6.2",
@@ -17744,9 +17744,9 @@
 					}
 				},
 				"ignore": {
-					"version": "5.1.4",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-					"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+					"version": "5.1.8",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
 					"dev": true
 				},
 				"is-number": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -376,9 +376,9 @@
       }
     },
     "@fluidframework/build-tools": {
-      "version": "0.1.28674",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/build-tools/-/build-tools-0.1.28674.tgz",
-      "integrity": "sha1-ktlv3apS6Tsb53S4kV49dU+X8Vo=",
+      "version": "0.1.28700",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/build-tools/-/build-tools-0.1.28700.tgz",
+      "integrity": "sha1-2Mjn9ff2rE1izYxIkoAfUL7PZAU=",
       "dev": true,
       "requires": {
         "async": "^2.6.2",
@@ -8181,9 +8181,9 @@
           }
         },
         "ignore": {
-          "version": "5.1.4",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
           "dev": true
         },
         "is-number": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@fluidframework/build-tools": "^0.1.27804",
+    "@fluidframework/build-tools": "^0.1.28700",
     "@microsoft/api-documenter": "^7.4.6",
     "@microsoft/api-extractor": "^7.7.2",
     "concurrently": "^5.2.0",

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -461,9 +461,9 @@
 			"integrity": "sha1-/r4fxBf1yVraARNHH6yU+5FYWPo="
 		},
 		"@fluidframework/build-tools": {
-			"version": "0.1.28674",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/build-tools/-/build-tools-0.1.28674.tgz",
-			"integrity": "sha1-ktlv3apS6Tsb53S4kV49dU+X8Vo=",
+			"version": "0.1.28700",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/build-tools/-/build-tools-0.1.28700.tgz",
+			"integrity": "sha1-2Mjn9ff2rE1izYxIkoAfUL7PZAU=",
 			"dev": true,
 			"requires": {
 				"async": "^2.6.2",
@@ -13968,9 +13968,9 @@
 					}
 				},
 				"ignore": {
-					"version": "5.1.4",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-					"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+					"version": "5.1.8",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
 					"dev": true
 				},
 				"is-number": {

--- a/server/routerlicious/package-lock.json
+++ b/server/routerlicious/package-lock.json
@@ -375,9 +375,9 @@
 			}
 		},
 		"@fluidframework/build-tools": {
-			"version": "0.1.28674",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/build-tools/-/build-tools-0.1.28674.tgz",
-			"integrity": "sha1-ktlv3apS6Tsb53S4kV49dU+X8Vo=",
+			"version": "0.1.28700",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/build-tools/-/build-tools-0.1.28700.tgz",
+			"integrity": "sha1-2Mjn9ff2rE1izYxIkoAfUL7PZAU=",
 			"dev": true,
 			"requires": {
 				"async": "^2.6.2",
@@ -8205,9 +8205,9 @@
 					}
 				},
 				"ignore": {
-					"version": "5.1.4",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-					"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+					"version": "5.1.8",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
 					"dev": true
 				},
 				"is-number": {

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@fluidframework/build-tools": "^0.1.27804",
+    "@fluidframework/build-tools": "^0.1.28700",
     "@microsoft/api-documenter": "^7.4.6",
     "@microsoft/api-extractor": "^7.7.2",
     "concurrently": "^5.2.0",


### PR DESCRIPTION
Bump the build-tools version in both client and server to 0.1.28700. This fixes an issue around not having copy-right headers on yo-fluid generator template files