### PR TITLE
Intercept non-listened DDS events for update event

### DIFF
--- a/components/experimental/clicker-intercept/.eslintrc.js
+++ b/components/experimental/clicker-intercept/.eslintrc.js
@@ -1,0 +1,11 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+module.exports = {
+    "extends": [
+        "@fluidframework/eslint-config-fluid"
+    ],
+    "rules": {}
+}

--- a/components/experimental/clicker-intercept/.gitignore
+++ b/components/experimental/clicker-intercept/.gitignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+lib

--- a/components/experimental/clicker-intercept/.npmignore
+++ b/components/experimental/clicker-intercept/.npmignore
@@ -1,0 +1,3 @@
+nyc
+*.log
+**/*.tsbuildinfo

--- a/components/experimental/clicker-intercept/README.md
+++ b/components/experimental/clicker-intercept/README.md
@@ -1,0 +1,40 @@
+# @fluid-example/clicker-intercept
+
+**Clicker** is a Fluid Component that displays a number with a button. Pressing the button
+increments the counter. This is a basic example component using the interface model and stock
+classes.
+
+**Clicker** also demonstrates how use the built in taskManager to setup a simple agent.
+
+
+There is another experimental implementation of Clicker using a WiP Fluid React Component in components/experimental/clicker-react. While it uses a state update model instead of an event-listening model that some React developers may find more familiar, the code is still being developed and may contain bugs.
+
+## Getting Started
+
+If you want to run this component follow the following steps:
+
+1. Run `npm install` from the `FluidFramework` root directory
+2. Navigate to this directory
+3. Run `npm run start`
+
+## Testing
+
+```bash
+    npm run test:jest
+```
+
+For in browser testing update `./jest-puppeteer.config.js` to:
+
+```javascript
+  launch: {
+    dumpio: true, // output browser console to cmd line
+    slowMo: 500,
+    headless: false,
+  },
+```
+
+## Data model
+
+Badge uses the following distributed data structures:
+
+- SharedDirectory - root

--- a/components/experimental/clicker-intercept/jest-puppeteer.config.js
+++ b/components/experimental/clicker-intercept/jest-puppeteer.config.js
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+module.exports = {
+  server: {
+    command: `npm run start -- --no-live-reload --port ${process.env["PORT"]}`,
+    port: process.env["PORT"],
+    launchTimeout:10000,
+    usedPortAction: 'error'
+  },
+  launch: {
+    args: ['--no-sandbox', '--disable-setuid-sandbox'], // https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#setting-up-chrome-linux-sandbox
+    dumpio: true, // output browser console to cmd line
+    // slowMo: 500, // slows down process for easier viewing
+    // headless: false, // run in the browser
+  },
+};

--- a/components/experimental/clicker-intercept/jest.config.js
+++ b/components/experimental/clicker-intercept/jest.config.js
@@ -1,0 +1,23 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Get the test port from the global map and set it in env for this test
+const testTools = require("@fluidframework/test-tools");
+const { name } = require("./package.json");
+
+mappedPort = testTools.getTestPort(name);
+process.env["PORT"] = mappedPort;
+
+module.exports = {
+  preset: "jest-puppeteer",
+  globals: {
+    PATH: `http://localhost:${mappedPort}`
+  },
+  testMatch: ["**/?(*.)+(spec|test).[t]s"],
+  testPathIgnorePatterns: ['/node_modules/', 'dist'],
+  transform: {
+		"^.+\\.ts?$": "ts-jest"
+	},
+};

--- a/components/experimental/clicker-intercept/package.json
+++ b/components/experimental/clicker-intercept/package.json
@@ -1,0 +1,98 @@
+{
+  "name": "@fluid-example/clicker-intercept",
+  "version": "0.21.0",
+  "description": "Minimal Fluid component sample to implement a collaborative counter.",
+  "repository": "microsoft/FluidFramework",
+  "license": "MIT",
+  "author": "Microsoft",
+  "main": "dist/index.js",
+  "module": "lib/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "concurrently npm:build:compile npm:lint",
+    "build:compile": "concurrently npm:tsc npm:build:esnext",
+    "build:esnext": "tsc --project ./tsconfig.esnext.json",
+    "build:full": "concurrently npm:build npm:webpack",
+    "build:full:compile": "concurrently npm:build:compile npm:webpack",
+    "clean": "rimraf dist lib *.tsbuildinfo *.build.log",
+    "eslint": "eslint --ext=ts,tsx --format stylish src",
+    "eslint:fix": "eslint --ext=ts,tsx --format stylish src --fix",
+    "lint": "npm run eslint",
+    "lint:fix": "npm run eslint:fix",
+    "prepack": "npm run webpack",
+    "start": "webpack-dev-server --config webpack.config.js --package package.json",
+    "start:docker": "webpack-dev-server --config webpack.config.js --package package.json --env.mode docker",
+    "start:r11s": "webpack-dev-server --config webpack.config.js --package package.json --env.mode r11s",
+    "start:spo": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo",
+    "start:spo-df": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo-df",
+    "start:tinylicious": "webpack-dev-server --config webpack.config.js --package package.json --env.mode tinylicious",
+    "test": "npm run test:jest",
+    "test:jest": "jest",
+    "tsc": "tsc",
+    "tsfmt": "tsfmt --verify",
+    "tsfmt:fix": "tsfmt --replace",
+    "webpack": "webpack --env.production",
+    "webpack:dev": "webpack --env.development"
+  },
+  "dependencies": {
+    "@fluidframework/aqueduct": "^0.21.0",
+    "@fluidframework/dds-interceptions": "^0.21.0",
+    "@fluidframework/component-core-interfaces": "^0.21.0",
+    "@fluidframework/counter": "^0.21.0",
+    "@fluidframework/runtime-definitions": "^0.21.0",
+    "@fluidframework/view-interfaces": "^0.21.0",
+    "react": "^16.10.2",
+    "react-dom": "^16.10.2"
+  },
+  "devDependencies": {
+    "@fluidframework/build-common": "^0.18.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.18.0",
+    "@fluidframework/test-tools": "^0.1.0",
+    "@fluidframework/webpack-component-loader": "^0.21.0",
+    "@types/expect-puppeteer": "2.2.1",
+    "@types/jest": "22.2.3",
+    "@types/jest-environment-puppeteer": "2.2.0",
+    "@types/node": "^10.17.24",
+    "@types/puppeteer": "1.3.0",
+    "@types/react": "^16.9.15",
+    "@types/react-dom": "^16.9.4",
+    "@typescript-eslint/eslint-plugin": "~2.17.0",
+    "@typescript-eslint/parser": "~2.17.0",
+    "concurrently": "^5.2.0",
+    "eslint": "~6.8.0",
+    "eslint-plugin-eslint-comments": "~3.1.2",
+    "eslint-plugin-import": "2.20.0",
+    "eslint-plugin-no-null": "~1.0.2",
+    "eslint-plugin-optimize-regex": "~1.1.7",
+    "eslint-plugin-prefer-arrow": "~1.1.7",
+    "eslint-plugin-react": "~7.18.0",
+    "eslint-plugin-unicorn": "~15.0.1",
+    "jest": "^24.9.0",
+    "jest-junit": "^10.0.0",
+    "jest-puppeteer": "^4.3.0",
+    "puppeteer": "^1.20.0",
+    "rimraf": "^2.6.2",
+    "ts-jest": "24.1.0",
+    "ts-loader": "^6.1.2",
+    "typescript": "~3.7.4",
+    "typescript-formatter": "7.1.0",
+    "webpack": "^4.43.0",
+    "webpack-cli": "^3.3.11",
+    "webpack-dev-server": "^3.8.0",
+    "webpack-merge": "^4.1.4"
+  },
+  "fluid": {
+    "browser": {
+      "umd": {
+        "files": [
+          "dist/main.bundle.js"
+        ],
+        "library": "main"
+      }
+    }
+  },
+  "jest-junit": {
+    "outputDirectory": "nyc",
+    "outputName": "jest-junit-report.xml"
+  }
+}

--- a/components/experimental/clicker-intercept/src/index.tsx
+++ b/components/experimental/clicker-intercept/src/index.tsx
@@ -1,0 +1,110 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { PrimedComponent, PrimedComponentFactory } from "@fluidframework/aqueduct";
+import { IComponentHandle } from "@fluidframework/component-core-interfaces";
+import { SharedCounter } from "@fluidframework/counter";
+import { IComponentHTMLView } from "@fluidframework/view-interfaces";
+import { injectSharedObjectInterception } from "@fluidframework/dds-interceptions";
+import React from "react";
+import ReactDOM from "react-dom";
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const pkg = require("../package.json");
+export const ClickerName = pkg.name as string;
+
+const counterKey = "counter";
+
+/**
+ * Basic Clicker example using new interfaces and stock component classes.
+ */
+export class Clicker extends PrimedComponent implements IComponentHTMLView {
+    public get IComponentHTMLView() { return this; }
+
+    private _counter: SharedCounter | undefined;
+
+    /**
+     * Do setup work here
+     */
+    protected async componentInitializingFirstTime() {
+        const counter = SharedCounter.create(this.runtime);
+        this.root.set(counterKey, counter.handle);
+    }
+
+    protected async componentHasInitialized() {
+        const counterHandle = this.root.get<IComponentHandle<SharedCounter>>(counterKey);
+        this._counter = await counterHandle.get();
+    }
+
+    // #region IComponentHTMLView
+
+    /**
+     * Will return a new Clicker view
+     */
+    public render(div: HTMLElement) {
+        // Get our counter object that we set in initialize and pass it in to the view.
+        ReactDOM.render(
+            <CounterReactView counter={this.counter} />,
+            div,
+        );
+        return div;
+    }
+
+    // #endregion IComponentHTMLView
+
+    private get counter() {
+        if (this._counter === undefined) {
+            throw new Error("SharedCounter not initialized");
+        }
+        return this._counter;
+    }
+}
+
+// ----- REACT STUFF -----
+
+interface CounterProps {
+    counter: SharedCounter;
+}
+
+type CounterState = CounterProps;
+
+class CounterReactView extends React.Component<CounterProps, CounterState> {
+    constructor(props: CounterProps) {
+        super(props);
+        this.state = {
+            counter: props.counter,
+        };
+    }
+
+    componentDidMount() {
+        const { counter } = this.state;
+        injectSharedObjectInterception(counter, []);
+        counter.on("update", (newCounter: SharedCounter) => {
+            this.setState({ counter: newCounter });
+        });
+    }
+
+    render() {
+        return (
+            <div>
+                <span className="clicker-value-class">
+                    {this.state.counter.value}
+                </span>
+                <button onClick={() => { this.state.counter.increment(1); }}>+</button>
+            </div>
+        );
+    }
+}
+
+// ----- FACTORY SETUP -----
+
+export const ClickerInstantiationFactory = new PrimedComponentFactory(
+    ClickerName,
+    Clicker,
+    [SharedCounter.getFactory()],
+    {},
+);
+
+export const fluidExport = ClickerInstantiationFactory;

--- a/components/experimental/clicker-intercept/tests/clicker.test.ts
+++ b/components/experimental/clicker-intercept/tests/clicker.test.ts
@@ -1,0 +1,72 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { globals } from "../jest.config";
+
+describe("clicker", () => {
+    const getValue = async (index: number) => {
+        return page.evaluate((i: number) => {
+            const clickerElements = document.getElementsByClassName("clicker-value-class");
+            const clicker = clickerElements[i] as HTMLDivElement;
+            if (clicker) {
+                return clicker.innerText;
+            }
+
+            return "";
+        }, index);
+    };
+
+    beforeAll(async () => {
+        // Wait for the page to load first before running any tests
+        // so this time isn't attributed to the first test
+        await page.goto(globals.PATH, { waitUntil: "load", timeout: 0 });
+    }, 45000);
+
+    beforeEach(async () => {
+        await page.goto(globals.PATH, { waitUntil: "load" });
+        await page.waitFor(() => window["fluidStarted"]);
+    });
+
+    it("There's a button to be clicked", async () => {
+        await expect(page).toClick("button", { text: "+" });
+    });
+
+    it("Clicking the button updates both users", async () => {
+        // Validate both users have 0 as their value
+        const preValue = await getValue(0);
+        expect(preValue).toEqual("0");
+        const preValue2 = await getValue(1);
+        expect(preValue2).toEqual("0");
+
+        // Click the button
+        await expect(page).toClick("button", { text: "+" });
+
+        // Validate both users have 1 as their value
+        const postValue = await getValue(0);
+        expect(postValue).toEqual("1");
+        const postValue2 = await getValue(1);
+        expect(postValue2).toEqual("1");
+    });
+
+    it("Clicking the button after refresh updates both users", async () => {
+        await page.reload({ waitUntil: ["load"] });
+        await page.waitFor(() => window["fluidStarted"]);
+
+        // Validate both users have 0 as their value
+        const preValue = await getValue(0);
+        expect(preValue).toEqual("0");
+        const preValue2 = await getValue(1);
+        expect(preValue2).toEqual("0");
+
+        // Click the button
+        await expect(page).toClick("button", { text: "+" });
+
+        // Validate both users have 1 as their value
+        const postValue = await getValue(0);
+        expect(postValue).toEqual("1");
+        const postValue2 = await getValue(1);
+        expect(postValue2).toEqual("1");
+    });
+});

--- a/components/experimental/clicker-intercept/tsconfig.esnext.json
+++ b/components/experimental/clicker-intercept/tsconfig.esnext.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "./lib",
+        "module": "esnext"
+    },
+}

--- a/components/experimental/clicker-intercept/tsconfig.json
+++ b/components/experimental/clicker-intercept/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "extends": "@fluidframework/build-common/ts-common-config.json",
+    "exclude": [
+        "dist",
+        "node_modules"
+    ],
+    "compilerOptions": {
+        "module": "esnext",
+        "outDir": "dist",
+        "jsx": "react",
+        "types": ["jest", "puppeteer", "jest-environment-puppeteer", "expect-puppeteer", "react", "react-dom"],
+    },
+    "include": [
+        "src/**/*"
+    ]
+}

--- a/components/experimental/clicker-intercept/webpack.config.js
+++ b/components/experimental/clicker-intercept/webpack.config.js
@@ -1,0 +1,55 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+const fluidRoute = require("@fluidframework/webpack-component-loader");
+const path = require("path");
+const merge = require("webpack-merge");
+
+const pkg = require("./package.json");
+const fluidPackageName = pkg.name.slice(1);
+
+module.exports = env => {
+    const isProduction = env && env.production;
+
+    return merge({
+        entry: {
+            main: "./src/index.tsx"
+        },
+        resolve: {
+            extensions: [".ts", ".tsx", ".js"],
+        },
+        module: {
+            rules: [{
+                test: /\.tsx?$/,
+                loader: "ts-loader"
+            }]
+        },
+        output: {
+            filename: "[name].bundle.js",
+            path: path.resolve(__dirname, "dist"),
+            library: "[name]",
+            // https://github.com/webpack/webpack/issues/5767
+            // https://github.com/webpack/webpack/issues/7939
+            devtoolNamespace: fluidPackageName,
+            // This is required to run webpacked code in webworker/node
+            // https://github.com/webpack/webpack/issues/6522
+            globalObject: "(typeof self !== 'undefined' ? self : this)",
+            libraryTarget: "umd"
+        },
+        devServer: {
+            headers: {
+                'Access-Control-Allow-Origin': '*'
+            },
+            publicPath: '/dist',
+            before: (app, server) => fluidRoute.before(app, server, env),
+            after: (app, server) => fluidRoute.after(app, server, __dirname, env),
+            watchOptions: {
+                ignored: "**/node_modules/**",
+            }
+        }
+    }, isProduction
+        ? require("./webpack.prod")
+        : require("./webpack.dev"));
+};

--- a/components/experimental/clicker-intercept/webpack.dev.js
+++ b/components/experimental/clicker-intercept/webpack.dev.js
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export * from "./sequence";
-export * from "./map";
-export * from "./sharedObject";
+module.exports = {
+    mode: "development",
+    devtool: "inline-source-map"
+};

--- a/components/experimental/clicker-intercept/webpack.prod.js
+++ b/components/experimental/clicker-intercept/webpack.prod.js
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export * from "./sequence";
-export * from "./map";
-export * from "./sharedObject";
+module.exports = {
+    mode: "production",
+    devtool: "source-map"
+};

--- a/packages/framework/dds-interceptions/README.md
+++ b/packages/framework/dds-interceptions/README.md
@@ -1,6 +1,6 @@
 # @fluidframework/dds-interceptions
 
-This package provides factory methods to create a wrapper around some of the basic Distributed Data Structures (DDS) that support an interception callback. Apps can provide a callback when creating these wrappers and this callback will be called when the DDS is modified. This allows apps to support features such as basic user attibution on a SharedString.
+This package provides factory methods to create a wrapper around some of the basic Distributed Data Structures (DDS) that support an interception callback. Apps can provide a callback when creating these wrappers and this callback will be called when the DDS is modified. This allows apps to support features such as basic user attribution on a SharedString.
 
 ## Shared String With Interception
 

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -54,7 +54,8 @@
     "@fluidframework/map": "^0.21.0",
     "@fluidframework/merge-tree": "^0.21.0",
     "@fluidframework/runtime-definitions": "^0.21.0",
-    "@fluidframework/sequence": "^0.21.0"
+    "@fluidframework/sequence": "^0.21.0",
+    "@fluidframework/shared-object-base": "^0.21.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.18.0-0",

--- a/packages/framework/dds-interceptions/src/sharedObject/index.ts
+++ b/packages/framework/dds-interceptions/src/sharedObject/index.ts
@@ -3,6 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export * from "./sequence";
-export * from "./map";
-export * from "./sharedObject";
+export * from "./injectSharedObjectInterception";

--- a/packages/framework/dds-interceptions/src/sharedObject/injectSharedObjectInterception.ts
+++ b/packages/framework/dds-interceptions/src/sharedObject/injectSharedObjectInterception.ts
@@ -1,0 +1,26 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+const runtimeEvents = [
+    "op",
+    "pre-op",
+    "update",
+];
+
+export function injectSharedObjectInterception(
+    sharedObject: any,
+    listenedEvents?: string[],
+) {
+    sharedObject.internalEmit = sharedObject.emit.bind(sharedObject);
+    const allEvents: string[] = [...runtimeEvents, ...(listenedEvents ?? [])];
+    const emitFunction = ((event: string | symbol, ...args: any[]) => {
+        if (!allEvents.includes(event as string)) {
+            sharedObject.internalEmit("update", sharedObject);
+            return sharedObject.internalEmit(event, ...args);
+        }
+    });
+    sharedObject.emit = emitFunction.bind(sharedObject);
+    return sharedObject;
+}


### PR DESCRIPTION
- Adds injectSharedObjectInterception in dds-interceptions
- Adds a clicker-intercept example that uses it. it doesn't listen to any events and purely relies on update to send the update counter. Then it just sets that to the state and relies on React state-update logic to efficiently update the view value