### PR TITLE
Fix for remote op not applied when there is a pending op submitted in local state

### DIFF
--- a/packages/runtime/map/src/directory.ts
+++ b/packages/runtime/map/src/directory.ts
@@ -607,8 +607,8 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
      * this op while it has not been ack'd. This will be sent when we receive this op back from the server.
      * @internal
      */
-    public submitDirectoryMessage(op: IDirectoryOperation, localOpMetadata: unknown) {
-        this.submitLocalMessage(op, localOpMetadata);
+    public submitDirectoryMessage(op: IDirectoryOperation, localOpMetadata: unknown): number {
+        return this.submitLocalMessage(op, localOpMetadata);
     }
 
     /**
@@ -951,7 +951,7 @@ class SubDirectory implements IDirectory {
     /**
      * This is used to assign a unique id to every outgoing operation and helps in tracking unack'd ops.
      */
-    private pendingMessageId: number = -1;
+    private pendingMessageId: number = 0;
 
     /**
      * If a clear has been performed locally but not yet ack'd from the server, then this stores the pending id
@@ -1383,9 +1383,9 @@ class SubDirectory implements IDirectory {
      * @internal
      */
     public submitClearMessage(op: IDirectoryClearOperation): void {
-        const pendingMessageId = ++this.pendingMessageId;
-        this.directory.submitDirectoryMessage(op, pendingMessageId);
-        this.pendingClearMessageId = pendingMessageId;
+        if (this.directory.submitDirectoryMessage(op, this.pendingMessageId) !== -1) {
+            this.pendingClearMessageId = this.pendingMessageId++;
+        }
     }
 
     /**
@@ -1394,9 +1394,9 @@ class SubDirectory implements IDirectory {
      * @internal
      */
     public submitKeyMessage(op: IDirectoryKeyOperation): void {
-        const pendingMessageId = ++this.pendingMessageId;
-        this.directory.submitDirectoryMessage(op, pendingMessageId);
-        this.pendingKeys.set(op.key, pendingMessageId);
+        if (this.directory.submitDirectoryMessage(op, this.pendingMessageId) !== -1) {
+            this.pendingKeys.set(op.key, this.pendingMessageId++);
+        }
     }
 
     /**
@@ -1405,9 +1405,9 @@ class SubDirectory implements IDirectory {
      * @internal
      */
     public submitSubDirectoryMessage(op: IDirectorySubDirectoryOperation): void {
-        const pendingMessageId = ++this.pendingMessageId;
-        this.directory.submitDirectoryMessage(op, pendingMessageId);
-        this.pendingSubDirectories.set(op.subdirName, pendingMessageId);
+        if (this.directory.submitDirectoryMessage(op, this.pendingMessageId) !== -1) {
+            this.pendingSubDirectories.set(op.subdirName, this.pendingMessageId++);
+        }
     }
 
     /**

--- a/packages/runtime/map/src/map.ts
+++ b/packages/runtime/map/src/map.ts
@@ -144,7 +144,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
         this.kernel = new MapKernel(
             runtime,
             this.handle,
-            (op, localOpMetadata) => this.submitLocalMessage(op, localOpMetadata),
+            (content, localOpMetadata) => this.trySubmitLocalMessage(content, localOpMetadata),
             valueTypes,
             this,
         );
@@ -322,6 +322,21 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 
     public getSerializableStorage(): IMapDataObjectSerializable {
         return this.kernel.getSerializableStorage();
+    }
+
+    /**
+     * Tries to submit a message.
+     * @param content - The content of the message to be submitted
+     * @param localOpMetadata - The metadata associated with the op
+     * @returns - false, if we are local. true, otherwise
+     */
+    private trySubmitLocalMessage(content: any, localOpMetadata: unknown): boolean {
+        if (this.isLocal()) {
+            return false;
+        }
+
+        this.submitLocalMessage(content, localOpMetadata);
+        return true;
     }
 
     /**

--- a/packages/runtime/map/src/map.ts
+++ b/packages/runtime/map/src/map.ts
@@ -144,7 +144,8 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
         this.kernel = new MapKernel(
             runtime,
             this.handle,
-            (content, localOpMetadata) => this.trySubmitLocalMessage(content, localOpMetadata),
+            (op, localOpMetadata) => this.submitLocalMessage(op, localOpMetadata),
+            () => this.isLocal(),
             valueTypes,
             this,
         );
@@ -322,21 +323,6 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 
     public getSerializableStorage(): IMapDataObjectSerializable {
         return this.kernel.getSerializableStorage();
-    }
-
-    /**
-     * Tries to submit a message.
-     * @param content - The content of the message to be submitted
-     * @param localOpMetadata - The metadata associated with the op
-     * @returns - false, if we are local. true, otherwise
-     */
-    private trySubmitLocalMessage(content: any, localOpMetadata: unknown): boolean {
-        if (this.isLocal()) {
-            return false;
-        }
-
-        this.submitLocalMessage(content, localOpMetadata);
-        return true;
     }
 
     /**

--- a/packages/runtime/map/src/mapKernel.ts
+++ b/packages/runtime/map/src/mapKernel.ts
@@ -163,7 +163,7 @@ export class MapKernel {
     /**
      * This is used to assign a unique id to every outgoing operation and helps in tracking unack'd ops.
      */
-    private pendingMessageId: number = -1;
+    private pendingMessageId: number = 0;
 
     /**
      * If a clear has been performed locally but not yet ack'd from the server, then this stores the pending id
@@ -187,7 +187,7 @@ export class MapKernel {
     constructor(
         private readonly runtime: IComponentRuntime,
         private readonly handle: IComponentHandle,
-        private readonly submitMessage: (op: any, localOpMetadata: unknown) => void,
+        private readonly submitMessage: (op: any, localOpMetadata: unknown) => number,
         valueTypes: Readonly<IValueType<any>[]>,
         public readonly eventEmitter = new TypedEventEmitter<ISharedMapEvents>(),
     ) {
@@ -714,9 +714,9 @@ export class MapKernel {
      * @param op - The clear message
      */
     private submitMapClearMessage(op: IMapClearOperation): void {
-        const pendingMessageId = ++this.pendingMessageId;
-        this.submitMessage(op, pendingMessageId);
-        this.pendingClearMessageId = pendingMessageId;
+        if (this.submitMessage(op, this.pendingMessageId) !== -1) {
+            this.pendingClearMessageId = this.pendingMessageId++;
+        }
     }
 
     /**
@@ -724,9 +724,9 @@ export class MapKernel {
      * @param op - The map key message
      */
     private submitMapKeyMessage(op: IMapKeyOperation): void {
-        const pendingMessageId = ++this.pendingMessageId;
-        this.submitMessage(op, pendingMessageId);
-        this.pendingKeys.set(op.key, pendingMessageId);
+        if (this.submitMessage(op, this.pendingMessageId) !== -1) {
+            this.pendingKeys.set(op.key, this.pendingMessageId++);
+        }
     }
 
     /**

--- a/packages/runtime/sequence/src/sequence.ts
+++ b/packages/runtime/sequence/src/sequence.ts
@@ -164,7 +164,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
         this.intervalMapKernel = new MapKernel(
             this.runtime,
             this.handle,
-            (op, localOpMetadata) => this.submitLocalMessage(op, localOpMetadata),
+            (content, localOpMetadata) => this.trySubmitLocalMessage(content, localOpMetadata),
             [new SequenceIntervalCollectionValueType()]);
     }
 
@@ -416,6 +416,21 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
         };
 
         return tree;
+    }
+
+    /**
+     * Tries to submit a message.
+     * @param content - The content of the message to be submitted
+     * @param localOpMetadata - The metadata associated with the op
+     * @returns - false, if we are local. true, otherwise
+     */
+    private trySubmitLocalMessage(content: any, localOpMetadata: unknown): boolean {
+        if (this.isLocal()) {
+            return false;
+        }
+
+        this.submitLocalMessage(content, localOpMetadata);
+        return true;
     }
 
     /**

--- a/packages/runtime/sequence/src/sequence.ts
+++ b/packages/runtime/sequence/src/sequence.ts
@@ -164,7 +164,8 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
         this.intervalMapKernel = new MapKernel(
             this.runtime,
             this.handle,
-            (content, localOpMetadata) => this.trySubmitLocalMessage(content, localOpMetadata),
+            (op, localOpMetadata) => this.submitLocalMessage(op, localOpMetadata),
+            () => this.isLocal(),
             [new SequenceIntervalCollectionValueType()]);
     }
 
@@ -416,21 +417,6 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
         };
 
         return tree;
-    }
-
-    /**
-     * Tries to submit a message.
-     * @param content - The content of the message to be submitted
-     * @param localOpMetadata - The metadata associated with the op
-     * @returns - false, if we are local. true, otherwise
-     */
-    private trySubmitLocalMessage(content: any, localOpMetadata: unknown): boolean {
-        if (this.isLocal()) {
-            return false;
-        }
-
-        this.submitLocalMessage(content, localOpMetadata);
-        return true;
     }
 
     /**

--- a/packages/runtime/sequence/src/sharedIntervalCollection.ts
+++ b/packages/runtime/sequence/src/sharedIntervalCollection.ts
@@ -116,7 +116,7 @@ export class SharedIntervalCollection<TInterval extends ISerializableInterval = 
         this.intervalMapKernel = new MapKernel(
             runtime,
             this.handle,
-            (op, localOpMetadata) => this.submitLocalMessage(op, localOpMetadata),
+            (content, localOpMetadata) => this.trySubmitLocalMessage(content, localOpMetadata),
             [new IntervalCollectionValueType()],
         );
     }
@@ -161,6 +161,21 @@ export class SharedIntervalCollection<TInterval extends ISerializableInterval = 
         };
 
         return tree;
+    }
+
+    /**
+     * Tries to submit a message.
+     * @param content - The content of the message to be submitted
+     * @param localOpMetadata - The metadata associated with the op
+     * @returns - false, if we are local. true, otherwise
+     */
+    private trySubmitLocalMessage(content: any, localOpMetadata: unknown): boolean {
+        if (this.isLocal()) {
+            return false;
+        }
+
+        this.submitLocalMessage(content, localOpMetadata);
+        return true;
     }
 
     protected reSubmitCore(content: any, localOpMetadata: unknown) {

--- a/packages/runtime/sequence/src/sharedIntervalCollection.ts
+++ b/packages/runtime/sequence/src/sharedIntervalCollection.ts
@@ -116,7 +116,8 @@ export class SharedIntervalCollection<TInterval extends ISerializableInterval = 
         this.intervalMapKernel = new MapKernel(
             runtime,
             this.handle,
-            (content, localOpMetadata) => this.trySubmitLocalMessage(content, localOpMetadata),
+            (op, localOpMetadata) => this.submitLocalMessage(op, localOpMetadata),
+            () => this.isLocal(),
             [new IntervalCollectionValueType()],
         );
     }
@@ -161,21 +162,6 @@ export class SharedIntervalCollection<TInterval extends ISerializableInterval = 
         };
 
         return tree;
-    }
-
-    /**
-     * Tries to submit a message.
-     * @param content - The content of the message to be submitted
-     * @param localOpMetadata - The metadata associated with the op
-     * @returns - false, if we are local. true, otherwise
-     */
-    private trySubmitLocalMessage(content: any, localOpMetadata: unknown): boolean {
-        if (this.isLocal()) {
-            return false;
-        }
-
-        this.submitLocalMessage(content, localOpMetadata);
-        return true;
     }
 
     protected reSubmitCore(content: any, localOpMetadata: unknown) {


### PR DESCRIPTION
Fixes #2400

The issue here is that when an op is submitted when a SharedMap / SharedDirectory is not connected, it gets added to the pending queue. This won't get removed from the queue because there won't be an ack for it.
Now, if there are remote ops with the same key as the op in the pending queue, the remote ops are ignored.

The fix is to not add local op to the pending queue, if we are not connected.

We need unit test for this scenario and for testing remote map and directory ops in general. I have created #2406 to add these.