### PR TITLE
Remove repeated value in host-node compiler options

### DIFF
--- a/examples/hosts/node/tsconfig.json
+++ b/examples/hosts/node/tsconfig.json
@@ -5,7 +5,6 @@
         "node_modules"
     ],
     "compilerOptions": {
-        "sourceMap": true,
         "rootDir": "./src",
         "outDir": "dist",
         "types": []


### PR DESCRIPTION
Small change, was seeing this warning in npm run build:fast