### PR TITLE
Move a dependency from devDeps to deps list

### DIFF
--- a/tools/build-tools/package.json
+++ b/tools/build-tools/package.json
@@ -40,6 +40,6 @@
     "@types/lodash.isequal": "^4.5.5",
     "@types/node": "^11.9.4",
     "@types/rimraf": "^2.0.3",
-    "@types/semver": "^7.1.0",
+    "@types/semver": "^7.1.0"
   }
 }

--- a/tools/build-tools/package.json
+++ b/tools/build-tools/package.json
@@ -28,6 +28,7 @@
     "commander": "^2.20.0",
     "glob": "^7.1.3",
     "lodash.isequal": "^4.5.0",
+    "replace-in-file": "^6.0.0",
     "rimraf": "^2.6.2",
     "semver": "^7.1.2",
     "sort-package-json": "1.40.0",
@@ -40,6 +41,5 @@
     "@types/node": "^11.9.4",
     "@types/rimraf": "^2.0.3",
     "@types/semver": "^7.1.0",
-    "replace-in-file": "^6.0.0"
   }
 }


### PR DESCRIPTION
replace-in-file needs to be in `dependencies` list not `devDependencies`.  See failed CI run when I tried updating to the latest version of build-tools:  https://offnet.visualstudio.com/officenet/_build/results?buildId=32495&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=baa7d181-d9ee-513a-8016-f44a98fd040e