### PR TITLE
add end-to-end yo tests to CI

### DIFF
--- a/tools/generator-fluid/app/templates/package.json
+++ b/tools/generator-fluid/app/templates/package.json
@@ -7,13 +7,13 @@
   "module": "lib/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "webpack && npm run tsc",
+    "build": "npm run webpack && npm run tsc",
     "start": "npm run start:local -- --open",
     "start:local": "webpack-dev-server --config webpack.config.js --package package.json --env.mode local",
     "start:tiny": "webpack-dev-server --config webpack.config.js --package package.json --env.mode tinylicious",
     "test": "jest",
     "tsc": "tsc",
-    "webpack": "npm run build"
+    "webpack": "webpack"
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.19.5",

--- a/tools/generator-fluid/package.json
+++ b/tools/generator-fluid/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "check": "npm ls --global --depth 0",
     "link": "npm install && npm link",
-    "test": "npm run test:unit",
+    "test": "npm run test:unit & npm run test:end-to-end",
     "test:end-to-end": "mocha test/endToEnd.js -r make-promises-safe",
     "test:unit": "mocha test/testApp.js -r make-promises-safe",
     "unlink": "npm rm --global generator-fluid"


### PR DESCRIPTION
The tests are all there. Just need to enable them and when I did it before it didn't work and didn't want to block the tests getting in.