### PR TITLE
Fix performanceNow export

### DIFF
--- a/common/lib/common-utils/src/performanceNowNode.ts
+++ b/common/lib/common-utils/src/performanceNowNode.ts
@@ -3,4 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export { default as performanceNow } from "performance-now";
+import performanceNow from "performance-now";
+export { performanceNow };

--- a/common/lib/common-utils/test/gitHash.spec.ts
+++ b/common/lib/common-utils/test/gitHash.spec.ts
@@ -23,7 +23,7 @@ async function getFileContents(p: string): Promise<Buffer> {
 
 const dataDir = ".";
 
-describe("Core-Utils", () => {
+describe("Common-Utils", () => {
     // Expected hashes are from git hash-object file...
     // Make sure the hash is of the file and not of an LFS stub
     describe("#gitHashFileAsync", () => {


### PR DESCRIPTION
I changed it to import export in the last check in, instead of import and call in another export function.
But although it compiled fine, caller couldn't call it (with a performanceNow is not a function error at runtime)
The fix is by import and then export separately.