### PR TITLE
Fix Container.attached reference after porting 0.19.x fix and rename

### DIFF
--- a/packages/loader/container-definitions/src/chaincode.ts
+++ b/packages/loader/container-definitions/src/chaincode.ts
@@ -175,12 +175,6 @@ export interface IRuntime extends IDisposable {
     createSummary(): ISummaryTree;
 }
 
-export enum ContainerState {
-    Detached = "Detached",
-    Attaching = "Attaching",
-    Attached = "Attached",
-}
-
 export interface IMessageScheduler {
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
 }


### PR DESCRIPTION
There is an Container.attached reference that is in 0.20.x but not in 0.19.x.  So after the properties is renamed to attachmentState, build starts to failed in 0.20.x.

This fixes it and also rename it to simply attachState.
Also renamed the enum to ContainerAttachState, move it with the Container make it not exported (it is not exposed to be a public interface.