### PR TITLE
Matrix: Move to latest Tiny-Calc interfaces

### DIFF
--- a/packages/runtime/matrix/bench/src/read/map.ts
+++ b/packages/runtime/matrix/bench/src/read/map.ts
@@ -8,16 +8,18 @@ import { pointwise } from "./test";
 export class Map256x256<T> {
     private readonly cells = new Map<number, T>();
 
-    public get numRows() { return 256; }
-    public get numCols() { return 256; }
+    public get rowCount() { return 256; }
+    public get colCount() { return 256; }
 
-    public read(row: number, col: number) {
+    public getCell(row: number, col: number) {
         return this.cells.get((row << 8) + col);
     }
 
     public setCell(row: number, col: number, value: T) {
         this.cells.set((row << 8) + col, value);
     }
+
+    public get matrixProducer() { return undefined as any; }
 }
 
 pointwise(undefined, new Map256x256<number>());

--- a/packages/runtime/matrix/bench/src/read/nativearray.ts
+++ b/packages/runtime/matrix/bench/src/read/nativearray.ts
@@ -8,16 +8,18 @@ import { pointwise } from "./test";
 export class Array256x256<T> {
     private readonly cells: T[] = new Array(256 * 256).fill(0);
 
-    public get numRows() { return 256; }
-    public get numCols() { return 256; }
+    public get rowCount() { return 256; }
+    public get colCount() { return 256; }
 
-    public read(row: number, col: number) {
+    public getCell(row: number, col: number) {
         return this.cells[(row << 8) + col];
     }
 
     public setCell(row: number, col: number, value: T) {
         this.cells[(row << 8) + col] = value;
     }
+
+    public get matrixProducer() { return undefined as any; }
 }
 
 pointwise(undefined, new Array256x256<number>());

--- a/packages/runtime/matrix/bench/src/read/test.ts
+++ b/packages/runtime/matrix/bench/src/read/test.ts
@@ -23,7 +23,7 @@ export function pointwise<T>(name: string | undefined, arr: IArray2D<T>) {
             let sum = 0;
             for (let r = row; r < numRows; r++) {
                 for (let c = col; c < numCols; c++) {
-                    sum += (arr.read(r, c) as any | 0);
+                    sum += (arr.getCell(r, c) as any | 0);
                 }
             }
             return sum;

--- a/packages/runtime/matrix/bench/src/read/tiled.ts
+++ b/packages/runtime/matrix/bench/src/read/tiled.ts
@@ -216,16 +216,18 @@ function initGrid<T>(): SparseGrid<T> {
 export class TiledGrid<T> {
     private readonly cells: SparseGrid<T> = initGrid();
 
-    public get numRows() { return Consts.sizeH; }
-    public get numCols() { return Consts.sizeW; }
+    public get rowCount() { return Consts.sizeH; }
+    public get colCount() { return Consts.sizeW; }
 
-    public read(row: number, col: number) {
+    public getCell(row: number, col: number) {
         return getCell(row, col, this.cells);
     }
 
     public setCell(row: number, col: number, value: T) {
         setCell(row, col, this.cells, value);
     }
+
+    public get matrixProducer() { return undefined as any; }
 }
 
 pointwise("TiledGrid", new TiledGrid<number>());

--- a/packages/runtime/matrix/bench/src/util.ts
+++ b/packages/runtime/matrix/bench/src/util.ts
@@ -5,7 +5,6 @@
 
 import { MockRuntime } from "@fluidframework/test-runtime-utils";
 import { SharedMatrix, SharedMatrixFactory } from "./imports";
-import { strict as assert } from "assert";
 import { insertFragmented } from "../../test/utils";
 const process = require("process");
 
@@ -16,42 +15,39 @@ let cached: any;
  * Paranoid defense against dead code elimination.
  */
 export function consume(value: any) {
-  count++;
-  if (count >>> 0 === 0) {
-    cached = value;
-  }
+    count++;
+    if (count >>> 0 === 0) {
+        cached = value;
+    }
 }
 
 // Prevent v8"s optimizer from identifying "cached" as an unused value.
 process.on("exit", () => {
-  if (count >>> 0 === 0) {
-    console.log(`Ignore this: ${cached}`);
-  }
+    if (count >>> 0 === 0) {
+        console.log(`Ignore this: ${cached}`);
+    }
 });
 
 export function randomId() {
-  // tslint:disable-next-line:insecure-random
-  return Math.random()
-    .toString(36)
-    .slice(2);
+    // tslint:disable-next-line:insecure-random
+    return Math.random()
+        .toString(36)
+        .slice(2);
 }
 
-export function createContiguousMatrix(numRows: number, numCols: number) {
-  const runtime = new MockRuntime();
-  const matrix = new SharedMatrixFactory().create(runtime, randomId()) as SharedMatrix;
-  matrix.insertRows(0, numRows);
-  matrix.insertCols(0, numCols);
-  return matrix;
+export function createMatrix() {
+    return new SharedMatrixFactory().create(new MockRuntime(), randomId()) as SharedMatrix;
 }
 
-export function createFragmentedMatrix(numRows: number, numCols: number) {
-  const runtime = new MockRuntime();
-  const matrix = new SharedMatrixFactory().create(runtime, randomId()) as SharedMatrix;
+export function createContiguousMatrix(rowCount: number, colCount: number) {
+    const matrix = createMatrix();
+    matrix.insertRows(0, rowCount);
+    matrix.insertCols(0, colCount);
+    return matrix;
+}
 
-  insertFragmented(matrix, numRows, numCols);
-
-  assert.equal(matrix.numRows, numRows);
-  assert.equal(matrix.numCols, numCols);
-
-  return matrix;
+export function createFragmentedMatrix(rowCount: number, colCount: number) {
+    const matrix = createMatrix();
+    insertFragmented(matrix, rowCount, colCount);
+    return matrix;
 }

--- a/packages/runtime/matrix/package.json
+++ b/packages/runtime/matrix/package.json
@@ -54,7 +54,7 @@
     "@fluidframework/protocol-definitions": "^0.1006.0-0",
     "@fluidframework/runtime-utils": "^0.19.0",
     "@fluidframework/shared-object-base": "^0.19.0",
-    "@tiny-calc/nano": "0.0.20329",
+    "@tiny-calc/nano": "0.0.28777",
     "debug": "^4.1.1",
     "tslib": "^1.10.0"
   },

--- a/packages/runtime/matrix/src/matrix.ts
+++ b/packages/runtime/matrix/src/matrix.ts
@@ -18,7 +18,7 @@ import {
 } from "@fluidframework/component-runtime-definitions";
 import { makeHandlesSerializable, parseHandles, SharedObject } from "@fluidframework/shared-object-base";
 import { ObjectStoragePartition } from "@fluidframework/runtime-utils";
-import { IMatrixProducer, IMatrixConsumer, IMatrixReader } from "@tiny-calc/nano";
+import { IMatrixProducer, IMatrixConsumer, IMatrixReader, IMatrixWriter } from "@tiny-calc/nano";
 import { debug } from "./debug";
 import { MatrixOp } from "./ops";
 import { PermutationVector } from "./permutationvector";
@@ -33,8 +33,11 @@ const enum SnapshotPath {
     cells = "cells",
 }
 
-export class SharedMatrix<T extends Serializable = Serializable> extends SharedObject
-    implements IMatrixProducer<T | undefined | null>, IMatrixReader<T | undefined | null>
+export class SharedMatrix<T extends Serializable = Serializable>
+    extends SharedObject
+    implements IMatrixProducer<T | undefined | null>,
+        IMatrixReader<T | undefined | null>,
+        IMatrixWriter<T | undefined>
 {
     private readonly consumers = new Set<IMatrixConsumer<T | undefined | null>>();
 
@@ -71,23 +74,23 @@ export class SharedMatrix<T extends Serializable = Serializable> extends SharedO
 
     // #region IMatrixProducer
 
-    removeMatrixConsumer(consumer: IMatrixConsumer<T | undefined | null>): void {
-        this.consumers.delete(consumer);
-    }
-
     openMatrix(consumer: IMatrixConsumer<T | undefined | null>): IMatrixReader<T | undefined | null> {
         this.consumers.add(consumer);
         return this;
+    }
+
+    closeMatrix(consumer: IMatrixConsumer<T | undefined | null>): void {
+        this.consumers.delete(consumer);
     }
 
     // #endregion IMatrixProducer
 
     // #region IMatrixReader
 
-    public get numRows() { return this.rows.getLength(); }
-    public get numCols() { return this.cols.getLength(); }
+    public get rowCount() { return this.rows.getLength(); }
+    public get colCount() { return this.cols.getLength(); }
 
-    public read(row: number, col: number): T | undefined | null {
+    public getCell(row: number, col: number): T | undefined | null {
         // Map the logical (row, col) to associated storage handles.
         const rowHandle = this.rows.handles[row];
 
@@ -96,7 +99,7 @@ export class SharedMatrix<T extends Serializable = Serializable> extends SharedO
         //       assert with range check on node v12 x64)
         if (!(rowHandle >= Handle.valid)) {
             assert(rowHandle === Handle.unallocated, "'row' out of range.");
-            assert(0 <= col && col < this.numCols, "'col' out of range.");
+            assert(0 <= col && col < this.colCount, "'col' out of range.");
             return undefined;
         }
 
@@ -110,49 +113,49 @@ export class SharedMatrix<T extends Serializable = Serializable> extends SharedO
             return undefined;
         }
 
-        return this.cells.read(rowHandle, colHandle);
+        return this.cells.getCell(rowHandle, colHandle);
     }
+
+    public get matrixProducer(): IMatrixProducer<T | undefined | null> { return this; }
 
     // #endregion IMatrixReader
 
     public setCell(row: number, col: number, value: T) {
-        assert(0 <= row && row < this.numRows
-            && 0 <= col && col < this.numCols);
+        assert(0 <= row && row < this.rowCount
+            && 0 <= col && col < this.colCount);
 
         this.setCellCore(row, col, value);
 
         // Avoid reentrancy by raising change notifications after the op is queued.
         for (const consumer of this.consumers.values()) {
-            // TODO: Pretty lame to alloc an array to send a single value.  Probably warrants a
-            //       singular `cellChanged` API.
-            consumer.cellsChanged(row, col, 1, 1, [value], this);
+            consumer.cellsChanged(row, col, 1, 1, this);
         }
     }
 
-    public setCells(row: number, col: number, numCols: number, values: readonly T[]) {
-        const numRows = Math.ceil(values.length / numCols);
+    public setCells(rowStart: number, colStart: number, colCount: number, values: readonly T[]) {
+        const rowCount = Math.ceil(values.length / colCount);
 
-        assert((0 <= row && row < this.numRows)
-            && (0 <= col && col < this.numCols)
-            && (1 <= numCols && numCols <= (this.numCols - col))
-            && (numRows <= (this.numRows - row)));
+        assert((0 <= rowStart && rowStart < this.rowCount)
+            && (0 <= colStart && colStart < this.colCount)
+            && (1 <= colCount && colCount <= (this.colCount - colStart))
+            && (rowCount <= (this.rowCount - rowStart)));
 
-        const endCol = col + numCols;
-        let r = row;
-        let c = col;
+        const endCol = colStart + colCount;
+        let r = rowStart;
+        let c = colStart;
 
         for (const value of values) {
             this.setCellCore(r, c, value);
 
             if (++c === endCol) {
-                c = col;
+                c = colStart;
                 r++;
             }
         }
 
         // Avoid reentrancy by raising change notifications after the op is queued.
         for (const consumer of this.consumers.values()) {
-            consumer.cellsChanged(row, col, numRows, numCols, values, this);
+            consumer.cellsChanged(rowStart, colStart, rowCount, colCount, this);
         }
     }
 
@@ -178,20 +181,20 @@ export class SharedMatrix<T extends Serializable = Serializable> extends SharedO
         }
     }
 
-    public insertCols(startCol: number, count: number) {
-        this.insert(this.cols, SnapshotPath.cols, startCol, count);
+    public insertCols(colStart: number, count: number) {
+        this.insert(this.cols, SnapshotPath.cols, colStart, count);
     }
 
-    public removeCols(startCol: number, count: number) {
-        this.remove(this.cols, SnapshotPath.cols, startCol, count);
+    public removeCols(colStart: number, count: number) {
+        this.remove(this.cols, SnapshotPath.cols, colStart, count);
     }
 
-    public insertRows(startRow: number, count: number) {
-        this.insert(this.rows, SnapshotPath.rows, startRow, count);
+    public insertRows(rowStart: number, count: number) {
+        this.insert(this.rows, SnapshotPath.rows, rowStart, count);
     }
 
-    public removeRows(startRow: number, count: number) {
-        this.remove(this.rows, SnapshotPath.rows, startRow, count);
+    public removeRows(rowStart: number, count: number) {
+        this.remove(this.rows, SnapshotPath.rows, rowStart, count);
     }
 
     public snapshot(): ITree {
@@ -285,7 +288,7 @@ export class SharedMatrix<T extends Serializable = Serializable> extends SharedO
                     assert.equal(rawMessage.clientSequenceNumber, cliSeq);
 
                     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    const actualCliSeq = this.pendingCliSeqs.read(rowHandle, colHandle)!;
+                    const actualCliSeq = this.pendingCliSeqs.getCell(rowHandle, colHandle)!;
 
                     // Note while we're awaiting the local set, it's possible for the row/col to be locally
                     // removed and the row/col handles recycled.  If this happens, the actualCliSeq will be
@@ -312,12 +315,12 @@ export class SharedMatrix<T extends Serializable = Serializable> extends SharedO
                             assert(rowHandle >= Handle.valid
                                 && colHandle >= Handle.valid);
 
-                            if (this.pendingCliSeqs.read(rowHandle, colHandle) === undefined) {
+                            if (this.pendingCliSeqs.getCell(rowHandle, colHandle) === undefined) {
                                 const { value } = contents;
                                 this.cells.setCell(rowHandle, colHandle, value);
 
                                 for (const consumer of this.consumers.values()) {
-                                    consumer.cellsChanged(adjustedRow, adjustedCol, 1, 1, [value], this);
+                                    consumer.cellsChanged(adjustedRow, adjustedCol, 1, 1, this);
                                 }
                             }
                         }
@@ -364,21 +367,21 @@ export class SharedMatrix<T extends Serializable = Serializable> extends SharedO
     }
 
     // Invoked by PermutationVector to notify IMatrixConsumers of row insertion/deletions.
-    private readonly onRowDelta = (position: number, numRemoved: number, numInserted: number) => {
+    private readonly onRowDelta = (position: number, removedCount: number, insertedCount: number) => {
         for (const consumer of this.consumers) {
-            consumer.rowsChanged(position, numRemoved, numInserted, this);
+            consumer.rowsChanged(position, removedCount, insertedCount, this);
         }
     };
 
     // Invoked by PermutationVector to notify IMatrixConsumers of col insertion/deletions.
-    private readonly onColDelta = (position: number, numRemoved: number, numInserted: number) => {
+    private readonly onColDelta = (position: number, removedCount: number, insertedCount: number) => {
         for (const consumer of this.consumers) {
-            consumer.colsChanged(position, numRemoved, numInserted, this);
+            consumer.colsChanged(position, removedCount, insertedCount, this);
         }
     };
 
     private readonly onRowHandlesRecycled = (rowHandles: Handle[]) => {
-        for (let col = 0; col < this.numCols; col++) {
+        for (let col = 0; col < this.colCount; col++) {
             const colHandle = this.cols.handles[col];
             if (colHandle !== Handle.unallocated) {
                 for (const rowHandle of rowHandles) {
@@ -390,7 +393,7 @@ export class SharedMatrix<T extends Serializable = Serializable> extends SharedO
     };
 
     private readonly onColHandlesRecycled = (colHandles: Handle[]) => {
-        for (let row = 0; row < this.numRows; row++) {
+        for (let row = 0; row < this.rowCount; row++) {
             const rowHandle = this.rows.handles[row];
             if (rowHandle !== Handle.unallocated) {
                 for (const colHandle of colHandles) {
@@ -404,14 +407,14 @@ export class SharedMatrix<T extends Serializable = Serializable> extends SharedO
     public toString() {
         let s = `client:${this.runtime.clientId}\nrows: ${this.rows.toString()}\ncols: ${this.cols.toString()}\n\n`;
 
-        for (let r = 0; r < this.numRows; r++) {
+        for (let r = 0; r < this.rowCount; r++) {
             s += `  [`;
-            for (let c = 0; c < this.numCols; c++) {
+            for (let c = 0; c < this.colCount; c++) {
                 if (c > 0) {
                     s += ", ";
                 }
 
-                s += `${JSON.stringify(this.read(r, c))}`;
+                s += `${JSON.stringify(this.getCell(r, c))}`;
             }
             s += "]\n";
         }

--- a/packages/runtime/matrix/src/sparsearray2d.ts
+++ b/packages/runtime/matrix/src/sparsearray2d.ts
@@ -5,11 +5,9 @@
 
 /* eslint-disable no-bitwise */
 
-import { IMatrixReader } from "@tiny-calc/nano";
+import { IMatrixReader, IMatrixWriter } from "@tiny-calc/nano";
 
-export interface IArray2D<T> extends IMatrixReader<T | undefined | null> {
-    setCell(row: number, col: number, value: T | undefined): void;
-}
+export interface IArray2D<T> extends IMatrixReader<T | undefined | null>, IMatrixWriter<T | undefined> { }
 
 // Build a lookup table that maps a uint8 to the corresponding uint16 where 0s
 // are interleaved between the original bits. (e.g., 1111... -> 01010101...).
@@ -61,10 +59,10 @@ type UA<T> = (T | undefined)[];
 export class SparseArray2D<T> implements IArray2D<T> {
     constructor(private readonly root: UA<UA<UA<UA<UA<T>>>>> = [undefined]) {}
 
-    public get numRows() { return 0xFFFFFFFF; }
-    public get numCols() { return 0xFFFFFFFF; }
+    public get rowCount() { return 0xFFFFFFFF; }
+    public get colCount() { return 0xFFFFFFFF; }
 
-    read(row: number, col: number): T | undefined | null {
+    getCell(row: number, col: number): T | undefined | null {
         const keyHi = r0c0ToMorton2x16(row >>> 16, col >>> 16);
         const level0 = this.root[keyHi];
         if (level0 !== undefined) {
@@ -83,6 +81,8 @@ export class SparseArray2D<T> implements IArray2D<T> {
 
         return undefined;
     }
+
+    public get matrixProducer() { return undefined as any; }
 
     setCell(row: number, col: number, value: T | undefined) {
         const keyHi = r0c0ToMorton2x16(row >>> 16, col >>> 16);

--- a/packages/runtime/matrix/test/matrix.big.spec.ts
+++ b/packages/runtime/matrix/test/matrix.big.spec.ts
@@ -33,7 +33,7 @@ async function snapshot<T extends Serializable>(matrix: SharedMatrix<T>) {
     });
 
     // Vet that the 2nd matrix is equivalent to the original.
-    expectSize(matrix2, matrix.numRows, matrix.numCols);
+    expectSize(matrix2, matrix.rowCount, matrix.colCount);
 
     return matrix2;
 }
@@ -99,8 +99,8 @@ describe("Big Matrix", function () {
             await sync();
             checkCorners(matrix2);
 
-            matrix1.removeRows(0, matrix1.numRows);
-            matrix1.removeCols(0, matrix1.numCols);
+            matrix1.removeRows(0, matrix1.rowCount);
+            matrix1.removeCols(0, matrix1.colCount);
             expectSize(matrix1, 0, 0);
 
             await sync();

--- a/packages/runtime/matrix/test/matrix.spec.ts
+++ b/packages/runtime/matrix/test/matrix.spec.ts
@@ -29,7 +29,7 @@ async function snapshot<T extends Serializable>(matrix: SharedMatrix<T>) {
     });
 
     // Vet that the 2nd matrix is equivalent to the original.
-    expectSize(matrix2, matrix.numRows, matrix.numCols);
+    expectSize(matrix2, matrix.rowCount, matrix.colCount);
     assert.deepEqual(extract(matrix), extract(matrix2), 'Matrix must round-trip through snapshot/load.');
 
     return matrix2;
@@ -50,7 +50,7 @@ describe("Matrix", () => {
 
     describe("local client", () => {
         let matrix: SharedMatrix<number>;       // SharedMatrix under test
-        let consumer: TestConsumer<number>;     // Test IMatrixConsumer that builds a copy of `matrix` via observed events.
+        let consumer: TestConsumer<undefined | null | number>;     // Test IMatrixConsumer that builds a copy of `matrix` via observed events.
 
         async function sync() {
             await TestHost.sync(host1, host2);
@@ -76,8 +76,7 @@ describe("Matrix", () => {
             matrix = await host1.createType(uuid(), SharedMatrixFactory.Type);
 
             // Attach a new IMatrixConsumer
-            consumer = new TestConsumer();
-            matrix.openMatrix(consumer);
+            consumer = new TestConsumer(matrix);
         });
 
         afterEach(async () => {
@@ -91,9 +90,9 @@ describe("Matrix", () => {
             assert.deepEqual(consumer.extract(), extract(matrix));
 
             // Sanity check that removing the consumer stops change notifications.
-            matrix.removeMatrixConsumer(consumer);
+            matrix.closeMatrix(consumer);
             matrix.insertCols(0, 1);
-            assert.equal(consumer.numCols, matrix.numCols - 1);
+            assert.equal(consumer.colCount, matrix.colCount - 1);
         });
 
         // Vet our three variants of an empty matrix (no rows, no cols, and both no rows and no cols).
@@ -101,20 +100,20 @@ describe("Matrix", () => {
             // Note: We check the num rows/cols explicitly in these tests to differentiate between
             //       matrices that are 0 length in one or both dimensions.
             it("0x0", async () => {
-                expectSize(matrix, /* numRows: */ 0, /* numCols: */ 0);
-                expectSize(await expect([]), /* numRows: */ 0, /* numCols: */ 0);
+                expectSize(matrix, /* rowCount: */ 0, /* colCount: */ 0);
+                expectSize(await expect([]), /* rowCount: */ 0, /* colCount: */ 0);
             });
 
             it("0x1", async () => {
                 matrix.insertCols(/* start: */ 0, /* count: */ 1);
-                expectSize(matrix, /* numRows: */ 0, /* numCols: */ 1);
-                expectSize(await expect([]), /* numRows: */ 0, /* numCols: */ 1);
+                expectSize(matrix, /* rowCount: */ 0, /* colCount: */ 1);
+                expectSize(await expect([]), /* rowCount: */ 0, /* colCount: */ 1);
             });
 
             it("1x0", async () => {
                 matrix.insertRows(/* start: */ 0, /* count: */ 1);
-                expectSize(matrix, /* numRows: */ 1, /* numCols: */ 0);
-                expectSize(await expect([[]]), /* numRows: */ 1, /* numCols: */ 0);
+                expectSize(matrix, /* rowCount: */ 1, /* colCount: */ 0);
+                expectSize(await expect([[]]), /* rowCount: */ 1, /* colCount: */ 0);
             });
         });
 
@@ -141,7 +140,7 @@ describe("Matrix", () => {
             ]);
 
             // Note: It's valid to leave the last row incomplete.
-            matrix.setCells(/* row: */ 1, /* col: */ 1, /* numCols: */ 2, [
+            matrix.setCells(/* row: */ 1, /* col: */ 1, /* colCount: */ 2, [
                 1, 2,
                 3, 4,
                 5
@@ -158,18 +157,18 @@ describe("Matrix", () => {
         // Vet that we can set and read back the cell in a 1x1 matrix.
         it("out-of-bounds read must throw", async () => {
             // Reading cell (0,0) of an empty matrix must throw.
-            assert.throws(() => { matrix.read(0, 0); });
+            assert.throws(() => { matrix.getCell(0, 0); });
 
             matrix.insertRows(0, 1);
             matrix.insertCols(0, 2);
 
             // Reading negative indices must throw.
-            assert.throws(() => { matrix.read(-1, 0); });
-            assert.throws(() => { matrix.read(0, -1); });
+            assert.throws(() => { matrix.getCell(-1, 0); });
+            assert.throws(() => { matrix.getCell(0, -1); });
 
             // Reading past end of matrix must throw.
-            assert.throws(() => { matrix.read(1, 0);  });
-            assert.throws(() => { matrix.read(0, 2); });
+            assert.throws(() => { matrix.getCell(1, 0);  });
+            assert.throws(() => { matrix.getCell(0, 2); });
         });
 
         // Vet that we can insert a column in a 1x2 matrix.
@@ -212,10 +211,10 @@ describe("Matrix", () => {
         it("remove 1 row, insert 2 rows", async () => {
             matrix.insertRows(0,4);
             matrix.insertCols(0,1);
-            matrix.setCells(/* row: */ 0, /* col: */ 0, /* numCols: */ 1, [0,1,2,3]);
+            matrix.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, [0,1,2,3]);
             matrix.removeRows(2,1);
             matrix.insertRows(0,2);
-            matrix.setCells(/* row: */ 0, /* col: */ 0, /* numCols: */ 1, [84,45]);
+            matrix.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, [84,45]);
             await expect([
                 [84],
                 [45],
@@ -229,16 +228,16 @@ describe("Matrix", () => {
             it("read/write 256x256", () => {
                 matrix.insertRows(0, 256);
                 matrix.insertCols(0, 256);
-                fill(matrix, /* row: */ 0, /* col: */ 0, /* numRows: */ 16, /* numCols: */ 16);
-                check(matrix, /* row: */ 0, /* col: */ 0, /* numRows: */ 16, /* numCols: */ 16);
+                fill(matrix, /* row: */ 0, /* col: */ 0, /* rowCount: */ 16, /* colCount: */ 16);
+                check(matrix, /* row: */ 0, /* col: */ 0, /* rowCount: */ 16, /* colCount: */ 16);
             });
         });
 
         describe("fragmented", () => {
             it("read/write 16x16", () => {
                 insertFragmented(matrix, 16, 16);
-                fill(matrix, /* row: */ 0, /* col: */ 0, /* numRows: */ 16, /* numCols: */ 16);
-                check(matrix, /* row: */ 0, /* col: */ 0, /* numRows: */ 16, /* numCols: */ 16);
+                fill(matrix, /* row: */ 0, /* col: */ 0, /* rowCount: */ 16, /* colCount: */ 16);
+                check(matrix, /* row: */ 0, /* col: */ 0, /* rowCount: */ 16, /* colCount: */ 16);
             });
         });
 
@@ -306,17 +305,17 @@ describe("Matrix", () => {
 
         beforeEach(async () => {
             matrix1 = await host1.createType(uuid(), SharedMatrixFactory.Type);
-            matrix1.openMatrix(consumer1 = new TestConsumer());
+            consumer1 = new TestConsumer(matrix1);
 
             matrix2 = await host2.getType(matrix1.id);
-            matrix2.openMatrix(consumer2 = new TestConsumer());
+            consumer2 = new TestConsumer(matrix2);
         });
 
         afterEach(async () => {
             await expect();
 
-            matrix1.removeMatrixConsumer(consumer1);
-            matrix2.removeMatrixConsumer(consumer2);
+            matrix1.closeMatrix(consumer1);
+            matrix2.closeMatrix(consumer2);
         });
 
         describe("conflict", () => {
@@ -356,7 +355,7 @@ describe("Matrix", () => {
                 matrix1.insertCols(0,2);
                 await expect();
                 matrix1.insertRows(0,1);
-                matrix1.setCells(/* row: */ 0, /* col: */ 1, /* numCols: */ 1, ["x"]);
+                matrix1.setCells(/* row: */ 0, /* col: */ 1, /* colCount: */ 1, ["x"]);
                 await expect([[undefined, "x"]]);
             });
 
@@ -367,7 +366,7 @@ describe("Matrix", () => {
                     [],
                 ]);
                 matrix1.insertCols(0,1);
-                matrix1.setCells(/* row: */ 1, /* col: */ 0, /* numCols: */ 1, ["x"]);
+                matrix1.setCells(/* row: */ 1, /* col: */ 0, /* colCount: */ 1, ["x"]);
                 await expect([
                     [undefined],
                     ["x"]
@@ -449,7 +448,7 @@ describe("Matrix", () => {
             it("insert col vs. remove row", async () => {
                 matrix1.insertCols(0, 2);
                 matrix1.insertRows(0, 3);
-                matrix1.setCells(/* row: */ 0, /* col: */ 0, /* numCols: */ 2, [
+                matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 2, [
                     "A1", "C1",
                     "A2", "C2",
                     "A3", "C3",
@@ -462,7 +461,7 @@ describe("Matrix", () => {
                 ]);
 
                 matrix1.insertCols(1, 1);
-                matrix1.setCells(/* row: */ 0, /* col: */ 1, /* numCols: */ 1, [
+                matrix1.setCells(/* row: */ 0, /* col: */ 1, /* colCount: */ 1, [
                     "B1",
                     "B2",
                     "B3",
@@ -479,7 +478,7 @@ describe("Matrix", () => {
             it("insert row vs. remove col", async () => {
                 matrix1.insertRows(0, 2);
                 matrix1.insertCols(0, 3);
-                matrix1.setCells(/* row: */ 0, /* col: */ 0, /* numCols: */ 3, [
+                matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 3, [
                     "A1", "B1", "C1",
                     "A3", "B3", "C3",
                 ]);
@@ -490,7 +489,7 @@ describe("Matrix", () => {
                 ]);
 
                 matrix1.insertRows(1, 1);
-                matrix1.setCells(/* row: */ 1, /* col: */ 0, /* numCols: */ 3, [
+                matrix1.setCells(/* row: */ 1, /* col: */ 0, /* colCount: */ 3, [
                     "A2", "B2", "C2",
                 ]);
 
@@ -506,7 +505,7 @@ describe("Matrix", () => {
             it("insert row vs. remove col", async () => {
                 matrix1.insertRows(0, 2);
                 matrix1.insertCols(0, 3);
-                matrix1.setCells(/* row: */ 0, /* col: */ 0, /* numCols: */ 3, [
+                matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 3, [
                     "A1", "B1", "C1",
                     "A3", "B3", "C3",
                 ]);
@@ -517,7 +516,7 @@ describe("Matrix", () => {
                 ]);
 
                 matrix1.insertRows(1, 1);
-                matrix1.setCells(/* row: */ 1, /* col: */ 0, /* numCols: */ 3, [
+                matrix1.setCells(/* row: */ 1, /* col: */ 0, /* colCount: */ 3, [
                     "A2", "B2", "C2",
                 ]);
 
@@ -534,7 +533,7 @@ describe("Matrix", () => {
             it("insert col vs. insert & remove row", async () => {
                 matrix1.insertRows(0, 2);
                 matrix1.insertCols(0, 2);
-                matrix1.setCells(/* row: */ 0, /* col: */ 0, /* numCols: */ 2, [
+                matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 2, [
                     "A1", "C1",
                     "A2", "C2",
                 ]);
@@ -559,7 +558,7 @@ describe("Matrix", () => {
 
                 matrix1.insertRows(0,1);
                 matrix2.insertRows(0,2);
-                matrix2.setCells(/* row: */ 0, /* col: */ 0, /* numCols: */ 4, ["A","B","C","D"]);
+                matrix2.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 4, ["A","B","C","D"]);
                 matrix1.insertCols(1,1);
 
                 await expect();
@@ -577,24 +576,24 @@ describe("Matrix", () => {
                 await expect();
 
                 matrix1.removeRows(1,1);
-                matrix2.setCells(/* row: */ 0, /* col: */ 0, /* numCols: */ 1, ["A", "B", "C"]);
+                matrix2.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, ["A", "B", "C"]);
                 await expect();
             });
 
             // This case is interesting because the removal of [0..1] is split on client2 to straddle the
             // inserted "B".
             it("overlapping insert/set vs. remove/insert/set", async () => {
-                matrix1.insertRows(0,1);    // numRows: 0, numCols: 0
-                matrix1.insertCols(0,4);    // numRows: 1, numCols: 0
-                matrix1.setCells(/* row: */ 0, /* col: */ 0, /* numCols: */ 4, [0,1,2,3]);
+                matrix1.insertRows(0,1);    // rowCount: 0, colCount: 0
+                matrix1.insertCols(0,4);    // rowCount: 1, colCount: 0
+                matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 4, [0,1,2,3]);
                 await expect([
                     [0, 1, 2, 3]
                 ]);
-                matrix2.insertCols(1,1);    // numRows: 1, numCols: 5
-                matrix2.setCells(/* row: */ 0, /* col: */ 1, /* numCols: */ 1, ["A"]);
-                matrix1.removeCols(0,2);    // numRows: 1, numCols: 2
-                matrix1.insertCols(0,1);    // numRows: 1, numCols: 3
-                matrix1.setCells(/* row: */ 0, /* col: */ 0, /* numCols: */ 1, ["B"]);
+                matrix2.insertCols(1,1);    // rowCount: 1, colCount: 5
+                matrix2.setCells(/* row: */ 0, /* col: */ 1, /* colCount: */ 1, ["A"]);
+                matrix1.removeCols(0,2);    // rowCount: 1, colCount: 2
+                matrix1.insertCols(0,1);    // rowCount: 1, colCount: 3
+                matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, ["B"]);
                 await expect([
                     ["B", "A", 2, 3]
                 ]);

--- a/packages/runtime/matrix/test/matrix.stress.spec.ts
+++ b/packages/runtime/matrix/test/matrix.stress.spec.ts
@@ -32,7 +32,7 @@ describe("Matrix", () => {
                 assert.deepEqual(actual0, actualN);
 
                 // Vet that empty matrices have identical dimensions (see notes on `expectSize`).
-                expectSize(matrixN, matrix0.numRows, matrix0.numCols);
+                expectSize(matrixN, matrix0.rowCount, matrix0.colCount);
             }
         };
 
@@ -73,29 +73,29 @@ describe("Matrix", () => {
                     .map(() => int32(100));
 
                 // Invokes 'setCells()' on the matrix w/the given index and logs the command to the trace.
-                const setCells = (matrixIndex: number, row: number, col: number, numCols: number, values: any[]) => {
+                const setCells = (matrixIndex: number, row: number, col: number, colCount: number, values: any[]) => {
                     const matrix = matrices[matrixIndex];
-                    trace?.push(`matrix${matrixIndex + 1}.setCells(/* row: */ ${row}, /* col: */ ${col}, /* numCols: */ ${numCols}, ${JSON.stringify(values)});    // numRows: ${matrix.numRows} numCols: ${matrix.numCols} stride: ${matrix.numCols} length: ${values.length}`);
-                    matrix.setCells(row, col, numCols, values);
+                    trace?.push(`matrix${matrixIndex + 1}.setCells(/* row: */ ${row}, /* col: */ ${col}, /* colCount: */ ${colCount}, ${JSON.stringify(values)});    // rowCount: ${matrix.rowCount} colCount: ${matrix.colCount} stride: ${matrix.colCount} length: ${values.length}`);
+                    matrix.setCells(row, col, colCount, values);
                 }
 
                 // Initialize with [0..5] row and [0..5] cols, filling the cells.
                 {
-                    const numRows = int32(5);
-                    if (numRows > 0) {
-                        trace?.push(`matrix1.insertRows(0,${numRows});    // numRows: ${matrix0.numRows}, numCols: ${matrix0.numCols}`);
-                        matrix0.insertRows(0, numRows);
+                    const rowCount = int32(5);
+                    if (rowCount > 0) {
+                        trace?.push(`matrix1.insertRows(0,${rowCount});    // rowCount: ${matrix0.rowCount}, colCount: ${matrix0.colCount}`);
+                        matrix0.insertRows(0, rowCount);
                     }
 
-                    const numCols = int32(5);
-                    if (numCols > 0) {
-                        trace?.push(`matrix1.insertCols(0,${numCols});    // numRows: ${matrix0.numRows}, numCols: ${matrix0.numCols}`);
-                        matrix0.insertCols(0, numCols);
+                    const colCount = int32(5);
+                    if (colCount > 0) {
+                        trace?.push(`matrix1.insertCols(0,${colCount});    // rowCount: ${matrix0.rowCount}, colCount: ${matrix0.colCount}`);
+                        matrix0.insertCols(0, colCount);
                     }
 
-                    if (numCols > 0 && numRows > 0) {
-                        setCells(/* matrixIndex: */ 0, /* row: */ 0, /* col: */ 0, numCols,
-                            new Array(numCols * numRows).fill(0).map((_, index) => index));
+                    if (colCount > 0 && rowCount > 0) {
+                        setCells(/* matrixIndex: */ 0, /* row: */ 0, /* col: */ 0, colCount,
+                            new Array(colCount * rowCount).fill(0).map((_, index) => index));
                     }
                 }
 
@@ -113,20 +113,20 @@ describe("Matrix", () => {
                     const matrixIndex = int32(matrices.length);
                     const matrix = matrices[matrixIndex];
 
-                    const { numRows, numCols } = matrix;
-                    const row = int32(numRows);
-                    const col = int32(numCols);
+                    const { rowCount, colCount } = matrix;
+                    const row = int32(rowCount);
+                    const col = int32(colCount);
 
                     switch(int32(7)) {
                         case 0: {
                             // remove 1 or more rows (if any exist)
-                            if (numRows > 0) {
+                            if (rowCount > 0) {
                                 // 10% probability of removing multiple rows.
                                 const numRemoved = float64() < 0.1
-                                    ? int32(numRows - row - 1) + 1
+                                    ? int32(rowCount - row - 1) + 1
                                     : 1;
 
-                                trace?.push(`matrix${matrixIndex + 1}.removeRows(${row},${numRemoved});    // numRows: ${matrix.numRows - numRemoved}, numCols: ${matrix.numCols}`);
+                                trace?.push(`matrix${matrixIndex + 1}.removeRows(${row},${numRemoved});    // rowCount: ${matrix.rowCount - numRemoved}, colCount: ${matrix.colCount}`);
                                 matrix.removeRows(row, numRemoved);
                             }
                             break;
@@ -134,13 +134,13 @@ describe("Matrix", () => {
 
                         case 1: {
                             // remove 1 or more cols (if any exist)
-                            if (numCols > 0) {
+                            if (colCount > 0) {
                                 // 10% probability of removing multiple cols.
                                 const numRemoved = float64() < 0.1
-                                    ? int32(numCols - col - 1) + 1
+                                    ? int32(colCount - col - 1) + 1
                                     : 1;
 
-                                trace?.push(`matrix${matrixIndex + 1}.removeCols(${col},${numRemoved});    // numRows: ${matrix.numRows}, numCols: ${matrix.numCols - numRemoved}`);
+                                trace?.push(`matrix${matrixIndex + 1}.removeCols(${col},${numRemoved});    // rowCount: ${matrix.rowCount}, colCount: ${matrix.colCount - numRemoved}`);
                                 matrix.removeCols(col, numRemoved);
                             }
                             break;
@@ -152,14 +152,14 @@ describe("Matrix", () => {
                                 ? int32(3) + 1
                                 : 1;
 
-                            trace?.push(`matrix${matrixIndex + 1}.insertRows(${row},${numInserted});    // numRows: ${matrix.numRows + numInserted}, numCols: ${matrix.numCols}`);
+                            trace?.push(`matrix${matrixIndex + 1}.insertRows(${row},${numInserted});    // rowCount: ${matrix.rowCount + numInserted}, colCount: ${matrix.colCount}`);
                             matrix.insertRows(row, numInserted);
 
                             // 90% probability of filling the newly inserted row with values.
                             if (float64() < 0.9) {
-                                if (numCols > 0) {
-                                    setCells(matrixIndex, row, /* col: */ 0, matrix.numCols,
-                                        values(matrix.numCols * numInserted));
+                                if (colCount > 0) {
+                                    setCells(matrixIndex, row, /* col: */ 0, matrix.colCount,
+                                        values(matrix.colCount * numInserted));
                                 }
                             }
                             break;
@@ -171,14 +171,14 @@ describe("Matrix", () => {
                                 ? int32(3) + 1
                                 : 1;
 
-                            trace?.push(`matrix${matrixIndex + 1}.insertCols(${col},${numInserted});    // numRows: ${matrix.numRows}, numCols: ${matrix.numCols + numInserted}`);
+                            trace?.push(`matrix${matrixIndex + 1}.insertCols(${col},${numInserted});    // rowCount: ${matrix.rowCount}, colCount: ${matrix.colCount + numInserted}`);
                             matrix.insertCols(col, numInserted);
 
                             // 90% probability of filling the newly inserted col with values.
                             if (float64() < 0.9) {
-                                if (numRows > 0) {
+                                if (rowCount > 0) {
                                     setCells(matrixIndex, /* row: */ 0, col, numInserted,
-                                        values(matrix.numRows * numInserted));
+                                        values(matrix.rowCount * numInserted));
                                 }
                             }
                             break;
@@ -186,9 +186,9 @@ describe("Matrix", () => {
 
                         default: {
                             // set a range of cells (if matrix is non-empty)
-                            if (numRows > 0 && numCols > 0) {
-                                const stride = int32(numCols - col - 1) + 1;
-                                const length = (int32(numRows - row - 1) + 1) * stride;
+                            if (rowCount > 0 && colCount > 0) {
+                                const stride = int32(colCount - col - 1) + 1;
+                                const length = (int32(rowCount - row - 1) + 1) * stride;
                                 setCells(matrixIndex, row, col, stride, values(length));
                             }
                             break;

--- a/packages/runtime/matrix/test/utils.ts
+++ b/packages/runtime/matrix/test/utils.ts
@@ -15,12 +15,12 @@ export function fill<T extends IArray2D<U>, U>(
     matrix: T,
     row = 0,
     col = 0,
-    numRows = 256,
-    numCols = 256,
-    value = (row: number, col: number) => row * numRows + col
+    rowCount = 256,
+    colCount = 256,
+    value = (row: number, col: number) => row * rowCount + col
 ): T {
-    for (let r = row + numRows - 1; r >= row; r--) {
-        for (let c = col + numCols - 1; c >= col; c--) {
+    for (let r = row + rowCount - 1; r >= row; r--) {
+        for (let c = col + colCount - 1; c >= col; c--) {
             matrix.setCell(r, c, value(r, c) as any);
         }
     }
@@ -32,19 +32,19 @@ export function fill<T extends IArray2D<U>, U>(
  */
 export function setCorners<T extends IArray2D<U>, U>(matrix: T) {
     matrix.setCell(0, 0, "TopLeft" as any);
-    matrix.setCell(0, matrix.numCols - 1, "TopRight" as any);
-    matrix.setCell(matrix.numRows - 1, matrix.numCols - 1, "BottomRight" as any);
-    matrix.setCell(matrix.numRows - 1, 0, "BottomLeft" as any);
+    matrix.setCell(0, matrix.colCount - 1, "TopRight" as any);
+    matrix.setCell(matrix.rowCount - 1, matrix.colCount - 1, "BottomRight" as any);
+    matrix.setCell(matrix.rowCount - 1, 0, "BottomLeft" as any);
 }
 
 /**
  * Checks the corners of the given matrix.
  */
 export function checkCorners<T extends IArray2D<U>, U>(matrix: T) {
-    assert.equal(matrix.read(0, 0), "TopLeft");
-    assert.equal(matrix.read(0, matrix.numCols - 1), "TopRight");
-    assert.equal(matrix.read(matrix.numRows - 1, matrix.numCols - 1), "BottomRight");
-    assert.equal(matrix.read(matrix.numRows - 1, 0), "BottomLeft");
+    assert.equal(matrix.getCell(0, 0), "TopLeft");
+    assert.equal(matrix.getCell(0, matrix.colCount - 1), "TopRight");
+    assert.equal(matrix.getCell(matrix.rowCount - 1, matrix.colCount - 1), "BottomRight");
+    assert.equal(matrix.getCell(matrix.rowCount - 1, 0), "BottomLeft");
 }
 
 /**
@@ -55,13 +55,13 @@ export function check<T extends IArray2D<U>, U>(
     matrix: T,
     row = 0,
     col = 0,
-    numRows = 256,
-    numCols = 256,
-    value = (row: number, col: number) => row * numRows + col
+    rowCount = 256,
+    colCount = 256,
+    value = (row: number, col: number) => row * rowCount + col
 ): T {
-    for (let r = row + numRows - 1; r >= row; r--) {
-        for (let c = col + numCols - 1; c >= col; c--) {
-            assert.equal(matrix.read(r, c), value(r, c) as any);
+    for (let r = row + rowCount - 1; r >= row; r--) {
+        for (let c = col + colCount - 1; c >= col; c--) {
+            assert.equal(matrix.getCell(r, c), value(r, c) as any);
         }
     }
     return matrix;
@@ -73,12 +73,12 @@ export function check<T extends IArray2D<U>, U>(
  */
 export function extract<T extends Serializable>(actual: SharedMatrix<T>): ReadonlyArray<ReadonlyArray<T>> {
     const m: T[][] = [];
-    for (let r = 0; r < actual.numRows; r++) {
+    for (let r = 0; r < actual.rowCount; r++) {
         const row: T[] = [];
         m.push(row);
 
-        for (let c = 0; c < actual.numCols; c++) {
-            row.push(actual.read(r, c) as T);
+        for (let c = 0; c < actual.colCount; c++) {
+            row.push(actual.getCell(r, c) as T);
         }
     }
 
@@ -89,9 +89,9 @@ export function extract<T extends Serializable>(actual: SharedMatrix<T>): Readon
  * Asserts that given `SharedMatrix` has the specified dimensions.  This is useful for distinguishing
  * between variants of empty matrices (zero rows vs. zero cols vs. zero rows and zero cols).
  */
-export function expectSize<T extends Serializable>(matrix: SharedMatrix<T>, numRows: number, numCols: number) {
-    assert.equal(matrix.numRows, numRows, "'matrix' must have expected number of rows.");
-    assert.equal(matrix.numCols, numCols, "'matrix' must have expected number of columns.");
+export function expectSize<T extends Serializable>(matrix: SharedMatrix<T>, rowCount: number, colCount: number) {
+    assert.equal(matrix.rowCount, rowCount, "'matrix' must have expected number of rows.");
+    assert.equal(matrix.colCount, colCount, "'matrix' must have expected number of columns.");
 }
 
 /**
@@ -101,22 +101,24 @@ export function expectSize<T extends Serializable>(matrix: SharedMatrix<T>, numR
  * This is achieved by inserting even row/cols at the end of the matrix and odd row/cols
  * at the middle of the matrix (e.g, [1,3,5,7,0,2,4,6]).
  */
-export function insertFragmented(matrix: SharedMatrix, numRows: number, numCols: number) {
-    for (let r = 0; r < numRows; r++) {
+export function insertFragmented(matrix: SharedMatrix, rowCount: number, colCount: number) {
+    for (let r = 0; r < rowCount; r++) {
         matrix.insertRows(
             (r & 1) === 0
-                ? matrix.numRows
+                ? matrix.rowCount
                 : r >> 1,
             1);
     }
 
-    for (let c = 0; c < numCols; c++) {
+    for (let c = 0; c < colCount; c++) {
         matrix.insertCols(
             (c & 1) === 0
-                ? matrix.numCols
+                ? matrix.colCount
                 : c >> 1,
             1);
     }
+
+    expectSize(matrix, rowCount, colCount);
 
     return matrix;
 }


### PR DESCRIPTION
Updates SparseMatrix v2 to the latest Tiny-Calc interfaces:
* Implements new IMatrixWriter interface
* Change notifications no longer carry values, just the changed region (Perf)
* IMatrixReader exposes a ref to the underlying IMatrixProducer
* Minor renaming:
    * numRows/Cols -> rowCount/colCount
    * read -> getCell
