### PR TITLE
Fix mismatch build-common version in new server package

### DIFF
--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -39,7 +39,7 @@
     "winston": "^3.1.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.16.0",
+    "@fluidframework/build-common": "^0.17.0-0",
     "@fluidframework/eslint-config-fluid": "^0.18.0-0",
     "@types/debug": "^4.1.5",
     "@types/lodash": "^4.14.118",


### PR DESCRIPTION
Two PR collide and the build-common version became mismatched in the server project.