### PR TITLE
Lift Sheetlet from table-document to table-view (Fixes #2699)

### DIFF
--- a/components/experimental/table-document/package.json
+++ b/components/experimental/table-document/package.json
@@ -52,7 +52,6 @@
     "@fluidframework/protocol-definitions": "^0.1008.0-0",
     "@fluidframework/runtime-definitions": "^0.21.0",
     "@fluidframework/sequence": "^0.21.0",
-    "@tiny-calc/micro": "0.0.0-alpha.0",
     "debug": "^4.1.1"
   },
   "devDependencies": {

--- a/components/experimental/table-document/src/document.ts
+++ b/components/experimental/table-document/src/document.ts
@@ -55,14 +55,6 @@ export class TableDocument extends PrimedComponent<{}, {}, ITableDocumentEvents>
     private maybeCols?: SharedNumberSequence;
     private maybeMatrix?: SparseMatrix;
 
-    public evaluateCell(row: number, col: number): TableDocumentItem {
-        return "Not Implemented";
-    }
-
-    public evaluateFormula(formula: string): TableDocumentItem {
-        return "Not Implemented";
-    }
-
     public getCellValue(row: number, col: number): TableDocumentItem {
         return this.matrix.getItem(row, col);
     }

--- a/components/experimental/table-document/src/document.ts
+++ b/components/experimental/table-document/src/document.ts
@@ -13,7 +13,6 @@ import {
     SparseMatrix,
     SequenceDeltaEvent,
 } from "@fluidframework/sequence";
-import { ISheetlet, createSheetletProducer } from "@tiny-calc/micro";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { IEvent } from "@fluidframework/common-definitions";
 import { CellRange } from "./cellrange";
@@ -51,27 +50,17 @@ export class TableDocument extends PrimedComponent<{}, {}, ITableDocumentEvents>
     public get numRows() { return this.matrix.numRows; }
 
     private get matrix(): SparseMatrix { return this.maybeMatrix; }
-    private get workbook() { return this.maybeWorkbook; }
 
     private maybeRows?: SharedNumberSequence;
     private maybeCols?: SharedNumberSequence;
     private maybeMatrix?: SparseMatrix;
-    private maybeWorkbook?: ISheetlet;
 
     public evaluateCell(row: number, col: number): TableDocumentItem {
-        try {
-            return this.workbook.evaluateCell(row, col);
-        } catch (e) {
-            return `${e}`;
-        }
+        return "Not Implemented";
     }
 
     public evaluateFormula(formula: string): TableDocumentItem {
-        try {
-            return this.workbook.evaluateFormula(formula);
-        } catch (e) {
-            return `${e}`;
-        }
+        return "Not Implemented";
     }
 
     public getCellValue(row: number, col: number): TableDocumentItem {
@@ -80,7 +69,6 @@ export class TableDocument extends PrimedComponent<{}, {}, ITableDocumentEvents>
 
     public setCellValue(row: number, col: number, value: TableDocumentItem, properties?: PropertySet) {
         this.matrix.setItems(row, col, [value], properties);
-        this.workbook.invalidate(row, col);
     }
 
     public async getRange(label: string) {
@@ -181,58 +169,9 @@ export class TableDocument extends PrimedComponent<{}, {}, ITableDocumentEvents>
         this.maybeRows = await maybeRowsHandle.get();
         this.maybeCols = await maybeColsHandle.get();
 
-        this.matrix.on("op", (op, local, target) => {
-            if (!local) {
-                // Temporarily, we invalidate the entire matrix when we receive a remote op.
-                // This can be improved w/the new SparseMatrix, which makes it easier to decode
-                // the range of cells impacted by matrix ops.
-                for (let row = 0; row < this.numRows; row++) {
-                    for (let col = 0; col < this.numCols; col++) {
-                        this.workbook.invalidate(row, col);
-                    }
-                }
-            }
-        });
         this.forwardEvent(this.maybeCols, "op", "sequenceDelta");
         this.forwardEvent(this.maybeRows, "op", "sequenceDelta");
         this.forwardEvent(this.matrix, "op", "sequenceDelta");
-
-        // eslint-disable-next-line @typescript-eslint/no-this-alias
-        const table = this;
-
-        const producer = {
-            get rowCount() { return table.numRows; },
-            get colCount() { return table.numCols; },
-            getCell: (row, col) => {
-                const raw = table.matrix.getItem(row, col);
-                return typeof raw === "object"
-                    ? undefined
-                    : raw;
-            },
-            openMatrix() { return this; },
-            closeMatrix() { },
-            get matrixProducer() { return this; },
-        };
-
-        const grid = {
-            getCell: (row: number, col: number) => table.matrix.getTag(row, col),
-            write(row: number, col: number, value: any) {
-                table.matrix.setTag(row, col, value);
-            },
-            readOrWrite(row: number, col: number, value: () => any) {
-                const existing = this.getCell(row, col);
-                if (existing !== undefined) {
-                    return existing;
-                }
-
-                this.write(row, col, value());
-            },
-            clear(row: number, col: number) {
-                this.write(row, col, undefined);
-            },
-        };
-
-        this.maybeWorkbook = createSheetletProducer(producer, grid);
     }
 
     private readonly localRefToRowCol = (localRef: LocalReference) => {

--- a/components/experimental/table-document/src/slice.ts
+++ b/components/experimental/table-document/src/slice.ts
@@ -42,15 +42,6 @@ export class TableSlice extends PrimedComponent<{}, ITableSliceConfig> implement
     private maybeDoc?: TableDocument;
     private maybeValues?: CellRange;
 
-    public evaluateCell(row: number, col: number): TableDocumentItem {
-        this.validateInSlice(row, col);
-        return this.doc.evaluateCell(row, col);
-    }
-
-    public evaluateFormula(formula: string): TableDocumentItem {
-        return this.doc.evaluateFormula(formula);
-    }
-
     public getCellValue(row: number, col: number): TableDocumentItem {
         this.validateInSlice(row, col);
         return this.doc.getCellValue(row, col);

--- a/components/experimental/table-document/src/table.ts
+++ b/components/experimental/table-document/src/table.ts
@@ -18,8 +18,6 @@ export interface ITable {
 
     getCellValue(row: number, col: number): TableDocumentItem;
     setCellValue(row: number, col: number, value: TableDocumentItem, properties?: PropertySet);
-    evaluateFormula(formula: string): TableDocumentItem;
-    evaluateCell(row: number, col: number): TableDocumentItem;
     annotateRows(startRow: number, endRow: number, properties: PropertySet, op?: ICombiningOp);
     getRowProperties(row: number): PropertySet;
     annotateCols(startCol: number, endCol: number, properties: PropertySet, op?: ICombiningOp);

--- a/components/experimental/table-document/src/test/table.spec.ts
+++ b/components/experimental/table-document/src/test/table.spec.ts
@@ -113,64 +113,6 @@ describe("TableDocument", () => {
         });
     });
 
-    describe("eval", () => {
-        it("=A1", () => {
-            table.insertRows(0, 1);
-            table.insertCols(0, 2);
-            table.setCellValue(0, 0, 10);
-            table.setCellValue(0, 1, "=A1");
-            assert.strictEqual(table.evaluateCell(0, 1), 10);
-        });
-
-        it("=A1 w/invalidation", () => {
-            table.insertRows(0, 1);
-            table.insertCols(0, 2);
-            table.setCellValue(0, 0, 10);
-            table.setCellValue(0, 1, "=A1");
-            assert.strictEqual(table.evaluateCell(0, 1), 10);
-            table.setCellValue(0, 0, 20);
-            assert.strictEqual(table.evaluateCell(0, 1), 20);
-        });
-
-        it("=A1 w/insert col", () => {
-            table.insertRows(0, 1);
-            table.insertCols(0, 2);
-            table.setCellValue(0, 0, 10);
-            table.setCellValue(0, 1, "=A1");
-            assert.strictEqual(table.evaluateCell(0, 1), 10);
-            table.insertCols(1, 1);
-            assert.strictEqual(table.evaluateCell(0, 1), undefined);
-            assert.strictEqual(table.evaluateCell(0, 2), 10);
-        });
-
-        it("=A1 w/insert row", () => {
-            table.insertRows(0, 1);
-            table.insertCols(0, 2);
-            table.setCellValue(0, 0, 10);
-            table.setCellValue(0, 1, "=A1");
-            assert.strictEqual(table.evaluateCell(0, 1), 10);
-            table.insertRows(0, 1);
-            assert.strictEqual(table.evaluateCell(0, 1), undefined);
-            assert.strictEqual(table.evaluateCell(1, 1), 10);
-        });
-
-        it("cascading recalcs", () => {
-            table.insertRows(0, 1);
-            table.insertCols(0, 4);
-            table.setCellValue(0, 1, "=A1");
-            table.setCellValue(0, 2, "=B1");
-            table.setCellValue(0, 3, "=C1");
-            for (const expected of [10, 20, 30]) {
-                table.setCellValue(0, 0, expected);
-                for (let r = 0; r < table.numRows; r++) {
-                    for (let c = 0; c < table.numCols; c++) {
-                        assert.strictEqual(table.evaluateCell(r, c), expected);
-                    }
-                }
-            }
-        });
-    });
-
     describe("annotations", () => {
         it("row", () => {
             table.insertRows(0, 2);

--- a/components/experimental/table-view/package.json
+++ b/components/experimental/table-view/package.json
@@ -40,7 +40,8 @@
     "@fluid-example/table-document": "^0.21.0",
     "@fluidframework/aqueduct": "^0.21.0",
     "@fluidframework/component-core-interfaces": "^0.21.0",
-    "@fluidframework/view-interfaces": "^0.21.0"
+    "@fluidframework/view-interfaces": "^0.21.0",
+    "@tiny-calc/micro": "0.0.0-alpha.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.18.0-0",


### PR DESCRIPTION
This is the smallest change possible to remove the sheetlet code from table-document.

I have not changed the `ITable` api and removed `evaluateFormula` and `evaluateCell` - they now just return default values. (I don't know if anyone was using them). I'm happy to remove the functions or throw an error, but someone will need to track down the consumers that might be broken by changing `ITable`.

I didn't change table-document to implement `IMatrix`. I didn't think it was worth it because I'm not sure how long table-document will be around. Again, I'm happy to change it if needs be.

Fixes #2699