### PR TITLE
Invalid assert in odsp  driver

### DIFF
--- a/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
@@ -527,8 +527,6 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
 
     // back-compat: 0.14 uploadSummary
     public async uploadSummary(tree: api.ISummaryTree): Promise<api.ISummaryHandle> {
-        assert(this.hostPolicy.summarizerClient);
-
         this.checkSnapshotUrl();
 
         const { result, blobsShaToPathCacheLatest } = await this.writeSummaryTree({

--- a/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-socket-storage/src/odspDocumentStorageManager.ts
@@ -388,9 +388,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                     let appCommit: string | undefined;
                     this.initTreesCache(trees);
                     for (const [key, treeVal] of this.treesCache.entries()) {
-                        if (appCommit) {
-                            break;
-                        }
+                        // Path for app entries in cache starts with .app, so look for appCommit first in the entries.
                         for (const entry of treeVal.entries) {
                             if (entry.type === "commit" && entry.path === ".app") {
                                 // This is the unacked handle of the latest summary generated.
@@ -398,7 +396,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                                 break;
                             }
                         }
-                        assert(appCommit); // .app commit should be first entry in first entry.
+
                         for (const entry of treeVal.entries) {
                             if (entry.type === "blob") {
                                 blobsIdToPathMap.set(idFromSpoEntry(entry), key === appCommit ? `/.app/${entry.path}` : `/${entry.path}`);


### PR DESCRIPTION
1.) This assumption does not comply with the snapshot format that we get after posting detach container summary.
2.) assert is also not required because if extract it from the entries. If not present if handle that case while putting entries in cache.