### PR TITLE
Unit tests for @fluidframework/map package with remote client and reconnection

### DIFF
--- a/packages/runtime/map/src/test/directory.spec.ts
+++ b/packages/runtime/map/src/test/directory.spec.ts
@@ -358,7 +358,7 @@ describe("Directory", () => {
             // Process the message.
             containerRuntimeFactory.processAllMessages();
 
-            // Verify that both the directory get the new value.
+            // Verify that both the directories get the new value.
             assert.equal(directory.get(key), newValue, "The first directory did not get the new value");
             assert.equal(directory2.get(key), newValue, "The second directory did not get the new value");
         });
@@ -408,7 +408,7 @@ describe("Directory", () => {
         });
     });
 
-    describe("SharedDirectory in connected state with a remote directory", () => {
+    describe("SharedDirectory in connected state with a remote SharedDirectory", () => {
         let containerRuntimeFactory: MockContainerRuntimeFactory;
         let directory2: SharedDirectory;
 

--- a/packages/runtime/map/src/test/directory.spec.ts
+++ b/packages/runtime/map/src/test/directory.spec.ts
@@ -48,6 +48,10 @@ describe("Directory", () => {
     });
 
     describe("SharedDirectory in local state", () => {
+        beforeEach(() => {
+            componentRuntime.local = true;
+        });
+
         it("Can create a new directory", () => {
             assert.ok(directory, "could not create a new directory");
         });
@@ -91,6 +95,317 @@ describe("Directory", () => {
                 directory.createSubDirectory(null);
             }, "Should throw for null subdirectory name");
         });
+
+        describe(".serialize", () => {
+            it("Should serialize an empty directory as a JSON object", () => {
+                const serialized = serialize(directory);
+                assert.equal(serialized, "{}");
+            });
+
+            it("Should serialize a directory without subdirectories as a JSON object", () => {
+                directory.set("first", "second");
+                directory.set("third", "fourth");
+                directory.set("fifth", "sixth");
+                const subMap = mapFactory.create(componentRuntime, "subMap");
+                directory.set("object", subMap.handle);
+
+                const serialized = serialize(directory);
+                // eslint-disable-next-line max-len
+                const expected = `{"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain","value":"sixth"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"subMap"}}}}`;
+                assert.equal(serialized, expected);
+            });
+
+            it("Should serialize a directory with subdirectories as a JSON object", () => {
+                directory.set("first", "second");
+                directory.set("third", "fourth");
+                directory.set("fifth", "sixth");
+                const subMap = mapFactory.create(componentRuntime, "subMap");
+                directory.set("object", subMap.handle);
+                const nestedDirectory = directory.createSubDirectory("nested");
+                nestedDirectory.set("deepKey1", "deepValue1");
+                nestedDirectory.createSubDirectory("nested2")
+                    .createSubDirectory("nested3")
+                    .set("deepKey2", "deepValue2");
+
+                const serialized = serialize(directory);
+                // eslint-disable-next-line max-len
+                const expected = `{"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain","value":"sixth"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"subMap"}}},"subdirectories":{"nested":{"storage":{"deepKey1":{"type":"Plain","value":"deepValue1"}},"subdirectories":{"nested2":{"subdirectories":{"nested3":{"storage":{"deepKey2":{"type":"Plain","value":"deepValue2"}}}}}}}}}`;
+                assert.equal(serialized, expected);
+            });
+
+            it("Should serialize an undefined value", () => {
+                directory.set("first", "second");
+                directory.set("third", "fourth");
+                directory.set("fifth", undefined);
+                assert.ok(directory.has("fifth"));
+                const subMap = mapFactory.create(componentRuntime, "subMap");
+                directory.set("object", subMap.handle);
+                const nestedDirectory = directory.createSubDirectory("nested");
+                nestedDirectory.set("deepKey1", "deepValue1");
+                nestedDirectory.set("deepKeyUndefined", undefined);
+                assert.ok(nestedDirectory.has("deepKeyUndefined"));
+                nestedDirectory.createSubDirectory("nested2")
+                    .createSubDirectory("nested3")
+                    .set("deepKey2", "deepValue2");
+
+                const serialized = serialize(directory);
+                // eslint-disable-next-line max-len
+                const expected = `{"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"subMap"}}},"subdirectories":{"nested":{"storage":{"deepKey1":{"type":"Plain","value":"deepValue1"},"deepKeyUndefined":{"type":"Plain"}},"subdirectories":{"nested2":{"subdirectories":{"nested3":{"storage":{"deepKey2":{"type":"Plain","value":"deepValue2"}}}}}}}}}`;
+                assert.equal(serialized, expected);
+            });
+        });
+
+        describe(".populate", () => {
+            it("Should populate the directory from an empty JSON object (old format)", async () => {
+                await populate(directory, {});
+                assert.equal(directory.size, 0, "Failed to initialize to empty directory storage");
+                directory.set("testKey", "testValue");
+                assert.equal(directory.get("testKey"), "testValue", "Failed to set testKey");
+                directory.createSubDirectory("testSubDir").set("testSubKey", "testSubValue");
+                assert.equal(
+                    directory.getWorkingDirectory("testSubDir").get("testSubKey"),
+                    "testSubValue",
+                    "Failed to set testSubKey",
+                );
+            });
+
+            it("Should populate the directory from a basic JSON object (old format)", async () => {
+                await populate(directory, {
+                    storage: {
+                        testKey: {
+                            type: "Plain",
+                            value: "testValue4",
+                        },
+                        testKey2: {
+                            type: "Plain",
+                            value: "testValue5",
+                        },
+                    },
+                    subdirectories: {
+                        foo: {
+                            storage: {
+                                testKey: {
+                                    type: "Plain",
+                                    value: "testValue",
+                                },
+                                testKey2: {
+                                    type: "Plain",
+                                    value: "testValue2",
+                                },
+                            },
+                        },
+                        bar: {
+                            storage: {
+                                testKey3: {
+                                    type: "Plain",
+                                    value: "testValue3",
+                                },
+                            },
+                        },
+                    },
+                });
+                assert.equal(directory.size, 2, "Failed to initialize directory storage correctly");
+                assert.equal(directory.getWorkingDirectory("/foo").get("testKey"), "testValue");
+                assert.equal(directory.getWorkingDirectory("foo").get("testKey2"), "testValue2");
+                assert.equal(directory.getWorkingDirectory("/bar").get("testKey3"), "testValue3");
+                assert.equal(directory.getWorkingDirectory("").get("testKey"), "testValue4");
+                assert.equal(directory.getWorkingDirectory("/").get("testKey2"), "testValue5");
+                directory.set("testKey", "newValue");
+                assert.equal(directory.get("testKey"), "newValue", "Failed to set testKey");
+                directory.createSubDirectory("testSubDir").set("testSubKey", "newSubValue");
+                assert.equal(
+                    directory.getWorkingDirectory("testSubDir").get("testSubKey"),
+                    "newSubValue",
+                    "Failed to set testSubKey",
+                );
+            });
+
+            it("Should populate the directory with undefined values (old format)", async () => {
+                await populate(directory, {
+                    storage: {
+                        testKey: {
+                            type: "Plain",
+                            value: "testValue4",
+                        },
+                        testKey2: {
+                            type: "Plain",
+                        },
+                    },
+                    subdirectories: {
+                        foo: {
+                            storage: {
+                                testKey: {
+                                    type: "Plain",
+                                    value: "testValue",
+                                },
+                                testKey2: {
+                                    type: "Plain",
+                                },
+                            },
+                        },
+                        bar: {
+                            storage: {
+                                testKey3: {
+                                    type: "Plain",
+                                    value: "testValue3",
+                                },
+                            },
+                        },
+                    },
+                });
+                assert.equal(directory.size, 2, "Failed to initialize directory storage correctly");
+                assert.equal(directory.getWorkingDirectory("/foo").get("testKey"), "testValue");
+                assert.equal(directory.getWorkingDirectory("foo").get("testKey2"), undefined);
+                assert.equal(directory.getWorkingDirectory("/bar").get("testKey3"), "testValue3");
+                assert.equal(directory.getWorkingDirectory("").get("testKey"), "testValue4");
+                assert.equal(directory.getWorkingDirectory("/").get("testKey2"), undefined);
+                assert.ok(directory.has("testKey2"));
+                assert.ok(directory.getWorkingDirectory("/foo").has("testKey2"));
+                directory.set("testKey", "newValue");
+                assert.equal(directory.get("testKey"), "newValue", "Failed to set testKey");
+                directory.createSubDirectory("testSubDir").set("testSubKey", "newSubValue");
+                assert.equal(
+                    directory.getWorkingDirectory("testSubDir").get("testSubKey"),
+                    "newSubValue",
+                    "Failed to set testSubKey",
+                );
+            });
+
+            it("Should populate, serialize and de-serialize directory with long property values", async () => {
+                // 40K word
+                let longWord = "0123456789";
+                for (let i = 0; i < 12; i++) {
+                    longWord = longWord + longWord;
+                }
+                const logWord2 = `${longWord}_2`;
+
+                directory.set("first", "second");
+                directory.set("long1", longWord);
+                const nestedDirectory = directory.createSubDirectory("nested");
+                nestedDirectory.set("deepKey1", "deepValue1");
+                nestedDirectory.set("long2", logWord2);
+
+                const tree = directory.snapshot();
+                assert(tree.entries.length === 3);
+                assert(tree.entries[0].path === "blob0");
+                assert(tree.entries[1].path === "blob1");
+                assert(tree.entries[2].path === "header");
+                assert((tree.entries[0].value as IBlob).contents.length >= 1024);
+                assert((tree.entries[1].value as IBlob).contents.length >= 1024);
+                assert((tree.entries[2].value as IBlob).contents.length <= 200);
+
+                const directory2 = new SharedDirectory("test", componentRuntime, DirectoryFactory.Attributes);
+                const storage = MockSharedObjectServices.createFromTree(tree);
+                await directory2.load("branchId", storage);
+
+                assert.equal(directory2.get("first"), "second");
+                assert.equal(directory2.get("long1"), longWord);
+                assert.equal(directory2.getWorkingDirectory("/nested").get("deepKey1"), "deepValue1");
+                assert.equal(directory2.getWorkingDirectory("/nested").get("long2"), logWord2);
+            });
+        });
+    });
+
+    describe("SharedDirectory op processing in local state", () => {
+        /**
+         * These tests test the scenario found in the following bug:
+         * https://github.com/microsoft/FluidFramework/issues/2400
+         *
+         * - A SharedDirectory in local state performs a set or directory operation.
+         * - A second SharedDirectory is then created from the snapshot of the first one.
+         * - The second SharedDirectory performs the same operation as the first one but with a different value.
+         * - The expected behavior is that the first SharedDirectory updates the key with the new value. But in the
+         *   bug, the first SharedDirectory stores the key in its pending state even though it does not send out an
+         *   an op. So when it gets a remote op with the same key, it ignores it as it has a pending op with the
+         *   same key.
+         */
+        it("should correctly process a set operation sent in local state", async () => {
+            // Set the component runtime to local.
+            componentRuntime.local = true;
+
+            // Set a key in local state.
+            const key = "testKey";
+            const value = "testValue";
+            directory.set(key, value);
+
+            // Load a new SharedDirectory in connected state from the snapshot of the first one.
+            const containerRuntimeFactory = new MockContainerRuntimeFactory();
+            const componentRuntime2 = new MockComponentRuntime();
+            const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const services2 = MockSharedObjectServices.createFromTree(directory.snapshot());
+            services2.deltaConnection = containerRuntime2.createDeltaConnection();
+
+            const directory2 = new SharedDirectory("directory2", componentRuntime2, DirectoryFactory.Attributes);
+            await directory2.load("branchId", services2);
+
+            // Now connect the first SharedDirectory
+            componentRuntime.local = false;
+            const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime);
+            const services1 = {
+                deltaConnection: containerRuntime1.createDeltaConnection(),
+                objectStorage: new MockStorage(undefined),
+            };
+            directory.connect(services1);
+
+            // Verify that both the directories have the key.
+            assert.equal(directory.get(key), value, "The first directory does not have the key");
+            assert.equal(directory2.get(key), value, "The second directory does not have the key");
+
+            // Set a new value for the same key in the second SharedDirectory.
+            const newValue = "newvalue";
+            directory2.set(key, newValue);
+
+            // Process the message.
+            containerRuntimeFactory.processAllMessages();
+
+            // Verify that both the directory get the new value.
+            assert.equal(directory.get(key), newValue, "The first directory did not get the new value");
+            assert.equal(directory2.get(key), newValue, "The second directory did not get the new value");
+        });
+
+        it("should correctly process a sub directory operation sent in local state", async () => {
+            // Set the component runtime to local.
+            componentRuntime.local = true;
+
+            // Create a sub directory in local state.
+            const subDirName = "testSubDir";
+            directory.createSubDirectory(subDirName);
+
+            // Load a new SharedDirectory in connected state from the snapshot of the first one.
+            const containerRuntimeFactory = new MockContainerRuntimeFactory();
+            const componentRuntime2 = new MockComponentRuntime();
+            const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const services2 = MockSharedObjectServices.createFromTree(directory.snapshot());
+            services2.deltaConnection = containerRuntime2.createDeltaConnection();
+
+            const directory2 = new SharedDirectory("directory2", componentRuntime2, DirectoryFactory.Attributes);
+            await directory2.load("branchId", services2);
+
+            // Now connect the first SharedDirectory
+            componentRuntime.local = false;
+            const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime);
+            const services1 = {
+                deltaConnection: containerRuntime1.createDeltaConnection(),
+                objectStorage: new MockStorage(undefined),
+            };
+            directory.connect(services1);
+
+            // Verify that both the directories have the key.
+            assert.ok(directory.getSubDirectory(subDirName), "The first directory does not have the sub directory");
+            assert.ok(directory2.getSubDirectory(subDirName), "The second directory does not have the sub directory");
+
+            // Delete the subdirectory in the second SharedDirectory.
+            directory2.deleteSubDirectory(subDirName);
+
+            // Process the message.
+            containerRuntimeFactory.processAllMessages();
+
+            // Verify that both the directory have the sub directory deleted.
+            assert.equal(
+                directory.getSubDirectory(subDirName), undefined, "The first directory did not process the delete");
+            assert.equal(
+                directory2.getSubDirectory(subDirName), undefined, "The second directory did not process the delete");
+        });
     });
 
     describe("SharedDirectory in connected state with a remote directory", () => {
@@ -98,7 +413,7 @@ describe("Directory", () => {
         let directory2: SharedDirectory;
 
         beforeEach(async () => {
-            // Connect the first map
+            // Connect the first directory
             containerRuntimeFactory = new MockContainerRuntimeFactory();
             const containerRuntime = containerRuntimeFactory.createContainerRuntime(componentRuntime);
             const services = {
@@ -107,7 +422,7 @@ describe("Directory", () => {
             };
             directory.connect(services);
 
-            // Create and connect a second map
+            // Create and connect a second directory
             const componentRuntime2 = new MockComponentRuntime();
             directory2 = new SharedDirectory("directory2", componentRuntime2, DirectoryFactory.Attributes);
             const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
@@ -717,220 +1032,6 @@ describe("Directory", () => {
                 }
                 assert.ok(expectedDirectories2.size === 0);
             });
-        });
-    });
-
-    describe(".serialize", () => {
-        it("Should serialize an empty directory as a JSON object", () => {
-            const serialized = serialize(directory);
-            assert.equal(serialized, "{}");
-        });
-
-        it("Should serialize a directory without subdirectories as a JSON object", () => {
-            directory.set("first", "second");
-            directory.set("third", "fourth");
-            directory.set("fifth", "sixth");
-            const subMap = mapFactory.create(componentRuntime, "subMap");
-            directory.set("object", subMap.handle);
-
-            const serialized = serialize(directory);
-            // eslint-disable-next-line max-len
-            const expected = `{"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain","value":"sixth"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"subMap"}}}}`;
-            assert.equal(serialized, expected);
-        });
-
-        it("Should serialize a directory with subdirectories as a JSON object", () => {
-            directory.set("first", "second");
-            directory.set("third", "fourth");
-            directory.set("fifth", "sixth");
-            const subMap = mapFactory.create(componentRuntime, "subMap");
-            directory.set("object", subMap.handle);
-            const nestedDirectory = directory.createSubDirectory("nested");
-            nestedDirectory.set("deepKey1", "deepValue1");
-            nestedDirectory.createSubDirectory("nested2")
-                .createSubDirectory("nested3")
-                .set("deepKey2", "deepValue2");
-
-            const serialized = serialize(directory);
-            // eslint-disable-next-line max-len
-            const expected = `{"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain","value":"sixth"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"subMap"}}},"subdirectories":{"nested":{"storage":{"deepKey1":{"type":"Plain","value":"deepValue1"}},"subdirectories":{"nested2":{"subdirectories":{"nested3":{"storage":{"deepKey2":{"type":"Plain","value":"deepValue2"}}}}}}}}}`;
-            assert.equal(serialized, expected);
-        });
-
-        it("Should serialize an undefined value", () => {
-            directory.set("first", "second");
-            directory.set("third", "fourth");
-            directory.set("fifth", undefined);
-            assert.ok(directory.has("fifth"));
-            const subMap = mapFactory.create(componentRuntime, "subMap");
-            directory.set("object", subMap.handle);
-            const nestedDirectory = directory.createSubDirectory("nested");
-            nestedDirectory.set("deepKey1", "deepValue1");
-            nestedDirectory.set("deepKeyUndefined", undefined);
-            assert.ok(nestedDirectory.has("deepKeyUndefined"));
-            nestedDirectory.createSubDirectory("nested2")
-                .createSubDirectory("nested3")
-                .set("deepKey2", "deepValue2");
-
-            const serialized = serialize(directory);
-            // eslint-disable-next-line max-len
-            const expected = `{"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"subMap"}}},"subdirectories":{"nested":{"storage":{"deepKey1":{"type":"Plain","value":"deepValue1"},"deepKeyUndefined":{"type":"Plain"}},"subdirectories":{"nested2":{"subdirectories":{"nested3":{"storage":{"deepKey2":{"type":"Plain","value":"deepValue2"}}}}}}}}}`;
-            assert.equal(serialized, expected);
-        });
-    });
-
-    describe(".populate", () => {
-        beforeEach(() => {
-            // We are only testing local state for loading from snapshot.
-            componentRuntime.local = true;
-        });
-
-        it("Should populate the directory from an empty JSON object (old format)", async () => {
-            await populate(directory, {});
-            assert.equal(directory.size, 0, "Failed to initialize to empty directory storage");
-            directory.set("testKey", "testValue");
-            assert.equal(directory.get("testKey"), "testValue", "Failed to set testKey");
-            directory.createSubDirectory("testSubDir").set("testSubKey", "testSubValue");
-            assert.equal(
-                directory.getWorkingDirectory("testSubDir").get("testSubKey"),
-                "testSubValue",
-                "Failed to set testSubKey",
-            );
-        });
-
-        it("Should populate the directory from a basic JSON object (old format)", async () => {
-            await populate(directory, {
-                storage: {
-                    testKey: {
-                        type: "Plain",
-                        value: "testValue4",
-                    },
-                    testKey2: {
-                        type: "Plain",
-                        value: "testValue5",
-                    },
-                },
-                subdirectories: {
-                    foo: {
-                        storage: {
-                            testKey: {
-                                type: "Plain",
-                                value: "testValue",
-                            },
-                            testKey2: {
-                                type: "Plain",
-                                value: "testValue2",
-                            },
-                        },
-                    },
-                    bar: {
-                        storage: {
-                            testKey3: {
-                                type: "Plain",
-                                value: "testValue3",
-                            },
-                        },
-                    },
-                },
-            });
-            assert.equal(directory.size, 2, "Failed to initialize directory storage correctly");
-            assert.equal(directory.getWorkingDirectory("/foo").get("testKey"), "testValue");
-            assert.equal(directory.getWorkingDirectory("foo").get("testKey2"), "testValue2");
-            assert.equal(directory.getWorkingDirectory("/bar").get("testKey3"), "testValue3");
-            assert.equal(directory.getWorkingDirectory("").get("testKey"), "testValue4");
-            assert.equal(directory.getWorkingDirectory("/").get("testKey2"), "testValue5");
-            directory.set("testKey", "newValue");
-            assert.equal(directory.get("testKey"), "newValue", "Failed to set testKey");
-            directory.createSubDirectory("testSubDir").set("testSubKey", "newSubValue");
-            assert.equal(
-                directory.getWorkingDirectory("testSubDir").get("testSubKey"),
-                "newSubValue",
-                "Failed to set testSubKey",
-            );
-        });
-
-        it("Should populate the directory with undefined values (old format)", async () => {
-            await populate(directory, {
-                storage: {
-                    testKey: {
-                        type: "Plain",
-                        value: "testValue4",
-                    },
-                    testKey2: {
-                        type: "Plain",
-                    },
-                },
-                subdirectories: {
-                    foo: {
-                        storage: {
-                            testKey: {
-                                type: "Plain",
-                                value: "testValue",
-                            },
-                            testKey2: {
-                                type: "Plain",
-                            },
-                        },
-                    },
-                    bar: {
-                        storage: {
-                            testKey3: {
-                                type: "Plain",
-                                value: "testValue3",
-                            },
-                        },
-                    },
-                },
-            });
-            assert.equal(directory.size, 2, "Failed to initialize directory storage correctly");
-            assert.equal(directory.getWorkingDirectory("/foo").get("testKey"), "testValue");
-            assert.equal(directory.getWorkingDirectory("foo").get("testKey2"), undefined);
-            assert.equal(directory.getWorkingDirectory("/bar").get("testKey3"), "testValue3");
-            assert.equal(directory.getWorkingDirectory("").get("testKey"), "testValue4");
-            assert.equal(directory.getWorkingDirectory("/").get("testKey2"), undefined);
-            assert.ok(directory.has("testKey2"));
-            assert.ok(directory.getWorkingDirectory("/foo").has("testKey2"));
-            directory.set("testKey", "newValue");
-            assert.equal(directory.get("testKey"), "newValue", "Failed to set testKey");
-            directory.createSubDirectory("testSubDir").set("testSubKey", "newSubValue");
-            assert.equal(
-                directory.getWorkingDirectory("testSubDir").get("testSubKey"),
-                "newSubValue",
-                "Failed to set testSubKey",
-            );
-        });
-
-        it("Should populate, serialize and de-serialize directory with long property values", async () => {
-            // 40K word
-            let longWord = "0123456789";
-            for (let i = 0; i < 12; i++) {
-                longWord = longWord + longWord;
-            }
-            const logWord2 = `${longWord}_2`;
-
-            directory.set("first", "second");
-            directory.set("long1", longWord);
-            const nestedDirectory = directory.createSubDirectory("nested");
-            nestedDirectory.set("deepKey1", "deepValue1");
-            nestedDirectory.set("long2", logWord2);
-
-            const tree = directory.snapshot();
-            assert(tree.entries.length === 3);
-            assert(tree.entries[0].path === "blob0");
-            assert(tree.entries[1].path === "blob1");
-            assert(tree.entries[2].path === "header");
-            assert((tree.entries[0].value as IBlob).contents.length >= 1024);
-            assert((tree.entries[1].value as IBlob).contents.length >= 1024);
-            assert((tree.entries[2].value as IBlob).contents.length <= 200);
-
-            const directory2 = new SharedDirectory("test", componentRuntime, DirectoryFactory.Attributes);
-            const storage = MockSharedObjectServices.createFromTree(tree);
-            await directory2.load("branchId", storage);
-
-            assert.equal(directory2.get("first"), "second");
-            assert.equal(directory2.get("long1"), longWord);
-            assert.equal(directory2.getWorkingDirectory("/nested").get("deepKey1"), "deepValue1");
-            assert.equal(directory2.getWorkingDirectory("/nested").get("long2"), logWord2);
         });
     });
 });

--- a/packages/runtime/map/src/test/directory.spec.ts
+++ b/packages/runtime/map/src/test/directory.spec.ts
@@ -12,614 +12,925 @@ import {
 } from "@fluidframework/protocol-definitions";
 import {
     MockComponentRuntime,
+    MockContainerRuntimeFactory,
     MockSharedObjectServices,
+    MockStorage,
 } from "@fluidframework/test-runtime-utils";
 
-import * as map from "../";
-import { SharedDirectory } from "../directory";
+import { DirectoryFactory, IDirectoryNewStorageFormat, SharedDirectory } from "../directory";
+import { MapFactory } from "../map";
 
-async function populate(directory: map.ISharedDirectory, content: object) {
+async function populate(directory: SharedDirectory, content: object) {
     const storage = new MockSharedObjectServices({
         header: JSON.stringify(content),
     });
-    return (directory as SharedDirectory).load("branchId", storage);
+    return directory.load("branchId", storage);
 }
 
-function serialize(directory: map.ISharedDirectory): string {
+function serialize(directory: SharedDirectory): string {
     const tree = directory.snapshot();
     assert(tree.entries.length === 1);
     assert(tree.entries[0].path === "header");
     assert(tree.entries[0].type === TreeEntry[TreeEntry.Blob]);
     const contents = (tree.entries[0].value as IBlob).contents;
-    return JSON.stringify((JSON.parse(contents) as map.IDirectoryNewStorageFormat).content);
+    return JSON.stringify((JSON.parse(contents) as IDirectoryNewStorageFormat).content);
 }
 
-describe("Routerlicious", () => {
-    describe("Directory", () => {
-        let rootDirectory: map.ISharedDirectory;
-        let testDirectory: map.ISharedDirectory;
-        let directoryFactory: map.DirectoryFactory;
-        let mapFactory: map.MapFactory;
-        let componentRuntime: MockComponentRuntime;
+describe("Directory", () => {
+    let directory: SharedDirectory;
+    let mapFactory: MapFactory;
+    let componentRuntime: MockComponentRuntime;
 
-        beforeEach(async () => {
-            componentRuntime = new MockComponentRuntime();
-            // We only want to test local state of the DDS.
-            componentRuntime.local = true;
-            directoryFactory = new map.DirectoryFactory();
-            mapFactory = new map.MapFactory();
-            rootDirectory = directoryFactory.create(componentRuntime, "root");
-            testDirectory = directoryFactory.create(componentRuntime, "test");
-        });
+    beforeEach(async () => {
+        componentRuntime = new MockComponentRuntime();
+        mapFactory = new MapFactory();
+        directory = new SharedDirectory("directory", componentRuntime, DirectoryFactory.Attributes);
+    });
 
-        it("Can get the root directory", () => {
-            assert.ok(rootDirectory);
-        });
-
+    describe("SharedDirectory in local state", () => {
         it("Can create a new directory", () => {
-            assert.ok(testDirectory);
+            assert.ok(directory, "could not create a new directory");
         });
 
         it("Knows its absolute path", () => {
-            assert.equal(rootDirectory.absolutePath, "/");
+            assert.equal(directory.absolutePath, "/", "the absolute path is not correct");
         });
 
         it("Can set and get keys one level deep", () => {
-            testDirectory.set("testKey", "testValue");
-            testDirectory.set("testKey2", "testValue2");
-            assert.equal(testDirectory.get("testKey"), "testValue");
-            assert.equal(testDirectory.get("testKey2"), "testValue2");
+            directory.set("testKey", "testValue");
+            directory.set("testKey2", "testValue2");
+            assert.equal(directory.get("testKey"), "testValue", "could not retrieve set key 1");
+            assert.equal(directory.get("testKey2"), "testValue2", "could not retrieve set key 2");
+        });
+
+        it("should fire correct directory events", async () => {
+            const dummyDirectory = directory;
+            let called1: boolean = false;
+            let called2: boolean = false;
+            dummyDirectory.on("op", (agr1, arg2, arg3) => called1 = true);
+            dummyDirectory.on("valueChanged", (agr1, arg2, arg3, arg4) => called2 = true);
+            dummyDirectory.set("dwyane", "johnson");
+            assert.equal(called1, false, "did not receive op event");
+            assert.equal(called2, true, "did not receive valueChanged event");
         });
 
         it("Rejects a undefined and null key set", () => {
             assert.throws(() => {
-                testDirectory.set(undefined, "testValue");
+                directory.set(undefined, "testValue");
             }, "Should throw for key of undefined");
             assert.throws(() => {
-                testDirectory.set(null, "testValue");
+                directory.set(null, "testValue");
             }, "Should throw for key of null");
         });
 
-        it("Can set and get keys two levels deep", () => {
-            const fooDirectory = testDirectory.createSubDirectory("foo");
-            const barDirectory = testDirectory.createSubDirectory("bar");
-            fooDirectory.set("testKey", "testValue");
-            fooDirectory.set("testKey2", "testValue2");
-            barDirectory.set("testKey3", "testValue3");
-            assert.equal(testDirectory.getWorkingDirectory("foo").get("testKey"), "testValue");
-            assert.equal(testDirectory.getWorkingDirectory("foo/").get("testKey2"), "testValue2");
-            assert.equal(testDirectory.getWorkingDirectory("bar").get("testKey3"), "testValue3");
+        it("Rejects subdirectories with undefined and null names", () => {
+            assert.throws(() => {
+                directory.createSubDirectory(undefined);
+            }, "Should throw for undefined subdirectory name");
+            assert.throws(() => {
+                directory.createSubDirectory(null);
+            }, "Should throw for null subdirectory name");
+        });
+    });
+
+    describe("SharedDirectory in connected state with a remote directory", () => {
+        let containerRuntimeFactory: MockContainerRuntimeFactory;
+        let directory2: SharedDirectory;
+
+        beforeEach(async () => {
+            // Connect the first map
+            containerRuntimeFactory = new MockContainerRuntimeFactory();
+            const containerRuntime = containerRuntimeFactory.createContainerRuntime(componentRuntime);
+            const services = {
+                deltaConnection: containerRuntime.createDeltaConnection(),
+                objectStorage: new MockStorage(undefined),
+            };
+            directory.connect(services);
+
+            // Create and connect a second map
+            const componentRuntime2 = new MockComponentRuntime();
+            directory2 = new SharedDirectory("directory2", componentRuntime2, DirectoryFactory.Attributes);
+            const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const services2 = {
+                deltaConnection: containerRuntime2.createDeltaConnection(),
+                objectStorage: new MockStorage(undefined),
+            };
+            directory2.connect(services2);
         });
 
-        it("Can clear keys stored directly under the root", () => {
-            const fooDirectory = testDirectory.createSubDirectory("foo");
-            const barDirectory = testDirectory.createSubDirectory("bar");
-            fooDirectory.set("testKey", "testValue");
-            fooDirectory.set("testKey2", "testValue2");
-            barDirectory.set("testKey3", "testValue3");
-            testDirectory.set("testKey", "testValue4");
-            testDirectory.set("testKey2", "testValue5");
-            testDirectory.clear();
-            assert.equal(testDirectory.getWorkingDirectory("/foo/").get("testKey"), "testValue");
-            assert.equal(testDirectory.getWorkingDirectory("./foo").get("testKey2"), "testValue2");
-            assert.equal(testDirectory.getWorkingDirectory("bar").get("testKey3"), "testValue3");
-            assert.equal(testDirectory.get("testKey"), undefined);
-            assert.equal(testDirectory.get("testKey2"), undefined);
-        });
+        describe(".set() / .get()", () => {
+            it("Can set and get keys one level deep", () => {
+                directory.set("testKey", "testValue");
 
-        it("Can delete keys from the root", () => {
-            const fooDirectory = testDirectory.createSubDirectory("foo");
-            const barDirectory = testDirectory.createSubDirectory("bar");
-            fooDirectory.set("testKey", "testValue");
-            fooDirectory.set("testKey2", "testValue2");
-            barDirectory.set("testKey3", "testValue3");
-            testDirectory.set("testKey", "testValue4");
-            testDirectory.set("testKey2", "testValue5");
-            testDirectory.delete("testKey2");
-            assert.equal(testDirectory.getWorkingDirectory("foo").get("testKey"), "testValue");
-            assert.equal(testDirectory.getWorkingDirectory("foo").get("testKey2"), "testValue2");
-            assert.equal(testDirectory.getWorkingDirectory("bar").get("testKey3"), "testValue3");
-            assert.equal(testDirectory.get("testKey"), "testValue4");
-            assert.equal(testDirectory.get("testKey2"), undefined);
-        });
+                containerRuntimeFactory.processAllMessages();
 
-        it("Can iterate over the subdirectories in the root", () => {
-            testDirectory.createSubDirectory("foo");
-            testDirectory.createSubDirectory("bar");
-            const expectedDirectories = new Set(["foo", "bar"]);
-            for (const [subDirName] of testDirectory.subdirectories()) {
-                assert.ok(expectedDirectories.has(subDirName));
-                expectedDirectories.delete(subDirName);
-            }
-            assert.ok(expectedDirectories.size === 0);
-        });
+                // Verify the local SharedDirectory
+                assert.equal(directory.get("testKey"), "testValue", "could not retrieve key");
 
-        describe(".serialize", () => {
-            it("Should serialize an empty directory as a JSON object", () => {
-                const serialized = serialize(testDirectory);
-                assert.equal(serialized, "{}");
+                // Verify the remote SharedDirectory
+                assert.equal(directory2.get("testKey"), "testValue", "could not retrieve key from remote directory");
             });
 
-            it("Should serialize a directory without subdirectories as a JSON object", () => {
-                testDirectory.set("first", "second");
-                testDirectory.set("third", "fourth");
-                testDirectory.set("fifth", "sixth");
-                const subMap = mapFactory.create(componentRuntime, "subMap");
-                testDirectory.set("object", subMap.handle);
+            it("Can set and get keys two levels deep", () => {
+                const fooDirectory = directory.createSubDirectory("foo");
+                const barDirectory = directory.createSubDirectory("bar");
+                fooDirectory.set("testKey", "testValue");
+                fooDirectory.set("testKey2", "testValue2");
+                barDirectory.set("testKey3", "testValue3");
 
-                const serialized = serialize(testDirectory);
-                // eslint-disable-next-line max-len
-                const expected = `{"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain","value":"sixth"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"subMap"}}}}`;
-                assert.equal(serialized, expected);
-            });
+                containerRuntimeFactory.processAllMessages();
 
-            it("Should serialize a directory with subdirectories as a JSON object", () => {
-                testDirectory.set("first", "second");
-                testDirectory.set("third", "fourth");
-                testDirectory.set("fifth", "sixth");
-                const subMap = mapFactory.create(componentRuntime, "subMap");
-                testDirectory.set("object", subMap.handle);
-                const nestedDirectory = testDirectory.createSubDirectory("nested");
-                nestedDirectory.set("deepKey1", "deepValue1");
-                nestedDirectory.createSubDirectory("nested2")
-                    .createSubDirectory("nested3")
-                    .set("deepKey2", "deepValue2");
+                // Verify the local SharedDirectory
+                assert.equal(directory.getWorkingDirectory("foo").get("testKey"), "testValue");
+                assert.equal(directory.getWorkingDirectory("foo/").get("testKey2"), "testValue2");
+                assert.equal(directory.getWorkingDirectory("bar").get("testKey3"), "testValue3");
 
-                const serialized = serialize(testDirectory);
-                // eslint-disable-next-line max-len
-                const expected = `{"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain","value":"sixth"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"subMap"}}},"subdirectories":{"nested":{"storage":{"deepKey1":{"type":"Plain","value":"deepValue1"}},"subdirectories":{"nested2":{"subdirectories":{"nested3":{"storage":{"deepKey2":{"type":"Plain","value":"deepValue2"}}}}}}}}}`;
-                assert.equal(serialized, expected);
-            });
-
-            it("Should serialize an undefined value", () => {
-                testDirectory.set("first", "second");
-                testDirectory.set("third", "fourth");
-                testDirectory.set("fifth", undefined);
-                assert.ok(testDirectory.has("fifth"));
-                const subMap = mapFactory.create(componentRuntime, "subMap");
-                testDirectory.set("object", subMap.handle);
-                const nestedDirectory = testDirectory.createSubDirectory("nested");
-                nestedDirectory.set("deepKey1", "deepValue1");
-                nestedDirectory.set("deepKeyUndefined", undefined);
-                assert.ok(nestedDirectory.has("deepKeyUndefined"));
-                nestedDirectory.createSubDirectory("nested2")
-                    .createSubDirectory("nested3")
-                    .set("deepKey2", "deepValue2");
-
-                const serialized = serialize(testDirectory);
-                // eslint-disable-next-line max-len
-                const expected = `{"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"subMap"}}},"subdirectories":{"nested":{"storage":{"deepKey1":{"type":"Plain","value":"deepValue1"},"deepKeyUndefined":{"type":"Plain"}},"subdirectories":{"nested2":{"subdirectories":{"nested3":{"storage":{"deepKey2":{"type":"Plain","value":"deepValue2"}}}}}}}}}`;
-                assert.equal(serialized, expected);
+                // Verify the remote SharedDirectory
+                assert.equal(directory2.getWorkingDirectory("foo").get("testKey"), "testValue");
+                assert.equal(directory2.getWorkingDirectory("foo/").get("testKey2"), "testValue2");
+                assert.equal(directory2.getWorkingDirectory("bar").get("testKey3"), "testValue3");
             });
         });
 
-        describe(".populate", () => {
-            it("Should populate the directory from an empty JSON object (old format)", async () => {
-                await populate(testDirectory, {});
-                assert.equal(testDirectory.size, 0, "Failed to initialize to empty directory storage");
-                testDirectory.set("testKey", "testValue");
-                assert.equal(testDirectory.get("testKey"), "testValue", "Failed to set testKey");
-                testDirectory.createSubDirectory("testSubDir").set("testSubKey", "testSubValue");
-                assert.equal(
-                    testDirectory.getWorkingDirectory("testSubDir").get("testSubKey"),
-                    "testSubValue",
-                    "Failed to set testSubKey",
-                );
+        describe(".delete() / .clear()", () => {
+            it("Can clear keys stored directly under the root", () => {
+                const fooDirectory = directory.createSubDirectory("foo");
+                const barDirectory = directory.createSubDirectory("bar");
+                fooDirectory.set("testKey", "testValue");
+                fooDirectory.set("testKey2", "testValue2");
+                barDirectory.set("testKey3", "testValue3");
+                directory.set("testKey", "testValue4");
+                directory.set("testKey2", "testValue5");
+                directory.clear();
+
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedDirectory
+                assert.equal(directory.getWorkingDirectory("/foo/").get("testKey"), "testValue");
+                assert.equal(directory.getWorkingDirectory("./foo").get("testKey2"), "testValue2");
+                assert.equal(directory.getWorkingDirectory("bar").get("testKey3"), "testValue3");
+                assert.equal(directory.get("testKey"), undefined);
+                assert.equal(directory.get("testKey2"), undefined);
+
+                // Verify the remote SharedDirectory
+                assert.equal(directory2.getWorkingDirectory("/foo/").get("testKey"), "testValue");
+                assert.equal(directory2.getWorkingDirectory("./foo").get("testKey2"), "testValue2");
+                assert.equal(directory2.getWorkingDirectory("bar").get("testKey3"), "testValue3");
+                assert.equal(directory2.get("testKey"), undefined);
+                assert.equal(directory2.get("testKey2"), undefined);
             });
 
-            it("Should populate the directory from a basic JSON object (old format)", async () => {
-                await populate(testDirectory, {
-                    storage: {
-                        testKey: {
-                            type: "Plain",
-                            value: "testValue4",
-                        },
-                        testKey2: {
-                            type: "Plain",
-                            value: "testValue5",
-                        },
-                    },
-                    subdirectories: {
-                        foo: {
-                            storage: {
-                                testKey: {
-                                    type: "Plain",
-                                    value: "testValue",
-                                },
-                                testKey2: {
-                                    type: "Plain",
-                                    value: "testValue2",
-                                },
-                            },
-                        },
-                        bar: {
-                            storage: {
-                                testKey3: {
-                                    type: "Plain",
-                                    value: "testValue3",
-                                },
-                            },
-                        },
-                    },
-                });
-                assert.equal(testDirectory.size, 2, "Failed to initialize directory storage correctly");
-                assert.equal(testDirectory.getWorkingDirectory("/foo").get("testKey"), "testValue");
-                assert.equal(testDirectory.getWorkingDirectory("foo").get("testKey2"), "testValue2");
-                assert.equal(testDirectory.getWorkingDirectory("/bar").get("testKey3"), "testValue3");
-                assert.equal(testDirectory.getWorkingDirectory("").get("testKey"), "testValue4");
-                assert.equal(testDirectory.getWorkingDirectory("/").get("testKey2"), "testValue5");
-                testDirectory.set("testKey", "newValue");
-                assert.equal(testDirectory.get("testKey"), "newValue", "Failed to set testKey");
-                testDirectory.createSubDirectory("testSubDir").set("testSubKey", "newSubValue");
-                assert.equal(
-                    testDirectory.getWorkingDirectory("testSubDir").get("testSubKey"),
-                    "newSubValue",
-                    "Failed to set testSubKey",
-                );
-            });
+            it("Can delete keys from the root", () => {
+                const fooDirectory = directory.createSubDirectory("foo");
+                const barDirectory = directory.createSubDirectory("bar");
+                fooDirectory.set("testKey", "testValue");
+                fooDirectory.set("testKey2", "testValue2");
+                barDirectory.set("testKey3", "testValue3");
+                directory.set("testKey", "testValue4");
+                directory.set("testKey2", "testValue5");
+                directory.delete("testKey2");
 
-            it("Should populate the directory with undefined values (old format)", async () => {
-                await populate(testDirectory, {
-                    storage: {
-                        testKey: {
-                            type: "Plain",
-                            value: "testValue4",
-                        },
-                        testKey2: {
-                            type: "Plain",
-                        },
-                    },
-                    subdirectories: {
-                        foo: {
-                            storage: {
-                                testKey: {
-                                    type: "Plain",
-                                    value: "testValue",
-                                },
-                                testKey2: {
-                                    type: "Plain",
-                                },
-                            },
-                        },
-                        bar: {
-                            storage: {
-                                testKey3: {
-                                    type: "Plain",
-                                    value: "testValue3",
-                                },
-                            },
-                        },
-                    },
-                });
-                assert.equal(testDirectory.size, 2, "Failed to initialize directory storage correctly");
-                assert.equal(testDirectory.getWorkingDirectory("/foo").get("testKey"), "testValue");
-                assert.equal(testDirectory.getWorkingDirectory("foo").get("testKey2"), undefined);
-                assert.equal(testDirectory.getWorkingDirectory("/bar").get("testKey3"), "testValue3");
-                assert.equal(testDirectory.getWorkingDirectory("").get("testKey"), "testValue4");
-                assert.equal(testDirectory.getWorkingDirectory("/").get("testKey2"), undefined);
-                assert.ok(testDirectory.has("testKey2"));
-                assert.ok(testDirectory.getWorkingDirectory("/foo").has("testKey2"));
-                testDirectory.set("testKey", "newValue");
-                assert.equal(testDirectory.get("testKey"), "newValue", "Failed to set testKey");
-                testDirectory.createSubDirectory("testSubDir").set("testSubKey", "newSubValue");
-                assert.equal(
-                    testDirectory.getWorkingDirectory("testSubDir").get("testSubKey"),
-                    "newSubValue",
-                    "Failed to set testSubKey",
-                );
-            });
+                containerRuntimeFactory.processAllMessages();
 
-            it("Should populate, serialize and de-serialize directory with long property values", async () => {
-                // 40K word
-                let longWord = "0123456789";
-                for (let i = 0; i < 12; i++) {
-                    longWord = longWord + longWord;
-                }
-                const logWord2 = `${longWord}_2`;
+                // Verify the local SharedDirectory
+                assert.equal(directory.getWorkingDirectory("foo").get("testKey"), "testValue");
+                assert.equal(directory.getWorkingDirectory("foo").get("testKey2"), "testValue2");
+                assert.equal(directory.getWorkingDirectory("bar").get("testKey3"), "testValue3");
+                assert.equal(directory.get("testKey"), "testValue4");
+                assert.equal(directory.get("testKey2"), undefined);
 
-                testDirectory.set("first", "second");
-                testDirectory.set("long1", longWord);
-                const nestedDirectory = testDirectory.createSubDirectory("nested");
-                nestedDirectory.set("deepKey1", "deepValue1");
-                nestedDirectory.set("long2", logWord2);
-
-                const tree = testDirectory.snapshot();
-                assert(tree.entries.length === 3);
-                assert(tree.entries[0].path === "blob0");
-                assert(tree.entries[1].path === "blob1");
-                assert(tree.entries[2].path === "header");
-                assert((tree.entries[0].value as IBlob).contents.length >= 1024);
-                assert((tree.entries[1].value as IBlob).contents.length >= 1024);
-                assert((tree.entries[2].value as IBlob).contents.length <= 200);
-
-                const testDirectory2 = directoryFactory.create(componentRuntime, "test");
-                const storage = MockSharedObjectServices.createFromTree(tree);
-                await (testDirectory2 as SharedDirectory).load("branchId", storage);
-
-                assert.equal(testDirectory2.get("first"), "second");
-                assert.equal(testDirectory2.get("long1"), longWord);
-                assert.equal(testDirectory2.getWorkingDirectory("/nested").get("deepKey1"), "deepValue1");
-                assert.equal(testDirectory2.getWorkingDirectory("/nested").get("long2"), logWord2);
+                // Verify the remote SharedDirectory
+                assert.equal(directory2.getWorkingDirectory("foo").get("testKey"), "testValue");
+                assert.equal(directory2.getWorkingDirectory("foo").get("testKey2"), "testValue2");
+                assert.equal(directory2.getWorkingDirectory("bar").get("testKey3"), "testValue3");
+                assert.equal(directory2.get("testKey"), "testValue4");
+                assert.equal(directory2.get("testKey2"), undefined);
             });
         });
 
-        describe("eventsDirectory", () => {
-            it("listeners should listen to fired map events", async () => {
-                const dummyDirectory = testDirectory;
-                let called1: boolean = false;
-                let called2: boolean = false;
-                dummyDirectory.on("op", (agr1, arg2, arg3) => called1 = true);
-                dummyDirectory.on("valueChanged", (agr1, arg2, arg3, arg4) => called2 = true);
-                dummyDirectory.set("dwyane", "johnson");
-                assert.equal(called1, false, "op");
-                assert.equal(called2, true, "valueChanged");
+        describe(".wait()", () => {
+            it("Should resolve returned promise for existing keys", async () => {
+                directory.set("test", "resolved");
+
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedDirectory
+                assert.ok(directory.has("test"));
+                await directory.wait("test");
+
+                // Verify the remote SharedDirectory
+                assert.ok(directory2.has("test"));
+                await directory2.wait("test");
+            });
+
+            it("Should resolve returned promise once unavailable key is available", async () => {
+                assert.ok(!directory.has("test"));
+
+                const waitP = directory.wait("test");
+                const waitP2 = directory2.wait("test");
+
+                directory.set("test", "resolved");
+
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedDirectory
+                await waitP;
+
+                // Verify the remote SharedDirectory
+                await waitP2;
             });
         });
 
         describe("SubDirectory", () => {
+            it("Can iterate over the subdirectories in the root", () => {
+                directory.createSubDirectory("foo");
+                directory.createSubDirectory("bar");
+
+                containerRuntimeFactory.processAllMessages();
+
+                const expectedDirectories = new Set(["foo", "bar"]);
+
+                // Verify the local SharedDirectory
+                for (const [subDirName] of directory.subdirectories()) {
+                    assert.ok(expectedDirectories.has(subDirName));
+                }
+
+                // Verify the remote SharedDirectory
+                for (const [subDirName] of directory2.subdirectories()) {
+                    assert.ok(expectedDirectories.has(subDirName));
+                    expectedDirectories.delete(subDirName);
+                }
+                assert.ok(expectedDirectories.size === 0);
+            });
+
             it("Can get a subdirectory", () => {
-                const fooDirectory = testDirectory.createSubDirectory("foo");
-                const barDirectory = testDirectory.createSubDirectory("bar");
+                const fooDirectory = directory.createSubDirectory("foo");
+                const barDirectory = directory.createSubDirectory("bar");
                 fooDirectory.set("testKey", "testValue");
                 fooDirectory.set("testKey2", "testValue2");
                 barDirectory.set("testKey3", "testValue3");
-                const testSubdir = testDirectory.getWorkingDirectory("/foo");
-                assert.ok(testSubdir);
+
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedDirectory
+                assert.ok(directory.getWorkingDirectory("/foo"));
+                assert.ok(directory.getSubDirectory("foo"));
+
+                // Verify the remote SharedDirectory
+                assert.ok(directory2.getWorkingDirectory("/foo"));
+                assert.ok(directory2.getSubDirectory("foo"));
             });
 
             it("Knows its absolute path", () => {
-                const fooDirectory = testDirectory.createSubDirectory("foo");
+                const fooDirectory = directory.createSubDirectory("foo");
                 const barDirectory = fooDirectory.createSubDirectory("bar");
+
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedDirectory
                 assert.equal(fooDirectory.absolutePath, "/foo");
                 assert.equal(barDirectory.absolutePath, "/foo/bar");
+
+                // Verify the remote SharedDirectory
+                const fooDirectory2 = directory2.getSubDirectory("foo");
+                const barDirectory2 = fooDirectory2.getSubDirectory("bar");
+                assert.equal(fooDirectory2.absolutePath, "/foo");
+                assert.equal(barDirectory2.absolutePath, "/foo/bar");
             });
 
             it("Can get and set keys from a subdirectory using relative paths", () => {
-                const fooDirectory = testDirectory.createSubDirectory("foo");
-                const barDirectory = testDirectory.createSubDirectory("bar");
+                const fooDirectory = directory.createSubDirectory("foo");
+                const barDirectory = directory.createSubDirectory("bar");
                 fooDirectory.set("testKey", "testValue");
                 fooDirectory.set("testKey2", "testValue2");
                 barDirectory.set("testKey3", "testValue3");
-                const testSubdir = testDirectory.getWorkingDirectory("/foo");
+
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedDirectory
+                const testSubdir = directory.getWorkingDirectory("/foo");
                 assert.equal(testSubdir.has("testKey"), true);
                 assert.equal(testSubdir.has("garbage"), false);
                 assert.equal(testSubdir.get("testKey"), "testValue");
                 assert.equal(testSubdir.get("testKey2"), "testValue2");
                 assert.equal(testSubdir.get("testKey3"), undefined);
+
+                // Verify the remote SharedDirectory
+                const barSubDir = directory2.getWorkingDirectory("/foo");
+                assert.equal(barSubDir.has("testKey"), true);
+                assert.equal(barSubDir.has("garbage"), false);
+                assert.equal(barSubDir.get("testKey"), "testValue");
+                assert.equal(barSubDir.get("testKey2"), "testValue2");
+                assert.equal(barSubDir.get("testKey3"), undefined);
+
+                // Set value in sub directory.
                 testSubdir.set("fromSubdir", "testValue4");
-                assert.equal(testDirectory.getWorkingDirectory("foo").get("fromSubdir"), "testValue4");
-            });
 
-            it("Rejects subdirectories with undefined and null names", () => {
-                assert.throws(() => {
-                    testDirectory.createSubDirectory(undefined);
-                }, "Should throw for undefined subdirectory name");
-                assert.throws(() => {
-                    testDirectory.createSubDirectory(null);
-                }, "Should throw for null subdirectory name");
-            });
+                containerRuntimeFactory.processAllMessages();
 
-            describe(".wait()", () => {
-                it("Should resolve returned promise for existing keys", async () => {
-                    testDirectory.set("test", "resolved");
-                    assert.ok(testDirectory.has("test"));
-                    await testDirectory.wait("test");
-                });
+                // Verify the local sub directory
+                assert.equal(directory.getWorkingDirectory("foo").get("fromSubdir"), "testValue4");
 
-                it("Should resolve returned promise once unavailable key is available", async () => {
-                    assert.ok(!testDirectory.has("test"));
-
-                    const waitP = testDirectory.wait("test");
-                    testDirectory.set("test", "resolved");
-
-                    await waitP;
-                });
+                // Verify the remote sub directory
+                assert.equal(directory.getWorkingDirectory("foo").get("fromSubdir"), "testValue4");
             });
 
             it("Can be cleared from the subdirectory", () => {
-                const fooDirectory = testDirectory.createSubDirectory("foo");
-                const barDirectory = testDirectory.createSubDirectory("bar");
+                const fooDirectory = directory.createSubDirectory("foo");
+                const barDirectory = directory.createSubDirectory("bar");
                 fooDirectory.set("testKey", "testValue");
                 fooDirectory.set("testKey2", "testValue2");
                 barDirectory.set("testKey3", "testValue3");
-                testDirectory.set("testKey", "testValue4");
-                testDirectory.set("testKey2", "testValue5");
-                const testSubdir = testDirectory.getWorkingDirectory("/foo");
+                directory.set("testKey", "testValue4");
+                directory.set("testKey2", "testValue5");
+                const testSubdir = directory.getWorkingDirectory("/foo");
                 testSubdir.clear();
-                assert.equal(testDirectory.getWorkingDirectory("foo").get("testKey"), undefined);
-                assert.equal(testDirectory.getWorkingDirectory("foo").get("testKey2"), undefined);
-                assert.equal(testDirectory.getWorkingDirectory("bar").get("testKey3"), "testValue3");
-                assert.equal(testDirectory.getWorkingDirectory("..").get("testKey"), "testValue4");
-                assert.equal(testDirectory.getWorkingDirectory(".").get("testKey2"), "testValue5");
+
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedDirectory
+                assert.equal(directory.getWorkingDirectory("foo").get("testKey"), undefined);
+                assert.equal(directory.getWorkingDirectory("foo").get("testKey2"), undefined);
+                assert.equal(directory.getWorkingDirectory("bar").get("testKey3"), "testValue3");
+                assert.equal(directory.getWorkingDirectory("..").get("testKey"), "testValue4");
+                assert.equal(directory.getWorkingDirectory(".").get("testKey2"), "testValue5");
+
+                // Verify the remote SharedDirectory
+                assert.equal(directory2.getWorkingDirectory("foo").get("testKey"), undefined);
+                assert.equal(directory2.getWorkingDirectory("foo").get("testKey2"), undefined);
+                assert.equal(directory2.getWorkingDirectory("bar").get("testKey3"), "testValue3");
+                assert.equal(directory2.getWorkingDirectory("..").get("testKey"), "testValue4");
+                assert.equal(directory2.getWorkingDirectory(".").get("testKey2"), "testValue5");
             });
 
             it("Can delete keys from the subdirectory", () => {
-                const fooDirectory = testDirectory.createSubDirectory("foo");
-                const barDirectory = testDirectory.createSubDirectory("bar");
+                const fooDirectory = directory.createSubDirectory("foo");
+                const barDirectory = directory.createSubDirectory("bar");
                 fooDirectory.set("testKey", "testValue");
                 fooDirectory.set("testKey2", "testValue2");
                 barDirectory.set("testKey3", "testValue3");
-                testDirectory.set("testKey", "testValue4");
-                testDirectory.set("testKey2", "testValue5");
-                const testSubdirFoo = testDirectory.getWorkingDirectory("/foo");
+                directory.set("testKey", "testValue4");
+                directory.set("testKey2", "testValue5");
+                const testSubdirFoo = directory.getWorkingDirectory("/foo");
                 testSubdirFoo.delete("testKey2");
-                const testSubdirBar = testDirectory.getWorkingDirectory("/bar");
+                const testSubdirBar = directory.getWorkingDirectory("/bar");
                 testSubdirBar.delete("testKey3");
-                assert.equal(testDirectory.getWorkingDirectory("foo").get("testKey"), "testValue");
-                assert.equal(testDirectory.getWorkingDirectory("foo").get("testKey2"), undefined);
-                assert.equal(testDirectory.getWorkingDirectory("bar").get("testKey3"), undefined);
-                assert.equal(testDirectory.get("testKey"), "testValue4");
-                assert.equal(testDirectory.get("testKey2"), "testValue5");
+
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedDirectory
+                assert.equal(directory.getWorkingDirectory("foo").get("testKey"), "testValue");
+                assert.equal(directory.getWorkingDirectory("foo").get("testKey2"), undefined);
+                assert.equal(directory.getWorkingDirectory("bar").get("testKey3"), undefined);
+                assert.equal(directory.get("testKey"), "testValue4");
+                assert.equal(directory.get("testKey2"), "testValue5");
+
+                // Verify the remote SharedDirectory
+                assert.equal(directory2.getWorkingDirectory("foo").get("testKey"), "testValue");
+                assert.equal(directory2.getWorkingDirectory("foo").get("testKey2"), undefined);
+                assert.equal(directory2.getWorkingDirectory("bar").get("testKey3"), undefined);
+                assert.equal(directory2.get("testKey"), "testValue4");
+                assert.equal(directory2.get("testKey2"), "testValue5");
             });
 
             it("Knows the size of the subdirectory", () => {
-                const fooDirectory = testDirectory.createSubDirectory("foo");
-                const barDirectory = testDirectory.createSubDirectory("bar");
+                const fooDirectory = directory.createSubDirectory("foo");
+                const barDirectory = directory.createSubDirectory("bar");
                 fooDirectory.set("testKey", "testValue");
                 fooDirectory.set("testKey2", "testValue2");
                 barDirectory.set("testKey3", "testValue3");
-                testDirectory.set("testKey", "testValue4");
-                testDirectory.set("testKey2", "testValue5");
-                const testSubdirFoo = testDirectory.getWorkingDirectory("/foo");
+                directory.set("testKey", "testValue4");
+                directory.set("testKey2", "testValue5");
+
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedDirectory
+                const testSubdirFoo = directory.getWorkingDirectory("/foo");
                 assert.equal(testSubdirFoo.size, 2);
+                // Verify the remote SharedDirectory
+                const testSubdirFoo2 = directory2.getWorkingDirectory("/foo");
+                assert.equal(testSubdirFoo2.size, 2);
+
                 testSubdirFoo.delete("testKey2");
+
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedDirectory
                 assert.equal(testSubdirFoo.size, 1);
-                testDirectory.delete("testKey");
+                // Verify the remote SharedDirectory
+                assert.equal(testSubdirFoo2.size, 1);
+
+                directory.delete("testKey");
+
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedDirectory
                 assert.equal(testSubdirFoo.size, 1);
-                const testSubdirBar = testDirectory.getWorkingDirectory("/bar");
+                // Verify the remote SharedDirectory
+                assert.equal(testSubdirFoo2.size, 1);
+
+                const testSubdirBar = directory.getWorkingDirectory("/bar");
                 testSubdirBar.delete("testKey3");
+
+                // Verify the local SharedDirectory
                 assert.equal(testSubdirFoo.size, 1);
-                testDirectory.clear();
+                // Verify the remote SharedDirectory
+                assert.equal(testSubdirFoo2.size, 1);
+
+                directory.clear();
+
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedDirectory
                 assert.equal(testSubdirFoo.size, 1);
+                // Verify the remote SharedDirectory
+                assert.equal(testSubdirFoo2.size, 1);
+
                 testSubdirFoo.clear();
+
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedDirectory
                 assert.equal(testSubdirFoo.size, 0);
+                // Verify the remote SharedDirectory
+                assert.equal(testSubdirFoo2.size, 0);
             });
 
             it("Can get a subdirectory from a subdirectory", () => {
-                const fooDirectory = testDirectory.createSubDirectory("foo");
-                const barDirectory = testDirectory.createSubDirectory("bar");
+                const fooDirectory = directory.createSubDirectory("foo");
+                const barDirectory = directory.createSubDirectory("bar");
                 const bazDirectory = barDirectory.createSubDirectory("baz");
                 fooDirectory.set("testKey", "testValue");
                 fooDirectory.set("testKey2", "testValue2");
                 barDirectory.set("testKey3", "testValue3");
                 bazDirectory.set("testKey4", "testValue4");
-                const testSubdir = testDirectory.getWorkingDirectory("/bar");
-                assert.ok(testSubdir);
-                const testSubdir2 = testSubdir.getWorkingDirectory("./baz");
-                assert.ok(testSubdir2);
-                assert.equal(testSubdir2.get("testKey4"), "testValue4");
+
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedDirectory
+                const barSubdir = directory.getWorkingDirectory("/bar");
+                assert.ok(barSubdir);
+                const bazSubDir = barSubdir.getWorkingDirectory("./baz");
+                assert.ok(bazSubDir);
+                assert.equal(bazSubDir.get("testKey4"), "testValue4");
+
+                // Verify the remote SharedDirectory
+                const barSubdir2 = directory2.getWorkingDirectory("/bar");
+                assert.ok(barSubdir2);
+                const bazSubDir2 = barSubdir2.getWorkingDirectory("./baz");
+                assert.ok(bazSubDir2);
+                assert.equal(bazSubDir2.get("testKey4"), "testValue4");
             });
 
             it("Can delete a child subdirectory", () => {
-                const fooDirectory = testDirectory.createSubDirectory("foo");
-                const barDirectory = testDirectory.createSubDirectory("bar");
+                const fooDirectory = directory.createSubDirectory("foo");
+                const barDirectory = directory.createSubDirectory("bar");
                 const bazDirectory = barDirectory.createSubDirectory("baz");
                 fooDirectory.set("testKey", "testValue");
                 fooDirectory.set("testKey2", "testValue2");
                 barDirectory.set("testKey3", "testValue3");
                 bazDirectory.set("testKey4", "testValue4");
                 barDirectory.deleteSubDirectory("baz");
+
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedDirectory
                 assert.equal(barDirectory.getWorkingDirectory("baz"), undefined);
+
+                // Verify the remote SharedDirectory
+                const barDirectory2 = directory2.getSubDirectory("bar");
+                assert.equal(barDirectory2.getWorkingDirectory("baz"), undefined);
             });
 
             it("Can delete a child subdirectory with children", () => {
-                const fooDirectory = testDirectory.createSubDirectory("foo");
-                const barDirectory = testDirectory.createSubDirectory("bar");
+                const fooDirectory = directory.createSubDirectory("foo");
+                const barDirectory = directory.createSubDirectory("bar");
                 const bazDirectory = barDirectory.createSubDirectory("baz");
                 fooDirectory.set("testKey", "testValue");
                 fooDirectory.set("testKey2", "testValue2");
                 barDirectory.set("testKey3", "testValue3");
                 bazDirectory.set("testKey4", "testValue4");
-                testDirectory.deleteSubDirectory("bar");
-                assert.equal(testDirectory.getWorkingDirectory("bar"), undefined);
+                directory.deleteSubDirectory("bar");
+
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedDirectory
+                assert.equal(directory.getWorkingDirectory("bar"), undefined);
+
+                // Verify the remote SharedDirectory
+                assert.equal(directory2.getWorkingDirectory("bar"), undefined);
             });
 
             it("Can get and use a keys iterator", () => {
-                const fooDirectory = testDirectory.createSubDirectory("foo");
-                const barDirectory = testDirectory.createSubDirectory("bar");
+                const fooDirectory = directory.createSubDirectory("foo");
+                const barDirectory = directory.createSubDirectory("bar");
                 const bazDirectory = barDirectory.createSubDirectory("baz");
                 fooDirectory.set("testKey", "testValue");
                 fooDirectory.set("testKey2", "testValue2");
                 barDirectory.set("testKey3", "testValue3");
                 bazDirectory.set("testKey4", "testValue4");
 
-                const testSubdir1 = testDirectory.getWorkingDirectory("/foo");
-                const testSubdir1Iterator = testSubdir1.keys();
-                const testSubdir1Result1 = testSubdir1Iterator.next();
-                assert.equal(testSubdir1Result1.value, "testKey");
-                assert.equal(testSubdir1Result1.done, false);
-                const testSubdir1Result2 = testSubdir1Iterator.next();
-                assert.equal(testSubdir1Result2.value, "testKey2");
-                assert.equal(testSubdir1Result2.done, false);
-                const testSubdir1Result3 = testSubdir1Iterator.next();
-                assert.equal(testSubdir1Result3.value, undefined);
-                assert.equal(testSubdir1Result3.done, true);
+                containerRuntimeFactory.processAllMessages();
 
-                const testSubdir2 = testDirectory.getWorkingDirectory("/bar");
-                const testSubdir2Iterator = testSubdir2.keys();
-                const testSubdir2Result1 = testSubdir2Iterator.next();
-                assert.equal(testSubdir2Result1.value, "testKey3");
-                assert.equal(testSubdir2Result1.done, false);
-                const testSubdir2Result2 = testSubdir2Iterator.next();
-                assert.equal(testSubdir2Result2.value, undefined);
-                assert.equal(testSubdir2Result2.done, true);
+                // Verify the local SharedDirectory
+                const fooSubDir = directory.getWorkingDirectory("/foo");
+                const fooSubDirIterator = fooSubDir.keys();
+                const fooSubDirResult1 = fooSubDirIterator.next();
+                assert.equal(fooSubDirResult1.value, "testKey");
+                assert.equal(fooSubDirResult1.done, false);
+                const fooSubDirResult2 = fooSubDirIterator.next();
+                assert.equal(fooSubDirResult2.value, "testKey2");
+                assert.equal(fooSubDirResult2.done, false);
+                const fooSubDirResult3 = fooSubDirIterator.next();
+                assert.equal(fooSubDirResult3.value, undefined);
+                assert.equal(fooSubDirResult3.done, true);
+
+                const barSubDir = directory.getWorkingDirectory("/bar");
+                const barSubDirIterator = barSubDir.keys();
+                const barSubDirResult1 = barSubDirIterator.next();
+                assert.equal(barSubDirResult1.value, "testKey3");
+                assert.equal(barSubDirResult1.done, false);
+                const barSubDirResult2 = barSubDirIterator.next();
+                assert.equal(barSubDirResult2.value, undefined);
+                assert.equal(barSubDirResult2.done, true);
+
+                // Verify the remote SharedDirectory
+                const fooSubDir2 = directory2.getWorkingDirectory("/foo");
+                const fooSubDir2Iterator = fooSubDir2.keys();
+                const fooSubDir2Result1 = fooSubDir2Iterator.next();
+                assert.equal(fooSubDir2Result1.value, "testKey");
+                assert.equal(fooSubDir2Result1.done, false);
+                const fooSubDir2Result2 = fooSubDir2Iterator.next();
+                assert.equal(fooSubDir2Result2.value, "testKey2");
+                assert.equal(fooSubDir2Result2.done, false);
+                const fooSubDir2Result3 = fooSubDir2Iterator.next();
+                assert.equal(fooSubDir2Result3.value, undefined);
+                assert.equal(fooSubDir2Result3.done, true);
+
+                const barSubDir2 = directory2.getWorkingDirectory("/bar");
+                const barSubDir2Iterator = barSubDir2.keys();
+                const barSubDir2Result1 = barSubDir2Iterator.next();
+                assert.equal(barSubDir2Result1.value, "testKey3");
+                assert.equal(barSubDir2Result1.done, false);
+                const barSubDir2Result2 = barSubDir2Iterator.next();
+                assert.equal(barSubDir2Result2.value, undefined);
+                assert.equal(barSubDir2Result2.done, true);
             });
 
             it("Can get and use a values iterator", () => {
-                const fooDirectory = testDirectory.createSubDirectory("foo");
-                const barDirectory = testDirectory.createSubDirectory("bar");
+                const fooDirectory = directory.createSubDirectory("foo");
+                const barDirectory = directory.createSubDirectory("bar");
                 const bazDirectory = barDirectory.createSubDirectory("baz");
                 fooDirectory.set("testKey", "testValue");
                 fooDirectory.set("testKey2", "testValue2");
                 barDirectory.set("testKey3", "testValue3");
                 bazDirectory.set("testKey4", "testValue4");
 
-                const testSubdir1 = testDirectory.getWorkingDirectory("/foo");
-                const testSubdir1Iterator = testSubdir1.values();
-                const testSubdir1Result1 = testSubdir1Iterator.next();
-                assert.equal(testSubdir1Result1.value, "testValue");
-                assert.equal(testSubdir1Result1.done, false);
-                const testSubdir1Result2 = testSubdir1Iterator.next();
-                assert.equal(testSubdir1Result2.value, "testValue2");
-                assert.equal(testSubdir1Result2.done, false);
-                const testSubdir1Result3 = testSubdir1Iterator.next();
-                assert.equal(testSubdir1Result3.value, undefined);
-                assert.equal(testSubdir1Result3.done, true);
+                containerRuntimeFactory.processAllMessages();
 
-                const testSubdir2 = testDirectory.getWorkingDirectory("/bar");
-                const testSubdir2Iterator = testSubdir2.values();
-                const testSubdir2Result1 = testSubdir2Iterator.next();
-                assert.equal(testSubdir2Result1.value, "testValue3");
-                assert.equal(testSubdir2Result1.done, false);
-                const testSubdir2Result2 = testSubdir2Iterator.next();
-                assert.equal(testSubdir2Result2.value, undefined);
-                assert.equal(testSubdir2Result2.done, true);
+                // Verify the local SharedDirectory
+                const fooSubDir = directory.getWorkingDirectory("/foo");
+                const fooSubDirIterator = fooSubDir.values();
+                const fooSubDirResult1 = fooSubDirIterator.next();
+                assert.equal(fooSubDirResult1.value, "testValue");
+                assert.equal(fooSubDirResult1.done, false);
+                const fooSubDirResult2 = fooSubDirIterator.next();
+                assert.equal(fooSubDirResult2.value, "testValue2");
+                assert.equal(fooSubDirResult2.done, false);
+                const fooSubDirResult3 = fooSubDirIterator.next();
+                assert.equal(fooSubDirResult3.value, undefined);
+                assert.equal(fooSubDirResult3.done, true);
+
+                const barSubDir = directory.getWorkingDirectory("/bar");
+                const barSubDirIterator = barSubDir.values();
+                const barSubDirResult1 = barSubDirIterator.next();
+                assert.equal(barSubDirResult1.value, "testValue3");
+                assert.equal(barSubDirResult1.done, false);
+                const barSubDirResult2 = barSubDirIterator.next();
+                assert.equal(barSubDirResult2.value, undefined);
+                assert.equal(barSubDirResult2.done, true);
+
+                // Verify the remote SharedDirectory
+                const fooSubDir2 = directory2.getWorkingDirectory("/foo");
+                const fooSubDir2Iterator = fooSubDir2.values();
+                const fooSubDir2Result1 = fooSubDir2Iterator.next();
+                assert.equal(fooSubDir2Result1.value, "testValue");
+                assert.equal(fooSubDir2Result1.done, false);
+                const fooSubDir2Result2 = fooSubDir2Iterator.next();
+                assert.equal(fooSubDir2Result2.value, "testValue2");
+                assert.equal(fooSubDir2Result2.done, false);
+                const fooSubDir2Result3 = fooSubDir2Iterator.next();
+                assert.equal(fooSubDir2Result3.value, undefined);
+                assert.equal(fooSubDir2Result3.done, true);
+
+                const barSubDir2 = directory2.getWorkingDirectory("/bar");
+                const barSubDir2Iterator = barSubDir2.values();
+                const barSubDir2Result1 = barSubDir2Iterator.next();
+                assert.equal(barSubDir2Result1.value, "testValue3");
+                assert.equal(barSubDir2Result1.done, false);
+                const barSubDir2Result2 = barSubDir2Iterator.next();
+                assert.equal(barSubDir2Result2.value, undefined);
+                assert.equal(barSubDir2Result2.done, true);
             });
 
             it("Can get and use an entries iterator", () => {
-                const fooDirectory = testDirectory.createSubDirectory("foo");
-                const barDirectory = testDirectory.createSubDirectory("bar");
+                const fooDirectory = directory.createSubDirectory("foo");
+                const barDirectory = directory.createSubDirectory("bar");
                 const bazDirectory = barDirectory.createSubDirectory("baz");
                 fooDirectory.set("testKey", "testValue");
                 fooDirectory.set("testKey2", "testValue2");
                 barDirectory.set("testKey3", "testValue3");
                 bazDirectory.set("testKey4", "testValue4");
 
-                const testSubdir1 = testDirectory.getWorkingDirectory("/foo");
-                const testSubdir1Iterator = testSubdir1.entries();
-                const testSubdir1Result1 = testSubdir1Iterator.next();
-                assert.equal(testSubdir1Result1.value[0], "testKey");
-                assert.equal(testSubdir1Result1.value[1], "testValue");
-                assert.equal(testSubdir1Result1.done, false);
-                const testSubdir1Result2 = testSubdir1Iterator.next();
-                assert.equal(testSubdir1Result2.value[0], "testKey2");
-                assert.equal(testSubdir1Result2.value[1], "testValue2");
-                assert.equal(testSubdir1Result2.done, false);
-                const testSubdir1Result3 = testSubdir1Iterator.next();
-                assert.equal(testSubdir1Result3.value, undefined);
-                assert.equal(testSubdir1Result3.done, true);
+                containerRuntimeFactory.processAllMessages();
 
-                const testSubdir2 = testDirectory.getWorkingDirectory("/bar");
+                // Verify the local SharedDirectory
+                const fooSubDir = directory.getWorkingDirectory("/foo");
+                const fooSubDirIterator = fooSubDir.entries();
+                const fooSubDirResult1 = fooSubDirIterator.next();
+                assert.equal(fooSubDirResult1.value[0], "testKey");
+                assert.equal(fooSubDirResult1.value[1], "testValue");
+                assert.equal(fooSubDirResult1.done, false);
+                const fooSubDirResult2 = fooSubDirIterator.next();
+                assert.equal(fooSubDirResult2.value[0], "testKey2");
+                assert.equal(fooSubDirResult2.value[1], "testValue2");
+                assert.equal(fooSubDirResult2.done, false);
+                const fooSubDirResult3 = fooSubDirIterator.next();
+                assert.equal(fooSubDirResult3.value, undefined);
+                assert.equal(fooSubDirResult3.done, true);
+
+                const barSubDir = directory.getWorkingDirectory("/bar");
 
                 const expectedEntries = new Set(["testKey3"]);
-                for (const entry of testSubdir2) {
+                for (const entry of barSubDir) {
                     assert.ok(expectedEntries.has(entry[0]));
                     expectedEntries.delete(entry[0]);
                 }
                 assert.ok(expectedEntries.size === 0);
+
+                // Verify the remote SharedDirectory
+                const fooSubDir2 = directory2.getWorkingDirectory("/foo");
+                const fooSubDir2Iterator = fooSubDir2.entries();
+                const fooSubDir2Result1 = fooSubDir2Iterator.next();
+                assert.equal(fooSubDir2Result1.value[0], "testKey");
+                assert.equal(fooSubDir2Result1.value[1], "testValue");
+                assert.equal(fooSubDir2Result1.done, false);
+                const fooSubDir2Result2 = fooSubDir2Iterator.next();
+                assert.equal(fooSubDir2Result2.value[0], "testKey2");
+                assert.equal(fooSubDir2Result2.value[1], "testValue2");
+                assert.equal(fooSubDir2Result2.done, false);
+                const fooSubDir2Result3 = fooSubDir2Iterator.next();
+                assert.equal(fooSubDir2Result3.value, undefined);
+                assert.equal(fooSubDir2Result3.done, true);
+
+                const barSubDir2 = directory2.getWorkingDirectory("/bar");
+
+                const expectedEntries2 = new Set(["testKey3"]);
+                for (const entry of barSubDir2) {
+                    assert.ok(expectedEntries2.has(entry[0]));
+                    expectedEntries2.delete(entry[0]);
+                }
+                assert.ok(expectedEntries2.size === 0);
             });
 
             it("Can iterate over its subdirectories", () => {
-                const fooDirectory = testDirectory.createSubDirectory("foo");
+                const fooDirectory = directory.createSubDirectory("foo");
                 fooDirectory.createSubDirectory("bar");
                 fooDirectory.createSubDirectory("baz");
+
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedDirectory
                 const expectedDirectories = new Set(["bar", "baz"]);
                 for (const [subDirName] of fooDirectory.subdirectories()) {
                     assert.ok(expectedDirectories.has(subDirName));
                     expectedDirectories.delete(subDirName);
                 }
                 assert.ok(expectedDirectories.size === 0);
+
+                // Verify the remote SharedDirectory
+                const fooDirectory2 = directory2.getSubDirectory("foo");
+                const expectedDirectories2 = new Set(["bar", "baz"]);
+                for (const [subDirName] of fooDirectory2.subdirectories()) {
+                    assert.ok(expectedDirectories2.has(subDirName));
+                    expectedDirectories2.delete(subDirName);
+                }
+                assert.ok(expectedDirectories2.size === 0);
             });
+        });
+    });
+
+    describe(".serialize", () => {
+        it("Should serialize an empty directory as a JSON object", () => {
+            const serialized = serialize(directory);
+            assert.equal(serialized, "{}");
+        });
+
+        it("Should serialize a directory without subdirectories as a JSON object", () => {
+            directory.set("first", "second");
+            directory.set("third", "fourth");
+            directory.set("fifth", "sixth");
+            const subMap = mapFactory.create(componentRuntime, "subMap");
+            directory.set("object", subMap.handle);
+
+            const serialized = serialize(directory);
+            // eslint-disable-next-line max-len
+            const expected = `{"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain","value":"sixth"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"subMap"}}}}`;
+            assert.equal(serialized, expected);
+        });
+
+        it("Should serialize a directory with subdirectories as a JSON object", () => {
+            directory.set("first", "second");
+            directory.set("third", "fourth");
+            directory.set("fifth", "sixth");
+            const subMap = mapFactory.create(componentRuntime, "subMap");
+            directory.set("object", subMap.handle);
+            const nestedDirectory = directory.createSubDirectory("nested");
+            nestedDirectory.set("deepKey1", "deepValue1");
+            nestedDirectory.createSubDirectory("nested2")
+                .createSubDirectory("nested3")
+                .set("deepKey2", "deepValue2");
+
+            const serialized = serialize(directory);
+            // eslint-disable-next-line max-len
+            const expected = `{"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain","value":"sixth"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"subMap"}}},"subdirectories":{"nested":{"storage":{"deepKey1":{"type":"Plain","value":"deepValue1"}},"subdirectories":{"nested2":{"subdirectories":{"nested3":{"storage":{"deepKey2":{"type":"Plain","value":"deepValue2"}}}}}}}}}`;
+            assert.equal(serialized, expected);
+        });
+
+        it("Should serialize an undefined value", () => {
+            directory.set("first", "second");
+            directory.set("third", "fourth");
+            directory.set("fifth", undefined);
+            assert.ok(directory.has("fifth"));
+            const subMap = mapFactory.create(componentRuntime, "subMap");
+            directory.set("object", subMap.handle);
+            const nestedDirectory = directory.createSubDirectory("nested");
+            nestedDirectory.set("deepKey1", "deepValue1");
+            nestedDirectory.set("deepKeyUndefined", undefined);
+            assert.ok(nestedDirectory.has("deepKeyUndefined"));
+            nestedDirectory.createSubDirectory("nested2")
+                .createSubDirectory("nested3")
+                .set("deepKey2", "deepValue2");
+
+            const serialized = serialize(directory);
+            // eslint-disable-next-line max-len
+            const expected = `{"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"subMap"}}},"subdirectories":{"nested":{"storage":{"deepKey1":{"type":"Plain","value":"deepValue1"},"deepKeyUndefined":{"type":"Plain"}},"subdirectories":{"nested2":{"subdirectories":{"nested3":{"storage":{"deepKey2":{"type":"Plain","value":"deepValue2"}}}}}}}}}`;
+            assert.equal(serialized, expected);
+        });
+    });
+
+    describe(".populate", () => {
+        beforeEach(() => {
+            // We are only testing local state for loading from snapshot.
+            componentRuntime.local = true;
+        });
+
+        it("Should populate the directory from an empty JSON object (old format)", async () => {
+            await populate(directory, {});
+            assert.equal(directory.size, 0, "Failed to initialize to empty directory storage");
+            directory.set("testKey", "testValue");
+            assert.equal(directory.get("testKey"), "testValue", "Failed to set testKey");
+            directory.createSubDirectory("testSubDir").set("testSubKey", "testSubValue");
+            assert.equal(
+                directory.getWorkingDirectory("testSubDir").get("testSubKey"),
+                "testSubValue",
+                "Failed to set testSubKey",
+            );
+        });
+
+        it("Should populate the directory from a basic JSON object (old format)", async () => {
+            await populate(directory, {
+                storage: {
+                    testKey: {
+                        type: "Plain",
+                        value: "testValue4",
+                    },
+                    testKey2: {
+                        type: "Plain",
+                        value: "testValue5",
+                    },
+                },
+                subdirectories: {
+                    foo: {
+                        storage: {
+                            testKey: {
+                                type: "Plain",
+                                value: "testValue",
+                            },
+                            testKey2: {
+                                type: "Plain",
+                                value: "testValue2",
+                            },
+                        },
+                    },
+                    bar: {
+                        storage: {
+                            testKey3: {
+                                type: "Plain",
+                                value: "testValue3",
+                            },
+                        },
+                    },
+                },
+            });
+            assert.equal(directory.size, 2, "Failed to initialize directory storage correctly");
+            assert.equal(directory.getWorkingDirectory("/foo").get("testKey"), "testValue");
+            assert.equal(directory.getWorkingDirectory("foo").get("testKey2"), "testValue2");
+            assert.equal(directory.getWorkingDirectory("/bar").get("testKey3"), "testValue3");
+            assert.equal(directory.getWorkingDirectory("").get("testKey"), "testValue4");
+            assert.equal(directory.getWorkingDirectory("/").get("testKey2"), "testValue5");
+            directory.set("testKey", "newValue");
+            assert.equal(directory.get("testKey"), "newValue", "Failed to set testKey");
+            directory.createSubDirectory("testSubDir").set("testSubKey", "newSubValue");
+            assert.equal(
+                directory.getWorkingDirectory("testSubDir").get("testSubKey"),
+                "newSubValue",
+                "Failed to set testSubKey",
+            );
+        });
+
+        it("Should populate the directory with undefined values (old format)", async () => {
+            await populate(directory, {
+                storage: {
+                    testKey: {
+                        type: "Plain",
+                        value: "testValue4",
+                    },
+                    testKey2: {
+                        type: "Plain",
+                    },
+                },
+                subdirectories: {
+                    foo: {
+                        storage: {
+                            testKey: {
+                                type: "Plain",
+                                value: "testValue",
+                            },
+                            testKey2: {
+                                type: "Plain",
+                            },
+                        },
+                    },
+                    bar: {
+                        storage: {
+                            testKey3: {
+                                type: "Plain",
+                                value: "testValue3",
+                            },
+                        },
+                    },
+                },
+            });
+            assert.equal(directory.size, 2, "Failed to initialize directory storage correctly");
+            assert.equal(directory.getWorkingDirectory("/foo").get("testKey"), "testValue");
+            assert.equal(directory.getWorkingDirectory("foo").get("testKey2"), undefined);
+            assert.equal(directory.getWorkingDirectory("/bar").get("testKey3"), "testValue3");
+            assert.equal(directory.getWorkingDirectory("").get("testKey"), "testValue4");
+            assert.equal(directory.getWorkingDirectory("/").get("testKey2"), undefined);
+            assert.ok(directory.has("testKey2"));
+            assert.ok(directory.getWorkingDirectory("/foo").has("testKey2"));
+            directory.set("testKey", "newValue");
+            assert.equal(directory.get("testKey"), "newValue", "Failed to set testKey");
+            directory.createSubDirectory("testSubDir").set("testSubKey", "newSubValue");
+            assert.equal(
+                directory.getWorkingDirectory("testSubDir").get("testSubKey"),
+                "newSubValue",
+                "Failed to set testSubKey",
+            );
+        });
+
+        it("Should populate, serialize and de-serialize directory with long property values", async () => {
+            // 40K word
+            let longWord = "0123456789";
+            for (let i = 0; i < 12; i++) {
+                longWord = longWord + longWord;
+            }
+            const logWord2 = `${longWord}_2`;
+
+            directory.set("first", "second");
+            directory.set("long1", longWord);
+            const nestedDirectory = directory.createSubDirectory("nested");
+            nestedDirectory.set("deepKey1", "deepValue1");
+            nestedDirectory.set("long2", logWord2);
+
+            const tree = directory.snapshot();
+            assert(tree.entries.length === 3);
+            assert(tree.entries[0].path === "blob0");
+            assert(tree.entries[1].path === "blob1");
+            assert(tree.entries[2].path === "header");
+            assert((tree.entries[0].value as IBlob).contents.length >= 1024);
+            assert((tree.entries[1].value as IBlob).contents.length >= 1024);
+            assert((tree.entries[2].value as IBlob).contents.length <= 200);
+
+            const directory2 = new SharedDirectory("test", componentRuntime, DirectoryFactory.Attributes);
+            const storage = MockSharedObjectServices.createFromTree(tree);
+            await directory2.load("branchId", storage);
+
+            assert.equal(directory2.get("first"), "second");
+            assert.equal(directory2.get("long1"), longWord);
+            assert.equal(directory2.getWorkingDirectory("/nested").get("deepKey1"), "deepValue1");
+            assert.equal(directory2.getWorkingDirectory("/nested").get("long2"), logWord2);
         });
     });
 });

--- a/packages/runtime/map/src/test/map.spec.ts
+++ b/packages/runtime/map/src/test/map.spec.ts
@@ -269,13 +269,13 @@ describe("Map", () => {
             // Process the message.
             containerRuntimeFactory.processAllMessages();
 
-            // Verify that both the map get the new value.
+            // Verify that both the maps have the new value.
             assert.equal(map.get(key), newValue, "The first map did not get the new value");
             assert.equal(map2.get(key), newValue, "The second map did not get the new value");
         });
     });
 
-    describe("SharedMap in connected state with a remote map", () => {
+    describe("SharedMap in connected state with a remote SharedMap", () => {
         let containerRuntimeFactory: MockContainerRuntimeFactory;
         let map2: SharedMap;
 

--- a/packages/runtime/map/src/test/map.spec.ts
+++ b/packages/runtime/map/src/test/map.spec.ts
@@ -6,318 +6,397 @@
 import assert from "assert";
 import { IComponentHandle } from "@fluidframework/component-core-interfaces";
 import { IBlob } from "@fluidframework/protocol-definitions";
-import { MockComponentRuntime, MockSharedObjectServices } from "@fluidframework/test-runtime-utils";
+import {
+    MockComponentRuntime,
+    MockContainerRuntimeFactory,
+    MockSharedObjectServices,
+    MockStorage,
+} from "@fluidframework/test-runtime-utils";
+import { MapFactory, SharedMap } from "../map";
 
-import * as map from "../";
-import { SharedMap } from "../map";
+describe("Map", () => {
+    let map: SharedMap;
+    let factory: MapFactory;
+    let componentRuntime: MockComponentRuntime;
 
-describe("Routerlicious", () => {
-    describe("Map", () => {
-        let rootMap: map.ISharedMap;
-        let testMap: map.ISharedMap;
-        let factory: map.MapFactory;
-        let componentRuntime: MockComponentRuntime;
+    beforeEach(async () => {
+        componentRuntime = new MockComponentRuntime();
+        factory = new MapFactory();
+        map = new SharedMap("testMap", componentRuntime, MapFactory.Attributes);
+    });
+
+    describe("SharedMap in local state", () => {
+        it("Can create a new map", () => {
+            assert.ok(map, "could not create a new map");
+        });
+
+        it("Can set and get map data", async () => {
+            map.set("testKey", "testValue");
+            map.set("testKey2", "testValue2");
+            assert.equal(map.get("testKey"), "testValue", "could not retrieve set key 1");
+            assert.equal(map.get("testKey2"), "testValue2", "could not retreive set key 2");
+        });
+
+        it("should fire correct map events", async () => {
+            const dummyMap = map;
+            let called1: boolean = false;
+            let called2: boolean = false;
+            dummyMap.on("op", (agr1, arg2, arg3) => called1 = true);
+            dummyMap.on("valueChanged", (agr1, arg2, arg3, arg4) => called2 = true);
+            dummyMap.set("marco", "polo");
+            assert.equal(called1, false, "did not receive op event");
+            assert.equal(called2, true, "did not receive valueChanged event");
+        });
+
+        it("Should return undefined when a key does not exist in the map", () => {
+            assert.equal(map.get("missing"), undefined, "get() did not return undefined for missing key");
+        });
+
+        it("Should reject undefined and null key sets", () => {
+            assert.throws(() => {
+                map.set(undefined, "one");
+            }, "Should throw for key of undefined");
+            assert.throws(() => {
+                map.set(null, "two");
+            }, "Should throw for key of null");
+        });
+    });
+
+    describe("SharedMap in connected state with a remote map", () => {
+        let containerRuntimeFactory: MockContainerRuntimeFactory;
+        let map2: SharedMap;
 
         beforeEach(async () => {
-            componentRuntime = new MockComponentRuntime();
-            // We only want to test local state of the DDS.
-            componentRuntime.local = true;
-            factory = new map.MapFactory();
-            rootMap = factory.create(componentRuntime, "root");
-            testMap = factory.create(componentRuntime, "test");
+            // Connect the first map
+            containerRuntimeFactory = new MockContainerRuntimeFactory();
+            const containerRuntime = containerRuntimeFactory.createContainerRuntime(componentRuntime);
+            const services = {
+                deltaConnection: containerRuntime.createDeltaConnection(),
+                objectStorage: new MockStorage(undefined),
+            };
+            map.connect(services);
+
+            // Create and connect a second map
+            const componentRuntime2 = new MockComponentRuntime();
+            map2 = new SharedMap("testMap2", componentRuntime2, MapFactory.Attributes);
+            const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const services2 = {
+                deltaConnection: containerRuntime2.createDeltaConnection(),
+                objectStorage: new MockStorage(undefined),
+            };
+            map2.connect(services2);
         });
 
-        describe("SharedMap", () => {
-            it("Can get the root map", () => {
-                assert.ok(rootMap);
-            });
+        describe(".get()", () => {
+            it("Should be able to retrieve a key", () => {
+                const value = "value";
+                map.set("test", value);
 
-            it("Can create a map", () => {
-                assert.ok(testMap);
-            });
+                containerRuntimeFactory.processAllMessages();
 
-            it("Can set and get map data", async () => {
-                testMap.set("testKey", "testValue");
-                testMap.set("testKey2", "testValue2");
-                assert.equal(testMap.get("testKey"), "testValue");
-                assert.equal(testMap.get("testKey2"), "testValue2");
-            });
-        });
+                // Verify the local SharedMap
+                assert.equal(map.get("test"), value, "could not retrieve key");
 
-        describe("eventsMap", () => {
-            it("listeners should listen to fired map events", async () => {
-                const dummyMap = testMap;
-                let called1: boolean = false;
-                let called2: boolean = false;
-                dummyMap.on("op", (agr1, arg2, arg3) => called1 = true);
-                dummyMap.on("valueChanged", (agr1, arg2, arg3, arg4) => called2 = true);
-                dummyMap.set("marco", "polo");
-                assert.equal(called1, false, "op");
-                assert.equal(called2, true, "valueChanged");
+                // Verify the remote SharedMap
+                assert.equal(map2.get("test"), value, "could not retrieve key from the remote map");
             });
         });
 
-        describe("MapView", () => {
-            let sharedMap: map.ISharedMap;
-
-            beforeEach(async () => {
-                sharedMap = testMap;
+        describe(".has()", () => {
+            it("Should return false when a key is not in the map", () => {
+                assert.equal(map.has("notInSet"), false, "has() did not return false for missing key");
             });
 
-            describe(".get()", () => {
-                it("Should be able to retrieve a key", () => {
-                    const value = "value";
-                    sharedMap.set("test", value);
-                    assert.equal(value, sharedMap.get("test"));
-                });
+            it("Should return true when a key is in the map", () => {
+                map.set("inSet", "value");
 
-                it("Should return undefined when a key does not exist in the map", () => {
-                    assert.equal(undefined, sharedMap.get("missing"));
-                });
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedMap
+                assert.equal(map.has("inSet"), true, "could not find the key");
+
+                // Verify the remote SharedMap
+                assert.equal(map2.has("inSet"), true, "could not find the key in the remote map");
+            });
+        });
+
+        describe(".set()", () => {
+            it("Should set a key to a value", () => {
+                const value = "value";
+                map.set("test", value);
+
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedMap
+                assert.equal(map.has("test"), true, "could not find the set key");
+                assert.equal(map.get("test"), value, "could not get the set key");
+
+                // Verify the remote SharedMap
+                assert.equal(map2.has("test"), true, "could not find the set key in remote map");
+                assert.equal(map2.get("test"), value, "could note get the set key from remote map");
             });
 
-            describe(".has()", () => {
-                it("Should return false when a key is not in the map", () => {
-                    assert.equal(false, sharedMap.has("notInSet"));
-                });
+            it("Should be able to set a shared object handle as a key", () => {
+                const subMap = factory.create(componentRuntime, "subMap");
+                map.set("test", subMap.handle);
 
-                it("Should return true when a key is in the map", () => {
-                    sharedMap.set("inSet", "value");
-                    assert.equal(true, sharedMap.has("inSet"));
-                });
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedMap
+                assert.equal(
+                    map.get<IComponentHandle>("test").path,
+                    subMap.id,
+                    "could not get the set shared object");
+
+                // Verify the remote SharedMap
+                assert.equal(
+                    map2.get<IComponentHandle>("test").path,
+                    subMap.id,
+                    "could not get the set shared object from remote map");
             });
 
-            describe(".set()", () => {
-                it("Should set a key to a value", () => {
-                    const value = "value";
-                    sharedMap.set("test", value);
-                    assert.equal(true, sharedMap.has("test"));
-                    assert.equal(value, sharedMap.get("test"));
+            it("Should be able to set and retrieve a plain object with nested handles", async () => {
+                const subMap = factory.create(componentRuntime, "subMap");
+                const subMap2 = factory.create(componentRuntime, "subMap2");
+                const containingObject = {
+                    subMapHandle: subMap.handle,
+                    nestedObj: {
+                        subMap2Handle: subMap2.handle,
+                    },
+                };
+                map.set("object", containingObject);
+
+                containerRuntimeFactory.processAllMessages();
+
+                const retrieved = map.get("object");
+                const retrievedSubMap = await retrieved.subMapHandle.get();
+                assert.equal(retrievedSubMap, subMap, "could not get nested map 1");
+                const retrievedSubMap2 = await retrieved.nestedObj.subMap2Handle.get();
+                assert.equal(retrievedSubMap2, subMap2, "could not get nested map 2");
+            });
+        });
+
+        describe(".forEach()", () => {
+            it("Should iterate over all keys in the map", () => {
+                // We use a set to mark the values we want to insert. When we iterate we will remove from the set
+                // and then check it's empty at the end
+                const set = new Set<string>();
+                set.add("first");
+                set.add("second");
+                set.add("third");
+
+                for (const value of set) {
+                    map.set(value, value);
+                }
+
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedMap
+                map.forEach((value, key) => {
+                    assert.ok(set.has(key), "the key should be present in the set");
+                    assert.equal(key, value, "the value should match the set value");
+                    assert.equal(map.get(key), value, "could not get key");
                 });
 
-                it("Should be able to set a shared object handle as a key", () => {
-                    const subMap = factory.create(componentRuntime, "subMap");
-                    sharedMap.set("test", subMap.handle);
-                    assert.equal(sharedMap.get<IComponentHandle>("test").path, subMap.id);
+                // Verify the remote SharedMap
+                map2.forEach((value, key) => {
+                    assert.ok(set.has(key), "the key in remote map should be present in the set");
+                    assert.equal(key, value, "the value should match the set value in the remote map");
+                    assert.equal(map2.get(key), value, "could not get key in the remote map");
+                    set.delete(key);
                 });
 
-                it("Should be able to set and retrieve a plain object with nested handles", async () => {
-                    const subMap = factory.create(componentRuntime, "subMap");
-                    const subMap2 = factory.create(componentRuntime, "subMap2");
-                    const containingObject = {
-                        subMapHandle: subMap.handle,
-                        nestedObj: {
-                            subMap2Handle: subMap2.handle,
-                        },
-                    };
-                    sharedMap.set("object", containingObject);
+                assert.equal(set.size, 0);
+            });
+        });
 
-                    const retrieved = sharedMap.get("object");
-                    assert.equal(await retrieved.subMapHandle.get(), subMap);
-                    assert.equal(await retrieved.nestedObj.subMap2Handle.get(), subMap2);
-                });
+        describe(".wait()", () => {
+            it("Should resolve returned promise for existing keys", async () => {
+                map.set("test", "resolved");
+                assert.ok(map.has("test"));
 
-                it("Should reject undefined and null key sets", () => {
-                    assert.throws(() => {
-                        sharedMap.set(undefined, "one");
-                    }, "Should throw for key of undefined");
-                    assert.throws(() => {
-                        sharedMap.set(null, "two");
-                    }, "Should throw for key of null");
-                });
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedMap
+                assert.equal(await map.wait("test"), "resolved", "promise not resolved for existing key");
+
+                // Verify the remote SharedMap
+                assert.equal(
+                    await map2.wait("test"), "resolved", "promise not resolved for existing key in remote map");
             });
 
-            describe(".forEach()", () => {
-                it("Should iterate over all keys in the map", () => {
-                    // We use a set to mark the values we want to insert. When we iterate we will remove from the set
-                    // and then check it's empty at the end
-                    const set = new Set<string>();
-                    set.add("first");
-                    set.add("second");
-                    set.add("third");
+            it("Should resolve returned promise once unavailable key is available", async () => {
+                assert.ok(!map.has("test"));
 
-                    for (const value of set) {
-                        sharedMap.set(value, value);
+                const waitP = map.wait("test");
+                const waitP2 = map2.wait("test");
+
+                map.set("test", "resolved");
+
+                containerRuntimeFactory.processAllMessages();
+
+                // Verify the local SharedMap
+                assert.equal(await waitP, "resolved", "promise not resolved after key is available");
+
+                // Verify the remote SharedMap
+                assert.equal(await waitP2, "resolved", "promise not resolved after key is available in remote map");
+            });
+        });
+
+        describe(".serialize", () => {
+            beforeEach(() => {
+                // We are only testing local state for snapshot / load
+                componentRuntime.local = true;
+            });
+
+            it("Should serialize the map as a JSON object", () => {
+                map.set("first", "second");
+                map.set("third", "fourth");
+                map.set("fifth", "sixth");
+                const subMap = factory.create(componentRuntime, "subMap");
+                map.set("object", subMap.handle);
+
+                const parsed = map.getSerializableStorage();
+
+                map.forEach((value, key) => {
+                    if (!value.IComponentHandle) {
+                        assert.equal(parsed[key].type, "Plain");
+                        assert.equal(parsed[key].value, value);
+                    } else {
+                        assert.equal(parsed[key].type, "Plain");
+                        assert.equal(parsed[key].value.url, subMap.id);
                     }
-
-                    sharedMap.forEach((value, key) => {
-                        assert.ok(set.has(key));
-                        assert.equal(key, value);
-                        assert.equal(sharedMap.get(key), value);
-                        set.delete(key);
-                    });
-
-                    assert.equal(set.size, 0);
                 });
             });
 
-            describe(".serialize", () => {
-                it("Should serialize the map as a JSON object", () => {
-                    sharedMap.set("first", "second");
-                    sharedMap.set("third", "fourth");
-                    sharedMap.set("fifth", "sixth");
-                    const subMap = factory.create(componentRuntime, "subMap");
-                    sharedMap.set("object", subMap.handle);
+            it("Should serialize an undefined value", () => {
+                map.set("first", "second");
+                map.set("third", "fourth");
+                map.set("fifth", undefined);
+                assert.ok(map.has("fifth"));
+                const subMap = factory.create(componentRuntime, "subMap");
+                map.set("object", subMap.handle);
 
-                    const parsed = (sharedMap as SharedMap).getSerializableStorage();
+                const parsed = map.getSerializableStorage();
 
-                    sharedMap.forEach((value, key) => {
-                        if (!value.IComponentHandle) {
-                            assert.equal(parsed[key].type, "Plain");
-                            assert.equal(parsed[key].value, value);
-                        } else {
-                            assert.equal(parsed[key].type, "Plain");
-                            assert.equal(parsed[key].value.url, subMap.id);
-                        }
-                    });
+                map.forEach((value, key) => {
+                    if (!value || !value.IComponentHandle) {
+                        assert.equal(parsed[key].type, "Plain");
+                        assert.equal(parsed[key].value, value);
+                    } else {
+                        assert.equal(parsed[key].type, "Plain");
+                        assert.equal(parsed[key].value.url, subMap.id);
+                    }
+                });
+            });
+
+            it("Should serialize an object with nested handles", async () => {
+                const subMap = factory.create(componentRuntime, "subMap");
+                const subMap2 = factory.create(componentRuntime, "subMap2");
+                const containingObject = {
+                    subMapHandle: subMap.handle,
+                    nestedObj: {
+                        subMap2Handle: subMap2.handle,
+                    },
+                };
+                map.set("object", containingObject);
+
+                const serialized = JSON.stringify(map.getSerializableStorage());
+                // eslint-disable-next-line max-len
+                assert.equal(serialized, `{"object":{"type":"Plain","value":{"subMapHandle":{"type":"__fluid_handle__","url":"subMap"},"nestedObj":{"subMap2Handle":{"type":"__fluid_handle__","url":"subMap2"}}}}}`);
+            });
+
+            it("can load old serialization format", async () => {
+                map.set("key", "value");
+
+                const content = JSON.stringify({
+                    key: {
+                        type: "Plain",
+                        value: "value",
+                    },
                 });
 
-                it("Should serialize an undefined value", () => {
-                    sharedMap.set("first", "second");
-                    sharedMap.set("third", "fourth");
-                    sharedMap.set("fifth", undefined);
-                    assert.ok(sharedMap.has("fifth"));
-                    const subMap = factory.create(componentRuntime, "subMap");
-                    sharedMap.set("object", subMap.handle);
+                const services = new MockSharedObjectServices({ header: content });
+                const loadedMap = await factory.load(
+                    componentRuntime, "mapId", services, "branchId", factory.attributes,
+                );
+                assert(loadedMap.get("key") === "value");
+            });
 
-                    const parsed = (sharedMap as SharedMap).getSerializableStorage();
+            it("new serialization format for small maps", async () => {
+                map.set("key", "value");
 
-                    sharedMap.forEach((value, key) => {
-                        if (!value || !value.IComponentHandle) {
-                            assert.equal(parsed[key].type, "Plain");
-                            assert.equal(parsed[key].value, value);
-                        } else {
-                            assert.equal(parsed[key].type, "Plain");
-                            assert.equal(parsed[key].value.url, subMap.id);
-                        }
-                    });
-                });
-
-                it("Should serialize an object with nested handles", async () => {
-                    const subMap = factory.create(componentRuntime, "subMap");
-                    const subMap2 = factory.create(componentRuntime, "subMap2");
-                    const containingObject = {
-                        subMapHandle: subMap.handle,
-                        nestedObj: {
-                            subMap2Handle: subMap2.handle,
-                        },
-                    };
-                    sharedMap.set("object", containingObject);
-
-                    const serialized = JSON.stringify((sharedMap as any).getSerializableStorage());
-                    // eslint-disable-next-line max-len
-                    assert.equal(serialized, `{"object":{"type":"Plain","value":{"subMapHandle":{"type":"__fluid_handle__","url":"subMap"},"nestedObj":{"subMap2Handle":{"type":"__fluid_handle__","url":"subMap2"}}}}}`);
-                });
-
-                it("can load old serialization format", async () => {
-                    sharedMap.set("key", "value");
-
-                    const content = JSON.stringify({
+                const tree = map.snapshot();
+                assert(tree.entries.length === 1);
+                const content = JSON.stringify({
+                    blobs: [],
+                    content: {
                         key: {
                             type: "Plain",
                             value: "value",
                         },
-                    });
-
-                    const services = new MockSharedObjectServices({ header: content });
-                    const map2 = await factory.load(
-                        componentRuntime, "mapId", services, "branchId", factory.attributes,
-                    );
-                    assert(map2.get("key") === "value");
+                    },
                 });
+                assert(tree.entries.length === 1);
+                assert((tree.entries[0].value as IBlob).contents === content);
 
-                it("new serialization format for small maps", async () => {
-                    sharedMap.set("key", "value");
-
-                    const tree = sharedMap.snapshot();
-                    assert(tree.entries.length === 1);
-                    const content = JSON.stringify({
-                        blobs: [],
-                        content: {
-                            key: {
-                                type: "Plain",
-                                value: "value",
-                            },
-                        },
-                    });
-                    assert(tree.entries.length === 1);
-                    assert((tree.entries[0].value as IBlob).contents === content);
-
-                    const services = new MockSharedObjectServices({ header: content });
-                    const map2 = await factory.load(
-                        componentRuntime, "mapId", services, "branchId", factory.attributes,
-                    );
-                    assert(map2.get("key") === "value");
-                });
-
-                it("new serialization format for big maps", async () => {
-                    sharedMap.set("key", "value");
-
-                    // 40K char string
-                    let longString = "01234567890";
-                    for (let i = 0; i < 12; i++) {
-                        longString = longString + longString;
-                    }
-                    sharedMap.set("longValue", longString);
-                    sharedMap.set("zzz", "the end");
-
-                    const tree = sharedMap.snapshot();
-                    assert(tree.entries.length === 2);
-                    const content1 = JSON.stringify({
-                        blobs: ["blob0"],
-                        content: {
-                            key: {
-                                type: "Plain",
-                                value: "value",
-                            },
-                            zzz: {
-                                type: "Plain",
-                                value: "the end",
-                            },
-                        },
-                    });
-                    const content2 = JSON.stringify({
-                        longValue: {
-                            type: "Plain",
-                            value: longString,
-                        },
-                    });
-
-                    assert(tree.entries.length === 2);
-                    assert(tree.entries[1].path === "header");
-                    assert((tree.entries[1].value as IBlob).contents === content1);
-
-                    assert(tree.entries[0].path === "blob0");
-                    assert((tree.entries[0].value as IBlob).contents === content2);
-
-                    const services = new MockSharedObjectServices({
-                        header: content1,
-                        blob0: content2,
-                    });
-                    const map2 = await factory.load(
-                        componentRuntime, "mapId", services, "branchId", factory.attributes,
-                    );
-                    assert(map2.get("key") === "value");
-                    assert(map2.get("longValue") === longString);
-                    assert(map2.get("zzz") === "the end");
-                });
+                const services = new MockSharedObjectServices({ header: content });
+                const loadedMap = await factory.load(
+                    componentRuntime, "mapId", services, "branchId", factory.attributes,
+                );
+                assert(loadedMap.get("key") === "value");
             });
 
-            describe(".wait()", () => {
-                it("Should resolve returned promise for existing keys", async () => {
-                    sharedMap.set("test", "resolved");
-                    assert.ok(sharedMap.has("test"));
-                    await sharedMap.wait("test");
+            it("new serialization format for big maps", async () => {
+                map.set("key", "value");
+
+                // 40K char string
+                let longString = "01234567890";
+                for (let i = 0; i < 12; i++) {
+                    longString = longString + longString;
+                }
+                map.set("longValue", longString);
+                map.set("zzz", "the end");
+
+                const tree = map.snapshot();
+                assert(tree.entries.length === 2);
+                const content1 = JSON.stringify({
+                    blobs: ["blob0"],
+                    content: {
+                        key: {
+                            type: "Plain",
+                            value: "value",
+                        },
+                        zzz: {
+                            type: "Plain",
+                            value: "the end",
+                        },
+                    },
+                });
+                const content2 = JSON.stringify({
+                    longValue: {
+                        type: "Plain",
+                        value: longString,
+                    },
                 });
 
-                it("Should resolve returned promise once unavailable key is available", async () => {
-                    assert.ok(!sharedMap.has("test"));
+                assert(tree.entries.length === 2);
+                assert(tree.entries[1].path === "header");
+                assert((tree.entries[1].value as IBlob).contents === content1);
 
-                    const waitP = sharedMap.wait("test");
-                    sharedMap.set("test", "resolved");
+                assert(tree.entries[0].path === "blob0");
+                assert((tree.entries[0].value as IBlob).contents === content2);
 
-                    await waitP;
+                const services = new MockSharedObjectServices({
+                    header: content1,
+                    blob0: content2,
                 });
+                const loadedMap = await factory.load(
+                    componentRuntime, "mapId", services, "branchId", factory.attributes,
+                );
+                assert(loadedMap.get("key") === "value");
+                assert(loadedMap.get("longValue") === longString);
+                assert(loadedMap.get("zzz") === "the end");
             });
         });
     });

--- a/packages/runtime/map/src/test/reconnection.spec.ts
+++ b/packages/runtime/map/src/test/reconnection.spec.ts
@@ -1,0 +1,252 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import assert from "assert";
+import {
+    MockComponentRuntime,
+    MockContainerRuntimeFactoryForReconnection,
+    MockContainerRuntimeForReconnection,
+    MockStorage,
+} from "@fluidframework/test-runtime-utils";
+import { MapFactory, SharedMap } from "../map";
+import { DirectoryFactory, SharedDirectory } from "../directory";
+
+describe("Reconnection", () => {
+    describe("SharedMap", () => {
+        let containerRuntimeFactory: MockContainerRuntimeFactoryForReconnection;
+        let containerRuntime1: MockContainerRuntimeForReconnection;
+        let containerRuntime2: MockContainerRuntimeForReconnection;
+        let map1: SharedMap;
+        let map2: SharedMap;
+
+        beforeEach(async () => {
+            containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
+
+            // Create the first SharedMap.
+            const componentRuntime1 = new MockComponentRuntime();
+            containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime1);
+            const services1 = {
+                deltaConnection: containerRuntime1.createDeltaConnection(),
+                objectStorage: new MockStorage(),
+            };
+            map1 = new SharedMap("shared-map-1", componentRuntime1, MapFactory.Attributes);
+            map1.connect(services1);
+
+            // Create the second SharedMap.
+            const componentRuntime2 = new MockComponentRuntime();
+            containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const services2 = {
+                deltaConnection: containerRuntime2.createDeltaConnection(),
+                objectStorage: new MockStorage(),
+            };
+            map2 = new SharedMap("shared-map-2", componentRuntime2, MapFactory.Attributes);
+            map2.connect(services2);
+        });
+
+        it("can resend unacked ops on reconnection", async () => {
+            const key = "testKey";
+            const value = "testValue";
+
+            // Set a value on the first SharedMap.
+            map1.set(key, value);
+
+            // Disconnect and reconnect the first client.
+            containerRuntime1.connected = false;
+            containerRuntime1.connected = true;
+
+            // Process the messages.
+            containerRuntimeFactory.processAllMessages();
+
+            // Verify that the set value is processed by both clients.
+            assert.equal(map1.get(key), value, "The local client did not process the set");
+            assert.equal(map2.get(key), value, "The remote client did not process the set");
+
+            // Delete the value from the second SharedMap.
+            map2.delete(key);
+
+            // Disconnect and reconnect the second client.
+            containerRuntime2.connected = false;
+            containerRuntime2.connected = true;
+
+            // Process the messages.
+            containerRuntimeFactory.processAllMessages();
+
+            // Verify that the deleted value is processed by both clients.
+            assert.equal(map1.get(key), undefined, "The local client did not process the delete");
+            assert.equal(map2.get(key), undefined, "The remote client did not process the delete");
+        });
+
+        it("can store ops in disconnected state and resend them on reconnection", async () => {
+            const key = "testKey";
+            const value = "testValue";
+
+            // Disconnect the first client.
+            containerRuntime1.connected = false;
+
+            // Set a value on the first SharedMap.
+            map1.set(key, value);
+
+            // Reconnect the first client.
+            containerRuntime1.connected = true;
+
+            // Process the messages.
+            containerRuntimeFactory.processAllMessages();
+
+            // Verify that the set value is processed by both clients.
+            assert.equal(map1.get(key), value, "The local client did not process the set");
+            assert.equal(map2.get(key), value, "The remote client did not process the set");
+
+            // Disconnect the first client.
+            containerRuntime2.connected = false;
+
+            // Delete the value from the second SharedMap.
+            map2.delete(key);
+
+            // Reconnect the first client.
+            containerRuntime2.connected = true;
+
+            // Process the messages.
+            containerRuntimeFactory.processAllMessages();
+
+            // Verify that the deleted value is processed by both clients.
+            assert.equal(map1.get(key), undefined, "The local client did not process the delete");
+            assert.equal(map2.get(key), undefined, "The remote client did not process the delete");
+        });
+    });
+
+    describe("SharedDirectory", () => {
+        let containerRuntimeFactory: MockContainerRuntimeFactoryForReconnection;
+        let containerRuntime1: MockContainerRuntimeForReconnection;
+        let containerRuntime2: MockContainerRuntimeForReconnection;
+        let directory1: SharedDirectory;
+        let directory2: SharedDirectory;
+
+        beforeEach(async () => {
+            containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
+
+            // Create the first SharedDirectory.
+            const componentRuntime1 = new MockComponentRuntime();
+            containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime1);
+            const services1 = {
+                deltaConnection: containerRuntime1.createDeltaConnection(),
+                objectStorage: new MockStorage(),
+            };
+            directory1 = new SharedDirectory("shared-directory-1", componentRuntime1, DirectoryFactory.Attributes);
+            directory1.connect(services1);
+
+            // Create the second SharedDirectory.
+            const componentRuntime2 = new MockComponentRuntime();
+            containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const services2 = {
+                deltaConnection: containerRuntime2.createDeltaConnection(),
+                objectStorage: new MockStorage(),
+            };
+            directory2 = new SharedDirectory("shared-directory-2", componentRuntime2, DirectoryFactory.Attributes);
+            directory2.connect(services2);
+        });
+
+        it("can resend unacked ops on reconnection", async () => {
+            const key = "testKey";
+            const value = "testValue";
+            const subDirName = "subDir";
+            const subDirKey = "testSubDirKey";
+            const subDirValue = "testSubDirValue";
+
+            // Set a value on the first SharedDirectory.
+            directory1.set(key, value);
+            // Create a subdirectory and set a value on it.
+            const subDir = directory1.createSubDirectory(subDirName);
+            subDir.set(subDirKey, subDirValue);
+
+            // Disconnect and reconnect the first client.
+            containerRuntime1.connected = false;
+            containerRuntime1.connected = true;
+
+            // Process the messages.
+            containerRuntimeFactory.processAllMessages();
+
+            // Verify that the ops are processed by both clients.
+            assert.equal(directory1.get(key), value, "The local client did not process the set");
+            assert.equal(directory2.get(key), value, "The remote client did not process the set");
+
+            const subDir1 = directory1.getSubDirectory(subDirName);
+            assert.ok(subDir1);
+            assert.equal(subDir1.get(subDirKey), subDirValue);
+
+            const subDir2 = directory2.getSubDirectory(subDirName);
+            assert.ok(subDir2);
+            assert.equal(subDir2.get(subDirKey), subDirValue);
+
+            // Delete the sub directory from the second SharedDirectory.
+            directory2.deleteSubDirectory(subDirName);
+
+            // Disconnect and reconnect the second client.
+            containerRuntime2.connected = false;
+            containerRuntime2.connected = true;
+
+            // Process the messages.
+            containerRuntimeFactory.processAllMessages();
+
+            // Verify that the delete is processed by both clients.
+            assert.equal(
+                directory1.getSubDirectory(subDirName), undefined, "The local client did not delete sub directory");
+            assert.equal(
+                directory2.getSubDirectory(subDirName), undefined, "The remote client did not delete sub directory");
+        });
+
+        it("can store ops in disconnected state and resend them on reconnection", async () => {
+            const key = "testKey";
+            const value = "testValue";
+            const subDirName = "subDir";
+            const subDirKey = "testSubDirKey";
+            const subDirValue = "testSubDirValue";
+
+            // Disconnect the first client.
+            containerRuntime1.connected = false;
+
+            // Set a value on the first SharedDirectory.
+            directory1.set(key, value);
+            // Create a subdirectory and set a value on it.
+            const subDir = directory1.createSubDirectory(subDirName);
+            subDir.set(subDirKey, subDirValue);
+
+            // Reconnect the first client.
+            containerRuntime1.connected = true;
+
+            // Process the messages.
+            containerRuntimeFactory.processAllMessages();
+
+            // Verify that the ops are processed by both clients.
+            assert.equal(directory1.get(key), value, "The local client did not process the set");
+            assert.equal(directory2.get(key), value, "The remote client did not process the set");
+
+            const subDir1 = directory1.getSubDirectory(subDirName);
+            assert.ok(subDir1);
+            assert.equal(subDir1.get(subDirKey), subDirValue);
+
+            const subDir2 = directory2.getSubDirectory(subDirName);
+            assert.ok(subDir2);
+            assert.equal(subDir2.get(subDirKey), subDirValue);
+
+            // Disconnect the second client.
+            containerRuntime2.connected = false;
+
+            // Delete the sub directory from the second SharedDirectory.
+            directory2.deleteSubDirectory(subDirName);
+
+            // Reconnect the second client.
+            containerRuntime2.connected = true;
+
+            // Process the messages.
+            containerRuntimeFactory.processAllMessages();
+
+            // Verify that the delete is processed by both clients.
+            assert.equal(
+                directory1.getSubDirectory(subDirName), undefined, "The local client did not delete sub directory");
+            assert.equal(
+                directory2.getSubDirectory(subDirName), undefined, "The remote client did not delete sub directory");
+        });
+    });
+});

--- a/packages/runtime/map/src/test/reconnection.spec.ts
+++ b/packages/runtime/map/src/test/reconnection.spec.ts
@@ -98,13 +98,13 @@ describe("Reconnection", () => {
             assert.equal(map1.get(key), value, "The local client did not process the set");
             assert.equal(map2.get(key), value, "The remote client did not process the set");
 
-            // Disconnect the first client.
+            // Disconnect the second client.
             containerRuntime2.connected = false;
 
             // Delete the value from the second SharedMap.
             map2.delete(key);
 
-            // Reconnect the first client.
+            // Reconnect the second client.
             containerRuntime2.connected = true;
 
             // Process the messages.

--- a/packages/test/end-to-end/src/test/directoryEndToEndTests.spec.ts
+++ b/packages/test/end-to-end/src/test/directoryEndToEndTests.spec.ts
@@ -553,6 +553,97 @@ describe("Directory", () => {
         });
     });
 
+    describe("Operations in local state", () => {
+        describe("Load new directory with data from local state and process ops", () => {
+            /**
+             * These tests test the scenario found in the following bug:
+             * https://github.com/microsoft/FluidFramework/issues/2400
+             *
+             * - A SharedDirectory in local state performs a set or directory operation.
+             * - A second SharedDirectory is then created from the snapshot of the first one.
+             * - The second SharedDirectory performs the same operation as the first one but with a different value.
+             * - The expected behavior is that the first SharedDirectory updates the key with the new value. But in the
+             *   bug, the first SharedDirectory stores the key in its pending state even though it does not send out an
+             *   an op. So when it gets a remote op with the same key, it ignores it as it has a pending op with the
+             *   same key.
+             */
+
+            it("can process set in local state", async () => {
+                // Create a new directory in local (detached) state.
+                const newDirectory1 = SharedDirectory.create(component1.runtime);
+
+                // Set a value while in local state.
+                newDirectory1.set("newKey", "newValue");
+
+                // Now add the handle to an attached directory so the new directory gets attached too.
+                sharedDirectory1.set("newSharedDirectory", newDirectory1.handle);
+
+                await containerDeltaEventManager.process();
+
+                // The new directory should be availble in the remote client and it should contain that key that was
+                // set in local state.
+                const newDirectory2
+                    = await sharedDirectory2.get<IComponentHandle<SharedDirectory>>("newSharedDirectory").get();
+                assert.equal(
+                    newDirectory2.get("newKey"),
+                    "newValue",
+                    "The data set in local state is not available in directory 2");
+
+                // Set a new value for the same key in the remote directory.
+                newDirectory2.set("newKey", "anotherNewValue");
+
+                await containerDeltaEventManager.process();
+
+                // Verify that the new value is updated in both the directories.
+                assert.equal(
+                    newDirectory2.get("newKey"),
+                    "anotherNewValue",
+                    "The new value is not updated in directory 2");
+                assert.equal(
+                    newDirectory1.get("newKey"),
+                    "anotherNewValue",
+                    "The new value is not updated in directory 1");
+            });
+
+            it("can process sub directory op in local state", async () => {
+                // Create a new directory in local (detached) state.
+                const newDirectory1 = SharedDirectory.create(component1.runtime);
+
+                // Create a sub directory while in local state.
+                const subDirName = "testSubDir";
+                newDirectory1.createSubDirectory(subDirName);
+
+                // Now add the handle to an attached directory so the new directory gets attached too.
+                sharedDirectory1.set("newSharedDirectory", newDirectory1.handle);
+
+                await containerDeltaEventManager.process();
+
+                // The new directory should be availble in the remote client and it should contain that key that was
+                // set in local state.
+                const newDirectory2
+                    = await sharedDirectory2.get<IComponentHandle<SharedDirectory>>("newSharedDirectory").get();
+                assert.ok(
+                    newDirectory2.getSubDirectory(subDirName),
+                    "The subdirectory created in local state is not available in directory 2");
+
+                // Delete the sub directory from the remote client.
+                newDirectory2.deleteSubDirectory(subDirName);
+
+                await containerDeltaEventManager.process();
+
+                // Verify that the sub directory is deleted from both the directories.
+                assert.equal(
+                    newDirectory2.getSubDirectory(subDirName),
+                    undefined,
+                    "The sub directory is not deleted from directory 2");
+                assert.equal(
+                    newDirectory1.getSubDirectory(subDirName),
+                    undefined,
+                    "The sub directory is not deleted from directory 1");
+            });
+        });
+    });
+
     afterEach(async () => {
         await deltaConnectionServer.webSocketServer.close();
     });

--- a/packages/test/end-to-end/src/test/directoryEndToEndTests.spec.ts
+++ b/packages/test/end-to-end/src/test/directoryEndToEndTests.spec.ts
@@ -605,7 +605,7 @@ describe("Directory", () => {
                     "The new value is not updated in directory 1");
             });
 
-            it("can process sub directory op in local state", async () => {
+            it("can process sub directory ops in local state", async () => {
                 // Create a new directory in local (detached) state.
                 const newDirectory1 = SharedDirectory.create(component1.runtime);
 


### PR DESCRIPTION
Fixes #2406.

- Added unit tests and end-to-end tests to verify the scenario in #2400.
- Added unit tests for SharedMap and SharedDirectory that test a client in local state and when its connected and there is a remote client.
- Added reconnection tests for both of them.