### PR TITLE
fix contextChanged event typing

### DIFF
--- a/packages/loader/container-definitions/src/loader.ts
+++ b/packages/loader/container-definitions/src/loader.ts
@@ -69,7 +69,8 @@ export interface ICodeAllowList {
 
 export interface IContainerEvents extends IEvent {
     (event: "readonly", listener: (readonly: boolean) => void): void;
-    (event: "connected" | "contextChanged", listener: (clientId: string) => void);
+    (event: "connected", listener: (clientId: string) => void);
+    (event: "contextChanged", listener: (codeDetails: IFluidCodeDetails) => void);
     (event: "disconnected" | "joining", listener: () => void);
     (event: "closed", listener: (error?: CriticalContainerError) => void);
     (event: "warning", listener: (error: ContainerWarning) => void);


### PR DESCRIPTION
It seems that `Container` `"contextChanged"` events are emitted with `Container.pkg`, which is of type `IFluidCodeDetails | undefined`.