### PR TITLE
Fix MergeTree Reconnect Bug for Removed Segments

### DIFF
--- a/packages/runtime/merge-tree/src/client.ts
+++ b/packages/runtime/merge-tree/src/client.ts
@@ -682,33 +682,29 @@ export class Client {
             position taking into account local segments that were modified,
             after the current segment.
 
-            TODO: Consider embeding this infomation into the tree for
-            more efficent look up of pending segment positions.
+            TODO: Consider embedding this information into the tree for
+            more efficient look up of pending segment positions.
         */
         this.mergeTree.walkAllSegments(this.mergeTree.root, (seg) => {
-            if (seg !== segment) {
-                // segment isn't local, so count it
-                if (seg.localSeq === undefined && seg.localRemovedSeq === undefined) {
-                    if (seg.removedSeq === undefined) {
-                        segmentPosition += seg.cachedLength;
-                        return true;
-                    }
-                }
-                // segment is remove locally before this op, so skip it
-                if (seg.localRemovedSeq !== undefined) {
-                    if (seg.localRemovedSeq <= localSeq) {
-                        return true;
-                    }
-                }
-                // segment is inserted locally before this op, so count it
-                if (seg.localSeq <= localSeq) {
-                    segmentPosition += seg.cachedLength;
-                    return true;
-                }
-                return true;
+            // If we've found the desired segment, terminate the walk and return 'segmentPosition'.
+            if (seg === segment) {
+                return false;
             }
-            return false;
+
+            // Otherwise, advance segmentPosition if the segment has been inserted and not removed
+            // with respect to the given 'localSeq'.
+            //
+            // Note that all ACKed / remote ops are applied and we only need concern ourself with
+            // determining if locally pending ops fall before/after the given 'localSeq'.
+            if ((seg.localSeq === undefined || seg.localSeq <= localSeq)                // Is inserted
+                && (seg.removedSeq === undefined || seg.localRemovedSeq > localSeq)     // Not removed
+            ) {
+                segmentPosition += seg.cachedLength;
+            }
+
+            return true;
         });
+
         return segmentPosition;
     }
 


### PR DESCRIPTION
The bug was that the original code excluded segments when:

The segment has been globally inserted (i.e., localSeq === undefined)
The segment has a pending local remove (i.e., localRemovedSeq !== undefined)
But the pending local remove not be applied (i.e., localSeq > localRemovedSeq)
This was causing matrix set ops to be adjusted incorrectly when the targeted a row whose position later shifts during a remove.

related to #2626 