### PR TITLE
revert badge example to office-ui-fabric-react to resolve local build issue

### DIFF
--- a/components/examples/badge/package.json
+++ b/components/examples/badge/package.json
@@ -32,7 +32,6 @@
     "webpack:dev": "webpack --env.development"
   },
   "dependencies": {
-    "@fluentui/react": "^7.28.1",
     "@fluidframework/aqueduct": "^0.21.0",
     "@fluidframework/cell": "^0.21.0",
     "@fluidframework/component-core-interfaces": "^0.21.0",
@@ -40,6 +39,7 @@
     "@fluidframework/sequence": "^0.21.0",
     "@fluidframework/view-interfaces": "^0.21.0",
     "@uifabric/fluent-theme": "^7.1.3",
+    "office-ui-fabric-react": "^7.28.1",
     "react": "^16.10.2",
     "react-dom": "^16.10.2"
   },

--- a/components/examples/badge/src/Badge.types.ts
+++ b/components/examples/badge/src/Badge.types.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { IIconProps, IColor } from "@fluentui/react";
+import { IIconProps, IColor } from "office-ui-fabric-react";
 import { SharedCell } from "@fluidframework/cell";
 import { SharedMap } from "@fluidframework/map";
 import { SharedObjectSequence } from "@fluidframework/sequence";

--- a/components/examples/badge/src/BadgeClient.tsx
+++ b/components/examples/badge/src/BadgeClient.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 import * as React from "react";
-import { IColor } from "@fluentui/react";
+import { IColor } from "office-ui-fabric-react";
 import { BadgeView } from "./BadgeView";
 import { IBadgeClientProps, IBadgeType } from "./Badge.types";
 

--- a/components/examples/badge/src/BadgeView.tsx
+++ b/components/examples/badge/src/BadgeView.tsx
@@ -20,7 +20,7 @@ import {
     Stack,
     TextField,
     IContextualMenuItem,
-} from "@fluentui/react";
+} from "office-ui-fabric-react";
 import { MotionAnimations } from "@uifabric/fluent-theme";
 import { IBadgeViewProps, IBadgeType } from "./Badge.types";
 import {

--- a/components/examples/badge/src/helpers.ts
+++ b/components/examples/badge/src/helpers.ts
@@ -9,7 +9,7 @@ import {
     getColorFromHSV,
     getColorFromString,
     IButtonStyles,
-} from "@fluentui/react";
+} from "office-ui-fabric-react";
 import { SharedColors } from "@uifabric/fluent-theme";
 import { IBadgeType } from "./Badge.types";
 

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -553,141 +553,6 @@
 				"tslib": "^1.10.0"
 			}
 		},
-		"@fluentui/react": {
-			"version": "7.120.1",
-			"resolved": "https://registry.npmjs.org/@fluentui/react/-/react-7.120.1.tgz",
-			"integrity": "sha512-hD0cKbavutR4lOIrlxPm3vuXbZsg5FH+9NVIIoDh7ahnAlNqIlgts+NkwtjR+tuEb+uMauBVyHJira//iu3hKg==",
-			"requires": {
-				"@uifabric/set-version": "^7.0.13",
-				"office-ui-fabric-react": "^7.120.1",
-				"tslib": "^1.10.0"
-			},
-			"dependencies": {
-				"@fluentui/keyboard-key": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.2.1.tgz",
-					"integrity": "sha512-s2CYcspWWdqzwXNOvkNURifuRRiZun/5CQ3gcvRw9+S9/ONvPtedRkppNeTyj2wbW6Ctzf218bu2eJqu0aVK/Q==",
-					"requires": {
-						"tslib": "^1.10.0"
-					}
-				},
-				"@fluentui/react-focus": {
-					"version": "7.12.8",
-					"resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.12.8.tgz",
-					"integrity": "sha512-BqQMxmjqiE+XpprfSaLQk/5U6TgMUfzvSW1vhFTFaCJFS8GP9BBdUEjLcpO2nuw1/qlvSTMCPCqJum5uP9wR3w==",
-					"requires": {
-						"@fluentui/keyboard-key": "^0.2.1",
-						"@uifabric/merge-styles": "^7.14.1",
-						"@uifabric/set-version": "^7.0.13",
-						"@uifabric/styling": "^7.12.18",
-						"@uifabric/utilities": "^7.21.0",
-						"tslib": "^1.10.0"
-					}
-				},
-				"@fluentui/react-icons": {
-					"version": "0.1.28",
-					"resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-0.1.28.tgz",
-					"integrity": "sha512-MoXrCFPFwuXjt4B/YPaFm53sP/g9bEJNdkp0bIgCAVnFoLlsnt5/qcpdqlWE2stzWGGQizwexpANHe4v81akpQ==",
-					"requires": {
-						"@microsoft/load-themed-styles": "^1.10.26",
-						"@uifabric/set-version": "^7.0.13",
-						"@uifabric/utilities": "^7.21.0",
-						"tslib": "^1.10.0"
-					}
-				},
-				"@uifabric/foundation": {
-					"version": "7.7.25",
-					"resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.7.25.tgz",
-					"integrity": "sha512-dNFpxf+Xk1Yyi9JpYxZUzun8aoXpOOciL77x94JP4bS6I9MYubdOO5I5GUKSoC5qbn567AOZg2+jJjdcg1o/fQ==",
-					"requires": {
-						"@uifabric/merge-styles": "^7.14.1",
-						"@uifabric/set-version": "^7.0.13",
-						"@uifabric/styling": "^7.12.18",
-						"@uifabric/utilities": "^7.21.0",
-						"tslib": "^1.10.0"
-					}
-				},
-				"@uifabric/icons": {
-					"version": "7.3.51",
-					"resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.3.51.tgz",
-					"integrity": "sha512-71vw3jvhcgPmJDctayszSkJi3q51317WDd7+Zgvaw1oYviOxFZRN8pKqA5nBBJsA/ICBGBnI4kbi4g2zWqXF8A==",
-					"requires": {
-						"@uifabric/set-version": "^7.0.13",
-						"@uifabric/styling": "^7.12.18",
-						"tslib": "^1.10.0"
-					}
-				},
-				"@uifabric/merge-styles": {
-					"version": "7.14.1",
-					"resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-7.14.1.tgz",
-					"integrity": "sha512-nKkk0o9XyVh8HL174ZSDqw3IUnN2qb+kO73vg/rwioKPEQyuPGoEfij8jrb+CGpcCGnMYi53IeB1tm8ySlNatg==",
-					"requires": {
-						"@uifabric/set-version": "^7.0.13",
-						"tslib": "^1.10.0"
-					}
-				},
-				"@uifabric/react-hooks": {
-					"version": "7.4.6",
-					"resolved": "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.4.6.tgz",
-					"integrity": "sha512-QuVPRv5kQHGtMUYt7yeKbYFAiFdes60UUNJTfe9orwKCJF0ahVIvqthj7s1gCthZxnPTxZPxOyqZjnWi6uPnLA==",
-					"requires": {
-						"@uifabric/set-version": "^7.0.13",
-						"@uifabric/utilities": "^7.21.0",
-						"tslib": "^1.10.0"
-					}
-				},
-				"@uifabric/set-version": {
-					"version": "7.0.13",
-					"resolved": "https://registry.npmjs.org/@uifabric/set-version/-/set-version-7.0.13.tgz",
-					"integrity": "sha512-SRsYaacvNykS9lRwKNJgrJuhPV4ytblthFNg0+Wi6+zvIf/w50k/nBlmXVetV5U9dAuX4njSkd+/3iOpgevkyw==",
-					"requires": {
-						"tslib": "^1.10.0"
-					}
-				},
-				"@uifabric/styling": {
-					"version": "7.12.18",
-					"resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.12.18.tgz",
-					"integrity": "sha512-75gfJkjpQDNTB5Yjlfy31PQohcufZGMJCTKSwR19O/cYyPurBVA69tcALJv3UWPLyI9bVxTf7vZt1+OIQO+Jiw==",
-					"requires": {
-						"@microsoft/load-themed-styles": "^1.10.26",
-						"@uifabric/merge-styles": "^7.14.1",
-						"@uifabric/set-version": "^7.0.13",
-						"@uifabric/utilities": "^7.21.0",
-						"tslib": "^1.10.0"
-					}
-				},
-				"@uifabric/utilities": {
-					"version": "7.21.0",
-					"resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.21.0.tgz",
-					"integrity": "sha512-K+BjTPzW56+N8JAbC4a32EnlGVEOUCk7q2CpBxsbRkf21tVsUX91rs4hMRTow+TMjK6eJudlqSotd3se1v9KPw==",
-					"requires": {
-						"@uifabric/merge-styles": "^7.14.1",
-						"@uifabric/set-version": "^7.0.13",
-						"prop-types": "^15.7.2",
-						"tslib": "^1.10.0"
-					}
-				},
-				"office-ui-fabric-react": {
-					"version": "7.120.1",
-					"resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.120.1.tgz",
-					"integrity": "sha512-0KUHZV64dB0t7RrT9EmytpnW2zWuO0For69CDNY/S508RpeIlFdaaxymVSYfWxwG+0wIcTlQtgevtptcsub69A==",
-					"requires": {
-						"@fluentui/react-focus": "^7.12.8",
-						"@fluentui/react-icons": "^0.1.28",
-						"@microsoft/load-themed-styles": "^1.10.26",
-						"@uifabric/foundation": "^7.7.25",
-						"@uifabric/icons": "^7.3.51",
-						"@uifabric/merge-styles": "^7.14.1",
-						"@uifabric/react-hooks": "^7.4.6",
-						"@uifabric/set-version": "^7.0.13",
-						"@uifabric/styling": "^7.12.18",
-						"@uifabric/utilities": "^7.21.0",
-						"prop-types": "^15.7.2",
-						"tslib": "^1.10.0"
-					}
-				}
-			}
-		},
 		"@fluentui/react-focus": {
 			"version": "7.12.4",
 			"resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.12.4.tgz",
@@ -713,59 +578,59 @@
 			}
 		},
 		"@fluidframework/agent-scheduler": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/agent-scheduler/-/agent-scheduler-0.19.6.tgz",
-			"integrity": "sha1-A4ti+J4hVX/gFRRZO17Mgjpqteo=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/agent-scheduler/-/agent-scheduler-0.19.7.tgz",
+			"integrity": "sha1-ZgY6oSCwH6oPqXQWqVNLRLQBxPE=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.19.6",
-				"@fluidframework/component-runtime": "^0.19.6",
-				"@fluidframework/component-runtime-definitions": "^0.19.6",
-				"@fluidframework/container-definitions": "^0.19.6",
-				"@fluidframework/map": "^0.19.6",
-				"@fluidframework/register-collection": "^0.19.6",
-				"@fluidframework/runtime-definitions": "^0.19.6",
-				"@fluidframework/shared-object-base": "^0.19.6",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
+				"@fluidframework/component-runtime": "^0.19.7",
+				"@fluidframework/component-runtime-definitions": "^0.19.7",
+				"@fluidframework/container-definitions": "^0.19.7",
+				"@fluidframework/map": "^0.19.7",
+				"@fluidframework/register-collection": "^0.19.7",
+				"@fluidframework/runtime-definitions": "^0.19.7",
+				"@fluidframework/shared-object-base": "^0.19.7",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/aqueduct/-/aqueduct-0.19.6.tgz",
-			"integrity": "sha1-EaEVrQd1m0pD54PGBaVKRuOfk2Y=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/aqueduct/-/aqueduct-0.19.7.tgz",
+			"integrity": "sha1-/135m8WYUVlHlR1mHeDXqBTi6Ro=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.19.1",
-				"@fluidframework/component-core-interfaces": "^0.19.6",
-				"@fluidframework/component-runtime": "^0.19.6",
-				"@fluidframework/component-runtime-definitions": "^0.19.6",
-				"@fluidframework/container-definitions": "^0.19.6",
-				"@fluidframework/container-runtime": "^0.19.6",
-				"@fluidframework/container-runtime-definitions": "^0.19.6",
-				"@fluidframework/framework-interfaces": "^0.19.6",
-				"@fluidframework/map": "^0.19.6",
-				"@fluidframework/runtime-definitions": "^0.19.6",
-				"@fluidframework/shared-object-base": "^0.19.6",
-				"@fluidframework/synthesize": "^0.19.6",
-				"@fluidframework/view-adapters": "^0.19.6",
-				"@fluidframework/view-interfaces": "^0.19.6",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
+				"@fluidframework/component-runtime": "^0.19.7",
+				"@fluidframework/component-runtime-definitions": "^0.19.7",
+				"@fluidframework/container-definitions": "^0.19.7",
+				"@fluidframework/container-runtime": "^0.19.7",
+				"@fluidframework/container-runtime-definitions": "^0.19.7",
+				"@fluidframework/framework-interfaces": "^0.19.7",
+				"@fluidframework/map": "^0.19.7",
+				"@fluidframework/runtime-definitions": "^0.19.7",
+				"@fluidframework/shared-object-base": "^0.19.7",
+				"@fluidframework/synthesize": "^0.19.7",
+				"@fluidframework/view-adapters": "^0.19.7",
+				"@fluidframework/view-interfaces": "^0.19.7",
 				"uuid": "^3.3.2"
 			}
 		},
 		"@fluidframework/base-host": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/base-host/-/base-host-0.19.6.tgz",
-			"integrity": "sha1-td1w6Uxjh9UjQFU2gaTSR59DL9Q=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/base-host/-/base-host-0.19.7.tgz",
+			"integrity": "sha1-7LAeGYIoTgMQcUXQF7iWQkRyEPI=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.19.1",
-				"@fluidframework/component-core-interfaces": "^0.19.6",
-				"@fluidframework/container-definitions": "^0.19.6",
-				"@fluidframework/container-loader": "^0.19.6",
-				"@fluidframework/driver-definitions": "^0.19.6",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
+				"@fluidframework/container-definitions": "^0.19.7",
+				"@fluidframework/container-loader": "^0.19.7",
+				"@fluidframework/driver-definitions": "^0.19.7",
 				"@fluidframework/protocol-base": "^0.1006.1",
 				"@fluidframework/protocol-definitions": "^0.1006.1",
-				"@fluidframework/web-code-loader": "^0.19.6"
+				"@fluidframework/web-code-loader": "^0.19.7"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {
@@ -842,27 +707,27 @@
 			}
 		},
 		"@fluidframework/component-core-interfaces": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/component-core-interfaces/-/component-core-interfaces-0.19.6.tgz",
-			"integrity": "sha1-3Z6EQnGhidfbWYZi1Spd0aK/2W0="
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/component-core-interfaces/-/component-core-interfaces-0.19.7.tgz",
+			"integrity": "sha1-Su/DlYXEQsYlUad93q6JPEvgir4="
 		},
 		"@fluidframework/component-runtime": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/component-runtime/-/component-runtime-0.19.6.tgz",
-			"integrity": "sha1-CXskbcYoA9tQI/HQJu1MVj5uHn0=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/component-runtime/-/component-runtime-0.19.7.tgz",
+			"integrity": "sha1-bylSMIgFV/7PYFxExSVzGxU/k4w=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.19.1",
-				"@fluidframework/component-core-interfaces": "^0.19.6",
-				"@fluidframework/component-runtime-definitions": "^0.19.6",
-				"@fluidframework/container-definitions": "^0.19.6",
-				"@fluidframework/driver-definitions": "^0.19.6",
-				"@fluidframework/driver-utils": "^0.19.6",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
+				"@fluidframework/component-runtime-definitions": "^0.19.7",
+				"@fluidframework/container-definitions": "^0.19.7",
+				"@fluidframework/driver-definitions": "^0.19.7",
+				"@fluidframework/driver-utils": "^0.19.7",
 				"@fluidframework/protocol-base": "^0.1006.1",
 				"@fluidframework/protocol-definitions": "^0.1006.1",
-				"@fluidframework/runtime-definitions": "^0.19.6",
-				"@fluidframework/runtime-utils": "^0.19.6",
-				"@fluidframework/shared-object-base": "^0.19.6",
+				"@fluidframework/runtime-definitions": "^0.19.7",
+				"@fluidframework/runtime-utils": "^0.19.7",
+				"@fluidframework/shared-object-base": "^0.19.7",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
 			},
@@ -894,15 +759,15 @@
 			}
 		},
 		"@fluidframework/component-runtime-definitions": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/component-runtime-definitions/-/component-runtime-definitions-0.19.6.tgz",
-			"integrity": "sha1-wQQG751GRdLXq/cM+pPQ6QKWqb8=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/component-runtime-definitions/-/component-runtime-definitions-0.19.7.tgz",
+			"integrity": "sha1-edhKDM2fefHT+3LhNqHkGcam8Tg=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
-				"@fluidframework/component-core-interfaces": "^0.19.6",
-				"@fluidframework/container-definitions": "^0.19.6",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
+				"@fluidframework/container-definitions": "^0.19.7",
 				"@fluidframework/protocol-definitions": "^0.1006.1",
-				"@fluidframework/runtime-definitions": "^0.19.6",
+				"@fluidframework/runtime-definitions": "^0.19.7",
 				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
@@ -917,13 +782,13 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-definitions/-/container-definitions-0.19.6.tgz",
-			"integrity": "sha1-cY1yjdklfL+LQvBhbcPFkAugOF8=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-definitions/-/container-definitions-0.19.7.tgz",
+			"integrity": "sha1-wK9XL4qrCbki5gGLQfpbKGJuJEA=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
-				"@fluidframework/component-core-interfaces": "^0.19.6",
-				"@fluidframework/driver-definitions": "^0.19.6",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
+				"@fluidframework/driver-definitions": "^0.19.7",
 				"@fluidframework/protocol-definitions": "^0.1006.1"
 			},
 			"dependencies": {
@@ -938,16 +803,16 @@
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-loader/-/container-loader-0.19.6.tgz",
-			"integrity": "sha1-R/Po9Mi3xGAEuSC2EgcYxfZLq8A=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-loader/-/container-loader-0.19.7.tgz",
+			"integrity": "sha1-0DWkEbu+C/fHWJvW7iH5mMW5Nhg=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.19.1",
-				"@fluidframework/component-core-interfaces": "^0.19.6",
-				"@fluidframework/container-definitions": "^0.19.6",
-				"@fluidframework/driver-definitions": "^0.19.6",
-				"@fluidframework/driver-utils": "^0.19.6",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
+				"@fluidframework/container-definitions": "^0.19.7",
+				"@fluidframework/driver-definitions": "^0.19.7",
+				"@fluidframework/driver-utils": "^0.19.7",
 				"@fluidframework/protocol-base": "^0.1006.1",
 				"@fluidframework/protocol-definitions": "^0.1006.1",
 				"@types/double-ended-queue": "^2.1.0",
@@ -986,22 +851,22 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-runtime/-/container-runtime-0.19.6.tgz",
-			"integrity": "sha1-3P8XQajQxnjreUHfMVG23ciay3E=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-runtime/-/container-runtime-0.19.7.tgz",
+			"integrity": "sha1-9h6hYOGCPUpQr476ciBvvtaIVsE=",
 			"requires": {
-				"@fluidframework/agent-scheduler": "^0.19.6",
+				"@fluidframework/agent-scheduler": "^0.19.7",
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.19.1",
-				"@fluidframework/component-core-interfaces": "^0.19.6",
-				"@fluidframework/container-definitions": "^0.19.6",
-				"@fluidframework/container-runtime-definitions": "^0.19.6",
-				"@fluidframework/driver-definitions": "^0.19.6",
-				"@fluidframework/driver-utils": "^0.19.6",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
+				"@fluidframework/container-definitions": "^0.19.7",
+				"@fluidframework/container-runtime-definitions": "^0.19.7",
+				"@fluidframework/driver-definitions": "^0.19.7",
+				"@fluidframework/driver-utils": "^0.19.7",
 				"@fluidframework/protocol-base": "^0.1006.1",
 				"@fluidframework/protocol-definitions": "^0.1006.1",
-				"@fluidframework/runtime-definitions": "^0.19.6",
-				"@fluidframework/runtime-utils": "^0.19.6",
+				"@fluidframework/runtime-definitions": "^0.19.7",
+				"@fluidframework/runtime-utils": "^0.19.7",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/node": "^10.17.24",
@@ -1039,15 +904,15 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.19.6.tgz",
-			"integrity": "sha1-SbcqU3KKKqDfThnKi0auQLsl+r0=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.19.7.tgz",
+			"integrity": "sha1-Ylg/U8bb4OiUjbQKiRE2mBOp8io=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.19.6",
-				"@fluidframework/container-definitions": "^0.19.6",
-				"@fluidframework/driver-definitions": "^0.19.6",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
+				"@fluidframework/container-definitions": "^0.19.7",
+				"@fluidframework/driver-definitions": "^0.19.7",
 				"@fluidframework/protocol-definitions": "^0.1006.1",
-				"@fluidframework/runtime-definitions": "^0.19.6",
+				"@fluidframework/runtime-definitions": "^0.19.7",
 				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
@@ -1062,13 +927,13 @@
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-base/-/driver-base-0.19.6.tgz",
-			"integrity": "sha1-WHYO05ay4EACLzlfhNhgeGJvlYI=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-base/-/driver-base-0.19.7.tgz",
+			"integrity": "sha1-iRo4fmN2aT6l9rOZ05CmaTgx0UM=",
 			"requires": {
 				"@fluidframework/common-utils": "^0.19.1",
-				"@fluidframework/driver-definitions": "^0.19.6",
-				"@fluidframework/driver-utils": "^0.19.6",
+				"@fluidframework/driver-definitions": "^0.19.7",
+				"@fluidframework/driver-utils": "^0.19.7",
 				"@fluidframework/protocol-definitions": "^0.1006.1",
 				"@types/debug": "^4.1.5",
 				"@types/node": "^10.17.24",
@@ -1087,12 +952,12 @@
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-definitions/-/driver-definitions-0.19.6.tgz",
-			"integrity": "sha1-i203FsrS1cjyf8RXzueAcpS8N18=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-definitions/-/driver-definitions-0.19.7.tgz",
+			"integrity": "sha1-qtrcQkzMZ4sv7aHfPlfYk2GBmK4=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
-				"@fluidframework/component-core-interfaces": "^0.19.6",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
 				"@fluidframework/protocol-definitions": "^0.1006.1"
 			},
 			"dependencies": {
@@ -1107,15 +972,15 @@
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-utils/-/driver-utils-0.19.6.tgz",
-			"integrity": "sha1-gtNAN4R0zndwfDzHOHdjbwpIwfA=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-utils/-/driver-utils-0.19.7.tgz",
+			"integrity": "sha1-oaKHqr68+YlTJuu9hfQyEi3vPA8=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.19.1",
-				"@fluidframework/component-core-interfaces": "^0.19.6",
-				"@fluidframework/container-definitions": "^0.19.6",
-				"@fluidframework/driver-definitions": "^0.19.6",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
+				"@fluidframework/container-definitions": "^0.19.7",
+				"@fluidframework/driver-definitions": "^0.19.7",
 				"@fluidframework/gitresources": "^0.1006.1",
 				"@fluidframework/protocol-base": "^0.1006.1",
 				"@fluidframework/protocol-definitions": "^0.1006.1"
@@ -1165,11 +1030,11 @@
 			}
 		},
 		"@fluidframework/framework-interfaces": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/framework-interfaces/-/framework-interfaces-0.19.6.tgz",
-			"integrity": "sha1-XbVNJpGzM3raqKhFd8v2DvPLDVY=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/framework-interfaces/-/framework-interfaces-0.19.7.tgz",
+			"integrity": "sha1-PeUY1HHV7Vr6LC2knJClbNQKBcI=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.19.6"
+				"@fluidframework/component-core-interfaces": "^0.19.7"
 			}
 		},
 		"@fluidframework/gitresources": {
@@ -1178,18 +1043,18 @@
 			"integrity": "sha1-vWhtFD3aKt9eXHKh5536wJlAr+I="
 		},
 		"@fluidframework/local-driver": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/local-driver/-/local-driver-0.19.6.tgz",
-			"integrity": "sha1-2V3uoUDUiQKW8SgVFO0xybkXW4Q=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/local-driver/-/local-driver-0.19.7.tgz",
+			"integrity": "sha1-SiL5yRHp2axtRiQZS2FQhBcPy9Q=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.19.1",
-				"@fluidframework/component-core-interfaces": "^0.19.6",
-				"@fluidframework/container-definitions": "^0.19.6",
-				"@fluidframework/driver-definitions": "^0.19.6",
-				"@fluidframework/driver-utils": "^0.19.6",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
+				"@fluidframework/container-definitions": "^0.19.7",
+				"@fluidframework/driver-definitions": "^0.19.7",
+				"@fluidframework/driver-utils": "^0.19.7",
 				"@fluidframework/protocol-definitions": "^0.1006.1",
-				"@fluidframework/routerlicious-driver": "^0.19.6",
+				"@fluidframework/routerlicious-driver": "^0.19.7",
 				"@fluidframework/server-local-server": "^0.1006.1",
 				"@fluidframework/server-services-client": "^0.1006.1",
 				"@fluidframework/server-services-core": "^0.1006.1",
@@ -1338,18 +1203,18 @@
 			}
 		},
 		"@fluidframework/map": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/map/-/map-0.19.6.tgz",
-			"integrity": "sha1-3th96ok87ExurMeqndPUKQHnOPY=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/map/-/map-0.19.7.tgz",
+			"integrity": "sha1-E138SqXpFiiXCts16RBNJRVSnYI=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.19.1",
-				"@fluidframework/component-core-interfaces": "^0.19.6",
-				"@fluidframework/component-runtime-definitions": "^0.19.6",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
+				"@fluidframework/component-runtime-definitions": "^0.19.7",
 				"@fluidframework/protocol-base": "^0.1006.1",
 				"@fluidframework/protocol-definitions": "^0.1006.1",
-				"@fluidframework/runtime-utils": "^0.19.6",
-				"@fluidframework/shared-object-base": "^0.19.6",
+				"@fluidframework/runtime-utils": "^0.19.7",
+				"@fluidframework/shared-object-base": "^0.19.7",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
@@ -1399,15 +1264,15 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/register-collection/-/register-collection-0.19.6.tgz",
-			"integrity": "sha1-zPy7GOReKLEtwvht6oH1VnW6+90=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/register-collection/-/register-collection-0.19.7.tgz",
+			"integrity": "sha1-/ptz/PeHEkPYkzhqd5jTZegrfKo=",
 			"requires": {
 				"@fluidframework/common-utils": "^0.19.1",
-				"@fluidframework/component-runtime-definitions": "^0.19.6",
+				"@fluidframework/component-runtime-definitions": "^0.19.7",
 				"@fluidframework/protocol-definitions": "^0.1006.1",
-				"@fluidframework/runtime-utils": "^0.19.6",
-				"@fluidframework/shared-object-base": "^0.19.6",
+				"@fluidframework/runtime-utils": "^0.19.7",
+				"@fluidframework/shared-object-base": "^0.19.7",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
@@ -1422,16 +1287,16 @@
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.19.6.tgz",
-			"integrity": "sha1-OLKbGyXvi/qVWLOoLzutSCbgxF0=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.19.7.tgz",
+			"integrity": "sha1-IkCdzNOy+44a7FYo6KnRoGGBo/I=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.19.6",
-				"@fluidframework/driver-base": "^0.19.6",
-				"@fluidframework/driver-definitions": "^0.19.6",
-				"@fluidframework/driver-utils": "^0.19.6",
+				"@fluidframework/container-definitions": "^0.19.7",
+				"@fluidframework/driver-base": "^0.19.7",
+				"@fluidframework/driver-definitions": "^0.19.7",
+				"@fluidframework/driver-utils": "^0.19.7",
 				"@fluidframework/gitresources": "^0.1006.1",
 				"@fluidframework/protocol-base": "^0.1006.1",
 				"@fluidframework/protocol-definitions": "^0.1006.1",
@@ -1487,14 +1352,14 @@
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/runtime-definitions/-/runtime-definitions-0.19.6.tgz",
-			"integrity": "sha1-mDX8b4/wFSXxWiNd0nJJkhiE/vQ=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/runtime-definitions/-/runtime-definitions-0.19.7.tgz",
+			"integrity": "sha1-IzxR84nwHub5ROFG0lQJftqPl90=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
-				"@fluidframework/component-core-interfaces": "^0.19.6",
-				"@fluidframework/container-definitions": "^0.19.6",
-				"@fluidframework/driver-definitions": "^0.19.6",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
+				"@fluidframework/container-definitions": "^0.19.7",
+				"@fluidframework/driver-definitions": "^0.19.7",
 				"@fluidframework/protocol-definitions": "^0.1006.1",
 				"@types/node": "^10.17.24"
 			},
@@ -1510,14 +1375,14 @@
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/runtime-utils/-/runtime-utils-0.19.6.tgz",
-			"integrity": "sha1-x7rv2YDaul6r/HtfMuwIJ74zJsY=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/runtime-utils/-/runtime-utils-0.19.7.tgz",
+			"integrity": "sha1-P1MCNjatccXHNKj0tbcsSe2OPkE=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.19.6",
-				"@fluidframework/component-runtime-definitions": "^0.19.6",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
+				"@fluidframework/component-runtime-definitions": "^0.19.7",
 				"@fluidframework/protocol-definitions": "^0.1006.1",
-				"@fluidframework/runtime-definitions": "^0.19.6"
+				"@fluidframework/runtime-definitions": "^0.19.7"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
@@ -1647,15 +1512,15 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/shared-object-base/-/shared-object-base-0.19.6.tgz",
-			"integrity": "sha1-urEW6Ug85ZNIVDY2yoxp+8HEqpc=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/shared-object-base/-/shared-object-base-0.19.7.tgz",
+			"integrity": "sha1-kKrZP79ZQSd25XB31EK4Alnf47A=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.19.1",
-				"@fluidframework/component-core-interfaces": "^0.19.6",
-				"@fluidframework/component-runtime-definitions": "^0.19.6",
-				"@fluidframework/container-definitions": "^0.19.6",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
+				"@fluidframework/component-runtime-definitions": "^0.19.7",
+				"@fluidframework/container-definitions": "^0.19.7",
 				"@fluidframework/protocol-definitions": "^0.1006.1",
 				"@types/debug": "^4.1.5",
 				"@types/node": "^10.17.24",
@@ -1674,11 +1539,11 @@
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/synthesize/-/synthesize-0.19.6.tgz",
-			"integrity": "sha1-XAm0vv4ngl7KaiNLvBEdxo+DF3s=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/synthesize/-/synthesize-0.19.7.tgz",
+			"integrity": "sha1-TV4STBtzKL4jjSfwjhvzpXj1dGk=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.19.6"
+				"@fluidframework/component-core-interfaces": "^0.19.7"
 			}
 		},
 		"@fluidframework/test-tools": {
@@ -1688,30 +1553,30 @@
 			"dev": true
 		},
 		"@fluidframework/view-adapters": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/view-adapters/-/view-adapters-0.19.6.tgz",
-			"integrity": "sha1-S0NVfY3xraXqjW40QP3kwM5RQE0=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/view-adapters/-/view-adapters-0.19.7.tgz",
+			"integrity": "sha1-BOcR0EHFdPOSlEZL4o6VvvYVmxs=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.19.6",
-				"@fluidframework/view-interfaces": "^0.19.6",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
+				"@fluidframework/view-interfaces": "^0.19.7",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			}
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/view-interfaces/-/view-interfaces-0.19.6.tgz",
-			"integrity": "sha1-Unp4PvNuVCgTQH/nHV/zoem0jdw=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/view-interfaces/-/view-interfaces-0.19.7.tgz",
+			"integrity": "sha1-7+WMH6F8eo/iAve+T6ahYgCYIiU=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.19.6"
+				"@fluidframework/component-core-interfaces": "^0.19.7"
 			}
 		},
 		"@fluidframework/web-code-loader": {
-			"version": "0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/web-code-loader/-/web-code-loader-0.19.6.tgz",
-			"integrity": "sha1-Rjk2zyQdfxAHECSCWggbwV/k3zQ=",
+			"version": "0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/web-code-loader/-/web-code-loader-0.19.7.tgz",
+			"integrity": "sha1-vP7Ui/IBrogRMrRF3DIzNJW4mwI=",
 			"requires": {
-				"@fluidframework/container-definitions": "^0.19.6",
+				"@fluidframework/container-definitions": "^0.19.7",
 				"@types/node": "^10.17.24",
 				"isomorphic-fetch": "^2.2.1"
 			}
@@ -15364,36 +15229,36 @@
 			}
 		},
 		"old-aqueduct": {
-			"version": "npm:@fluidframework/aqueduct@0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/aqueduct/-/aqueduct-0.19.6.tgz",
-			"integrity": "sha1-EaEVrQd1m0pD54PGBaVKRuOfk2Y=",
+			"version": "npm:@fluidframework/aqueduct@0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/aqueduct/-/aqueduct-0.19.7.tgz",
+			"integrity": "sha1-/135m8WYUVlHlR1mHeDXqBTi6Ro=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.19.1",
-				"@fluidframework/component-core-interfaces": "^0.19.6",
-				"@fluidframework/component-runtime": "^0.19.6",
-				"@fluidframework/component-runtime-definitions": "^0.19.6",
-				"@fluidframework/container-definitions": "^0.19.6",
-				"@fluidframework/container-runtime": "^0.19.6",
-				"@fluidframework/container-runtime-definitions": "^0.19.6",
-				"@fluidframework/framework-interfaces": "^0.19.6",
-				"@fluidframework/map": "^0.19.6",
-				"@fluidframework/runtime-definitions": "^0.19.6",
-				"@fluidframework/shared-object-base": "^0.19.6",
-				"@fluidframework/synthesize": "^0.19.6",
-				"@fluidframework/view-adapters": "^0.19.6",
-				"@fluidframework/view-interfaces": "^0.19.6",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
+				"@fluidframework/component-runtime": "^0.19.7",
+				"@fluidframework/component-runtime-definitions": "^0.19.7",
+				"@fluidframework/container-definitions": "^0.19.7",
+				"@fluidframework/container-runtime": "^0.19.7",
+				"@fluidframework/container-runtime-definitions": "^0.19.7",
+				"@fluidframework/framework-interfaces": "^0.19.7",
+				"@fluidframework/map": "^0.19.7",
+				"@fluidframework/runtime-definitions": "^0.19.7",
+				"@fluidframework/shared-object-base": "^0.19.7",
+				"@fluidframework/synthesize": "^0.19.7",
+				"@fluidframework/view-adapters": "^0.19.7",
+				"@fluidframework/view-interfaces": "^0.19.7",
 				"uuid": "^3.3.2"
 			}
 		},
 		"old-container-definitions": {
-			"version": "npm:@fluidframework/container-definitions@0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-definitions/-/container-definitions-0.19.6.tgz",
-			"integrity": "sha1-cY1yjdklfL+LQvBhbcPFkAugOF8=",
+			"version": "npm:@fluidframework/container-definitions@0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-definitions/-/container-definitions-0.19.7.tgz",
+			"integrity": "sha1-wK9XL4qrCbki5gGLQfpbKGJuJEA=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
-				"@fluidframework/component-core-interfaces": "^0.19.6",
-				"@fluidframework/driver-definitions": "^0.19.6",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
+				"@fluidframework/driver-definitions": "^0.19.7",
 				"@fluidframework/protocol-definitions": "^0.1006.1"
 			},
 			"dependencies": {
@@ -15408,16 +15273,16 @@
 			}
 		},
 		"old-container-loader": {
-			"version": "npm:@fluidframework/container-loader@0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-loader/-/container-loader-0.19.6.tgz",
-			"integrity": "sha1-R/Po9Mi3xGAEuSC2EgcYxfZLq8A=",
+			"version": "npm:@fluidframework/container-loader@0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-loader/-/container-loader-0.19.7.tgz",
+			"integrity": "sha1-0DWkEbu+C/fHWJvW7iH5mMW5Nhg=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.19.1",
-				"@fluidframework/component-core-interfaces": "^0.19.6",
-				"@fluidframework/container-definitions": "^0.19.6",
-				"@fluidframework/driver-definitions": "^0.19.6",
-				"@fluidframework/driver-utils": "^0.19.6",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
+				"@fluidframework/container-definitions": "^0.19.7",
+				"@fluidframework/driver-definitions": "^0.19.7",
+				"@fluidframework/driver-utils": "^0.19.7",
 				"@fluidframework/protocol-base": "^0.1006.1",
 				"@fluidframework/protocol-definitions": "^0.1006.1",
 				"@types/double-ended-queue": "^2.1.0",
@@ -15456,22 +15321,22 @@
 			}
 		},
 		"old-container-runtime": {
-			"version": "npm:@fluidframework/container-runtime@0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-runtime/-/container-runtime-0.19.6.tgz",
-			"integrity": "sha1-3P8XQajQxnjreUHfMVG23ciay3E=",
+			"version": "npm:@fluidframework/container-runtime@0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-runtime/-/container-runtime-0.19.7.tgz",
+			"integrity": "sha1-9h6hYOGCPUpQr476ciBvvtaIVsE=",
 			"requires": {
-				"@fluidframework/agent-scheduler": "^0.19.6",
+				"@fluidframework/agent-scheduler": "^0.19.7",
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.19.1",
-				"@fluidframework/component-core-interfaces": "^0.19.6",
-				"@fluidframework/container-definitions": "^0.19.6",
-				"@fluidframework/container-runtime-definitions": "^0.19.6",
-				"@fluidframework/driver-definitions": "^0.19.6",
-				"@fluidframework/driver-utils": "^0.19.6",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
+				"@fluidframework/container-definitions": "^0.19.7",
+				"@fluidframework/container-runtime-definitions": "^0.19.7",
+				"@fluidframework/driver-definitions": "^0.19.7",
+				"@fluidframework/driver-utils": "^0.19.7",
 				"@fluidframework/protocol-base": "^0.1006.1",
 				"@fluidframework/protocol-definitions": "^0.1006.1",
-				"@fluidframework/runtime-definitions": "^0.19.6",
-				"@fluidframework/runtime-utils": "^0.19.6",
+				"@fluidframework/runtime-definitions": "^0.19.7",
+				"@fluidframework/runtime-utils": "^0.19.7",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/node": "^10.17.24",
@@ -15509,14 +15374,14 @@
 			}
 		},
 		"old-runtime-definitions": {
-			"version": "npm:@fluidframework/runtime-definitions@0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/runtime-definitions/-/runtime-definitions-0.19.6.tgz",
-			"integrity": "sha1-mDX8b4/wFSXxWiNd0nJJkhiE/vQ=",
+			"version": "npm:@fluidframework/runtime-definitions@0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/runtime-definitions/-/runtime-definitions-0.19.7.tgz",
+			"integrity": "sha1-IzxR84nwHub5ROFG0lQJftqPl90=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
-				"@fluidframework/component-core-interfaces": "^0.19.6",
-				"@fluidframework/container-definitions": "^0.19.6",
-				"@fluidframework/driver-definitions": "^0.19.6",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
+				"@fluidframework/container-definitions": "^0.19.7",
+				"@fluidframework/driver-definitions": "^0.19.7",
 				"@fluidframework/protocol-definitions": "^0.1006.1",
 				"@types/node": "^10.17.24"
 			},
@@ -15532,22 +15397,22 @@
 			}
 		},
 		"old-test-utils": {
-			"version": "npm:@fluidframework/test-utils@0.19.6",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/test-utils/-/test-utils-0.19.6.tgz",
-			"integrity": "sha1-LqQXs/lzxTqj7Eyxik015Yi4R5o=",
+			"version": "npm:@fluidframework/test-utils@0.19.7",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/test-utils/-/test-utils-0.19.7.tgz",
+			"integrity": "sha1-Yca1cQXNSdDMvVM+7UNbZqMX+bw=",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.19.6",
-				"@fluidframework/base-host": "^0.19.6",
-				"@fluidframework/component-core-interfaces": "^0.19.6",
-				"@fluidframework/component-runtime": "^0.19.6",
-				"@fluidframework/component-runtime-definitions": "^0.19.6",
-				"@fluidframework/container-definitions": "^0.19.6",
-				"@fluidframework/container-loader": "^0.19.6",
-				"@fluidframework/local-driver": "^0.19.6",
-				"@fluidframework/map": "^0.19.6",
-				"@fluidframework/runtime-definitions": "^0.19.6",
+				"@fluidframework/aqueduct": "^0.19.7",
+				"@fluidframework/base-host": "^0.19.7",
+				"@fluidframework/component-core-interfaces": "^0.19.7",
+				"@fluidframework/component-runtime": "^0.19.7",
+				"@fluidframework/component-runtime-definitions": "^0.19.7",
+				"@fluidframework/container-definitions": "^0.19.7",
+				"@fluidframework/container-loader": "^0.19.7",
+				"@fluidframework/local-driver": "^0.19.7",
+				"@fluidframework/map": "^0.19.7",
+				"@fluidframework/runtime-definitions": "^0.19.7",
 				"@fluidframework/server-local-server": "^0.1006.1",
-				"@fluidframework/shared-object-base": "^0.19.6"
+				"@fluidframework/shared-object-base": "^0.19.7"
 			},
 			"dependencies": {
 				"@fluidframework/gitresources": {


### PR DESCRIPTION
not sure why this issue is happening, but when switching from office-ui-fabric-react to Fluent UI (which is literally the same code publish to both locations) we're hitting an issue doing a local build of the package (oddly it works in CI). 

While it'd be best to promote the new package name, we can't do it at the expense of running local builds! I'll revert it for now and hopefully find a way to switch it back later. 