### PR TITLE
Fix MergeTree Reconnect and Tests

### DIFF
--- a/packages/runtime/merge-tree/src/client.ts
+++ b/packages/runtime/merge-tree/src/client.ts
@@ -720,7 +720,7 @@ export class Client {
         assert(segmentGroup === NACKedSegmentGroup, "Segment group not at head of merge tree pending queue");
 
         const opList = [];
-        for (const segment of segmentGroup.segments) {
+        for (const segment of segmentGroup.segments.sort((a, b) => a.ordinal < b.ordinal ? -1 : 1)) {
             const segmentSegGroup = segment.segmentGroups.dequeue();
             assert(segmentGroup === segmentSegGroup,
                 "Segment group not at head of segment pending queue");
@@ -744,10 +744,11 @@ export class Client {
                     break;
 
                 case ops.MergeTreeDeltaType.REMOVE:
-                    assert(segment.removedSeq === UnassignedSequenceNumber);
-                    newOp = OpBuilder.createRemoveRangeOp(
-                        segmentPosition,
-                        segmentPosition + segment.cachedLength);
+                    if (segment.localRemovedSeq !== undefined) {
+                        newOp = OpBuilder.createRemoveRangeOp(
+                            segmentPosition,
+                            segmentPosition + segment.cachedLength);
+                    }
                     break;
 
                 default:

--- a/packages/runtime/merge-tree/src/client.ts
+++ b/packages/runtime/merge-tree/src/client.ts
@@ -720,6 +720,11 @@ export class Client {
         assert(segmentGroup === NACKedSegmentGroup, "Segment group not at head of merge tree pending queue");
 
         const opList = [];
+        // We need to sort the segments by ordinal, as the segments are not sorted in the segment group.
+        // The reason they need them sorted, as they have the same local sequnence number and which means
+        // farther segments will  take into account nearer segements when calcualting their position.
+        // By sorting we ensure the nearer segment will be applied and sequenced before the father segments
+        // so their recalulated positions will be correct.
         for (const segment of segmentGroup.segments.sort((a, b) => a.ordinal < b.ordinal ? -1 : 1)) {
             const segmentSegGroup = segment.segmentGroups.dequeue();
             assert(segmentGroup === segmentSegGroup,

--- a/packages/runtime/merge-tree/src/test/client.reconnectFarm.spec.ts
+++ b/packages/runtime/merge-tree/src/test/client.reconnectFarm.spec.ts
@@ -50,7 +50,7 @@ function applyMessagesWithReconnect(
                 opData[0],
                 opData[1],
             ));
-            newMsg.minimumSequenceNumber = minSeq;
+        newMsg.minimumSequenceNumber = minSeq;
         // apply message doesn't use the segment group, so just pass undefined
         reconnectMsgs.push([newMsg, undefined]);
     });
@@ -58,7 +58,7 @@ function applyMessagesWithReconnect(
     return applyMessages(seq, reconnectMsgs, clients, logger);
 }
 
-export const defaultOptions: IMergeTreeOperationRunnerConfig & {minLength: number, clients: IConfigRange } = {
+export const defaultOptions: IMergeTreeOperationRunnerConfig & { minLength: number, clients: IConfigRange } = {
     minLength: 16,
     clients: { min: 2, max: 8 },
     opsPerRoundRange: { min: 40, max: 320 },

--- a/packages/runtime/merge-tree/src/test/client.reconnectFarm.spec.ts
+++ b/packages/runtime/merge-tree/src/test/client.reconnectFarm.spec.ts
@@ -14,6 +14,8 @@ import {
     annotateRange,
     removeRange,
     applyMessages,
+    IMergeTreeOperationRunnerConfig,
+    IConfigRange,
 } from "./mergeTreeOperationRunner";
 import { TestClient } from "./testClient";
 import { TestClientLogger } from "./testClientLogger";
@@ -26,6 +28,7 @@ function applyMessagesWithReconnect(
 ) {
     let seq = startingSeq;
     const reconnectClientMsgs: [IMergeTreeOp, SegmentGroup | SegmentGroup[]][] = [];
+    let minSeq = 0;
     // log and apply all the ops created in the round
     while (messageDatas.length > 0) {
         const [message, sg] = messageDatas.shift();
@@ -36,6 +39,7 @@ function applyMessagesWithReconnect(
             logger.log(message, (c) => {
                 c.applyMsg(message);
             });
+            minSeq = message.minimumSequenceNumber;
         }
     }
 
@@ -46,6 +50,7 @@ function applyMessagesWithReconnect(
                 opData[0],
                 opData[1],
             ));
+            newMsg.minimumSequenceNumber = minSeq;
         // apply message doesn't use the segment group, so just pass undefined
         reconnectMsgs.push([newMsg, undefined]);
     });
@@ -53,10 +58,10 @@ function applyMessagesWithReconnect(
     return applyMessages(seq, reconnectMsgs, clients, logger);
 }
 
-export const defaultOptions = {
+export const defaultOptions: IMergeTreeOperationRunnerConfig & {minLength: number, clients: IConfigRange } = {
     minLength: 16,
     clients: { min: 2, max: 8 },
-    opsPerRoundRange: { min: 200, max: 800 },
+    opsPerRoundRange: { min: 40, max: 320 },
     rounds: 3,
     operations: [annotateRange, removeRange],
     growthFunc: (input: number) => input * 2,
@@ -69,7 +74,7 @@ describe("MergeTree.Client", () => {
     // Generate a list of single character client names, support up to 69 clients
     const clientNames = generateClientNames();
 
-    doOverRange(opts.clients, opts.growthFunc, (clientCount) => {
+    doOverRange(opts.clients, opts.growthFunc.bind(opts), (clientCount) => {
         // tslint:enable: mocha-no-side-effect-code
         it(`ReconnectFarm_${clientCount}`, async () => {
             const mt = random.engines.mt19937();

--- a/packages/runtime/merge-tree/src/test/mergeTreeOperationRunner.ts
+++ b/packages/runtime/merge-tree/src/test/mergeTreeOperationRunner.ts
@@ -84,7 +84,7 @@ export function runMergeTreeOperationRunner(
                 minLength,
                 config.operations,
             );
-            seq = applyMessages(seq, messageData, clients, logger);
+            seq = apply(seq, messageData, clients, logger);
             // validate that all the clients match at the end of the round
             logger.validate();
         }


### PR DESCRIPTION
There was a but in the mergetree reconnect stress test that were making them not actually run reconnect logic. After fixing this bug i found a couple issues in the reconnect logic. These are fixed here as well.