### PR TITLE
Add work item template to issue template list

### DIFF
--- a/.github/ISSUE_TEMPLATE/work_item.md
+++ b/.github/ISSUE_TEMPLATE/work_item.md
@@ -1,0 +1,29 @@
+---
+name: Work Item
+about: Track project work related to Fluid Framework
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Work Item
+**Describe the outcome you expect**
+<!--A clear and concise description of the deliverable for this work item -->
+
+**Approach**
+<!--Describe the high level approach to this work  -->
+
+**Open questions**
+<!--List any unknowns that need to be addressed with this work -->
+
+**Additional context**
+<!--Add any other context about this work you'd like to provide -->
+
+**Acceptance criteria**
+<!--The full list of things that must be true before this work can be considered done -->
+
+
+<!-- By filing an Issue, you are expected to comply with the Code of Conduct: https://github.com/microsoft/FluidFramework/blob/master/CODE_OF_CONDUCT.md -->
+
+<!-- Lastly, be sure to preview your issue before saving. Thanks! -->


### PR DESCRIPTION
We talked about this at standup on June 5th and Sam suggested I take a stab at defining what I want to see in work items, so I decided to take it all the way. 