### PR TITLE
Fixed documentDirty not cleared when a batch is sent

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -952,9 +952,9 @@ implements IContainerRuntime, IContainerRuntimeDirtyable, IRuntime, ISummarizerR
                     localMessageMetadata = this.pendingStateManager.processPendingLocalMessage(message);
                 }
 
-                // If there are no more pending states after processing a local message,
+                // If there are no more pending messages after processing a local message,
                 // the document is no longer dirty.
-                if (!this.pendingStateManager.isPendingState()) {
+                if (!this.pendingStateManager.hasPendingMessages()) {
                     this.updateDocumentDirtyState(false);
                 }
             }
@@ -1050,6 +1050,8 @@ implements IContainerRuntime, IContainerRuntimeDirtyable, IRuntime, ISummarizerR
             debug("DeltaManager does not yet support flush modes");
             return;
         }
+
+        this.pendingStateManager.onFlush();
 
         // If flush has already been called then exit early
         if (!this.needsFlush) {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1051,6 +1051,10 @@ implements IContainerRuntime, IContainerRuntimeDirtyable, IRuntime, ISummarizerR
             return;
         }
 
+        // Let the PendingStateManager know that there was an attempt to flush messages.
+        // Note that this should happen before the `this.needsFlush` check below because in the scenario where we are
+        // not connected, `this.needsFlush` will be false but the PendingStateManager might have pending messages and
+        // hence needs to track this.
         this.pendingStateManager.onFlush();
 
         // If flush has already been called then exit early

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -26,6 +26,10 @@ export class DataCorruptionError extends CustomErrorWithProps implements IErrorB
     }
 }
 
+/**
+ * This represents a message that has been submitted and is added to the pending queue when `submit` is called on the
+ * ContainerRuntime. This message has either not been ack'd by the server or has not been submitted to the server yet.
+ */
 interface IPendingMessage {
     type: "message";
     messageType: ContainerMessageType;
@@ -34,11 +38,19 @@ interface IPendingMessage {
     localOpMetadata: unknown;
 }
 
+/**
+ * This represents a FlushMode update and is added to the pending queue when `setFlushMode` is called on the
+ * ContainerRuntime and the FlushMode changes.
+ */
 interface IPendingFlushMode {
     type: "flushMode";
     flushMode: FlushMode;
 }
 
+/**
+ * This represents a manual flush and is added to the pending queue when `flush` is called on the ContainerRuntime to
+ * flush any pending messages. This is applicable only when the FlushMode is Manual.
+ */
 interface IPendingFlush {
     type: "flush";
 }

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -70,7 +70,7 @@ export class PendingStateManager {
     private readonly pendingStates = new Deque<IPendingState>();
 
     // Maintains the count of messages that are currently unacked.
-    private pendingMessageCount: number = 0;
+    private pendingMessagesCount: number = 0;
 
     // Indicates whether we are processing a batch.
     private isProcessingBatch: boolean = false;
@@ -102,7 +102,7 @@ export class PendingStateManager {
      * @returns A boolean indicating whether there are messages or not.
      */
     public hasPendingMessages(): boolean {
-        return this.pendingMessageCount !== 0;
+        return this.pendingMessagesCount !== 0;
     }
 
     constructor(private readonly containerRuntime: ContainerRuntime) { }
@@ -130,7 +130,7 @@ export class PendingStateManager {
 
         this.pendingStates.push(pendingMessage);
 
-        this.pendingMessageCount++;
+        this.pendingMessagesCount++;
     }
 
     /**
@@ -219,7 +219,7 @@ export class PendingStateManager {
             return;
         }
 
-        this.pendingMessageCount--;
+        this.pendingMessagesCount--;
 
         // Post-processing part - If we are processing a batch then this could be the last message in the batch.
         if (this.isProcessingBatch) {
@@ -317,7 +317,7 @@ export class PendingStateManager {
         }
 
         // Reset the pending message count because all these messages will be removed from the queue.
-        this.pendingMessageCount = 0;
+        this.pendingMessagesCount = 0;
 
         // Save the current FlushMode so that we can revert it back after replaying the states.
         const savedFlushMode = this.containerRuntime.flushMode;

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -54,28 +54,42 @@ export class PendingStateManager {
 
     // Indicates whether we are processing a batch.
     private isProcessingBatch: boolean = false;
-    // This stores all the messages in the batch that we are processing. This is used to verify that we get the
-    // correct batch metadata.
-    private pendingBatchMessages: ISequencedDocumentMessage[] = [];
+    // This stores the first message in the batch that we are processing. This is used to verify that we get
+    // the correct batch metadata.
+    private pendingBatchBeginMessage: ISequencedDocumentMessage | undefined;
 
     private get connected(): boolean {
         return this.containerRuntime.connected;
     }
 
+    /**
+     * Called when the Container's connection state changes. If the Container gets connected, it replays all the pending
+     * states in its queue.
+     * @param connected - true if we got connected, false if we got disconnected.
+     */
     public setConnectionState(connected: boolean) {
         assert(this.connected === connected, "The connection state is not consistent with the runtime");
 
+        // If we got connected, replay the pending states that have not been ack'd yet.
         if (connected) {
             this.replayPendingStates();
         }
     }
 
+    /**
+     * Called to check if there are any pending states in the pending state queue.
+     * @returns A boolean indicating whether the queue is empty or not.
+     */
     public isPendingState(): boolean {
         return !this.pendingStates.isEmpty();
     }
 
     constructor(private readonly containerRuntime: ContainerRuntime) { }
 
+    /**
+     * Called when the FlushMode is updated. Adds the FlushMode to the pending state queue.
+     * @param flushMode - The flushMode that was updated.
+     */
     public onFlushModeUpdated(flushMode: FlushMode) {
         // If no messages were sent between FlushMode.Manual and FlushMode.Automatic, then we do not have to track
         // them. Remove them from the pending queue and return.
@@ -97,6 +111,14 @@ export class PendingStateManager {
         this.pendingStates.push(pendingFlushMode);
     }
 
+    /**
+     * Called when a message is submitted locally. Adds the message and the associated details to the pending state
+     * queue.
+     * @param type - The container message type.
+     * @param clientSequenceNumber - The clientSequenceNumber associated with the message.
+     * @param content - The message content.
+     * @param localOpMetadata - The local metadata associated with the message.
+     */
     public onSubmitMessage(
         type: ContainerMessageType,
         clientSequenceNumber: number,
@@ -113,21 +135,26 @@ export class PendingStateManager {
         this.pendingStates.push(pendingMessage);
     }
 
+    /**
+     * Processes a local message once its ack'd by the server. It verifies that there was no data corruption and that
+     * the batch information was preserved for batch messages.
+     * @param message - The messsage that got ack'd and needs to be processed.
+     */
     public processPendingLocalMessage(message: ISequencedDocumentMessage): unknown {
-        let pendingState = this.pendingStates.peekFront();
-        assert(pendingState, "No pending message found for this remote message");
+        // Pre-processing part - This may be the start of a batch.
+        // If so, there must be a pending "flush" state marking the beginning of a batch. Process batch begin and get
+        // the pending "message" state that follows.
+        let pendingState = this.getNextPendingState();
+        if (pendingState.type === "flush") {
+            // Process the beginning of the batch.
+            this.processBatchBegin(pendingState, message);
 
-        // Process "flush" type messages first, if any.
-        while (pendingState.type !== "message") {
-            // Process the pending "flush" state and verify that we get correct batch metadata.
-            this.processFlushState(pendingState);
-
-            // Get the next message from the pending queue.
-            this.pendingStates.shift();
-            pendingState = this.pendingStates.peekFront();
-            assert(pendingState, "No pending message found for this remote message");
+            // Get the next state from the pending queue and verify that it is of type "message".
+            pendingState = this.getNextPendingState();
+            assert(pendingState.type === "message", "No pending message found for this remote message");
         }
 
+        // Processing part - Verify that there has been no data corruption.
         // The clientSequenceNumber of the incoming message must match that of the pending message.
         if (pendingState.clientSequenceNumber !== message.clientSequenceNumber) {
             // Close the container because this indicates data corruption.
@@ -145,20 +172,15 @@ export class PendingStateManager {
             return;
         }
 
-        // Remove the first message from the pending list since it has been processed.
-        this.pendingStates.shift();
-
+        // Post-processing part - If we are processing a batch then this could be the last message in the batch.
+        // If so, there must be a pending "flush" state marking end of the batch. Verify that and process batch end.
         if (this.isProcessingBatch) {
-            // If we are processing a batch, add this message to the pending batch queue.
-            this.pendingBatchMessages.push(message);
-
-            // This may be the last message in the batch. If so, we need to process the "flush" state for batch end as
-            // we have received the entire batch.
             const nextPendingState = this.pendingStates.peekFront();
             assert(nextPendingState, "We should at least have the pending flush state indicating end of batch");
 
             if (nextPendingState.type === "flush") {
-                this.processFlushState(nextPendingState);
+                // Got the last message in the batch. Process batch end and remove the "flush" state from the queue.
+                this.processBatchEnd(nextPendingState, message);
                 this.pendingStates.shift();
             }
         }
@@ -167,52 +189,67 @@ export class PendingStateManager {
     }
 
     /**
-     * Verifies that the batch metadata is received as the per the "flush" state.
-     * @param pendingState - The "flush" state to process.
+     * Processes the beginning of a batch. Verifies the pending "flush" state and the pending batch state are correct.
+     * @param pendingState - The pending "flush" state marking the beginning of the batch.
+     * @param message - The first message in the batch.
      */
-    private processFlushState(pendingState: IPendingState) {
-        assert(pendingState.type === "flush", "Invalid pending state type");
+    private processBatchBegin(pendingState: IPendingState, message: ISequencedDocumentMessage) {
+        assert(pendingState.type === "flush", "The pending state should be of type flush");
+        assert(pendingState.flushMode === FlushMode.Manual, "The flush mode must be Manual for batch begin");
+        // We should not already be processing a batch and there should be no pending batch begin message.
+        assert(!this.isProcessingBatch && this.pendingBatchBeginMessage === undefined,
+            "The pending batch state indicates we are already processing a batch");
 
-        const pendingFlushMode = pendingState.flushMode;
-
-        // If FlushMode was set to Manual, this is the beginning of a batch.
-        if (pendingFlushMode === FlushMode.Manual) {
-            // We should not already be processing a batch.
-            assert(!this.isProcessingBatch, "FlushMode should never be set to Manual in the middle of a batch");
-
-            this.pendingBatchMessages = [];
-            this.isProcessingBatch = true;
-            return;
-        }
-
-        // If FlushMode was set to Automatic, a batch just ended. Verify that we received the correct batch metadata
-        // for this batch.
-        if (pendingFlushMode === FlushMode.Automatic) {
-            // We should have been processing a batch.
-            assert(this.isProcessingBatch, "Did not receive batch messages as expected");
-
-            const batchCount = this.pendingBatchMessages.length;
-            // There should be at least one batch message.
-            assert(batchCount > 0, "Did not receive any batch message in the batch");
-
-            const batchBeginMetadata = this.pendingBatchMessages[0].metadata?.batch;
-            const batchEndMetadata = this.pendingBatchMessages[batchCount - 1].metadata?.batch;
-
-            if (batchCount === 1) {
-                // If there is a single message in the batch, it should not have any batch metadata.
-                assert(batchBeginMetadata === undefined,
-                    "Batch with single message should not have batch metadata");
-            } else {
-                // For multiple messages in the batch, assert that we got batch begin and end metadata.
-                assert(batchBeginMetadata === true, "Did not receive batch begin metadata");
-                assert(batchEndMetadata === false, "Did not receive batch end metadata");
-            }
-
-            this.pendingBatchMessages = [];
-            this.isProcessingBatch = false;
-        }
+        // Set the pending batch state indicating we have started processing a batch.
+        this.pendingBatchBeginMessage = message;
+        this.isProcessingBatch = true;
     }
 
+    /**
+     * Processes the end of a batch. Verifies the pending "flush" state and the pending batch state are correct.
+     * @param pendingState - The pending "flush" state marking the end of the batch.
+     * @param message - The last message in the batch.
+     */
+    private processBatchEnd(pendingState: IPendingState, message: ISequencedDocumentMessage) {
+        assert(pendingState.type === "flush", "The pending state should have been of type flush");
+        assert(pendingState.flushMode === FlushMode.Automatic, "The flush mode must be Automatic for batch end");
+        // We should be processing a batch and there should be a pending batch begin message.
+        assert(this.isProcessingBatch && this.pendingBatchBeginMessage !== undefined,
+            "The pending batch state indicates we are not processing a batch");
+
+        // Get the batch begin metadata from the first message in the batch.
+        const batchBeginMetadata = this.pendingBatchBeginMessage.metadata?.batch;
+
+        // There could be just a single message in the batch. If so, it should not have any batch metadata. If there
+        // are multiple messages in the batch, verify that we got the correct batch begin and end metadata.
+        if (this.pendingBatchBeginMessage === message) {
+            assert(batchBeginMetadata === undefined,
+                "Batch with single message should not have batch metadata");
+        } else {
+            // Get the batch metadat from the last message in the batch.
+            const batchEndMetadata = message.metadata?.batch;
+            assert(batchBeginMetadata === true, "Did not receive batch begin metadata");
+            assert(batchEndMetadata === false, "Did not receive batch end metadata");
+        }
+
+        // Clear the pending batch state now that we have processed the entire batch.
+        this.pendingBatchBeginMessage = undefined;
+        this.isProcessingBatch = false;
+    }
+
+    /**
+     * Returns the next pending state from the pending state queue.
+     */
+    private getNextPendingState(): IPendingState {
+        const nextPendingState = this.pendingStates.shift();
+        assert(nextPendingState, "No pending state found for the remote message");
+        return nextPendingState;
+    }
+
+    /**
+     * Replays all the pending states that are currently in the queue. This includes setting the FlushMode and
+     * trigerring resubmission of unacked ops. This typically happens when we reconnect.
+     */
     private replayPendingStates() {
         const pendingStatesCount = this.pendingStates.length;
         if (pendingStatesCount === 0) {

--- a/packages/test/end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/batching.spec.ts
@@ -173,11 +173,11 @@ describe("Batching", () => {
                 assert.equal(
                     component2BatchMessages.length, 4, "Incorrect number of messages received on remote client");
 
-                // Verify the first batch.
+                // Verify the local client's batches.
                 verifyBatchMetadata(component1BatchMessages.slice(0, 2));
                 verifyBatchMetadata(component1BatchMessages.slice(2, 4));
 
-                // Verify the second batch.
+                // Verify the remote client's batches.
                 verifyBatchMetadata(component2BatchMessages.slice(0, 2));
                 verifyBatchMetadata(component2BatchMessages.slice(2, 4));
             });
@@ -298,6 +298,13 @@ describe("Batching", () => {
                 // Manually flush the batch.
                 (component2.context.containerRuntime as IContainerRuntime).flush();
 
+                // Send a third set of ops that are to be batched together.
+                component2map1.set("key5", "value5");
+                component2map2.set("key6", "value6");
+
+                // Manually flush the batch.
+                (component2.context.containerRuntime as IContainerRuntime).flush();
+
                 // Set the FlushMode back to Automatic.
                 component2.context.containerRuntime.setFlushMode(FlushMode.Automatic);
 
@@ -305,17 +312,19 @@ describe("Batching", () => {
                 await containerDeltaEventManager.process();
 
                 assert.equal(
-                    component1BatchMessages.length, 4, "Incorrect number of messages received on local client");
+                    component1BatchMessages.length, 6, "Incorrect number of messages received on local client");
                 assert.equal(
-                    component2BatchMessages.length, 4, "Incorrect number of messages received on remote client");
+                    component2BatchMessages.length, 6, "Incorrect number of messages received on remote client");
 
-                // Verify the first batch.
+                // Verify the local client's batches.
                 verifyBatchMetadata(component1BatchMessages.slice(0, 2));
                 verifyBatchMetadata(component1BatchMessages.slice(2, 4));
+                verifyBatchMetadata(component1BatchMessages.slice(4, 6));
 
-                // Verify the second batch.
+                // Verify the remote client's batches.
                 verifyBatchMetadata(component2BatchMessages.slice(0, 2));
                 verifyBatchMetadata(component2BatchMessages.slice(2, 4));
+                verifyBatchMetadata(component2BatchMessages.slice(4, 6));
             });
         });
 

--- a/packages/test/end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/batching.spec.ts
@@ -223,46 +223,49 @@ describe("Batching", () => {
     });
 
     describe("Document Dirty State", () => {
+        // Verifies that the document dirty state for the given document is as expected.
+        function verifyDocumentDirtyState(component: ITestFluidComponent, expectedState: boolean) {
+            const dirty = (component.context.containerRuntime as IContainerRuntime).isDocumentDirty();
+            assert.equal(dirty, expectedState, "The document dirty state is not as expected");
+        }
+
         it("should clean document dirty state after a batch is sent", async () => {
             // Send a batch with a single message.
             component1.context.containerRuntime.orderSequentially(() => {
                 component1map1.set("key1", "value1");
             });
 
-            // Check that the document is correctly set to dirty.
-            let dirty = (component1.context.containerRuntime as IContainerRuntime).isDocumentDirty();
-            assert.equal(dirty, true, "The document should be dirty on submitting an op");
+            // Verify that the document is correctly set to dirty.
+            verifyDocumentDirtyState(component1, true);
 
             // Wait for the ops to get processed by both the containers.
             await containerDeltaEventManager.process();
 
-            // Check that the document dirty state is cleaned after the ops are processed.
-            dirty = (component1.context.containerRuntime as IContainerRuntime).isDocumentDirty();
-            assert.equal(dirty, false, "The document dirty state should have been cleaned");
+            // Verify that the document dirty state is cleaned after the ops are processed.
+            verifyDocumentDirtyState(component1, false);
         });
 
         it("should clean document dirty state after consecutive batches are sent", async () => {
             // Send a couple of batches consecutively.
             component1.context.containerRuntime.orderSequentially(() => {
                 component1map1.set("key1", "value1");
-                component1map2.set("key2", "value2");
             });
 
             component1.context.containerRuntime.orderSequentially(() => {
+                component1map2.set("key2", "value2");
                 component1map1.set("key3", "value3");
                 component1map2.set("key4", "value4");
             });
 
-            // Check that the document is correctly set to dirty.
-            let dirty = (component1.context.containerRuntime as IContainerRuntime).isDocumentDirty();
-            assert.equal(dirty, true, "The document should be dirty on submitting an op");
+            // Verify that the document is correctly set to dirty.
+            verifyDocumentDirtyState(component1, true);
 
             // Wait for the ops to get processed by both the containers.
             await containerDeltaEventManager.process();
 
             // Check that the document dirty state is cleaned after the ops are processed.
-            dirty = (component1.context.containerRuntime as IContainerRuntime).isDocumentDirty();
-            assert.equal(dirty, false, "The document dirty state should have been cleaned");
+            // Verify that the document dirty state is cleaned after the ops are processed.
+            verifyDocumentDirtyState(component1, false);
         });
 
         it("should clean document dirty state after batch and not-batch messages are sent", async () => {
@@ -273,26 +276,24 @@ describe("Batching", () => {
             component1.context.containerRuntime.orderSequentially(() => {
                 component1map2.set("key2", "value2");
                 component1map1.set("key3", "value3");
+                component1map2.set("key4", "value4");
             });
 
             component1.context.containerRuntime.orderSequentially(() => {
-                component1map2.set("key4", "value4");
                 component1map1.set("key5", "value5");
             });
 
             // Send another non-batch message.
             component1map1.set("key5", "value5");
 
-            // Check that the document is correctly set to dirty.
-            let dirty = (component1.context.containerRuntime as IContainerRuntime).isDocumentDirty();
-            assert.equal(dirty, true, "The document should be dirty on submitting an op");
+            // Verify that the document is correctly set to dirty.
+            verifyDocumentDirtyState(component1, true);
 
             // Wait for the ops to get processed by both the containers.
             await containerDeltaEventManager.process();
 
-            // Check that the document dirty state is cleaned after the ops are processed.
-            dirty = (component1.context.containerRuntime as IContainerRuntime).isDocumentDirty();
-            assert.equal(dirty, false, "The document dirty state should have been cleaned");
+            // Verify that the document dirty state is cleaned after the ops are processed.
+            verifyDocumentDirtyState(component1, false);
         });
     });
 

--- a/packages/test/end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/batching.spec.ts
@@ -6,6 +6,8 @@
 import assert from "assert";
 import { IFluidCodeDetails } from "@fluidframework/container-definitions";
 import { Container } from "@fluidframework/container-loader";
+import { ContainerMessageType } from "@fluidframework/container-runtime";
+import { IContainerRuntime } from  "@fluidframework/container-runtime-definitions";
 import { DocumentDeltaEventManager } from "@fluidframework/local-driver";
 import { SharedMap } from "@fluidframework/map";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
@@ -17,7 +19,6 @@ import {
     ITestFluidComponent,
     TestFluidComponentFactory,
 } from "@fluidframework/test-utils";
-import { ContainerMessageType } from "@fluidframework/container-runtime";
 
 describe("Batching", () => {
     const id = `fluid-test://localhost/batchingTest`;
@@ -36,8 +37,6 @@ describe("Batching", () => {
     let component1map2: SharedMap;
     let component2map1: SharedMap;
     let component2map2: SharedMap;
-    let component1BatchMessages: ISequencedDocumentMessage[] = [];
-    let component2BatchMessages: ISequencedDocumentMessage[] = [];
 
     async function createContainer(): Promise<Container> {
         const factory = new TestFluidComponentFactory(
@@ -101,117 +100,203 @@ describe("Batching", () => {
         containerDeltaEventManager.registerDocuments(component1.runtime, component2.runtime);
 
         await containerDeltaEventManager.process();
-
-        setupBacthMessageListener(component1, component1BatchMessages);
-        setupBacthMessageListener(component2, component2BatchMessages);
     });
 
-    it("can send and receive mulitple batch ops correctly", async () => {
-        // Send messages in batch in the first component.
-        component1.context.containerRuntime.orderSequentially(() => {
+    describe("Local ops batch metadata verification", () => {
+        let component1BatchMessages: ISequencedDocumentMessage[] = [];
+        let component2BatchMessages: ISequencedDocumentMessage[] = [];
+
+        beforeEach(() => {
+            setupBacthMessageListener(component1, component1BatchMessages);
+            setupBacthMessageListener(component2, component2BatchMessages);
+        });
+
+        it("can send and receive mulitple batch ops correctly", async () => {
+            // Send messages in batch in the first component.
+            component1.context.containerRuntime.orderSequentially(() => {
+                component1map1.set("key1", "value1");
+                component1map2.set("key2", "value2");
+                component1map1.set("key3", "value3");
+                component1map2.set("key4", "value4");
+            });
+
+            // Wait for the ops to get processed by both the containers.
+            await containerDeltaEventManager.process();
+
+            assert.equal(component1BatchMessages.length, 4, "Incorrect number of messages received on local client");
+            assert.equal(component2BatchMessages.length, 4, "Incorrect number of messages received on remote client");
+
+            verifyBatchMetadata(component1BatchMessages);
+            verifyBatchMetadata(component2BatchMessages);
+        });
+
+        it("can send and receive single batch op correctly", async () => {
+            component2.context.containerRuntime.orderSequentially(() => {
+                component2map1.set("key1", "value1");
+            });
+
+            // Wait for the ops to get processed by both the containers.
+            await containerDeltaEventManager.process();
+
+            assert.equal(component1BatchMessages.length, 1, "Incorrect number of messages received on local client");
+            assert.equal(component2BatchMessages.length, 1, "Incorrect number of messages received on remote client");
+
+            verifyBatchMetadata(component1BatchMessages);
+            verifyBatchMetadata(component2BatchMessages);
+        });
+
+        it("can send and receive consecutive batches correctly", async () => {
+            /**
+             * This test verifies that among other things, the PendingStateManager's algorithm of handling consecutive
+             * batches is correct.
+             */
+            component2.context.containerRuntime.orderSequentially(() => {
+                component2map1.set("key1", "value1");
+                component2map2.set("key2", "value2");
+            });
+
+            component2.context.containerRuntime.orderSequentially(() => {
+                component2map1.set("key3", "value3");
+                component2map2.set("key4", "value4");
+            });
+
+            // Wait for the ops to get processed by both the containers.
+            await containerDeltaEventManager.process();
+
+            assert.equal(component1BatchMessages.length, 4, "Incorrect number of messages received on local client");
+            assert.equal(component2BatchMessages.length, 4, "Incorrect number of messages received on remote client");
+
+            // Verify the first batch.
+            verifyBatchMetadata(component1BatchMessages.slice(0, 2));
+            verifyBatchMetadata(component1BatchMessages.slice(2, 4));
+
+            // Verify the second batch.
+            verifyBatchMetadata(component2BatchMessages.slice(0, 2));
+            verifyBatchMetadata(component2BatchMessages.slice(2, 4));
+        });
+
+        it("can handle calls to orderSequentially with no batch messages", async () => {
+            /**
+             * This test verifies that among other things, the PendingStateManager's algorithm of handling batches with
+             * no messages is correct.
+             */
+            component1.context.containerRuntime.orderSequentially(() => {
+            });
+
+            // Wait for the ops to get processed by both the containers.
+            await containerDeltaEventManager.process();
+
+            assert.equal(component1BatchMessages.length, 0, "Incorrect number of messages received on local client");
+            assert.equal(component2BatchMessages.length, 0, "Incorrect number of messages received on remote client");
+        });
+
+        it("can handle nested orderSequentially by ignoring inner calls to it", async () => {
+            // If orderSequentially is nested, only the outermost is considered as the beginning and end of the batch.
+            // The inner ones are ignored.
+            component1.context.containerRuntime.orderSequentially(() => {
+                component1map1.set("key1", "value1");
+                // Level 1 nesting.
+                component1.context.containerRuntime.orderSequentially(() => {
+                    component1map2.set("key2", "value2");
+                    // Level 2 nesting.
+                    component1.context.containerRuntime.orderSequentially(() => {
+                        component1map1.set("key3", "value3");
+                    });
+                });
+                component1map2.set("key4", "value4");
+            });
+
+            // Wait for the ops to get processed by both the containers.
+            await containerDeltaEventManager.process();
+
+            assert.equal(component1BatchMessages.length, 4, "Incorrect number of messages received on local client");
+            assert.equal(component2BatchMessages.length, 4, "Incorrect number of messages received on remote client");
+
+            verifyBatchMetadata(component1BatchMessages);
+            verifyBatchMetadata(component2BatchMessages);
+        });
+
+        afterEach(async () => {
+            component1BatchMessages = [];
+            component2BatchMessages = [];
+        });
+    });
+
+    describe("Document Dirty State", () => {
+        it("should clean document dirty state after a batch is sent", async () => {
+            // Send a batch with a single message.
+            component1.context.containerRuntime.orderSequentially(() => {
+                component1map1.set("key1", "value1");
+            });
+
+            // Check that the document is correctly set to dirty.
+            let dirty = (component1.context.containerRuntime as IContainerRuntime).isDocumentDirty();
+            assert.equal(dirty, true, "The document should be dirty on submitting an op");
+
+            // Wait for the ops to get processed by both the containers.
+            await containerDeltaEventManager.process();
+
+            // Check that the document dirty state is cleaned after the ops are processed.
+            dirty = (component1.context.containerRuntime as IContainerRuntime).isDocumentDirty();
+            assert.equal(dirty, false, "The document dirty state should have been cleaned");
+        });
+
+        it("should clean document dirty state after consecutive batches are sent", async () => {
+            // Send a couple of batches consecutively.
+            component1.context.containerRuntime.orderSequentially(() => {
+                component1map1.set("key1", "value1");
+                component1map2.set("key2", "value2");
+            });
+
+            component1.context.containerRuntime.orderSequentially(() => {
+                component1map1.set("key3", "value3");
+                component1map2.set("key4", "value4");
+            });
+
+            // Check that the document is correctly set to dirty.
+            let dirty = (component1.context.containerRuntime as IContainerRuntime).isDocumentDirty();
+            assert.equal(dirty, true, "The document should be dirty on submitting an op");
+
+            // Wait for the ops to get processed by both the containers.
+            await containerDeltaEventManager.process();
+
+            // Check that the document dirty state is cleaned after the ops are processed.
+            dirty = (component1.context.containerRuntime as IContainerRuntime).isDocumentDirty();
+            assert.equal(dirty, false, "The document dirty state should have been cleaned");
+        });
+
+        it("should clean document dirty state after batch and not-batch messages are sent", async () => {
+            // Send a non-batch message.
             component1map1.set("key1", "value1");
-            component1map2.set("key2", "value2");
-            component1map1.set("key3", "value3");
-            component1map2.set("key4", "value4");
+
+            // Send a couple of batches consecutively.
+            component1.context.containerRuntime.orderSequentially(() => {
+                component1map2.set("key2", "value2");
+                component1map1.set("key3", "value3");
+            });
+
+            component1.context.containerRuntime.orderSequentially(() => {
+                component1map2.set("key4", "value4");
+                component1map1.set("key5", "value5");
+            });
+
+            // Send another non-batch message.
+            component1map1.set("key5", "value5");
+
+            // Check that the document is correctly set to dirty.
+            let dirty = (component1.context.containerRuntime as IContainerRuntime).isDocumentDirty();
+            assert.equal(dirty, true, "The document should be dirty on submitting an op");
+
+            // Wait for the ops to get processed by both the containers.
+            await containerDeltaEventManager.process();
+
+            // Check that the document dirty state is cleaned after the ops are processed.
+            dirty = (component1.context.containerRuntime as IContainerRuntime).isDocumentDirty();
+            assert.equal(dirty, false, "The document dirty state should have been cleaned");
         });
-
-        // Send a non-batch message after sending the batch so that PendingStateManager's processFlushState
-        // algorithm can run on the batch.
-        component1map1.set("key5", "value5");
-
-        // Wait for the ops to get processed by both the containers.
-        await containerDeltaEventManager.process();
-
-        // Remove the additional non-batch message.
-        component1BatchMessages.pop();
-        component2BatchMessages.pop();
-
-        assert.equal(component1BatchMessages.length, 4, "Incorrect number of messages received on local client");
-        assert.equal(component2BatchMessages.length, 4, "Incorrect number of messages received on remote client");
-
-        verifyBatchMetadata(component1BatchMessages);
-        verifyBatchMetadata(component2BatchMessages);
-    });
-
-    it("can send and receive single batch op correctly", async () => {
-        component2.context.containerRuntime.orderSequentially(() => {
-            component2map1.set("key1", "value1");
-        });
-
-        // Send a non-batch message after sending the batch so that PendingStateManager's processFlushState
-        // algorithm can run on the batch.
-        component2map2.set("key2", "value2");
-
-        // Wait for the ops to get processed by both the containers.
-        await containerDeltaEventManager.process();
-
-        // Remove the additional non-batch message.
-        component1BatchMessages.pop();
-        component2BatchMessages.pop();
-
-        assert.equal(component1BatchMessages.length, 1, "Incorrect number of messages received on local client");
-        assert.equal(component2BatchMessages.length, 1, "Incorrect number of messages received on remote client");
-
-        verifyBatchMetadata(component1BatchMessages);
-        verifyBatchMetadata(component2BatchMessages);
-    });
-
-    it("can send and receive consecutive batches correctly", async () => {
-        /**
-         * This test verifies that among other things, the PendingStateManager's algorithm of handling consecutive
-         * batches is correct.
-         */
-        component2.context.containerRuntime.orderSequentially(() => {
-            component2map1.set("key1", "value1");
-            component2map2.set("key2", "value2");
-        });
-
-        component2.context.containerRuntime.orderSequentially(() => {
-            component2map1.set("key3", "value3");
-            component2map2.set("key4", "value4");
-        });
-
-        // Send a non-batch message after sending the batch so that PendingStateManager's processFlushState
-        // algorithm can run on the batch.
-        component2map1.set("key5", "value5");
-
-        // Wait for the ops to get processed by both the containers.
-        await containerDeltaEventManager.process();
-
-        // Remove the additional non-batch message.
-        component1BatchMessages.pop();
-        component2BatchMessages.pop();
-
-        assert.equal(component1BatchMessages.length, 4, "Incorrect number of messages received on local client");
-        assert.equal(component2BatchMessages.length, 4, "Incorrect number of messages received on remote client");
-
-        // Verify the first batch.
-        verifyBatchMetadata(component1BatchMessages.slice(0, 2));
-        verifyBatchMetadata(component1BatchMessages.slice(2, 4));
-
-        // Verify the second batch.
-        verifyBatchMetadata(component2BatchMessages.slice(0, 2));
-        verifyBatchMetadata(component2BatchMessages.slice(2, 4));
-    });
-
-    it("can handle calls to orderSequentially with no batch messages", async () => {
-        /**
-         * This test verifies that among other things, the PendingStateManager's algorithm of handling batches with
-         * no messages is correct.
-         */
-        component1.context.containerRuntime.orderSequentially(() => {
-        });
-
-        // Wait for the ops to get processed by both the containers.
-        await containerDeltaEventManager.process();
-
-        assert.equal(component1BatchMessages.length, 0, "Incorrect number of messages received on local client");
-        assert.equal(component2BatchMessages.length, 0, "Incorrect number of messages received on remote client");
     });
 
     afterEach(async () => {
         await deltaConnectionServer.webSocketServer.close();
-        component1BatchMessages = [];
-        component2BatchMessages = [];
     });
 });

--- a/packages/test/end-to-end-tests/src/test/documentDirty.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/documentDirty.spec.ts
@@ -144,8 +144,7 @@ describe("Document Dirty", () => {
                 "Document is cleaned after all ops have been acked");
         });
 
-        // TODO: Enable this test once #2653 is fixed
-        it.skip("marks state as dirty when batch ops are sent and clean when acks are received", async () => {
+        it("marks state as dirty when batch ops are sent and clean when acks are received", async () => {
             containerComp.context.containerRuntime.orderSequentially(() => {
                 containerCompMap.set("key1", "value1");
                 containerCompMap.set("key2", "value2");

--- a/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
@@ -483,7 +483,7 @@ describe("Ops on Reconnect", () => {
                 expectedValues, receivedValues, "Did not receive the ops that were sent in disconnected state");
         });
 
-        it("can resend manually flushed batch ops in a component in right order on connect", async () => {
+        it("can resend consecutive manually flushed batches in right order on connect", async () => {
             firstContainerClientId = firstContainer.clientId;
 
             // Create a second container and set up a listener to store the received map / directory values.
@@ -532,7 +532,7 @@ describe("Ops on Reconnect", () => {
                 expectedValues, receivedValues, "Did not receive the ops that were sent in disconnected state");
         });
 
-        it("can resend manually flushed batch ops in a component in right order on connect - 2", async () => {
+        it("can resend manually flushed batch in right order on connect", async () => {
             firstContainerClientId = firstContainer.clientId;
 
             // Create a second container and set up a listener to store the received map / directory values.
@@ -554,6 +554,9 @@ describe("Ops on Reconnect", () => {
 
             // Manually flush the ops so that they are sent as a batch.
             (firstContainerComp1.context.containerRuntime as IContainerRuntime).flush();
+
+            // Set the FlushMode back to Automatic.
+            firstContainerComp1.context.containerRuntime.setFlushMode(FlushMode.Automatic);
 
             // Wait for the Container to get reconnected.
             await waitForContainerReconnection(firstContainer);


### PR DESCRIPTION
Fixes #2653 

When a batch is sent and received back from the server, PendingStateManager did not remove the trailing "FlushMode.Automatic" pending state from its queue until another local op is received. Basically, a "flush" type pending state was only cleared when a message followed it.

Fixed a couple of things here:
- Added a pending message count to PendingStateManager that tracks only messages and not other pending states. That is used to determine whether we need to clear the dirty state or not.
- Reworked the logic to handle the case for manual flushing of messages both when they are resent on reconnection and when processing acks.
- Added tests for the above scenarios.