### PR TITLE
Update how deterministic op timestamps work

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -540,10 +540,6 @@ export class DeliLambda implements IPartitionLambda {
         sequenceNumber: number,
         systemContent,
     ): ISequencedDocumentMessage {
-        // prefer the server/client provided timestamp, fallback to current time
-        // we fallback to current time to ensure all ops have a timestamp
-        const timestamp = message.operation.timestamp ?? Date.now();
-
         const outputMessage: ISequencedDocumentMessage = {
             clientId: message.clientId,
             clientSequenceNumber: message.operation.clientSequenceNumber,
@@ -555,7 +551,7 @@ export class DeliLambda implements IPartitionLambda {
             referenceSequenceNumber: message.operation.referenceSequenceNumber,
             sequenceNumber,
             term: this.term,
-            timestamp,
+            timestamp: message.timestamp,
             traces: message.operation.traces,
             type: message.operation.type,
         };

--- a/server/routerlicious/packages/protocol-definitions/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/protocol.ts
@@ -122,9 +122,6 @@ export interface IDocumentMessage {
     // Server provided metadata about the operation
     serverMetadata?: any;
 
-    // Optional server/client provided timestamp for when the op was submitted
-    timestamp?: number;
-
     // Traces related to the packet.
     traces?: ITrace[];
 }


### PR DESCRIPTION
A follow up on pr #2239. I added a new `timestamp` field to `IDocumentMessage` while there was already an existing `timestamp` field on `IRawOperationMessage` that was already filled out everywhere. We should use that existing field instead.