### PR TITLE
[docs] Some minor copy/formatting fixes.

### DIFF
--- a/docs/guide/SharedMap.md
+++ b/docs/guide/SharedMap.md
@@ -24,7 +24,7 @@ const myMap = SharedMap.create(this.runtime, id);
 ## Usage
 
 Unlike JavaScript Maps, a SharedMap's keys must be strings. The value must only be plain JS objects, `SharedObject`
-handles, or value types., including another distributed data structure. Thus, you can use nested SharedMaps and other
+handles, or value types, including another distributed data structure. Thus, you can use nested SharedMaps and other
 distributed data structures to construct a Fluid data model.
 
 !!!include(object-serialization.md)!!!

--- a/docs/guide/components.md
+++ b/docs/guide/components.md
@@ -136,22 +136,22 @@ export interface IComponentHTMLOptions {
 
 For an introduction to the Fluid Data model, please read [What is Fluid?](../what-is-fluid.md)
 
-The Fluid distributed data structures can be instantiated and accessed via methods in the core Runtime and implementing the
-`IComponentLoadable` interface.
+The Fluid distributed data structures can be instantiated and accessed via methods in the core Runtime and implementing
+the `IComponentLoadable` interface.
 
 However, we expect most component developers to access the data model via the base classes in Fluid’s Aqueduct package
 (this package contains implementations of the Fluid Framework interfaces that help developers to quickly get started),
 specifically [PrimedComponent][], and then use distributed data structures via their APIs (SharedDirectory, SharedMap,
 SharedString, etc).
 
-[PrimedComponent][] ensures that a root distributed data structure is created and ready for the developer to use. The root
-is a SharedDirectory, which is a Map-like data structure. Additional distributed data structures can be added easily.
-[PrimedComponent][] is the recommended starting point for building a component.
+[PrimedComponent][] ensures that a root distributed data structure is created and ready for the developer to use. The
+root is a SharedDirectory, which is a Map-like data structure. Additional distributed data structures can be added
+easily. [PrimedComponent][] is the recommended starting point for building a component.
 
-[PrimedComponent][] exposes some component lifecycle functions that components can override. For example, a component might
-override the componentInitializingFirstTime function to set up any state that should be configured only once during a
-components life, or override the componentHasInitialized method which will be called every time the component has
-initialized.
+[PrimedComponent][] exposes some component lifecycle functions that components can override. For example, a component
+might override the `componentInitializingFirstTime` function to set up any state that should be configured only once
+during a components life, or override the `componentHasInitialized` method which will be called every time the component
+has initialized.
 
 ### Fluid Experience Interfaces
 

--- a/docs/guide/dds.md
+++ b/docs/guide/dds.md
@@ -5,9 +5,9 @@ uid: dds
 # Distributed Data Structures
 
 Much of Fluid's power lies in a set of base primitives called distributed data structures. These data structures, such
-as such as [SharedMap](./SharedMap.md) and the various types in the @fluidframework/sequence package, are eventually
-consistent. The Fluid runtime manages these data structures; as changes are made locally and remotely, they are merged
-in seamlessly by the runtime.
+as [SharedMap](./SharedMap.md) and the various types in the @fluidframework/sequence package, are eventually consistent.
+The Fluid runtime manages these data structures; as changes are made locally and remotely, they are merged in seamlessly
+by the runtime.
 
 When you're working with a DDS, you can largely treat it as a local object. You can make changes to it as needed.
 However, this local object can be changed not only by your local code, but also by the Fluid runtime. The Fluid runtime


### PR DESCRIPTION
Just some minor things I came across as I was reading the docs.

PS: It might be a good idea to either add a ruler setting to `settings.json` or a prettier config that formats the markdown, as I noticed an ambition to break lines at 120 columns but not a strict adherence.