### PR TITLE
Implement "reducer of concurrency" in snapshot tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "clean:docs": "rimraf **/_api-extractor-temp docs/api/*/**",
     "clean:nyc": "rimraf nyc/**",
     "clean:r11s": "cd server/routerlicious && npm run clean",
-    "postinstall": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" && npm run postinstall:lerna",
+    "postinstall": "npm run postinstall:lerna",
     "layer-check": "fluid-layer-check",
     "lint": "lerna run lint --no-sort --stream",
     "lint:fix": "lerna run lint:fix --no-sort --stream",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -22,7 +22,6 @@
     "test:coverage": "nyc npm test -- --reporter mocha-junit-reporter --reporter-options mochaFile=nyc/junit-report.xml",
     "test:generate": "node --experimental-worker dist/generateSnapshotFiles.js",
     "test:mocha": "mocha --experimental-worker --recursive dist/test --exit -r make-promises-safe",
-    "test:sequential": "mocha --recursive dist/test --exit -r make-promises-safe",
     "tsc": "tsc",
     "tsfmt": "tsfmt --verify",
     "tsfmt:fix": "tsfmt --replace"
@@ -48,6 +47,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
+    "@fluidframework/common-utils": "^0.19.1",
     "@fluidframework/protocol-definitions": "^0.1006.1",
     "@fluidframework/replay-tool": "^0.20.0"
   },

--- a/packages/test/snapshots/src/replayMultipleFiles.ts
+++ b/packages/test/snapshots/src/replayMultipleFiles.ts
@@ -3,10 +3,14 @@
  * Licensed under the MIT License.
  */
 
+import assert from "assert";
 import fs from "fs";
 import { ReplayArgs, ReplayTool } from "@fluidframework/replay-tool";
+import { Deferred } from "@fluidframework/common-utils";
 
 const fileLocation: string = "content/snapshotTestContent";
+
+const numberOfThreads = 4;
 
 export enum Mode {
     Write,   // Write out files
@@ -18,6 +22,38 @@ export interface IWorkerArgs {
     folder: string;
     mode: Mode;
     snapFreq: number;
+}
+
+class ConcurrencyLimiter {
+    private readonly promises: Promise<void>[] = [];
+    private deferred: Deferred<void> | undefined;
+
+    constructor(private limit: number) { }
+
+    async addWork(worker: () => Promise<void>) {
+        this.limit--;
+        if (this.limit < 0) {
+            assert(this.deferred === undefined);
+            this.deferred = new Deferred<void>();
+            await this.deferred.promise;
+            assert(this.deferred === undefined);
+            assert(this.limit >= 0);
+        }
+
+        const p = worker().then(() => {
+            this.limit++;
+            if (this.deferred) {
+                assert(this.limit === 0);
+                this.deferred.resolve();
+                this.deferred = undefined;
+            }
+        });
+        this.promises.push(p);
+    }
+
+    async waitAll() {
+        return Promise.all(this.promises);
+    }
 }
 
 export async function processOneFile(args: IWorkerArgs) {
@@ -51,8 +87,6 @@ export async function processOneFile(args: IWorkerArgs) {
 }
 
 export async function processContent(mode: Mode, concurrently = true) {
-    const promises: Promise<unknown>[] = [];
-
     // "worker_threads" does not resolve without --experimental-worker flag on command line
     let threads: typeof import("worker_threads");
     try {
@@ -60,6 +94,8 @@ export async function processContent(mode: Mode, concurrently = true) {
         threads.Worker.EventEmitter.defaultMaxListeners = 20;
     } catch (err) {
     }
+
+    const limiter = new ConcurrencyLimiter(numberOfThreads);
 
     for (const node of fs.readdirSync(fileLocation, { withFileTypes: true })) {
         if (!node.isDirectory()) {
@@ -80,19 +116,18 @@ export async function processContent(mode: Mode, concurrently = true) {
         // 1) Stress test - testing eventual consistency only
         // 2) Testing backward compat - only testing snapshots at every 1000 ops
         const snapFreq = mode === Mode.Stress ? 50 : 1000;
-        const workerData: IWorkerArgs = {
+        const data: IWorkerArgs = {
             folder,
             mode,
             snapFreq,
         };
 
         if (!concurrently || !threads) {
-            console.log(folder);
-            await processOneFile(workerData);
+            await processOneFile(data);
             continue;
         }
 
-        const work = new Promise((resolve, reject) => {
+        await (async (workerData: IWorkerArgs) => limiter.addWork(async () => new Promise((resolve, reject) => {
             const worker = new threads.Worker("./dist/replayWorker.js", { workerData });
 
             worker.on("message", (error: string) => {
@@ -115,10 +150,8 @@ export async function processContent(mode: Mode, concurrently = true) {
                 }
                 resolve();
             });
-        });
-
-        promises.push(work);
+        })))(data);
     }
 
-    return Promise.all(promises);
+    return limiter.waitAll();
 }


### PR DESCRIPTION
I'm limiting it to 4 threads, which in my experience reduces memory consumption by 2x, but also increases test runtime 2x.