### PR TITLE
Generate composite package.json with dependencies for Component Governance scan of our MonoRepo

### DIFF
--- a/tools/fluid-build-tools/src/common/monoRepo.ts
+++ b/tools/fluid-build-tools/src/common/monoRepo.ts
@@ -14,6 +14,7 @@ export enum MonoRepoKind {
 
 export class MonoRepo {
     public readonly packages: Package[] = [];
+    public readonly version: string;
     constructor(public readonly kind: MonoRepoKind, public readonly repoPath: string) {
         const lernaPath = path.join(repoPath, "lerna.json");
         if (!existsSync(lernaPath)) {
@@ -25,6 +26,7 @@ export class MonoRepo {
             const loadDir = dir.endsWith("/**") ? dir.substr(0, dir.length - 3) : dir;
             this.packages.push(...Packages.loadDir(path.join(this.repoPath, loadDir), this));
         }
+        this.version = lerna.version;
     }
 
     public static isSame(a: MonoRepo | undefined, b: MonoRepo | undefined) {

--- a/tools/fluid-build-tools/src/genMonoRepoPackageJson/genMonoRepoPackageJson.ts
+++ b/tools/fluid-build-tools/src/genMonoRepoPackageJson/genMonoRepoPackageJson.ts
@@ -1,0 +1,116 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { FluidRepoBase } from "../common/fluidRepoBase";
+import { MonoRepo, MonoRepoKind } from "../common/monoRepo";
+import { Timer } from "../common/timer";
+import { getResolvedFluidRoot } from "../common/fluidUtils";
+import { commonOptions, commonOptionString, parseOption } from "../common/commonOptions";
+import { readJsonSync, writeFileAsync } from "../common/utils";
+import { Package } from "../common/npmPackage";
+import path from "path";
+
+function printUsage() {
+    console.log(
+        `
+Usage: fluid-gen-pkg-lock <options>
+Options:
+${commonOptionString}
+`);
+}
+
+
+function parseOptions(argv: string[]) {
+    let error = false;
+    for (let i = 2; i < process.argv.length; i++) {
+        const argParsed = parseOption(argv, i);
+        if (argParsed < 0) {
+            error = true;
+            break;
+        }
+        if (argParsed > 0) {
+            i += argParsed - 1;
+            continue;
+        }
+
+        const arg = process.argv[i];
+
+        if (arg === "-?" || arg === "--help") {
+            printUsage();
+            process.exit(0);
+        }
+
+        console.error(`ERROR: Invalid arguments ${arg}`);
+        error = true;
+        break;
+    }
+
+    if (error) {
+        printUsage();
+        process.exit(-1);
+    }
+}
+
+parseOptions(process.argv);
+
+
+async function generateMonoRepoInstallPackageJson(monoRepo: MonoRepo) {
+    const packageMap = new Map<string, Package>(monoRepo.packages.map(pkg => [pkg.name, pkg]));
+    const repoPackageJson: any = {};
+    repoPackageJson.name = `@fluid-internal/${MonoRepoKind[monoRepo.kind].toLowerCase()}`;
+    repoPackageJson.version = monoRepo.version;
+    repoPackageJson.dependencies = {};
+    repoPackageJson.devDependencies = {};
+    monoRepo.packages.forEach((pkg) => {
+        for (const dep in pkg.packageJson.dependencies) {
+            if (packageMap.has(dep)) { continue; }
+            const version = pkg.packageJson.dependencies[dep];
+            const existing = repoPackageJson.dependencies[dep];
+            if (existing) {
+                if (existing !== version) {
+                    throw new Error(`Dependency version mismatch for ${dep}: ${existing} and ${version}`);
+                }
+                continue;
+            }
+            repoPackageJson.dependencies[dep] = pkg.packageJson.dependencies[dep];
+        }
+    });
+    monoRepo.packages.forEach((pkg) => {
+        for (const dep in pkg.packageJson.devDependencies) {
+            if (packageMap.has(dep)) { continue; }
+            const version = pkg.packageJson.devDependencies[dep];
+            const existing = repoPackageJson.dependencies[dep]?? repoPackageJson.devDependencies[dep];
+            if (existing) {
+                if (existing !== version) {
+                    throw new Error(`Dependency version mismatch for ${dep}: ${existing} and ${version}`);
+                }
+                continue;
+            }
+            repoPackageJson.devDependencies[dep] = pkg.packageJson.devDependencies[dep];
+        }
+    });
+
+    await writeFileAsync(path.join(monoRepo.repoPath, "repo-package.json"), JSON.stringify(repoPackageJson, undefined, 2));
+}
+
+async function main() {
+    const timer = new Timer(commonOptions.timer);
+
+    const resolvedRoot = await getResolvedFluidRoot();
+
+    // Load the package
+    const repo = new FluidRepoBase(resolvedRoot, false);
+    timer.time("Package scan completed");
+
+    return Promise.all([
+        generateMonoRepoInstallPackageJson(repo.clientMonoRepo),
+        generateMonoRepoInstallPackageJson(repo.serverMonoRepo)
+    ]);
+};
+
+main().catch(error => {
+    console.error("ERROR: Unexpected error");
+    console.error(error.stack);
+});

--- a/tools/fluid-build-tools/src/layerCheck/layerCheck.ts
+++ b/tools/fluid-build-tools/src/layerCheck/layerCheck.ts
@@ -7,7 +7,6 @@ import { LayerGraph } from "./layerGraph";
 import { commonOptions, commonOptionString, parseOption } from "../common/commonOptions";
 import { Timer } from "../common/timer";
 import { getResolvedFluidRoot } from "../common/fluidUtils";
-import * as path from "path";
 import { writeFileAsync } from "../common/utils";
 import { FluidRepoBase } from "../common/fluidRepoBase";
 


### PR DESCRIPTION
the component governance scan requires a package.json along with a  package-lock.json file.
A monorepo lock doesn't have that so we have to generated it.