### PR TITLE
Deprecated path in IComponentHandleContext and added absolutePath

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,6 +1,8 @@
 # Breaking changes
 
 ## 0.22 Breaking Changes
+- [Removed `path` from `IComponentHandleContext`](#Removed-`path`-from-`IComponentHandleContext`)
+
 
 ### Removed `path` from `IComponentHandleContext`
 Removed the `path` field from the interface `IComponentHandleContext`. This means it is removed from `IComponentHandle` as well.

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,5 +1,12 @@
 # Breaking changes
 
+## 0.22 Breaking Changes
+
+### Removed `path` from `IComponentHandleContext`
+Removed the `path` field from the interface `IComponentHandleContext`. This means it is removed from `IComponentHandle` as well.
+
+Added an `absolutePath` field to `IComponentHandleContext` which is the absolute path to reach it from the container runtime.
+
 ## 0.21 Breaking Changes
 - [Removed `@fluidframework/local-test-utils`](#removed-`@fluidframework/local-test-utils`)
 - [IComponentHTMLVisual deprecated](#IComponentHTMLVisual-deprecated)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,11 +1,11 @@
 # Breaking changes
 
 ## 0.22 Breaking Changes
-- [Removed `path` from `IComponentHandleContext`](#Removed-`path`-from-`IComponentHandleContext`)
+- [Deprecated `path` from `IComponentHandleContext`](#Deprecated-`path`-from-`IComponentHandleContext`)
 
 
-### Removed `path` from `IComponentHandleContext`
-Removed the `path` field from the interface `IComponentHandleContext`. This means it is removed from `IComponentHandle` as well.
+### Deprecated `path` from `IComponentHandleContext`
+Deprecated the `path` field from the interface `IComponentHandleContext`. This means that `IComponentHandle` will not have this going forward as well.
 
 Added an `absolutePath` field to `IComponentHandleContext` which is the absolute path to reach it from the container runtime.
 

--- a/components/experimental/client-ui-lib/src/controls/flowView.ts
+++ b/components/experimental/client-ui-lib/src/controls/flowView.ts
@@ -4500,7 +4500,7 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
                     }, (10000));
                 },
                 () => {
-                    console.log(`Failed to fetch ${commentHandle.id}`);
+                    console.log(`Failed to fetch ${commentHandle.absolutePath}`);
                 });
         }
     }

--- a/components/experimental/client-ui-lib/src/controls/flowView.ts
+++ b/components/experimental/client-ui-lib/src/controls/flowView.ts
@@ -4500,7 +4500,7 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
                     }, (10000));
                 },
                 () => {
-                    console.log(`Failed to fetch ${commentHandle.path}`);
+                    console.log(`Failed to fetch ${commentHandle.id}`);
                 });
         }
     }

--- a/packages/dds/map/src/test/directory.spec.ts
+++ b/packages/dds/map/src/test/directory.spec.ts
@@ -109,9 +109,11 @@ describe("Directory", () => {
                 const subMap = mapFactory.create(componentRuntime, "subMap");
                 directory.set("object", subMap.handle);
 
+                const subMapHandleUrl = subMap.handle.absolutePath;
+
                 const serialized = serialize(directory);
                 // eslint-disable-next-line max-len
-                const expected = `{"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain","value":"sixth"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"subMap"}}}}`;
+                const expected = `{"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain","value":"sixth"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"${subMapHandleUrl}"}}}}`;
                 assert.equal(serialized, expected);
             });
 
@@ -127,9 +129,10 @@ describe("Directory", () => {
                     .createSubDirectory("nested3")
                     .set("deepKey2", "deepValue2");
 
+                const subMapHandleUrl = subMap.handle.absolutePath;
                 const serialized = serialize(directory);
                 // eslint-disable-next-line max-len
-                const expected = `{"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain","value":"sixth"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"subMap"}}},"subdirectories":{"nested":{"storage":{"deepKey1":{"type":"Plain","value":"deepValue1"}},"subdirectories":{"nested2":{"subdirectories":{"nested3":{"storage":{"deepKey2":{"type":"Plain","value":"deepValue2"}}}}}}}}}`;
+                const expected = `{"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain","value":"sixth"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"${subMapHandleUrl}"}}},"subdirectories":{"nested":{"storage":{"deepKey1":{"type":"Plain","value":"deepValue1"}},"subdirectories":{"nested2":{"subdirectories":{"nested3":{"storage":{"deepKey2":{"type":"Plain","value":"deepValue2"}}}}}}}}}`;
                 assert.equal(serialized, expected);
             });
 
@@ -148,9 +151,10 @@ describe("Directory", () => {
                     .createSubDirectory("nested3")
                     .set("deepKey2", "deepValue2");
 
+                const subMapHandleUrl = subMap.handle.absolutePath;
                 const serialized = serialize(directory);
                 // eslint-disable-next-line max-len
-                const expected = `{"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"subMap"}}},"subdirectories":{"nested":{"storage":{"deepKey1":{"type":"Plain","value":"deepValue1"},"deepKeyUndefined":{"type":"Plain"}},"subdirectories":{"nested2":{"subdirectories":{"nested3":{"storage":{"deepKey2":{"type":"Plain","value":"deepValue2"}}}}}}}}}`;
+                const expected = `{"storage":{"first":{"type":"Plain","value":"second"},"third":{"type":"Plain","value":"fourth"},"fifth":{"type":"Plain"},"object":{"type":"Plain","value":{"type":"__fluid_handle__","url":"${subMapHandleUrl}"}}},"subdirectories":{"nested":{"storage":{"deepKey1":{"type":"Plain","value":"deepValue1"},"deepKeyUndefined":{"type":"Plain"}},"subdirectories":{"nested2":{"subdirectories":{"nested3":{"storage":{"deepKey2":{"type":"Plain","value":"deepValue2"}}}}}}}}}`;
                 assert.equal(serialized, expected);
             });
         });

--- a/packages/dds/map/src/test/map.spec.ts
+++ b/packages/dds/map/src/test/map.spec.ts
@@ -80,8 +80,7 @@ describe("Map", () => {
                         assert.equal(parsed[key].type, "Plain");
                         assert.equal(parsed[key].value, value);
                     } else {
-                        const val = parsed[key];
-                        assert.equal(val.type, "Plain");
+                        assert.equal(parsed[key].type, "Plain");
                         assert.equal(parsed[key].value.url, subMap.handle.absolutePath);
                     }
                 });

--- a/packages/dds/map/src/test/map.spec.ts
+++ b/packages/dds/map/src/test/map.spec.ts
@@ -357,12 +357,10 @@ describe("Map", () => {
 
                 // Verify the local SharedMap
                 const localSubMap = map.get<IComponentHandle>("test");
-                assert.equal(localSubMap.id, subMap.id, "could not get the handle's id");
                 assert.equal(localSubMap.absolutePath, subMap.handle.absolutePath, "could not get the handle's path");
 
                 // Verify the remote SharedMap
                 const remoteSubMap = map2.get<IComponentHandle>("test");
-                assert.equal(remoteSubMap.id, subMap.id, "could not get the handle's id in remote map");
                 assert.equal(
                     remoteSubMap.absolutePath,
                     subMap.handle.absolutePath,

--- a/packages/dds/map/src/test/map.spec.ts
+++ b/packages/dds/map/src/test/map.spec.ts
@@ -356,16 +356,17 @@ describe("Map", () => {
                 containerRuntimeFactory.processAllMessages();
 
                 // Verify the local SharedMap
-                assert.equal(
-                    map.get<IComponentHandle>("test").path,
-                    subMap.id,
-                    "could not get the set shared object");
+                const localSubMap = map.get<IComponentHandle>("test");
+                assert.equal(localSubMap.id, subMap.id, "could not get the handle's id");
+                assert.equal(localSubMap.absolutePath, subMap.handle.absolutePath, "could not get the handle's path");
 
                 // Verify the remote SharedMap
+                const remoteSubMap = map2.get<IComponentHandle>("test");
+                assert.equal(remoteSubMap.id, subMap.id, "could not get the handle's id in remote map");
                 assert.equal(
-                    map2.get<IComponentHandle>("test").path,
-                    subMap.id,
-                    "could not get the set shared object from remote map");
+                    remoteSubMap.absolutePath,
+                    subMap.handle.absolutePath,
+                    "could not get the handle's path in remote map");
             });
 
             it("Should be able to set and retrieve a plain object with nested handles", async () => {

--- a/packages/dds/map/src/test/map.spec.ts
+++ b/packages/dds/map/src/test/map.spec.ts
@@ -80,8 +80,9 @@ describe("Map", () => {
                         assert.equal(parsed[key].type, "Plain");
                         assert.equal(parsed[key].value, value);
                     } else {
-                        assert.equal(parsed[key].type, "Plain");
-                        assert.equal(parsed[key].value.url, subMap.id);
+                        const val = parsed[key];
+                        assert.equal(val.type, "Plain");
+                        assert.equal(parsed[key].value.url, subMap.handle.absolutePath);
                     }
                 });
             });
@@ -102,7 +103,7 @@ describe("Map", () => {
                         assert.equal(parsed[key].value, value);
                     } else {
                         assert.equal(parsed[key].type, "Plain");
-                        assert.equal(parsed[key].value.url, subMap.id);
+                        assert.equal(parsed[key].value.url, subMap.handle.absolutePath);
                     }
                 });
             });
@@ -118,9 +119,11 @@ describe("Map", () => {
                 };
                 map.set("object", containingObject);
 
+                const subMapHandleUrl = subMap.handle.absolutePath;
+                const subMap2HandleUrl = subMap2.handle.absolutePath;
                 const serialized = JSON.stringify(map.getSerializableStorage());
                 // eslint-disable-next-line max-len
-                assert.equal(serialized, `{"object":{"type":"Plain","value":{"subMapHandle":{"type":"__fluid_handle__","url":"subMap"},"nestedObj":{"subMap2Handle":{"type":"__fluid_handle__","url":"subMap2"}}}}}`);
+                assert.equal(serialized, `{"object":{"type":"Plain","value":{"subMapHandle":{"type":"__fluid_handle__","url":"${subMapHandleUrl}"},"nestedObj":{"subMap2Handle":{"type":"__fluid_handle__","url":"${subMap2HandleUrl}"}}}}}`);
             });
 
             it("can load old serialization format", async () => {

--- a/packages/dds/ordered-collection/src/test/consensusOrderedCollection.spec.ts
+++ b/packages/dds/ordered-collection/src/test/consensusOrderedCollection.spec.ts
@@ -70,7 +70,6 @@ describe("ConsensusOrderedCollection", () => {
                 await addItem(handle);
 
                 const acquiredValue = await removeItem();
-                assert.strictEqual(acquiredValue.id, handle.id);
                 assert.strictEqual(acquiredValue.absolutePath, handle.absolutePath);
                 const component = await handle.get();
                 assert.strictEqual(component.url, testCollection.url);

--- a/packages/dds/ordered-collection/src/test/consensusOrderedCollection.spec.ts
+++ b/packages/dds/ordered-collection/src/test/consensusOrderedCollection.spec.ts
@@ -70,7 +70,8 @@ describe("ConsensusOrderedCollection", () => {
                 await addItem(handle);
 
                 const acquiredValue = await removeItem();
-                assert.strictEqual(acquiredValue.path, handle.path);
+                assert.strictEqual(acquiredValue.id, handle.id);
+                assert.strictEqual(acquiredValue.absolutePath, handle.absolutePath);
                 const component = await handle.get();
                 assert.strictEqual(component.url, testCollection.url);
 

--- a/packages/dds/register-collection/src/test/consensusRegisterCollection.spec.ts
+++ b/packages/dds/register-collection/src/test/consensusRegisterCollection.spec.ts
@@ -70,7 +70,8 @@ describe("ConsensusRegisterCollection", () => {
                 if (handle === undefined) { assert.fail("Need an actual handle to test this case"); }
                 const writeResult = await writeAndProcessMsg("key1", handle);
                 const readValue = crc.read("key1");
-                assert.strictEqual(readValue.path, handle.path);
+                assert.strictEqual(readValue.id, handle.id);
+                assert.strictEqual(readValue.absolutePath, handle.absolutePath);
                 assert.strictEqual(writeResult, true, "No concurrency expected");
             });
 

--- a/packages/dds/register-collection/src/test/consensusRegisterCollection.spec.ts
+++ b/packages/dds/register-collection/src/test/consensusRegisterCollection.spec.ts
@@ -70,7 +70,6 @@ describe("ConsensusRegisterCollection", () => {
                 if (handle === undefined) { assert.fail("Need an actual handle to test this case"); }
                 const writeResult = await writeAndProcessMsg("key1", handle);
                 const readValue = crc.read("key1");
-                assert.strictEqual(readValue.id, handle.id);
                 assert.strictEqual(readValue.absolutePath, handle.absolutePath);
                 assert.strictEqual(writeResult, true, "No concurrency expected");
             });

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -33,6 +33,7 @@
     "@fluidframework/component-runtime-definitions": "^0.22.0",
     "@fluidframework/container-definitions": "^0.22.0",
     "@fluidframework/protocol-definitions": "^0.1008.0",
+    "@fluidframework/runtime-utils": "^0.22.0",
     "@fluidframework/telemetry-utils": "^0.22.0",
     "@types/debug": "^4.1.5",
     "@types/node": "^10.17.24",

--- a/packages/dds/shared-object-base/src/handle.ts
+++ b/packages/dds/shared-object-base/src/handle.ts
@@ -28,6 +28,7 @@ export class SharedObjectComponentHandle implements IComponentHandle {
      * The set of handles to other shared objects that should be registered before this one.
      */
     private bound: Set<IComponentHandle> | undefined;
+    public readonly absolutePath: string;
 
     public get IComponentHandle() { return this; }
     public get IComponentRouter() { return this; }
@@ -41,31 +42,17 @@ export class SharedObjectComponentHandle implements IComponentHandle {
     }
 
     /**
-     * @param value - The shared object this handle is for
-     * @param id - An id for the shared object
-     * @param routeContext - Component handle context for the container, used to provide request services
+     * Creates a new SharedObjectComponentHandle.
+     * @param value - The shared object this handle is for.
+     * @param path - The id of the shared object. It is also the path to this object relative to the routeContext.
+     * @param routeContext - The parent IComponentHandleContext that has a route to this handle.
      */
     constructor(
         private readonly value: ISharedObject,
-        public readonly id: string,
+        path: string,
         public readonly routeContext: IComponentHandleContext,
     ) {
-    }
-
-    /**
-     * Path to the handle context relative to the routeContext
-     * @deprecated Use `id` instead for the path relative to the routeContext.
-     * For absolute path from the Container use `absolutePath`.
-     */
-    public get path() {
-        return this.id;
-    }
-
-    /**
-     * Returns the absolute path for this ComponentHandle.
-     */
-    public get absolutePath(): string {
-        return generateHandleContextPath(this);
+        this.absolutePath = generateHandleContextPath(path, this.routeContext);
     }
 
     /**

--- a/packages/dds/shared-object-base/src/handle.ts
+++ b/packages/dds/shared-object-base/src/handle.ts
@@ -49,7 +49,7 @@ export class SharedObjectComponentHandle implements IComponentHandle {
      */
     constructor(
         private readonly value: ISharedObject,
-        path: string,
+        public readonly path: string,
         public readonly routeContext: IComponentHandleContext,
     ) {
         this.absolutePath = generateHandleContextPath(path, this.routeContext);

--- a/packages/dds/shared-object-base/src/handle.ts
+++ b/packages/dds/shared-object-base/src/handle.ts
@@ -10,6 +10,7 @@ import {
     IResponse,
 } from "@fluidframework/component-core-interfaces";
 import { AttachState } from "@fluidframework/container-definitions";
+import { generateHandleContextPath } from "@fluidframework/runtime-utils";
 import { ISharedObject } from "./types";
 
 /**
@@ -41,14 +42,30 @@ export class SharedObjectComponentHandle implements IComponentHandle {
 
     /**
      * @param value - The shared object this handle is for
-     * @param path - An id for the shared object
+     * @param id - An id for the shared object
      * @param routeContext - Component handle context for the container, used to provide request services
      */
     constructor(
         private readonly value: ISharedObject,
-        public readonly path: string,
+        public readonly id: string,
         public readonly routeContext: IComponentHandleContext,
     ) {
+    }
+
+    /**
+     * Path to the handle context relative to the routeContext
+     * @deprecated Use `id` instead for the path relative to the routeContext.
+     * For absolute path from the Container use `absolutePath`.
+     */
+    public get path() {
+        return this.id;
+    }
+
+    /**
+     * Returns the absolute path for this ComponentHandle.
+     */
+    public get absolutePath(): string {
+        return generateHandleContextPath(this);
     }
 
     /**

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -73,7 +73,7 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
      * The loadable URL for this SharedObject
      */
     public get url(): string {
-        return this.handle.id;
+        return this.id;
     }
 
     /**

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -73,7 +73,7 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
      * The loadable URL for this SharedObject
      */
     public get url(): string {
-        return this.handle.path;
+        return this.handle.id;
     }
 
     /**

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -66,6 +66,7 @@
     "@fluidframework/framework-interfaces": "^0.22.0",
     "@fluidframework/map": "^0.22.0",
     "@fluidframework/runtime-definitions": "^0.22.0",
+    "@fluidframework/runtime-utils": "^0.22.0",
     "@fluidframework/shared-object-base": "^0.22.0",
     "@fluidframework/synthesize": "^0.22.0",
     "@fluidframework/view-adapters": "^0.22.0",

--- a/packages/framework/aqueduct/src/components/blobHandle.ts
+++ b/packages/framework/aqueduct/src/components/blobHandle.ts
@@ -29,31 +29,18 @@ export class BlobHandle implements IComponentHandle {
         return true;
     }
 
+    public readonly absolutePath: string;
+
     constructor(
-        public readonly id: string,
+        private readonly path: string,
         private readonly directory: ISharedDirectory,
         public readonly routeContext: IComponentHandleContext,
     ) {
-    }
-
-    /**
-     * Path to the handle context relative to the routeContext
-     * @deprecated Use `id` instead for the path relative to the routeContext.
-     * For absolute path from the Container use `absolutePath`.
-     */
-    public get path() {
-        return this.id;
-    }
-
-    /**
-     * Returns the absolute path for this ComponentHandle.
-     */
-    public get absolutePath(): string {
-        return generateHandleContextPath(this);
+        this.absolutePath = generateHandleContextPath(path, this.routeContext);
     }
 
     public async get(): Promise<any> {
-        return this.directory.get<string>(this.id);
+        return this.directory.get<string>(this.path);
     }
 
     public attachGraph(): void {

--- a/packages/framework/aqueduct/src/components/blobHandle.ts
+++ b/packages/framework/aqueduct/src/components/blobHandle.ts
@@ -10,6 +10,7 @@ import {
     IRequest,
     IResponse,
 } from "@fluidframework/component-core-interfaces";
+import { generateHandleContextPath } from "@fluidframework/runtime-utils";
 import { ISharedDirectory } from "@fluidframework/map";
 
 /**
@@ -29,14 +30,30 @@ export class BlobHandle implements IComponentHandle {
     }
 
     constructor(
-        public readonly path: string,
+        public readonly id: string,
         private readonly directory: ISharedDirectory,
         public readonly routeContext: IComponentHandleContext,
     ) {
     }
 
+    /**
+     * Path to the handle context relative to the routeContext
+     * @deprecated Use `id` instead for the path relative to the routeContext.
+     * For absolute path from the Container use `absolutePath`.
+     */
+    public get path() {
+        return this.id;
+    }
+
+    /**
+     * Returns the absolute path for this ComponentHandle.
+     */
+    public get absolutePath(): string {
+        return generateHandleContextPath(this);
+    }
+
     public async get(): Promise<any> {
-        return this.directory.get<string>(this.path);
+        return this.directory.get<string>(this.id);
     }
 
     public attachGraph(): void {

--- a/packages/framework/aqueduct/src/components/blobHandle.ts
+++ b/packages/framework/aqueduct/src/components/blobHandle.ts
@@ -32,7 +32,7 @@ export class BlobHandle implements IComponentHandle {
     public readonly absolutePath: string;
 
     constructor(
-        private readonly path: string,
+        public readonly path: string,
         private readonly directory: ISharedDirectory,
         public readonly routeContext: IComponentHandleContext,
     ) {

--- a/packages/framework/aqueduct/src/components/sharedComponent.ts
+++ b/packages/framework/aqueduct/src/components/sharedComponent.ts
@@ -80,7 +80,10 @@ export abstract class SharedComponent<P extends IComponent = object, S = undefin
         this.context = props.context;
         this.providers = props.providers;
 
-        this.innerHandle = new ComponentHandle(this, this.url, this.runtime.IComponentHandleContext);
+        // Create a ComponentHandle with empty string as `id`. This is because our `id` is the ComponentRuntime's `id`
+        // which is also the routeContent for this handle. Adding our `id` here would mess up the absolutePath of the
+        // ComponentHandle.
+        this.innerHandle = new ComponentHandle(this, "", this.runtime.IComponentHandleContext);
 
         // Container event handlers
         this.runtime.once("dispose", () => {

--- a/packages/framework/aqueduct/src/components/sharedComponent.ts
+++ b/packages/framework/aqueduct/src/components/sharedComponent.ts
@@ -80,9 +80,9 @@ export abstract class SharedComponent<P extends IComponent = object, S = undefin
         this.context = props.context;
         this.providers = props.providers;
 
-        // Create a ComponentHandle with empty string as `id`. This is because our `id` is the ComponentRuntime's `id`
-        // which is also the routeContent for this handle. Adding our `id` here would mess up the absolutePath of the
-        // ComponentHandle.
+        // Create a ComponentHandle with empty string as `path`. This is because reaching this SharedComponent is the
+        // same as reaching its routeContext (ComponentRuntime) so there is so the relative path to it from the
+        // routeContext is empty.
         this.innerHandle = new ComponentHandle(this, "", this.runtime.IComponentHandleContext);
 
         // Container event handlers

--- a/packages/framework/component-base/src/sharedcomponent.ts
+++ b/packages/framework/component-base/src/sharedcomponent.ts
@@ -76,7 +76,7 @@ export abstract class SharedComponent<
     /**
      * Absolute URL to the component within the document
      */
-    public get url() { return this.runtime.IComponentHandleContext.path; }
+    public get url() { return this.runtime.IComponentHandleContext.absolutePath; }
 
     // #endregion IComponentLoadable
 

--- a/packages/framework/react/src/fluidComponent/syncedComponent.ts
+++ b/packages/framework/react/src/fluidComponent/syncedComponent.ts
@@ -165,7 +165,7 @@ export abstract class SyncedComponent<
             const storedFluidState = SharedMap.create(this.runtime);
             // Add it to the fluid component map so that it will have a listener added to it once
             // we enter the render lifecycle
-            this.fluidComponentMap.set(storedFluidState.handle.path, {
+            this.fluidComponentMap.set(storedFluidState.handle.absolutePath, {
                 component: storedFluidState,
                 isRuntimeMap: true,
             });
@@ -182,7 +182,7 @@ export abstract class SyncedComponent<
                 const createCallback = value.sharedObjectCreate;
                 if (createCallback) {
                     const sharedObject = createCallback(this.runtime);
-                    this.fluidComponentMap.set(sharedObject.handle.path, {
+                    this.fluidComponentMap.set(sharedObject.handle.absolutePath, {
                         component: sharedObject,
                         listenedEvents: value.listenedEvents || ["valueChanged"],
                     });
@@ -211,21 +211,21 @@ export abstract class SyncedComponent<
                     .handle as IComponentHandle<SharedMap>,
             };
             this.fluidComponentMap.set(
-                componentSchema.fluidMatchingMap.handle.path,
+                componentSchema.fluidMatchingMap.handle.absolutePath,
                 {
                     component: componentSchema.fluidMatchingMap,
                     isRuntimeMap: true,
                 },
             );
             this.fluidComponentMap.set(
-                componentSchema.viewMatchingMap.handle.path,
+                componentSchema.viewMatchingMap.handle.absolutePath,
                 {
                     component: componentSchema.viewMatchingMap,
                     isRuntimeMap: true,
                 },
             );
             this.fluidComponentMap.set(
-                componentSchema.storedHandleMap.handle.path,
+                componentSchema.storedHandleMap.handle.absolutePath,
                 {
                     component: componentSchema.storedHandleMap,
                     isRuntimeMap: true,
@@ -262,7 +262,7 @@ export abstract class SyncedComponent<
             const storedFluidState = await storedFluidStateHandle.get();
             // Add it to the fluid component map so that it will have a listener added to it once
             // we enter the render lifecycle
-            this.fluidComponentMap.set(storedFluidStateHandle.path, {
+            this.fluidComponentMap.set(storedFluidStateHandle.absolutePath, {
                 component: storedFluidState,
                 isRuntimeMap: true,
             });
@@ -281,7 +281,7 @@ export abstract class SyncedComponent<
                             `Failed to find ${fluidKey} in synced state`,
                         );
                     }
-                    this.fluidComponentMap.set(handle.path, {
+                    this.fluidComponentMap.set(handle.absolutePath, {
                         component: await handle.get(),
                         listenedEvents: value.listenedEvents || ["valueChanged"],
                     });
@@ -291,7 +291,7 @@ export abstract class SyncedComponent<
                         : storedFluidState.get(fluidKey);
                     const handle = storedValue?.IComponentHandle;
                     if (handle) {
-                        this.fluidComponentMap.set(handle.path, {
+                        this.fluidComponentMap.set(handle.absolutePath, {
                             component: await handle.get(),
                             listenedEvents: value.listenedEvents || [
                                 "valueChanged",
@@ -312,21 +312,21 @@ export abstract class SyncedComponent<
                 );
             }
             this.fluidComponentMap.set(
-                componentSchemaHandles.fluidMatchingMapHandle.path,
+                componentSchemaHandles.fluidMatchingMapHandle.absolutePath,
                 {
                     component: await componentSchemaHandles.fluidMatchingMapHandle.get(),
                     isRuntimeMap: true,
                 },
             );
             this.fluidComponentMap.set(
-                componentSchemaHandles.viewMatchingMapHandle.path,
+                componentSchemaHandles.viewMatchingMapHandle.absolutePath,
                 {
                     component: await componentSchemaHandles.viewMatchingMapHandle.get(),
                     isRuntimeMap: true,
                 },
             );
             this.fluidComponentMap.set(
-                componentSchemaHandles.storedHandleMapHandle.path,
+                componentSchemaHandles.storedHandleMapHandle.absolutePath,
                 {
                     component: await componentSchemaHandles.storedHandleMapHandle.get(),
                     isRuntimeMap: true,

--- a/packages/framework/react/src/helpers/getFluidState.ts
+++ b/packages/framework/react/src/helpers/getFluidState.ts
@@ -50,10 +50,10 @@ export function getFluidState<
             ?.sharedObjectCreate;
         let value = componentState.get(fluidKey);
         if (value && createCallback) {
-            const possibleComponentPath = (value as IComponent)
-                ?.IComponentHandle?.path;
-            if (possibleComponentPath !== undefined) {
-                value = componentMap.get(possibleComponentPath);
+            const possibleComponentId = (value as IComponent)
+                ?.IComponentHandle?.id;
+            if (possibleComponentId !== undefined) {
+                value = componentMap.get(possibleComponentId);
                 fluidState[fluidKey] = value?.component;
             } else {
                 fluidState[fluidKey] = value;

--- a/packages/framework/react/src/helpers/getFluidState.ts
+++ b/packages/framework/react/src/helpers/getFluidState.ts
@@ -39,7 +39,7 @@ export function getFluidState<
     if (componentStateHandle === undefined) {
         return;
     }
-    const componentState = componentMap.get(componentStateHandle.path)
+    const componentState = componentMap.get(componentStateHandle.absolutePath)
         ?.component as SharedMap;
     if (componentState === undefined) {
         return;

--- a/packages/framework/react/src/helpers/getFluidState.ts
+++ b/packages/framework/react/src/helpers/getFluidState.ts
@@ -51,7 +51,7 @@ export function getFluidState<
         let value = componentState.get(fluidKey);
         if (value && createCallback) {
             const possibleComponentId = (value as IComponent)
-                ?.IComponentHandle?.id;
+                ?.IComponentHandle?.absolutePath;
             if (possibleComponentId !== undefined) {
                 value = componentMap.get(possibleComponentId);
                 fluidState[fluidKey] = value?.component;

--- a/packages/framework/react/src/helpers/getViewFromFluid.ts
+++ b/packages/framework/react/src/helpers/getViewFromFluid.ts
@@ -61,7 +61,7 @@ export function getViewFromFluid<
         const partialViewState: Partial<SV> = {};
         const valueAsIComponentHandle = (value as IComponent).IComponentHandle;
         const convertedValue = valueAsIComponentHandle
-            ? fluidComponentMap.get(valueAsIComponentHandle.path)
+            ? fluidComponentMap.get(valueAsIComponentHandle.id)
             : value;
         partialViewState[fluidKey as string] = convertedValue;
         return partialViewState;

--- a/packages/framework/react/src/helpers/getViewFromFluid.ts
+++ b/packages/framework/react/src/helpers/getViewFromFluid.ts
@@ -61,7 +61,7 @@ export function getViewFromFluid<
         const partialViewState: Partial<SV> = {};
         const valueAsIComponentHandle = (value as IComponent).IComponentHandle;
         const convertedValue = valueAsIComponentHandle
-            ? fluidComponentMap.get(valueAsIComponentHandle.id)
+            ? fluidComponentMap.get(valueAsIComponentHandle.absolutePath)
             : value;
         partialViewState[fluidKey as string] = convertedValue;
         return partialViewState;

--- a/packages/framework/react/src/helpers/initializeState.ts
+++ b/packages/framework/react/src/helpers/initializeState.ts
@@ -58,67 +58,18 @@ export async function initializeState<
         syncedStateId,
         syncedState,
     );
-<<<<<<< HEAD
-    if (componentSchemaHandles?.storedHandleMapHandle.path === undefined) {
+    if (componentSchemaHandles?.storedHandleMapHandle.absolutePath === undefined) {
         throw Error(`Component schema not initialized prior to render for ${syncedStateId}`);
-=======
-    // TODO #2457 - Move synced state initializing into component lifecycle, expose API for update
-    if (storedFluidStateHandle === undefined) {
-        const storedFluidState = SharedMap.create(dataProps.runtime);
-        dataProps.fluidComponentMap.set(storedFluidState.handle.absolutePath, {
-            component: storedFluidState,
-            isRuntimeMap: true,
-        });
-        root.set(`syncedState-${syncedStateId}`, storedFluidState.handle);
-        storedFluidStateHandle = storedFluidState.handle;
-    } else {
-        dataProps.fluidComponentMap.set(storedFluidStateHandle.absolutePath, {
-            component: await storedFluidStateHandle.get(),
-            isRuntimeMap: true,
-        });
->>>>>>> Replaced path with id in IComponentHandleContext and added absolutePath.
     }
     const storedHandleMap = dataProps.fluidComponentMap.get(
-        componentSchemaHandles?.storedHandleMapHandle.path,
+        componentSchemaHandles?.storedHandleMapHandle.absolutePath,
     )?.component as SharedMap;
     if (storedHandleMap === undefined) {
         throw Error(`Stored handle map not initialized prior to render for ${syncedStateId}`);
     }
-<<<<<<< HEAD
     const unlistenedHandles: IComponentHandle[] = [];
     for (const handle of storedHandleMap.values()) {
         unlistenedHandles.push(handle);
-=======
-
-    for (const key of fluidToView.keys()) {
-        const fluidKey = key as string;
-        const rootKey = fluidToView?.get(fluidKey as keyof SF)?.rootKey;
-        const createCallback = fluidToView?.get(fluidKey as keyof SF)
-            ?.sharedObjectCreate;
-        if (createCallback) {
-            if (fluidStateMap.get(fluidKey) === undefined) {
-                const sharedObject = createCallback(dataProps.runtime);
-                dataProps.fluidComponentMap.set(sharedObject.handle.absolutePath, {
-                    component: sharedObject,
-                    listenedEvents: fluidToView?.get(fluidKey as keyof SF)
-                        ?.listenedEvents || ["valueChanged"],
-                });
-                fluidStateMap.set(fluidKey, sharedObject.handle);
-                if (rootKey) {
-                    root.set(rootKey, sharedObject.handle);
-                }
-            } else {
-                const handle = fluidStateMap.get(fluidKey);
-                dataProps.fluidComponentMap.set(handle.path, {
-                    component: await handle.get(),
-                    listenedEvents: fluidToView?.get(fluidKey as keyof SF)
-                        ?.listenedEvents,
-                });
-            }
-        } else if (rootKey) {
-            fluidStateMap.set(fluidKey, root.get(rootKey));
-        }
->>>>>>> Replaced path with id in IComponentHandleContext and added absolutePath.
     }
 
     const currentFluidState = getFluidState(
@@ -144,42 +95,9 @@ export async function initializeState<
 
     state.isInitialized = true;
     state.syncedStateId = syncedStateId;
-<<<<<<< HEAD
     // Define the synced state callback listener that will be responsible for triggering state updates on synced state
     // value changes
     const syncedStateCallback = (
-=======
-
-    // Add the list of SharedMap handles for the schema and any unlistened handles passed in through the component
-    // map to the list of handles we will fetch and start listening to
-    unlistenedComponentHandles = [
-        ...unlistenedComponentHandles,
-        ...[
-            componentSchemaHandles.componentKeyMapHandle,
-            componentSchemaHandles.fluidMatchingMapHandle,
-            componentSchemaHandles.viewMatchingMapHandle,
-        ],
-    ];
-    const unlistenedMapHandles = [...unlistenedComponentHandles];
-
-    dataProps.fluidComponentMap.forEach((value: IFluidComponent, k) => {
-        if (!value.isListened && value.component?.handle !== undefined) {
-            unlistenedComponentHandles.push(value.component.handle);
-        }
-    });
-
-    // Initialize the FluidComponentMap with our data handles
-    for (const handle of unlistenedMapHandles) {
-        dataProps.fluidComponentMap.set(handle.absolutePath, {
-            isListened: false,
-            isRuntimeMap: true,
-            component: await handle.get(),
-        });
-    }
-
-    // Define the root callback listener that will be responsible for triggering state updates on root value changes
-    const initRootCallback = (
->>>>>>> Replaced path with id in IComponentHandleContext and added absolutePath.
         change: IDirectoryValueChanged,
         local: boolean,
     ) => {
@@ -204,8 +122,8 @@ export async function initializeState<
         local: boolean,
     ) => {
         const handle = storedHandleMap.get<IComponentHandle>(change.key);
-        if (handle !== undefined && !state.fluidComponentMap?.has(handle.path)) {
-            state.fluidComponentMap?.set(handle.path, {
+        if (handle !== undefined && !state.fluidComponentMap?.has(handle.absolutePath)) {
+            state.fluidComponentMap?.set(handle.absolutePath, {
                 isListened: false,
             });
             // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/packages/framework/react/src/helpers/initializeState.ts
+++ b/packages/framework/react/src/helpers/initializeState.ts
@@ -65,14 +65,14 @@ export async function initializeState<
     // TODO #2457 - Move synced state initializing into component lifecycle, expose API for update
     if (storedFluidStateHandle === undefined) {
         const storedFluidState = SharedMap.create(dataProps.runtime);
-        dataProps.fluidComponentMap.set(storedFluidState.handle.id, {
+        dataProps.fluidComponentMap.set(storedFluidState.handle.absolutePath, {
             component: storedFluidState,
             isRuntimeMap: true,
         });
         root.set(`syncedState-${syncedStateId}`, storedFluidState.handle);
         storedFluidStateHandle = storedFluidState.handle;
     } else {
-        dataProps.fluidComponentMap.set(storedFluidStateHandle.id, {
+        dataProps.fluidComponentMap.set(storedFluidStateHandle.absolutePath, {
             component: await storedFluidStateHandle.get(),
             isRuntimeMap: true,
         });
@@ -98,7 +98,7 @@ export async function initializeState<
         if (createCallback) {
             if (fluidStateMap.get(fluidKey) === undefined) {
                 const sharedObject = createCallback(dataProps.runtime);
-                dataProps.fluidComponentMap.set(sharedObject.handle.id, {
+                dataProps.fluidComponentMap.set(sharedObject.handle.absolutePath, {
                     component: sharedObject,
                     listenedEvents: fluidToView?.get(fluidKey as keyof SF)
                         ?.listenedEvents || ["valueChanged"],
@@ -170,7 +170,7 @@ export async function initializeState<
 
     // Initialize the FluidComponentMap with our data handles
     for (const handle of unlistenedMapHandles) {
-        dataProps.fluidComponentMap.set(handle.id, {
+        dataProps.fluidComponentMap.set(handle.absolutePath, {
             isListened: false,
             isRuntimeMap: true,
             component: await handle.get(),

--- a/packages/framework/react/src/helpers/setFluidState.ts
+++ b/packages/framework/react/src/helpers/setFluidState.ts
@@ -36,7 +36,7 @@ export function setFluidState<SV, SF>(
     const storedStateHandle = syncedState.get<IComponentHandle>(
         `syncedState-${syncedStateId}`,
     );
-    let storedState = componentMap.get(storedStateHandle?.path)
+    let storedState = componentMap.get(storedStateHandle?.absolutePath)
         ?.component as ISharedMap;
     if (storedStateHandle === undefined || storedState === undefined) {
         const newState = SharedMap.create(runtime);

--- a/packages/framework/react/src/helpers/setFluidState.ts
+++ b/packages/framework/react/src/helpers/setFluidState.ts
@@ -40,7 +40,7 @@ export function setFluidState<SV, SF>(
         ?.component as ISharedMap;
     if (storedStateHandle === undefined || storedState === undefined) {
         const newState = SharedMap.create(runtime);
-        componentMap.set(newState.handle.id, {
+        componentMap.set(newState.handle.absolutePath, {
             component: newState,
             isRuntimeMap: true,
         });
@@ -57,7 +57,7 @@ export function setFluidState<SV, SF>(
         if (createCallback) {
             if (storedState.get(fluidKey) === undefined) {
                 const sharedObject = createCallback(runtime);
-                componentMap.set(sharedObject.handle.id, {
+                componentMap.set(sharedObject.handle.absolutePath, {
                     component: sharedObject,
                     listenedEvents: fluidToView?.get(fluidKey as keyof SF)
                         ?.listenedEvents || ["valueChanged"],

--- a/packages/framework/react/src/helpers/setFluidState.ts
+++ b/packages/framework/react/src/helpers/setFluidState.ts
@@ -40,7 +40,7 @@ export function setFluidState<SV, SF>(
         ?.component as ISharedMap;
     if (storedStateHandle === undefined || storedState === undefined) {
         const newState = SharedMap.create(runtime);
-        componentMap.set(newState.handle.path, {
+        componentMap.set(newState.handle.id, {
             component: newState,
             isRuntimeMap: true,
         });
@@ -57,7 +57,7 @@ export function setFluidState<SV, SF>(
         if (createCallback) {
             if (storedState.get(fluidKey) === undefined) {
                 const sharedObject = createCallback(runtime);
-                componentMap.set(sharedObject.handle.path, {
+                componentMap.set(sharedObject.handle.id, {
                     component: sharedObject,
                     listenedEvents: fluidToView?.get(fluidKey as keyof SF)
                         ?.listenedEvents || ["valueChanged"],

--- a/packages/framework/react/src/helpers/syncState.ts
+++ b/packages/framework/react/src/helpers/syncState.ts
@@ -79,9 +79,9 @@ export function syncState<
         fluidMatchingMapHandle,
     } = componentSchemaHandles;
 
-    const viewMatchingMap = fluidComponentMap.get(viewMatchingMapHandle.path)
+    const viewMatchingMap = fluidComponentMap.get(viewMatchingMapHandle.absolutePath)
         ?.component as ISharedMap;
-    const fluidMatchingMap = fluidComponentMap.get(fluidMatchingMapHandle.path)
+    const fluidMatchingMap = fluidComponentMap.get(fluidMatchingMapHandle.absolutePath)
         ?.component as ISharedMap;
 
     if (viewMatchingMap === undefined || fluidMatchingMap === undefined) {

--- a/packages/framework/react/src/helpers/utils.tsx
+++ b/packages/framework/react/src/helpers/utils.tsx
@@ -58,23 +58,23 @@ export const addComponent = async <
     refreshView: () => void,
     storedHandleMap: SharedMap,
 ): Promise<void> => {
-    const maybeValue: IFluidComponent | undefined = fluidComponentMap.get(handle.path);
+    const maybeValue: IFluidComponent | undefined = fluidComponentMap.get(handle.absolutePath);
     let value: IFluidComponent = {
         isListened: false,
         isRuntimeMap: false,
     };
     if (maybeValue === undefined) {
         fluidComponentMap.set(
-            handle.path,
+            handle.absolutePath,
             value,
         );
     } else {
         value = maybeValue;
     }
     value.isListened = false;
-    fluidComponentMap.set(handle.path, value);
-    if (!storedHandleMap.has(handle.path)) {
-        storedHandleMap.set(handle.path, handle);
+    fluidComponentMap.set(handle.absolutePath, value);
+    if (!storedHandleMap.has(handle.absolutePath)) {
+        storedHandleMap.set(handle.absolutePath, handle);
     }
     return handle.get().then((component) => {
         if (value.isRuntimeMap) {

--- a/packages/framework/react/src/helpers/utils.tsx
+++ b/packages/framework/react/src/helpers/utils.tsx
@@ -86,7 +86,7 @@ export const addComponent = async <
         }
         value.component = component;
         value.isListened = true;
-        fluidComponentMap.set(handle.path, value);
+        fluidComponentMap.set(handle.id, value);
     });
 };
 

--- a/packages/framework/react/src/helpers/utils.tsx
+++ b/packages/framework/react/src/helpers/utils.tsx
@@ -86,7 +86,7 @@ export const addComponent = async <
         }
         value.component = component;
         value.isListened = true;
-        fluidComponentMap.set(handle.id, value);
+        fluidComponentMap.set(handle.absolutePath, value);
     });
 };
 

--- a/packages/framework/react/src/useReducerFluid.tsx
+++ b/packages/framework/react/src/useReducerFluid.tsx
@@ -334,7 +334,7 @@ export function useReducerFluid<
                     handle &&
                     instanceOfComponentSelectorFunction<SV, SF, C>(action) &&
                     combinedFetchDataProps.fluidComponentMap.get(
-                        handle.path,
+                        handle.id,
                     ) === undefined
                 ) {
                     newHandles.push(handle);

--- a/packages/framework/react/src/useReducerFluid.tsx
+++ b/packages/framework/react/src/useReducerFluid.tsx
@@ -334,7 +334,7 @@ export function useReducerFluid<
                     handle &&
                     instanceOfComponentSelectorFunction<SV, SF, C>(action) &&
                     combinedFetchDataProps.fluidComponentMap.get(
-                        handle.id,
+                        handle.absolutePath,
                     ) === undefined
                 ) {
                     newHandles.push(handle);

--- a/packages/framework/react/src/useReducerFluid.tsx
+++ b/packages/framework/react/src/useReducerFluid.tsx
@@ -66,11 +66,11 @@ export function useReducerFluid<
         syncedStateId,
         syncedState,
     );
-    if (componentSchemaHandles?.storedHandleMapHandle.path === undefined) {
+    if (componentSchemaHandles?.storedHandleMapHandle.absolutePath === undefined) {
         throw Error(`Component schema not initialized prior to render for ${syncedStateId}`);
     }
     const storedHandleMap = dataProps.fluidComponentMap.get(
-        componentSchemaHandles?.storedHandleMapHandle.path,
+        componentSchemaHandles?.storedHandleMapHandle.absolutePath,
     )?.component as SharedMap;
     if (storedHandleMap === undefined) {
         throw Error(`Stored handle map not initialized prior to render for ${syncedStateId}`);

--- a/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
+++ b/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
@@ -15,6 +15,7 @@ import { ComponentHandle } from "@fluidframework/component-runtime";
 import { DependencyContainer } from "..";
 
 const mockHandleContext: IComponentHandleContext = {
+    path: "",
     absolutePath: "",
     isAttached: false,
     IComponentRouter: undefined as any,

--- a/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
+++ b/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
@@ -16,6 +16,8 @@ import { DependencyContainer } from "..";
 
 const mockHandleContext: IComponentHandleContext = {
     path: "",
+    id: "",
+    absolutePath: "",
     isAttached: false,
     IComponentRouter: undefined as any,
     IComponentHandleContext: undefined as any,

--- a/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
+++ b/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
@@ -15,8 +15,6 @@ import { ComponentHandle } from "@fluidframework/component-runtime";
 import { DependencyContainer } from "..";
 
 const mockHandleContext: IComponentHandleContext = {
-    path: "",
-    id: "",
     absolutePath: "",
     isAttached: false,
     IComponentRouter: undefined as any,

--- a/packages/loader/component-core-interfaces/src/handles.ts
+++ b/packages/loader/component-core-interfaces/src/handles.ts
@@ -19,8 +19,20 @@ export interface IProvideComponentHandleContext {
 export interface IComponentHandleContext extends IComponentRouter, IProvideComponentHandleContext {
     /**
      * Path to the handle context relative to the routeContext
+     * @deprecated Use `id` instead for the path relative to the routeContext.
+     * For absolute path from the Container use `absolutePath`.
      */
     path: string;
+
+    /**
+     * An id for the IComponentHandleContext.
+     */
+    id: string;
+
+    /**
+     * The absolute path to the handle context from the Container.
+     */
+    absolutePath: string;
 
     /**
      * The parent IComponentHandleContext that has provided a route path to this IComponentHandleContext or undefined

--- a/packages/loader/component-core-interfaces/src/handles.ts
+++ b/packages/loader/component-core-interfaces/src/handles.ts
@@ -18,19 +18,7 @@ export interface IProvideComponentHandleContext {
  */
 export interface IComponentHandleContext extends IComponentRouter, IProvideComponentHandleContext {
     /**
-     * Path to the handle context relative to the routeContext
-     * @deprecated Use `id` instead for the path relative to the routeContext.
-     * For absolute path from the Container use `absolutePath`.
-     */
-    path: string;
-
-    /**
-     * An id for the IComponentHandleContext.
-     */
-    id: string;
-
-    /**
-     * The absolute path to the handle context from the Container.
+     * The absolute path to the handle context from the container runtime.
      */
     absolutePath: string;
 

--- a/packages/loader/component-core-interfaces/src/handles.ts
+++ b/packages/loader/component-core-interfaces/src/handles.ts
@@ -18,6 +18,12 @@ export interface IProvideComponentHandleContext {
  */
 export interface IComponentHandleContext extends IComponentRouter, IProvideComponentHandleContext {
     /**
+     * @deprecated - Use `absolutePath` to get the path to the handle context from the root.
+     * Path to the handle context relative to the routeContext
+     */
+    path: string;
+
+    /**
      * The absolute path to the handle context from the root.
      */
     absolutePath: string;

--- a/packages/loader/component-core-interfaces/src/handles.ts
+++ b/packages/loader/component-core-interfaces/src/handles.ts
@@ -18,7 +18,7 @@ export interface IProvideComponentHandleContext {
  */
 export interface IComponentHandleContext extends IComponentRouter, IProvideComponentHandleContext {
     /**
-     * The absolute path to the handle context from the container runtime.
+     * The absolute path to the handle context from the root.
      */
     absolutePath: string;
 

--- a/packages/runtime/component-runtime/src/componentHandle.ts
+++ b/packages/runtime/component-runtime/src/componentHandle.ts
@@ -18,6 +18,7 @@ export class ComponentHandle implements IComponentHandle {
     // This is used to break the recursion while attaching the graph. Also tells the attach state of the graph.
     private graphAttachState: AttachState = AttachState.Detached;
     private bound: Set<IComponentHandle> | undefined;
+    public readonly absolutePath: string;
 
     public get IComponentRouter(): IComponentRouter { return this; }
     public get IComponentHandleContext(): IComponentHandleContext { return this; }
@@ -27,27 +28,18 @@ export class ComponentHandle implements IComponentHandle {
         return this.routeContext.isAttached;
     }
 
+    /**
+     * Creates a new ComponentHandle.
+     * @param value - The IComponent object this handle is for.
+     * @param path - The path to this handle relative to the routeContext.
+     * @param routeContext - The parent IComponentHandleContext that has a route to this handle.
+     */
     constructor(
         private readonly value: IComponent,
-        public readonly id: string,
+        path: string,
         public readonly routeContext: IComponentHandleContext,
     ) {
-    }
-
-    /**
-     * Path to the handle context relative to the routeContext
-     * @deprecated Use `id` instead for the path relative to the routeContext.
-     * For absolute path from the Container use `absolutePath`.
-     */
-    public get path() {
-        return this.id;
-    }
-
-    /**
-     * Returns the absolute path for this ComponentHandle.
-     */
-    public get absolutePath(): string {
-        return generateHandleContextPath(this);
+        this.absolutePath = generateHandleContextPath(path, this.routeContext);
     }
 
     public async get(): Promise<any> {

--- a/packages/runtime/component-runtime/src/componentHandle.ts
+++ b/packages/runtime/component-runtime/src/componentHandle.ts
@@ -12,6 +12,7 @@ import {
     IResponse,
 } from "@fluidframework/component-core-interfaces";
 import { AttachState } from "@fluidframework/container-definitions";
+import { generateHandleContextPath } from "@fluidframework/runtime-utils";
 
 export class ComponentHandle implements IComponentHandle {
     // This is used to break the recursion while attaching the graph. Also tells the attach state of the graph.
@@ -28,9 +29,25 @@ export class ComponentHandle implements IComponentHandle {
 
     constructor(
         private readonly value: IComponent,
-        public readonly path: string,
+        public readonly id: string,
         public readonly routeContext: IComponentHandleContext,
     ) {
+    }
+
+    /**
+     * Path to the handle context relative to the routeContext
+     * @deprecated Use `id` instead for the path relative to the routeContext.
+     * For absolute path from the Container use `absolutePath`.
+     */
+    public get path() {
+        return this.id;
+    }
+
+    /**
+     * Returns the absolute path for this ComponentHandle.
+     */
+    public get absolutePath(): string {
+        return generateHandleContextPath(this);
     }
 
     public async get(): Promise<any> {

--- a/packages/runtime/component-runtime/src/componentHandle.ts
+++ b/packages/runtime/component-runtime/src/componentHandle.ts
@@ -36,7 +36,7 @@ export class ComponentHandle implements IComponentHandle {
      */
     constructor(
         private readonly value: IComponent,
-        path: string,
+        public readonly path: string,
         public readonly routeContext: IComponentHandleContext,
     ) {
         this.absolutePath = generateHandleContextPath(path, this.routeContext);

--- a/packages/runtime/component-runtime/src/componentRuntime.ts
+++ b/packages/runtime/component-runtime/src/componentRuntime.ts
@@ -47,7 +47,7 @@ import {
     IInboundSignalMessage,
     SchedulerType,
 } from "@fluidframework/runtime-definitions";
-import { unreachableCase } from "@fluidframework/runtime-utils";
+import { generateHandleContextPath, unreachableCase } from "@fluidframework/runtime-utils";
 import { IChannel, IComponentRuntime } from "@fluidframework/component-runtime-definitions";
 import { ISharedObjectFactory } from "@fluidframework/shared-object-base";
 import { v4 as uuid } from "uuid";
@@ -135,8 +135,16 @@ export class ComponentRuntime extends EventEmitter implements IComponentRuntimeC
         return this._attachState;
     }
 
+    /**
+     * Path to the handle context relative to the routeContext
+     * @deprecated Use `id` instead.
+     */
     public get path(): string {
         return this.id;
+    }
+
+    public get absolutePath(): string {
+        return generateHandleContextPath(this.IComponentHandleContext);
     }
 
     public get routeContext(): IComponentHandleContext {

--- a/packages/runtime/component-runtime/src/componentRuntime.ts
+++ b/packages/runtime/component-runtime/src/componentRuntime.ts
@@ -135,16 +135,8 @@ export class ComponentRuntime extends EventEmitter implements IComponentRuntimeC
         return this._attachState;
     }
 
-    /**
-     * Path to the handle context relative to the routeContext
-     * @deprecated Use `id` instead.
-     */
-    public get path(): string {
-        return this.id;
-    }
-
     public get absolutePath(): string {
-        return generateHandleContextPath(this.IComponentHandleContext);
+        return generateHandleContextPath(this.id, this.routeContext);
     }
 
     public get routeContext(): IComponentHandleContext {

--- a/packages/runtime/component-runtime/src/componentRuntime.ts
+++ b/packages/runtime/component-runtime/src/componentRuntime.ts
@@ -135,6 +135,13 @@ export class ComponentRuntime extends EventEmitter implements IComponentRuntimeC
         return this._attachState;
     }
 
+    /**
+     * @deprecated - 0.21 back-compat
+     */
+    public get path(): string {
+        return this.id;
+    }
+
     public get absolutePath(): string {
         return generateHandleContextPath(this.id, this.routeContext);
     }

--- a/packages/runtime/container-runtime/src/componentHandleContext.ts
+++ b/packages/runtime/container-runtime/src/componentHandleContext.ts
@@ -10,6 +10,7 @@ import {
     IResponse,
 } from "@fluidframework/component-core-interfaces";
 import { IRuntime } from "@fluidframework/container-definitions";
+import { generateHandleContextPath } from "@fluidframework/runtime-utils";
 
 export class ComponentHandleContext implements IComponentHandleContext {
     public get IComponentRouter() { return this; }
@@ -17,10 +18,26 @@ export class ComponentHandleContext implements IComponentHandleContext {
     public readonly isAttached = true;
 
     constructor(
-        public readonly path: string,
+        public readonly id: string,
         private readonly runtime: IRuntime,
         public readonly routeContext?: IComponentHandleContext,
     ) {
+    }
+
+    /**
+     * Path to the handle context relative to the routeContext
+     * @deprecated Use `id` instead for the path relative to the routeContext.
+     * For absolute path from the Container use `absolutePath`.
+     */
+    public get path() {
+        return this.id;
+    }
+
+    /**
+     * Returns the absolute path for this ComponentHandle.
+     */
+    public get absolutePath(): string {
+        return generateHandleContextPath(this);
     }
 
     public attachGraph(): void {

--- a/packages/runtime/container-runtime/src/componentHandleContext.ts
+++ b/packages/runtime/container-runtime/src/componentHandleContext.ts
@@ -25,7 +25,7 @@ export class ComponentHandleContext implements IComponentHandleContext {
      * @param routeContext - The parent IComponentHandleContext that has a route to this handle.
      */
     constructor(
-        path: string,
+        public readonly path: string,
         private readonly runtime: IRuntime,
         public readonly routeContext?: IComponentHandleContext,
     ) {

--- a/packages/runtime/container-runtime/src/componentHandleContext.ts
+++ b/packages/runtime/container-runtime/src/componentHandleContext.ts
@@ -16,28 +16,20 @@ export class ComponentHandleContext implements IComponentHandleContext {
     public get IComponentRouter() { return this; }
     public get IComponentHandleContext() { return this; }
     public readonly isAttached = true;
+    public readonly absolutePath: string;
 
+    /**
+     * Creates a new ComponentHandleContext.
+     * @param path - The path to this handle relative to the routeContext.
+     * @param runtime - The IRuntime object this context represents.
+     * @param routeContext - The parent IComponentHandleContext that has a route to this handle.
+     */
     constructor(
-        public readonly id: string,
+        path: string,
         private readonly runtime: IRuntime,
         public readonly routeContext?: IComponentHandleContext,
     ) {
-    }
-
-    /**
-     * Path to the handle context relative to the routeContext
-     * @deprecated Use `id` instead for the path relative to the routeContext.
-     * For absolute path from the Container use `absolutePath`.
-     */
-    public get path() {
-        return this.id;
-    }
-
-    /**
-     * Returns the absolute path for this ComponentHandle.
-     */
-    public get absolutePath(): string {
-        return generateHandleContextPath(this);
+        this.absolutePath = generateHandleContextPath(path, this.routeContext);
     }
 
     public attachGraph(): void {

--- a/packages/runtime/container-runtime/src/test/summarizerHandle.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerHandle.spec.ts
@@ -11,6 +11,7 @@ import {
 import { SummarizerHandle } from "../summarizerHandle";
 
 const mockHandleContext: IComponentHandleContext = {
+    path: "",
     absolutePath: "",
     isAttached: false,
     IComponentRouter: undefined as any,

--- a/packages/runtime/container-runtime/src/test/summarizerHandle.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerHandle.spec.ts
@@ -12,6 +12,8 @@ import { SummarizerHandle } from "../summarizerHandle";
 
 const mockHandleContext: IComponentHandleContext = {
     path: "",
+    id: "",
+    absolutePath: "",
     isAttached: false,
     IComponentRouter: undefined as any,
     IComponentHandleContext: undefined as any,

--- a/packages/runtime/container-runtime/src/test/summarizerHandle.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerHandle.spec.ts
@@ -11,8 +11,6 @@ import {
 import { SummarizerHandle } from "../summarizerHandle";
 
 const mockHandleContext: IComponentHandleContext = {
-    path: "",
-    id: "",
     absolutePath: "",
     isAttached: false,
     IComponentRouter: undefined as any,

--- a/packages/runtime/runtime-utils/src/componentHandleContextUtils.ts
+++ b/packages/runtime/runtime-utils/src/componentHandleContextUtils.ts
@@ -1,0 +1,24 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IComponentHandleContext } from "@fluidframework/component-core-interfaces";
+
+/**
+ * Generates the absolute path for the ComponentHandle by iterating through the routeContexts.
+ */
+export function generateHandleContextPath(handleContext: IComponentHandleContext): string {
+    let result = "";
+    let context: IComponentHandleContext | undefined = handleContext;
+
+    while (context !== undefined) {
+        if (context.id !== "") {
+            result = `/${context.id}${result}`;
+        }
+
+        context = context.routeContext;
+    }
+
+    return result;
+}

--- a/packages/runtime/runtime-utils/src/componentHandleContextUtils.ts
+++ b/packages/runtime/runtime-utils/src/componentHandleContextUtils.ts
@@ -6,18 +6,20 @@
 import { IComponentHandleContext } from "@fluidframework/component-core-interfaces";
 
 /**
- * Generates the absolute path for the ComponentHandle by iterating through the routeContexts.
+ * Generates the absolute path for an IComponentHandleContext given its path and its parent routeContext.
  */
-export function generateHandleContextPath(handleContext: IComponentHandleContext): string {
-    let result = "";
-    let context: IComponentHandleContext | undefined = handleContext;
+export function generateHandleContextPath(path: string, routeContext?: IComponentHandleContext): string {
+    let result: string;
 
-    while (context !== undefined) {
-        if (context.id !== "") {
-            result = `/${context.id}${result}`;
-        }
-
-        context = context.routeContext;
+    if (path === "") {
+        // The `path` is empty.
+        // If the routeContext does not exist, this is the root and it shouldn't have an absolute path.
+        // If the routeContext exists, the absolute path is the same as that of the routeContext.
+        result = routeContext === undefined ? "" : routeContext.absolutePath;
+    } else {
+        // If the routeContext does not exist, path is the absolute path.
+        // If the routeContext exists, absolute path is routeContext's absolute path plus the path.
+        result = routeContext === undefined ? `/${path}` : `${routeContext.absolutePath}/${path}`;
     }
 
     return result;

--- a/packages/runtime/runtime-utils/src/dynamicComponentHandle.ts
+++ b/packages/runtime/runtime-utils/src/dynamicComponentHandle.ts
@@ -13,8 +13,9 @@ import {
 
 /**
  * Handle to dynamically load a component. This is created on parsing a seralized ComponentHandle.
- * This class is used to represent generic IComponent (through request handler on ComponentRuntime),
- * as well as shared objects (see ComponentRuntime.request for details).
+ * This class is used to generate an IComponentHandle when de-serializing Fluid Component and
+ * SharedObject handles that are stored in SharedObjects. The Component or SharedObject corresponding
+ * to the IComponentHandle can be retrieved by calling `get` on it.
  */
 export class DynamicComponentHandle implements IComponentHandle {
     public get IComponentRouter() { return this; }

--- a/packages/runtime/runtime-utils/src/dynamicComponentHandle.ts
+++ b/packages/runtime/runtime-utils/src/dynamicComponentHandle.ts
@@ -36,6 +36,13 @@ export class DynamicComponentHandle implements IComponentHandle {
     ) {
     }
 
+    /**
+     * @deprecated - This returns the absolute path.
+     */
+    public get path() {
+        return this.absolutePath;
+    }
+
     public async get(): Promise<any> {
         if (this.componentP === undefined) {
             this.componentP = this.routeContext.request({ url: this.absolutePath })

--- a/packages/runtime/runtime-utils/src/dynanmicComponentHandle.ts
+++ b/packages/runtime/runtime-utils/src/dynanmicComponentHandle.ts
@@ -10,13 +10,14 @@ import {
     IRequest,
     IResponse,
 } from "@fluidframework/component-core-interfaces";
+import { generateHandleContextPath } from "./componentHandleContextUtils";
 
 /**
- * Handle to a dynamically loaded component
+ * Handle to dynamically load a component. This is created on parsing a seralized ComponentHandle.
  * This class is used to represent generic IComponent (through request handler on ComponentRuntime),
- * as well as shared objects (see ComponentRuntime.request for details)
+ * as well as shared objects (see ComponentRuntime.request for details).
  */
-export class ComponentHandle implements IComponentHandle {
+export class DynamicComponentHandle implements IComponentHandle {
     public get IComponentRouter() { return this; }
     public get IComponentHandleContext() { return this; }
     public get IComponentHandle() { return this; }
@@ -24,15 +25,40 @@ export class ComponentHandle implements IComponentHandle {
     public readonly isAttached = true;
     private componentP: Promise<IComponent> | undefined;
 
+    /**
+     * Creates a new DynamicComponentHandle. The `id` can either be an absolutePath or relative to the
+     * routeContext.
+     * For example, when storing a handle to a DDS inside another DDS in the same ComponentRuntime, the
+     * `id` is relative to the ComponentRuntime.
+     * When storing a handle to a ComponentRuntime in a DDS of another ComponentRuntime, the `id` is the
+     * absolute path.
+     */
     constructor(
-        public readonly path: string,
+        public readonly id: string,
         public readonly routeContext: IComponentHandleContext,
     ) {
     }
 
+    /**
+     * Path to the handle context relative to the routeContext
+     * @deprecated Use `id` instead for the path relative to the routeContext.
+     * For absolute path from the Container use `absolutePath`.
+     */
+    public get path() {
+        return this.id;
+    }
+
+    /**
+     * Returns the absolute path for this ComponentHandle. The `id` itself could be the absolute path and
+     * if so, return it. Else, generate the absolutePath from the routeContexts.
+     */
+    public get absolutePath(): string {
+        return this.id.startsWith("/") ? this.id : generateHandleContextPath(this);
+    }
+
     public async get(): Promise<any> {
         if (this.componentP === undefined) {
-            this.componentP = this.routeContext.request({ url: this.path })
+            this.componentP = this.routeContext.request({ url: this.id })
                 .then<IComponent>((response) =>
                     response.mimeType === "fluid/component"
                         ? response.value as IComponent

--- a/packages/runtime/runtime-utils/src/dynanmicComponentHandle.ts
+++ b/packages/runtime/runtime-utils/src/dynanmicComponentHandle.ts
@@ -10,7 +10,6 @@ import {
     IRequest,
     IResponse,
 } from "@fluidframework/component-core-interfaces";
-import { generateHandleContextPath } from "./componentHandleContextUtils";
 
 /**
  * Handle to dynamically load a component. This is created on parsing a seralized ComponentHandle.
@@ -26,39 +25,19 @@ export class DynamicComponentHandle implements IComponentHandle {
     private componentP: Promise<IComponent> | undefined;
 
     /**
-     * Creates a new DynamicComponentHandle. The `id` can either be an absolutePath or relative to the
-     * routeContext.
-     * For example, when storing a handle to a DDS inside another DDS in the same ComponentRuntime, the
-     * `id` is relative to the ComponentRuntime.
-     * When storing a handle to a ComponentRuntime in a DDS of another ComponentRuntime, the `id` is the
-     * absolute path.
+     * Creates a new DynamicComponentHandle when parsing an IComponentHandle.
+     * @param absolutePath - The absolute path to the handle from the container runtime.
+     * @param routeContext - The root IComponentHandleContext that has a route to this handle.
      */
     constructor(
-        public readonly id: string,
+        public readonly absolutePath: string,
         public readonly routeContext: IComponentHandleContext,
     ) {
     }
 
-    /**
-     * Path to the handle context relative to the routeContext
-     * @deprecated Use `id` instead for the path relative to the routeContext.
-     * For absolute path from the Container use `absolutePath`.
-     */
-    public get path() {
-        return this.id;
-    }
-
-    /**
-     * Returns the absolute path for this ComponentHandle. The `id` itself could be the absolute path and
-     * if so, return it. Else, generate the absolutePath from the routeContexts.
-     */
-    public get absolutePath(): string {
-        return this.id.startsWith("/") ? this.id : generateHandleContextPath(this);
-    }
-
     public async get(): Promise<any> {
         if (this.componentP === undefined) {
-            this.componentP = this.routeContext.request({ url: this.id })
+            this.componentP = this.routeContext.request({ url: this.absolutePath })
                 .then<IComponent>((response) =>
                     response.mimeType === "fluid/component"
                         ? response.value as IComponent

--- a/packages/runtime/runtime-utils/src/index.ts
+++ b/packages/runtime/runtime-utils/src/index.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+export * from "./componentHandleContextUtils";
 export * from "./serializer";
 export * from "./summaryTracker";
 export * from "./utils";

--- a/packages/runtime/runtime-utils/src/remoteComponentHandle.ts
+++ b/packages/runtime/runtime-utils/src/remoteComponentHandle.ts
@@ -12,12 +12,12 @@ import {
 } from "@fluidframework/component-core-interfaces";
 
 /**
- * Handle to dynamically load a component. This is created on parsing a seralized ComponentHandle.
- * This class is used to generate an IComponentHandle when de-serializing Fluid Component and
- * SharedObject handles that are stored in SharedObjects. The Component or SharedObject corresponding
- * to the IComponentHandle can be retrieved by calling `get` on it.
+ * Handle to dynamically load a component on a remote client and is created on parsing a seralized ComponentHandle.
+ * This class is used to generate an IComponentHandle when de-serializing Fluid Component and SharedObject handles
+ * that are stored in SharedObjects. The Component or SharedObject corresponding to the IComponentHandle can be
+ * retrieved by calling `get` on it.
  */
-export class DynamicComponentHandle implements IComponentHandle {
+export class RemoteComponentHandle implements IComponentHandle {
     public get IComponentRouter() { return this; }
     public get IComponentHandleContext() { return this; }
     public get IComponentHandle() { return this; }
@@ -26,7 +26,7 @@ export class DynamicComponentHandle implements IComponentHandle {
     private componentP: Promise<IComponent> | undefined;
 
     /**
-     * Creates a new DynamicComponentHandle when parsing an IComponentHandle.
+     * Creates a new RemoteComponentHandle when parsing an IComponentHandle.
      * @param absolutePath - The absolute path to the handle from the container runtime.
      * @param routeContext - The root IComponentHandleContext that has a route to this handle.
      */

--- a/packages/runtime/runtime-utils/src/serializer.ts
+++ b/packages/runtime/runtime-utils/src/serializer.ts
@@ -17,7 +17,7 @@ import { isSerializedHandle } from "./utils";
  */
 function toAbsoluteUrl(handle: IComponentHandle): string {
     let result = "";
-    let context: any = handle;
+    let context: IComponentHandleContext | undefined = handle;
 
     while (context !== undefined) {
         if (context.path !== "") {

--- a/packages/runtime/runtime-utils/src/serializer.ts
+++ b/packages/runtime/runtime-utils/src/serializer.ts
@@ -8,7 +8,7 @@ import {
     IComponentHandleContext,
     IComponentSerializer,
 } from "@fluidframework/component-core-interfaces";
-import { DynamicComponentHandle } from "./dynamicComponentHandle";
+import { RemoteComponentHandle } from "./remoteComponentHandle";
 import { isSerializedHandle } from "./utils";
 
 /**
@@ -75,7 +75,7 @@ export class ComponentSerializer implements IComponentSerializer {
                 }
 
                 // 0.21 back-compat
-                // 0.22 onwards, we always use the routeContext of the root to create the DynamicComponentHandle.
+                // 0.22 onwards, we always use the routeContext of the root to create the RemoteComponentHandle.
                 // We won't need to check for the if condition below once we remove the back-compat code.
                 const absoluteUrl = value.url.startsWith("/");
                 if (absoluteUrl && root === undefined) {
@@ -86,7 +86,7 @@ export class ComponentSerializer implements IComponentSerializer {
                     }
                 }
 
-                const handle = new DynamicComponentHandle(value.url, absoluteUrl ? root : context);
+                const handle = new RemoteComponentHandle(value.url, absoluteUrl ? root : context);
 
                 return handle;
             });

--- a/packages/runtime/runtime-utils/src/serializer.ts
+++ b/packages/runtime/runtime-utils/src/serializer.ts
@@ -8,7 +8,7 @@ import {
     IComponentHandleContext,
     IComponentSerializer,
 } from "@fluidframework/component-core-interfaces";
-import { DynamicComponentHandle } from "./dynanmicComponentHandle";
+import { DynamicComponentHandle } from "./dynamicComponentHandle";
 import { isSerializedHandle } from "./utils";
 
 /**
@@ -140,7 +140,7 @@ export class ComponentSerializer implements IComponentSerializer {
         bind.bind(handle);
         let url: string;
 
-        if (handle.absolutePath !== undefined) {
+        if ("absolutePath" in handle) {
             url = handle.absolutePath;
         } else {
             // 0.21 back-compat

--- a/packages/runtime/runtime-utils/src/serializer.ts
+++ b/packages/runtime/runtime-utils/src/serializer.ts
@@ -68,7 +68,9 @@ export class ComponentSerializer implements IComponentSerializer {
                 }
 
                 // Create a dynamic component handle that will be used to load the component via call to `get`.
-                const handle = new DynamicComponentHandle(value.url, absoluteUrl ? root : context);
+                const handle = new DynamicComponentHandle(
+                    absoluteUrl ? value.url.substr(1) : value.url,
+                    absoluteUrl ? root : context);
 
                 return handle;
             });

--- a/packages/runtime/runtime-utils/src/test/utils.ts
+++ b/packages/runtime/runtime-utils/src/test/utils.ts
@@ -7,6 +7,7 @@ import { IComponentHandle, IComponentHandleContext } from "@fluidframework/compo
 import { DynamicComponentHandle } from "../dynamicComponentHandle";
 
 export const mockHandleContext: IComponentHandleContext = {
+    path: "",
     absolutePath: "",
     isAttached: false,
     IComponentRouter: undefined as any,

--- a/packages/runtime/runtime-utils/src/test/utils.ts
+++ b/packages/runtime/runtime-utils/src/test/utils.ts
@@ -7,8 +7,6 @@ import { IComponentHandle, IComponentHandleContext } from "@fluidframework/compo
 import { DynamicComponentHandle } from "../dynanmicComponentHandle";
 
 export const mockHandleContext: IComponentHandleContext = {
-    path: "",
-    id: "",
     absolutePath: "",
     isAttached: false,
     IComponentRouter: undefined as any,

--- a/packages/runtime/runtime-utils/src/test/utils.ts
+++ b/packages/runtime/runtime-utils/src/test/utils.ts
@@ -4,7 +4,7 @@
  */
 
 import { IComponentHandle, IComponentHandleContext } from "@fluidframework/component-core-interfaces";
-import { DynamicComponentHandle } from "../dynamicComponentHandle";
+import { RemoteComponentHandle } from "../remoteComponentHandle";
 
 export const mockHandleContext: IComponentHandleContext = {
     path: "",
@@ -24,7 +24,7 @@ export const mockHandleContext: IComponentHandleContext = {
     },
 };
 
-export const handle: IComponentHandle = new DynamicComponentHandle("", mockHandleContext);
+export const handle: IComponentHandle = new RemoteComponentHandle("", mockHandleContext);
 
 /**
  * Creates a Jsonable object graph of a specified breadth/depth.  The 'createLeaf' callback

--- a/packages/runtime/runtime-utils/src/test/utils.ts
+++ b/packages/runtime/runtime-utils/src/test/utils.ts
@@ -4,10 +4,12 @@
  */
 
 import { IComponentHandle, IComponentHandleContext } from "@fluidframework/component-core-interfaces";
-import { ComponentHandle } from "../componentHandle";
+import { DynamicComponentHandle } from "../dynanmicComponentHandle";
 
 export const mockHandleContext: IComponentHandleContext = {
     path: "",
+    id: "",
+    absolutePath: "",
     isAttached: false,
     IComponentRouter: undefined as any,
     IComponentHandleContext: undefined as any,
@@ -23,7 +25,7 @@ export const mockHandleContext: IComponentHandleContext = {
     },
 };
 
-export const handle: IComponentHandle = new ComponentHandle("", mockHandleContext);
+export const handle: IComponentHandle = new DynamicComponentHandle("", mockHandleContext);
 
 /**
  * Creates a Jsonable object graph of a specified breadth/depth.  The 'createLeaf' callback

--- a/packages/runtime/runtime-utils/src/test/utils.ts
+++ b/packages/runtime/runtime-utils/src/test/utils.ts
@@ -4,7 +4,7 @@
  */
 
 import { IComponentHandle, IComponentHandleContext } from "@fluidframework/component-core-interfaces";
-import { DynamicComponentHandle } from "../dynanmicComponentHandle";
+import { DynamicComponentHandle } from "../dynamicComponentHandle";
 
 export const mockHandleContext: IComponentHandleContext = {
     absolutePath: "",

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -373,7 +373,6 @@ export class MockComponentRuntime extends EventEmitter
     public options: any = {};
     public clientId: string | undefined = uuid();
     public readonly parentBranch: string;
-    public readonly path = "";
     public readonly connected = true;
     public readonly leader: boolean;
     public deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage> = new MockDeltaManager();
@@ -381,6 +380,14 @@ export class MockComponentRuntime extends EventEmitter
     public readonly logger: ITelemetryLogger = DebugLogger.create("fluid:MockComponentRuntime");
     private readonly activeDeferred = new Deferred<void>();
     public readonly quorum = new MockQuorum();
+
+    public get path() {
+        return this.id;
+    }
+
+    public get absolutePath() {
+        return this.id;
+    }
 
     private _local = false;
 

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -368,7 +368,7 @@ export class MockComponentRuntime extends EventEmitter
     public readonly IComponentSerializer = new ComponentSerializer();
 
     public readonly documentId: string;
-    public readonly id: string;
+    public readonly id: string = uuid();
     public readonly existing: boolean;
     public options: any = {};
     public clientId: string | undefined = uuid();
@@ -380,11 +380,6 @@ export class MockComponentRuntime extends EventEmitter
     public readonly logger: ITelemetryLogger = DebugLogger.create("fluid:MockComponentRuntime");
     private readonly activeDeferred = new Deferred<void>();
     public readonly quorum = new MockQuorum();
-
-    constructor() {
-        super();
-        this.id = uuid();
-    }
 
     public get absolutePath() {
         return `/${this.id}`;

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -381,8 +381,13 @@ export class MockComponentRuntime extends EventEmitter
     private readonly activeDeferred = new Deferred<void>();
     public readonly quorum = new MockQuorum();
 
+    constructor() {
+        super();
+        this.id = uuid();
+    }
+
     public get absolutePath() {
-        return this.id;
+        return `/${this.id}`;
     }
 
     private _local = false;

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -381,10 +381,6 @@ export class MockComponentRuntime extends EventEmitter
     private readonly activeDeferred = new Deferred<void>();
     public readonly quorum = new MockQuorum();
 
-    public get path() {
-        return this.id;
-    }
-
     public get absolutePath() {
         return this.id;
     }

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -373,6 +373,7 @@ export class MockComponentRuntime extends EventEmitter
     public options: any = {};
     public clientId: string | undefined = uuid();
     public readonly parentBranch: string;
+    public readonly path = "";
     public readonly connected = true;
     public readonly leader: boolean;
     public deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage> = new MockDeltaManager();

--- a/packages/test/end-to-end-tests/src/test/componentHandle.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/componentHandle.spec.ts
@@ -4,11 +4,7 @@
  */
 
 import assert from "assert";
-import {
-    ContainerRuntimeFactoryWithDefaultComponent,
-    PrimedComponent,
-    PrimedComponentFactory,
-} from "@fluidframework/aqueduct";
+import { PrimedComponent, PrimedComponentFactory } from "@fluidframework/aqueduct";
 import { IComponentHandle } from "@fluidframework/component-core-interfaces";
 import { IFluidCodeDetails } from "@fluidframework/container-definitions";
 import { Container } from "@fluidframework/container-loader";
@@ -38,12 +34,6 @@ class TestSharedComponent extends PrimedComponent {
     }
 }
 
-const TestSharedComponentFactory = new PrimedComponentFactory(
-    "default",
-    TestSharedComponent,
-    [SharedMap.getFactory()],
-    []);
-
 describe("ComponentHandle", () => {
     const id = "fluid-test://localhost/componentHandleTest";
     const codeDetails: IFluidCodeDetails = {
@@ -56,6 +46,7 @@ describe("ComponentHandle", () => {
     let container1Component1: TestSharedComponent;
     let container1Component2: TestSharedComponent;
     let container2Component1: TestSharedComponent;
+    let factory: PrimedComponentFactory;
 
     async function getComponent(componentId: string, container: Container): Promise<TestSharedComponent> {
         const response = await container.request({ url: componentId });
@@ -66,16 +57,13 @@ describe("ComponentHandle", () => {
     }
 
     async function createContainer(): Promise<Container> {
-        const runtimeFactory =
-            new ContainerRuntimeFactoryWithDefaultComponent(
-                "default",
-                [
-                    ["default", Promise.resolve(TestSharedComponentFactory)],
-                    ["component2", Promise.resolve(TestSharedComponentFactory)],
-                ],
-            );
-
-        const loader = createLocalLoader([[codeDetails, runtimeFactory]], deltaConnectionServer);
+        factory = new PrimedComponentFactory(
+            "default",
+            TestSharedComponent,
+            [SharedMap.getFactory()],
+            [],
+        );
+        const loader = createLocalLoader([[codeDetails, factory]], deltaConnectionServer);
         return initializeLocalContainer(id, loader, codeDetails);
     }
 
@@ -84,8 +72,7 @@ describe("ComponentHandle", () => {
 
         const container1 = await createContainer();
         container1Component1 = await getComponent("default", container1);
-        container1Component2 =
-            await TestSharedComponentFactory.createComponent(container1Component1._context) as TestSharedComponent;
+        container1Component2 = await factory.createComponent(container1Component1._context) as TestSharedComponent;
 
         const container2 = await createContainer();
         container2Component1 = await getComponent("default", container2);

--- a/packages/test/end-to-end-tests/src/test/componentHandle.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/componentHandle.spec.ts
@@ -1,0 +1,191 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import assert from "assert";
+import {
+    ContainerRuntimeFactoryWithDefaultComponent,
+    PrimedComponent,
+    PrimedComponentFactory,
+} from "@fluidframework/aqueduct";
+import { IComponentHandle } from "@fluidframework/component-core-interfaces";
+import { IFluidCodeDetails } from "@fluidframework/container-definitions";
+import { Container } from "@fluidframework/container-loader";
+import { DocumentDeltaEventManager } from "@fluidframework/local-driver";
+import { SharedMap } from "@fluidframework/map";
+import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
+import {
+    createLocalLoader,
+    initializeLocalContainer,
+    TestFluidComponent,
+} from "@fluidframework/test-utils";
+
+/**
+ * Test component that extends PrimedComponent so that we can test the ComponentHandle created by SharedComponent.
+ */
+class TestSharedComponent extends PrimedComponent {
+    public get _root() {
+        return this.root;
+    }
+
+    public get _runtime() {
+        return this.runtime;
+    }
+
+    public get _context() {
+        return this.context;
+    }
+}
+
+const TestSharedComponentFactory = new PrimedComponentFactory(
+    "default",
+    TestSharedComponent,
+    [SharedMap.getFactory()],
+    []);
+
+describe("ComponentHandle", () => {
+    const id = "fluid-test://localhost/componentHandleTest";
+    const codeDetails: IFluidCodeDetails = {
+        package: "componentHandleTestPackage",
+        config: {},
+    };
+
+    let deltaConnectionServer: ILocalDeltaConnectionServer;
+    let containerDeltaEventManager: DocumentDeltaEventManager;
+    let container1Component1: TestSharedComponent;
+    let container1Component2: TestSharedComponent;
+    let container2Component1: TestSharedComponent;
+
+    async function getComponent(componentId: string, container: Container): Promise<TestSharedComponent> {
+        const response = await container.request({ url: componentId });
+        if (response.status !== 200 || response.mimeType !== "fluid/component") {
+            throw new Error(`Component with id: ${componentId} not found`);
+        }
+        return response.value as TestSharedComponent;
+    }
+
+    async function createContainer(): Promise<Container> {
+        const runtimeFactory =
+            new ContainerRuntimeFactoryWithDefaultComponent(
+                "default",
+                [
+                    ["default", Promise.resolve(TestSharedComponentFactory)],
+                    ["component2", Promise.resolve(TestSharedComponentFactory)],
+                ],
+            );
+
+        const loader = createLocalLoader([[codeDetails, runtimeFactory]], deltaConnectionServer);
+        return initializeLocalContainer(id, loader, codeDetails);
+    }
+
+    beforeEach(async () => {
+        deltaConnectionServer = LocalDeltaConnectionServer.create();
+
+        const container1 = await createContainer();
+        container1Component1 = await getComponent("default", container1);
+        container1Component2 =
+            await TestSharedComponentFactory.createComponent(container1Component1._context) as TestSharedComponent;
+
+        const container2 = await createContainer();
+        container2Component1 = await getComponent("default", container2);
+
+        containerDeltaEventManager = new DocumentDeltaEventManager(deltaConnectionServer);
+        containerDeltaEventManager.registerDocuments(container1Component1._runtime, container2Component1._runtime);
+
+        await containerDeltaEventManager.process();
+    });
+
+    it("can store and retrieve a DDS from handle within same component runtime", async () => {
+        // Create a new SharedMap in `container1Component1` and set a value.
+        const sharedMap = SharedMap.create(container1Component1._runtime);
+        sharedMap.set("key1", "value1");
+
+        const absolutePath = `/default/${sharedMap.id}`;
+
+        const sharedMapHandle = sharedMap.handle;
+        assert.equal(sharedMapHandle.id, sharedMap.id, "The handle's id is incorrect");
+        assert.equal(sharedMapHandle.absolutePath, absolutePath, "The handle's absolutepath is not correct");
+
+        // Add the handle to the root DDS of `container1Component1`.
+        container1Component1._root.set("sharedMap", sharedMapHandle);
+
+        await containerDeltaEventManager.process();
+
+        // Get the handle in the remote client.
+        const remoteSharedMapHandle = container2Component1._root.get<IComponentHandle<SharedMap>>("sharedMap");
+
+        // The `id` should be the id of the shared map. It  is the path relative to the ComponentRuntime since both
+        // the DDS have the same ComponentRuntime.
+        assert.equal(remoteSharedMapHandle.id, sharedMap.id, "The remote handle's id is incorrect");
+        assert.equal(remoteSharedMapHandle.absolutePath, absolutePath, "The remote handle's absolutepath is incorrect");
+
+        // Get the SharedMap from the handle.
+        const remoteSharedMap = await remoteSharedMapHandle.get();
+        // Verify that it has the value that was set in the local client.
+        assert.equal(remoteSharedMap.get("key1"), "value1", "The map does not have the value that was set");
+    });
+
+    it("can store and retrieve a DDS from handle in different component runtime", async () => {
+        // Create a new SharedMap in `container1Component2` and set a value.
+        const sharedMap = SharedMap.create(container1Component2._runtime);
+        sharedMap.set("key1", "value1");
+
+        const absolutePath = `/${container1Component2._runtime.id}/${sharedMap.id}`;
+
+        const sharedMapHandle = sharedMap.handle;
+        assert.equal(sharedMapHandle.id, sharedMap.id, "The handle's id is incorrect");
+        assert.equal(sharedMapHandle.absolutePath, absolutePath, "The handle's absolutepath is not correct");
+
+        // Add the handle to the root DDS of `container1Component1` so that the ComponentRuntime is different.
+        container1Component1._root.set("sharedMap", sharedMap.handle);
+
+        await containerDeltaEventManager.process();
+
+        // Get the handle in the remote client.
+        const remoteSharedMapHandle = container2Component1._root.get<IComponentHandle<SharedMap>>("sharedMap");
+
+        // The `id` should be the absolutePath since the two DDSs have different ComponentRuntimes.
+        assert.equal(remoteSharedMapHandle.id, absolutePath, "The remote handle's id is incorrect");
+        assert.equal(remoteSharedMapHandle.absolutePath, absolutePath, "The remote handle's absolutePath is incorrect");
+
+        // Get the SharedMap from the handle.
+        const remoteSharedMap = await remoteSharedMapHandle.get();
+        // Verify that it has the value that was set in the local client.
+        assert.equal(remoteSharedMap.get("key1"), "value1", "The map does not have the value that was set");
+    });
+
+    it("can store and retrieve a Component from handle in different component runtime", async () => {
+        const absolutePath = `/${container1Component2._runtime.id}`;
+
+        const componentHandle = container1Component2.handle;
+        // The ComponentHandle's `id` should be an empty string. This is because SharedComponent's ComponentHandle
+        // is essentially just a wrapper around the ComponentRuntime's handle.
+        assert.equal(componentHandle.id, "", "The handle's id is incorrect");
+        assert.equal(componentHandle.absolutePath, absolutePath, "The handle's absolutepath is not correct");
+
+        // Add `container1Component2's` handle to the root DDS of `container1Component1` so that the ComponentRuntime
+        // is different.
+        container1Component1._root.set("component2", container1Component2.handle);
+
+        await containerDeltaEventManager.process();
+
+        // Get the handle in the remote client.
+        const remoteComponentHandle =
+            container2Component1._root.get<IComponentHandle<TestFluidComponent>>("component2");
+
+        // The `id` should be the absolutePath since the DDS has a different ComponentRuntime than the Component whose
+        // handle is stored in it.
+        assert.equal(remoteComponentHandle.id, absolutePath, "The remote handle's id is incorrect");
+        assert.equal(remoteComponentHandle.absolutePath, absolutePath, "The remote handle's absolutePath is incorrect");
+
+        // Get the component from the handle.
+        const container2Component2 = await remoteComponentHandle.get();
+        // Verify that the `url` matches with that of the component in container1.
+        assert.equal(container2Component2.url, container1Component2.url, "The urls do not match");
+    });
+
+    afterEach(async () => {
+        await deltaConnectionServer.webSocketServer.close();
+    });
+});

--- a/packages/test/end-to-end-tests/src/test/componentHandle.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/componentHandle.spec.ts
@@ -145,8 +145,10 @@ describe("ComponentHandle", () => {
         // Get the handle in the remote client.
         const remoteSharedMapHandle = container2Component1._root.get<IComponentHandle<SharedMap>>("sharedMap");
 
-        // The `id` should be the absolutePath since the two DDSs have different ComponentRuntimes.
-        assert.equal(remoteSharedMapHandle.id, absolutePath, "The remote handle's id is incorrect");
+        // The `id` should be the path relative to the ContainerRuntime since the two DDSs have different
+        // ComponentRuntimes.
+        const expectedId = `${container1Component2._runtime.id}/${sharedMap.id}`;
+        assert.equal(remoteSharedMapHandle.id, expectedId, "The remote handle's id is incorrect");
         assert.equal(remoteSharedMapHandle.absolutePath, absolutePath, "The remote handle's absolutePath is incorrect");
 
         // Get the SharedMap from the handle.
@@ -174,9 +176,9 @@ describe("ComponentHandle", () => {
         const remoteComponentHandle =
             container2Component1._root.get<IComponentHandle<TestFluidComponent>>("component2");
 
-        // The `id` should be the absolutePath since the DDS has a different ComponentRuntime than the Component whose
-        // handle is stored in it.
-        assert.equal(remoteComponentHandle.id, absolutePath, "The remote handle's id is incorrect");
+        // The `id` should be the path relative to the ContainerRuntime since the DDS has a different ComponentRuntime
+        // than the Component whose handle is stored in it.
+        assert.equal(remoteComponentHandle.id, container1Component2._runtime.id, "The remote handle's id is incorrect");
         assert.equal(remoteComponentHandle.absolutePath, absolutePath, "The remote handle's absolutePath is incorrect");
 
         // Get the component from the handle.

--- a/packages/test/test-utils/src/interfaces.ts
+++ b/packages/test/test-utils/src/interfaces.ts
@@ -3,8 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { IComponentContext } from "@fluidframework/runtime-definitions";
 import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { ISharedMap } from "@fluidframework/map";
+import { IComponentContext } from "@fluidframework/runtime-definitions";
 
 declare module "@fluidframework/component-core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -16,6 +17,7 @@ export interface IProvideTestFluidComponent {
 }
 
 export interface ITestFluidComponent extends IProvideTestFluidComponent {
+    root: ISharedMap;
     readonly runtime: IComponentRuntime;
     readonly context: IComponentContext;
     getSharedObject<T = any>(id: string): Promise<T>;

--- a/packages/test/test-utils/src/testFluidComponent.ts
+++ b/packages/test/test-utils/src/testFluidComponent.ts
@@ -38,7 +38,7 @@ export class TestFluidComponent implements ITestFluidComponent, IComponentLoadab
     public get handle(): IComponentHandle<this> { return this.innerHandle; }
 
     public url: string;
-    private root!: ISharedMap;
+    public root!: ISharedMap;
     private readonly innerHandle: IComponentHandle<this>;
 
     /**
@@ -54,7 +54,7 @@ export class TestFluidComponent implements ITestFluidComponent, IComponentLoadab
         private readonly factoryEntriesMap: Map<string, ISharedObjectFactory>,
     ) {
         this.url = context.id;
-        this.innerHandle = new ComponentHandle(this, this.url, runtime.IComponentHandleContext);
+        this.innerHandle = new ComponentHandle(this, "", runtime.IComponentHandleContext);
     }
 
     /**


### PR DESCRIPTION
Fixes #2654.

**Issue:**
The bug is that when a `ComponentHandle` for a `SharedComponent` is stored in a DDS, it serializes the path incorrectly. The URL that is generated and sent in the op is of the format `id/id` where id is `ComponentRuntime`'s id.
For Bohemia, on a remote client, when trying to load the component by calling `get` on the `ComponentHandle`, it fails because the request URL is `id/id` and their parser cannot parse it.

**Expected behavior:**
The URL to request a `Component` (with id `componentId`) should be of the format `/containerId/componentId`. In FluidFramework, the `containerId` is "", so the URL becomes just `/componentId`.

**Fix:**
This PR does a few things to fix this and make sure that all the `IComponentHandle` implementations are consistent:
- Remove the `path` field from `IComponentHandleContext` and hence from the `ComponentHandle`. You still have to provide a `path` to create a `ComponentHandle` but it is only used to generate the `absolutePath` for it.
The `path` is the path to this handle / context relative to its `routeContext`.
- Added an `absolutePath` field to `IComponentHandleContext`. This is the path to reach the handle context from the ContainerRuntime.
- Renamed the `ComponentHandle` in runtime-utils to `DynamicComponentHandle` to remove some confusion around it. This is used to dynamically load a component on a remote client.
The `DynamicComponentHandle` is created by passing the `absolutePath` to it from the ContainerRuntime and the ContainerRuntime as the routeContext.
- Changed the serialize and parse logic in `serializer.ts` to use absolute paths.
-  Added end-to-end tests to make sure that the 'id' and 'absolutePath` are as expected in various scenarios.