### PR TITLE
Add ICreateComponentWithAny

### DIFF
--- a/packages/runtime/runtime-definitions/src/componentFactory.ts
+++ b/packages/runtime/runtime-definitions/src/componentFactory.ts
@@ -21,7 +21,7 @@ export interface IProvideComponentFactory {
 /**
  * The interface implemented by a component module.
  */
-export interface IComponentFactory extends IProvideComponentFactory, Partial<IProvideCreateComponentWithAny> {
+export interface IComponentFactory extends IProvideComponentFactory {
     /**
      * String that uniquely identifies the type of component created by this factory.
      */

--- a/packages/runtime/runtime-definitions/src/componentFactory.ts
+++ b/packages/runtime/runtime-definitions/src/componentFactory.ts
@@ -21,7 +21,7 @@ export interface IProvideComponentFactory {
 /**
  * The interface implemented by a component module.
  */
-export interface IComponentFactory extends IProvideComponentFactory {
+export interface IComponentFactory extends IProvideComponentFactory, Partial<IProvideCreateComponentWithAny> {
     /**
      * String that uniquely identifies the type of component created by this factory.
      */
@@ -41,4 +41,20 @@ export interface IComponentFactory extends IProvideComponentFactory {
      * @param context - Context for the component.
      */
     instantiateComponent(context: IComponentContext): void;
+}
+
+export const ICreateComponentWithAny: keyof IProvideCreateComponentWithAny = "ICreateComponentWithAny";
+
+export interface IProvideCreateComponentWithAny {
+    readonly ICreateComponentWithAny: ICreateComponentWithAny;
+}
+
+/**
+ * Interface that exposes a createComponent signature that allows any initial state for cases that need it,
+ * such as when loading and creating arbitrary components where the specific component factory is not known
+ * beforehand.  In all other cases, consumers should prefer using the initial state generics in the Component
+ * and ComponentFactory implementations provided in Aqueduct istead.
+ */
+export interface ICreateComponentWithAny extends IProvideCreateComponentWithAny {
+    createComponent(context: IComponentContext, initialState?: any): Promise<IComponent & IComponentLoadable>;
 }

--- a/packages/runtime/runtime-definitions/src/componentRegistry.ts
+++ b/packages/runtime/runtime-definitions/src/componentRegistry.ts
@@ -3,14 +3,15 @@
  * Licensed under the MIT License.
  */
 
-import { IProvideComponentFactory } from "./componentFactory";
+import { IProvideComponentFactory, IProvideCreateComponentWithAny } from "./componentFactory";
 
 declare module "@fluidframework/component-core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
     export interface IComponent extends Readonly<Partial<IProvideComponentRegistry>> { }
 }
 
-export type ComponentRegistryEntry = Readonly<Partial<IProvideComponentRegistry & IProvideComponentFactory>>;
+export type ComponentRegistryEntry =
+    Readonly<Partial<IProvideComponentRegistry & IProvideComponentFactory & IProvideCreateComponentWithAny>>;
 export type NamedComponentRegistryEntry = [string, Promise<ComponentRegistryEntry>];
 export type NamedComponentRegistryEntries = Iterable<NamedComponentRegistryEntry>;
 


### PR DESCRIPTION
This is to help the specific Bohemia case where they want to dynamically get an unknown component that conforms to a certain data provider, and want to provide initial state but don't have compile-time access to the specific component factory.  Factories in this case are handled as IComponentFactorys, so this functionality needs to be available through that interface.

I added `ICreateComponentWithAny` and `IProvideCreateComponentWithAny` and made the latter partial in `IComponentFactory`.  Factory consumers can then check if their `IComponentFactory` instance provides an `ICreateComponentWithAny` getter, which then provides a `createComponent` call that takes any typing for initial state (instead of providing it through the component context).

Components/factories that want to be consumed in this way will need to extend `PrimedComponentFactory` to implement `get ICreateComponentWithAny`, and provide the `any` type for the initial state generic when extending `PrimedComponent`