### PR TITLE
react-inputs: Reduce public/exported surface and add TSDoc

### DIFF
--- a/components/experimental/react-inputs/README.md
+++ b/components/experimental/react-inputs/README.md
@@ -3,11 +3,10 @@
 Simple examples of React Input Components integrated with the FluidFramework.
 
 ## collabarativeCheckbox
-Fluid enabled checkbox
-The checkbox uses the counter to ensure consistency if two people both hit the button.
+Given a SharedCell will produce a collaborative checkbox.
 
 ## collaborativeInput
 Given a SharedString will produce a collaborative input element.
 
 ## collaborativeTextArea
-Given a SharedString will produce a collaborative textarea
+Given a SharedString will produce a collaborative textarea.

--- a/components/experimental/react-inputs/src/CollaborativeCheckbox.tsx
+++ b/components/experimental/react-inputs/src/CollaborativeCheckbox.tsx
@@ -18,7 +18,7 @@ export interface ICollaborativeCheckboxProps {
     style?: React.CSSProperties;
 }
 
-interface ICollaborativeCheckboxState {
+export interface ICollaborativeCheckboxState {
     checked: boolean;
 }
 

--- a/components/experimental/react-inputs/src/CollaborativeCheckbox.tsx
+++ b/components/experimental/react-inputs/src/CollaborativeCheckbox.tsx
@@ -6,19 +6,24 @@ import { SharedCell } from "@fluidframework/cell";
 import React from "react";
 
 export interface ICollaborativeCheckboxProps {
+    /**
+     * The SharedCell that will store the checkbox value.
+     */
     data: SharedCell;
+    /**
+     * The value for the "name" property of the checkbox input
+     */
     id: string;
     className?: string;
     style?: React.CSSProperties;
 }
 
-export interface ICollaborativeCheckboxState {
+interface ICollaborativeCheckboxState {
     checked: boolean;
 }
 
 /**
- * Fluid enabled checkbox
- * The checkbox uses the counter to ensure consistency if two people both hit the button.
+ * Given a SharedCell will produce a collaborative checkbox.
  */
 export class CollaborativeCheckbox
     extends React.Component<ICollaborativeCheckboxProps, ICollaborativeCheckboxState> {

--- a/components/experimental/react-inputs/src/CollaborativeInput.tsx
+++ b/components/experimental/react-inputs/src/CollaborativeInput.tsx
@@ -11,7 +11,7 @@ export interface ICollaborativeInputProps {
      */
     sharedString: SharedString;
     /**
-     * Whether spellCheck should be enabled.  Defaults to false.
+     * Whether spellCheck should be enabled.  Defaults to true.
      */
     spellCheck?: boolean;
     className?: string;

--- a/components/experimental/react-inputs/src/CollaborativeInput.tsx
+++ b/components/experimental/react-inputs/src/CollaborativeInput.tsx
@@ -18,7 +18,7 @@ export interface ICollaborativeInputProps {
     style?: React.CSSProperties;
 }
 
-interface ICollaborativeInputState {
+export interface ICollaborativeInputState {
     selectionEnd: number;
     selectionStart: number;
 }

--- a/components/experimental/react-inputs/src/CollaborativeInput.tsx
+++ b/components/experimental/react-inputs/src/CollaborativeInput.tsx
@@ -6,13 +6,19 @@ import { SharedString } from "@fluidframework/sequence";
 import React from "react";
 
 export interface ICollaborativeInputProps {
+    /**
+     * The SharedString that will store the input value.
+     */
     sharedString: SharedString;
+    /**
+     * Whether spellCheck should be enabled.  Defaults to false.
+     */
     spellCheck?: boolean;
     className?: string;
     style?: React.CSSProperties;
 }
 
-export interface ICollaborativeInputState {
+interface ICollaborativeInputState {
     selectionEnd: number;
     selectionStart: number;
 }

--- a/components/experimental/react-inputs/src/CollaborativeTextArea.tsx
+++ b/components/experimental/react-inputs/src/CollaborativeTextArea.tsx
@@ -18,7 +18,7 @@ export interface ICollaborativeTextAreaProps {
     style?: React.CSSProperties;
 }
 
-interface ICollaborativeTextAreaState {
+export interface ICollaborativeTextAreaState {
     selectionEnd: number;
     selectionStart: number;
     text: string;

--- a/components/experimental/react-inputs/src/CollaborativeTextArea.tsx
+++ b/components/experimental/react-inputs/src/CollaborativeTextArea.tsx
@@ -6,22 +6,26 @@ import { SharedString } from "@fluidframework/sequence";
 import React from "react";
 
 export interface ICollaborativeTextAreaProps {
+    /**
+     * The SharedString that will store the text from the textarea.
+     */
     sharedString: SharedString;
+    /**
+     * Whether spellCheck should be enabled.  Defaults to false.
+     */
     spellCheck?: boolean;
     className?: string;
     style?: React.CSSProperties;
 }
 
-export interface ICollaborativeTextAreaState {
+interface ICollaborativeTextAreaState {
     selectionEnd: number;
     selectionStart: number;
     text: string;
 }
 
 /**
- * Given a cell will provide an editable component
- * This produces a single line content editable box. It's single line because doing
- * multiple lines means you have to manage line breaks which is hard.
+ * Given a SharedString will produce a collaborative textarea.
  */
 export class CollaborativeTextArea
     extends React.Component<ICollaborativeTextAreaProps, ICollaborativeTextAreaState> {
@@ -112,7 +116,7 @@ export class CollaborativeTextArea
         });
     }
 
-    public setCaretPosition(newStart: number, newEnd: number) {
+    private setCaretPosition(newStart: number, newEnd: number) {
         if (this.ref.current) {
             this.ref.current.selectionStart = newStart;
             this.ref.current.selectionEnd = newEnd;


### PR DESCRIPTION
Stopped exporting a few interfaces and converted a few members to private.  Added TSDoc for all remaining interesting public items.