### PR TITLE
update docker-compose & verdaccio permissions

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -71,7 +71,7 @@ services:
             - NODE_ENV=development
         restart: always
     historian:
-        image: prague.azurecr.io/historian:5109
+        image: prague.azurecr.io/historian:30824
         ports:
             - "3001:3000"
         environment:
@@ -79,7 +79,7 @@ services:
             - NODE_ENV=development
         restart: always
     gitrest:
-        image: prague.azurecr.io/gitrest:4048
+        image: prague.azurecr.io/gitrest:30825
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
@@ -135,12 +135,7 @@ services:
         ports:
             - "4873:4873"
         volumes:
-            - ./verdaccio/conf:/verdaccio/conf
-    headless-agent:
-        image: prague.azurecr.io/headless-agent:6258
-        cap_add:
-            - SYS_ADMIN
-        restart: always
+            - ./routerlicious/verdaccio/conf:/verdaccio/conf
 volumes:
   git:
     driver: local

--- a/server/routerlicious/docker-compose.yml
+++ b/server/routerlicious/docker-compose.yml
@@ -87,7 +87,7 @@ services:
             - NODE_ENV=development
         restart: always
     historian:
-        image: prague.azurecr.io/historian:5109
+        image: prague.azurecr.io/historian:30824
         ports:
             - "3001:3000"
         environment:
@@ -95,7 +95,7 @@ services:
             - NODE_ENV=development
         restart: always
     gitrest:
-        image: prague.azurecr.io/gitrest:4048
+        image: prague.azurecr.io/gitrest:30825
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
@@ -152,11 +152,6 @@ services:
             - "4873:4873"
         volumes:
             - ./verdaccio/conf:/verdaccio/conf
-    headless-agent:
-        image: prague.azurecr.io/headless-agent:6258
-        cap_add:
-            - SYS_ADMIN
-        restart: always
 volumes:
   git:
     driver: local

--- a/server/routerlicious/verdaccio/conf/config.yaml
+++ b/server/routerlicious/verdaccio/conf/config.yaml
@@ -40,8 +40,8 @@ publish:
 packages:
   '@*/*':
     # scoped packages
-    access: $authenticated
-    publish: $authenticated
+    access: $all
+    publish: $all
     proxy: npmjs
 
   '**':
@@ -50,11 +50,11 @@ packages:
     #
     # you can specify usernames/groupnames (depending on your auth plugin)
     # and three keywords: "$all", "$anonymous", "$authenticated"
-    access: $authenticated
+    access: $all
 
     # allow all known users to publish packages
     # (anyone can register by default, remember?)
-    publish: $authenticated
+    publish: $all
 
     # if package is not available locally, proxy requests to 'npmjs' registry
     proxy: npmjs


### PR DESCRIPTION
We can have verdaccio be unauthenticated because it'll only be used for local docker usage. This should make things a bit simpler.