### PR TITLE
Always set last summary attempt

### DIFF
--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -100,12 +100,12 @@ export interface ISummarizerRuntime extends IConnectableRuntime {
  */
 export interface ISummaryAttempt {
     /**
-     * Reference sequence number when summary was generated
+     * Reference sequence number when summary was generated or attempted
      */
     readonly refSequenceNumber: number;
 
     /**
-     * Time of summary attempt after it was sent
+     * Time of summary attempt after it was sent or attempted
      */
     readonly summaryTime: number;
 
@@ -126,11 +126,15 @@ const checkNotTimeout = <T>(something: T | IPromiseTimerResult | undefined): som
  * This class contains the heuristics for when to summarize.
  */
 class SummarizerHeuristics {
+    private _lastAttempted: ISummaryAttempt;
+    private _lastAcked: ISummaryAttempt;
+
     /**
      * Last sent summary attempt
      */
-    public lastSent: ISummaryAttempt;
-    private _lastAcked: ISummaryAttempt;
+    public get lastAttempted(): ISummaryAttempt {
+        return this._lastAttempted;
+    }
 
     /**
      * Last acked summary attempt
@@ -150,7 +154,7 @@ class SummarizerHeuristics {
         public lastOpSeqNumber: number,
         firstAck: ISummaryAttempt,
     ) {
-        this.lastSent = firstAck;
+        this._lastAttempted = firstAck;
         this._lastAcked = firstAck;
         this.idleTimer = new Timer(
             this.configuration.idleTime,
@@ -158,10 +162,32 @@ class SummarizerHeuristics {
     }
 
     /**
+     * Sets the last attempted summary and last acked summary.
+     * @param lastSummary - last acked summary
+     */
+    public initialize(lastSummary: ISummaryAttempt) {
+        this._lastAttempted = lastSummary;
+        this._lastAcked = lastSummary;
+    }
+
+    /**
+     * Records a summary attempt. If the attempt was successfully sent,
+     * provide the reference sequence number, otherwise it will be set
+     * to the last seen op sequence number.
+     * @param refSequenceNumber - reference sequence number of sent summary
+     */
+    public recordAttempt(refSequenceNumber?: number) {
+        this._lastAttempted = {
+            refSequenceNumber: refSequenceNumber ?? this.lastOpSeqNumber,
+            summaryTime: Date.now(),
+        };
+    }
+
+    /**
      * Mark the last sent summary attempt as acked.
      */
     public ackLastSent() {
-        this._lastAcked = this.lastSent;
+        this._lastAcked = this.lastAttempted;
     }
 
     /**
@@ -270,9 +296,9 @@ export class RunningSummarizer implements IDisposable {
                 this.logger.sendErrorEvent({
                     eventName: "SummaryAckWaitTimeout",
                     maxAckWaitTime: this.configuration.maxAckWaitTime,
-                    refSequenceNumber: this.heuristics.lastSent.refSequenceNumber,
-                    summarySequenceNumber: this.heuristics.lastSent.summarySequenceNumber,
-                    timePending: Date.now() - this.heuristics.lastSent.summaryTime,
+                    refSequenceNumber: this.heuristics.lastAttempted.refSequenceNumber,
+                    summarySequenceNumber: this.heuristics.lastAttempted.summarySequenceNumber,
+                    timePending: Date.now() - this.heuristics.lastAttempted.summaryTime,
                 });
             });
     }
@@ -345,12 +371,11 @@ export class RunningSummarizer implements IDisposable {
         this.pendingAckTimer.clear();
 
         if (checkNotTimeout(maybeLastAck)) {
-            this.heuristics.lastSent = {
+            this.heuristics.initialize({
                 refSequenceNumber: maybeLastAck.summaryOp.referenceSequenceNumber,
                 summaryTime: maybeLastAck.summaryOp.timestamp,
                 summarySequenceNumber: maybeLastAck.summaryOp.sequenceNumber,
-            };
-            this.heuristics.ackLastSent();
+            });
         }
     }
 
@@ -410,16 +435,12 @@ export class RunningSummarizer implements IDisposable {
     ): Promise<boolean | undefined> {
         // Wait to generate and send summary
         const summaryData = await this.generateSummaryWithLogging(reason, safe);
+        this.heuristics.recordAttempt(summaryData?.referenceSequenceNumber);
         if (!summaryData || !summaryData.submitted) {
             // Did not send the summary op
             this.raiseSummarizingError("Error while generating or submitting summary");
             return undefined;
         }
-
-        this.heuristics.lastSent = {
-            refSequenceNumber: summaryData.referenceSequenceNumber,
-            summaryTime: Date.now(),
-        };
 
         const pendingTimeoutP = this.pendingAckTimer.start().catch(() => undefined);
         const summary = this.summaryWatcher.watchSummary(summaryData.clientSequenceNumber);
@@ -430,10 +451,10 @@ export class RunningSummarizer implements IDisposable {
         if (!checkNotTimeout(summaryOp)) {
             return undefined;
         }
-        this.heuristics.lastSent.summarySequenceNumber = summaryOp.sequenceNumber;
+        this.heuristics.lastAttempted.summarySequenceNumber = summaryOp.sequenceNumber;
         this.logger.sendTelemetryEvent({
             eventName: "SummaryOp",
-            timeWaiting: Date.now() - this.heuristics.lastSent.summaryTime,
+            timeWaiting: Date.now() - this.heuristics.lastAttempted.summaryTime,
             refSequenceNumber: summaryOp.referenceSequenceNumber,
             summarySequenceNumber: summaryOp.sequenceNumber,
             handle: summaryOp.contents.handle,
@@ -447,7 +468,7 @@ export class RunningSummarizer implements IDisposable {
         this.logger.sendTelemetryEvent({
             eventName: ackNack.type === MessageType.SummaryAck ? "SummaryAck" : "SummaryNack",
             category: ackNack.type === MessageType.SummaryAck ? "generic" : "error",
-            timeWaiting: Date.now() - this.heuristics.lastSent.summaryTime,
+            timeWaiting: Date.now() - this.heuristics.lastAttempted.summaryTime,
             summarySequenceNumber: ackNack.contents.summaryProposal.summarySequenceNumber,
             error: ackNack.type === MessageType.SummaryNack ? ackNack.contents.errorMessage : undefined,
             handle: ackNack.type === MessageType.SummaryAck ? ackNack.contents.handle : undefined,
@@ -474,7 +495,7 @@ export class RunningSummarizer implements IDisposable {
             eventName: "Summarizing",
             message,
             summarizeCount: ++this.summarizeCount,
-            timeSinceLastAttempt: Date.now() - this.heuristics.lastSent.summaryTime,
+            timeSinceLastAttempt: Date.now() - this.heuristics.lastAttempted.summaryTime,
             timeSinceLastSummary: Date.now() - this.heuristics.lastAcked.summaryTime,
             safe: safe || undefined,
         });
@@ -499,7 +520,7 @@ export class RunningSummarizer implements IDisposable {
             ...summaryData,
             ...summaryData.summaryStats,
             refSequenceNumber: summaryData.referenceSequenceNumber,
-            opsSinceLastAttempt: summaryData.referenceSequenceNumber - this.heuristics.lastSent.refSequenceNumber,
+            opsSinceLastAttempt: summaryData.referenceSequenceNumber - this.heuristics.lastAttempted.refSequenceNumber,
             opsSinceLastSummary: summaryData.referenceSequenceNumber - this.heuristics.lastAcked.refSequenceNumber,
         };
         telemetryProps.summaryStats = undefined;


### PR DESCRIPTION
Fixes #547

We can use the telemetry around last attempted summary to verify the summary heuristics are behaving as intended.  This change always sets the last attempted summary even if it wasn't sent.