### PR TITLE
LocalDeltaConnectionServer service configuration

### DIFF
--- a/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
+++ b/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
@@ -4,35 +4,36 @@
  */
 
 import {
+    IClient,
+    IConnect,
+    IConnected,
+    IContentMessage,
+    ISequencedDocumentMessage,
+    IServiceConfiguration,
+    ISignalMessage,
+} from "@fluidframework/protocol-definitions";
+import { configureWebSocketServices } from "@fluidframework/server-lambdas";
+import {
     DefaultMetricClient,
     IDatabaseManager,
     IDocumentStorage,
+    ILogger,
+    IWebSocket,
     IWebSocketServer,
     MongoDatabaseManager,
     MongoManager,
-    ILogger,
-    IWebSocket,
 } from "@fluidframework/server-services-core";
 import {
+    DebugLogger,
     ITestDbFactory,
+    TestClientManager,
     TestDbFactory,
     TestDocumentStorage,
-    TestTenantManager,
-    TestWebSocketServer,
-    TestClientManager,
-    DebugLogger,
     TestHistorian,
     TestTaskMessageSender,
+    TestTenantManager,
+    TestWebSocketServer,
 } from "@fluidframework/server-test-utils";
-import { configureWebSocketServices } from "@fluidframework/server-lambdas";
-import {
-    IClient,
-    IConnected,
-    IConnect,
-    ISequencedDocumentMessage,
-    IContentMessage,
-    ISignalMessage,
-} from "@fluidframework/protocol-definitions";
 import { MemoryOrdererManager } from "./memoryOrdererManager";
 
 /**
@@ -58,7 +59,10 @@ export class LocalDeltaConnectionServer implements ILocalDeltaConnectionServer {
     /**
      * Creates and returns a local delta connection server.
      */
-    public static create(testDbFactory: ITestDbFactory = new TestDbFactory({})): ILocalDeltaConnectionServer {
+    public static create(
+        testDbFactory: ITestDbFactory = new TestDbFactory({}),
+        serviceConfiguration?: Partial<IServiceConfiguration>,
+    ): ILocalDeltaConnectionServer {
         const nodesCollectionName = "nodes";
         const documentsCollectionName = "documents";
         const deltasCollectionName = "deltas";
@@ -89,7 +93,8 @@ export class LocalDeltaConnectionServer implements ILocalDeltaConnectionServer {
             {},
             16 * 1024,
             async () => new TestHistorian(testDbFactory.testDatabase),
-            logger);
+            logger,
+            serviceConfiguration);
 
         configureWebSocketServices(
             webSocketServer,

--- a/server/routerlicious/packages/local-server/src/memoryOrdererManager.ts
+++ b/server/routerlicious/packages/local-server/src/memoryOrdererManager.ts
@@ -3,19 +3,17 @@
  * Licensed under the MIT License.
  */
 
+import { IServiceConfiguration } from "@fluidframework/protocol-definitions";
 import { LocalOrderer } from "@fluidframework/server-memory-orderer";
+import { GitManager, IHistorian } from "@fluidframework/server-services-client";
 import {
-    GitManager,
-    IHistorian,
-} from "@fluidframework/server-services-client";
-import {
-    IOrderer,
-    IOrdererManager,
     IDatabaseManager,
     IDocumentStorage,
+    ILogger,
+    IOrderer,
+    IOrdererManager,
     ITaskMessageSender,
     ITenantManager,
-    ILogger,
 } from "@fluidframework/server-services-core";
 
 export class MemoryOrdererManager implements IOrdererManager {
@@ -30,6 +28,7 @@ export class MemoryOrdererManager implements IOrdererManager {
         private readonly maxMessageSize: number,
         private readonly createHistorian: (tenant: string) => Promise<IHistorian>,
         private readonly logger: ILogger,
+        private readonly serviceConfiguration?: Partial<IServiceConfiguration>,
     ) {
     }
 
@@ -73,7 +72,16 @@ export class MemoryOrdererManager implements IOrdererManager {
             this.permission,
             this.maxMessageSize,
             this.logger,
-            gitManager);
+            gitManager,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            this.serviceConfiguration);
 
         const lambdas = [
             orderer.broadcasterLambda,

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -4,6 +4,7 @@
  */
 
 import assert from "assert";
+import { merge } from "lodash";
 import { ProtocolOpHandler } from "@fluidframework/protocol-base";
 import { IClient, IServiceConfiguration } from "@fluidframework/protocol-definitions";
 import {
@@ -180,7 +181,7 @@ export class LocalOrderer implements IOrderer {
         scribeContext: IContext = new LocalContext(logger),
         deliContext: IContext = new LocalContext(logger),
         clientTimeout: number = ClientSequenceTimeout,
-        serviceConfiguration = DefaultServiceConfiguration,
+        serviceConfiguration: Partial<IServiceConfiguration> = {},
         scribeNackOnSummarizeException = false,
     ) {
         const documentDetails = await setup.documentP();
@@ -202,7 +203,7 @@ export class LocalOrderer implements IOrderer {
             scribeContext,
             deliContext,
             clientTimeout,
-            serviceConfiguration,
+            merge({}, DefaultServiceConfiguration, serviceConfiguration),
             scribeNackOnSummarizeException);
     }
 


### PR DESCRIPTION
Allow passing an `IServiceConfiguration` into `LocalDeltaConnectionServer`, which enables e.g. changing summarizer config values for testing purposes.