### PR TITLE
Fix Backspace CollaborativeInput

### DIFF
--- a/packages/framework/aqueduct-react/src/react/collaborativeInput.tsx
+++ b/packages/framework/aqueduct-react/src/react/collaborativeInput.tsx
@@ -89,9 +89,10 @@ export class CollaborativeInput extends React.Component<IProps, IState> {
 
         // Get the new caret position and use that to get the text that was inserted
         const newPosition = ev.currentTarget.selectionStart ? ev.currentTarget.selectionStart : 0;
-        const insertedText = newText.substring(this.state.selectionStart, newPosition);
-        const changeRangeLength = this.state.selectionEnd - this.state.selectionStart;
-        if (insertedText) {
+        const isTextInserted = newPosition - this.state.selectionStart > 0;
+        if (isTextInserted) {
+            const insertedText = newText.substring(this.state.selectionStart, newPosition);
+            const changeRangeLength = this.state.selectionEnd - this.state.selectionStart;
             if (changeRangeLength === 0) {
                 this.props.sharedString.insertText(this.state.selectionStart, insertedText);
             } else {


### PR DESCRIPTION
Backspace is broken in CollaborativeInput if you are not at the very end.

This was because `string.substring(start,end)` will swap the numbers if end < start. This bug was already fixed in CollaborativeText so I ported the code from there.