### PR TITLE
Fixed DocumentDeltaEventManager to not pause the documents when asked to process

### DIFF
--- a/packages/drivers/local-driver/src/documentEventManager.ts
+++ b/packages/drivers/local-driver/src/documentEventManager.ts
@@ -110,6 +110,7 @@ export class DocumentDeltaEventManager {
      */
     public async pauseProcessing(...docs: IDocumentDeltaEvent[]) {
         await this.pauseAndValidateDocs(...docs);
+        this.isNormalProcessingPaused = true;
     }
 
     /**
@@ -123,7 +124,6 @@ export class DocumentDeltaEventManager {
 
     private async pauseAndValidateDocs(...docs: IDocumentDeltaEvent[]): Promise<Iterable<IDocumentDeltaEvent>> {
         await Promise.all(Array.from(this.documents).map(DocumentDeltaEventManager.pauseDocument));
-        this.isNormalProcessingPaused = true;
 
         if (docs && docs.length > 0) {
             docs.forEach((doc) => {

--- a/packages/test/end-to-end/src/test/batching.spec.ts
+++ b/packages/test/end-to-end/src/test/batching.spec.ts
@@ -208,7 +208,8 @@ describe("Batching", () => {
         assert.equal(component2BatchMessages.length, 0, "Incorrect number of messages received on remote client");
     });
 
-    afterEach(() => {
+    afterEach(async () => {
+        await deltaConnectionServer.webSocketServer.close();
         component1BatchMessages = [];
         component2BatchMessages = [];
     });

--- a/packages/test/end-to-end/src/test/container.spec.ts
+++ b/packages/test/end-to-end/src/test/container.spec.ts
@@ -261,4 +261,8 @@ describe("Container", () => {
         assert.strictEqual(container.clientDetails.capabilities.interactive, true,
             "Client details should be set with interactive as true");
     });
+
+    afterEach(async () => {
+        await testDeltaConnectionServer.webSocketServer.close();
+    });
 });

--- a/packages/test/end-to-end/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/end-to-end/src/test/detachedContainerTests.spec.ts
@@ -174,4 +174,8 @@ describe("Detached Container", () => {
             "Value for registration should be same!!");
         assert.strictEqual(testChannel2.isLocal(), testChannel1.isLocal(), "Value for isLocal should persist!!");
     });
+
+    afterEach(async () => {
+        await testDeltaConnectionServer.webSocketServer.close();
+    });
 });

--- a/packages/test/end-to-end/src/test/error.spec.ts
+++ b/packages/test/end-to-end/src/test/error.spec.ts
@@ -84,6 +84,8 @@ describe("Errors Types", () => {
         } catch (error) {
             assert.equal(error.errorType, ErrorType.genericError, "Error should be a genericError");
         }
+
+        await testDeltaConnectionServer.webSocketServer.close();
     });
 
     it("GeneralError Logging Test", async () => {

--- a/packages/test/end-to-end/src/test/localLoader.spec.ts
+++ b/packages/test/end-to-end/src/test/localLoader.spec.ts
@@ -131,6 +131,10 @@ describe("LocalLoader", () => {
             containerDeltaEventManager = new DocumentDeltaEventManager(deltaConnectionServer);
         });
 
+        afterEach(async () => {
+            await deltaConnectionServer.webSocketServer.close();
+        });
+
         it("early open / late close", async () => {
             // Create/open both instance of TestComponent before applying ops.
             const container1 = await createContainer(testComponentFactory);


### PR DESCRIPTION
Fixes #2541

When `process`, `processIncoming` or `processOutgoing` is called on `DocumentDeltaEventManager`, it should leave the delta queues in the same state as they were when it is called.
There are scenarios where we want to wait for all the ops that pending to be processed and ack'd before we continue. So, we want to call one of the process APIs on DocumentDeltaEventManager.
However, `pauseAndValidateDocs` sets the `isNormalProcessingPaused` flag to true which causes the queues to be paused in `yieldWhileDocumentsHaveWork`. This leaves the queues paused when they were not paused before process was called. This is causing some tests to get stuck waiting for ops.

- The fix here is to set `isNormalProcessingPaused` to true only when the document is explicitly paused by calling `pauseProcessing`. This will ensure that all the process functions leave the queue in the state they were before.
- Added closing of the websocker sever in LocalDeltaConnectionServer to end-to-end tests where they were missing.
- Added a couple of cases in opsOnReconnect.spec.ts that test the scenario where container is disconnected after ops are sent but aren't ack'd yet.