### PR TITLE
Make Scope an IFluidObject

### DIFF
--- a/examples/hosts/iframe-host/src/inframehost.ts
+++ b/examples/hosts/iframe-host/src/inframehost.ts
@@ -17,7 +17,7 @@ import {
     AttachState,
 } from "@fluidframework/container-definitions";
 import { MultiUrlResolver, MultiDocumentServiceFactory } from "@fluidframework/driver-utils";
-import { IRequest, IResponse, IComponent } from "@fluidframework/component-core-interfaces";
+import { IRequest, IResponse, IComponent, IFluidScope } from "@fluidframework/component-core-interfaces";
 import { IDocumentServiceFactory, IUrlResolver } from "@fluidframework/driver-definitions";
 import { ISequencedDocumentMessage, ITree, ISummaryTree } from "@fluidframework/protocol-definitions";
 
@@ -77,7 +77,7 @@ export interface IFrameOuterHostConfig {
 
     // A component that gives host provided capabilities/configurations
     // to the component in the container(such as auth).
-    scope?: IComponent;
+    scope?: IComponent & IFluidScope;
 
     proxyLoaderFactories?: Map<string, IProxyLoaderFactory>;
 }

--- a/examples/hosts/iframe-host/src/inframehost.ts
+++ b/examples/hosts/iframe-host/src/inframehost.ts
@@ -17,7 +17,7 @@ import {
     AttachState,
 } from "@fluidframework/container-definitions";
 import { MultiUrlResolver, MultiDocumentServiceFactory } from "@fluidframework/driver-utils";
-import { IRequest, IResponse, IComponent, IFluidScope } from "@fluidframework/component-core-interfaces";
+import { IRequest, IResponse, IComponent, IFluidObject } from "@fluidframework/component-core-interfaces";
 import { IDocumentServiceFactory, IUrlResolver } from "@fluidframework/driver-definitions";
 import { ISequencedDocumentMessage, ITree, ISummaryTree } from "@fluidframework/protocol-definitions";
 
@@ -77,7 +77,7 @@ export interface IFrameOuterHostConfig {
 
     // A component that gives host provided capabilities/configurations
     // to the component in the container(such as auth).
-    scope?: IComponent & IFluidScope;
+    scope?: IComponent & IFluidObject;
 
     proxyLoaderFactories?: Map<string, IProxyLoaderFactory>;
 }

--- a/packages/framework/synthesize/src/IComponentDependencySynthesizer.ts
+++ b/packages/framework/synthesize/src/IComponentDependencySynthesizer.ts
@@ -14,6 +14,9 @@ import {
 declare module "@fluidframework/component-core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
     export interface IComponent extends Readonly<Partial<IProvideComponentDependencySynthesizer>> { }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    export interface IFluidScope extends Readonly<Partial<IProvideComponentDependencySynthesizer>> { }
 }
 
 export const IComponentDependencySynthesizer: keyof IProvideComponentDependencySynthesizer

--- a/packages/framework/synthesize/src/IComponentDependencySynthesizer.ts
+++ b/packages/framework/synthesize/src/IComponentDependencySynthesizer.ts
@@ -16,7 +16,7 @@ declare module "@fluidframework/component-core-interfaces" {
     export interface IComponent extends Readonly<Partial<IProvideComponentDependencySynthesizer>> { }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    export interface IFluidScope extends Readonly<Partial<IProvideComponentDependencySynthesizer>> { }
+    export interface IFluidObject extends Readonly<Partial<IProvideComponentDependencySynthesizer>> { }
 }
 
 export const IComponentDependencySynthesizer: keyof IProvideComponentDependencySynthesizer

--- a/packages/hosts/base-host/src/hostConfig.ts
+++ b/packages/hosts/base-host/src/hostConfig.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IComponent } from "@fluidframework/component-core-interfaces";
+import { IComponent, IFluidScope } from "@fluidframework/component-core-interfaces";
 import { ICodeAllowList, IProxyLoaderFactory, IFluidCodeResolver } from "@fluidframework/container-definitions";
 import { IDocumentServiceFactory, IUrlResolver } from "@fluidframework/driver-definitions";
 
@@ -21,7 +21,7 @@ export interface IBaseHostConfig {
 
     // A component that gives host provided capabilities/configurations
     // to the component in the container(such as auth).
-    scope?: IComponent;
+    scope?: IComponent & IFluidScope;
 
     proxyLoaderFactories?: Map<string, IProxyLoaderFactory>;
 

--- a/packages/hosts/base-host/src/hostConfig.ts
+++ b/packages/hosts/base-host/src/hostConfig.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IComponent, IFluidScope } from "@fluidframework/component-core-interfaces";
+import { IComponent, IFluidObject } from "@fluidframework/component-core-interfaces";
 import { ICodeAllowList, IProxyLoaderFactory, IFluidCodeResolver } from "@fluidframework/container-definitions";
 import { IDocumentServiceFactory, IUrlResolver } from "@fluidframework/driver-definitions";
 
@@ -21,7 +21,7 @@ export interface IBaseHostConfig {
 
     // A component that gives host provided capabilities/configurations
     // to the component in the container(such as auth).
-    scope?: IComponent & IFluidScope;
+    scope?: IComponent & IFluidObject;
 
     proxyLoaderFactories?: Map<string, IProxyLoaderFactory>;
 

--- a/packages/loader/component-core-interfaces/src/index.ts
+++ b/packages/loader/component-core-interfaces/src/index.ts
@@ -12,9 +12,6 @@ export * from "./legacy";
 // IFluidObject as opposed to an export *
 export { IFluidObject } from "./fluidObject";
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface IFluidScope {}
-
 export * from "./fluidLoadable";
 export * from "./fluidRouter";
 export * from "./handles";

--- a/packages/loader/component-core-interfaces/src/index.ts
+++ b/packages/loader/component-core-interfaces/src/index.ts
@@ -11,6 +11,10 @@ export * from "./legacy";
 // when merging declarations the module path must match exactly. Because of this we need to explicitly export
 // IFluidObject as opposed to an export *
 export { IFluidObject } from "./fluidObject";
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface IFluidScope {}
+
 export * from "./fluidLoadable";
 export * from "./fluidRouter";
 export * from "./handles";

--- a/packages/loader/container-definitions/src/runtime.ts
+++ b/packages/loader/container-definitions/src/runtime.ts
@@ -9,7 +9,7 @@ import {
     IComponentConfiguration,
     IRequest,
     IResponse,
-    IFluidScope,
+    IFluidObject,
 } from "@fluidframework/component-core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import {
@@ -129,7 +129,7 @@ export interface IContainerContext extends IMessageScheduler, IDisposable {
     /**
      * Ambient services provided with the context
      */
-    readonly scope: IComponent & IFluidScope;
+    readonly scope: IComponent & IFluidObject;
 
     raiseContainerWarning(warning: ContainerWarning): void;
     requestSnapshot(tagMessage: string): Promise<void>;

--- a/packages/loader/container-definitions/src/runtime.ts
+++ b/packages/loader/container-definitions/src/runtime.ts
@@ -9,6 +9,7 @@ import {
     IComponentConfiguration,
     IRequest,
     IResponse,
+    IFluidScope,
 } from "@fluidframework/component-core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import {
@@ -128,7 +129,7 @@ export interface IContainerContext extends IMessageScheduler, IDisposable {
     /**
      * Ambient services provided with the context
      */
-    readonly scope: IComponent;
+    readonly scope: IComponent & IFluidScope;
 
     raiseContainerWarning(warning: ContainerWarning): void;
     requestSnapshot(tagMessage: string): Promise<void>;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -11,7 +11,7 @@ import {
     ITelemetryBaseLogger,
     ITelemetryLogger,
 } from "@fluidframework/common-definitions";
-import { IComponent, IRequest, IResponse } from "@fluidframework/component-core-interfaces";
+import { IComponent, IRequest, IResponse, IFluidScope } from "@fluidframework/component-core-interfaces";
 import {
     IAudience,
     ICodeLoader,
@@ -133,7 +133,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         serviceFactory: IDocumentServiceFactory,
         codeLoader: ICodeLoader,
         options: any,
-        scope: IComponent,
+        scope: IComponent & IFluidScope,
         loader: Loader,
         request: IRequest,
         resolvedUrl: IFluidResolvedUrl,
@@ -191,7 +191,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     public static async create(
         codeLoader: ICodeLoader,
         options: any,
-        scope: IComponent,
+        scope: IComponent & IFluidScope,
         loader: Loader,
         source: IFluidCodeDetails,
         serviceFactory: IDocumentServiceFactory,
@@ -356,7 +356,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
     constructor(
         public readonly options: any,
-        private readonly scope: IComponent,
+        private readonly scope: IComponent & IFluidScope,
         private readonly codeLoader: ICodeLoader,
         private readonly loader: Loader,
         private readonly serviceFactory: IDocumentServiceFactory,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -11,7 +11,7 @@ import {
     ITelemetryBaseLogger,
     ITelemetryLogger,
 } from "@fluidframework/common-definitions";
-import { IComponent, IRequest, IResponse, IFluidScope } from "@fluidframework/component-core-interfaces";
+import { IComponent, IRequest, IResponse, IFluidObject } from "@fluidframework/component-core-interfaces";
 import {
     IAudience,
     ICodeLoader,
@@ -133,7 +133,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         serviceFactory: IDocumentServiceFactory,
         codeLoader: ICodeLoader,
         options: any,
-        scope: IComponent & IFluidScope,
+        scope: IComponent & IFluidObject,
         loader: Loader,
         request: IRequest,
         resolvedUrl: IFluidResolvedUrl,
@@ -191,7 +191,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     public static async create(
         codeLoader: ICodeLoader,
         options: any,
-        scope: IComponent & IFluidScope,
+        scope: IComponent & IFluidObject,
         loader: Loader,
         source: IFluidCodeDetails,
         serviceFactory: IDocumentServiceFactory,
@@ -356,7 +356,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
     constructor(
         public readonly options: any,
-        private readonly scope: IComponent & IFluidScope,
+        private readonly scope: IComponent & IFluidObject,
         private readonly codeLoader: ICodeLoader,
         private readonly loader: Loader,
         private readonly serviceFactory: IDocumentServiceFactory,

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -10,6 +10,7 @@ import {
     IComponentConfiguration,
     IRequest,
     IResponse,
+    IFluidScope,
 } from "@fluidframework/component-core-interfaces";
 import {
     IAudience,
@@ -47,7 +48,7 @@ import { NullRuntime } from "./nullRuntime";
 export class ContainerContext implements IContainerContext {
     public static async createOrLoad(
         container: Container,
-        scope: IComponent,
+        scope: IComponent & IFluidScope,
         codeLoader: ICodeLoader,
         runtimeFactory: IRuntimeFactory,
         baseSnapshot: ISnapshotTree | null,
@@ -167,7 +168,7 @@ export class ContainerContext implements IContainerContext {
 
     constructor(
         private readonly container: Container,
-        public readonly scope: IComponent,
+        public readonly scope: IComponent & IFluidScope,
         public readonly codeLoader: ICodeLoader,
         public readonly runtimeFactory: IRuntimeFactory,
         private readonly _baseSnapshot: ISnapshotTree | null,

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -10,7 +10,7 @@ import {
     IComponentConfiguration,
     IRequest,
     IResponse,
-    IFluidScope,
+    IFluidObject,
 } from "@fluidframework/component-core-interfaces";
 import {
     IAudience,
@@ -48,7 +48,7 @@ import { NullRuntime } from "./nullRuntime";
 export class ContainerContext implements IContainerContext {
     public static async createOrLoad(
         container: Container,
-        scope: IComponent & IFluidScope,
+        scope: IComponent & IFluidObject,
         codeLoader: ICodeLoader,
         runtimeFactory: IRuntimeFactory,
         baseSnapshot: ISnapshotTree | null,
@@ -168,7 +168,7 @@ export class ContainerContext implements IContainerContext {
 
     constructor(
         private readonly container: Container,
-        public readonly scope: IComponent & IFluidScope,
+        public readonly scope: IComponent & IFluidObject,
         public readonly codeLoader: ICodeLoader,
         public readonly runtimeFactory: IRuntimeFactory,
         private readonly _baseSnapshot: ISnapshotTree | null,

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -10,7 +10,7 @@ import {
     IComponent,
     IRequest,
     IResponse,
-    IFluidScope,
+    IFluidObject,
 } from "@fluidframework/component-core-interfaces";
 import {
     ICodeLoader,
@@ -144,7 +144,7 @@ export class Loader extends EventEmitter implements ILoader {
         documentServiceFactory: IDocumentServiceFactory | IDocumentServiceFactory[],
         private readonly codeLoader: ICodeLoader,
         private readonly options: any,
-        private readonly scope: IComponent & IFluidScope,
+        private readonly scope: IComponent & IFluidObject,
         private readonly proxyLoaderFactories: Map<string, IProxyLoaderFactory>,
         logger?: ITelemetryBaseLogger,
     ) {

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -10,6 +10,7 @@ import {
     IComponent,
     IRequest,
     IResponse,
+    IFluidScope,
 } from "@fluidframework/component-core-interfaces";
 import {
     ICodeLoader,
@@ -143,7 +144,7 @@ export class Loader extends EventEmitter implements ILoader {
         documentServiceFactory: IDocumentServiceFactory | IDocumentServiceFactory[],
         private readonly codeLoader: ICodeLoader,
         private readonly options: any,
-        private readonly scope: IComponent,
+        private readonly scope: IComponent & IFluidScope,
         private readonly proxyLoaderFactories: Map<string, IProxyLoaderFactory>,
         logger?: ITelemetryBaseLogger,
     ) {

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -4,7 +4,7 @@
  */
 
 import {
-    IComponent,
+    IComponent, IFluidScope,
 } from "@fluidframework/component-core-interfaces";
 import {
     IAudience,
@@ -64,7 +64,7 @@ export interface IContainerRuntime extends
     readonly loader: ILoader;
     readonly flushMode: FlushMode;
     readonly snapshotFn: (message: string) => Promise<void>;
-    readonly scope: IComponent;
+    readonly scope: IComponent & IFluidScope;
     /**
      * Indicates the attachment state of the container to a host service.
      */

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -4,7 +4,7 @@
  */
 
 import {
-    IComponent, IFluidScope,
+    IComponent, IFluidObject,
 } from "@fluidframework/component-core-interfaces";
 import {
     IAudience,
@@ -64,7 +64,7 @@ export interface IContainerRuntime extends
     readonly loader: ILoader;
     readonly flushMode: FlushMode;
     readonly snapshotFn: (message: string) => Promise<void>;
-    readonly scope: IComponent & IFluidScope;
+    readonly scope: IComponent & IFluidObject;
     /**
      * Indicates the attachment state of the container to a host service.
      */

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -6,7 +6,13 @@
 import assert from "assert";
 import EventEmitter from "events";
 import { IDisposable } from "@fluidframework/common-definitions";
-import { IComponent, IComponentLoadable, IRequest, IResponse } from "@fluidframework/component-core-interfaces";
+import {
+    IComponent,
+    IComponentLoadable,
+    IRequest,
+    IResponse,
+    IFluidScope,
+} from "@fluidframework/component-core-interfaces";
 import {
     IAudience,
     IBlobManager,
@@ -171,7 +177,7 @@ export abstract class ComponentContext extends EventEmitter implements
         public readonly id: string,
         public readonly existing: boolean,
         public readonly storage: IDocumentStorageService,
-        public readonly scope: IComponent,
+        public readonly scope: IComponent & IFluidScope,
         public readonly summaryTracker: SummaryTracker,
         private bindState: BindState,
         bindComponent: (componentRuntime: IComponentRuntimeChannel) => void,
@@ -583,7 +589,7 @@ export class RemotedComponentContext extends ComponentContext {
         private readonly initSnapshotValue: Promise<ISnapshotTree> | string | null,
         runtime: ContainerRuntime,
         storage: IDocumentStorageService,
-        scope: IComponent,
+        scope: IComponent & IFluidScope,
         summaryTracker: SummaryTracker,
         pkg?: string[],
     ) {
@@ -660,7 +666,7 @@ export class LocalComponentContext extends ComponentContext {
         pkg: string[],
         runtime: ContainerRuntime,
         storage: IDocumentStorageService,
-        scope: IComponent,
+        scope: IComponent & IFluidScope,
         summaryTracker: SummaryTracker,
         bindComponent: (componentRuntime: IComponentRuntimeChannel) => void,
         /**

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -11,7 +11,7 @@ import {
     IComponentLoadable,
     IRequest,
     IResponse,
-    IFluidScope,
+    IFluidObject,
 } from "@fluidframework/component-core-interfaces";
 import {
     IAudience,
@@ -177,7 +177,7 @@ export abstract class ComponentContext extends EventEmitter implements
         public readonly id: string,
         public readonly existing: boolean,
         public readonly storage: IDocumentStorageService,
-        public readonly scope: IComponent & IFluidScope,
+        public readonly scope: IComponent & IFluidObject,
         public readonly summaryTracker: SummaryTracker,
         private bindState: BindState,
         bindComponent: (componentRuntime: IComponentRuntimeChannel) => void,
@@ -589,7 +589,7 @@ export class RemotedComponentContext extends ComponentContext {
         private readonly initSnapshotValue: Promise<ISnapshotTree> | string | null,
         runtime: ContainerRuntime,
         storage: IDocumentStorageService,
-        scope: IComponent & IFluidScope,
+        scope: IComponent & IFluidObject,
         summaryTracker: SummaryTracker,
         pkg?: string[],
     ) {
@@ -666,7 +666,7 @@ export class LocalComponentContext extends ComponentContext {
         pkg: string[],
         runtime: ContainerRuntime,
         storage: IDocumentStorageService,
-        scope: IComponent & IFluidScope,
+        scope: IComponent & IFluidObject,
         summaryTracker: SummaryTracker,
         bindComponent: (componentRuntime: IComponentRuntimeChannel) => void,
         /**

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -13,6 +13,7 @@ import {
     IComponentSerializer,
     IRequest,
     IResponse,
+    IFluidObject,
 } from "@fluidframework/component-core-interfaces";
 import {
     IAudience,
@@ -440,7 +441,7 @@ implements IContainerRuntime, IContainerRuntimeDirtyable, IRuntime, ISummarizerR
         registryEntries: NamedComponentRegistryEntries,
         requestHandler?: (request: IRequest, runtime: IContainerRuntime) => Promise<IResponse>,
         runtimeOptions?: IContainerRuntimeOptions,
-        containerScope: IComponent = context.scope,
+        containerScope: IComponent & IFluidObject = context.scope,
     ): Promise<ContainerRuntime> {
         // Back-compat: <= 0.18 loader
         if (context.deltaManager.lastSequenceNumber === undefined) {
@@ -542,7 +543,7 @@ implements IContainerRuntime, IContainerRuntimeDirtyable, IRuntime, ISummarizerR
         return this._flushMode;
     }
 
-    public get scope(): IComponent {
+    public get scope(): IComponent & IFluidObject {
         return this.containerScope;
     }
 
@@ -625,7 +626,7 @@ implements IContainerRuntime, IContainerRuntimeDirtyable, IRuntime, ISummarizerR
         private readonly registry: IComponentRegistry,
         chunks: [string, string[]][],
         private readonly runtimeOptions: IContainerRuntimeOptions = { generateSummaries: true, enableWorker: false },
-        private readonly containerScope: IComponent,
+        private readonly containerScope: IComponent & IFluidObject,
         private readonly requestHandler?: (request: IRequest, runtime: IContainerRuntime) => Promise<IResponse>,
     ) {
         super();

--- a/packages/runtime/container-runtime/src/test/componentContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/componentContext.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from "assert";
-import { IComponent, IFluidScope } from "@fluidframework/component-core-interfaces";
+import { IComponent, IFluidObject } from "@fluidframework/component-core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { BlobCacheStorageService } from "@fluidframework/driver-utils";
 import { IBlob, ISnapshotTree } from "@fluidframework/protocol-definitions";
@@ -28,7 +28,7 @@ describe("Component Context Tests", () => {
     describe("LocalComponentContext Initialization", () => {
         let localComponentContext: LocalComponentContext;
         let storage: IDocumentStorageService;
-        let scope: IComponent & IFluidScope;
+        let scope: IComponent & IFluidObject;
         const attachCb = (mR: IComponentRuntimeChannel) => { };
         let containerRuntime: ContainerRuntime;
         beforeEach(async () => {
@@ -144,7 +144,7 @@ describe("Component Context Tests", () => {
         let remotedComponentContext: RemotedComponentContext;
         let componentAttributes: IComponentAttributes;
         const storage: Partial<IDocumentStorageService> = {};
-        let scope: IComponent & IFluidScope;
+        let scope: IComponent & IFluidObject;
         let containerRuntime: ContainerRuntime;
         beforeEach(async () => {
             const factory: { [key: string]: any } = {};

--- a/packages/runtime/container-runtime/src/test/componentContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/componentContext.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from "assert";
-import { IComponent } from "@fluidframework/component-core-interfaces";
+import { IComponent, IFluidScope } from "@fluidframework/component-core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { BlobCacheStorageService } from "@fluidframework/driver-utils";
 import { IBlob, ISnapshotTree } from "@fluidframework/protocol-definitions";
@@ -28,7 +28,7 @@ describe("Component Context Tests", () => {
     describe("LocalComponentContext Initialization", () => {
         let localComponentContext: LocalComponentContext;
         let storage: IDocumentStorageService;
-        let scope: IComponent;
+        let scope: IComponent & IFluidScope;
         const attachCb = (mR: IComponentRuntimeChannel) => { };
         let containerRuntime: ContainerRuntime;
         beforeEach(async () => {
@@ -144,7 +144,7 @@ describe("Component Context Tests", () => {
         let remotedComponentContext: RemotedComponentContext;
         let componentAttributes: IComponentAttributes;
         const storage: Partial<IDocumentStorageService> = {};
-        let scope: IComponent;
+        let scope: IComponent & IFluidScope;
         let containerRuntime: ContainerRuntime;
         beforeEach(async () => {
             const factory: { [key: string]: any } = {};

--- a/packages/runtime/container-runtime/src/test/componentCreation.spec.ts
+++ b/packages/runtime/container-runtime/src/test/componentCreation.spec.ts
@@ -11,7 +11,7 @@ import {
     ComponentRegistryEntry,
     NamedComponentRegistryEntries,
 } from "@fluidframework/runtime-definitions";
-import { IComponent, IFluidScope } from "@fluidframework/component-core-interfaces";
+import { IComponent, IFluidObject } from "@fluidframework/component-core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { MockComponentRuntime } from "@fluidframework/test-runtime-utils";
 import { SummaryTracker } from "@fluidframework/runtime-utils";
@@ -34,7 +34,7 @@ describe("Component Creation Tests", () => {
          */
 
         let storage: IDocumentStorageService;
-        let scope: IComponent & IFluidScope;
+        let scope: IComponent & IFluidObject;
         const attachCb = (mR: IComponentRuntimeChannel) => { };
         let containerRuntime: ContainerRuntime;
         const defaultName = "default";

--- a/packages/runtime/container-runtime/src/test/componentCreation.spec.ts
+++ b/packages/runtime/container-runtime/src/test/componentCreation.spec.ts
@@ -11,7 +11,7 @@ import {
     ComponentRegistryEntry,
     NamedComponentRegistryEntries,
 } from "@fluidframework/runtime-definitions";
-import { IComponent } from "@fluidframework/component-core-interfaces";
+import { IComponent, IFluidScope } from "@fluidframework/component-core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { MockComponentRuntime } from "@fluidframework/test-runtime-utils";
 import { SummaryTracker } from "@fluidframework/runtime-utils";
@@ -34,7 +34,7 @@ describe("Component Creation Tests", () => {
          */
 
         let storage: IDocumentStorageService;
-        let scope: IComponent;
+        let scope: IComponent & IFluidScope;
         const attachCb = (mR: IComponentRuntimeChannel) => { };
         let containerRuntime: ContainerRuntime;
         const defaultName = "default";

--- a/packages/runtime/runtime-definitions/src/componentContext.ts
+++ b/packages/runtime/runtime-definitions/src/componentContext.ts
@@ -13,6 +13,7 @@ import {
     IProvideComponentSerializer,
     IRequest,
     IResponse,
+    IFluidScope,
 } from "@fluidframework/component-core-interfaces";
 import {
     IAudience,
@@ -279,7 +280,7 @@ export interface IComponentContext extends EventEmitter {
     /**
      * Ambient services provided with the context
      */
-    readonly scope: IComponent;
+    readonly scope: IComponent & IFluidScope;
     readonly summaryTracker: ISummaryTracker;
 
     on(event: "leader" | "notleader" | "attaching" | "attached", listener: () => void): this;

--- a/packages/runtime/runtime-definitions/src/componentContext.ts
+++ b/packages/runtime/runtime-definitions/src/componentContext.ts
@@ -13,7 +13,7 @@ import {
     IProvideComponentSerializer,
     IRequest,
     IResponse,
-    IFluidScope,
+    IFluidObject,
 } from "@fluidframework/component-core-interfaces";
 import {
     IAudience,
@@ -280,7 +280,7 @@ export interface IComponentContext extends EventEmitter {
     /**
      * Ambient services provided with the context
      */
-    readonly scope: IComponent & IFluidScope;
+    readonly scope: IComponent & IFluidObject;
     readonly summaryTracker: ISummaryTracker;
 
     on(event: "leader" | "notleader" | "attaching" | "attached", listener: () => void): this;


### PR DESCRIPTION
As part of the forward compatibility needed for host to support the rename, we will also need a new object to host scope interfaces off. So allow scope to be and IFluidObject
 
Related #2777 