### PR TITLE
Update Auspkn Endpoints

### DIFF
--- a/components/experimental/external-component-loader/src/urlRegistry.ts
+++ b/components/experimental/external-component-loader/src/urlRegistry.ts
@@ -58,7 +58,7 @@ export class UrlRegistry implements IComponentRegistry {
         const codeDetails: IFluidCodeDetails = {
             package: fluidPackage,
             config:{
-                cdn:"https://pragueauspkn-3873244262.azureedge.net",
+                cdn:"https://pragueauspkn.azureedge.net",
             },
         };
         const fluidModule = await this.webloader.load(codeDetails);

--- a/components/experimental/scribe/src/scribe.ts
+++ b/components/experimental/scribe/src/scribe.ts
@@ -224,7 +224,7 @@ function initialize(
 
         const details: IFluidCodeDetails = {
             config: {
-                "@fluid-example:cdn": "https://pragueauspkn-3873244262.azureedge.net",
+                "@fluid-example:cdn": "https://pragueauspkn.azureedge.net",
             },
             package: `@fluid-example/shared-text@${version}`,
         };

--- a/components/experimental/shared-text/src/index.ts
+++ b/components/experimental/shared-text/src/index.ts
@@ -130,7 +130,7 @@ class SharedTextFactoryComponent implements IComponentFactory, IRuntimeFactory {
                 [SharedTextFactoryComponent.type, Promise.resolve(this)],
                 [
                     "verdaccio",
-                    Promise.resolve(new MyRegistry(context, "https://pragueauspkn-3873244262.azureedge.net")),
+                    Promise.resolve(new MyRegistry(context, "https://pragueauspkn.azureedge.net")),
                 ],
             ],
             [SharedTextFactoryComponent.containerRequestHandler]);

--- a/examples/hosts/iframe-host/src/inner.ts
+++ b/examples/hosts/iframe-host/src/inner.ts
@@ -24,7 +24,7 @@ export async function runInner(divId: string) {
     const pkg: IFluidCodeDetails = {
         package: "@fluid-example/todo@^0.15.0",
         config:{
-            "@fluid-example:cdn":"https://pragueauspkn-3873244262.azureedge.net",
+            "@fluid-example:cdn":"https://pragueauspkn.azureedge.net",
         },
     };
 

--- a/examples/hosts/iframe-host/src/outer.ts
+++ b/examples/hosts/iframe-host/src/outer.ts
@@ -86,7 +86,7 @@ export async function loadDiv(divId: string) {
     const pkg: IFluidCodeDetails = {
         package: "@fluid-example/todo@^0.15.0",
         config:{
-            "@fluid-example:cdn":"https://pragueauspkn-3873244262.azureedge.net",
+            "@fluid-example:cdn":"https://pragueauspkn.azureedge.net",
         },
     };
 

--- a/packages/test/context-reload/@fluid-example/version-test-2/src/main.tsx
+++ b/packages/test/context-reload/@fluid-example/version-test-2/src/main.tsx
@@ -78,7 +78,7 @@ export class VersionTest extends PrimedComponent implements IComponentHTMLView {
   private quorumProposeCode() {
     setTimeout(() => this.runtime.getQuorum().propose(
       "code",
-      { "config": { "cdn": `https://pragueauspkn-3873244262.azureedge.net/@yo-fluid/${ this.upgradeToPkg }` }, "package": `${ this.upgradeToPkg }@${ this.upgradeToVersion }` },
+      { "config": { "cdn": `https://pragueauspkn.azureedge.net/@yo-fluid/${ this.upgradeToPkg }` }, "package": `${ this.upgradeToPkg }@${ this.upgradeToVersion }` },
     ), 3000);
   }
 }


### PR DESCRIPTION
Fixes waterpark (external component loader)

With the Github Breach, we moved the auspkn endpoint. 

This  auspkn endpoint is now a proxy for this VSTS scoped feed https://offnet.visualstudio.com/officenet/_packaging?_a=feed&feed=fluid-doc-types

This issue tracks what we decide to eventually do with hardcoded auspkn issues: https://github.com/microsoft/FluidFramework/issues/2401