### PR TITLE
Try adding sync create

### DIFF
--- a/components/experimental/image-collection/package.json
+++ b/components/experimental/image-collection/package.json
@@ -25,6 +25,7 @@
     "webpack:dev": "webpack --env=\"development\""
   },
   "dependencies": {
+    "@fluidframework/aqueduct": "^0.20.0",
     "@fluidframework/component-base": "^0.20.0",
     "@fluidframework/component-core-interfaces": "^0.20.0",
     "@fluidframework/component-runtime": "^0.20.0",

--- a/components/experimental/table-view/src/tableview.ts
+++ b/components/experimental/table-view/src/tableview.ts
@@ -92,7 +92,7 @@ export class TableView extends PrimedComponent implements IComponentHTMLView {
 
     protected async componentInitializingFirstTime() {
         // Set up internal table doc
-        const doc = await TableDocument.getFactory().createComponent(this.context) as TableDocument;
+        const doc = TableDocument.getFactory().createComponentSync(this.context) as TableDocument;
         this.root.set(innerDocKey, doc.handle);
         doc.insertRows(0, 5);
         doc.insertCols(0, 8);

--- a/packages/framework/aqueduct/src/componentFactories/index.ts
+++ b/packages/framework/aqueduct/src/componentFactories/index.ts
@@ -5,3 +5,4 @@
 
 export * from "./primedComponentFactory";
 export * from "./sharedComponentFactory";
+export * from "./syncComponentFactory";

--- a/packages/framework/aqueduct/src/componentFactories/sharedComponentFactory.ts
+++ b/packages/framework/aqueduct/src/componentFactories/sharedComponentFactory.ts
@@ -33,14 +33,14 @@ export class SharedComponentFactory<P extends IComponent, S = undefined> impleme
     IComponentFactory,
     Partial<IProvideComponentRegistry>
 {
-    private readonly sharedObjectRegistry: ISharedObjectRegistry;
+    protected readonly sharedObjectRegistry: ISharedObjectRegistry;
     private readonly registry: IComponentRegistry | undefined;
 
     constructor(
         public readonly type: string,
-        private readonly ctor: new (props: ISharedComponentProps<P>) => SharedComponent<P, S>,
+        protected readonly ctor: new (props: ISharedComponentProps<P>) => SharedComponent<P, S>,
         sharedObjects: readonly ISharedObjectFactory[],
-        private readonly optionalProviders: ComponentSymbolProvider<P>,
+        protected readonly optionalProviders: ComponentSymbolProvider<P>,
         registryEntries?: NamedComponentRegistryEntries,
         private readonly onDemandInstantiation = true,
     ) {

--- a/packages/framework/aqueduct/src/componentFactories/syncComponentFactory.ts
+++ b/packages/framework/aqueduct/src/componentFactories/syncComponentFactory.ts
@@ -1,0 +1,78 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    IComponent,
+} from "@fluidframework/component-core-interfaces";
+import { ComponentRuntime } from "@fluidframework/component-runtime";
+import {
+    DirectoryFactory,
+    SharedDirectory,
+} from "@fluidframework/map";
+import {
+    IComponentContext,
+    NamedComponentRegistryEntries,
+} from "@fluidframework/runtime-definitions";
+import { ISharedObjectFactory } from "@fluidframework/shared-object-base";
+import { ComponentSymbolProvider, DependencyContainer } from "@fluidframework/synthesize";
+
+import { ISharedComponentProps, SyncComponent } from "../components";
+import { SharedComponentFactory } from "./sharedComponentFactory";
+
+/**
+ * P - represents a type that will define optional providers that will be injected
+ * S - the initial state type that the produced component may take during creation
+ */
+export class SyncComponentFactory<
+    P extends IComponent = object,
+    S = undefined>
+    extends SharedComponentFactory<P, S>
+{
+    constructor(
+        type: string,
+        ctor: new (props: ISharedComponentProps<P>) => SyncComponent<P, S>,
+        sharedObjects: readonly ISharedObjectFactory[] = [],
+        optionalProviders: ComponentSymbolProvider<P>,
+        registryEntries?: NamedComponentRegistryEntries,
+        onDemandInstantiation = true,
+    ) {
+        const mergedObjects = [...sharedObjects];
+
+        if (!sharedObjects.find((factory) => factory.type === DirectoryFactory.Type)) {
+            // User did not register for directory
+            mergedObjects.push(SharedDirectory.getFactory());
+        }
+
+        super(
+            type,
+            ctor,
+            mergedObjects,
+            optionalProviders,
+            registryEntries,
+            onDemandInstantiation,
+        );
+    }
+
+    public createComponentSync(
+        context: IComponentContext,
+        initialState?: S,
+    ): SyncComponent {
+        if (this.type === "") {
+            throw new Error("undefined type member");
+        }
+
+        const { containerRuntime, packagePath } = context;
+        const childContext = containerRuntime.createComponentContext(packagePath.concat(this.type));
+        const childRuntime = ComponentRuntime.load(childContext, this.sharedObjectRegistry, this.IComponentRegistry);
+
+        const dependencyContainer = new DependencyContainer(context.scope.IComponentDependencySynthesizer);
+        const providers = dependencyContainer.synthesize<P>(this.optionalProviders, {});
+        // Create a new instance of our component
+        const props = { runtime: childRuntime, context: childContext, providers };
+        const instance = new this.ctor(props) as SyncComponent<P, S>;
+        instance.initializeSync(initialState);
+        return instance;
+    }
+}

--- a/packages/framework/aqueduct/src/components/index.ts
+++ b/packages/framework/aqueduct/src/components/index.ts
@@ -9,3 +9,4 @@ export {
     ISharedComponentProps,
     SharedComponent,
 } from "./sharedComponent";
+export { SyncComponent } from "./syncComponent";

--- a/packages/framework/aqueduct/src/components/sharedComponent.ts
+++ b/packages/framework/aqueduct/src/components/sharedComponent.ts
@@ -41,7 +41,7 @@ export abstract class SharedComponent<P extends IComponent = object, S = undefin
     extends EventForwarder<E>
     implements IComponentLoadable, IComponentRouter, IProvideComponentHandle
 {
-    private initializeP: Promise<void> | undefined;
+    protected initializeP: Promise<void> | undefined;
     private readonly innerHandle: IComponentHandle<this>;
     private _disposed = false;
 

--- a/packages/framework/aqueduct/src/components/syncComponent.ts
+++ b/packages/framework/aqueduct/src/components/syncComponent.ts
@@ -1,0 +1,110 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    IComponent,
+} from "@fluidframework/component-core-interfaces";
+import { ISharedDirectory, SharedDirectory } from "@fluidframework/map";
+import { IEvent } from "@fluidframework/common-definitions";
+import { SharedComponent } from "./sharedComponent";
+
+/**
+ * SyncComponent is a base component that is primed with a root directory and
+ * ensures it is created and ready before you can access it.  Additionally, it
+ * provides hooks for synchronous creation.
+ *
+ * Having a single root directory allows for easier development. Instead of creating
+ * and registering channels with the runtime any new DDS that is set on the root
+ * will automatically be registered.
+ *
+ * Generics:
+ * P - represents a type that will define optional providers that will be injected
+ * S - the initial state type that the produced component may take during creation
+ * E - represents events that will be available in the EventForwarder
+ */
+export abstract class SyncComponent<P extends IComponent = object, S = undefined, E extends IEvent = IEvent>
+    extends SharedComponent<P, S, E>
+{
+    private internalRoot: ISharedDirectory | undefined;
+    private readonly rootDirectoryId = "root";
+
+    /**
+     * The root directory will either be ready or will return an error. If an error is thrown
+     * the root has not been correctly created/set.
+     */
+    protected get root(): ISharedDirectory {
+        if (!this.internalRoot) {
+            throw new Error(this.getUninitializedErrorString(`root`));
+        }
+
+        return this.internalRoot;
+    }
+
+    private createRoot(): void {
+        // Create a root directory and register it before calling component initialization
+        this.internalRoot = SharedDirectory.create(this.runtime, this.rootDirectoryId);
+        this.internalRoot.register();
+    }
+
+    /**
+     * Calls initializeFirstTimeSync or componentInitializingFromExisting.
+     * Caller is responsible for ensuring this is only invoked once.
+     */
+    protected async initializeInternal(props?: any): Promise<void> {
+        if (!this.runtime.existing) {
+            this.createRoot();
+            this.initializeFirstTimeSync(props);
+        } else {
+            // Component has a root directory so we just need to set it before calling componentInitializingFromExisting
+            this.internalRoot = await this.runtime.getChannel(this.rootDirectoryId) as ISharedDirectory;
+
+            await this.componentInitializingFromExisting();
+        }
+    }
+
+    private getUninitializedErrorString(item: string) {
+        return `${item} must be initialized before being accessed.`;
+    }
+
+    /**
+     * Synchronous version of SharedComponent's initialize(...) method.
+     * Guarantees initialization will only happen once
+     */
+    public initializeSync(initialState?: S): void {
+        // We want to ensure if this gets called more than once it only executes the initialize code once.
+        if (!this.initializeP) {
+            this.initializeP = Promise.resolve();
+
+            this.createRoot();
+            this.initializeFirstTimeSync(initialState);
+        }
+    }
+
+    /**
+     * Called the first time the component is initialized when created through
+     * SyncComponentFactory's createComponentSync
+     * Parallel to SharedComponent's componentInitializingFirstTime
+     *
+     * @param initialState - Optional initialState to be passed in on create
+     */
+    protected initializeFirstTimeSync(initialState?: S): void { }
+
+    /**
+     * Inherited from SharedComponent; do not call this on a SyncComponent
+     *
+     * @param props - Optional props to be passed in on create
+     * @deprecated 0.16 Issue #1635 Initial props should be provided through a factory override
+     */
+    protected async componentInitializingFirstTime(props?: any): Promise<void> {
+        throw new Error("Should not call componentInitializingFirstTime on SyncComponent");
+    }
+
+    /**
+     * Inherited from SharedComponent; do not call this on a SyncComponent
+     */
+    protected async componentHasInitialized(): Promise<void> {
+        throw new Error("Should not call componentHashInitialized on SyncComponent");
+    }
+}


### PR DESCRIPTION
Relates to #2334 

Tried digging deeper into what might need to happen to add synchronous create into aqueduct; would love anyone's thoughts on how this ended up.

#### New SyncComponent and SyncComponentFactory classes extending SharedComponent{Factory}
Shared/PrimedComponent have a lot of stuff that we want to reuse here, but also stuff we don't want.  I tried simply adding a synchronous `createComponentSync` method to PrimedComponentFactory first (mostly because PrimedComponent already handles setting up root), but this didn't work super great with the existing initialization code.  PrimedComponent also sets up the task manager there (which involves async requests to the runtime) along with calling `componentHasInitialized`, so I couldn't cleanly add a sync parallel version without also messing up the initialization methods that components override.

Ignoring the task manager, I tried seeing how an existing component might need to refactor its initialization overrides to support sync create, using TableDocument as the test.  The pattern that TableDocument (and a lot of other components use) is to:
-use `componentInitializingFirstTime` to create member components and do non-component related init
-use `componentInitializingFromExisting` to do the same non-component related init as ^
-use `componentHasInitialized` to load the member components from root and do any initialization involving those components
The end result was that supporting all 3 scenarios of async create new, sync create new, and create from existing through the overrides was very messy code-wise when `componentHasInitialized` needed to do component-related init due to the async nature of pulling components from root.

Thus a new SyncComponent class with a different initialization flow where only `componentInitializingFromExisting` and `initializeFirstTimeSync` (new override) get called.  This makes sync create more explicitly opt in, but unfortunately retains the unused `componentInitializingFirstTime` and `componentHasInitialized` hooks from SharedComponent (otherwise would probably need to duplicate even more code when not extending SharedComponent).

I think the code duplication and disjoint functionality is problematic here, but I haven't looked too deeply into what to do about it.

#### Updated examples
TableDocument is an experiment to see how it might look to convert a normal aqueduct component; I don't plan on retaining this change.
Image-collection is a conversion example for a component-base consumer (though migrating component-base consumers to existing aqueduct classes is fairly straightforward anyway).

#### Other thoughts
The hopping back-and-forth between the context and the runtime in the existing `createComponent` path can probably be simplified in the same way as done in `createComponentSync`