### PR TITLE
Add policy exclusions for tutorial code files

### DIFF
--- a/tools/fluid-build-tools/data/exclusions.json
+++ b/tools/fluid-build-tools/data/exclusions.json
@@ -1,4 +1,5 @@
 [
+    "docs/tutorials/.*\\.tsx?",
     "server/routerlicious/packages/services-client/src/dockerNames.ts",
     "tools/generator-fluid/app/templates/"
 ]


### PR DESCRIPTION
These files shouldn't have the copyright header on them, so excluding them from policy-check.