### PR TITLE
Increase odsp driver socket reference buffer time

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -25,8 +25,8 @@ import { errorObjectFromSocketError } from "./odspUtils";
 const protocolVersions = ["^0.4.0", "^0.3.0", "^0.2.0", "^0.1.0"];
 
 // How long to wait before disconnecting the socket after the last reference is removed
-// This allows reconnection after receiving a nack to be smooth
-const socketReferenceBufferTime = 2000;
+// This allows multiplexing scenarios and reconnections after receiving a nack to be smoother
+const socketReferenceBufferTime = 5000;
 
 class SocketReference {
     public references: number = 1;


### PR DESCRIPTION
The fluid app can continue using the same websocket connection when switching between documents (only when using the new push service).
It works most of the time with 2 seconds, but sometimes switching between documents takes a little longer than that, resulting in the websocket closing and a new one opening. Increasing it to 5 seconds should make it more reliable.