### PR TITLE
Yo fluid add scaffolding option

### DIFF
--- a/tools/generator-fluid/README.md
+++ b/tools/generator-fluid/README.md
@@ -2,6 +2,8 @@
 
 Use this tool to quickly bootstrap a new Fluid component package based on the example [Dice Roller](//TODO:Add-Link) Fluid component.
 
+The generator can bootstrap with a beginner or advanced scaf
+
 ## Basic Getting Started
 
 To get started ensure you have [Node.js](https://nodejs.org/en/) and [Git](https://git-scm.com/) installed, then install [Yeoman](https://yeoman.io/) and the [Fluid Component Generator](https://www.npmjs.com/package/generator-fluid) with:
@@ -31,7 +33,30 @@ npm start
 
 ## Directory Structure
 
-When running the generator a new folder will be generated with the following contents:
+There are two types of structure outputs depending on your scaffolding choice.
+
+### Beginner Scaffolding
+
+Use beginner scaffolding if you are new to the Fluid Framework, are looking to prototype, or are unfamiliar with
+existing web technologies.
+
+```text
+.
+├── src
+|   ├── component.ts(x)            // Fluid Component source code with view
+|   └── index.ts                   // Export file
+├── .gitignore                     // Ignore dist and node_modules
+├── jest-puppeteer.config.js       // jest-puppeteer configuration
+├── jest.config.js                 // Jest configuration
+├── package.json                   // Package manifest
+├── README.md                      // Description of your component's functionality
+├── tsconfig.json                  // TypeScript configuration
+└── webpack.config.js              // Webpack configuration
+```
+
+### Advanced Scaffolding
+
+Use advanced scaffolding if you have a strong understanding of TypeScript and are looking to build a Fluid component that will scale.
 
 ```text
 .
@@ -49,20 +74,22 @@ When running the generator a new folder will be generated with the following con
 └── webpack.config.js              // Webpack configuration
 ```
 
-## Advanced (Command Line)
+## Command Line
 
 ```text
 Usage:
   yo fluid [<componentName>] [options]
 
 Options:
-  -h,    --help           # Print the generator's options and usage
-         --skip-cache     # Do not remember prompt answers               Default: false
-         --skip-install   # Do not automatically install dependencies    Default: false
-         --force-install  # Fail on install dependencies error           Default: false
-         --ask-answered   # Show prompts for already configured options  Default: false
-  -r,    --react          # Sets React as Default View
-  -v,    --vanilla        # Sets VanillaJS as Default View
+  -h,   --help           # Print the generator's options and usage
+        --skip-cache     # Do not remember prompt answers               Default: false
+        --skip-install   # Do not automatically install dependencies    Default: false
+        --force-install  # Fail on install dependencies error           Default: false
+        --ask-answered   # Show prompts for already configured options  Default: false
+        --view-react     # Sets React as Default View
+        --view-none      # Sets None as Default View
+        --beginner       # Sets beginner as scaffolding
+        --advanced       # Sets advanced as scaffolding
 
 Arguments:
   componentName  # Defines the Component Name  Type: String  Required: false

--- a/tools/generator-fluid/app/index.js
+++ b/tools/generator-fluid/app/index.js
@@ -58,14 +58,14 @@ module.exports = class extends Generator {
     
     // Adding two options to specify the scaffolding inline
     this.option(
-      "s-beginner",
+      scaffoldingBeginner,
       {
-        description: "Sets beginner as scaffolding",
+        description: `Sets ${scaffoldingBeginner} as scaffolding`,
       });
     this.option(
-      "s-production",
+      scaffoldingAdvanced,
       {
-        description: "Sets production as scaffolding",
+        description: `Sets ${scaffoldingAdvanced} as scaffolding`,
       });
 
     // Adding argument to specify the component name inline
@@ -100,13 +100,13 @@ module.exports = class extends Generator {
       questionsCollection.push(questions.viewFramework);
     }
 
-    if (this.options["s-beginner"] && this.options["s-production"]) {
-      this.log(chalk.red("Both --s-beginner and --s-production options have been included. Prompting question."));
-      delete this.options["s-beginner"];
-      delete this.options["s-production"];
+    if (this.options[scaffoldingBeginner] && this.options[scaffoldingAdvanced]) {
+      this.log(chalk.red(`Both --${scaffoldingBeginner} and --${scaffoldingAdvanced} options have been included. Prompting question.`));
+      delete this.options[scaffoldingBeginner];
+      delete this.options[scaffoldingAdvanced];
     }
 
-    if (this.options["s-beginner"] || this.options["s-production"]) {
+    if (this.options[scaffoldingBeginner] || this.options[scaffoldingAdvanced]) {
       this.log(`${chalk.green("?")} ${questions.scaffolding.message} ${chalk.blue(this._isBeginnerScaffolding ? scaffoldingBeginner : scaffoldingAdvanced)}`)
     } else {
       questionsCollection.push(questions.scaffolding);

--- a/tools/generator-fluid/app/index.js
+++ b/tools/generator-fluid/app/index.js
@@ -402,7 +402,7 @@ module.exports = class extends Generator {
     const project = new Project({});
 
     return project.createSourceFile(
-      this.destinationPath(currentFilePath),
+      this.destinationPath(destinationPath),
       fileString,
     );
   }

--- a/tools/generator-fluid/app/templates/README-Simple.md
+++ b/tools/generator-fluid/app/templates/README-Simple.md
@@ -1,0 +1,102 @@
+# A Fluid Component Appeared...
+
+This project was bootstrapped with the [yo-fluid generator](...)
+
+## Getting Started
+
+### Running your Fluid Component
+
+To start testing run the following:
+
+```bash
+    npm start
+```
+
+### Code Structure
+
+All the code logic lives within the `./src` folder. There are 4 files that makeup a basic component.
+
+The important thing to note is that the Fluid component represents the data model which is separated out from our view via an interface. This separation allows us to build view agnostic, reusable, and scalable Fluid component objects.
+
+#### `./src/component<%= extension %>`
+
+The `component<%= extension %>` file contains the Fluid component and the logic for our data model.
+
+#### `./src/index.ts`
+
+The `index.ts` file is not very interesting and simply defines our exports. We are exporting two things:
+
+**The Fluid component itself** which allows other packages to consume the Fluid component object directly.
+
+**The `fluidExport`** which points to our Fluid component factory is used for dynamic Fluid component loading. Our `webpack-component-loader` uses this to find the Fluid component entry point when running `npm start`.
+
+#### `./src/interface.ts`
+
+The `interface.ts` file defines the interface between our Fluid component and our view. This abstraction is important to ensure we are building reusable and scalable components.
+
+#### `./src/view<%= extension %>`
+
+The `view<%= extension %>` file contains all the view logic.
+
+### Directory Anatomy
+
+```text
+.
+├── src
+|   ├── component<%= extension %>              // Fluid Component source code
+|   └── index.ts                   // Export file
+├── .gitignore                     // Ignore dist and node_modules
+├── jest-puppeteer.config.js       // jest-puppeteer configuration
+├── jest.config.js                 // Jest configuration
+├── package.json                   // Package manifest
+├── README.md                      // Description of your component's functionality
+├── tsconfig.json                  // TypeScript configuration
+└── webpack.config.js              // Webpack configuration
+```
+
+## Available Scripts
+
+Below are the following available scripts. They can be run from the project root with the following command:
+
+```bash
+npm run [script-name]
+```
+
+### `build`
+
+Runs [`tsc`](###-tsc) and [`webpack`](###-webpack) and outputs the results in `./dist`.
+
+### `start`
+
+A shortcut cmd from `start:local`
+
+### `start:local`
+
+Uses `webpack-dev-server` to start a local webserver that will host your webpack file.
+
+Once you run `start:local` you can navigate to `http://localhost:8080` in any browser window to test your fluid example.
+
+Uses [sessionStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) and an in memory Fluid Server implementation to allow for fluid collaboration within a Tab instance.
+
+### `start:tiny`
+
+> Requires `tinylicious` Fluid server running locally at `http://localhost:3000`.
+
+Uses `webpack-dev-server` to start a local webserver that will host your webpack file.
+
+Once you run `start:local` you can navigate to `http://localhost:8080` in any browser window to test your fluid example.
+
+`tinylicious` is a Fluid server implementation that runs locally and
+allows for cross browser/tab testing. To learn more about `tinylicious` go to `TODO://ADD LINK`
+
+### `test`
+
+Runs end to end test using [Jest](https://jestjs.io/) and [Puppeteer](https://github.com/puppeteer/puppeteer/).
+
+### `tsc`
+
+Compiles the TypeScript code. Output is written to the ./dist folder.
+
+### `webpack`
+
+Compiles and webpacks the TypeScript code. Output is written to the ./dist folder.

--- a/tools/generator-fluid/app/templates/README-Simple.md
+++ b/tools/generator-fluid/app/templates/README-Simple.md
@@ -20,7 +20,7 @@ The important thing to note is that the Fluid component represents the data mode
 
 #### `./src/component<%= extension %>`
 
-The `component<%= extension %>` file contains the Fluid component and the logic for our data model.
+The `component<%= extension %>` file contains the Fluid component as well as the view logic.
 
 #### `./src/index.ts`
 
@@ -29,14 +29,6 @@ The `index.ts` file is not very interesting and simply defines our exports. We a
 **The Fluid component itself** which allows other packages to consume the Fluid component object directly.
 
 **The `fluidExport`** which points to our Fluid component factory is used for dynamic Fluid component loading. Our `webpack-component-loader` uses this to find the Fluid component entry point when running `npm start`.
-
-#### `./src/interface.ts`
-
-The `interface.ts` file defines the interface between our Fluid component and our view. This abstraction is important to ensure we are building reusable and scalable components.
-
-#### `./src/view<%= extension %>`
-
-The `view<%= extension %>` file contains all the view logic.
 
 ### Directory Anatomy
 

--- a/tools/generator-fluid/app/templates/src/component-simple.ts
+++ b/tools/generator-fluid/app/templates/src/component-simple.ts
@@ -1,0 +1,63 @@
+import {
+    PrimedComponent,
+    PrimedComponentFactory,
+} from "@fluidframework/aqueduct";
+import { IComponentHTMLView } from "@fluidframework/view-interfaces";
+
+const diceValueKey = "diceValue";
+
+/**
+ * Fluid component
+ */
+export class DiceRoller extends PrimedComponent implements IComponentHTMLView {
+    public static get ComponentName() { return "dice-roller"; }
+
+    public get IComponentHTMLView() { return this; }
+
+    /**
+     * The factory defines how to create an instance of the component as well as the
+     * dependencies of the component.
+     */
+    public static readonly factory = new PrimedComponentFactory(
+        DiceRoller.ComponentName,
+        DiceRoller,
+        [],
+        {},
+    );
+
+    /**
+     * componentInitializingFirstTime is called only once, it is executed only by the first client to open the
+     * component and all work will resolve before the view is presented to any user.
+     *
+     * This method is used to perform component setup, which can include setting an initial schema or initial values.
+     */
+    protected async componentInitializingFirstTime() {
+        this.root.set(diceValueKey, 1);
+    }
+
+    /**
+     * Render the dice.
+     */
+    public render(div: HTMLElement) {
+        const diceSpan = document.createElement("span");
+        diceSpan.classList.add("diceSpan");
+        diceSpan.style.fontSize = "50px";
+        diceSpan.textContent = this.root.get(diceValueKey);
+        div.appendChild(diceSpan);
+
+        const rollButton = document.createElement("button");
+        rollButton.classList.add("rollButton");
+        rollButton.textContent = "Roll";
+        rollButton.onclick = () => {
+            const rollValue = Math.floor(Math.random() * 6) + 1;
+            this.root.set(diceValueKey, rollValue);
+        };
+        div.appendChild(rollButton);
+
+        // When the value of the dice changes we will re-render the
+        // value in the dice span
+        this.root.on("valueChanged", () => {
+            diceSpan.textContent = this.root.get(diceValueKey);
+        });
+    }
+}

--- a/tools/generator-fluid/app/templates/src/component-simple.ts
+++ b/tools/generator-fluid/app/templates/src/component-simple.ts
@@ -39,10 +39,13 @@ export class DiceRoller extends PrimedComponent implements IComponentHTMLView {
      * Render the dice.
      */
     public render(div: HTMLElement) {
+        const getDiceChar = (): string => {
+            return String.fromCodePoint(0x267F + this.root.get(diceValueKey));
+        };
         const diceSpan = document.createElement("span");
         diceSpan.classList.add("diceSpan");
         diceSpan.style.fontSize = "50px";
-        diceSpan.textContent = this.root.get(diceValueKey);
+        diceSpan.textContent = getDiceChar();
         div.appendChild(diceSpan);
 
         const rollButton = document.createElement("button");
@@ -57,7 +60,7 @@ export class DiceRoller extends PrimedComponent implements IComponentHTMLView {
         // When the value of the dice changes we will re-render the
         // value in the dice span
         this.root.on("valueChanged", () => {
-            diceSpan.textContent = this.root.get(diceValueKey);
+            diceSpan.textContent = getDiceChar();
         });
     }
 }

--- a/tools/generator-fluid/app/templates/src/component-simple.tsx
+++ b/tools/generator-fluid/app/templates/src/component-simple.tsx
@@ -1,0 +1,87 @@
+import {
+    PrimedComponent,
+    PrimedComponentFactory,
+} from "@fluidframework/aqueduct";
+import { ISharedDirectory } from "@fluidframework/map";
+import { IComponentHTMLView } from "@fluidframework/view-interfaces";
+
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+
+const diceValueKey = "diceValue";
+
+/**
+ * Fluid component
+ */
+export class DiceRoller extends PrimedComponent implements IComponentHTMLView {
+    public static get ComponentName() { return "dice-roller"; }
+
+    public get IComponentHTMLView() { return this; }
+
+    /**
+     * The factory defines how to create an instance of the component as well as the
+     * dependencies of the component.
+     */
+    public static readonly factory = new PrimedComponentFactory(
+        DiceRoller.ComponentName,
+        DiceRoller,
+        [],
+        {},
+    );
+
+    /**
+     * componentInitializingFirstTime is called only once, it is executed only by the first client to open the
+     * component and all work will resolve before the view is presented to any user.
+     *
+     * This method is used to perform component setup, which can include setting an initial schema or initial values.
+     */
+    protected async componentInitializingFirstTime() {
+        this.root.set(diceValueKey, 1);
+    }
+
+    /**
+     * Render the dice.
+     */
+    public render(div: HTMLElement) {
+        ReactDOM.render(
+            <DiceRollerView root={this.root} />,
+            div,
+        );
+    }
+}
+
+interface IProps {
+    root: ISharedDirectory;
+}
+
+interface IState {
+    value: number;
+}
+
+class DiceRollerView extends React.Component<IProps, IState>{
+    constructor(props:IProps) {
+        super(props);
+        
+        this.state = {
+            value: props.root.get(diceValueKey)
+        }
+
+        props.root.on("valueChanged", () => {
+            this.setState({value: this.props.root.get(diceValueKey)})
+        });
+    }
+
+    roll = () => {
+        const rollValue = Math.floor(Math.random() * 6) + 1;
+        this.props.root.set(diceValueKey, rollValue);
+    };
+
+    render() {
+        return (
+            <div>
+                <span style={{ fontSize: 50 }}>{this.state.value}</span>
+                <button onClick={this.roll}>Roll</button>
+            </div>
+        );
+    }
+}

--- a/tools/generator-fluid/app/templates/src/component-simple.tsx
+++ b/tools/generator-fluid/app/templates/src/component-simple.tsx
@@ -76,10 +76,14 @@ class DiceRollerView extends React.Component<IProps, IState>{
         this.props.root.set(diceValueKey, rollValue);
     };
 
+    getDiceChar = (): string => {
+        return String.fromCodePoint(0x267F + this.state.value)
+    };
+
     render() {
         return (
             <div>
-                <span style={{ fontSize: 50 }}>{this.state.value}</span>
+                <span style={{ fontSize: 50 }}>{this.getDiceChar()}</span>
                 <button onClick={this.roll}>Roll</button>
             </div>
         );

--- a/tools/generator-fluid/test/endToEnd.js
+++ b/tools/generator-fluid/test/endToEnd.js
@@ -13,7 +13,7 @@ describe("Yo fluid", function () {
     this.timeout(300000);
 
     describe("End to End", () => {
-        describe("View - React", () => {
+        describe("View - React - beginner", () => {
             let runContext;
             let dirPath;
             let oldCwd;
@@ -22,7 +22,8 @@ describe("Yo fluid", function () {
                 runContext = helpers.run(path.join(__dirname, "../app/index.js"))
                     .withPrompts({
                         componentName: "foobar",
-                        viewFramework: "react"
+                        viewFramework: "react",
+                        scaffolding: "beginner",
                     }).inTmpDir((dir) => {
                         dirPath = dir
                     });
@@ -56,7 +57,7 @@ describe("Yo fluid", function () {
             });
         });
 
-        describe("View - None", () => {
+        describe("View - React - advanced", () => {
             let runContext;
             let dirPath;
             let oldCwd;
@@ -65,7 +66,96 @@ describe("Yo fluid", function () {
                 runContext = helpers.run(path.join(__dirname, "../app/index.js"))
                     .withPrompts({
                         componentName: "foobar",
-                        viewFramework: "none"
+                        viewFramework: "react",
+                        scaffolding: "advanced",
+                    }).inTmpDir((dir) => {
+                        dirPath = dir
+                    });
+                return runContext;
+            });
+
+            it("installs and runs tests tests with output", () => {
+                // Validate that there is an expected file
+                const expectedFiles = ["README.md"];
+                assert.file(expectedFiles);
+
+                // Navigate to the temp folder that 
+                const tempComponentPath = `${dirPath}/foobar`;
+                shell.echo(`Navigating to temp path ${tempComponentPath}`);
+                shell.cd(tempComponentPath);
+
+                // Navigate to the temp folder that is created
+                shell.echo("Running npm i - this can take some time...");
+                const installResponse = shell.exec("npm i", { silent: true });
+                assert.equal(installResponse.code, 0, `npm install failed with code: ${installResponse.code} - error: ${installResponse.stderr}`);
+                
+                // Run jest test for new component
+                shell.echo("Running npm test - this can take some time...");
+                const testResponse = shell.exec("npm test", { silent: true });
+                assert.equal(testResponse.code && testResponse.code, 0, `npm test failed with code: ${testResponse.code} - error: ${testResponse.stderr}`);
+            });
+
+            after(() => {
+                process.chdir(oldCwd);
+                runContext.cleanTestDirectory();
+            });
+        });
+
+        describe("View - None - beginner", () => {
+            let runContext;
+            let dirPath;
+            let oldCwd;
+            before(() => {
+                oldCwd = process.cwd();
+                runContext = helpers.run(path.join(__dirname, "../app/index.js"))
+                    .withPrompts({
+                        componentName: "foobar",
+                        viewFramework: "none",
+                        scaffolding: "beginner",
+                    }).inTmpDir((dir) => {
+                        dirPath = dir
+                    });
+                return runContext;
+            });
+
+            it("installs and runs tests tests with output", () => {
+                // Validate that there is an expected file
+                const expectedFiles = ["README.md"];
+                assert.file(expectedFiles);
+
+                // Navigate to the temp folder that 
+                const tempComponentPath = `${dirPath}/foobar`;
+                shell.echo(`Navigating to temp path ${tempComponentPath}`);
+                shell.cd(tempComponentPath);
+
+                // Navigate to the temp folder that is created
+                shell.echo("Running npm i - this can take some time...");
+                const installResponse = shell.exec("npm i", { silent: true });
+                assert.equal(installResponse.code, 0, `npm install failed with code: ${installResponse.code} - error: ${installResponse.stderr}`);
+                
+                // Run jest test for new component
+                shell.echo("Running npm test - this can take some time...");
+                const testResponse = shell.exec("npm test", { silent: true });
+                assert.equal(testResponse.code && testResponse.code, 0, `npm test failed with code: ${testResponse.code} - error: ${testResponse.stderr}`);
+            });
+
+            after(() => {
+                process.chdir(oldCwd);
+                runContext.cleanTestDirectory();
+            });
+        });
+        
+        describe("View - None - advance", () => {
+            let runContext;
+            let dirPath;
+            let oldCwd;
+            before(() => {
+                oldCwd = process.cwd();
+                runContext = helpers.run(path.join(__dirname, "../app/index.js"))
+                    .withPrompts({
+                        componentName: "foobar",
+                        viewFramework: "none",
+                        scaffolding: "advanced",
                     }).inTmpDir((dir) => {
                         dirPath = dir
                     });

--- a/tools/generator-fluid/test/testApp.js
+++ b/tools/generator-fluid/test/testApp.js
@@ -13,7 +13,7 @@ describe("Yo fluid", function () {
     this.timeout(10000);
 
     describe("Unit", () => {
-        describe("View - React", () => {
+        describe("View - React - advanced", () => {
             let runContext;
             let oldCwd;
             before(() => {
@@ -21,7 +21,8 @@ describe("Yo fluid", function () {
                 runContext = helpers.run(path.join(__dirname, "../app/index.js"))
                     .withPrompts({
                         componentName: "foobar",
-                        viewFramework: "react"
+                        viewFramework: "react",
+                        scaffolding: "advanced",
                     });
                 return runContext;
             });
@@ -56,7 +57,7 @@ describe("Yo fluid", function () {
             });
         });
 
-        describe("View - None", () => {
+        describe("View - React - beginner", () => {
             let runContext;
             let oldCwd;
             before(() => {
@@ -64,7 +65,50 @@ describe("Yo fluid", function () {
                 runContext = helpers.run(path.join(__dirname, "../app/index.js"))
                     .withPrompts({
                         componentName: "foobar",
-                        viewFramework: "none"
+                        viewFramework: "react",
+                        scaffolding: "beginner",
+                    });
+                return runContext;
+            });
+
+            it("Produces the expected files", () => {
+                const expectedFiles = [
+                    "src/component.tsx",
+                    "src/index.ts",
+                    ".gitignore",
+                    ".npmrc",
+                    "jest-puppeteer.config.js",
+                    "jest.config.js",
+                    "package.json",
+                    "README.md",
+                    "tsconfig.json",
+                    "webpack.config.js",
+                ]
+                assert.file(expectedFiles);
+
+                const unexpectedFiles = [
+                    "src/component.ts",
+                    "src/view.ts",
+                ]
+                assert.noFile(unexpectedFiles);
+            });
+
+            after(() => {
+                process.chdir(oldCwd);
+                runContext.cleanTestDirectory();
+            });
+        });
+
+        describe("View - None - advanced", () => {
+            let runContext;
+            let oldCwd;
+            before(() => {
+                oldCwd = process.cwd();
+                runContext = helpers.run(path.join(__dirname, "../app/index.js"))
+                    .withPrompts({
+                        componentName: "foobar",
+                        viewFramework: "none",
+                        scaffolding: "advanced",
                     });
                 return runContext;
             });
@@ -75,6 +119,49 @@ describe("Yo fluid", function () {
                     "src/index.ts",
                     "src/interface.ts",
                     "src/view.ts",
+                    ".gitignore",
+                    ".npmrc",
+                    "jest-puppeteer.config.js",
+                    "jest.config.js",
+                    "package.json",
+                    "README.md",
+                    "tsconfig.json",
+                    "webpack.config.js",
+                ]
+                assert.file(expectedFiles);
+
+                const unexpectedFiles = [
+                    "src/component.tsx",
+                    "src/view.tsx",
+                ]
+                assert.noFile(unexpectedFiles);
+            });
+
+            after(() => {
+                process.chdir(oldCwd);
+                runContext.cleanTestDirectory();
+            });
+        });
+
+        
+        describe("View - None - beginner", () => {
+            let runContext;
+            let oldCwd;
+            before(() => {
+                oldCwd = process.cwd();
+                runContext = helpers.run(path.join(__dirname, "../app/index.js"))
+                    .withPrompts({
+                        componentName: "foobar",
+                        viewFramework: "none",
+                        scaffolding: "beginner",
+                    });
+                return runContext;
+            });
+
+            it("Produces the expected files", () => {
+                const expectedFiles = [
+                    "src/component.ts",
+                    "src/index.ts",
                     ".gitignore",
                     ".npmrc",
                     "jest-puppeteer.config.js",


### PR DESCRIPTION
This is a draft pr to add a scaffolding option to yo fluid. the options are beginner and advanced and it defaults to beginner. The beginner is a single component file with the minimal possible to enable the dice roller scenario. I stuck to classes for react and don't even have a separate class for the view-none.

I expose the data structures directly in the view to make it simple. I think this represents a good teaching tool while keeping around the advanced in hopes that developers will quickly upgrade their skills.

Having them answer the question will probably lead the to beginner at first but then having them want more.