### PR TITLE
Restrict trigger for the doc build

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -39,6 +39,17 @@ resources:
       - release/*
       - master
 
+trigger:
+  branches:
+  - release/*
+  - master
+  path:
+    exclude:
+    - packages
+    - server/routerlicious
+    - common/lib/common-utils
+    - common/lib/common-definitions
+
 # no PR triggers
 pr: none
 


### PR DESCRIPTION
Without a trigger, the pipeline is triggering on every push to the repo.

Only triggers if it is commit to release/* and master.  Also ignore the directories that are covered by the other pipelines.