### PR TITLE
Stop recommending the tsfmt extension b/c it doesn't work in monorepos

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,8 +4,7 @@
     // List of extensions which should be recommended for users of this workspace.
     "recommendations": [
         "dbaeumer.vscode-eslint",
-        "editorconfig.editorconfig",
-        "eternalphane.tsfmt-vscode"
+        "editorconfig.editorconfig"
     ],
     // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
     "unwantedRecommendations": []


### PR DESCRIPTION
The extensions doesn't seem to pick up the monorepo TS compiler, so newer TS features get flagged as invalid syntax, and formatting goes haywire. More info here: https://github.com/eternalphane/tsfmt-vscode/issues/7