### PR TITLE
Small changes, deprecations, and TSDoc for view-interfaces and view-adapters

### DIFF
--- a/components/experimental/spaces/src/storage/spacesStorageView.tsx
+++ b/components/experimental/spaces/src/storage/spacesStorageView.tsx
@@ -80,7 +80,7 @@ const SpacesComponentView: React.FC<ISpacesComponentViewProps> =
                 <div className="spaces-embedded-component-wrapper">
                     {
                         component &&
-                        <ReactViewAdapter component={component} />
+                        <ReactViewAdapter view={component} />
                     }
                 </div>
             </div>

--- a/components/experimental/sudoku/src/fluidSudoku.tsx
+++ b/components/experimental/sudoku/src/fluidSudoku.tsx
@@ -99,7 +99,7 @@ export class FluidSudoku extends PrimedComponent
         });
     }
 
-    public createJSXElement(props?: any): JSX.Element {
+    public createJSXElement(): JSX.Element {
         if (this.puzzle) {
             return (
                 <SudokuView

--- a/components/experimental/todo/src/TodoItem/TodoItemDetailsView.tsx
+++ b/components/experimental/todo/src/TodoItem/TodoItemDetailsView.tsx
@@ -73,7 +73,7 @@ export class TodoItemDetailsView extends React.Component<TodoItemDetailsViewProp
             // createInnerComponent will create the model component for the chosen option.  We then need to get the
             // view component out of it (for now).  Preferably, we would instead take the returned model and feed it
             // into our own view component of our choosing.
-            return <ReactViewAdapter component={this.state.innerComponent} />;
+            return <ReactViewAdapter view={this.state.innerComponent} />;
         }
     }
 }

--- a/components/experimental/vltava/src/components/library/embeddedComponent.tsx
+++ b/components/experimental/vltava/src/components/library/embeddedComponent.tsx
@@ -34,7 +34,7 @@ export class EmbeddedComponentWrapper
     async componentDidMount() {
         const component = await this.props.getComponent(this.props.id);
         if (component) {
-            const element = <ReactViewAdapter component={component} />;
+            const element = <ReactViewAdapter view={component} />;
             this.setState({ element });
         }
     }

--- a/components/experimental/vltava/src/components/vltava/view.tsx
+++ b/components/experimental/vltava/src/components/vltava/view.tsx
@@ -57,7 +57,7 @@ export class VltavaView extends React.Component<IVltavaViewProps, IVltavaViewSta
     async componentDidMount() {
         const component = await this.props.dataModel.getDefaultComponent();
         this.setState({
-            view: <ReactViewAdapter component={component} />,
+            view: <ReactViewAdapter view={component} />,
         });
     }
 

--- a/docs/tutorials/sudoku.md
+++ b/docs/tutorials/sudoku.md
@@ -144,7 +144,7 @@ itself.
 The implementation is as follows:
 
 ```typescript
-public createJSXElement(props?: any): JSX.Element {
+public createJSXElement(): JSX.Element {
     if (this.puzzle) {
         return (
             <SudokuView
@@ -415,7 +415,7 @@ for storing the presence data, and a function to update the map with presence da
 1. Replace the `createJSXElement` method with the following code:
 
    ```ts
-   public createJSXElement(props?: any): JSX.Element {
+   public createJSXElement(): JSX.Element {
        if (this.puzzle) {
            return (
                <SudokuView

--- a/packages/framework/view-adapters/src/htmlview/htmlViewAdapter.tsx
+++ b/packages/framework/view-adapters/src/htmlview/htmlViewAdapter.tsx
@@ -9,20 +9,22 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 /**
- * Abstracts rendering of components via the IComponentHTMLView interface.  Supports React elements, as well as
+ * Abstracts rendering of views via the IComponentHTMLView interface.  Supports React elements, as well as
  * components that implement IComponentReactViewable, IComponentHTMLView, or IComponentHTMLVisual.
- *
- * If the component is none of these, we render an empty <span />
  */
 export class HTMLViewAdapter implements IComponentHTMLView {
     public get IComponentHTMLView() { return this; }
 
-    public static canAdapt(component: IComponent) {
+    /**
+     * Test whether the given component can be successfully adapted by an HTMLViewAdapter.
+     * @param view - the component to test if it is adaptable.
+     */
+    public static canAdapt(view: IComponent) {
         return (
-            React.isValidElement(component)
-            || component.IComponentReactViewable !== undefined
-            || component.IComponentHTMLView !== undefined
-            || component.IComponentHTMLVisual !== undefined
+            React.isValidElement(view)
+            || view.IComponentReactViewable !== undefined
+            || view.IComponentHTMLView !== undefined
+            || view.IComponentHTMLVisual !== undefined
         );
     }
 

--- a/packages/framework/view-adapters/src/mountableview/mountableView.tsx
+++ b/packages/framework/view-adapters/src/mountableview/mountableView.tsx
@@ -19,12 +19,15 @@ import * as ReactDOM from "react-dom";
 export class MountableView implements IComponentMountableView {
     public get IComponentMountableView() { return this; }
 
-    public static canMount(viewProvider: IComponent) {
+    /**
+     * {@inheritDoc @fluidframework/view-interfaces#IComponentMountableViewClass.canMount}
+     */
+    public static canMount(view: IComponent) {
         return (
-            React.isValidElement(viewProvider)
-            || viewProvider.IComponentReactViewable !== undefined
-            || viewProvider.IComponentHTMLView !== undefined
-            || viewProvider.IComponentHTMLVisual !== undefined
+            React.isValidElement(view)
+            || view.IComponentReactViewable !== undefined
+            || view.IComponentHTMLView !== undefined
+            || view.IComponentHTMLVisual !== undefined
         );
     }
 
@@ -46,12 +49,18 @@ export class MountableView implements IComponentMountableView {
      */
     private reactView: JSX.Element | undefined;
 
-    constructor(private readonly viewProvider: IComponent) {
-        if (!MountableView.canMount(this.viewProvider)) {
+    /**
+     * {@inheritDoc @fluidframework/view-interfaces#IComponentMountableViewClass.new}
+     */
+    constructor(private readonly view: IComponent) {
+        if (!MountableView.canMount(this.view)) {
             throw new Error("Unmountable view type");
         }
     }
 
+    /**
+     * {@inheritDoc @fluidframework/view-interfaces#IComponentMountableView.mount}
+     */
     public mount(container: HTMLElement) {
         if (this.containerElement !== undefined) {
             throw new Error("Already mounted");
@@ -61,9 +70,9 @@ export class MountableView implements IComponentMountableView {
 
         // Try to get an IComponentHTMLView if we don't have one already.
         if (this.htmlView === undefined) {
-            this.htmlView = this.viewProvider.IComponentHTMLView;
+            this.htmlView = this.view.IComponentHTMLView;
             if (this.htmlView === undefined) {
-                this.htmlView = this.viewProvider.IComponentHTMLVisual?.addView();
+                this.htmlView = this.view.IComponentHTMLVisual?.addView();
             }
         }
         // Render with IComponentHTMLView if possible.
@@ -79,10 +88,10 @@ export class MountableView implements IComponentMountableView {
         // IComponentHTMLVisual temporarily, so that we have the best chance of cross-bundle adaptation.
         // Try to get a React view if we don't have one already.
         if (this.reactView === undefined) {
-            if (React.isValidElement(this.viewProvider)) {
-                this.reactView = this.viewProvider;
+            if (React.isValidElement(this.view)) {
+                this.reactView = this.view;
             } else {
-                this.reactView = this.viewProvider.IComponentReactViewable?.createJSXElement();
+                this.reactView = this.view.IComponentReactViewable?.createJSXElement();
             }
         }
         // Render with React if possible.
@@ -95,6 +104,9 @@ export class MountableView implements IComponentMountableView {
         throw new Error("Failed to mount");
     }
 
+    /**
+     * {@inheritDoc @fluidframework/view-interfaces#IComponentMountableView.unmount}
+     */
     public unmount() {
         // Do nothing if we are already unmounted.
         if (this.containerElement === undefined) {

--- a/packages/framework/view-adapters/src/react/reactViewAdapter.tsx
+++ b/packages/framework/view-adapters/src/react/reactViewAdapter.tsx
@@ -8,6 +8,9 @@ import { IComponentHTMLView, IComponentHTMLVisual } from "@fluidframework/view-i
 import React from "react";
 
 export interface IReactViewAdapterProps {
+    /**
+     * The view to adapt into a React component.
+     */
     view: IComponent;
 }
 

--- a/packages/framework/view-adapters/src/react/reactViewAdapter.tsx
+++ b/packages/framework/view-adapters/src/react/reactViewAdapter.tsx
@@ -12,21 +12,28 @@ export interface IEmbeddedComponentProps {
 }
 
 /**
- * Abstracts rendering of components as a React component.  Supports React elements, as well as
+ * Abstracts rendering of views as a React component.  Supports React elements, as well as
  * components that implement IComponentReactViewable, IComponentHTMLView, or IComponentHTMLVisual.
  *
  * If the component is none of these, we render nothing.
  */
 export class ReactViewAdapter extends React.Component<IEmbeddedComponentProps> {
-    public static canAdapt(component: IComponent) {
+    /**
+     * Test whether the given component can be successfully adapted by a ReactViewAdapter.
+     * @param view - the component to test if it is adaptable.
+     */
+    public static canAdapt(view: IComponent) {
         return (
-            React.isValidElement(component)
-            || component.IComponentReactViewable !== undefined
-            || component.IComponentHTMLView !== undefined
-            || component.IComponentHTMLVisual !== undefined
+            React.isValidElement(view)
+            || view.IComponentReactViewable !== undefined
+            || view.IComponentHTMLView !== undefined
+            || view.IComponentHTMLVisual !== undefined
         );
     }
 
+    /**
+     * Once we've adapted the view to a React element, we'll retain a reference to render.
+     */
     private readonly element: JSX.Element;
 
     constructor(props: IEmbeddedComponentProps) {
@@ -45,13 +52,13 @@ export class ReactViewAdapter extends React.Component<IEmbeddedComponentProps> {
 
         const htmlView = this.props.component.IComponentHTMLView;
         if (htmlView !== undefined) {
-            this.element = <HTMLViewEmbeddedComponent component={htmlView} />;
+            this.element = <HTMLViewEmbeddedComponent htmlView={htmlView} />;
             return;
         }
 
         const htmlVisual = this.props.component.IComponentHTMLVisual;
         if (htmlVisual !== undefined) {
-            this.element = <HTMLVisualEmbeddedComponent component={htmlVisual} />;
+            this.element = <HTMLVisualEmbeddedComponent htmlVisual={htmlVisual} />;
             return;
         }
 
@@ -64,7 +71,7 @@ export class ReactViewAdapter extends React.Component<IEmbeddedComponentProps> {
 }
 
 interface IHTMLViewProps {
-    component: IComponentHTMLView;
+    htmlView: IComponentHTMLView;
 }
 
 /**
@@ -82,7 +89,7 @@ class HTMLViewEmbeddedComponent extends React.Component<IHTMLViewProps> {
     public async componentDidMount() {
         // eslint-disable-next-line no-null/no-null
         if (this.ref.current !== null) {
-            this.props.component.render(this.ref.current);
+            this.props.htmlView.render(this.ref.current);
         }
     }
 
@@ -92,7 +99,7 @@ class HTMLViewEmbeddedComponent extends React.Component<IHTMLViewProps> {
 }
 
 interface IHTMLVisualProps {
-    component: IComponentHTMLVisual;
+    htmlVisual: IComponentHTMLVisual;
 }
 
 /**
@@ -110,7 +117,7 @@ class HTMLVisualEmbeddedComponent extends React.Component<IHTMLVisualProps> {
     public async componentDidMount() {
         // eslint-disable-next-line no-null/no-null
         if (this.ref.current !== null) {
-            const view = this.props.component.addView();
+            const view = this.props.htmlVisual.addView();
             view.render(this.ref.current);
         }
     }

--- a/packages/framework/view-adapters/src/react/reactViewAdapter.tsx
+++ b/packages/framework/view-adapters/src/react/reactViewAdapter.tsx
@@ -7,8 +7,8 @@ import { IComponent } from "@fluidframework/component-core-interfaces";
 import { IComponentHTMLView, IComponentHTMLVisual } from "@fluidframework/view-interfaces";
 import React from "react";
 
-export interface IEmbeddedComponentProps {
-    component: IComponent;
+export interface IReactViewAdapterProps {
+    view: IComponent;
 }
 
 /**
@@ -17,7 +17,7 @@ export interface IEmbeddedComponentProps {
  *
  * If the component is none of these, we render nothing.
  */
-export class ReactViewAdapter extends React.Component<IEmbeddedComponentProps> {
+export class ReactViewAdapter extends React.Component<IReactViewAdapterProps> {
     /**
      * Test whether the given component can be successfully adapted by a ReactViewAdapter.
      * @param view - the component to test if it is adaptable.
@@ -36,27 +36,27 @@ export class ReactViewAdapter extends React.Component<IEmbeddedComponentProps> {
      */
     private readonly element: JSX.Element;
 
-    constructor(props: IEmbeddedComponentProps) {
+    constructor(props: IReactViewAdapterProps) {
         super(props);
 
-        if (React.isValidElement(this.props.component)) {
-            this.element = this.props.component;
+        if (React.isValidElement(this.props.view)) {
+            this.element = this.props.view;
             return;
         }
 
-        const reactViewable = this.props.component.IComponentReactViewable;
+        const reactViewable = this.props.view.IComponentReactViewable;
         if (reactViewable !== undefined) {
             this.element = reactViewable.createJSXElement();
             return;
         }
 
-        const htmlView = this.props.component.IComponentHTMLView;
+        const htmlView = this.props.view.IComponentHTMLView;
         if (htmlView !== undefined) {
             this.element = <HTMLViewEmbeddedComponent htmlView={htmlView} />;
             return;
         }
 
-        const htmlVisual = this.props.component.IComponentHTMLVisual;
+        const htmlVisual = this.props.view.IComponentHTMLVisual;
         if (htmlVisual !== undefined) {
             this.element = <HTMLVisualEmbeddedComponent htmlVisual={htmlVisual} />;
             return;

--- a/packages/framework/view-interfaces/src/htmlView.ts
+++ b/packages/framework/view-interfaces/src/htmlView.ts
@@ -38,8 +38,14 @@ export interface IComponentHTMLView extends IProvideComponentHTMLView {
     remove?(): void;
 }
 
+/**
+ * @deprecated - See IComponentHTMLVisual
+ */
 export const IComponentHTMLVisual: keyof IProvideComponentHTMLVisual = "IComponentHTMLVisual";
 
+/**
+ * @deprecated - See IComponentHTMLVisual
+ */
 export interface IProvideComponentHTMLVisual {
     readonly IComponentHTMLVisual: IComponentHTMLVisual;
 }
@@ -47,7 +53,8 @@ export interface IProvideComponentHTMLVisual {
 /**
  * An IComponentHTMLVisual is a view factory.  Typically (though not necessarily) it will be a model,
  * binding itself to the views it creates.
- * TODO: Consider renaming to IComponentHTMLViewFactory
+ * @deprecated - To support multiview scenarios, consider split view/model patterns like those demonstrated in
+ * the multiview sample.
  */
 export interface IComponentHTMLVisual extends IProvideComponentHTMLVisual {
     addView(scope?: IComponent): IComponentHTMLView;

--- a/packages/framework/view-interfaces/src/mountableView.ts
+++ b/packages/framework/view-interfaces/src/mountableView.ts
@@ -11,9 +11,19 @@ export interface IProvideComponentMountableView {
     readonly IComponentMountableView: IComponentMountableView;
 }
 
+/**
+ * IComponentMountableViewClass defines the statics on our class implementing IComponentMountableView.
+ */
 export interface IComponentMountableViewClass {
-    new(viewProvider: IComponent): IComponentMountableView;
-    canMount(viewProvider: IComponent): boolean;
+    /**
+     * @param view - The view to make mountable
+     */
+    new(view: IComponent): IComponentMountableView;
+    /**
+     * Test whether the given view can be successfully mounted by a MountableView.
+     * @param view - the view to test if it can be mounted.
+     */
+    canMount(view: IComponent): boolean;
 }
 
 /**
@@ -30,6 +40,7 @@ export interface IComponentMountableViewClass {
 export interface IComponentMountableView extends IProvideComponentMountableView {
     /**
      * Mounts the view at the given element.
+     * @param container - the DOM parent of the view we will mount
      */
     mount(container: HTMLElement): void;
 

--- a/packages/framework/view-interfaces/src/reactView.ts
+++ b/packages/framework/view-interfaces/src/reactView.ts
@@ -3,16 +3,27 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * @deprecated - See IComponentReactViewable
+ */
 export const IComponentReactViewable: keyof IProvideComponentReactViewable = "IComponentReactViewable";
 
+/**
+ * @deprecated - See IComponentReactViewable
+ */
 export interface IProvideComponentReactViewable {
     readonly IComponentReactViewable: IComponentReactViewable;
 }
 /**
- * If something is react viewable then render can simply return a JSX Element
+ * Interface describing components that can produce React elements when requested.
+ * @deprecated - To support multiview scenarios, consider split view/model patterns like those demonstrated in
+ * the multiview sample.
  */
 export interface IComponentReactViewable extends IProvideComponentReactViewable {
-    createJSXElement(props?: {}): JSX.Element;
+    /**
+     * Create a React element.
+     */
+    createJSXElement(): JSX.Element;
 }
 
 declare module "@fluidframework/component-core-interfaces" {


### PR DESCRIPTION
Part of #1316 and #1041 

Does 3 things in view-interfaces and view-adapters:
1. Adds TSDocs
2. Marks the "view factory" interfaces as deprecated, referring to the multiview sample for how to accomplish the scenario
3. Makes a few small code tweaks for naming appropriateness and to simplify where we just weren't using features (rather than try to document unused functionality).