### PR TITLE
Adding Keyboard navigation contracts

### DIFF
--- a/packages/framework/framework-experimental/src/keyboardNavigation/componentFocusable.md
+++ b/packages/framework/framework-experimental/src/keyboardNavigation/componentFocusable.md
@@ -1,0 +1,76 @@
+# IComponentFocusable
+
+IComponentFocusable interface specifies contracts for managing focus between components and their hosts.
+
+## Interface Methods
+
+- giveFocus(focusDirection?: FocusDirection): boolean
+  giveFocus is used by a component to focus to its nested component or vice versa. It returns true if focus was successfully accepted by that component.
+  Parameters:
+  `FocusDirection` specifies if the current position of focus is `before` or `after` the component we are trying to give focus to.
+- isComponentFocused():boolean
+  Allows us to query the component to know if it currently has focus.
+- setHostComponentFocusable(hostComponent:IComponentFocusable):void
+  The host can pass to the nested component an implementation of IComponentFocusable, that allows nested component to return focus to host by calling `hostComponent.IComponentFocusable.giveFocus`
+
+## Example Implementation
+
+After a component is loaded, a host can use setHostComponentFocusable to provide a way for the nested component to move back focus to the host.
+
+```typescript
+...
+ // Host Component
+ // hostComponent loads the nested component
+ loadComponent(componenturl).then((component)=>{
+    if (component?.IComponentFocusable?.setHostComponentFocusable){
+      component.IComponentFocusable.setHostComponentFocusable(getHostComponentFocusable());
+    }
+ });
+ private someFunctionToFocusNestedComponent(focusDirection: FocusDirection){
+   component.IComponentFocusable?.giveFocus(focusDirection);
+ }
+  // hostComponent IComponentFocusable implementation to be passed to nested components
+ private getHostComponentFocusable(): IComponentFocusable {
+    const hostComponentFocusable: IComponentFocusable = {
+      get ComponentFocusable(): IComponentFocusable {
+        return this;
+      },
+      isComponentFocused: () => {
+        // return true if parent component or any of its children is focused
+      },
+      giveFocus: (direction: FocusDirection) => {
+        // set focus in host component
+      }
+    };
+    return hostComponentFocusable;
+  }
+...
+```
+
+```typescript
+...
+// Nested Component
+ComponentFoo implements IComponentFocusable{
+  private hostComponent: IComponent |undefined;
+  private isFocused:boolean;
+  public get ComponentFocusable() {
+    return this;
+  }
+  public giveFocus(focusDirection: FocusDirection){
+    // component Foo implementation to focus
+    this.isFocused=true;
+  }
+  public isComponentFocused(){
+    // return component focus state
+    return this.isFocused;
+  }
+  public setHostComponentFocusable(hostComponentFocusable:IComponentFocusable){
+    this.hostComponent= {...this.hostComponent, IComponentFocusable:hostComponentFocusable}
+  }
+  private someFunctionThatShouldReturnFocusToHost(focusDirection: FocusDirection){
+    this.hostComponent?.IComponentFocusable?.giveFocus(focusDirection);
+    this.isFocused=false;
+  }
+}
+...
+```

--- a/packages/framework/framework-experimental/src/keyboardNavigation/componentFocusable.ts
+++ b/packages/framework/framework-experimental/src/keyboardNavigation/componentFocusable.ts
@@ -1,0 +1,64 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * IComponentFocusable interface specifies patterns to manage focus between components and their hosts.
+ * This allows each component to decide how it implements focus and allows the host to configure what happens when
+ * a component gives the focus back to the host.
+ *
+ * The main flow is: After component is loaded, the host can pass an implementation
+ * of IComponentFocusable to allow the nested component to call giveFocus on the host when it wishes to
+ * return back focus to the host.
+ * If the host wants to give focus to a nested component, it notifies the nested component through giveFocus.
+ * The implementation of how the nested component handles that is up to the component itself.
+ * A component's focus state can be found through isComponentFocused. If a component has nested components
+ * that are currently focused then the parent component is considered focused. The component itself is responsible
+ * for maintaining its correct focus state
+ *
+ * Disclaimer: These interfaces are experimental and are subject to change.
+ */
+
+  declare module "@fluidframework/component-core-interfaces" {
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    export interface IComponent extends Readonly<Partial<IProvideComponentFocusable>> {}
+  }
+
+  export interface IProvideComponentFocusable {
+    readonly ComponentFocusable: IComponentFocusable;
+  }
+
+  /**
+   * Indicates where focus is respective to the component before attempting to move focus.
+   */
+  export enum FocusDirection {
+    before,
+    after
+  }
+
+  /**
+   * ComponentFocusable is the contract for a component that can handle focus passes into
+   * and out of the component.
+   */
+  export interface IComponentFocusable extends IProvideComponentFocusable {
+    /**
+     * Notifies Component that it should get focus
+     * @returns true if the component successfully focuses its view
+     * @param focusDirection optional additional information passed to component
+     * to decide where focus should be placed in the component
+     */
+    giveFocus: (focusDirection?: FocusDirection) => boolean;
+
+    /**
+     * Allows us to interrogate the component to know if it currently has focus.
+     * @returns true if the component or a any of its nested components has focus
+     */
+    isComponentFocused: () => boolean;
+
+     /**
+     *  host component's ComponentFocusable to allow the nested component to call giveFocus on the host
+     *  when it wishes to return focus
+     */
+    setHostComponentFocusable?: (hostComponent: IComponentFocusable) => void;
+  }

--- a/packages/framework/framework-experimental/src/keyboardNavigation/componentSelection.md
+++ b/packages/framework/framework-experimental/src/keyboardNavigation/componentSelection.md
@@ -1,0 +1,82 @@
+# IComponentSelection
+
+IComponentSelection interface specifies contracts for managing selection between components and their hosts.
+
+## Interface Methods
+
+- setSelection(selectionParams: SetSelectionParams): boolean
+  SetSelection is used by a component to move selection to its nested component or vice versa. It returns true if selection was successfully moved to that component.
+  Parameters: `SetSelectionParams` is an exported type of the interface , it includes:
+  1. `SelectionMode` specifies whether the selection is ip selection or select all selection.
+  2. `currentCoordinates` x y client coordinates of the selection before moving. For example in case of moving to a table component the x y coordinates of the ip can help specify which cell to move selection to.
+  3. `SelectionDirection` specifies the direction from where selection is being moved (right, left, up or down). For example moving selection with right arrow key should correspond to SelectionDirection.right
+- clearSelection():void
+  Allows host to clear selection in a nested component or vice versa
+- setHostComponentSelection(hostComponent: IComponentSelection):void
+  The host can pass to the nested component an implementation of IComponentSelection, that allows nested component to return selection to host by calling `hostComponent.IComponentSelection.setSelection`
+
+## Example Implementation
+
+After a component is loaded , a host can use setHostComponentSelection to provide a way for the nested component to move back selection to the host.
+
+```typescript
+...
+ // Host Component
+ // hostComponent loads the nested component
+ loadComponent(componenturl).then((component)=>{
+    if (component?.IComponentSelection?.setHostComponent){
+      component.IComponentSelection.setHostComponentSelection(getHostComponentSelection());
+    }
+ });
+
+ private someFunctionToSelectNestedComponent(currentSelection: SetSelectionParams){
+   component.IComponentSelection?.setSelection(currentSelection);
+ }
+
+   // hostComponent IComponentSelection implementation to be passed to nested components
+    private getHostComponentSelection(): IComponentSelection {
+      const hostComponentSelection: IComponentSelection = {
+        get ComponentSelection(): IComponentSelection {
+          return this;
+        },
+        clearSelection: () => {
+          // clear selection in host component
+        },
+        setSelection: (params: SetSelectionParams) => {
+          // set selection in host component
+        }
+    };
+    return hostComponentSelection;
+  }
+...
+```
+
+```typescript
+...
+// Nested Component
+ComponentFoo implements IComponentSelection{
+
+  private hostComponent: IComponent |undefined;
+  public get ComponentSelection() {
+    return this;
+  }
+
+  public setSelection(selectionParams:SetSelectionParams){
+    // component Foo implementation to set selection
+  }
+
+  public clearSelection(){
+    // component Foo implementation to clear selection
+  }
+
+  public setHostComponentSelection(hostComponentSelection:IComponentSelection){
+    this.hostComponent= {...this.hostComponent, IComponentSelection:hostComponentSelection}
+  }
+
+  private someFunctionThatShouldReturnSelectionToHost(selectionParams:SetSelectionParams){
+    this.hostComponent?.IComponentSelection?.setSelection(selectionParams)
+  }
+
+}
+...
+```

--- a/packages/framework/framework-experimental/src/keyboardNavigation/componentSelection.ts
+++ b/packages/framework/framework-experimental/src/keyboardNavigation/componentSelection.ts
@@ -1,0 +1,85 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * IComponentSelection interface specifies contracts for managing selection between components and their hosts.
+ * It supports two selection modes: IP selection and FullRange selection.
+ * The main flow is: After component is loaded, the host can pass an implementation of IComponentSelection to
+ * allow the nested component to call setSelection on the host when it wishes to return back selection to the host.
+ * If the host wants to move selection to a nested component, it notifies the nested component through
+ * setSelection. Similarly, clear selection can be used to remove selection from a nested component.
+ * The implementation of how the nested component handles that is up to the component itself.
+ * Disclaimer: These interface is experimental and is subject to change.
+ */
+
+  declare module "@fluidframework/component-core-interfaces" {
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    export interface IComponent extends Readonly<Partial<IProvideComponentSelection>> {}
+  }
+
+  export interface IProvideComponentSelection {
+    readonly ComponentSelection: IComponentSelection;
+  }
+
+/**
+ * Direction of selection movement. In case of ip selection indicates which direction the ip is coming from
+ */
+  export enum SelectionDirection {
+    left,
+    right,
+    up,
+    down
+  }
+  export enum SelectionMode {
+    /**
+     * ip selection mode
+     */
+    ip,
+    /**
+     * Select All mode if the component supports it, can be used for overtyping
+     */
+    fullRange
+  }
+
+  /**
+   * Client screen coordinates for where the ip selection is coming from.
+   */
+  export interface SelectionCoordinates {
+    x: number;
+    y: number;
+  }
+
+  export interface SetSelectionParams {
+    /**
+     * ip selection or select all mode
+     */
+    mode: SelectionMode;
+    /**
+     * x y coordinates of selection before it moves to component
+     */
+    currentCoordinates?: SelectionCoordinates;
+    /**
+     * Direction to move selection (typically corresponding to arrow key used to move selection to component)
+     */
+    direction?: SelectionDirection;
+  }
+
+  export interface IComponentSelection extends IProvideComponentSelection {
+    /**
+     * Moves Selection to component.
+     * @param details information about the current selection.
+     * @returns true if selection is successfully set in the component
+     */
+    setSelection(details: SetSelectionParams): boolean;
+    /**
+     * Removes current selection from the component.
+     */
+    clearSelection?(): void;
+    /**
+     * Allows host to pass an IComponent that implements ComponentSelection to enable
+     * nested to component to move set selection in the host
+     */
+    setHostComponentSelection?(hostComponent: IComponentSelection): void;
+  }

--- a/packages/framework/framework-experimental/src/keyboardNavigation/index.ts
+++ b/packages/framework/framework-experimental/src/keyboardNavigation/index.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+export * from "./componentFocusable";
+export * from "./componentSelection";


### PR DESCRIPTION
Adding IComponentFocusable and IComponentSelection interfaces to support keyboard navigation between components. Detailed description of the interfaces can be found in the accompanying md files.