### PR TITLE
Deprecated `id` in SharedComponent and updated `url` to return the absolute path

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -6,6 +6,8 @@
 - [ContainerRuntime.load Request Handler Changes](#ContainerRuntime.load-Request-Handler-Changes)
 - [IComponentHTMLVisual removed](#IComponentHTMLVisual-removed)
 - [IComponentReactViewable deprecated](#IComponentReactViewable-deprecated)
+- [Deprecated `id` from `SharedComponent`](#Deprecated-`id`-from-`SharedComponent`)
+- [Updated `url` in `SharedComponent` and `SharedObject`](#Updated-`url`-in-`SharedComponent`-and-`SharedObject`)
 
 ### Deprecated `path` from `IComponentHandleContext`
 Deprecated the `path` field from the interface `IComponentHandleContext`. This means that `IComponentHandle` will not have this going forward as well.
@@ -48,6 +50,27 @@ The `IComponentHTMLVisual` interface was deprecated in 0.21, and is now removed 
 
 ### IComponentReactViewable deprecated
 The `IComponentReactViewable` interface is deprecated and will be removed in an upcoming release.  For multiview scenarios, instead use a pattern like the one demonstrated in the sample in /components/experimental/multiview.  This sample demonstrates how to create multiple views for a component.
+
+### Deprecated `id` from `SharedComponent`
+`id` is deprecated from `SharedComponent` and will be removed in an upcoming release.
+
+Use `handle` in `SharedComponent` to retrieve it in local as well as in remote clients.
+
+To get the absolute path to the `SharedComponent` within a document, use `url`.
+
+### Updated `url` in `SharedComponent` and `SharedObject`
+`url` in `SharedComponent` and `SharedObject` now returns the absolute path to it within the document.
+
+Note that, as per `IComponentLoadable`, `url` is supposed to return the absolute path:
+```typescript
+export interface IComponentLoadable extends IProvideComponentLoadable {
+    // Absolute URL to the component within the document
+    readonly url: string;
+
+    // Handle to the loadable component
+    handle: IComponentHandle;
+}
+```
 
 ## 0.21 Breaking Changes
 - [Removed `@fluidframework/local-test-utils`](#removed-`@fluidframework/local-test-utils`)

--- a/components/experimental/codemirror/src/codemirror.ts
+++ b/components/experimental/codemirror/src/codemirror.ts
@@ -226,8 +226,8 @@ export class CodeMirrorComponent
         /* Private */ context: IComponentContext,
     ) {
         super();
-        this.url = context.id;
-        this.innerHandle = new ComponentHandle(this, this.url, runtime.IComponentHandleContext);
+        this.innerHandle = new ComponentHandle(this, "", runtime.IComponentHandleContext);
+        this.url = this.innerHandle.absolutePath;
     }
 
     public async request(request: IRequest): Promise<IResponse> {

--- a/components/experimental/progress-bars/src/progressBars.ts
+++ b/components/experimental/progress-bars/src/progressBars.ts
@@ -144,8 +144,8 @@ export class ProgressCollection
     constructor(private readonly runtime: IComponentRuntime, context: IComponentContext) {
         super();
 
-        this.url = context.id;
         this.handle = new ComponentHandle(this, "", this.runtime.IComponentHandleContext);
+        this.url = this.handle.absolutePath;
     }
 
     public changeValue(key: string, newValue: number) {

--- a/components/experimental/prosemirror/src/prosemirror.ts
+++ b/components/experimental/prosemirror/src/prosemirror.ts
@@ -127,8 +127,8 @@ export class ProseMirror extends EventEmitter
     ) {
         super();
 
-        this.url = context.id;
-        this.innerHandle = new ComponentHandle(this, this.url, runtime.IComponentHandleContext);
+        this.innerHandle = new ComponentHandle(this, "", runtime.IComponentHandleContext);
+        this.url = this.innerHandle.absolutePath;
     }
 
     public async request(request: IRequest): Promise<IResponse> {

--- a/components/experimental/scribe/src/scribe.ts
+++ b/components/experimental/scribe/src/scribe.ts
@@ -405,8 +405,8 @@ export class Scribe
     constructor(private readonly runtime: IComponentRuntime, private readonly context: IComponentContext) {
         super();
 
-        this.url = context.id;
-        this.innerHandle = new ComponentHandle(this, this.url, this.runtime.IComponentHandleContext);
+        this.innerHandle = new ComponentHandle(this, "", this.runtime.IComponentHandleContext);
+        this.url = this.innerHandle.absolutePath;
     }
 
     public async request(request: IRequest): Promise<IResponse> {

--- a/components/experimental/smde/src/smde.ts
+++ b/components/experimental/smde/src/smde.ts
@@ -66,8 +66,8 @@ export class Smde extends EventEmitter implements
     constructor(private readonly runtime: IComponentRuntime, private readonly context: IComponentContext) {
         super();
 
-        this.url = context.id;
-        this.innerHandle = new ComponentHandle(this, this.url, this.runtime.IComponentHandleContext);
+        this.innerHandle = new ComponentHandle(this, "", this.runtime.IComponentHandleContext);
+        this.url = this.innerHandle.absolutePath;
     }
 
     public async request(request: IRequest): Promise<IResponse> {

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -73,7 +73,7 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
      * The loadable URL for this SharedObject
      */
     public get url(): string {
-        return this.id;
+        return this.handle.absolutePath;
     }
 
     /**

--- a/packages/framework/aqueduct/src/components/sharedComponent.ts
+++ b/packages/framework/aqueduct/src/components/sharedComponent.ts
@@ -64,7 +64,12 @@ export abstract class SharedComponent<P extends IComponent = object, S = undefin
 
     public get disposed() { return this._disposed; }
 
+    /**
+     * @deprecated - `id` has been depcreated. Use `handle` to get the object. Use `url` for the aboslute
+     * path to this fluid object.
+     */
     public get id() { return this.runtime.id; }
+
     public get IComponentRouter() { return this; }
     public get IComponentLoadable() { return this; }
     public get IComponentHandle() { return this.innerHandle; }
@@ -133,7 +138,7 @@ export abstract class SharedComponent<P extends IComponent = object, S = undefin
     /**
      * Absolute URL to the component within the document
      */
-    public get url() { return this.context.id; }
+    public get url() { return this.handle.absolutePath; }
 
     // #endregion IComponentLoadable
 

--- a/packages/test/test-utils/src/testFluidComponent.ts
+++ b/packages/test/test-utils/src/testFluidComponent.ts
@@ -53,8 +53,8 @@ export class TestFluidComponent implements ITestFluidComponent, IComponentLoadab
         public readonly context: IComponentContext,
         private readonly factoryEntriesMap: Map<string, ISharedObjectFactory>,
     ) {
-        this.url = context.id;
         this.innerHandle = new ComponentHandle(this, "", runtime.IComponentHandleContext);
+        this.url = this.innerHandle.absolutePath;
     }
 
     /**


### PR DESCRIPTION
Fixes #2746.

- Deprecated `id` in `SharedComponent`. The user should never directly deal with `id`. To get the `SharedComponent`, handle should be used. `IComponentLoadable` also has `url` to get the absolute path to it.
Note: `id` in `SharedObject` also should be removed but we can't do that until we have aliasing support.

- Updated `url` in `SharedComponent` and `SharedObject` to return the absolute path to it within the document. It is currently returning the `id` which is incorrect.