### PR TITLE
Add indirect factory helper

### DIFF
--- a/packages/framework/aqueduct/src/componentFactories/index.ts
+++ b/packages/framework/aqueduct/src/componentFactories/index.ts
@@ -3,5 +3,6 @@
  * Licensed under the MIT License.
  */
 
+export * from "./indirectComponentFactory";
 export * from "./primedComponentFactory";
 export * from "./sharedComponentFactory";

--- a/packages/framework/aqueduct/src/componentFactories/indirectComponentFactory.ts
+++ b/packages/framework/aqueduct/src/componentFactories/indirectComponentFactory.ts
@@ -1,0 +1,66 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as assert from "assert";
+import {
+    IComponent,
+    IComponentLoadable,
+} from "@fluidframework/component-core-interfaces";
+import {
+    IComponentContext,
+    IComponentFactory,
+} from "@fluidframework/runtime-definitions";
+
+import { SharedComponentFactory } from "./sharedComponentFactory";
+
+/**
+ * A component factory that delegates factory component creation to another factory
+ * based on a decision lambda
+ *
+ * S is an optional initial state type that all constituent factories must accept
+ * D is an optional decision argument type that must be matched when creating a component
+ */
+export class IndirectComponentFactory<
+    S = undefined,
+    D = undefined>
+    implements IComponentFactory
+{
+    private defaultSelectionFn = (
+        registryEntries: [Promise<SharedComponentFactory<{}, S>>],
+        decisionArgs?: D,
+    ): Promise<SharedComponentFactory<{}, S>> => {
+        return registryEntries[0];
+    }
+
+    constructor(
+        // The general class of components
+        public readonly type: string,
+        private readonly registryEntries: [Promise<SharedComponentFactory<{}, S>>],
+        private readonly selectionFn?: (
+            registryEntries: [Promise<SharedComponentFactory<{}, S>>],
+            decisionArgs?: D,
+        ) => Promise<SharedComponentFactory<{}, S>>,
+    ) {
+        assert(registryEntries.length > 0);
+        if (this.selectionFn === undefined)
+        {
+            this.selectionFn = this.defaultSelectionFn;
+        }
+    }
+
+    public get IComponentFactory() { return this; }
+
+    public async createComponent(
+        context: IComponentContext,
+        initialState?: S,
+        decisionArgs?: D,
+    ): Promise<IComponent & IComponentLoadable> {
+        const matchedFactory = await this.selectionFn!(this.registryEntries, decisionArgs);
+        return matchedFactory.createComponent(context, initialState);
+    }
+
+    public instantiateComponent(context: IComponentContext): void {
+    }
+}


### PR DESCRIPTION
Draft request for comment.

A while back @leeviana had this PR for handling generic component types: https://office.visualstudio.com/OC/_git/office-bohemia/pullrequest/469189 .  Gist is that a container may want a component type to dynamically map to one of many matching components.  The existing infra makes this difficult to do with the component creation path we want to push.  And the general problem of "delegate mapping a type to one of many components to someone else while providing compatible initial state" seems like something that should be natively supported (and really, MUST be natively supported if we want to stop providing initial state/props through the context.

What I arrived at is essentially a factory wrapper that can be put into a container registry like any other factory, but when creating a component will send that creation to one of the constituent factories (list of which is specified at creation).

Parts I'm unsure about:
-This iteration has the list of components set at creation, suggesting the developer will likely need to know all the possible mappings upfront.  Given the way the component registry currently works, this seems to make sense but it could be more dynamic.
-This sort of delegation _seems_ like the sort of thing that would want to be super dynamic, e.g. get an unknown beforehand list of components for X type and pick the most appropriate.  Knowing the list beforehand _seems_ like the delegator could be calling the decision lambda directly, and the delegatee could be providing this decision lamba instead of the indirect factory.  This is probably my biggest hangup here.
-How should component creation delegation work with component registry entries?  (Unverified) Given the current architecture, will the delegator need to know all the possible outcomes?
