### PR TITLE
Updated Consensus DDSs to use the new reconnection model

### DIFF
--- a/packages/runtime/consensus-ordered-collection/src/consensusOrderedCollection.ts
+++ b/packages/runtime/consensus-ordered-collection/src/consensusOrderedCollection.ts
@@ -329,21 +329,11 @@ export class ConsensusOrderedCollection<T = any>
             if (local) {
                 strongAssert(
                     localOpMetadata, `localOpMetadata is missing from the local client's ${op.opName} operation`);
-                this.onLocalMessageAck(value, localOpMetadata as PendingResolve<T>);
+                // Resolve the pending promise for this operation now that we have received an ack for it.
+                const resolve = localOpMetadata as PendingResolve<T>;
+                resolve(value);
             }
         }
-    }
-
-    /**
-     * Resolve the promise of a local operation
-     *
-     * @param value - the value related to the operation
-     * @param resolve - the resolve function to call on the ack.
-     */
-    private onLocalMessageAck(
-        value: IConsensusOrderedCollectionValue<T> | undefined,
-        resolve: PendingResolve<T>) {
-        resolve(value);
     }
 
     private async submit<TMessage extends IConsensusOrderedCollectionOperation>(

--- a/packages/runtime/consensus-ordered-collection/src/test/consensusOrderedCollection.spec.ts
+++ b/packages/runtime/consensus-ordered-collection/src/test/consensusOrderedCollection.spec.ts
@@ -218,18 +218,24 @@ describe("ConsensusOrderedCollection", () => {
             containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
 
             // Create first ConsensusOrderedCollection
-            const runtime1 = new MockComponentRuntime();
-            containerRuntime1 = containerRuntimeFactory.createContainerRuntime(runtime1);
+            const componentRuntime1 = new MockComponentRuntime();
+            containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime1);
             const deltaConnection1 = containerRuntime1.createDeltaConnection();
-            testCollection1 =
-                await createConsensusOrderedCollection("consensus-ordered-collection1", runtime1, deltaConnection1);
+            testCollection1 = await createConsensusOrderedCollection(
+                "consensus-ordered-collection1",
+                componentRuntime1,
+                deltaConnection1,
+            );
 
             // Create second ConsensusOrderedCollection
-            const runtime2 = new MockComponentRuntime();
-            containerRuntime2 = containerRuntimeFactory.createContainerRuntime(runtime2);
+            const componentRuntime2 = new MockComponentRuntime();
+            containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
             const deltaConnection2 = containerRuntime2.createDeltaConnection();
-            testCollection2 =
-                await createConsensusOrderedCollection("consensus-ordered-collection2", runtime2, deltaConnection2);
+            testCollection2 = await createConsensusOrderedCollection(
+                "consensus-ordered-collection2",
+                componentRuntime2,
+                deltaConnection2,
+            );
         });
 
         it("can resend unacked ops on reconnection", async () => {

--- a/packages/runtime/consensus-ordered-collection/src/test/consensusOrderedCollection.spec.ts
+++ b/packages/runtime/consensus-ordered-collection/src/test/consensusOrderedCollection.spec.ts
@@ -208,7 +208,6 @@ describe("ConsensusOrderedCollection", () => {
                 deltaConnection,
                 objectStorage: new MockStorage(),
             };
-            componentRuntime.attach();
 
             const consensusOrderedCollection = factory.create(componentRuntime, id);
             consensusOrderedCollection.connect(services);
@@ -223,14 +222,14 @@ describe("ConsensusOrderedCollection", () => {
             containerRuntime1 = containerRuntimeFactory.createContainerRuntime(runtime1);
             const deltaConnection1 = containerRuntime1.createDeltaConnection();
             testCollection1 =
-                await createConsensusOrderedCollection("consenses-ordered-collection1", runtime1, deltaConnection1);
+                await createConsensusOrderedCollection("consensus-ordered-collection1", runtime1, deltaConnection1);
 
             // Create second ConsensusOrderedCollection
             const runtime2 = new MockComponentRuntime();
             containerRuntime2 = containerRuntimeFactory.createContainerRuntime(runtime2);
             const deltaConnection2 = containerRuntime2.createDeltaConnection();
             testCollection2 =
-                await createConsensusOrderedCollection("consenses-ordered-collection2", runtime2, deltaConnection2);
+                await createConsensusOrderedCollection("consensus-ordered-collection2", runtime2, deltaConnection2);
         });
 
         it("can resend unacked ops on reconnection", async () => {

--- a/packages/runtime/consensus-register-collection/src/consensusRegisterCollection.ts
+++ b/packages/runtime/consensus-register-collection/src/consensusRegisterCollection.ts
@@ -256,7 +256,9 @@ export class ConsensusRegisterCollection<T>
                         local);
                     if (local) {
                         strongAssert(localOpMetadata, "localOpMetadata is missing from the client's write operation");
-                        this.onLocalMessageAck(winner, localOpMetadata as PendingResolve);
+                        // Resolve the pending promise for this operation now that we have received an ack for it.
+                        const resolve = localOpMetadata as PendingResolve;
+                        resolve(winner);
                     }
                     break;
                 }
@@ -337,10 +339,6 @@ export class ConsensusRegisterCollection<T>
         this.emit("versionChanged", key, value, local);
 
         return winner;
-    }
-
-    private onLocalMessageAck(winner: boolean, resolve: PendingResolve) {
-        resolve(winner);
     }
 
     private stringify(value: any): string {

--- a/packages/runtime/consensus-register-collection/src/test/consensusRegisterCollection.spec.ts
+++ b/packages/runtime/consensus-register-collection/src/test/consensusRegisterCollection.spec.ts
@@ -163,33 +163,20 @@ describe("ConsensusRegisterCollection", () => {
         let testCollection1: IConsensusRegisterCollection;
         let testCollection2: IConsensusRegisterCollection;
 
-        // Creates a ConsensusRegisterCollection but does not connect it.
-        async function createConsensusRegisterCollection(
-            id: string,
-            componentRuntime: MockComponentRuntime,
-            deltaConnection: IDeltaConnection,
-        ): Promise<IConsensusRegisterCollection> {
-            componentRuntime.attach();
-            const consensusRegisterCollection = crcFactory.create(componentRuntime, id);
-            return consensusRegisterCollection;
-        }
-
         beforeEach(async () => {
             containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
 
             // Create first ConsensusOrderedCollection
-            const runtime1 = new MockComponentRuntime();
-            containerRuntime1 = containerRuntimeFactory.createContainerRuntime(runtime1);
+            const componentRuntime1 = new MockComponentRuntime();
+            containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime1);
             deltaConnection1 = containerRuntime1.createDeltaConnection();
-            testCollection1 =
-                await createConsensusRegisterCollection("consenses-register-collection1", runtime1, deltaConnection1);
+            testCollection1 = crcFactory.create(componentRuntime1, "consenses-register-collection1");
 
             // Create second ConsensusOrderedCollection
-            const runtime2 = new MockComponentRuntime();
-            containerRuntime2 = containerRuntimeFactory.createContainerRuntime(runtime2);
+            const componentRuntime2 = new MockComponentRuntime();
+            containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
             deltaConnection2 = containerRuntime2.createDeltaConnection();
-            testCollection2 =
-                await createConsensusRegisterCollection("consenses-register-collection2", runtime2, deltaConnection2);
+            testCollection2 = crcFactory.create(componentRuntime2, "consenses-register-collection2");
         });
 
         describe("Object not connected", () => {


### PR DESCRIPTION
Fixes #1783.

Updated `ConsensusOrderedCollection` and `ConsensusRegisterCollection` to use the default `reSubmit` logic in `SharedObject` to submit unack'd messages on reconnection.
It sends the pending `resolve` function as `localOpMetadata` on submit and on ack from the server, resolves it which is provided as the `localOpMetadata` in `process`.