### PR TITLE
SharedMatrix: Fix bug when setting 'runtime.options'

### DIFF
--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -69,14 +69,14 @@ export class SharedMatrix<T extends Serializable = Serializable>
         this.rows = new PermutationVector(
             SnapshotPath.rows,
             this.logger,
-            runtime.options,
+            runtime,
             this.onRowDelta,
             this.onRowHandlesRecycled);
 
         this.cols = new PermutationVector(
             SnapshotPath.cols,
             this.logger,
-            runtime.options,
+            runtime,
             this.onColDelta,
             this.onColHandlesRecycled);
     }

--- a/packages/dds/matrix/src/permutationvector.ts
+++ b/packages/dds/matrix/src/permutationvector.ts
@@ -97,9 +97,9 @@ export class PermutationVector extends Client {
         super(
             PermutationSegment.fromJSONObject,
             ChildLogger.create(logger, `Matrix.${path}.MergeTreeClient`), {
-            ...runtime.options,
-            newMergeTreeSnapshotFormat: true,
-        },
+                ...runtime.options,
+                newMergeTreeSnapshotFormat: true,
+            },
         );
 
         this.mergeTreeDeltaCallback = this.onDelta;

--- a/packages/dds/matrix/src/permutationvector.ts
+++ b/packages/dds/matrix/src/permutationvector.ts
@@ -98,8 +98,8 @@ export class PermutationVector extends Client {
             PermutationSegment.fromJSONObject,
             ChildLogger.create(logger, `Matrix.${path}.MergeTreeClient`), {
                 ...runtime.options,
-                newMergeTreeSnapshotFormat: true,
-            },
+                newMergeTreeSnapshotFormat: true,   // Temporarily force new snapshot format until it becomes the default.
+            },                                      // (See https://github.com/microsoft/FluidFramework/issues/84)
         );
 
         this.mergeTreeDeltaCallback = this.onDelta;

--- a/packages/dds/matrix/src/permutationvector.ts
+++ b/packages/dds/matrix/src/permutationvector.ts
@@ -98,7 +98,7 @@ export class PermutationVector extends Client {
             PermutationSegment.fromJSONObject,
             ChildLogger.create(logger, `Matrix.${path}.MergeTreeClient`), {
                 ...runtime.options,
-                newMergeTreeSnapshotFormat: true,   // Temporarily force new snapshot format until it becomes the default.
+                newMergeTreeSnapshotFormat: true,   // Temporarily force new snapshot format until it is the default.
             },                                      // (See https://github.com/microsoft/FluidFramework/issues/84)
         );
 


### PR DESCRIPTION
Silly bug that:
* Compiled because 'runtime.options' is typed to 'any'.
* Succeeded at runtime because '{ ...undefined }' -> '{}'