### PR TITLE
Fix up container/component language

### DIFF
--- a/components/examples/README.md
+++ b/components/examples/README.md
@@ -3,13 +3,12 @@
 We put together a group of Fluid components that explore a key group of concepts.
 
 ### Components
-[Badge](./badge) - A badge component demonstrating SharedDirectory, SharedMap, SharedCell, and SharedObjectSequence DDSs
-[Clicker](./clicker) - A clicker component that uses an agent and the task manager to monitor the clicker component
-[Collaborative Text Area](./collaborative-textarea) - A very minimal example of using a SharedString within a text area for collaboration
+* [Badge](./badge) - A badge component demonstrating SharedDirectory, SharedMap, SharedCell, and SharedObjectSequence DDSs
+* [Clicker](./clicker) - A clicker component that uses an agent and the task manager to monitor the clicker component
+* [Collaborative Text Area](./collaborative-textarea) - A very minimal example of using a SharedString within a text area for collaboration
 
 ### Containers
-
-[Dice Roller](./dice-roller) - A basic example that persists a value to the root SharedDirectory
-[Pond](./pond) - A collection of fluid scenarios used primarily for testing
-[Primitives](./primitives) - A container giving a UI to various DDS
-[Simple Component Embed](./simple-component-embed) - A simple example of embedding one component within another
+* [Dice Roller](./dice-roller) - A basic example that persists a value to the root SharedDirectory
+* [Pond](./pond) - A collection of fluid scenarios used primarily for testing
+* [Primitives](./primitives) - A container giving a UI to various DDS
+* [Simple Component Embed](./simple-component-embed) - A simple example of embedding one component within another

--- a/components/examples/README.md
+++ b/components/examples/README.md
@@ -1,3 +1,15 @@
-# Example Components
+# Example Components & Containers
 
-_Coming soon..._
+We put together a group of Fluid components that explore a key group of concepts.
+
+### Components
+[Badge](./badge) - A badge component demonstrating SharedDirectory, SharedMap, SharedCell, and SharedObjectSequence DDSs
+[Clicker](./clicker) - A clicker component that uses an agent and the task manager to monitor the clicker component
+[Collaborative Text Area](./collaborative-textarea) - A very minimal example of using a SharedString within a text area for collaboration
+
+### Containers
+
+[Dice Roller](./dice-roller) - A basic example that persists a value to the root SharedDirectory
+[Pond](./pond) - A collection of fluid scenarios used primarily for testing
+[Primitives](./primitives) - A container giving a UI to various DDS
+[Simple Component Embed](./simple-component-embed) - A simple example of embedding one component within another

--- a/components/examples/dice-roller/README.md
+++ b/components/examples/dice-roller/README.md
@@ -1,11 +1,12 @@
 # Dice Roller
 
 **Dice Roller** is a basic example that has a die and a button. Clicking the button re-rolls the die and 
-persists the value in the root SharedDirectory.
+persists the value in the root SharedDirectory. The Fluid Container is defined index.ts, the component is
+defined in main.tsx.
 
 ## Getting Started
 
-If you want to run this component follow the following steps:
+If you want to run this container follow the following steps:
 
 1. Run `npm install` from the `FluidFramework` root directory
 2. Navigate to this directory

--- a/components/examples/dice-roller/package.json
+++ b/components/examples/dice-roller/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fluid-example/diceroller",
   "version": "0.20.0",
-  "description": "Minimal Fluid Container sample to implement a collaborative dice roller.",
+  "description": "Minimal Fluid Container & Component sample to implement a collaborative dice roller.",
   "repository": "microsoft/FluidFramework",
   "license": "MIT",
   "author": "Microsoft",

--- a/components/examples/dice-roller/package.json
+++ b/components/examples/dice-roller/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fluid-example/diceroller",
   "version": "0.20.0",
-  "description": "Minimal Fluid component sample to implement a collaborative dice roller.",
+  "description": "Minimal Fluid Container sample to implement a collaborative dice roller.",
   "repository": "microsoft/FluidFramework",
   "license": "MIT",
   "author": "Microsoft",

--- a/components/examples/pond/README.md
+++ b/components/examples/pond/README.md
@@ -4,7 +4,7 @@ The pond is a collection of simple fluid scenarios used primarily for testing.
 
 ## Getting Started
 
-If you want to run this component follow the following steps:
+If you want to run this container follow the following steps:
 
 1. Run `npm install` from the `FluidFramework` root directory
 2. Navigate to this directory
@@ -38,3 +38,7 @@ The Container logic also initializes the UserInfo Provider below.
 ### [UserInfo Provider](./src/providers/userInfo.ts)
 
 An example Container Provider that implements the `IComponentUserInformation` interface.
+
+## Container Definition
+
+The container is defined in src/index.tsx

--- a/components/examples/pond/package.json
+++ b/components/examples/pond/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fluid-example/pond",
   "version": "0.20.0",
-  "description": "Grab bag of fluid scenarios.",
+  "description": "Grab bag of fluid scenarios in one Fluid Container.",
   "repository": "microsoft/FluidFramework",
   "license": "MIT",
   "author": "Microsoft",

--- a/components/examples/primitives/README.md
+++ b/components/examples/primitives/README.md
@@ -1,6 +1,6 @@
-# Primitives Component
+# Primitives Container
 
-This is a basic example component giving a UI to different distributed data structures.
+This is a basic example container giving a UI to different distributed data structures.
 
 ## Getting Started
 

--- a/components/examples/primitives/package.json
+++ b/components/examples/primitives/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fluid-example/primitives",
   "version": "0.20.0",
-  "description": "Minimal Fluid component sample to showcase some of the distributed data structures.",
+  "description": "Minimal Fluid container sample to showcase some of the distributed data structures.",
   "repository": "microsoft/FluidFramework",
   "license": "MIT",
   "author": "Microsoft",

--- a/components/examples/simple-component-embed/README.md
+++ b/components/examples/simple-component-embed/README.md
@@ -1,7 +1,7 @@
 # Simple Component Embed
 
-An example of how to embed another component. **Simple Component Embed** is a component that creates and loads
-the [`@fluid-example/clicker`](../clicker/README.md) component.
+An example of how to embed another component. **Simple Component Embed** is a Container, with a default component
+that creates and loads the [`@fluid-example/clicker`](../clicker/README.md) component.
 
 ## Getting Started
 

--- a/components/examples/simple-component-embed/package.json
+++ b/components/examples/simple-component-embed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fluid-example/simple-component-embed",
   "version": "0.20.0",
-  "description": "Simple component embed scenario",
+  "description": "Simple component embed container",
   "repository": "microsoft/FluidFramework",
   "license": "MIT",
   "author": "Microsoft",

--- a/examples/hosts/literate/README.md
+++ b/examples/hosts/literate/README.md
@@ -16,7 +16,7 @@ of code.
 ## Build steps
 
 The first (and hardest) step to get up and running is to authenticate against the Fluid private npm feed. To do so
-navigate to <https://offnet.visualstudio.com/officenet/_packaging?feed=prague&_a=feed>, click the "Connect to feed" link,
+navigate to <https://offnet.visualstudio.com/officenet/_packaging?feed=fluid&_a=feed>, click the "Connect to feed" link,
 choose "npm" and then follow the instructions.
 
 Once you've done that getting up and running is simple.


### PR DESCRIPTION
This addresses Part 2 of #2427 

Current component examples are either components or containers. This at least makes the README language accurate to each example.