### PR TITLE
Bump-version fix: Don't replace reference if there is an existing version already

### DIFF
--- a/tools/build-tools/src/bumpVersion/bumpVersion.ts
+++ b/tools/build-tools/src/bumpVersion/bumpVersion.ts
@@ -284,6 +284,8 @@ class ReferenceVersionBag extends VersionBag {
             this.nonDevDep.add(entryName);
         } else if (existing) {
             console.log(`      Ignored mismatched dev dependency ${pkg.name}@${version} vs ${existing}`);
+            // Don't replace the existing reference if it is an ignored dev dependency
+            return;
         }
         if (newReference) {
             this.referenceData.set(entryName, { reference: newReference, published });

--- a/tools/build-tools/src/common/logging.ts
+++ b/tools/build-tools/src/common/logging.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import * as chalk from "chalk";
+import chalk from "chalk";
 import { commonOptions } from "./commonOptions";
 
 export function logVerbose(msg: string) {
@@ -24,5 +24,5 @@ export function logStatus(msg: string) {
     if (mins.length === 1) { mins = '0' + mins; }
     let secs = date.getSeconds().toString();
     if (secs.length === 1) { secs = '0' + secs; }
-    console.log(chalk.default.yellow(`[${hours}:${mins}:${secs}] `) + msg);
+    console.log(chalk.yellow(`[${hours}:${mins}:${secs}] `) + msg);
 }


### PR DESCRIPTION
We shouldn't replace the reference if we are ignoring a conflicting dev reference.