### PR TITLE
Change PrimedComponent's internalRoot member to protected

### DIFF
--- a/packages/framework/aqueduct/src/components/primedComponent.ts
+++ b/packages/framework/aqueduct/src/components/primedComponent.ts
@@ -32,7 +32,7 @@ import { SharedComponent } from "./sharedComponent";
 export abstract class PrimedComponent<P extends IComponent = object, S = undefined, E extends IEvent = IEvent>
     extends SharedComponent<P, S, E>
 {
-    private internalRoot: ISharedDirectory | undefined;
+    protected internalRoot: ISharedDirectory | undefined;
     private internalTaskManager: ITaskManager | undefined;
     private readonly rootDirectoryId = "root";
     private readonly bigBlobs = "bigBlobs/";


### PR DESCRIPTION
Updating Bohemia's components to use PrimedComponent exposes an issue where persisted components are not forward compatible with PrimedComponent.  PrimedComponent tries to use `internalRoot` internally, but it is unavailable when loading a persisted component from before the conversion, resulting in an unresolved promise and silent failure.

PrimedComponent either needs to explicitly handle this case or needs to allow child classes to access `internalRoot` to do it themselves (going with the latter here)