### PR TITLE
Fix SharedString Backcompat

### DIFF
--- a/packages/runtime/merge-tree/src/snapshotlegacy.ts
+++ b/packages/runtime/merge-tree/src/snapshotlegacy.ts
@@ -45,7 +45,7 @@ export interface SnapshotHeader {
 export class SnapshotLegacy {
     public static readonly header = "header";
     public static readonly body = "body";
-    public static readonly catchupOps = "catchupOps";
+    public static readonly catchupOps = "tardis";
 
     // Split snapshot into two entries - headers (small) and body (overflow) for faster loading initial content
     // Please note that this number has no direct relationship to anything other than size of raw text (characters).

--- a/packages/runtime/sequence/src/sequence.ts
+++ b/packages/runtime/sequence/src/sequence.ts
@@ -120,6 +120,8 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
     ) {
         super(id, document, attributes);
 
+        document.options.catchUpBlobName = document.options.catchUpBlobName ?? "tardis";
+
         this.client = new MergeTree.Client(
             segmentFromSpec,
             ChildLogger.create(this.logger, "SharedSegmentSequence.MergeTreeClient"),

--- a/packages/runtime/sequence/src/sequence.ts
+++ b/packages/runtime/sequence/src/sequence.ts
@@ -120,8 +120,6 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
     ) {
         super(id, document, attributes);
 
-        document.options.catchUpBlobName = document.options.catchUpBlobName ?? MergeTree.SnapshotLegacy.catchupOps;
-
         this.client = new MergeTree.Client(
             segmentFromSpec,
             ChildLogger.create(this.logger, "SharedSegmentSequence.MergeTreeClient"),

--- a/packages/runtime/sequence/src/sequence.ts
+++ b/packages/runtime/sequence/src/sequence.ts
@@ -35,6 +35,7 @@ import {
 } from "./intervalCollection";
 import { SequenceDeltaEvent, SequenceMaintenanceEvent } from "./sequenceDeltaEvent";
 import { ISharedIntervalCollection } from "./sharedIntervalCollection";
+import { SnapshotLegacy } from "@fluidframework/merge-tree";
 // eslint-disable-next-line max-len
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, import/no-internal-modules
 const cloneDeep = require("lodash/cloneDeep");
@@ -120,7 +121,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
     ) {
         super(id, document, attributes);
 
-        document.options.catchUpBlobName = document.options.catchUpBlobName ?? "tardis";
+        document.options.catchUpBlobName = document.options.catchUpBlobName ?? SnapshotLegacy.catchupOps;
 
         this.client = new MergeTree.Client(
             segmentFromSpec,

--- a/packages/runtime/sequence/src/sequence.ts
+++ b/packages/runtime/sequence/src/sequence.ts
@@ -35,7 +35,6 @@ import {
 } from "./intervalCollection";
 import { SequenceDeltaEvent, SequenceMaintenanceEvent } from "./sequenceDeltaEvent";
 import { ISharedIntervalCollection } from "./sharedIntervalCollection";
-import { SnapshotLegacy } from "@fluidframework/merge-tree";
 // eslint-disable-next-line max-len
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, import/no-internal-modules
 const cloneDeep = require("lodash/cloneDeep");
@@ -121,7 +120,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
     ) {
         super(id, document, attributes);
 
-        document.options.catchUpBlobName = document.options.catchUpBlobName ?? SnapshotLegacy.catchupOps;
+        document.options.catchUpBlobName = document.options.catchUpBlobName ?? MergeTree.SnapshotLegacy.catchupOps;
 
         this.client = new MergeTree.Client(
             segmentFromSpec,

--- a/packages/runtime/sequence/src/test/generateSharedStrings.ts
+++ b/packages/runtime/sequence/src/test/generateSharedStrings.ts
@@ -17,7 +17,7 @@ export const supportedVersions = new Map<string, any>([
     // so for legacy set it to another name to ensure
     // we keep support
     ["legacy", { catchUpBlobName: "randomNameForCatchUpOps" }],
-    ["legacyWithCatchUp", {catchUpBlobName: "catchupOps"}],
+    ["legacyWithCatchUp", { catchUpBlobName: "catchupOps" }],
     ["v1", { newMergeTreeSnapshotFormat: true }],
 ]);
 

--- a/packages/runtime/sequence/src/test/generateSharedStrings.ts
+++ b/packages/runtime/sequence/src/test/generateSharedStrings.ts
@@ -17,7 +17,7 @@ export const supportedVersions = new Map<string, any>([
     // so for legacy set it to another name to ensure
     // we keep support
     ["legacy", { catchUpBlobName: "randomNameForCatchUpOps" }],
-    ["legacyWithCatchUp", {}],
+    ["legacyWithCatchUp", {catchUpBlobName: "catchupOps"}],
     ["v1", { newMergeTreeSnapshotFormat: true }],
 ]);
 

--- a/packages/tools/replay-tool/src/replayMessages.ts
+++ b/packages/tools/replay-tool/src/replayMessages.ts
@@ -311,7 +311,7 @@ class Document {
                 ["@ms/tablero/TableroDocument", Promise.resolve(chaincode)],
                 ["@fluid-example/table-document/TableDocument", Promise.resolve(chaincode)],
             ]);
-        const options = {};
+        const options = { catchUpBlobName: "catchupOps" };
 
         // Load the Fluid document
         this.docLogger = ChildLogger.create(new Logger(containerDescription, errorHandler));


### PR DESCRIPTION
I checked in the change to remove the backcompat code from sharedstring too soon, as we only want to break that in 0.21, not 0.20. This brings back the backcompat. I'll basically revert this change once we cut 0.20