### PR TITLE
Updated SharedCell to not use ClientSequenceNumber and added unit tests

### DIFF
--- a/packages/runtime/cell/package.json
+++ b/packages/runtime/cell/package.json
@@ -54,6 +54,7 @@
     "@fluidframework/component-core-interfaces": "^0.20.0",
     "@fluidframework/component-runtime-definitions": "^0.20.0",
     "@fluidframework/protocol-definitions": "^0.1006.1",
+    "@fluidframework/runtime-utils": "^0.20.0",
     "@fluidframework/shared-object-base": "^0.20.0",
     "debug": "^4.1.1"
   },

--- a/packages/runtime/cell/src/cell.ts
+++ b/packages/runtime/cell/src/cell.ts
@@ -75,7 +75,16 @@ export class SharedCell extends SharedObject<ISharedCellEvents> implements IShar
      */
     private data: any;
 
+    /**
+     * This is used to assign a unique id to outgoing messages. It is used to track messages until
+     * they are ack'd.
+     */
     private messageId: number = -1;
+
+    /**
+     * This keeps track of the messageId of messages that have been ack'd. It is updated every time
+     * we a message is ack'd with it's messageId.
+     */
     private messageIdObserved: number = -1;
 
     /**

--- a/packages/runtime/cell/src/cell.ts
+++ b/packages/runtime/cell/src/cell.ts
@@ -17,6 +17,7 @@ import {
     IComponentRuntime,
     IObjectStorageService,
 } from "@fluidframework/component-runtime-definitions";
+import { strongAssert } from "@fluidframework/runtime-utils";
 import { ISharedObjectFactory, SharedObject, ValueType } from "@fluidframework/shared-object-base";
 import { CellFactory } from "./cellFactory";
 import { debug } from "./debug";
@@ -74,10 +75,8 @@ export class SharedCell extends SharedObject<ISharedCellEvents> implements IShar
      */
     private data: any;
 
-    /**
-     * Tracks the most recent clientSequenceNumber of any pending op, or -1 if there is no pending op.
-     */
-    private pendingClientSequenceNumber: number;
+    private messageId: number = -1;
+    private messageIdObserved: number = -1;
 
     /**
      * Constructs a new shared cell. If the object is non-local an id and service interfaces will
@@ -88,7 +87,6 @@ export class SharedCell extends SharedObject<ISharedCellEvents> implements IShar
      */
     constructor(id: string, runtime: IComponentRuntime, attributes: IChannelAttributes) {
         super(id, runtime, attributes);
-        this.pendingClientSequenceNumber = -1;
     }
 
     /**
@@ -106,17 +104,24 @@ export class SharedCell extends SharedObject<ISharedCellEvents> implements IShar
             throw new Error("SharedObject sets are no longer supported. Instead set the SharedObject handle.");
         }
 
+        // Serialize the value if required.
         const operationValue: ICellValue = {
             type: ValueType[ValueType.Plain],
             value: this.toSerializable(value),
         };
 
+        // Set the value locally.
+        this.setCore(value);
+
+        // If we are in local state, don't submit the op.
+        if (this.isLocal()) {
+            return;
+        }
+
         const op: ISetCellOperation = {
             type: "setCell",
             value: operationValue,
         };
-
-        this.setCore(value);
         this.submitCellMessage(op);
     }
 
@@ -124,11 +129,17 @@ export class SharedCell extends SharedObject<ISharedCellEvents> implements IShar
      * {@inheritDoc ISharedCell.delete}
      */
     public delete() {
+        // Delete the value locally.
+        this.deleteCore();
+
+        // If we are in local state, don't submit the op.
+        if (this.isLocal()) {
+            return;
+        }
+
         const op: IDeleteCellOperation = {
             type: "deleteCell",
         };
-
-        this.deleteCore();
         this.submitCellMessage(op);
     }
 
@@ -222,11 +233,15 @@ export class SharedCell extends SharedObject<ISharedCellEvents> implements IShar
      * For messages from a remote client, this will be undefined.
      */
     protected processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown) {
-        if (this.pendingClientSequenceNumber !== -1) {
+        if (this.messageId !== this.messageIdObserved) {
             // We are waiting for an ACK on our change to this cell - we will ignore all messages until we get it.
-            if (local && message.clientSequenceNumber === this.pendingClientSequenceNumber) {
-                // This is the ACK, so clear pending
-                this.pendingClientSequenceNumber = -1;
+            if (local) {
+                const messageIdReceived = localOpMetadata as number;
+                strongAssert(messageIdReceived !== undefined && messageIdReceived <= this.messageId,
+                    "messageId is incorrect from from the local client's ACK");
+
+                // We got an ACK. Update messageIdObserved.
+                this.messageIdObserved = localOpMetadata as number;
             }
             return;
         }
@@ -260,8 +275,7 @@ export class SharedCell extends SharedObject<ISharedCellEvents> implements IShar
     }
 
     private submitCellMessage(op: ICellOperation): void {
-        // We might already have a pendingClientSequenceNumber, but it doesn't matter - last one wins.
-        this.pendingClientSequenceNumber = this.submitLocalMessage(op);
+        this.submitLocalMessage(op, ++this.messageId);
     }
 
     private toSerializable(value: any) {

--- a/packages/runtime/cell/src/cell.ts
+++ b/packages/runtime/cell/src/cell.ts
@@ -131,7 +131,7 @@ export class SharedCell extends SharedObject<ISharedCellEvents> implements IShar
             type: "setCell",
             value: operationValue,
         };
-        this.submitCellMessage(op);
+        this.submitLocalMessage(op, ++this.messageId);
     }
 
     /**
@@ -149,7 +149,7 @@ export class SharedCell extends SharedObject<ISharedCellEvents> implements IShar
         const op: IDeleteCellOperation = {
             type: "deleteCell",
         };
-        this.submitCellMessage(op);
+        this.submitLocalMessage(op, ++this.messageId);
     }
 
     /**
@@ -281,10 +281,6 @@ export class SharedCell extends SharedObject<ISharedCellEvents> implements IShar
     private deleteCore() {
         this.data = undefined;
         this.emit("delete");
-    }
-
-    private submitCellMessage(op: ICellOperation): void {
-        this.submitLocalMessage(op, ++this.messageId);
     }
 
     private toSerializable(value: any) {

--- a/packages/runtime/cell/src/test/cell.spec.ts
+++ b/packages/runtime/cell/src/test/cell.spec.ts
@@ -4,28 +4,256 @@
  */
 
 import assert from "assert";
-import { MockComponentRuntime } from "@fluidframework/test-runtime-utils";
+import {
+    MockComponentRuntime,
+    MockContainerRuntimeFactory,
+    MockContainerRuntimeFactoryForReconnection,
+    MockContainerRuntimeForReconnection,
+    MockStorage,
+    MockSharedObjectServices,
+} from "@fluidframework/test-runtime-utils";
+import { SharedCell } from "../cell";
 import { CellFactory } from "../cellFactory";
-import { ISharedCell } from "..";
+import { ISharedCell } from "../interfaces";
 
-describe("Routerlicious", () => {
-    describe("Api", () => {
-        describe("cell", () => {
-            let testCell: ISharedCell;
+describe("Cell", () => {
+    let cell: SharedCell;
+    let componentRuntime: MockComponentRuntime;
 
-            beforeEach(async () => {
-                const factory = new CellFactory();
-                testCell = factory.create(new MockComponentRuntime(), "cell");
-            });
+    beforeEach(async () => {
+        componentRuntime = new MockComponentRuntime();
+        cell = new SharedCell("cell", componentRuntime, CellFactory.Attributes);
+    });
 
-            it("Can create a cell", () => {
-                assert.ok(testCell);
-            });
+    describe("SharedCell in local state", () => {
+        beforeEach(() => {
+            componentRuntime.local = true;
+        });
 
-            it("Can set and get cell data", async () => {
-                testCell.set("testValue");
-                assert.equal(testCell.get(), "testValue");
-            });
+        it("Can create a cell", () => {
+            assert.ok(cell, "Could not create a cell");
+        });
+
+        it("Can set and get cell data", () => {
+            cell.set("testValue");
+            assert.equal(cell.get(), "testValue", "Could not retrieve cell value");
+        });
+
+        it("can delete cell data", () => {
+            cell.set("testValue");
+            assert.equal(cell.get(), "testValue", "Could not retrieve cell value");
+
+            cell.delete();
+            assert.equal(cell.get(), undefined, "Could not delete cell value");
+        });
+
+        it("can load a SharedCell from snapshot", async () => {
+            cell.set("testValue");
+            assert.equal(cell.get(), "testValue", "Could not retrieve cell value");
+
+            const services = MockSharedObjectServices.createFromTree(cell.snapshot());
+            const cell2 = new SharedCell("cell2", componentRuntime, CellFactory.Attributes);
+            await cell2.load("branchId", services);
+
+            assert.equal(cell2.get(), "testValue", "Could not load SharedCell from snapshot");
+        });
+    });
+
+    describe("SharedCell op processing in local state", () => {
+        it("should correctly process a set operation sent in local state", async () => {
+            // Set the component runtime to local.
+            componentRuntime.local = true;
+
+            // Set a value in local state.
+            const value = "testValue";
+            cell.set(value);
+
+            // Load a new SharedCell in connected state from the snapshot of the first one.
+            const containerRuntimeFactory = new MockContainerRuntimeFactory();
+            const componentRuntime2 = new MockComponentRuntime();
+            const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const services2 = MockSharedObjectServices.createFromTree(cell.snapshot());
+            services2.deltaConnection = containerRuntime2.createDeltaConnection();
+
+            const cell2 = new SharedCell("cell2", componentRuntime2, CellFactory.Attributes);
+            await cell2.load("branchId", services2);
+
+            // Now connect the first SharedCell
+            componentRuntime.local = false;
+            const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime);
+            const services1 = {
+                deltaConnection: containerRuntime1.createDeltaConnection(),
+                objectStorage: new MockStorage(undefined),
+            };
+            cell.connect(services1);
+
+            // Verify that both the cells have the value.
+            assert.equal(cell.get(), value, "The first cell does not have the key");
+            assert.equal(cell2.get(), value, "The second cell does not have the key");
+
+            // Set a new value in the second SharedCell.
+            const newValue = "newvalue";
+            cell2.set(newValue);
+
+            // Process the message.
+            containerRuntimeFactory.processAllMessages();
+
+            // Verify that both the cells have the new value.
+            assert.equal(cell.get(), newValue, "The first cell did not get the new value");
+            assert.equal(cell2.get(), newValue, "The second cell did not get the new value");
+        });
+    });
+
+    describe("SharedCell in connected state with a remote SharedCell", () => {
+        let cell2: ISharedCell;
+        let containerRuntimeFactory: MockContainerRuntimeFactory;
+
+        beforeEach(() => {
+            containerRuntimeFactory = new MockContainerRuntimeFactory();
+
+            // Connect the first SharedCell.
+            componentRuntime.local = false;
+            const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime);
+            const services1 = {
+                deltaConnection: containerRuntime1.createDeltaConnection(),
+                objectStorage: new MockStorage(),
+            };
+            cell.connect(services1);
+
+            // Create and connect a second SharedCell.
+            const componentRuntime2 = new MockComponentRuntime();
+            const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const services2 = {
+                deltaConnection: containerRuntime2.createDeltaConnection(),
+                objectStorage: new MockStorage(),
+            };
+
+            cell2 = new SharedCell("cell2", componentRuntime2, CellFactory.Attributes);
+            cell2.connect(services2);
+        });
+
+        it("Can set and get cell data", () => {
+            cell.set("testValue");
+
+            containerRuntimeFactory.processAllMessages();
+
+            assert.equal(cell.get(), "testValue", "Could not retrieve cell value");
+            assert.equal(cell2.get(), "testValue", "Could not retrieve cell value from remote client");
+        });
+
+        it("can delete cell data", () => {
+            cell.set("testValue");
+
+            containerRuntimeFactory.processAllMessages();
+
+            assert.equal(cell.get(), "testValue", "Could not retrieve cell value");
+            assert.equal(cell2.get(), "testValue", "Could not retrieve cell value from remote client");
+
+            cell.delete();
+
+            containerRuntimeFactory.processAllMessages();
+
+            assert.equal(cell.get(), undefined, "Could not delete cell value");
+            assert.equal(cell2.get(), undefined, "Could not delete cell value from remote client");
+        });
+    });
+
+    describe("Reconnection flow", () => {
+        let containerRuntimeFactory: MockContainerRuntimeFactoryForReconnection;
+        let containerRuntime1: MockContainerRuntimeForReconnection;
+        let containerRuntime2: MockContainerRuntimeForReconnection;
+        let cell2: ISharedCell;
+
+        beforeEach(() => {
+            containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
+
+            // Connect the first SharedCell.
+            componentRuntime.local = false;
+            containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime);
+            const services1 = {
+                deltaConnection: containerRuntime1.createDeltaConnection(),
+                objectStorage: new MockStorage(),
+            };
+            cell.connect(services1);
+
+            // Create and connect a second SharedCell.
+            const componentRuntime2 = new MockComponentRuntime();
+            containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const services2 = {
+                deltaConnection: containerRuntime2.createDeltaConnection(),
+                objectStorage: new MockStorage(),
+            };
+
+            cell2 = new SharedCell("cell2", componentRuntime2, CellFactory.Attributes);
+            cell2.connect(services2);
+        });
+
+        it("can resend unacked ops on reconnection", async () => {
+            const value = "testValue";
+
+            // Set a value on the first SharedCell.
+            cell.set(value);
+
+            // Disconnect and reconnect the first client.
+            containerRuntime1.connected = false;
+            containerRuntime1.connected = true;
+
+            // Process the messages.
+            containerRuntimeFactory.processAllMessages();
+
+            // Verify that the set value is processed by both clients.
+            assert.equal(cell.get(), value, "The local client did not process the set");
+            assert.equal(cell2.get(), value, "The remote client did not process the set");
+
+            // Delete the value from the second SharedCell.
+            cell2.delete();
+
+            // Disconnect and reconnect the second client.
+            containerRuntime2.connected = false;
+            containerRuntime2.connected = true;
+
+            // Process the messages.
+            containerRuntimeFactory.processAllMessages();
+
+            // Verify that the deleted value is processed by both clients.
+            assert.equal(cell.get(), undefined, "The local client did not process the delete");
+            assert.equal(cell2.get(), undefined, "The remote client did not process the delete");
+        });
+
+        it("can store ops in disconnected state and resend them on reconnection", async () => {
+            const value = "testValue";
+
+            // Disconnect the first client.
+            containerRuntime1.connected = false;
+
+            // Set a value on the first SharedCell.
+            cell.set(value);
+
+            // Reconnect the first client.
+            containerRuntime1.connected = true;
+
+            // Process the messages.
+            containerRuntimeFactory.processAllMessages();
+
+            // Verify that the set value is processed by both clients.
+            assert.equal(cell.get(), value, "The local client did not process the set");
+            assert.equal(cell2.get(), value, "The remote client did not process the set");
+
+            // Disconnect the second client.
+            containerRuntime2.connected = false;
+
+            // Delete the value from the second SharedCell.
+            cell2.delete();
+
+            // Reconnect the second client.
+            containerRuntime2.connected = true;
+
+            // Process the messages.
+            containerRuntimeFactory.processAllMessages();
+
+            // Verify that the deleted value is processed by both clients.
+            assert.equal(cell.get(), undefined, "The local client did not process the delete");
+            assert.equal(cell2.get(), undefined, "The remote client did not process the delete");
         });
     });
 });

--- a/packages/runtime/runtime-test-utils/src/mocks.ts
+++ b/packages/runtime/runtime-test-utils/src/mocks.ts
@@ -697,7 +697,7 @@ export class MockSharedObjectServices implements ISharedObjectServices {
         return new MockSharedObjectServices(contents);
     }
 
-    public deltaConnection = new MockEmptyDeltaConnection();
+    public deltaConnection: IDeltaConnection = new MockEmptyDeltaConnection();
     public objectStorage: MockObjectStorageService;
 
     public constructor(contents: { [key: string]: string }) {


### PR DESCRIPTION
Fixes #2461

- Removed clientSequenceNumber usage from SharedCell. Instead it uses a local messageId to keep track of pending ops.
- Added unit tests with a remote client.
- Added reconnection unit tests.