### PR TITLE
rename yo generator package name

### DIFF
--- a/tools/generator-fluid/README.md
+++ b/tools/generator-fluid/README.md
@@ -4,16 +4,16 @@ Use this tool to quickly bootstrap a new Fluid component package based on the ex
 
 ## Basic Getting Started
 
-To get started ensure you have [Node.js](https://nodejs.org/en/) and [Git](https://git-scm.com/) installed, then install [Yeoman](https://yeoman.io/) and the [Fluid Component Generator](//TODO:Add-Link) with:
+To get started ensure you have [Node.js](https://nodejs.org/en/) and [Git](https://git-scm.com/) installed, then install [Yeoman](https://yeoman.io/) and the [Fluid Component Generator](https://www.npmjs.com/package/generator-fluid) with:
 
 ````bash
-npm install -g yo @microsoft/fluid
+npm install -g yo generator-fluid
 ````
 
 You're now set up to bootstrap a new Fluid component at any time. Run the generator and fill out a few prompts.
 
 ````bash
-yo @microsoft/fluid
+yo fluid
 
 # Congratulations! You've started building your own Fluid Component.
 # Let us help you get set up. Once we're done, you can start coding!
@@ -53,7 +53,7 @@ When running the generator a new folder will be generated with the following con
 
 ```text
 Usage:
-  yo @microsoft/fluid [<componentName>] [options]
+  yo fluid [<componentName>] [options]
 
 Options:
   -h,    --help           # Print the generator's options and usage

--- a/tools/generator-fluid/app/templates/README.md
+++ b/tools/generator-fluid/app/templates/README.md
@@ -44,8 +44,8 @@ The `view<%= extension %>` file contains all the view logic.
 .
 ├── src
 |   ├── component<%= extension %>              // Fluid Component source code
-|   ├── index.ts          // Export file
-|   ├── interface.ts      // Model Interface Definition
+|   ├── index.ts                   // Export file
+|   ├── interface.ts               // Model Interface Definition
 |   └── view<%= extension %>                   // View Logic
 ├── .gitignore                     // Ignore dist and node_modules
 ├── jest-puppeteer.config.js       // jest-puppeteer configuration

--- a/tools/generator-fluid/package-lock.json
+++ b/tools/generator-fluid/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@microsoft/generator-fluid",
-  "version": "0.19.0",
+  "name": "generator-fluid",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tools/generator-fluid/package.json
+++ b/tools/generator-fluid/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@microsoft/generator-fluid",
-  "version": "0.19.0",
+  "name": "generator-fluid",
+  "version": "0.2.0",
   "description": "A yeoman project generator for fluid components",
   "keywords": [
     "yeoman-generator"


### PR DESCRIPTION
Change the name of the yo generator. This makes getting stared cleaner since the cmd changes.

Old cmd:
`yo @microsoft/fluid`

New cmd:
`yo fluid`

We have this npm package name and I got the okay from @nmsimons .

I also change the README and fixed some formatting in the template README.

@curtisman , I also change the package version to 0.2.0 I want to disconnect the version of the runtime from the version of the generator to minimize confusion. I choose 2 and not 1 because we already have some packages published under 0.1.*.