### PR TITLE
Strongly Type Group Ops To Prevent Nesting

### DIFF
--- a/components/experimental/prosemirror/src/fluidBridge.ts
+++ b/components/experimental/prosemirror/src/fluidBridge.ts
@@ -6,7 +6,7 @@
 import assert from "assert";
 import {
     createInsertSegmentOp,
-    IMergeTreeOp,
+    IMergeTreeDeltaOp,
     Marker,
     MergeTreeDeltaType,
     ReferenceType,
@@ -372,8 +372,8 @@ export function sliceToGroupOps(
     schema: Schema,
     insert?: number,
     gapDistance?: number,
-): IMergeTreeOp[] {
-    const ops = new Array<IMergeTreeOp>();
+): IMergeTreeDeltaOp[] {
+    const ops = new Array<IMergeTreeDeltaOp>();
 
     const sliceOpenStart = slice.openStart || 0;
     const sliceOpenEnd = slice.openEnd || 0;
@@ -401,7 +401,7 @@ function sliceToGroupOpsInternal(
     openStart: number,
     openEnd: number,
     from: number,
-    ops: IMergeTreeOp[],
+    ops: IMergeTreeDeltaOp[],
     insert?: number,
     gapDistance?: number,
 ) {

--- a/components/experimental/prosemirror/src/fluidCollabManager.ts
+++ b/components/experimental/prosemirror/src/fluidCollabManager.ts
@@ -9,10 +9,10 @@ import { ILoader } from "@fluidframework/container-definitions";
 import {
     createGroupOp,
     createRemoveRangeOp,
-    IMergeTreeOp,
     Marker,
     ReferenceType,
     TextSegment,
+    IMergeTreeDeltaOp,
 } from "@fluidframework/merge-tree";
 import { SharedString } from "@fluidframework/sequence";
 import { buildMenuItems, exampleSetup } from "prosemirror-example-setup";
@@ -332,7 +332,7 @@ export class FluidCollabManager extends EventEmitter implements IRichTextEditor 
                     const from = stepAsJson.from;
                     const to = stepAsJson.to;
 
-                    let operations = new Array<IMergeTreeOp>();
+                    let operations = new Array<IMergeTreeDeltaOp>();
 
                     if (from !== to) {
                         const removeOp = createRemoveRangeOp(from, to);
@@ -354,7 +354,7 @@ export class FluidCollabManager extends EventEmitter implements IRichTextEditor 
                 }
 
                 case "replaceAround": {
-                    let operations = new Array<IMergeTreeOp>();
+                    let operations = new Array<IMergeTreeDeltaOp>();
 
                     const from = stepAsJson.from;
                     const to = stepAsJson.to;

--- a/packages/runtime/merge-tree/src/client.ts
+++ b/packages/runtime/merge-tree/src/client.ts
@@ -644,8 +644,8 @@ export class Client {
         return this.shortClientBranchIdMap[clientId];
     }
 
-    private resetPendingSegmentToOp(segment: ISegment): ops.IMergeTreeOp {
-        let op: ops.IMergeTreeOp;
+    private resetPendingSegmentToOp(segment: ISegment): ops.IMergeTreeDeltaOp {
+        let op: ops.IMergeTreeDeltaOp;
         if (!segment.segmentGroups.empty) {
             segment.segmentGroups.clear();
 
@@ -782,7 +782,7 @@ export class Client {
             }
         }
 
-        const opList: ops.IMergeTreeOp[] = [];
+        const opList: ops.IMergeTreeDeltaOp[] = [];
         for (const segment of orderedSegments.items) {
             const op = this.resetPendingSegmentToOp(segment);
             if (op) {

--- a/packages/runtime/merge-tree/src/opBuilder.ts
+++ b/packages/runtime/merge-tree/src/opBuilder.ts
@@ -9,9 +9,9 @@ import {
     IMergeTreeAnnotateMsg,
     IMergeTreeGroupMsg,
     IMergeTreeInsertMsg,
-    IMergeTreeOp,
     IMergeTreeRemoveMsg,
     MergeTreeDeltaType,
+    IMergeTreeDeltaOp,
 } from "./ops";
 import { PropertySet } from "./properties";
 
@@ -126,7 +126,7 @@ export function createInsertToRegisterOp(start: number, end: number, register: s
  * @param ops - The ops to group
  */
 export function createGroupOp(
-    ... ops: IMergeTreeOp[]): IMergeTreeGroupMsg {
+    ... ops: IMergeTreeDeltaOp[]): IMergeTreeGroupMsg {
     return {
         ops,
         type: MergeTreeDeltaType.GROUP,

--- a/packages/runtime/merge-tree/src/ops.ts
+++ b/packages/runtime/merge-tree/src/ops.ts
@@ -102,11 +102,13 @@ export interface IMergeTreeAnnotateMsg extends IMergeTreeDelta {
 
 export interface IMergeTreeGroupMsg extends IMergeTreeDelta {
     type: MergeTreeDeltaType.GROUP;
-    ops: IMergeTreeOp[];
+    ops: IMergeTreeDeltaOp[];
 }
 
 export interface IJSONSegment {
     props?: Record<string, any>;
 }
 
-export type IMergeTreeOp = IMergeTreeInsertMsg | IMergeTreeRemoveMsg | IMergeTreeAnnotateMsg | IMergeTreeGroupMsg;
+export type IMergeTreeDeltaOp = IMergeTreeInsertMsg | IMergeTreeRemoveMsg | IMergeTreeAnnotateMsg;
+
+export type IMergeTreeOp = IMergeTreeDeltaOp | IMergeTreeGroupMsg;

--- a/packages/runtime/sequence/src/sequence.ts
+++ b/packages/runtime/sequence/src/sequence.ts
@@ -57,8 +57,8 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
         return this.loadedDeferred.promise;
     }
 
-    private static createOpsFromDelta(event: SequenceDeltaEvent): MergeTree.IMergeTreeOp[] {
-        const ops: MergeTree.IMergeTreeOp[] = [];
+    private static createOpsFromDelta(event: SequenceDeltaEvent): MergeTree.IMergeTreeDeltaOp[] {
+        const ops: MergeTree.IMergeTreeDeltaOp[] = [];
         for (const r of event.ranges) {
             switch (event.deltaOperation) {
                 case MergeTree.MergeTreeDeltaType.ANNOTATE: {
@@ -532,7 +532,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
             this.runtime.IComponentSerializer,
             this.runtime.IComponentHandleContext);
 
-        const ops: MergeTree.IMergeTreeOp[] = [];
+        const ops: MergeTree.IMergeTreeDeltaOp[] = [];
         function transfromOps(event: SequenceDeltaEvent) {
             ops.push(...SharedSegmentSequence.createOpsFromDelta(event));
         }

--- a/packages/runtime/sequence/src/test/testFarm.ts
+++ b/packages/runtime/sequence/src/test/testFarm.ts
@@ -22,7 +22,7 @@ import {
     TextSegment,
     createGroupOp,
     PropertySet,
-    IMergeTreeOp,
+    IMergeTreeDeltaOp,
     MergeTreeTextHelper,
     // eslint-disable-next-line import/no-duplicates
 } from "@fluidframework/merge-tree";
@@ -419,7 +419,7 @@ export function TestPack(verbose = true) {
             if (word1) {
                 const removeStart = word1.pos;
                 const removeEnd = removeStart + word1.text.length;
-                const ops: IMergeTreeOp[] = [];
+                const ops: IMergeTreeDeltaOp[] = [];
                 const removeOp = client.removeRangeLocal(removeStart, removeEnd);
                 if (!useGroupOperationsForMoveWord) {
                     server.enqueueMsg(client.makeOpMessage(removeOp));


### PR DESCRIPTION
As part of the reconnection work, I also introduced this change to increase type safety. Breaking it our in a separate change to reduce the size of that PR.

This change limits the possible ops with-in a group op to non-group ops in order to prevent nesting of group ops in group ops.