### PR TITLE
Fix scheduler typing bug, use scheduler constant throughout

### DIFF
--- a/components/experimental/shared-text/src/component.ts
+++ b/components/experimental/shared-text/src/component.ts
@@ -26,7 +26,13 @@ import {
     SharedMap,
 } from "@fluidframework/map";
 import * as MergeTree from "@fluidframework/merge-tree";
-import { IComponentRuntimeChannel, IComponentContext, ITask, ITaskManager } from "@fluidframework/runtime-definitions";
+import {
+    IComponentRuntimeChannel,
+    IComponentContext,
+    ITask,
+    ITaskManager,
+    SchedulerType,
+} from "@fluidframework/runtime-definitions";
 import {
     IProvideSharedString,
     SharedNumberSequence,
@@ -178,7 +184,7 @@ export class SharedTextRunner
         debug(`id is ${this.runtime.id}`);
         debug(`Partial load fired: ${performanceNow()}`);
 
-        const schedulerResponse = await this.runtime.request({ url: "/_scheduler" });
+        const schedulerResponse = await this.runtime.request({ url: `/${SchedulerType}` });
         const schedulerComponent = schedulerResponse.value as IComponent;
         this.taskManager = schedulerComponent.ITaskManager;
 

--- a/packages/framework/aqueduct/src/components/primedComponent.ts
+++ b/packages/framework/aqueduct/src/components/primedComponent.ts
@@ -10,7 +10,7 @@ import {
     IResponse,
 } from "@fluidframework/component-core-interfaces";
 import { ISharedDirectory, MapFactory, SharedDirectory } from "@fluidframework/map";
-import { ITaskManager } from "@fluidframework/runtime-definitions";
+import { ITaskManager, SchedulerType } from "@fluidframework/runtime-definitions";
 import { v4 as uuid } from "uuid";
 import { IEvent } from "@fluidframework/common-definitions";
 import { BlobHandle } from "./blobHandle";
@@ -99,7 +99,7 @@ export abstract class PrimedComponent<P extends IComponent = object, S = undefin
         // Initialize task manager.
         const request = {
             headers: [[true]],
-            url: `/_scheduler`,
+            url: `/${SchedulerType}`,
         };
 
         this.internalTaskManager = await this.asComponent<ITaskManager>(this.context.containerRuntime.request(request));

--- a/packages/framework/last-edited-experimental/src/setup.ts
+++ b/packages/framework/last-edited-experimental/src/setup.ts
@@ -5,22 +5,20 @@
 
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { ISequencedDocumentMessage, IQuorum } from "@fluidframework/protocol-definitions";
-import { IAttachMessage, IEnvelope } from "@fluidframework/runtime-definitions";
+import { IAttachMessage, IEnvelope, SchedulerType } from "@fluidframework/runtime-definitions";
 import { ContainerMessageType } from "@fluidframework/container-runtime";
 import { IComponentLastEditedTracker, ILastEditDetails } from "./interfaces";
-
-const schedulerId = "_schdeuler";
 
 // Returns if an "Attach" or "Operation" type message is from the scheduler.
 function isSchedulerMessage(message: ISequencedDocumentMessage) {
     if (message.type === ContainerMessageType.Attach) {
         const attachMessage = message.contents as IAttachMessage;
-        if (attachMessage.id === schedulerId) {
+        if (attachMessage.id === SchedulerType) {
             return true;
         }
     } else if (message.type === ContainerMessageType.ComponentOp) {
         const envelope = message.contents as IEnvelope;
-        if (envelope.address === schedulerId) {
+        if (envelope.address === SchedulerType) {
             return true;
         }
     }

--- a/packages/runtime/agent-scheduler/src/scheduler.ts
+++ b/packages/runtime/agent-scheduler/src/scheduler.ts
@@ -17,15 +17,14 @@ import { ComponentRuntime, ComponentHandle } from "@fluidframework/component-run
 import { LoaderHeader } from "@fluidframework/container-definitions";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
 import { ConsensusRegisterCollection } from "@fluidframework/register-collection";
-import {
-    IComponentRuntime,
-} from "@fluidframework/component-runtime-definitions";
+import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
 import {
     IAgentScheduler,
     IComponentContext,
     IComponentFactory,
     ITask,
     ITaskManager,
+    SchedulerType,
 } from "@fluidframework/runtime-definitions";
 import { ISharedObjectFactory } from "@fluidframework/shared-object-base";
 import debug from "debug";
@@ -475,7 +474,7 @@ export class TaskManager implements ITaskManager {
 }
 
 export class AgentSchedulerFactory implements IComponentFactory {
-    public static readonly type = "_scheduler";
+    public static readonly type = SchedulerType;
     public readonly type = AgentSchedulerFactory.type;
 
     public get IComponentFactory() { return this; }

--- a/packages/runtime/component-runtime/src/componentRuntime.ts
+++ b/packages/runtime/component-runtime/src/componentRuntime.ts
@@ -42,6 +42,7 @@ import {
     IComponentRuntimeChannel,
     IEnvelope,
     IInboundSignalMessage,
+    SchedulerType,
 } from "@fluidframework/runtime-definitions";
 import { unreachableCase } from "@fluidframework/runtime-utils";
 import { IChannel, IComponentRuntime } from "@fluidframework/component-runtime-definitions";
@@ -218,7 +219,7 @@ export class ComponentRuntime extends EventEmitter implements IComponentRuntimeC
 
     public async request(request: IRequest): Promise<IResponse> {
         // System routes
-        if (request.url === "/_scheduler") {
+        if (request.url === `/${SchedulerType}`) {
             return this.componentContext.containerRuntime.request(request);
         }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -72,6 +72,7 @@ import {
     IInboundSignalMessage,
     ISignalEnvelop,
     NamedComponentRegistryEntries,
+    SchedulerType,
 } from "@fluidframework/runtime-definitions";
 import { ComponentSerializer, SummaryTracker, unreachableCase } from "@fluidframework/runtime-utils";
 import { v4 as uuid } from "uuid";
@@ -411,7 +412,7 @@ export class ScheduleManager {
     }
 }
 
-export const schedulerId = "_scheduler";
+export const schedulerId = SchedulerType;
 const schedulerRuntimeRequestHandler: RuntimeRequestHandler =
     async (request: RequestParser, runtime: IContainerRuntime) => {
         if (request.pathParts.length > 0 && request.pathParts[0] === schedulerId) {

--- a/packages/runtime/runtime-definitions/src/agent.ts
+++ b/packages/runtime/runtime-definitions/src/agent.ts
@@ -48,6 +48,7 @@ export interface ITaskManager extends IProvideTaskManager, IComponentLoadable, I
 }
 
 export const IAgentScheduler: keyof IProvideAgentScheduler = "IAgentScheduler";
+export const SchedulerType = "_scheduler";
 
 export interface IProvideAgentScheduler {
     readonly IAgentScheduler: IAgentScheduler;

--- a/packages/test/end-to-end-tests/src/test/agentScheduler.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/agentScheduler.spec.ts
@@ -8,7 +8,7 @@ import { AgentSchedulerFactory, TaskManager } from "@fluidframework/agent-schedu
 import { IFluidCodeDetails, ILoader } from "@fluidframework/container-definitions";
 import { Container } from "@fluidframework/container-loader";
 import { DocumentDeltaEventManager } from "@fluidframework/local-driver";
-import { IAgentScheduler } from "@fluidframework/runtime-definitions";
+import { IAgentScheduler, SchedulerType } from "@fluidframework/runtime-definitions";
 import { LocalDeltaConnectionServer, ILocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { createLocalLoader, initializeLocalContainer } from "@fluidframework/test-utils";
 
@@ -46,7 +46,7 @@ describe("AgentScheduler", () => {
             deltaConnectionServer = LocalDeltaConnectionServer.create();
 
             const container = await createContainer();
-            scheduler = await getComponent("_scheduler", container)
+            scheduler = await getComponent(`/${SchedulerType}`, container)
                 .then((taskManager) => taskManager.IAgentScheduler);
 
             // Make sure all initial ops (around leadership) are processed.
@@ -133,11 +133,11 @@ describe("AgentScheduler", () => {
             deltaConnectionServer = LocalDeltaConnectionServer.create();
 
             container1 = await createContainer();
-            scheduler1 = await getComponent("_scheduler", container1)
+            scheduler1 = await getComponent(`/${SchedulerType}`, container1)
                 .then((taskManager) => taskManager.IAgentScheduler);
 
             container2 = await createContainer();
-            scheduler2 = await getComponent("_scheduler", container2)
+            scheduler2 = await getComponent(`/${SchedulerType}`, container2)
                 .then((taskManager) => taskManager.IAgentScheduler);
 
             // Make sure all initial ops (around leadership) are processed.

--- a/packages/test/end-to-end-tests/src/test/agentScheduler.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/agentScheduler.spec.ts
@@ -46,7 +46,7 @@ describe("AgentScheduler", () => {
             deltaConnectionServer = LocalDeltaConnectionServer.create();
 
             const container = await createContainer();
-            scheduler = await getComponent(`/${SchedulerType}`, container)
+            scheduler = await getComponent(`${SchedulerType}`, container)
                 .then((taskManager) => taskManager.IAgentScheduler);
 
             // Make sure all initial ops (around leadership) are processed.
@@ -133,11 +133,11 @@ describe("AgentScheduler", () => {
             deltaConnectionServer = LocalDeltaConnectionServer.create();
 
             container1 = await createContainer();
-            scheduler1 = await getComponent(`/${SchedulerType}`, container1)
+            scheduler1 = await getComponent(`${SchedulerType}`, container1)
                 .then((taskManager) => taskManager.IAgentScheduler);
 
             container2 = await createContainer();
-            scheduler2 = await getComponent(`/${SchedulerType}`, container2)
+            scheduler2 = await getComponent(`${SchedulerType}`, container2)
                 .then((taskManager) => taskManager.IAgentScheduler);
 
             // Make sure all initial ops (around leadership) are processed.

--- a/packages/test/end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/batching.spec.ts
@@ -9,7 +9,7 @@ import { Container } from "@fluidframework/container-loader";
 import { DocumentDeltaEventManager } from "@fluidframework/local-driver";
 import { SharedMap } from "@fluidframework/map";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
-import { IEnvelope } from "@fluidframework/runtime-definitions";
+import { IEnvelope, SchedulerType } from "@fluidframework/runtime-definitions";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import {
     createLocalLoader,
@@ -62,7 +62,7 @@ describe("Batching", () => {
         component.context.containerRuntime.on("op", (message: ISequencedDocumentMessage) => {
             if (message.type === ContainerMessageType.ComponentOp) {
                 const envelope = message.contents as IEnvelope;
-                if (envelope.address !== "_scheduler") {
+                if (envelope.address !== `/${SchedulerType}`) {
                     receivedMessages.push(message);
                 }
             }

--- a/packages/test/end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/batching.spec.ts
@@ -62,7 +62,7 @@ describe("Batching", () => {
         component.context.containerRuntime.on("op", (message: ISequencedDocumentMessage) => {
             if (message.type === ContainerMessageType.ComponentOp) {
                 const envelope = message.contents as IEnvelope;
-                if (envelope.address !== `/${SchedulerType}`) {
+                if (envelope.address !== `${SchedulerType}`) {
                     receivedMessages.push(message);
                 }
             }

--- a/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
@@ -107,7 +107,7 @@ describe("Ops on Reconnect", () => {
             const message = unpackRuntimeMessage(containerMessage);
             if (message.type === ContainerMessageType.ComponentOp) {
                 const envelope = message.contents as IEnvelope;
-                if (envelope.address !== `/${SchedulerType}`) {
+                if (envelope.address !== `${SchedulerType}`) {
                     // The client ID of firstContainer should have changed on disconnect.
                     assert.notEqual(
                         message.clientId, firstContainerClientId, "The clientId did not change after disconnect");

--- a/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
@@ -11,7 +11,7 @@ import { Container, Loader } from "@fluidframework/container-loader";
 import { DocumentDeltaEventManager, TestDocumentServiceFactory, TestResolver } from "@fluidframework/local-driver";
 import { SharedMap, SharedDirectory } from "@fluidframework/map";
 import { ISequencedDocumentMessage, ConnectionState } from "@fluidframework/protocol-definitions";
-import { IEnvelope } from "@fluidframework/runtime-definitions";
+import { IEnvelope, SchedulerType } from "@fluidframework/runtime-definitions";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { SharedString } from "@fluidframework/sequence";
 import {
@@ -107,7 +107,7 @@ describe("Ops on Reconnect", () => {
             const message = unpackRuntimeMessage(containerMessage);
             if (message.type === ContainerMessageType.ComponentOp) {
                 const envelope = message.contents as IEnvelope;
-                if (envelope.address !== "_scheduler") {
+                if (envelope.address !== `/${SchedulerType}`) {
                     // The client ID of firstContainer should have changed on disconnect.
                     assert.notEqual(
                         message.clientId, firstContainerClientId, "The clientId did not change after disconnect");


### PR DESCRIPTION
- Use constant reference to refer to scheduler type throughout the codebase
- Fix typo in last edited scheduler reference
- Move typing constant to runtime-definitions to avoid circular dependencies on agent-scheduler package