### PR TITLE
Improve rendering fidelity of ink canvas

### DIFF
--- a/packages/dds/ink/README.md
+++ b/packages/dds/ink/README.md
@@ -66,7 +66,6 @@ Ink is an in-progress data structure with the purpose of facilitating collaborat
 
 ## Coordinate bundling
 - Enable bundled coordinate updates rather than one per op
-- Use PointerEvent.getCoalescedEvents(), along with the bundled coordinate updates to improve rendering fidelity and hang resistance
 
 ## Canvas consolidation
 - Replace client-ui-lib's OverlayCanvas with ink's InkCanvas, or remove it.

--- a/packages/dds/ink/src/inkCanvas.ts
+++ b/packages/dds/ink/src/inkCanvas.ts
@@ -133,7 +133,7 @@ export class InkCanvas {
             thickness: 7,
         };
 
-        this.redraw();
+        this.setSize(canvas.width, canvas.height);
     }
 
     public setPenColor(color: IColor) {
@@ -158,10 +158,17 @@ export class InkCanvas {
     }
 
     public setSize(width: number, height: number) {
-        this.canvas.width = width;
-        this.canvas.height = height;
+        // Scale the canvas size to match the physical pixel to avoid blurriness
+        const scale = window.devicePixelRatio;
+        this.canvas.width = Math.floor(width * scale);
+        this.canvas.height = Math.floor(height * scale);
+        // Set CSS pixel size as is
         this.canvas.style.width = `${width}px`;
         this.canvas.style.height = `${height}px`;
+        // Scale the context to bring back coordinate system in CSS pixels
+        this.context.setTransform(1, 0, 0, 1, 0, 0);
+        this.context.scale(scale, scale);
+
         this.redraw();
     }
 
@@ -179,7 +186,10 @@ export class InkCanvas {
 
     private handlePointerMove(evt: PointerEvent) {
         if (this.localActiveStrokeMap.has(evt.pointerId)) {
-            this.appendPointerEventToStroke(evt);
+            const evts = (evt as any)?.getCoalescedEvents() ?? [evt] as PointerEvent[];
+            for (const e of evts) {
+                this.appendPointerEventToStroke(e);
+            }
         }
     }
 


### PR DESCRIPTION
- Fix blurriness on HiDPI/Retina displays or browser zoom by scaling the canvas by window.devicePixelRatio.
- Use PointerEvent.getCoalescedEvents() to draw more points.