### PR TITLE
Add deprecated to client-api and testhost readme

### DIFF
--- a/packages/runtime/client-api/README.md
+++ b/packages/runtime/client-api/README.md
@@ -1,0 +1,3 @@
+# Deprecated
+
+This package should not be consumed and is in the process of being removed.

--- a/packages/server/local-test-utils/README.md
+++ b/packages/server/local-test-utils/README.md
@@ -1,3 +1,7 @@
+# Deprecated
+
+This package should not be consumed and is in the process of being removed.
+
 # Local Test Utils
 
 This has simple implementations for op storage and ordering, code loading for simple components, and a local test host.


### PR DESCRIPTION
Adds a comment in the readme of client-api and testhost that the packages are deprecated and we are in the process of removing them.