### PR TITLE
change ErrorType to string enum

### DIFF
--- a/packages/loader/container-definitions/src/error.ts
+++ b/packages/loader/container-definitions/src/error.ts
@@ -8,77 +8,77 @@ export enum ErrorType {
     /**
      * Some error, most likely an exception caught by runtime and propagated to container as critical error
      */
-    genericError,
+    genericError = "genericError",
 
     /**
      * Some non-categorized (below) networking error
      * Include errors like  fatal server error (usually 500).
      */
-    genericNetworkError,
+    genericNetworkError = "genericNetworkError",
 
     /**
      * Access denied - user does not have enough privileges to open a file, or continue to operate on a file
      */
-    authorizationError,
+    authorizationError = "authorizationError",
 
     /**
      * File not found, or file deleted during session
      */
-    fileNotFoundOrAccessDeniedError,
+    fileNotFoundOrAccessDeniedError = "fileNotFoundOrAccessDeniedError",
 
     /**
      * Storage is out of space
      */
-    outOfStorageError,
+    outOfStorageError = "outOfStorageError",
 
     /**
      * Invalid file name (at creation of the file)
      */
-    invalidFileNameError,
+    invalidFileNameError = "invalidFileNameError",
 
     /**
      * Throttling error from server. Server is busy and is asking not to reconnect for some time
      */
-    throttlingError,
+    throttlingError = "throttlingError",
 
     /**
      * Summarizing error. Currently raised on summarizing container only.
      * Work is planned to propagate these errors to main container.
      */
-    summarizingError,
+    summarizingError = "summarizingError",
 
     /**
      * User does not have write permissions to a file, but is changing content of a file.
      * That might be indication of some component error - components should not generate ops in readonly mode.
      */
-    writeError,
+    writeError = "writeError",
 
     /**
      * We can not reach server due to computer being offline.
      */
-    offlineError,
+    offlineError = "offlineError",
 
     /**
      * Snapshot is too big. Host application specified limit for snapshot size, and snapshot was bigger
      * that that limit, thus request failed. Hosting application is expected to have fall-back behavior for
      * such case.
      */
-    snapshotTooBig,
+    snapshotTooBig = "snapshotTooBig",
 
     /*
      * The data is corrupted. This indicates a critical error caused by storage.
      */
-    dataCorruptionError,
+    dataCorruptionError = "dataCorruptionError",
 
     /*
      * SPO admin toggle: fluid service is not enabled.
      */
-    fluidNotEnabled,
+    fluidNotEnabled = "fluidNotEnabled",
 
     /*
      * Unsupported client protocol
      */
-    unsupportedClientProtocolVersion,
+    unsupportedClientProtocolVersion = "unsupportedClientProtocolVersion",
 }
 
 /**


### PR DESCRIPTION
A string enum has the following advantages over a normal (numeric) enum here:
1. It makes telemetry clearer. Currently, the value reported is just a number, which isn't very readable. Furthermore, dashboards based on this telemetry can be difficult to interpret, since e.g. `ErrorType === 2` may not have meant the same thing 2 weeks ago as it does today if the enum has changed.
2. It seems to me that there is some potential for differing loader/runtime versions to be using different definitions, resulting in unexpected behavior. For example, if between versions a new value is added at the top of the enum, all existing values would change. In this case, errors generated in runtime may be misinterpreted by container if they are different versions.