### PR TITLE
Canvas layout fix

### DIFF
--- a/components/experimental/canvas/package.json
+++ b/components/experimental/canvas/package.json
@@ -25,6 +25,7 @@
     "start:r11s": "webpack-dev-server --config webpack.config.js --package package.json --env.mode r11s",
     "start:spo": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo",
     "start:spo-df": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo-df",
+    "start:tinylicious": "webpack-dev-server --config webpack.config.js --package package.json --env.mode tinylicious",
     "test": "npm run test:jest",
     "test:jest": "jest",
     "tsc": "tsc",

--- a/components/experimental/canvas/src/canvas.ts
+++ b/components/experimental/canvas/src/canvas.ts
@@ -29,12 +29,10 @@ export class Canvas extends PrimedComponent implements IComponentHTMLView {
 
     private ink: IInk;
     private inkCanvas: InkCanvas;
-    private inkComponentRoot: HTMLDivElement;
     private inkColorPicker: HTMLDivElement;
 
     public render(elm: HTMLElement, options?: IComponentHTMLOptions): void {
-        this.inkComponentRoot = this.createCanvasDom();
-        elm.appendChild(this.inkComponentRoot);
+        elm.appendChild(this.createCanvasDom());
         this.sizeCanvas();
 
         window.addEventListener("resize", this.sizeCanvas.bind(this));
@@ -59,7 +57,6 @@ export class Canvas extends PrimedComponent implements IComponentHTMLView {
 
         const canvasElement = document.createElement("canvas");
         canvasElement.classList.add("ink-canvas");
-        // TODO size canvas backing store
 
         this.inkCanvas = new InkCanvas(canvasElement, this.ink);
 
@@ -128,7 +125,6 @@ export class Canvas extends PrimedComponent implements IComponentHTMLView {
     }
 
     private sizeCanvas() {
-        const rootRect = this.inkComponentRoot.getBoundingClientRect();
-        this.inkCanvas.setSize(Math.floor(rootRect.width), Math.floor(rootRect.height) - 50);
+        this.inkCanvas.sizeCanvasBackingStore();
     }
 }

--- a/components/experimental/canvas/src/style.less
+++ b/components/experimental/canvas/src/style.less
@@ -10,14 +10,13 @@
 
 .ink-surface {
     height: 100%;
-    position: relative;
     display: flex;
     flex-direction: column;
 }
 
 .ink-canvas {
     flex-grow: 1;
-    width: 100%;
+    /* Save 50 px for the toolbar */
     max-height: calc(100% - 50px);
     background-color: #000;
     touch-action: none;

--- a/components/experimental/canvas/src/style.less
+++ b/components/experimental/canvas/src/style.less
@@ -1,19 +1,24 @@
 .ink-component-root {
     width: 100%;
     height: 100%;
-    position: relative;
+    /* Set a minimum usable size for the component, we won't tolerate anything smaller */
+    min-width: 300px;
+    min-height: 300px;
+    /* Absolute at the root so we don't inadvertently stretch our container element */
+    position: absolute;
 }
 
 .ink-surface {
-    width: 100%;
     height: 100%;
     position: relative;
+    display: flex;
+    flex-direction: column;
 }
 
 .ink-canvas {
+    flex-grow: 1;
     width: 100%;
-    height: calc(100% - 50px);
-    position: absolute;
+    max-height: calc(100% - 50px);
     background-color: #000;
     touch-action: none;
 }
@@ -21,8 +26,6 @@
 .ink-toolbar {
     width: 100%;
     height: 50px;
-    position: absolute;
-    bottom: 0;
     background-color: #222;
 }
 

--- a/packages/dds/ink/src/inkCanvas.ts
+++ b/packages/dds/ink/src/inkCanvas.ts
@@ -133,7 +133,7 @@ export class InkCanvas {
             thickness: 7,
         };
 
-        this.setSize(canvas.width, canvas.height);
+        this.sizeCanvasBackingStore();
     }
 
     public setPenColor(color: IColor) {
@@ -157,14 +157,12 @@ export class InkCanvas {
         this.redraw();
     }
 
-    public setSize(width: number, height: number) {
+    public sizeCanvasBackingStore() {
+        const canvasBoundingClientRect = this.canvas.getBoundingClientRect();
         // Scale the canvas size to match the physical pixel to avoid blurriness
         const scale = window.devicePixelRatio;
-        this.canvas.width = Math.floor(width * scale);
-        this.canvas.height = Math.floor(height * scale);
-        // Set CSS pixel size as is
-        this.canvas.style.width = `${width}px`;
-        this.canvas.style.height = `${height}px`;
+        this.canvas.width = Math.floor(canvasBoundingClientRect.width * scale);
+        this.canvas.height = Math.floor(canvasBoundingClientRect.height * scale);
         // Scale the context to bring back coordinate system in CSS pixels
         this.context.setTransform(1, 0, 0, 1, 0, 0);
         this.context.scale(scale, scale);


### PR DESCRIPTION
I realized some combination of the changes to the Canvas component plus the changes to the styles in webpack-component-loader caused the Canvas component to behave badly in single mode (as used by tinylicious, which we didn't have a script in there for).  This change:
1. Adds a tinylicious script
2. Adds min dimensions for the component as well as pulls it out of flow to avoid stretching its container element (now we use min-height on the #content div).
3. Removes places where we use the result of a `getBoundingClientRect()` call to set layout styles, so now sizing is all done in normal CSS to avoid weird results from layout cycle breaking.