### PR TITLE
FDL Rename: Rename Component on Runtime, Contexts, and Creation

### DIFF
--- a/components/examples/pond/src/index.tsx
+++ b/components/examples/pond/src/index.tsx
@@ -42,10 +42,10 @@ export class Pond extends PrimedComponent implements IComponentHTMLView {
    * Do setup work here
    */
     protected async componentInitializingFirstTime() {
-        const clickerComponent = await Clicker.getFactory().createComponent(this.context);
+        const clickerComponent = await Clicker.getFactory().createDataStore(this.context);
         this.root.set(Clicker.ComponentName, clickerComponent.handle);
 
-        const clickerComponentUsingProvider = await ExampleUsingProviders.getFactory().createComponent(this.context);
+        const clickerComponentUsingProvider = await ExampleUsingProviders.getFactory().createDataStore(this.context);
         this.root.set(ExampleUsingProviders.ComponentName, clickerComponentUsingProvider.handle);
     }
 

--- a/components/experimental/client-ui-lib/src/controls/flowView.ts
+++ b/components/experimental/client-ui-lib/src/controls/flowView.ts
@@ -4523,7 +4523,7 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
     public insertComponentNew(prefix: string, chaincode: string, inline = false) {
         const id = `${prefix}-${Date.now()}`;
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.collabDocument.context.createComponent(id, chaincode).then((doc) => doc.bindToContext());
+        this.collabDocument.context.createDataStore(id, chaincode).then((doc) => doc.bindToContext());
         const props = {
             crefTest: {
                 layout: { inline },

--- a/components/experimental/client-ui-lib/src/controls/presenceSignal.ts
+++ b/components/experimental/client-ui-lib/src/controls/presenceSignal.ts
@@ -4,13 +4,13 @@
  */
 
 import { EventEmitter } from "events";
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 
 const presenceKey = "presence";
 
 export class PresenceSignal extends EventEmitter {
-    constructor(private readonly runtime: IComponentRuntime) {
+    constructor(private readonly runtime: IFluidDataStoreRuntime) {
         super();
         this.listenForPresence();
     }

--- a/components/experimental/codemirror/src/codemirror.ts
+++ b/components/experimental/codemirror/src/codemirror.ts
@@ -11,7 +11,7 @@ import {
     IResponse,
     IComponentHandle,
 } from "@fluidframework/component-core-interfaces";
-import { ComponentHandle, ComponentRuntime } from "@fluidframework/component-runtime";
+import { ComponentHandle, FluidDataStoreRuntime } from "@fluidframework/component-runtime";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
 import {
     MergeTreeDeltaType,
@@ -20,8 +20,8 @@ import {
     reservedTileLabelsKey,
     Marker,
 } from "@fluidframework/merge-tree";
-import { IComponentContext, IComponentFactory } from "@fluidframework/runtime-definitions";
-import { IComponentRuntime, IChannelFactory } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreContext, IComponentFactory } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreRuntime, IChannelFactory } from "@fluidframework/component-runtime-definitions";
 import { SharedString, SequenceDeltaEvent } from "@fluidframework/sequence";
 import { IComponentHTMLOptions, IComponentHTMLView } from "@fluidframework/view-interfaces";
 import CodeMirror from "codemirror";
@@ -50,7 +50,7 @@ class CodemirrorView implements IComponentHTMLView {
 
     public get IComponentHTMLView() { return this; }
 
-    constructor(private readonly text: SharedString, private readonly runtime: IComponentRuntime) {
+    constructor(private readonly text: SharedString, private readonly runtime: IFluidDataStoreRuntime) {
     }
 
     public remove(): void {
@@ -202,7 +202,7 @@ class CodemirrorView implements IComponentHTMLView {
 export class CodeMirrorComponent
     extends EventEmitter
     implements IComponentLoadable, IComponentRouter, IComponentHTMLView {
-    public static async load(runtime: IComponentRuntime, context: IComponentContext) {
+    public static async load(runtime: IFluidDataStoreRuntime, context: IFluidDataStoreContext) {
         const collection = new CodeMirrorComponent(runtime, context);
         await collection.initialize();
 
@@ -221,8 +221,8 @@ export class CodeMirrorComponent
     private readonly innerHandle: IComponentHandle<this>;
 
     constructor(
-        private readonly runtime: IComponentRuntime,
-        /* Private */ context: IComponentContext,
+        private readonly runtime: IFluidDataStoreRuntime,
+        /* Private */ context: IFluidDataStoreContext,
     ) {
         super();
         this.url = context.id;
@@ -269,7 +269,7 @@ class SmdeFactory implements IComponentFactory {
 
     public get IComponentFactory() { return this; }
 
-    public instantiateComponent(context: IComponentContext): void {
+    public instantiateComponent(context: IFluidDataStoreContext): void {
         const dataTypes = new Map<string, IChannelFactory>();
         const mapFactory = SharedMap.getFactory();
         const sequenceFactory = SharedString.getFactory();
@@ -277,7 +277,7 @@ class SmdeFactory implements IComponentFactory {
         dataTypes.set(mapFactory.type, mapFactory);
         dataTypes.set(sequenceFactory.type, sequenceFactory);
 
-        const runtime = ComponentRuntime.load(
+        const runtime = FluidDataStoreRuntime.load(
             context,
             dataTypes);
 

--- a/components/experimental/codemirror/src/index.ts
+++ b/components/experimental/codemirror/src/index.ts
@@ -38,7 +38,7 @@ class CodeMirrorFactory implements IRuntimeFactory {
                 const componentId = requestUrl
                     ? requestUrl.substr(0, trailingSlash === -1 ? requestUrl.length : trailingSlash)
                     : defaultComponentId;
-                const component = await containerRuntime.getComponentRuntime(componentId, true);
+                const component = await containerRuntime.getDataStore(componentId, true);
 
                 return component.request({ url: trailingSlash === -1 ? "" : requestUrl.substr(trailingSlash + 1) });
             },
@@ -51,7 +51,7 @@ class CodeMirrorFactory implements IRuntimeFactory {
         // On first boot create the base component
         if (!runtime.existing) {
             await Promise.all([
-                runtime.createComponent(defaultComponentId, defaultComponent).then((componentRuntime) => {
+                runtime.createDataStore(defaultComponentId, defaultComponent).then((componentRuntime) => {
                     componentRuntime.bindToContext();
                 }),
             ]);

--- a/components/experimental/codemirror/src/presence.ts
+++ b/components/experimental/codemirror/src/presence.ts
@@ -4,7 +4,7 @@
  */
 
 import { EventEmitter } from "events";
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 import CodeMirror from "codemirror";
 
@@ -31,7 +31,7 @@ class PresenceManager extends EventEmitter {
     private readonly presenceKey: string;
     private readonly presenceMap: Map<string, IPresenceInfo> = new Map();
 
-    public constructor(private readonly runtime: IComponentRuntime) {
+    public constructor(private readonly runtime: IFluidDataStoreRuntime) {
         super();
         this.presenceKey = `presence-${runtime.id}`;
 
@@ -136,7 +136,7 @@ export class CodeMirrorPresenceManager extends EventEmitter {
         return this.codeMirror.getDoc();
     }
 
-    public constructor(private readonly codeMirror: CodeMirror.EditorFromTextArea, runtime: IComponentRuntime) {
+    public constructor(private readonly codeMirror: CodeMirror.EditorFromTextArea, runtime: IFluidDataStoreRuntime) {
         super();
         this.presenceManager = new PresenceManager(runtime);
 

--- a/components/experimental/draft-js/src/FluidEditor.tsx
+++ b/components/experimental/draft-js/src/FluidEditor.tsx
@@ -4,7 +4,7 @@
  */
 
 import { SharedMap } from "@fluidframework/map";
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { SequenceDeltaEvent, SharedString } from "@fluidframework/sequence";
 import { ContentState, Editor, EditorProps, EditorState, RichUtils } from "draft-js";
 import React from "react";
@@ -29,7 +29,7 @@ import "./css/RichEditor.css";
 interface IProps extends Partial<EditorProps> {
     sharedString: SharedString;
     authors: SharedMap;
-    runtime: IComponentRuntime;
+    runtime: IFluidDataStoreRuntime;
 }
 
 interface IState {

--- a/components/experimental/draft-js/src/PresenceManager.tsx
+++ b/components/experimental/draft-js/src/PresenceManager.tsx
@@ -7,7 +7,7 @@ import React from "react";
 
 import { SharedMap } from "@fluidframework/map";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { CharacterMetadata, CompositeDecorator, ContentBlock } from "draft-js";
 import { List } from "immutable";
 
@@ -34,7 +34,7 @@ const placeholderChar = "\u200B"; // Zero width space
 export class PresenceManager {
     private readonly coauthorPositions: Map<string, Author> = new Map<string, Author>();
 
-    public constructor(private readonly authorMap: SharedMap, private readonly runtime: IComponentRuntime) { }
+    public constructor(private readonly authorMap: SharedMap, private readonly runtime: IFluidDataStoreRuntime) { }
 
     public subscribe(renderCallback: (textRangeUpdater: (range: TextRange) => TextRange) => void) {
         this.authorMap.on("op", (op: ISequencedDocumentMessage, local: boolean) => {

--- a/components/experimental/external-component-loader/src/externalComponentLoader.tsx
+++ b/components/experimental/external-component-loader/src/externalComponentLoader.tsx
@@ -10,7 +10,7 @@ import {
     IResponse,
     IComponent,
 } from "@fluidframework/component-core-interfaces";
-import { IComponentRuntimeChannel } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreChannel } from "@fluidframework/runtime-definitions";
 import { v4 as uuid } from "uuid";
 import { UrlRegistry } from "./urlRegistry";
 
@@ -44,10 +44,10 @@ export class ExternalComponentLoader extends PrimedComponent {
 
         // Calling .get() on the urlReg registry will also add it to the registry if it's not already there.
         const pkgReg = await urlReg.IComponentRegistry.get(componentUrl) as IComponent & IFluidObject;
-        let componentRuntime: IComponentRuntimeChannel;
+        let componentRuntime: IFluidDataStoreChannel;
         const id = uuid();
         if (pkgReg?.IComponentDefaultFactoryName !== undefined) {
-            componentRuntime = await this.context.containerRuntime.createComponent(
+            componentRuntime = await this.context.containerRuntime.createDataStore(
                 id,
                 [
                     ...this.context.packagePath,
@@ -56,7 +56,7 @@ export class ExternalComponentLoader extends PrimedComponent {
                     pkgReg.IComponentDefaultFactoryName.getDefaultFactoryName(),
                 ]);
         } else if (pkgReg?.IComponentFactory !== undefined) {
-            componentRuntime = await this.context.containerRuntime.createComponent(
+            componentRuntime = await this.context.containerRuntime.createDataStore(
                 id,
                 [
                     ...this.context.packagePath,

--- a/components/experimental/image-collection/src/images.ts
+++ b/components/experimental/image-collection/src/images.ts
@@ -15,7 +15,7 @@ import { ComponentHandle } from "@fluidframework/component-runtime";
 import { IComponentLayout } from "@fluidframework/framework-experimental";
 import { IComponentCollection } from "@fluidframework/framework-interfaces";
 import { ISharedDirectory, SharedDirectory } from "@fluidframework/map";
-import { IComponentContext, IComponentFactory } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreContext, IComponentFactory } from "@fluidframework/runtime-definitions";
 import { SharedComponent, SharedComponentFactory } from "@fluidframework/component-base";
 import { IComponentHTMLOptions, IComponentHTMLView } from "@fluidframework/view-interfaces";
 
@@ -63,7 +63,7 @@ export class ImageCollection extends SharedComponent<ISharedDirectory> implement
 
     public static getFactory(): IComponentFactory { return ImageCollection.factory; }
 
-    public static create(parentContext: IComponentContext, props?: any) {
+    public static create(parentContext: IFluidDataStoreContext, props?: any) {
         return ImageCollection.factory.create(parentContext, props);
     }
 

--- a/components/experimental/key-value-cache/src/index.ts
+++ b/components/experimental/key-value-cache/src/index.ts
@@ -10,7 +10,7 @@ import {
     IRequest,
     IResponse,
 } from "@fluidframework/component-core-interfaces";
-import { ComponentRuntime } from "@fluidframework/component-runtime";
+import { FluidDataStoreRuntime } from "@fluidframework/component-runtime";
 import {
     IContainerContext,
     IRuntime,
@@ -19,11 +19,11 @@ import {
 import { ContainerRuntime } from "@fluidframework/container-runtime";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
 import {
-    IComponentContext,
+    IFluidDataStoreContext,
     IComponentFactory,
 } from "@fluidframework/runtime-definitions";
 import {
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelFactory,
 } from "@fluidframework/component-runtime-definitions";
 import {
@@ -55,7 +55,7 @@ declare module "@fluidframework/component-core-interfaces" {
 }
 
 class KeyValue implements IKeyValue, IFluidObject, IComponentRouter {
-    public static async load(runtime: IComponentRuntime, context: IComponentContext) {
+    public static async load(runtime: IFluidDataStoreRuntime, context: IFluidDataStoreContext) {
         const kevValue = new KeyValue(runtime);
         await kevValue.initialize();
 
@@ -72,7 +72,7 @@ class KeyValue implements IKeyValue, IFluidObject, IComponentRouter {
         return this._root;
     }
 
-    constructor(private readonly runtime: IComponentRuntime) {
+    constructor(private readonly runtime: IFluidDataStoreRuntime) {
     }
 
     public set(key: string, value: any): void {
@@ -132,16 +132,16 @@ export class KeyValueFactoryComponent implements IRuntimeFactory, IComponentFact
             : ComponentName;
 
         const pathForComponent = trailingSlash !== -1 ? requestUrl.substr(trailingSlash) : requestUrl;
-        const component = await runtime.getComponentRuntime(componentId, true);
+        const component = await runtime.getDataStore(componentId, true);
         return component.request({ url: pathForComponent });
     }
 
-    public instantiateComponent(context: IComponentContext): void {
+    public instantiateComponent(context: IFluidDataStoreContext): void {
         const dataTypes = new Map<string, IChannelFactory>();
         const mapFactory = SharedMap.getFactory();
         dataTypes.set(mapFactory.type, mapFactory);
 
-        const runtime = ComponentRuntime.load(
+        const runtime = FluidDataStoreRuntime.load(
             context,
             dataTypes,
         );
@@ -161,7 +161,7 @@ export class KeyValueFactoryComponent implements IRuntimeFactory, IComponentFact
         );
 
         if (!runtime.existing) {
-            const created = await runtime.createComponent(ComponentName, ComponentName);
+            const created = await runtime.createDataStore(ComponentName, ComponentName);
             created.bindToContext();
         }
 

--- a/components/experimental/math/src/mathComponent.ts
+++ b/components/experimental/math/src/mathComponent.ts
@@ -27,7 +27,7 @@ import {
 } from "@fluidframework/framework-interfaces";
 import { SharedDirectory, ISharedDirectory } from "@fluidframework/map";
 import * as MergeTree from "@fluidframework/merge-tree";
-import { IComponentContext, IComponentFactory } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreContext, IComponentFactory } from "@fluidframework/runtime-definitions";
 import * as Sequence from "@fluidframework/sequence";
 import { SharedComponentFactory, SharedComponent } from "@fluidframework/component-base";
 import { IComponentHTMLOptions, IComponentHTMLView } from "@fluidframework/view-interfaces";
@@ -504,7 +504,7 @@ export class MathCollection extends SharedComponent<ISharedDirectory> implements
 
     public static getFactory(): IComponentFactory { return MathCollection.factory; }
 
-    public static create(parentContext: IComponentContext, props?: any) {
+    public static create(parentContext: IFluidDataStoreContext, props?: any) {
         return MathCollection.factory.create(parentContext, props);
     }
 

--- a/components/experimental/multiview/container/src/container.tsx
+++ b/components/experimental/multiview/container/src/container.tsx
@@ -30,7 +30,7 @@ const registryEntries = new Map([
 // Just a little helper, since we're going to create multiple coordinates.
 const createAndAttachCoordinate = async (runtime: IContainerRuntime, id: string) => {
     const simpleCoordinateComponentRuntime =
-        await runtime.createComponent(id, Coordinate.ComponentName);
+        await runtime.createDataStore(id, Coordinate.ComponentName);
     const simpleResult = await simpleCoordinateComponentRuntime.request({ url: id });
     if (simpleResult.status !== 200 || simpleResult.mimeType !== "fluid/component") {
         throw new Error("Error in creating the default option picker model.");

--- a/components/experimental/progress-bars/src/progressBars.ts
+++ b/components/experimental/progress-bars/src/progressBars.ts
@@ -12,11 +12,11 @@ import {
     IRequest,
     IResponse,
 } from "@fluidframework/component-core-interfaces";
-import { ComponentHandle, ComponentRuntime } from "@fluidframework/component-runtime";
+import { ComponentHandle, FluidDataStoreRuntime } from "@fluidframework/component-runtime";
 import { IComponentCollection } from "@fluidframework/framework-interfaces";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
-import { IComponentRuntime, IChannelFactory } from "@fluidframework/component-runtime-definitions";
-import { IComponentContext, IComponentFactory } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreRuntime, IChannelFactory } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreContext, IComponentFactory } from "@fluidframework/runtime-definitions";
 import { IComponentHTMLView } from "@fluidframework/view-interfaces";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports,import/no-internal-modules,import/no-unassigned-import
@@ -123,7 +123,7 @@ export class ProgressBar extends EventEmitter implements
 export class ProgressCollection
     extends EventEmitter
     implements IComponentLoadable, IComponentRouter, IComponentCollection {
-    public static async load(runtime: IComponentRuntime, context: IComponentContext) {
+    public static async load(runtime: IFluidDataStoreRuntime, context: IFluidDataStoreContext) {
         const collection = new ProgressCollection(runtime, context);
         await collection.initialize();
 
@@ -140,7 +140,7 @@ export class ProgressCollection
     private readonly progressBars = new Map<string, ProgressBar>();
     private root: ISharedMap;
 
-    constructor(private readonly runtime: IComponentRuntime, context: IComponentContext) {
+    constructor(private readonly runtime: IFluidDataStoreRuntime, context: IFluidDataStoreContext) {
         super();
 
         this.url = context.id;
@@ -230,12 +230,12 @@ class ProgressBarsFactory implements IComponentFactory {
 
     public get IComponentFactory() { return this; }
 
-    public instantiateComponent(context: IComponentContext): void {
+    public instantiateComponent(context: IFluidDataStoreContext): void {
         const dataTypes = new Map<string, IChannelFactory>();
         const mapFactory = SharedMap.getFactory();
         dataTypes.set(mapFactory.type, mapFactory);
 
-        const runtime = ComponentRuntime.load(
+        const runtime = FluidDataStoreRuntime.load(
             context,
             dataTypes,
         );

--- a/components/experimental/prosemirror/src/index.ts
+++ b/components/experimental/prosemirror/src/index.ts
@@ -39,7 +39,7 @@ class ProseMirrorFactory implements IRuntimeFactory {
                 const componentId = requestUrl
                     ? requestUrl.substr(0, trailingSlash === -1 ? requestUrl.length : trailingSlash)
                     : defaultComponentId;
-                const component = await containerRuntime.getComponentRuntime(componentId, true);
+                const component = await containerRuntime.getDataStore(componentId, true);
 
                 return component.request({ url: trailingSlash === -1 ? "" : requestUrl.substr(trailingSlash + 1) });
             },
@@ -51,7 +51,7 @@ class ProseMirrorFactory implements IRuntimeFactory {
         // On first boot create the base component
         if (!runtime.existing) {
             await Promise.all([
-                runtime.createComponent(defaultComponentId, defaultComponent).then((componentRuntime) => {
+                runtime.createDataStore(defaultComponentId, defaultComponent).then((componentRuntime) => {
                     componentRuntime.bindToContext();
                 }),
             ]);

--- a/components/experimental/prosemirror/src/prosemirror.ts
+++ b/components/experimental/prosemirror/src/prosemirror.ts
@@ -11,7 +11,7 @@ import {
     IResponse,
     IComponentHandle,
 } from "@fluidframework/component-core-interfaces";
-import { ComponentHandle, ComponentRuntime } from "@fluidframework/component-runtime";
+import { ComponentHandle, FluidDataStoreRuntime } from "@fluidframework/component-runtime";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
 import {
     IMergeTreeInsertMsg,
@@ -20,8 +20,8 @@ import {
     MergeTreeDeltaType,
     createMap,
 } from "@fluidframework/merge-tree";
-import { IComponentContext, IComponentFactory } from "@fluidframework/runtime-definitions";
-import { IComponentRuntime, IChannelFactory } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreContext, IComponentFactory } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreRuntime, IChannelFactory } from "@fluidframework/component-runtime-definitions";
 import { SharedString } from "@fluidframework/sequence";
 import { IComponentHTMLOptions, IComponentHTMLView } from "@fluidframework/view-interfaces";
 import { EditorView } from "prosemirror-view";
@@ -99,7 +99,7 @@ class ProseMirrorView implements IComponentHTMLView {
  */
 export class ProseMirror extends EventEmitter
     implements IComponentLoadable, IComponentRouter, IComponentHTMLView, IProvideRichTextEditor {
-    public static async load(runtime: IComponentRuntime, context: IComponentContext) {
+    public static async load(runtime: IFluidDataStoreRuntime, context: IFluidDataStoreContext) {
         const collection = new ProseMirror(runtime, context);
         await collection.initialize();
 
@@ -121,8 +121,8 @@ export class ProseMirror extends EventEmitter
     private readonly innerHandle: IComponentHandle<this>;
 
     constructor(
-        private readonly runtime: IComponentRuntime,
-        /* Private */ context: IComponentContext,
+        private readonly runtime: IFluidDataStoreRuntime,
+        /* Private */ context: IFluidDataStoreContext,
     ) {
         super();
 
@@ -175,7 +175,7 @@ class ProseMirrorFactory implements IComponentFactory {
 
     public get IComponentFactory() { return this; }
 
-    public instantiateComponent(context: IComponentContext): void {
+    public instantiateComponent(context: IFluidDataStoreContext): void {
         const dataTypes = new Map<string, IChannelFactory>();
         const mapFactory = SharedMap.getFactory();
         const sequenceFactory = SharedString.getFactory();
@@ -183,7 +183,7 @@ class ProseMirrorFactory implements IComponentFactory {
         dataTypes.set(mapFactory.type, mapFactory);
         dataTypes.set(sequenceFactory.type, sequenceFactory);
 
-        const runtime = ComponentRuntime.load(
+        const runtime = FluidDataStoreRuntime.load(
             context,
             dataTypes,
         );

--- a/components/experimental/scribe/src/scribe.ts
+++ b/components/experimental/scribe/src/scribe.ts
@@ -12,7 +12,7 @@ import {
     IResponse,
     IComponentHandle,
 } from "@fluidframework/component-core-interfaces";
-import { ComponentRuntime, ComponentHandle } from "@fluidframework/component-runtime";
+import { FluidDataStoreRuntime, ComponentHandle } from "@fluidframework/component-runtime";
 import {
     IContainerContext,
     IFluidCodeDetails,
@@ -23,11 +23,11 @@ import { ContainerRuntime } from "@fluidframework/container-runtime";
 import { IDocumentFactory } from "@fluidframework/host-service-interfaces";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
 import {
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelFactory,
 } from "@fluidframework/component-runtime-definitions";
 import {
-    IComponentContext,
+    IFluidDataStoreContext,
     IComponentFactory,
 } from "@fluidframework/runtime-definitions";
 import {
@@ -162,8 +162,8 @@ function addLink(element: HTMLDivElement, link: string) {
 
 function initialize(
     div: HTMLDivElement,
-    context: IComponentContext,
-    runtime: IComponentRuntime,
+    context: IFluidDataStoreContext,
+    runtime: IFluidDataStoreRuntime,
     root: ISharedMap,
     template: string,
     speed: number,
@@ -382,7 +382,7 @@ const html =
 export class Scribe
     extends EventEmitter
     implements IComponentLoadable, IComponentRouter, IComponentHTMLView {
-    public static async load(runtime: IComponentRuntime, context: IComponentContext) {
+    public static async load(runtime: IFluidDataStoreRuntime, context: IFluidDataStoreContext) {
         const collection = new Scribe(runtime, context);
         await collection.initialize();
 
@@ -402,7 +402,7 @@ export class Scribe
     private root: ISharedMap;
     private div: HTMLDivElement;
 
-    constructor(private readonly runtime: IComponentRuntime, private readonly context: IComponentContext) {
+    constructor(private readonly runtime: IFluidDataStoreRuntime, private readonly context: IFluidDataStoreContext) {
         super();
 
         this.url = context.id;
@@ -478,7 +478,7 @@ class ScribeFactory implements IComponentFactory, IRuntimeFactory {
                 const componentId = requestUrl
                     ? requestUrl.substr(0, trailingSlash === -1 ? requestUrl.length : trailingSlash)
                     : defaultComponentId;
-                const component = await containerRuntime.getComponentRuntime(componentId, true);
+                const component = await containerRuntime.getDataStore(componentId, true);
 
                 return component.request({ url: trailingSlash === -1 ? "" : requestUrl.substr(trailingSlash + 1) });
             },
@@ -487,7 +487,7 @@ class ScribeFactory implements IComponentFactory, IRuntimeFactory {
         // On first boot create the base component
         if (!runtime.existing) {
             await Promise.all([
-                runtime.createComponent(defaultComponentId, ScribeFactory.type).then((componentRuntime) => {
+                runtime.createDataStore(defaultComponentId, ScribeFactory.type).then((componentRuntime) => {
                     componentRuntime.bindToContext();
                 }),
             ]);
@@ -496,12 +496,12 @@ class ScribeFactory implements IComponentFactory, IRuntimeFactory {
         return runtime;
     }
 
-    public instantiateComponent(context: IComponentContext): void {
+    public instantiateComponent(context: IFluidDataStoreContext): void {
         const dataTypes = new Map<string, IChannelFactory>();
         const mapFactory = SharedMap.getFactory();
         dataTypes.set(mapFactory.type, mapFactory);
 
-        const runtime = ComponentRuntime.load(
+        const runtime = FluidDataStoreRuntime.load(
             context,
             dataTypes,
         );

--- a/components/experimental/scribe/src/tools-core/author.ts
+++ b/components/experimental/scribe/src/tools-core/author.ts
@@ -9,7 +9,7 @@ import { ILoader } from "@fluidframework/container-definitions";
 import { ISharedMap } from "@fluidframework/map";
 import * as MergeTree from "@fluidframework/merge-tree";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { ISharedString } from "@fluidframework/sequence";
 // eslint-disable-next-line import/no-internal-modules
 import queue from "async/queue";
@@ -97,7 +97,7 @@ export declare type QueueCallback = (metrics: IScribeMetrics, author: IAuthor) =
 export async function typeFile(
     loader: ILoader,
     urlBase: string,
-    runtime: IComponentRuntime,
+    runtime: IFluidDataStoreRuntime,
     ss: ISharedString,
     chunkMap: ISharedMap,
     fileText: string,
@@ -236,7 +236,7 @@ export async function typeFile(
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export async function typeChunk(
     a: IAuthor,
-    runtime: IComponentRuntime,
+    runtime: IFluidDataStoreRuntime,
     chunkKey: string,
     chunk: string,
     intervalTime: number,

--- a/components/experimental/scribe/src/tools-core/scribe.ts
+++ b/components/experimental/scribe/src/tools-core/scribe.ts
@@ -9,7 +9,7 @@ import { IComponent } from "@fluidframework/component-core-interfaces";
 import { ILoader } from "@fluidframework/container-definitions";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
 import * as MergeTree from "@fluidframework/merge-tree";
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { ISharedString } from "@fluidframework/sequence";
 import * as author from "./author";
 
@@ -35,7 +35,7 @@ async function conductor(
     loader: ILoader,
     url: string,
     scribeMap: ISharedMap,
-    runtime: IComponentRuntime,
+    runtime: IFluidDataStoreRuntime,
     text,
     intervalTime,
     writers,
@@ -93,7 +93,7 @@ export async function type(
     loader: ILoader,
     urlBase: string,
     scribeMap: ISharedMap,
-    runtime: IComponentRuntime,
+    runtime: IFluidDataStoreRuntime,
     intervalTime: number,
     text: string,
     writers: number,

--- a/components/experimental/shared-text/src/document.ts
+++ b/components/experimental/shared-text/src/document.ts
@@ -4,7 +4,7 @@
  */
 
 import { ISharedMap, SharedMap } from "@fluidframework/map";
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { SharedString } from "@fluidframework/sequence";
 
 const rootMapId = "root";
@@ -13,7 +13,7 @@ const rootMapId = "root";
  * A document is a collection of collaborative types.
  */
 export class Document {
-    public static async load(runtime: IComponentRuntime): Promise<Document> {
+    public static async load(runtime: IFluidDataStoreRuntime): Promise<Document> {
         let root: ISharedMap;
 
         if (!runtime.existing) {
@@ -38,7 +38,7 @@ export class Document {
     /**
      * Constructs a new document from the provided details
      */
-    private constructor(public runtime: IComponentRuntime, private readonly root: ISharedMap) {
+    private constructor(public runtime: IFluidDataStoreRuntime, private readonly root: ISharedMap) {
     }
 
     public getRoot(): ISharedMap {

--- a/components/experimental/shared-text/src/index.ts
+++ b/components/experimental/shared-text/src/index.ts
@@ -12,7 +12,7 @@ import { IContainerContext, IRuntime, IRuntimeFactory } from "@fluidframework/co
 import { ContainerRuntime } from "@fluidframework/container-runtime";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import {
-    IComponentContext,
+    IFluidDataStoreContext,
     IComponentFactory,
     IComponentRegistry,
     NamedComponentRegistryEntries,
@@ -106,7 +106,7 @@ class SharedTextFactoryComponent implements IComponentFactory, IRuntimeFactory {
         const componentId = requestUrl
             ? requestUrl.substr(0, trailingSlash === -1 ? requestUrl.length : trailingSlash)
             : "text";
-        const component = await runtime.getComponentRuntime(componentId, true);
+        const component = await runtime.getDataStore(componentId, true);
 
         return component.request(
             {
@@ -115,7 +115,7 @@ class SharedTextFactoryComponent implements IComponentFactory, IRuntimeFactory {
             });
     }
 
-    public instantiateComponent(context: IComponentContext): void {
+    public instantiateComponent(context: IFluidDataStoreContext): void {
         return sharedTextComponent.instantiateComponent(context);
     }
 
@@ -138,7 +138,7 @@ class SharedTextFactoryComponent implements IComponentFactory, IRuntimeFactory {
         // On first boot create the base component
         if (!runtime.existing) {
             await Promise.all([
-                runtime.createComponent(DefaultComponentName, SharedTextFactoryComponent.type)
+                runtime.createDataStore(DefaultComponentName, SharedTextFactoryComponent.type)
                     .then((componentRuntime) => componentRuntime.bindToContext()),
             ]);
         }

--- a/components/experimental/smde/src/index.ts
+++ b/components/experimental/smde/src/index.ts
@@ -38,7 +38,7 @@ class SmdeContainerFactory implements IRuntimeFactory {
                 const componentId = requestUrl
                     ? requestUrl.substr(0, trailingSlash === -1 ? requestUrl.length : trailingSlash)
                     : defaultComponentId;
-                const component = await containerRuntime.getComponentRuntime(componentId, true);
+                const component = await containerRuntime.getDataStore(componentId, true);
 
                 return component.request({ url: trailingSlash === -1 ? "" : requestUrl.substr(trailingSlash + 1) });
             },
@@ -50,7 +50,7 @@ class SmdeContainerFactory implements IRuntimeFactory {
         // On first boot create the base component
         if (!runtime.existing) {
             await Promise.all([
-                runtime.createComponent(defaultComponentId, defaultComponent).then((componentRuntime) => {
+                runtime.createDataStore(defaultComponentId, defaultComponent).then((componentRuntime) => {
                     componentRuntime.bindToContext();
                 }),
             ]);

--- a/components/experimental/smde/src/smde.ts
+++ b/components/experimental/smde/src/smde.ts
@@ -14,7 +14,7 @@ import {
     IComponentHandle,
     IComponent,
 } from "@fluidframework/component-core-interfaces";
-import { ComponentRuntime, ComponentHandle } from "@fluidframework/component-runtime";
+import { FluidDataStoreRuntime, ComponentHandle } from "@fluidframework/component-runtime";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
 import {
     MergeTreeDeltaType,
@@ -23,8 +23,8 @@ import {
     reservedTileLabelsKey,
     Marker,
 } from "@fluidframework/merge-tree";
-import { IComponentContext, IComponentFactory } from "@fluidframework/runtime-definitions";
-import { IComponentRuntime, IChannelFactory } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreContext, IComponentFactory } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreRuntime, IChannelFactory } from "@fluidframework/component-runtime-definitions";
 import { SharedString } from "@fluidframework/sequence";
 import { IComponentHTMLOptions, IComponentHTMLView } from "@fluidframework/view-interfaces";
 import SimpleMDE from "simplemde";
@@ -37,7 +37,7 @@ export class Smde extends EventEmitter implements
     IComponentLoadable,
     IComponentRouter,
     IComponentHTMLView {
-    public static async load(runtime: IComponentRuntime, context: IComponentContext) {
+    public static async load(runtime: IFluidDataStoreRuntime, context: IFluidDataStoreContext) {
         const collection = new Smde(runtime, context);
         await collection.initialize();
 
@@ -63,7 +63,7 @@ export class Smde extends EventEmitter implements
         assert(this._text);
         return this._text;
     }
-    constructor(private readonly runtime: IComponentRuntime, private readonly context: IComponentContext) {
+    constructor(private readonly runtime: IFluidDataStoreRuntime, private readonly context: IFluidDataStoreContext) {
         super();
 
         this.url = context.id;
@@ -219,7 +219,7 @@ class SmdeFactory implements IComponentFactory {
 
     public get IComponentFactory() { return this; }
 
-    public instantiateComponent(context: IComponentContext): void {
+    public instantiateComponent(context: IFluidDataStoreContext): void {
         const dataTypes = new Map<string, IChannelFactory>();
         const mapFactory = SharedMap.getFactory();
         const sequenceFactory = SharedString.getFactory();
@@ -227,7 +227,7 @@ class SmdeFactory implements IComponentFactory {
         dataTypes.set(mapFactory.type, mapFactory);
         dataTypes.set(sequenceFactory.type, sequenceFactory);
 
-        const runtime = ComponentRuntime.load(
+        const runtime = FluidDataStoreRuntime.load(
             context,
             dataTypes,
         );

--- a/components/experimental/table-document/src/document.ts
+++ b/components/experimental/table-document/src/document.ts
@@ -76,7 +76,7 @@ export class TableDocument extends PrimedComponent<{}, {}, ITableDocumentEvents>
         minCol: number,
         maxRow: number,
         maxCol: number): Promise<ITable> {
-        const component = await TableSlice.getFactory().createComponent(
+        const component = await TableSlice.getFactory().createDataStore(
             this.context,
             { docId: this.runtime.id, name, minRow, minCol, maxRow, maxCol },
         ) as TableSlice;

--- a/components/experimental/table-document/src/interception/tableWithInterception.ts
+++ b/components/experimental/table-document/src/interception/tableWithInterception.ts
@@ -5,7 +5,7 @@
 
 import assert from "assert";
 import { PropertySet } from "@fluidframework/merge-tree";
-import { IComponentContext } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 import { ITable, TableDocumentItem } from "../table";
 import { TableDocument } from "../document";
 
@@ -20,14 +20,14 @@ import { TableDocument } from "../document";
  *   createTableWithInterception on the created TableSlice object.
  *
  * @param table - The underlying ITable object
- * @param context - The IComponentContext that will be used to call orderSequentially
+ * @param context - The IFluidDataStoreContext that will be used to call orderSequentially
  * @param propertyInterceptionCallback - The interception callback to be called
  *
  * @returns A new ITable object that intercepts the methods modifying the properties of cells, rows or columns.
  */
 export function createTableWithInterception<T extends ITable>(
     table: T,
-    context: IComponentContext,
+    context: IFluidDataStoreContext,
     propertyInterceptionCallback: (props?: PropertySet) => PropertySet): T {
     const tableWithInterception = Object.create(table);
 

--- a/components/experimental/table-document/src/test/tableWithInterception.spec.ts
+++ b/components/experimental/table-document/src/test/tableWithInterception.spec.ts
@@ -6,7 +6,7 @@
 import assert from "assert";
 import { ContainerRuntimeFactoryWithDefaultComponent } from "@fluidframework/aqueduct";
 import { PropertySet } from "@fluidframework/merge-tree";
-import { IComponentContext } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 import { LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { createLocalLoader, initializeLocalContainer } from "@fluidframework/test-utils";
 import { ITable } from "../table";
@@ -24,7 +24,7 @@ describe("Table Document with Interception", () => {
 
         const userAttributes = { userId: "Fake User" };
         let tableDocument: TableDocument;
-        let componentContext: IComponentContext;
+        let componentContext: IFluidDataStoreContext;
 
         // Sample interface used for storing the details of a cell.
         interface ICellType {
@@ -82,7 +82,7 @@ describe("Table Document with Interception", () => {
             tableDocument = response.value;
 
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            componentContext = { containerRuntime: { orderSequentially } } as IComponentContext;
+            componentContext = { containerRuntime: { orderSequentially } } as IFluidDataStoreContext;
         });
 
         it("should be able to intercept TableDocument methods by the interception", async () => {

--- a/components/experimental/table-view/src/tableview.ts
+++ b/components/experimental/table-view/src/tableview.ts
@@ -92,7 +92,7 @@ export class TableView extends PrimedComponent implements IComponentHTMLView {
 
     protected async componentInitializingFirstTime() {
         // Set up internal table doc
-        const doc = await TableDocument.getFactory().createComponent(this.context) as TableDocument;
+        const doc = await TableDocument.getFactory().createDataStore(this.context) as TableDocument;
         this.root.set(innerDocKey, doc.handle);
         doc.insertRows(0, 5);
         doc.insertCols(0, 8);

--- a/components/experimental/todo/src/Todo/Todo.tsx
+++ b/components/experimental/todo/src/Todo/Todo.tsx
@@ -82,7 +82,7 @@ export class Todo extends PrimedComponent implements IComponentHTMLView {
 
     public async addTodoItemComponent(props?: ITodoItemInitialState) {
         // Create a new todo item
-        const component = await TodoItem.getFactory().createComponent(this.context, props);
+        const component = await TodoItem.getFactory().createDataStore(this.context, props);
 
         // Store the id of the component in our ids map so we can reference it later
         this.todoItemsMap.set(component.url, component.handle);

--- a/components/experimental/todo/src/TodoItem/TodoItem.tsx
+++ b/components/experimental/todo/src/TodoItem/TodoItem.tsx
@@ -173,19 +173,19 @@ export class TodoItem extends PrimedComponent<{}, ITodoItemInitialState> impleme
         let component: IComponentLoadable;
         switch (type) {
             case "todo":
-                component = await TodoItem.getFactory().createComponent(
+                component = await TodoItem.getFactory().createDataStore(
                     this.context,
                     { startingText: type },
                 );
                 break;
             case "clicker":
-                component = await ClickerInstantiationFactory.createComponent(this.context);
+                component = await ClickerInstantiationFactory.createDataStore(this.context);
                 break;
             case "textBox":
-                component = await TextBoxInstantiationFactory.createComponent(this.context, type);
+                component = await TextBoxInstantiationFactory.createDataStore(this.context, type);
                 break;
             case "textList":
-                component = await TextListInstantiationFactory.createComponent(this.context);
+                component = await TextListInstantiationFactory.createDataStore(this.context);
                 break;
             default:
         }

--- a/components/experimental/video-players/src/videoPlayers.ts
+++ b/components/experimental/video-players/src/videoPlayers.ts
@@ -15,7 +15,7 @@ import { ComponentHandle } from "@fluidframework/component-runtime";
 import { IComponentLayout } from "@fluidframework/framework-experimental";
 import { IComponentCollection } from "@fluidframework/framework-interfaces";
 import { SharedDirectory, ISharedDirectory } from "@fluidframework/map";
-import { IComponentContext, IComponentFactory } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreContext, IComponentFactory } from "@fluidframework/runtime-definitions";
 import { SharedComponent, SharedComponentFactory } from "@fluidframework/component-base";
 import { IComponentHTMLView } from "@fluidframework/view-interfaces";
 
@@ -157,7 +157,7 @@ export class VideoPlayerCollection extends SharedComponent<ISharedDirectory> imp
 
     public static getFactory(): IComponentFactory { return VideoPlayerCollection.factory; }
 
-    public static create(parentContext: IComponentContext, props?: any) {
+    public static create(parentContext: IFluidDataStoreContext, props?: any) {
         return VideoPlayerCollection.factory.create(parentContext, props);
     }
 

--- a/components/experimental/vltava/src/components/vltava/dataModel.ts
+++ b/components/experimental/vltava/src/components/vltava/dataModel.ts
@@ -7,8 +7,8 @@ import { EventEmitter } from "events";
 
 import { IFluidObject, IComponentHandle } from "@fluidframework/component-core-interfaces";
 import { IComponentLastEditedTracker } from "@fluidframework/last-edited-experimental";
-import { IComponentContext } from "@fluidframework/runtime-definitions";
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { ISharedDirectory } from "@fluidframework/map";
 import { IQuorum, ISequencedClient } from "@fluidframework/protocol-definitions";
 
@@ -41,8 +41,8 @@ export class VltavaDataModel extends EventEmitter implements IVltavaDataModel {
 
     constructor(
         private readonly root: ISharedDirectory,
-        private readonly context: IComponentContext,
-        runtime: IComponentRuntime,
+        private readonly context: IFluidDataStoreContext,
+        runtime: IFluidDataStoreRuntime,
     ) {
         super();
 

--- a/components/experimental/vltava/src/containerServices/match-maker/matchMaker.ts
+++ b/components/experimental/vltava/src/containerServices/match-maker/matchMaker.ts
@@ -13,24 +13,25 @@ import {
     IComponentDiscoverInterfaces,
     IComponentDiscoverableInterfaces,
 } from "@fluidframework/framework-interfaces";
-import { IComponentContext } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 
 export const MatchMakerContainerServiceId = "matchMaker";
 
-const getMatchMakerContainerService = async (context: IComponentContext): Promise<IComponentInterfacesRegistry> => {
-    const response = await context.containerRuntime.request({
-        url: `/${serviceRoutePathRoot}/${MatchMakerContainerServiceId}`,
-    });
-    if (response.status === 200 && response.mimeType === "fluid/component") {
-        const value = response.value as IFluidObject;
-        const matchMaker = value.IComponentInterfacesRegistry;
-        if (matchMaker) {
-            return matchMaker;
+const getMatchMakerContainerService =
+    async (context: IFluidDataStoreContext): Promise<IComponentInterfacesRegistry> => {
+        const response = await context.containerRuntime.request({
+            url: `/${serviceRoutePathRoot}/${MatchMakerContainerServiceId}`,
+        });
+        if (response.status === 200 && response.mimeType === "fluid/component") {
+            const value = response.value as IFluidObject;
+            const matchMaker = value.IComponentInterfacesRegistry;
+            if (matchMaker) {
+                return matchMaker;
+            }
         }
-    }
 
-    throw new Error("MatchMaker Container Service not registered");
-};
+        throw new Error("MatchMaker Container Service not registered");
+    };
 
 /**
  * Helper function for registering with the MatchMaker. Manages getting the MatchMaker from the Container before
@@ -40,7 +41,7 @@ const getMatchMakerContainerService = async (context: IComponentContext): Promis
  * @param component - Discover/Discoverable instance
  */
 export const registerWithMatchMaker = async (
-    context: IComponentContext,
+    context: IFluidDataStoreContext,
     component: IProvideComponentDiscoverInterfaces | IProvideComponentDiscoverableInterfaces,
 ): Promise<void> => {
     const matchMaker = await getMatchMakerContainerService(context);
@@ -55,7 +56,7 @@ export const registerWithMatchMaker = async (
  * @param component - Discover/Discoverable instance
  */
 export const unregisterWithMatchMaker = async (
-    context: IComponentContext,
+    context: IFluidDataStoreContext,
     component: IProvideComponentDiscoverInterfaces | IProvideComponentDiscoverableInterfaces,
 ): Promise<void> => {
     const matchMaker = await getMatchMakerContainerService(context);

--- a/components/experimental/webflow/src/document/index.ts
+++ b/components/experimental/webflow/src/document/index.ts
@@ -23,7 +23,7 @@ import {
     reservedTileLabelsKey,
     TextSegment,
 } from "@fluidframework/merge-tree";
-import { IComponentContext, IComponentFactory } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreContext, IComponentFactory } from "@fluidframework/runtime-definitions";
 import {
     SharedString,
     SharedStringSegment,
@@ -139,7 +139,7 @@ export class FlowDocument extends SharedComponent<ISharedDirectory, IFlowDocumen
 
     public static getFactory(): IComponentFactory { return FlowDocument.factory; }
 
-    public static create(parentContext: IComponentContext, props?: any) {
+    public static create(parentContext: IFluidDataStoreContext, props?: any) {
         return FlowDocument.factory.create(parentContext, props);
     }
 

--- a/components/experimental/webflow/src/host/index.ts
+++ b/components/experimental/webflow/src/host/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { IComponentHandle } from "@fluidframework/component-core-interfaces";
-import { IComponentContext, IComponentFactory } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreContext, IComponentFactory } from "@fluidframework/runtime-definitions";
 import { SharedComponentFactory, SharedComponent } from "@fluidframework/component-base";
 import { ISharedDirectory, SharedDirectory } from "@fluidframework/map";
 import { IComponentHTMLView } from "@fluidframework/view-interfaces";
@@ -23,7 +23,7 @@ export class WebFlow extends SharedComponent<ISharedDirectory> implements ICompo
 
     public static getFactory(): IComponentFactory { return WebFlow.factory; }
 
-    public static create(parentContext: IComponentContext, props?: any) {
+    public static create(parentContext: IFluidDataStoreContext, props?: any) {
         return WebFlow.factory.create(parentContext, props);
     }
 

--- a/packages/dds/cell/src/cell.ts
+++ b/packages/dds/cell/src/cell.ts
@@ -15,7 +15,7 @@ import {
 } from "@fluidframework/protocol-definitions";
 import {
     IChannelAttributes,
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelStorageService,
     IChannelFactory,
 } from "@fluidframework/component-runtime-definitions";
@@ -59,7 +59,7 @@ export class SharedCell extends SharedObject<ISharedCellEvents> implements IShar
      * @param id - optional name of the shared map
      * @returns newly create shared map (but not attached yet)
      */
-    public static create(runtime: IComponentRuntime, id?: string) {
+    public static create(runtime: IFluidDataStoreRuntime, id?: string) {
         return runtime.createChannel(id, CellFactory.Type) as SharedCell;
     }
 
@@ -95,7 +95,7 @@ export class SharedCell extends SharedObject<ISharedCellEvents> implements IShar
      * @param runtime - component runtime the shared map belongs to
      * @param id - optional name of the shared map
      */
-    constructor(id: string, runtime: IComponentRuntime, attributes: IChannelAttributes) {
+    constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes) {
         super(id, runtime, attributes);
     }
 

--- a/packages/dds/cell/src/cellFactory.ts
+++ b/packages/dds/cell/src/cellFactory.ts
@@ -5,7 +5,7 @@
 
 import {
     IChannelAttributes,
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelServices,
     IChannelFactory,
 } from "@fluidframework/component-runtime-definitions";
@@ -34,7 +34,7 @@ export class CellFactory implements IChannelFactory {
     }
 
     public async load(
-        runtime: IComponentRuntime,
+        runtime: IFluidDataStoreRuntime,
         id: string,
         services: IChannelServices,
         branchId: string,
@@ -44,7 +44,7 @@ export class CellFactory implements IChannelFactory {
         return cell;
     }
 
-    public create(document: IComponentRuntime, id: string): ISharedCell {
+    public create(document: IFluidDataStoreRuntime, id: string): ISharedCell {
         const cell = new SharedCell(id, document, this.attributes);
         cell.initializeLocal();
         return cell;

--- a/packages/dds/counter/src/counter.ts
+++ b/packages/dds/counter/src/counter.ts
@@ -12,7 +12,7 @@ import {
     TreeEntry,
 } from "@fluidframework/protocol-definitions";
 import {
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelStorageService,
     IChannelFactory,
 } from "@fluidframework/component-runtime-definitions";
@@ -50,7 +50,7 @@ export class SharedCounter extends SharedObject<ISharedCounterEvents> implements
      * @param id - optional name of the shared counter
      * @returns newly create shared counter (but not attached yet)
      */
-    public static create(runtime: IComponentRuntime, id?: string) {
+    public static create(runtime: IFluidDataStoreRuntime, id?: string) {
         return runtime.createChannel(id, CounterFactory.Type) as SharedCounter;
     }
 

--- a/packages/dds/counter/src/counterFactory.ts
+++ b/packages/dds/counter/src/counterFactory.ts
@@ -5,7 +5,7 @@
 
 import {
     IChannelAttributes,
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelServices,
     IChannelFactory,
 } from "@fluidframework/component-runtime-definitions";
@@ -34,7 +34,7 @@ export class CounterFactory implements IChannelFactory {
     }
 
     public async load(
-        runtime: IComponentRuntime,
+        runtime: IFluidDataStoreRuntime,
         id: string,
         services: IChannelServices,
         branchId: string,
@@ -44,7 +44,7 @@ export class CounterFactory implements IChannelFactory {
         return counter;
     }
 
-    public create(document: IComponentRuntime, id: string): ISharedCounter {
+    public create(document: IFluidDataStoreRuntime, id: string): ISharedCounter {
         const counter = new SharedCounter(id, document, this.attributes);
         counter.initializeLocal();
         return counter;

--- a/packages/dds/ink/src/ink.ts
+++ b/packages/dds/ink/src/ink.ts
@@ -12,7 +12,7 @@ import {
     TreeEntry,
 } from "@fluidframework/protocol-definitions";
 import {
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelStorageService,
     IChannelAttributes,
 } from "@fluidframework/component-runtime-definitions";
@@ -48,7 +48,7 @@ export class Ink extends SharedObject<IInkEvents> implements IInk {
      * @param id - Optional name of the Ink; will be assigned a unique ID if not provided
      * @returns Newly create Ink object (but not attached yet)
      */
-    public static create(runtime: IComponentRuntime, id?: string) {
+    public static create(runtime: IFluidDataStoreRuntime, id?: string) {
         return runtime.createChannel(id, InkFactory.Type) as Ink;
     }
 
@@ -70,7 +70,7 @@ export class Ink extends SharedObject<IInkEvents> implements IInk {
      * @param runtime - The runtime the Ink will be associated with
      * @param id - Unique ID for the Ink
      */
-    constructor(runtime: IComponentRuntime, id: string, attributes: IChannelAttributes) {
+    constructor(runtime: IFluidDataStoreRuntime, id: string, attributes: IChannelAttributes) {
         super(id, runtime, attributes);
     }
 

--- a/packages/dds/ink/src/inkFactory.ts
+++ b/packages/dds/ink/src/inkFactory.ts
@@ -5,7 +5,7 @@
 
 import {
     IChannelAttributes,
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelServices,
     IChannelFactory,
 } from "@fluidframework/component-runtime-definitions";
@@ -50,7 +50,7 @@ export class InkFactory implements IChannelFactory {
      * {@inheritDoc @fluidframework/shared-object-base#IChannelFactory.load}
      */
     public async load(
-        runtime: IComponentRuntime,
+        runtime: IFluidDataStoreRuntime,
         id: string,
         services: IChannelServices,
         branchId: string,
@@ -64,7 +64,7 @@ export class InkFactory implements IChannelFactory {
     /**
      * {@inheritDoc @fluidframework/shared-object-base#IChannelFactory.create}
      */
-    public create(runtime: IComponentRuntime, id: string): ISharedObject {
+    public create(runtime: IFluidDataStoreRuntime, id: string): ISharedObject {
         const ink = new Ink(runtime, id, InkFactory.Attributes);
         ink.initializeLocal();
 

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -14,7 +14,7 @@ import {
 } from "@fluidframework/protocol-definitions";
 import {
     IChannelAttributes,
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelStorageService,
     IChannelServices,
     IChannelFactory,
@@ -332,7 +332,7 @@ export class DirectoryFactory {
      * {@inheritDoc @fluidframework/shared-object-base#IChannelFactory.load}
      */
     public async load(
-        runtime: IComponentRuntime,
+        runtime: IFluidDataStoreRuntime,
         id: string,
         services: IChannelServices,
         branchId: string,
@@ -346,7 +346,7 @@ export class DirectoryFactory {
     /**
      * {@inheritDoc @fluidframework/shared-object-base#IChannelFactory.create}
      */
-    public create(runtime: IComponentRuntime, id: string): ISharedDirectory {
+    public create(runtime: IFluidDataStoreRuntime, id: string): ISharedDirectory {
         const directory = new SharedDirectory(id, runtime, DirectoryFactory.Attributes);
         directory.initializeLocal();
 
@@ -376,7 +376,7 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
      * @param id - Optional name of the shared directory
      * @returns Newly create shared directory (but not attached yet)
      */
-    public static create(runtime: IComponentRuntime, id?: string): SharedDirectory {
+    public static create(runtime: IFluidDataStoreRuntime, id?: string): SharedDirectory {
         return runtime.createChannel(id, DirectoryFactory.Type) as SharedDirectory;
     }
 
@@ -425,7 +425,7 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
      */
     constructor(
         id: string,
-        runtime: IComponentRuntime,
+        runtime: IFluidDataStoreRuntime,
         attributes: IChannelAttributes,
     ) {
         super(id, runtime, attributes);
@@ -959,7 +959,7 @@ class SubDirectory implements IDirectory {
      */
     constructor(
         private readonly directory: SharedDirectory,
-        private readonly runtime: IComponentRuntime,
+        private readonly runtime: IFluidDataStoreRuntime,
         public readonly absolutePath: string) {
     }
 

--- a/packages/dds/map/src/localValues.ts
+++ b/packages/dds/map/src/localValues.ts
@@ -9,7 +9,7 @@ import {
     IComponentSerializer,
     ISerializedHandle,
 } from "@fluidframework/component-core-interfaces";
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import {
     ISharedObject,
     parseHandles,
@@ -213,7 +213,7 @@ export class LocalValueMaker {
      * Create a new LocalValueMaker.
      * @param runtime - The runtime this maker will be associated with
      */
-    constructor(private readonly runtime: IComponentRuntime) {
+    constructor(private readonly runtime: IFluidDataStoreRuntime) {
     }
 
     /**

--- a/packages/dds/map/src/map.ts
+++ b/packages/dds/map/src/map.ts
@@ -12,7 +12,7 @@ import {
 } from "@fluidframework/protocol-definitions";
 import {
     IChannelAttributes,
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelStorageService,
     IChannelServices,
     IChannelFactory,
@@ -75,7 +75,7 @@ export class MapFactory implements IChannelFactory {
    * {@inheritDoc @fluidframework/shared-object-base#IChannelFactory.load}
    */
     public async load(
-        runtime: IComponentRuntime,
+        runtime: IFluidDataStoreRuntime,
         id: string,
         services: IChannelServices,
         branchId: string,
@@ -89,7 +89,7 @@ export class MapFactory implements IChannelFactory {
     /**
    * {@inheritDoc @fluidframework/shared-object-base#IChannelFactory.create}
    */
-    public create(runtime: IComponentRuntime, id: string): ISharedMap {
+    public create(runtime: IFluidDataStoreRuntime, id: string): ISharedMap {
         const map = new SharedMap(id, runtime, MapFactory.Attributes);
         map.initializeLocal();
 
@@ -107,7 +107,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
    * @param id - Optional name of the shared map
    * @returns Newly create shared map (but not attached yet)
    */
-    public static create(runtime: IComponentRuntime, id?: string): SharedMap {
+    public static create(runtime: IFluidDataStoreRuntime, id?: string): SharedMap {
         return runtime.createChannel(id, MapFactory.Type) as SharedMap;
     }
 
@@ -137,7 +137,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
    */
     constructor(
         id: string,
-        runtime: IComponentRuntime,
+        runtime: IFluidDataStoreRuntime,
         attributes: IChannelAttributes,
     ) {
         super(id, runtime, attributes);

--- a/packages/dds/map/src/mapKernel.ts
+++ b/packages/dds/map/src/mapKernel.ts
@@ -6,7 +6,7 @@
 import assert from "assert";
 import { IComponentHandle } from "@fluidframework/component-core-interfaces";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { makeHandlesSerializable, parseHandles, ValueType } from "@fluidframework/shared-object-base";
 import { TypedEventEmitter } from "@fluidframework/common-utils";
 import {
@@ -187,7 +187,7 @@ export class MapKernel implements IValueTypeCreator {
      * @param eventEmitter - The object that will emit map events
      */
     constructor(
-        private readonly runtime: IComponentRuntime,
+        private readonly runtime: IFluidDataStoreRuntime,
         private readonly handle: IComponentHandle,
         private readonly submitMessage: (op: any, localOpMetadata: unknown) => void,
         private readonly isAttached: () => boolean,

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -11,7 +11,7 @@ import {
     TreeEntry,
 } from "@fluidframework/protocol-definitions";
 import {
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelStorageService,
     Serializable,
     IChannelAttributes,
@@ -63,7 +63,7 @@ export class SharedMatrix<T extends Serializable = Serializable>
     private cells = new SparseArray2D<T>();             // Stores cell values.
     private pending = new SparseArray2D<number>();      // Tracks pending writes.
 
-    constructor(runtime: IComponentRuntime, public id: string, attributes: IChannelAttributes) {
+    constructor(runtime: IFluidDataStoreRuntime, public id: string, attributes: IChannelAttributes) {
         super(id, runtime, attributes);
 
         this.rows = new PermutationVector(
@@ -81,7 +81,7 @@ export class SharedMatrix<T extends Serializable = Serializable>
             this.onColHandlesRecycled);
     }
 
-    public static create<T extends Serializable = Serializable>(runtime: IComponentRuntime, id?: string) {
+    public static create<T extends Serializable = Serializable>(runtime: IFluidDataStoreRuntime, id?: string) {
         return runtime.createChannel(id, SharedMatrixFactory.Type) as SharedMatrix<T>;
     }
 

--- a/packages/dds/matrix/src/permutationvector.ts
+++ b/packages/dds/matrix/src/permutationvector.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
-import { IComponentRuntime, IChannelStorageService } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime, IChannelStorageService } from "@fluidframework/component-runtime-definitions";
 import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 import {
     BaseSegment,
@@ -90,7 +90,7 @@ export class PermutationVector extends Client {
     constructor(
         path: string,
         logger: ITelemetryBaseLogger,
-        runtime: IComponentRuntime,
+        runtime: IFluidDataStoreRuntime,
         private readonly deltaCallback: (position: number, numRemoved: number, numInserted: number) => void,
         private readonly handlesRecycledCallback: (handles: Handle[]) => void,
     ) {
@@ -169,7 +169,7 @@ export class PermutationVector extends Client {
     }
 
     // Constructs an ITreeEntry for the cell data.
-    public snapshot(runtime: IComponentRuntime, handle: IComponentHandle): ITree {
+    public snapshot(runtime: IFluidDataStoreRuntime, handle: IComponentHandle): ITree {
         return {
             entries: [
                 {
@@ -185,7 +185,7 @@ export class PermutationVector extends Client {
         };
     }
 
-    public async load(runtime: IComponentRuntime, storage: IChannelStorageService, branchId?: string) {
+    public async load(runtime: IFluidDataStoreRuntime, storage: IChannelStorageService, branchId?: string) {
         const [handleTableData, handles] = await Promise.all([
             await deserializeBlob(runtime, storage, SnapshotPath.handleTable),
             await deserializeBlob(runtime, storage, SnapshotPath.handles),

--- a/packages/dds/matrix/src/runtime.ts
+++ b/packages/dds/matrix/src/runtime.ts
@@ -5,7 +5,7 @@
 
 import {
     IChannelAttributes,
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelServices,
     IChannel,
     IChannelFactory,
@@ -31,7 +31,7 @@ export class SharedMatrixFactory implements IChannelFactory {
     }
 
     public async load(
-        runtime: IComponentRuntime,
+        runtime: IFluidDataStoreRuntime,
         id: string,
         services: IChannelServices,
         branchId: string,
@@ -42,7 +42,7 @@ export class SharedMatrixFactory implements IChannelFactory {
         return matrix;
     }
 
-    public create(document: IComponentRuntime, id: string): IChannel {
+    public create(document: IFluidDataStoreRuntime, id: string): IChannel {
         const matrix = new SharedMatrix(document, id, this.attributes);
         matrix.initializeLocal();
         return matrix;

--- a/packages/dds/matrix/src/serialization.ts
+++ b/packages/dds/matrix/src/serialization.ts
@@ -3,13 +3,17 @@
  * Licensed under the MIT License.
  */
 
-import { Serializable, IComponentRuntime, IChannelStorageService } from "@fluidframework/component-runtime-definitions";
+import {
+    Serializable,
+    IFluidDataStoreRuntime,
+    IChannelStorageService,
+} from "@fluidframework/component-runtime-definitions";
 import { FileMode, TreeEntry } from "@fluidframework/protocol-definitions";
 import { IComponentHandle } from "@fluidframework/component-core-interfaces";
 import { fromBase64ToUtf8 } from "@fluidframework/common-utils";
 
 export function serializeBlob(
-    runtime: IComponentRuntime,
+    runtime: IFluidDataStoreRuntime,
     handle: IComponentHandle,
     path: string,
     snapshot: Serializable,
@@ -29,7 +33,7 @@ export function serializeBlob(
     };
 }
 
-export async function deserializeBlob(runtime: IComponentRuntime, storage: IChannelStorageService, path: string) {
+export async function deserializeBlob(runtime: IFluidDataStoreRuntime, storage: IChannelStorageService, path: string) {
     const handleTableChunk = await storage.read(path);
     const utf8 = fromBase64ToUtf8(handleTableChunk);
 

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { IComponentHandle } from "@fluidframework/component-core-interfaces";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
-import { IComponentRuntime, IChannelStorageService } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime, IChannelStorageService } from "@fluidframework/component-runtime-definitions";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { performanceNow } from "@fluidframework/common-utils";
 import { IIntegerRange } from "./base";
@@ -890,12 +890,14 @@ export class Client {
 
     // TODO: Remove `catchUpMsgs` once new snapshot format is adopted as default.
     //       (See https://github.com/microsoft/FluidFramework/issues/84)
-    public snapshot(runtime: IComponentRuntime, handle: IComponentHandle, catchUpMsgs: ISequencedDocumentMessage[]) {
+    public snapshot(
+        runtime: IFluidDataStoreRuntime, handle: IComponentHandle, catchUpMsgs: ISequencedDocumentMessage[]) {
         const deltaManager = runtime.deltaManager;
         const minSeq = deltaManager.minimumSequenceNumber;
 
         // Catch up to latest MSN, if we have not had a chance to do it.
-        // Required for case where ComponentRuntime.attachChannel() generates snapshot right after loading component.
+        // Required for case where FluidDataStoreRuntime.attachChannel()
+        // generates snapshot right after loading component.
 
         this.updateSeqNumbers(minSeq, deltaManager.lastSequenceNumber);
 
@@ -927,7 +929,7 @@ export class Client {
     }
 
     public async load(
-        runtime: IComponentRuntime,
+        runtime: IFluidDataStoreRuntime,
         storage: IChannelStorageService,
         branchId?: string,
     ): Promise<{ catchupOpsP: Promise<ISequencedDocumentMessage[]> }> {

--- a/packages/dds/merge-tree/src/snapshotLoader.ts
+++ b/packages/dds/merge-tree/src/snapshotLoader.ts
@@ -7,7 +7,7 @@ import assert from "assert";
 import { fromBase64ToUtf8 } from "@fluidframework/common-utils";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
-import { IComponentRuntime, IChannelStorageService } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime, IChannelStorageService } from "@fluidframework/component-runtime-definitions";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { Client } from "./client";
 import { NonCollabClient, UniversalSequenceNumber } from "./constants";
@@ -25,7 +25,7 @@ export class SnapshotLoader {
     private readonly logger: ITelemetryLogger;
 
     constructor(
-        private readonly runtime: IComponentRuntime,
+        private readonly runtime: IFluidDataStoreRuntime,
         private readonly client: Client,
         private readonly mergeTree: MergeTree,
         logger: ITelemetryLogger) {

--- a/packages/dds/merge-tree/src/test/snapshot.spec.ts
+++ b/packages/dds/merge-tree/src/test/snapshot.spec.ts
@@ -5,7 +5,7 @@
 
 import assert from "assert";
 import { ISequencedDocumentMessage, ITree } from "@fluidframework/protocol-definitions";
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { MockStorage } from "@fluidframework/test-runtime-utils";
 import { IMergeTreeOp } from "../ops";
 import { SnapshotV1 } from "../snapshotV1";
@@ -15,12 +15,12 @@ import { TestClient } from ".";
 async function loadSnapshot(tree: ITree) {
     const services = new MockStorage(tree);
     const client2 = new TestClient(undefined);
-    const runtime: Partial<IComponentRuntime> = {
+    const runtime: Partial<IFluidDataStoreRuntime> = {
         logger: client2.logger,
         clientId: "1",
     };
 
-    const { catchupOpsP } = await client2.load(runtime as IComponentRuntime, services);
+    const { catchupOpsP } = await client2.load(runtime as IFluidDataStoreRuntime, services);
     await catchupOpsP;
     return client2;
 }

--- a/packages/dds/merge-tree/src/test/snapshotlegacy.spec.ts
+++ b/packages/dds/merge-tree/src/test/snapshotlegacy.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from "assert";
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { MockStorage } from "@fluidframework/test-runtime-utils";
 import { SnapshotLegacy } from "../snapshotlegacy";
 import { TestClient } from ".";
@@ -26,11 +26,11 @@ describe("snapshot", () => {
         const services = new MockStorage(snapshotTree);
 
         const client2 = new TestClient(undefined);
-        const runtime: Partial<IComponentRuntime> = {
+        const runtime: Partial<IFluidDataStoreRuntime> = {
             logger: client2.logger,
             clientId: "1",
         };
-        await client2.load(runtime as IComponentRuntime, services);
+        await client2.load(runtime as IFluidDataStoreRuntime, services);
 
         assert.equal(client2.getLength(), client1.getLength());
         assert.equal(client2.getText(), client1.getText());
@@ -55,11 +55,11 @@ describe("snapshot", () => {
             snapshot.extractSync();
             const snapshotTree = snapshot.emit([]);
             const services = new MockStorage(snapshotTree);
-            const runtime: Partial<IComponentRuntime> = {
+            const runtime: Partial<IFluidDataStoreRuntime> = {
                 logger: client2.logger,
                 clientId: (i + 1).toString(),
             };
-            await client2.load(runtime as IComponentRuntime, services);
+            await client2.load(runtime as IFluidDataStoreRuntime, services);
 
             const client2Len = client2.getLength();
             assert.equal(

--- a/packages/dds/merge-tree/src/test/testClient.ts
+++ b/packages/dds/merge-tree/src/test/testClient.ts
@@ -6,7 +6,7 @@
 import assert from "assert";
 import { DebugLogger } from "@fluidframework/telemetry-utils";
 import { ISequencedDocumentMessage, ITree, MessageType } from "@fluidframework/protocol-definitions";
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { MockStorage } from "@fluidframework/test-runtime-utils";
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -66,7 +66,7 @@ export class TestClient extends Client {
             {
                 logger: client2.logger,
                 clientId: newLongClientId,
-            } as IComponentRuntime,
+            } as IFluidDataStoreRuntime,
             services);
         await catchupOpsP;
         return client2;

--- a/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
+++ b/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
@@ -14,7 +14,7 @@ import {
 } from "@fluidframework/protocol-definitions";
 import {
     IChannelAttributes,
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelStorageService,
 } from "@fluidframework/component-runtime-definitions";
 import { unreachableCase } from "@fluidframework/runtime-utils";
@@ -109,7 +109,7 @@ export class ConsensusOrderedCollection<T = any>
      */
     protected constructor(
         id: string,
-        runtime: IComponentRuntime,
+        runtime: IFluidDataStoreRuntime,
         attributes: IChannelAttributes,
         private readonly data: IOrderedCollection<T>,
     ) {

--- a/packages/dds/ordered-collection/src/consensusOrderedCollectionFactory.ts
+++ b/packages/dds/ordered-collection/src/consensusOrderedCollectionFactory.ts
@@ -5,7 +5,7 @@
 
 import {
     IChannelAttributes,
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelServices,
 } from "@fluidframework/component-runtime-definitions";
 import { ConsensusQueue } from "./consensusQueue";
@@ -33,7 +33,7 @@ export class ConsensusQueueFactory implements IConsensusOrderedCollectionFactory
     }
 
     public async load(
-        runtime: IComponentRuntime,
+        runtime: IFluidDataStoreRuntime,
         id: string,
         services: IChannelServices,
         branchId: string,
@@ -43,7 +43,7 @@ export class ConsensusQueueFactory implements IConsensusOrderedCollectionFactory
         return collection;
     }
 
-    public create(document: IComponentRuntime, id: string): IConsensusOrderedCollection {
+    public create(document: IFluidDataStoreRuntime, id: string): IConsensusOrderedCollection {
         const collection = new ConsensusQueue(id, document, this.attributes);
         collection.initializeLocal();
         return collection;

--- a/packages/dds/ordered-collection/src/consensusQueue.ts
+++ b/packages/dds/ordered-collection/src/consensusQueue.ts
@@ -4,7 +4,7 @@
  */
 
 import {
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelAttributes,
     IChannelFactory,
 } from "@fluidframework/component-runtime-definitions";
@@ -42,7 +42,7 @@ export class ConsensusQueue<T = any> extends ConsensusOrderedCollection<T> {
      * @param id - optional name of theconsensus queue
      * @returns newly create consensus queue (but not attached yet)
      */
-    public static create<T = any>(runtime: IComponentRuntime, id?: string) {
+    public static create<T = any>(runtime: IFluidDataStoreRuntime, id?: string) {
         return runtime.createChannel(id, ConsensusQueueFactory.Type) as ConsensusQueue<T>;
     }
 
@@ -59,7 +59,7 @@ export class ConsensusQueue<T = any> extends ConsensusOrderedCollection<T> {
      * Constructs a new consensus queue. If the object is non-local an id and service interfaces will
      * be provided
      */
-    public constructor(id: string, runtime: IComponentRuntime, attributes: IChannelAttributes) {
+    public constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes) {
         super(id, runtime, attributes, new SnapshotableQueue<T>());
     }
 }

--- a/packages/dds/ordered-collection/src/interfaces.ts
+++ b/packages/dds/ordered-collection/src/interfaces.ts
@@ -4,7 +4,7 @@
  */
 
 import {
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelServices,
     IChannelAttributes,
     IChannelFactory,
@@ -30,13 +30,13 @@ export type ConsensusCallback<T> = (value: T) => Promise<ConsensusResult>;
  */
 export interface IConsensusOrderedCollectionFactory extends IChannelFactory {
     load(
-        document: IComponentRuntime,
+        document: IFluidDataStoreRuntime,
         id: string,
         services: IChannelServices,
         branchId: string,
         attributes: IChannelAttributes): Promise<IConsensusOrderedCollection>;
 
-    create(document: IComponentRuntime, id: string): IConsensusOrderedCollection;
+    create(document: IFluidDataStoreRuntime, id: string): IConsensusOrderedCollection;
 }
 
 /**

--- a/packages/dds/register-collection/src/consensusRegisterCollection.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollection.ts
@@ -14,7 +14,7 @@ import {
 } from "@fluidframework/protocol-definitions";
 import {
     IChannelAttributes,
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelStorageService,
 } from "@fluidframework/component-runtime-definitions";
 import { unreachableCase } from "@fluidframework/runtime-utils";
@@ -101,7 +101,7 @@ export class ConsensusRegisterCollection<T>
      * @param id - optional name of the consensus register collection
      * @returns newly create consensus register collection (but not attached yet)
      */
-    public static create<T>(runtime: IComponentRuntime, id?: string) {
+    public static create<T>(runtime: IFluidDataStoreRuntime, id?: string) {
         return runtime.createChannel(id, ConsensusRegisterCollectionFactory.Type) as ConsensusRegisterCollection<T>;
     }
 
@@ -122,7 +122,7 @@ export class ConsensusRegisterCollection<T>
      */
     public constructor(
         id: string,
-        runtime: IComponentRuntime,
+        runtime: IFluidDataStoreRuntime,
         attributes: IChannelAttributes,
     ) {
         super(id, runtime, attributes);

--- a/packages/dds/register-collection/src/consensusRegisterCollectionFactory.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollectionFactory.ts
@@ -5,7 +5,7 @@
 
 import {
     IChannelAttributes,
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelServices,
 } from "@fluidframework/component-runtime-definitions";
 import { ConsensusRegisterCollection } from "./consensusRegisterCollection";
@@ -33,7 +33,7 @@ export class ConsensusRegisterCollectionFactory implements IConsensusRegisterCol
     }
 
     public async load(
-        runtime: IComponentRuntime,
+        runtime: IFluidDataStoreRuntime,
         id: string,
         services: IChannelServices,
         branchId: string,
@@ -43,7 +43,7 @@ export class ConsensusRegisterCollectionFactory implements IConsensusRegisterCol
         return collection;
     }
 
-    public create(document: IComponentRuntime, id: string): IConsensusRegisterCollection {
+    public create(document: IFluidDataStoreRuntime, id: string): IConsensusRegisterCollection {
         const collection = new ConsensusRegisterCollection(id, document, ConsensusRegisterCollectionFactory.Attributes);
         collection.initializeLocal();
         return collection;

--- a/packages/dds/register-collection/src/interfaces.ts
+++ b/packages/dds/register-collection/src/interfaces.ts
@@ -4,7 +4,7 @@
  */
 
 import {
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelServices,
     IChannelAttributes,
     IChannelFactory,
@@ -19,13 +19,13 @@ import { ISharedObject, ISharedObjectEvents } from "@fluidframework/shared-objec
  */
 export interface IConsensusRegisterCollectionFactory extends IChannelFactory {
     load(
-        document: IComponentRuntime,
+        document: IFluidDataStoreRuntime,
         id: string,
         services: IChannelServices,
         branchId: string,
         attributes: IChannelAttributes): Promise<IConsensusRegisterCollection>;
 
-    create(document: IComponentRuntime, id: string): IConsensusRegisterCollection;
+    create(document: IFluidDataStoreRuntime, id: string): IConsensusRegisterCollection;
 }
 
 export interface IConsensusRegisterCollectionEvents extends ISharedObjectEvents {

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -21,7 +21,7 @@ import {
 } from "@fluidframework/protocol-definitions";
 import {
     IChannelAttributes,
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelStorageService,
 } from "@fluidframework/component-runtime-definitions";
 import { ObjectStoragePartition } from "@fluidframework/runtime-utils";
@@ -121,7 +121,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
     private messagesSinceMSNChange: ISequencedDocumentMessage[] = [];
     private readonly intervalMapKernel: MapKernel;
     constructor(
-        private readonly componentRuntime: IComponentRuntime,
+        private readonly componentRuntime: IFluidDataStoreRuntime,
         public id: string,
         attributes: IChannelAttributes,
         public readonly segmentFromSpec: (spec: MergeTree.IJSONSegment) => MergeTree.ISegment,

--- a/packages/dds/sequence/src/sequenceFactory.ts
+++ b/packages/dds/sequence/src/sequenceFactory.ts
@@ -6,7 +6,7 @@
 import * as MergeTree from "@fluidframework/merge-tree";
 import {
     IChannelAttributes,
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelServices,
     IChannelFactory,
 } from "@fluidframework/component-runtime-definitions";
@@ -45,7 +45,7 @@ export class SharedStringFactory implements IChannelFactory {
     }
 
     public async load(
-        runtime: IComponentRuntime,
+        runtime: IFluidDataStoreRuntime,
         id: string,
         services: IChannelServices,
         branchId: string,
@@ -55,7 +55,7 @@ export class SharedStringFactory implements IChannelFactory {
         return sharedString;
     }
 
-    public create(document: IComponentRuntime, id: string): SharedString {
+    public create(document: IFluidDataStoreRuntime, id: string): SharedString {
         const sharedString = new SharedString(document, id, this.attributes);
         sharedString.initializeLocal();
         return sharedString;
@@ -91,7 +91,7 @@ export class SharedObjectSequenceFactory implements IChannelFactory {
     }
 
     public async load(
-        runtime: IComponentRuntime,
+        runtime: IFluidDataStoreRuntime,
         id: string,
         services: IChannelServices,
         branchId: string,
@@ -101,7 +101,7 @@ export class SharedObjectSequenceFactory implements IChannelFactory {
         return sharedSeq;
     }
 
-    public create(document: IComponentRuntime, id: string): ISharedObject {
+    public create(document: IFluidDataStoreRuntime, id: string): ISharedObject {
         const sharedString = new SharedObjectSequence(document, id, this.attributes);
         sharedString.initializeLocal();
         return sharedString;
@@ -137,7 +137,7 @@ export class SharedNumberSequenceFactory implements IChannelFactory {
     }
 
     public async load(
-        runtime: IComponentRuntime,
+        runtime: IFluidDataStoreRuntime,
         id: string,
         services: IChannelServices,
         branchId: string,
@@ -147,7 +147,7 @@ export class SharedNumberSequenceFactory implements IChannelFactory {
         return sharedSeq;
     }
 
-    public create(document: IComponentRuntime, id: string): ISharedObject {
+    public create(document: IFluidDataStoreRuntime, id: string): ISharedObject {
         const sharedString = new SharedNumberSequence(document, id, this.attributes);
         sharedString.initializeLocal();
         return sharedString;

--- a/packages/dds/sequence/src/sharedIntervalCollection.ts
+++ b/packages/dds/sequence/src/sharedIntervalCollection.ts
@@ -12,7 +12,7 @@ import {
 } from "@fluidframework/protocol-definitions";
 import {
     IChannelAttributes,
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelStorageService,
     IChannelServices,
     IChannelFactory,
@@ -52,7 +52,7 @@ export class SharedIntervalCollectionFactory implements IChannelFactory {
     }
 
     public async load(
-        runtime: IComponentRuntime,
+        runtime: IFluidDataStoreRuntime,
         id: string,
         services: IChannelServices,
         branchId: string,
@@ -63,7 +63,7 @@ export class SharedIntervalCollectionFactory implements IChannelFactory {
         return map;
     }
 
-    public create(runtime: IComponentRuntime, id: string): SharedIntervalCollection {
+    public create(runtime: IFluidDataStoreRuntime, id: string): SharedIntervalCollection {
         const map = new SharedIntervalCollection(
             id,
             runtime,
@@ -88,7 +88,7 @@ export class SharedIntervalCollection<TInterval extends ISerializableInterval = 
      * @param id - optional name of the shared map
      * @returns newly create shared map (but not attached yet)
      */
-    public static create(runtime: IComponentRuntime, id?: string) {
+    public static create(runtime: IFluidDataStoreRuntime, id?: string) {
         return runtime.createChannel(id, SharedIntervalCollectionFactory.Type) as SharedIntervalCollection;
     }
 
@@ -110,7 +110,7 @@ export class SharedIntervalCollection<TInterval extends ISerializableInterval = 
      */
     constructor(
         id: string,
-        runtime: IComponentRuntime,
+        runtime: IFluidDataStoreRuntime,
         attributes: IChannelAttributes,
     ) {
         super(id, runtime, attributes);

--- a/packages/dds/sequence/src/sharedNumberSequence.ts
+++ b/packages/dds/sequence/src/sharedNumberSequence.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IComponentRuntime, IChannelAttributes } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime, IChannelAttributes } from "@fluidframework/component-runtime-definitions";
 import { SharedNumberSequenceFactory } from "./sequenceFactory";
 import { SharedSequence } from "./sharedSequence";
 
@@ -15,7 +15,7 @@ export class SharedNumberSequence extends SharedSequence<number> {
      * @param id - optional name of the shared number sequence
      * @returns newly create shared number sequence (but not attached yet)
      */
-    public static create(runtime: IComponentRuntime, id?: string) {
+    public static create(runtime: IFluidDataStoreRuntime, id?: string) {
         return runtime.createChannel(id,
             SharedNumberSequenceFactory.Type) as SharedNumberSequence;
     }
@@ -29,7 +29,7 @@ export class SharedNumberSequence extends SharedSequence<number> {
         return new SharedNumberSequenceFactory();
     }
 
-    constructor(document: IComponentRuntime, public id: string, attributes: IChannelAttributes) {
+    constructor(document: IFluidDataStoreRuntime, public id: string, attributes: IChannelAttributes) {
         super(document, id, attributes, SharedNumberSequenceFactory.segmentFromSpec);
     }
 

--- a/packages/dds/sequence/src/sharedObjectSequence.ts
+++ b/packages/dds/sequence/src/sharedObjectSequence.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IComponentRuntime, IChannelAttributes } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime, IChannelAttributes } from "@fluidframework/component-runtime-definitions";
 import { SharedObjectSequenceFactory } from "./sequenceFactory";
 import { SharedSequence } from "./sharedSequence";
 
@@ -15,7 +15,7 @@ export class SharedObjectSequence<T> extends SharedSequence<T> {
      * @param id - optional name of the shared object sequence
      * @returns newly create shared object sequence (but not attached yet)
      */
-    public static create<T>(runtime: IComponentRuntime, id?: string) {
+    public static create<T>(runtime: IFluidDataStoreRuntime, id?: string) {
         return runtime.createChannel(id, SharedObjectSequenceFactory.Type) as SharedObjectSequence<T>;
     }
 
@@ -28,7 +28,7 @@ export class SharedObjectSequence<T> extends SharedSequence<T> {
         return new SharedObjectSequenceFactory();
     }
 
-    constructor(document: IComponentRuntime, public id: string, attributes: IChannelAttributes) {
+    constructor(document: IFluidDataStoreRuntime, public id: string, attributes: IChannelAttributes) {
         super(document, id, attributes, SharedObjectSequenceFactory.segmentFromSpec);
     }
 

--- a/packages/dds/sequence/src/sharedSequence.ts
+++ b/packages/dds/sequence/src/sharedSequence.ts
@@ -6,7 +6,7 @@
 import {
     BaseSegment, IJSONSegment, ISegment, PropertySet, LocalReferenceCollection,
 } from "@fluidframework/merge-tree";
-import { IChannelAttributes, IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IChannelAttributes, IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { SharedSegmentSequence } from "./sequence";
 
 const MaxRun = 128;
@@ -102,7 +102,7 @@ export class SubSequence<T> extends BaseSegment {
 
 export class SharedSequence<T> extends SharedSegmentSequence<SubSequence<T>> {
     constructor(
-        document: IComponentRuntime,
+        document: IFluidDataStoreRuntime,
         public id: string,
         attributes: IChannelAttributes,
         specToSegment: (spec: IJSONSegment) => ISegment,

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -6,7 +6,7 @@
 // eslint-disable-next-line import/no-unassigned-import
 import { } from "@fluidframework/component-core-interfaces";
 import * as MergeTree from "@fluidframework/merge-tree";
-import { IComponentRuntime, IChannelAttributes } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime, IChannelAttributes } from "@fluidframework/component-runtime-definitions";
 import { SharedSegmentSequence } from "./sequence";
 import { SharedStringFactory } from "./sequenceFactory";
 
@@ -42,7 +42,7 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
      * @param id - optional name of the shared string
      * @returns newly create shared string (but not attached yet)
      */
-    public static create(runtime: IComponentRuntime, id?: string) {
+    public static create(runtime: IFluidDataStoreRuntime, id?: string) {
         return runtime.createChannel(id, SharedStringFactory.Type) as SharedString;
     }
 
@@ -61,7 +61,7 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
 
     private readonly mergeTreeTextHelper: MergeTree.MergeTreeTextHelper;
 
-    constructor(document: IComponentRuntime, public id: string, attributes: IChannelAttributes) {
+    constructor(document: IFluidDataStoreRuntime, public id: string, attributes: IChannelAttributes) {
         super(document, id, attributes, SharedStringFactory.segmentFromSpec);
         this.mergeTreeTextHelper = this.client.createTextHelper();
     }

--- a/packages/dds/sequence/src/sparsematrix.ts
+++ b/packages/dds/sequence/src/sparsematrix.ts
@@ -14,7 +14,7 @@ import {
 } from "@fluidframework/merge-tree";
 import {
     IChannelAttributes,
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelServices,
     Jsonable,
     JsonablePrimitive,
@@ -196,7 +196,7 @@ export class SparseMatrix extends SharedSegmentSequence<MatrixSegment> {
      * @param id - optional name of the sparse matrix
      * @returns newly create sparse matrix (but not attached yet)
      */
-    public static create(runtime: IComponentRuntime, id?: string) {
+    public static create(runtime: IFluidDataStoreRuntime, id?: string) {
         return runtime.createChannel(id, SparseMatrixFactory.Type) as SparseMatrix;
     }
 
@@ -209,7 +209,7 @@ export class SparseMatrix extends SharedSegmentSequence<MatrixSegment> {
         return new SparseMatrixFactory();
     }
 
-    constructor(document: IComponentRuntime, public id: string, attributes: IChannelAttributes) {
+    constructor(document: IFluidDataStoreRuntime, public id: string, attributes: IChannelAttributes) {
         super(document, id, attributes, SparseMatrixFactory.segmentFromSpec);
     }
 
@@ -353,7 +353,7 @@ export class SparseMatrixFactory implements IChannelFactory {
     }
 
     public async load(
-        runtime: IComponentRuntime,
+        runtime: IFluidDataStoreRuntime,
         id: string,
         services: IChannelServices,
         branchId: string,
@@ -364,7 +364,7 @@ export class SparseMatrixFactory implements IChannelFactory {
         return sharedObject;
     }
 
-    public create(document: IComponentRuntime, id: string): ISharedObject {
+    public create(document: IFluidDataStoreRuntime, id: string): ISharedObject {
         const sharedObject = new SparseMatrix(document, id, this.attributes);
         sharedObject.initializeLocal();
         return sharedObject;

--- a/packages/dds/shared-object-base/src/handle.ts
+++ b/packages/dds/shared-object-base/src/handle.ts
@@ -16,7 +16,7 @@ import { ISharedObject } from "./types";
  * This object is used for already loaded (in-memory) shared object
  * and is used only for serialization purposes.
  * De-serialization process goes through ComponentHandle and request flow:
- * ComponentRuntime.request() recognizes requests in the form of '/<shared object id>'
+ * FluidDataStoreRuntime.request() recognizes requests in the form of '/<shared object id>'
  * and loads shared object.
  */
 export class SharedObjectComponentHandle extends ComponentHandle<ISharedObject> {

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -10,7 +10,7 @@ import { ChildLogger, EventEmitterWithErrorHandling } from "@fluidframework/tele
 import { ISequencedDocumentMessage, ITree } from "@fluidframework/protocol-definitions";
 import {
     IChannelAttributes,
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelStorageService,
     IChannelServices,
 } from "@fluidframework/component-runtime-definitions";
@@ -78,12 +78,12 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
 
     /**
      * @param id - The id of the shared object
-     * @param runtime - The IComponentRuntime which contains the shared object
+     * @param runtime - The IFluidDataStoreRuntime which contains the shared object
      * @param attributes - Attributes of the shared object
      */
     constructor(
         public id: string,
-        protected runtime: IComponentRuntime,
+        protected runtime: IFluidDataStoreRuntime,
         public readonly attributes: IChannelAttributes) {
         super();
 
@@ -287,7 +287,7 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
 
     /**
      * Promises that are waiting for an ack from the server before resolving should use this instead of new Promise.
-     * It ensures that if something changes that will interrupt that ack (e.g. the ComponentRuntime disposes),
+     * It ensures that if something changes that will interrupt that ack (e.g. the FluidDataStoreRuntime disposes),
      * the Promise will reject.
      */
     protected async newAckBasedPromise<T>(
@@ -296,7 +296,7 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
         let rejectBecauseDispose: () => void;
         return new Promise<T>((resolve, reject) => {
             rejectBecauseDispose =
-                () => reject(new Error("ComponentRuntime disposed while this ack-based Promise was pending"));
+                () => reject(new Error("FluidDataStoreRuntime disposed while this ack-based Promise was pending"));
 
             if (this.runtime.disposed) {
                 rejectBecauseDispose();

--- a/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
+++ b/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
@@ -12,7 +12,7 @@ import {
 } from "@fluidframework/protocol-definitions";
 import {
     IChannelAttributes,
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelStorageService,
     Jsonable,
     AsJsonable,
@@ -46,7 +46,7 @@ export class SharedSummaryBlock extends SharedObject implements ISharedSummaryBl
      * @param id - optional name of the shared summary block.
      * @returns newly created shared summary block (but not attached yet).
      */
-    public static create(runtime: IComponentRuntime, id?: string) {
+    public static create(runtime: IFluidDataStoreRuntime, id?: string) {
         return runtime.createChannel(id, SharedSummaryBlockFactory.Type) as SharedSummaryBlock;
     }
 
@@ -72,7 +72,7 @@ export class SharedSummaryBlock extends SharedObject implements ISharedSummaryBl
      * @param runtime - component runtime thee object belongs to.
      * @param attributes - The attributes for the object.
      */
-    constructor(id: string, runtime: IComponentRuntime, attributes: IChannelAttributes) {
+    constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes) {
         super(id, runtime, attributes);
     }
 

--- a/packages/dds/shared-summary-block/src/sharedSummaryBlockFactory.ts
+++ b/packages/dds/shared-summary-block/src/sharedSummaryBlockFactory.ts
@@ -5,7 +5,7 @@
 
 import {
     IChannelAttributes,
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelServices,
     IChannelFactory,
 } from "@fluidframework/component-runtime-definitions";
@@ -52,7 +52,7 @@ export class SharedSummaryBlockFactory implements IChannelFactory {
      * {@inheritDoc @fluidframework/shared-object-base#IChannelFactory.load}
      */
     public async load(
-        runtime: IComponentRuntime,
+        runtime: IFluidDataStoreRuntime,
         id: string,
         services: IChannelServices,
         branchId: string,
@@ -66,7 +66,7 @@ export class SharedSummaryBlockFactory implements IChannelFactory {
     /**
      * {@inheritDoc @fluidframework/shared-object-base#IChannelFactory.create}
      */
-    public create(runtime: IComponentRuntime, id: string): ISharedObject {
+    public create(runtime: IFluidDataStoreRuntime, id: string): ISharedObject {
         const sharedSummaryBlock = new SharedSummaryBlock(id, runtime, SharedSummaryBlockFactory.Attributes);
         sharedSummaryBlock.initializeLocal();
 

--- a/packages/framework/aqueduct/src/components/sharedComponent.ts
+++ b/packages/framework/aqueduct/src/components/sharedComponent.ts
@@ -13,8 +13,8 @@ import {
     IResponse,
 } from "@fluidframework/component-core-interfaces";
 import { AsyncComponentProvider, ComponentKey } from "@fluidframework/synthesize";
-import { IComponentContext } from "@fluidframework/runtime-definitions";
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { ComponentHandle } from "@fluidframework/component-runtime";
 import { IDirectory } from "@fluidframework/map";
 import { v4 as uuid } from "uuid";
@@ -23,8 +23,8 @@ import { IEvent } from "@fluidframework/common-definitions";
 import { serviceRoutePathRoot } from "../containerServices";
 
 export interface ISharedComponentProps<P extends IComponent = object> {
-    readonly runtime: IComponentRuntime,
-    readonly context: IComponentContext,
+    readonly runtime: IFluidDataStoreRuntime,
+    readonly context: IFluidDataStoreContext,
     readonly providers: AsyncComponentProvider<ComponentKey<P>, ComponentKey<object>>,
 }
 
@@ -45,14 +45,14 @@ export abstract class SharedComponent<P extends IComponent = object, S = undefin
     private _disposed = false;
 
     /**
-     * This is your ComponentRuntime object
+     * This is your FluidDataStoreRuntime object
      */
-    protected readonly runtime: IComponentRuntime;
+    protected readonly runtime: IFluidDataStoreRuntime;
 
     /**
      * This context is used to talk up to the ContainerRuntime
      */
-    protected readonly context: IComponentContext;
+    protected readonly context: IFluidDataStoreContext;
 
     /**
      * Providers are IComponent keyed objects that provide back a promise to the corresponding IComponent or undefined.
@@ -81,7 +81,7 @@ export abstract class SharedComponent<P extends IComponent = object, S = undefin
         this.providers = props.providers;
 
         // Create a ComponentHandle with empty string as `path`. This is because reaching this SharedComponent is the
-        // same as reaching its routeContext (ComponentRuntime) so there is so the relative path to it from the
+        // same as reaching its routeContext (FluidDataStoreRuntime) so there is so the relative path to it from the
         // routeContext is empty.
         this.innerHandle = new ComponentHandle(this, "", this.runtime.IComponentHandleContext);
 
@@ -179,7 +179,7 @@ export abstract class SharedComponent<P extends IComponent = object, S = undefin
     protected async createAndAttachComponent<T extends IComponent & IComponentLoadable>(
         pkg: string, props?: any,
     ): Promise<T> {
-        const componentRuntime = await this.context.createComponent(uuid(), pkg, props);
+        const componentRuntime = await this.context.createDataStore(uuid(), pkg, props);
         const component = await this.asComponent<T>(componentRuntime.request({ url: "/" }));
         componentRuntime.bindToContext();
         return component;

--- a/packages/framework/aqueduct/src/containerRuntimeFactories/containerRuntimeFactoryWithDefaultComponent.ts
+++ b/packages/framework/aqueduct/src/containerRuntimeFactories/containerRuntimeFactoryWithDefaultComponent.ts
@@ -50,7 +50,7 @@ export class ContainerRuntimeFactoryWithDefaultComponent extends BaseContainerRu
      * {@inheritDoc BaseContainerRuntimeFactory.containerInitializingFirstTime}
      */
     protected async containerInitializingFirstTime(runtime: IContainerRuntime) {
-        const componentRuntime = await runtime.createComponent(
+        const componentRuntime = await runtime.createDataStore(
             ContainerRuntimeFactoryWithDefaultComponent.defaultComponentId,
             this.defaultComponentName,
         );

--- a/packages/framework/aqueduct/src/utils/attachUtils.ts
+++ b/packages/framework/aqueduct/src/utils/attachUtils.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { AttachState } from "@fluidframework/container-definitions";
 
-export async function waitForAttach(componentRuntime: IComponentRuntime): Promise<void> {
+export async function waitForAttach(componentRuntime: IFluidDataStoreRuntime): Promise<void> {
     if (componentRuntime.attachState === AttachState.Attached) {
         return;
     }

--- a/packages/framework/component-base/src/runtimefactory.ts
+++ b/packages/framework/component-base/src/runtimefactory.ts
@@ -57,7 +57,7 @@ export class RuntimeFactory implements IRuntimeFactory {
                 remainingUrl = "";
             }
 
-            const component = await containerRuntime.getComponentRuntime(componentId, true);
+            const component = await containerRuntime.getDataStore(componentId, true);
 
             return component.request({ url: remainingUrl });
         });
@@ -74,7 +74,7 @@ export class RuntimeFactory implements IRuntimeFactory {
         // On first boot create the base component
         if (!runtime.existing && this.defaultComponent.type) {
             await runtime
-                .createComponent(defaultComponentId, this.defaultComponent.type)
+                .createDataStore(defaultComponentId, this.defaultComponent.type)
                 .then((componentRuntime) => {
                     componentRuntime.bindToContext();
                 });

--- a/packages/framework/component-base/src/sharedcomponent.ts
+++ b/packages/framework/component-base/src/sharedcomponent.ts
@@ -12,10 +12,10 @@ import {
     IProvideComponentHandle,
 } from "@fluidframework/component-core-interfaces";
 import {
-    IComponentContext,
+    IFluidDataStoreContext,
 } from "@fluidframework/runtime-definitions";
 import {
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
 } from "@fluidframework/component-runtime-definitions";
 import { ComponentHandle } from "@fluidframework/component-runtime";
 import { ISharedObject } from "@fluidframework/shared-object-base";
@@ -41,8 +41,8 @@ export abstract class SharedComponent<
     protected readonly root: TRoot;
 
     public constructor(
-        protected readonly context: IComponentContext,
-        protected readonly runtime: IComponentRuntime,
+        protected readonly context: IFluidDataStoreContext,
+        protected readonly runtime: IFluidDataStoreRuntime,
         root: ISharedObject,
     ) {
         super();

--- a/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
@@ -5,7 +5,7 @@
 
 import assert from "assert";
 import { IDirectory } from "@fluidframework/map";
-import { IComponentContext } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 
 /**
  * - Create a new object from the passed subDirectory.
@@ -19,7 +19,7 @@ import { IComponentContext } from "@fluidframework/runtime-definitions";
  *
  * @param baseDirectory - The base directory in the directory structure that is passed to the interception callback
  * @param subDirectory - The underlying object that is to be intercepted
- * @param context - The IComponentContext that will be used to call orderSequentially
+ * @param context - The IFluidDataStoreContext that will be used to call orderSequentially
  * @param setInterceptionCallback - The interception callback to be called
  *
  * @returns A new sub directory that intercepts the set method and calls the setInterceptionCallback.
@@ -27,7 +27,7 @@ import { IComponentContext } from "@fluidframework/runtime-definitions";
 function createSubDirectoryWithInterception<T extends IDirectory>(
     baseDirectory: T,
     subDirectory: T,
-    context: IComponentContext,
+    context: IFluidDataStoreContext,
     setInterceptionCallback: (
         baseDirectory: IDirectory,
         subDirectory: IDirectory,
@@ -111,7 +111,7 @@ function createSubDirectoryWithInterception<T extends IDirectory>(
  *   the interception callback.
  *
  * @param baseDirectory - The underlying object that is to be intercepted
- * @param context - The IComponentContext that will be used to call orderSequentially
+ * @param context - The IFluidDataStoreContext that will be used to call orderSequentially
  * @param setInterceptionCallback - The interception callback to be called
  *
  * @returns A new IDirectory object that intercepts the set method and calls the setInterceptionCallback.
@@ -119,7 +119,7 @@ function createSubDirectoryWithInterception<T extends IDirectory>(
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export function createDirectoryWithInterception<T extends IDirectory>(
     baseDirectory: T,
-    context: IComponentContext,
+    context: IFluidDataStoreContext,
     setInterceptionCallback: (
         baseDirectory: IDirectory,
         subDirectory: IDirectory,

--- a/packages/framework/dds-interceptions/src/map/sharedMapWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/map/sharedMapWithInterception.ts
@@ -5,7 +5,7 @@
 
 import assert from "assert";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
-import { IComponentContext } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 
 /**
  * - Create a new object from the passed SharedMap.
@@ -14,14 +14,14 @@ import { IComponentContext } from "@fluidframework/runtime-definitions";
  *   orderSequentially call to batch any operations that might happen in the callback.
  *
  * @param sharedMap - The underlying SharedMap
- * @param context - The IComponentContext that will be used to call orderSequentially
+ * @param context - The IFluidDataStoreContext that will be used to call orderSequentially
  * @param setInterceptionCallback - The interception callback to be called
  *
  * @returns A new SharedMap that intercepts the set method and calls the setInterceptionCallback.
  */
 export function createSharedMapWithInterception(
     sharedMap: SharedMap,
-    context: IComponentContext,
+    context: IFluidDataStoreContext,
     setInterceptionCallback: (sharedMap: ISharedMap, key: string, value: any) => void): SharedMap {
     const sharedMapWithInterception = Object.create(sharedMap);
 

--- a/packages/framework/dds-interceptions/src/sequence/sharedStringWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/sequence/sharedStringWithInterception.ts
@@ -6,7 +6,7 @@
 import assert from "assert";
 import * as MergeTree from "@fluidframework/merge-tree";
 import { SharedString } from "@fluidframework/sequence";
-import { IComponentContext } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 
 /**
  * - Create a new object from the passed SharedString.
@@ -17,14 +17,14 @@ import { IComponentContext } from "@fluidframework/runtime-definitions";
  *   orderSequentially call to batch any operations that might happen in the callback.
  *
  * @param sharedString - The underlying SharedString
- * @param context - The IComponentContext that will be used to call orderSequentially
+ * @param context - The IFluidDataStoreContext that will be used to call orderSequentially
  * @param propertyInterceptionCallback - The interception callback to be called
  *
  * @returns A new SharedString that intercepts the methods modifying the SharedString properties.
  */
 export function createSharedStringWithInterception(
     sharedString: SharedString,
-    context: IComponentContext,
+    context: IFluidDataStoreContext,
     propertyInterceptionCallback: (props?: MergeTree.PropertySet) => MergeTree.PropertySet): SharedString {
     const sharedStringWithInterception = Object.create(sharedString);
 

--- a/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
@@ -6,7 +6,7 @@
 import assert from "assert";
 import { MockComponentRuntime } from "@fluidframework/test-runtime-utils";
 import { IDirectory, SharedDirectory, DirectoryFactory } from "@fluidframework/map";
-import { IComponentContext } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 import { createDirectoryWithInterception } from "../map";
 
 describe("Shared Directory with Interception", () => {
@@ -16,7 +16,7 @@ describe("Shared Directory with Interception", () => {
         const attributionDirectoryName = "attribution";
         const attributionKey = (key: string) => `${key}.attribution`;
         let sharedDirectory: SharedDirectory;
-        let componentContext: IComponentContext;
+        let componentContext: IFluidDataStoreContext;
 
         // This function gets / creates the attribution directory for the given subdirectory path.
         function getAttributionDirectory(root: IDirectory, path: string) {
@@ -92,7 +92,7 @@ describe("Shared Directory with Interception", () => {
             componentRuntime.bindToContext();
 
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            componentContext = { containerRuntime: { orderSequentially } } as IComponentContext;
+            componentContext = { containerRuntime: { orderSequentially } } as IFluidDataStoreContext;
         });
 
         // Verifies that the props are stored correctly in the attribution sub directory - a sub directory

--- a/packages/framework/dds-interceptions/src/test/sharedMapWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedMapWithInterception.spec.ts
@@ -6,7 +6,7 @@
 import assert from "assert";
 import { MockComponentRuntime } from "@fluidframework/test-runtime-utils";
 import { ISharedMap, SharedMap, MapFactory } from "@fluidframework/map";
-import { IComponentContext } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 import { createSharedMapWithInterception } from "../map";
 
 describe("Shared Map with Interception", () => {
@@ -20,7 +20,7 @@ describe("Shared Map with Interception", () => {
         const documentId = "fakeId";
         const attributionKey = (key: string) => `${key}.attribution`;
         let sharedMap: SharedMap;
-        let componentContext: IComponentContext;
+        let componentContext: IFluidDataStoreContext;
 
         function orderSequentially(callback: () => void): void {
             callback();
@@ -36,7 +36,7 @@ describe("Shared Map with Interception", () => {
             componentRuntime.bindToContext();
 
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            componentContext = { containerRuntime: { orderSequentially } } as IComponentContext;
+            componentContext = { containerRuntime: { orderSequentially } } as IFluidDataStoreContext;
         });
 
         // Verifies that the props are stored correctly in the given map under a key derived from the

--- a/packages/framework/dds-interceptions/src/test/sharedStringWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedStringWithInterception.spec.ts
@@ -7,7 +7,7 @@ import assert from "assert";
 import { PropertySet } from "@fluidframework/merge-tree";
 import { MockComponentRuntime } from "@fluidframework/test-runtime-utils";
 import { SharedString, SharedStringFactory } from "@fluidframework/sequence";
-import { IComponentContext } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 import { createSharedStringWithInterception } from "../sequence";
 
 describe("Shared String with Interception", () => {
@@ -20,7 +20,7 @@ describe("Shared String with Interception", () => {
         const userAttributes = { userId: "Fake User" };
         const documentId = "fakeId";
         let sharedString: SharedString;
-        let componentContext: IComponentContext;
+        let componentContext: IFluidDataStoreContext;
 
         function orderSequentially(callback: () => void): void {
             callback();
@@ -48,7 +48,7 @@ describe("Shared String with Interception", () => {
             componentRuntime.bindToContext();
 
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            componentContext = { containerRuntime: { orderSequentially } } as IComponentContext;
+            componentContext = { containerRuntime: { orderSequentially } } as IFluidDataStoreContext;
         });
 
         it("should be able to intercept SharedString methods by the wrapper", async () => {

--- a/packages/framework/framework-experimental/src/clipboard/componentClipboardConsumer.ts
+++ b/packages/framework/framework-experimental/src/clipboard/componentClipboardConsumer.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { IComponentContext } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 
 declare module "@fluidframework/component-core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -36,11 +36,11 @@ export interface IComponentClipboardConsumer extends IProvideComponentClipboardC
     /**
    * Provide an alternate component identifier to be instantiated during the paste operation.
    * @alpha
-   * @param targetContext - IComponentContext of the target
+   * @param targetContext - IFluidDataStoreContext of the target
    * @param clipboardHTML - the html string that serialized by the component to the system clipboard.
    */
     getComponentFromClipboardHTML(
-        targetContext: IComponentContext,
+        targetContext: IFluidDataStoreContext,
         clipboardHTML: string | undefined,
     ): Promise<string | undefined>;
 }

--- a/packages/framework/react/src/helpers/generateComponentSchema.ts
+++ b/packages/framework/react/src/helpers/generateComponentSchema.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { SharedMap } from "@fluidframework/map";
 import {
     IFluidFunctionalComponentFluidState,
@@ -25,7 +25,7 @@ export function generateComponentSchema<
     SV extends IFluidFunctionalComponentViewState,
     SF extends IFluidFunctionalComponentFluidState
 >(
-    runtime: IComponentRuntime,
+    runtime: IFluidDataStoreRuntime,
     defaultViewState: SV,
     fluidToView: FluidToViewMap<SV, SF>,
     viewToFluid?: ViewToFluidMap<SV, SF>,

--- a/packages/framework/react/src/helpers/rootCallbackListener.ts
+++ b/packages/framework/react/src/helpers/rootCallbackListener.ts
@@ -4,7 +4,7 @@
  */
 
 import { ISharedMap, IDirectoryValueChanged } from "@fluidframework/map";
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import {
     FluidComponentMap,
     ViewToFluidMap,
@@ -40,7 +40,7 @@ export const syncedStateCallbackListener = <
     storedHandleMap: ISharedMap,
     syncedStateId,
     syncedState: ISyncedState,
-    runtime: IComponentRuntime,
+    runtime: IFluidDataStoreRuntime,
     state: SV,
     setState: (
         newState: SV,

--- a/packages/framework/react/src/helpers/setFluidState.ts
+++ b/packages/framework/react/src/helpers/setFluidState.ts
@@ -4,7 +4,7 @@
  */
 
 import { ISharedMap, SharedMap } from "@fluidframework/map";
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { IComponentHandle } from "@fluidframework/component-core-interfaces";
 import {
     FluidComponentMap,
@@ -26,7 +26,7 @@ import {
 export function setFluidState<SV, SF>(
     syncedStateId: string,
     syncedState: ISyncedState,
-    runtime: IComponentRuntime,
+    runtime: IFluidDataStoreRuntime,
     componentMap: FluidComponentMap,
     fluidToView: Map<keyof SF, IViewConverter<SV, SF>>,
     newViewState: SV,

--- a/packages/framework/react/src/helpers/syncState.ts
+++ b/packages/framework/react/src/helpers/syncState.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { ISharedMap } from "@fluidframework/map";
 import {
     FluidComponentMap,
@@ -43,7 +43,7 @@ export function syncState<
     isSyncedStateUpdate: boolean,
     syncedStateId: string,
     syncedState: ISyncedState,
-    runtime: IComponentRuntime,
+    runtime: IFluidDataStoreRuntime,
     viewState: SV,
     setState: (
         newState: SV,

--- a/packages/framework/react/src/helpers/updateStateAndComponentMap.ts
+++ b/packages/framework/react/src/helpers/updateStateAndComponentMap.ts
@@ -5,7 +5,7 @@
 
 import { IDirectoryValueChanged, SharedMap } from "@fluidframework/map";
 import { IComponentHandle } from "@fluidframework/component-core-interfaces";
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import {
     FluidComponentMap,
     IFluidFunctionalComponentFluidState,
@@ -45,7 +45,7 @@ export const updateStateAndComponentMap = async <
     isSyncedStateUpdate: boolean,
     syncedStateId: string,
     syncedState: ISyncedState,
-    runtime: IComponentRuntime,
+    runtime: IFluidDataStoreRuntime,
     viewState: SV,
     setState: (newState: SV, isSyncedStateUpdate?: boolean) => void,
     syncedStateCallback: (change: IDirectoryValueChanged, local: boolean) => void,

--- a/packages/framework/react/src/interface.ts
+++ b/packages/framework/react/src/interface.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 import { ISharedMap, IDirectoryValueChanged } from "@fluidframework/map";
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import {
     IComponentHandle,
     IComponentLoadable,
@@ -157,7 +157,7 @@ export interface IViewConverter<
      * If this is a fluid DDS SharedObject type (i.e. SharedCounter, SharedMap), supply its create function
      * here and add any events that it will fire to the listenedEvents param below to trigger state updates
      */
-    sharedObjectCreate?: (runtime: IComponentRuntime) => any;
+    sharedObjectCreate?: (runtime: IFluidDataStoreRuntime) => any;
     /**
      * List of events fired on this component that will trigger a state update
      */
@@ -271,7 +271,7 @@ export interface IFluidDataProps {
     /**
      * The Fluid component runtime passed in from component initialization
      */
-    runtime: IComponentRuntime;
+    runtime: IFluidDataStoreRuntime;
     /**
      * The running map of all the Fluid components being used to render the React component. This
      * can be view/data components, and they will be asynchronously loaded here so that they are,

--- a/packages/framework/react/src/syncedObjects/counter/syncedCounter.ts
+++ b/packages/framework/react/src/syncedObjects/counter/syncedCounter.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { SharedCounter } from "@fluidframework/counter";
 import { SyncedComponent } from "../..";
 import { ISyncedCounterViewState, ISyncedCounterFluidState, ISyncedCounterReducer } from "./interface";
@@ -21,7 +21,7 @@ export function setSyncedCounterConfig(
     syncedComponent: SyncedComponent,
     syncedStateId: string,
     defaultValue: number = 0,
-    sharedObjectCreate: (runtime: IComponentRuntime) => SharedCounter = SharedCounter.create,
+    sharedObjectCreate: (runtime: IFluidDataStoreRuntime) => SharedCounter = SharedCounter.create,
 ) {
     setFluidSyncedCounterConfig<ISyncedCounterViewState, ISyncedCounterFluidState>(
         syncedComponent,

--- a/packages/framework/request-handler/src/requestHandlers.ts
+++ b/packages/framework/request-handler/src/requestHandlers.ts
@@ -23,7 +23,7 @@ export const componentRuntimeRequestHandler: RuntimeRequestHandler =
                 wait = request.headers.wait;
             }
 
-            const component = await runtime.getComponentRuntime(request.pathParts[0], wait);
+            const component = await runtime.getDataStore(request.pathParts[0], wait);
             const subRequest = request.createSubRequest(1);
             if (subRequest !== undefined) {
                 return component.request(subRequest);

--- a/packages/framework/request-handler/src/test/requestHandlers.spec.ts
+++ b/packages/framework/request-handler/src/test/requestHandlers.spec.ts
@@ -6,7 +6,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 import assert from "assert";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
-import { IComponentRuntimeChannel } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreChannel } from "@fluidframework/runtime-definitions";
 import { RequestParser } from "@fluidframework/runtime-utils";
 import { componentRuntimeRequestHandler, createComponentResponse } from "../requestHandlers";
 
@@ -22,15 +22,15 @@ describe("RequestParser", () => {
         it("Component request without wait", async () => {
             const requestParser = new RequestParser({ url: "/componentId" });
             const runtime: IContainerRuntime = {
-                getComponentRuntime: async (id, wait): Promise<IComponentRuntimeChannel> => {
+                getDataStore: async (id, wait): Promise<IFluidDataStoreChannel> => {
                     assert.equal(id, "componentId");
                     assert.equal(wait, undefined);
-                    return Promise.resolve<IComponentRuntimeChannel>({
+                    return Promise.resolve<IFluidDataStoreChannel>({
                         request: async (r) => {
                             assert.equal(r.url, "");
                             return Promise.resolve(createComponentResponse({}));
                         },
-                    } as IComponentRuntimeChannel);
+                    } as IFluidDataStoreChannel);
                 },
             } as IContainerRuntime;
             const response = await componentRuntimeRequestHandler(requestParser, runtime);
@@ -40,15 +40,15 @@ describe("RequestParser", () => {
         it("Component request with wait", async () => {
             const requestParser = new RequestParser({ url: "/componentId", headers: { wait: true } });
             const runtime: IContainerRuntime = {
-                getComponentRuntime: async (id, wait): Promise<IComponentRuntimeChannel> => {
+                getDataStore: async (id, wait): Promise<IFluidDataStoreChannel> => {
                     assert.equal(id, "componentId");
                     assert.equal(wait, true);
-                    return Promise.resolve<IComponentRuntimeChannel>({
+                    return Promise.resolve<IFluidDataStoreChannel>({
                         request: async (r) => {
                             assert.equal(r.url, "");
                             return Promise.resolve(createComponentResponse({}));
                         },
-                    } as IComponentRuntimeChannel);
+                    } as IFluidDataStoreChannel);
                 },
             } as IContainerRuntime;
             const response = await componentRuntimeRequestHandler(requestParser, runtime);
@@ -58,15 +58,15 @@ describe("RequestParser", () => {
         it("Component request with sub route", async () => {
             const requestParser = new RequestParser({ url: "/componentId/route", headers: { wait: true } });
             const runtime: IContainerRuntime = {
-                getComponentRuntime: async (id, wait): Promise<IComponentRuntimeChannel> => {
+                getDataStore: async (id, wait): Promise<IFluidDataStoreChannel> => {
                     assert.equal(id, "componentId");
                     assert.equal(wait, true);
-                    return Promise.resolve<IComponentRuntimeChannel>({
+                    return Promise.resolve<IFluidDataStoreChannel>({
                         request: async (r) => {
                             assert.equal(r.url, "route");
                             return Promise.resolve(createComponentResponse({}));
                         },
-                    } as IComponentRuntimeChannel);
+                    } as IFluidDataStoreChannel);
                 },
             } as IContainerRuntime;
             const response = await componentRuntimeRequestHandler(requestParser, runtime);

--- a/packages/runtime/client-api/src/api/codeLoader.ts
+++ b/packages/runtime/client-api/src/api/codeLoader.ts
@@ -5,7 +5,7 @@
 
 import * as cell from "@fluidframework/cell";
 import { IRequest } from "@fluidframework/component-core-interfaces";
-import { ComponentRuntime } from "@fluidframework/component-runtime";
+import { FluidDataStoreRuntime } from "@fluidframework/component-runtime";
 import {
     ICodeLoader,
     IContainerContext,
@@ -20,7 +20,7 @@ import * as ink from "@fluidframework/ink";
 import * as map from "@fluidframework/map";
 import { ConsensusQueue } from "@fluidframework/ordered-collection";
 import {
-    IComponentContext,
+    IFluidDataStoreContext,
     IComponentFactory,
     NamedComponentRegistryEntries,
 } from "@fluidframework/runtime-definitions";
@@ -38,7 +38,7 @@ export class Chaincode implements IComponentFactory {
 
     public constructor(private readonly closeFn: () => void) { }
 
-    public instantiateComponent(context: IComponentContext): void {
+    public instantiateComponent(context: IFluidDataStoreContext): void {
         // Create channel factories
         const mapFactory = map.SharedMap.getFactory();
         const sharedStringFactory = sequence.SharedString.getFactory();
@@ -64,7 +64,7 @@ export class Chaincode implements IComponentFactory {
         modules.set(directoryFactory.type, directoryFactory);
         modules.set(sharedIntervalFactory.type, sharedIntervalFactory);
 
-        const runtime = ComponentRuntime.load(context, modules);
+        const runtime = FluidDataStoreRuntime.load(context, modules);
 
         // Initialize core data structures
         let root: map.ISharedMap;
@@ -110,7 +110,7 @@ export class ChaincodeFactory implements IRuntimeFactory {
 
         const componentId = trimmed !== "" ? trimmed : rootMapId;
 
-        const component = await runtime.getComponentRuntime(componentId, true);
+        const component = await runtime.getDataStore(componentId, true);
         return component.request({ url: trimmed.substr(1 + trimmed.length) });
     }
 
@@ -133,7 +133,7 @@ export class ChaincodeFactory implements IRuntimeFactory {
 
         // On first boot create the base component
         if (!runtime.existing) {
-            runtime.createComponent(rootMapId, "@fluid-internal/client-api")
+            runtime.createDataStore(rootMapId, "@fluid-internal/client-api")
                 .then((componentRuntime) => {
                     componentRuntime.bindToContext();
                 })

--- a/packages/runtime/client-api/src/api/document.ts
+++ b/packages/runtime/client-api/src/api/document.ts
@@ -5,7 +5,7 @@
 
 import { EventEmitter } from "events";
 import * as cell from "@fluidframework/cell";
-import { ComponentRuntime } from "@fluidframework/component-runtime";
+import { FluidDataStoreRuntime } from "@fluidframework/component-runtime";
 import {
     IDeltaManager,
     IFluidCodeDetails,
@@ -23,7 +23,7 @@ import {
     ISequencedClient,
     ISequencedDocumentMessage,
 } from "@fluidframework/protocol-definitions";
-import { IComponentContext } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 import * as sequence from "@fluidframework/sequence";
 import { ISharedObject } from "@fluidframework/shared-object-base";
 import { CodeLoader } from "./codeLoader";
@@ -99,8 +99,8 @@ export class Document extends EventEmitter {
      * Constructs a new document from the provided details
      */
     constructor(
-        public readonly runtime: ComponentRuntime,
-        public readonly context: IComponentContext,
+        public readonly runtime: FluidDataStoreRuntime,
+        public readonly context: IFluidDataStoreContext,
         private readonly root: ISharedMap,
         private readonly closeFn: () => void,
     ) {

--- a/packages/runtime/component-runtime-definitions/src/channel.ts
+++ b/packages/runtime/component-runtime-definitions/src/channel.ts
@@ -6,7 +6,7 @@
 import { IComponentLoadable } from "@fluidframework/component-core-interfaces";
 import { ISequencedDocumentMessage, ITree } from "@fluidframework/protocol-definitions";
 import { IChannelAttributes } from "./storage";
-import { IComponentRuntime } from "./componentRuntime";
+import { IFluidDataStoreRuntime } from "./componentRuntime";
 
 declare module "@fluidframework/component-core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -166,7 +166,7 @@ export interface IChannelFactory {
      * need a way to allow the document to provide later storage for the object.
      */
     load(
-        runtime: IComponentRuntime,
+        runtime: IFluidDataStoreRuntime,
         id: string,
         services: IChannelServices,
         branchId: string,
@@ -184,5 +184,5 @@ export interface IChannelFactory {
      * NOTE here - When we attach we need to submit all the pending ops prior to actually doing the attach
      * for consistency.
      */
-    create(runtime: IComponentRuntime, id: string): IChannel;
+    create(runtime: IFluidDataStoreRuntime, id: string): IChannel;
 }

--- a/packages/runtime/component-runtime-definitions/src/componentRuntime.ts
+++ b/packages/runtime/component-runtime-definitions/src/componentRuntime.ts
@@ -29,7 +29,7 @@ import { IChannel } from ".";
 /**
  * Represents the runtime for the component. Contains helper functions/state of the component.
  */
-export interface IComponentRuntime extends
+export interface IFluidDataStoreRuntime extends
     IComponentRouter,
     EventEmitter,
     IDisposable,

--- a/packages/runtime/component-runtime/src/componentRuntime.ts
+++ b/packages/runtime/component-runtime/src/componentRuntime.ts
@@ -40,15 +40,15 @@ import {
 } from "@fluidframework/protocol-definitions";
 import {
     IAttachMessage,
-    IComponentContext,
+    IFluidDataStoreContext,
     IComponentRegistry,
-    IComponentRuntimeChannel,
+    IFluidDataStoreChannel,
     IEnvelope,
     IInboundSignalMessage,
     SchedulerType,
 } from "@fluidframework/runtime-definitions";
 import { generateHandleContextPath, unreachableCase } from "@fluidframework/runtime-utils";
-import { IChannel, IComponentRuntime, IChannelFactory } from "@fluidframework/component-runtime-definitions";
+import { IChannel, IFluidDataStoreRuntime, IChannelFactory } from "@fluidframework/component-runtime-definitions";
 import { v4 as uuid } from "uuid";
 import { IChannelContext, snapshotChannel } from "./channelContext";
 import { LocalChannelContext } from "./localChannelContext";
@@ -69,8 +69,8 @@ export interface ISharedObjectRegistry {
 /**
  * Base component class
  */
-export class ComponentRuntime extends EventEmitter implements IComponentRuntimeChannel,
-    IComponentRuntime, IComponentHandleContext {
+export class FluidDataStoreRuntime extends EventEmitter implements IFluidDataStoreChannel,
+    IFluidDataStoreRuntime, IComponentHandleContext {
     /**
      * Loads the component runtime
      * @param context - The component context
@@ -79,12 +79,12 @@ export class ComponentRuntime extends EventEmitter implements IComponentRuntimeC
      * @param componentRegistry - The registry of components created and used by this component
      */
     public static load(
-        context: IComponentContext,
+        context: IFluidDataStoreContext,
         sharedObjectRegistry: ISharedObjectRegistry,
         componentRegistry?: IComponentRegistry,
-    ): ComponentRuntime {
+    ): FluidDataStoreRuntime {
         const logger = ChildLogger.create(context.containerRuntime.logger, undefined, { componentId: uuid() });
-        const runtime = new ComponentRuntime(
+        const runtime = new FluidDataStoreRuntime(
             context,
             context.documentId,
             context.id,
@@ -171,7 +171,7 @@ export class ComponentRuntime extends EventEmitter implements IComponentRuntimeC
     private _attachState: AttachState;
 
     private constructor(
-        private readonly componentContext: IComponentContext,
+        private readonly componentContext: IFluidDataStoreContext,
         public readonly documentId: string,
         public readonly id: string,
         public readonly parentBranch: string | null,

--- a/packages/runtime/component-runtime/src/localChannelContext.ts
+++ b/packages/runtime/component-runtime/src/localChannelContext.ts
@@ -9,8 +9,8 @@ import {
     ISequencedDocumentMessage,
     ITree,
 } from "@fluidframework/protocol-definitions";
-import { IChannel, IComponentRuntime } from "@fluidframework/component-runtime-definitions";
-import { IComponentContext } from "@fluidframework/runtime-definitions";
+import { IChannel, IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 import { createServiceEndpoints, IChannelContext, snapshotChannel } from "./channelContext";
 import { ChannelDeltaConnection } from "./channelDeltaConnection";
 import { ISharedObjectRegistry } from "./componentRuntime";
@@ -28,8 +28,8 @@ export class LocalChannelContext implements IChannelContext {
         id: string,
         registry: ISharedObjectRegistry,
         type: string,
-        runtime: IComponentRuntime,
-        private readonly componentContext: IComponentContext,
+        runtime: IFluidDataStoreRuntime,
+        private readonly componentContext: IFluidDataStoreContext,
         private readonly storageService: IDocumentStorageService,
         private readonly submitFn: (content: any, localOpMetadata: unknown) => number,
         dirtyFn: (address: string) => void,

--- a/packages/runtime/component-runtime/src/remoteChannelContext.ts
+++ b/packages/runtime/component-runtime/src/remoteChannelContext.ts
@@ -15,11 +15,11 @@ import {
 import {
     IChannel,
     IChannelAttributes,
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IChannelFactory,
 } from "@fluidframework/component-runtime-definitions";
 import {
-    IComponentContext,
+    IFluidDataStoreContext,
     ISummaryTracker,
 } from "@fluidframework/runtime-definitions";
 import { createServiceEndpoints, IChannelContext, snapshotChannel } from "./channelContext";
@@ -38,8 +38,8 @@ export class RemoteChannelContext implements IChannelContext {
         readonly objectStorage: ChannelStorageService,
     };
     constructor(
-        private readonly runtime: IComponentRuntime,
-        private readonly componentContext: IComponentContext,
+        private readonly runtime: IFluidDataStoreRuntime,
+        private readonly componentContext: IFluidDataStoreContext,
         storageService: IDocumentStorageService,
         submitFn: (content: any, localOpMetadata: unknown) => number,
         dirtyFn: (address: string) => void,

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -25,8 +25,8 @@ import {
 import {
     FlushMode,
     IContainerRuntimeBase,
-    IComponentRuntimeChannel,
-    IComponentContext,
+    IFluidDataStoreChannel,
+    IFluidDataStoreContext,
     IInboundSignalMessage,
 } from "@fluidframework/runtime-definitions";
 import { IProvideContainerRuntimeDirtyable } from "./containerRuntimeDirtyable";
@@ -90,7 +90,7 @@ export interface IContainerRuntime extends
      * @param id - Id supplied during creating the component.
      * @param wait - True if you want to wait for it.
      */
-    getComponentRuntime(id: string, wait?: boolean): Promise<IComponentRuntimeChannel>;
+    getDataStore(id: string, wait?: boolean): Promise<IFluidDataStoreChannel>;
 
     /**
      * Creates a new component using an optional realization function.  This API does not allow specifying
@@ -99,10 +99,10 @@ export interface IContainerRuntime extends
      * @param pkg - Package name of the component
      * @param realizationFn - Optional function to call to realize the component over the context default
      */
-    createComponentWithRealizationFn(
+    createDataStoreWithRealizationFn(
         pkg: string[],
-        realizationFn?: (context: IComponentContext) => void,
-    ): Promise<IComponentRuntimeChannel>;
+        realizationFn?: (context: IFluidDataStoreContext) => void,
+    ): Promise<IFluidDataStoreChannel>;
 
     /**
      * Returns the current quorum.
@@ -131,9 +131,9 @@ export interface IContainerRuntime extends
     flush(): void;
 
     /**
-     * Used to notify the HostingRuntime that the ComponentRuntime has be instantiated.
+     * Used to notify the HostingRuntime that the FluidDataStoreRuntime has be instantiated.
      */
-    notifyComponentInstantiated(componentContext: IComponentContext): void;
+    notifyDataStoreInstantiated(componentContext: IFluidDataStoreContext): void;
 
     /**
      * Get an absolute url for a provided container-relative request.

--- a/packages/runtime/container-runtime-definitions/src/containerRuntimeDirtyable.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntimeDirtyable.ts
@@ -26,7 +26,7 @@ IProvideContainerRuntimeDirtyable {
     /**
      * Will return true for any message that affects the dirty state of this document.
      * This function can be used to filter out any runtime operations that should not be affecting whether or not
-     * the IComponentRuntime.isDocumentDirty call returns true/false
+     * the IFluidDataStoreRuntime.isDocumentDirty call returns true/false
      * @param type - The type of ContainerRuntime message that is being checked
      * @param contents - The contents of the message that is being verified
      */

--- a/packages/runtime/container-runtime/src/test/componentCreation.spec.ts
+++ b/packages/runtime/container-runtime/src/test/componentCreation.spec.ts
@@ -4,8 +4,8 @@
  */
 import assert from "assert";
 import {
-    IComponentRuntimeChannel,
-    IComponentContext,
+    IFluidDataStoreChannel,
+    IFluidDataStoreContext,
     IComponentFactory,
     IComponentRegistry,
     ComponentRegistryEntry,
@@ -15,7 +15,7 @@ import { IComponent, IFluidObject } from "@fluidframework/component-core-interfa
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { MockComponentRuntime } from "@fluidframework/test-runtime-utils";
 import { SummaryTracker } from "@fluidframework/runtime-utils";
-import { LocalComponentContext } from "../componentContext";
+import { LocalFluidDataStoreContext } from "../componentContext";
 import { ContainerRuntime } from "../containerRuntime";
 
 describe("Component Creation Tests", () => {
@@ -35,7 +35,7 @@ describe("Component Creation Tests", () => {
 
         let storage: IDocumentStorageService;
         let scope: IComponent & IFluidObject;
-        const attachCb = (mR: IComponentRuntimeChannel) => { };
+        const attachCb = (mR: IFluidDataStoreChannel) => { };
         let containerRuntime: ContainerRuntime;
         const defaultName = "default";
         const componentAName = "componentA";
@@ -49,7 +49,7 @@ describe("Component Creation Tests", () => {
             const registryEntries = new Map(entries);
             const factory: IComponentFactory = {
                 get IComponentFactory() { return factory; },
-                instantiateComponent: (context: IComponentContext) => {
+                instantiateComponent: (context: IFluidDataStoreContext) => {
                     context.bindRuntime(new MockComponentRuntime());
                 },
             };
@@ -88,7 +88,7 @@ describe("Component Creation Tests", () => {
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             containerRuntime = {
                 IComponentRegistry: globalRegistry,
-                notifyComponentInstantiated: (c) => { },
+                notifyDataStoreInstantiated: (c) => { },
                 on: (event, listener) => {},
             } as ContainerRuntime;
             summaryTracker = new SummaryTracker("", 0, 0);
@@ -97,7 +97,7 @@ describe("Component Creation Tests", () => {
         it("Valid global component", async () => {
             let success: boolean = true;
             // Create the default component that is in the global registry.
-            const context: LocalComponentContext = new LocalComponentContext(
+            const context: LocalFluidDataStoreContext = new LocalFluidDataStoreContext(
                 "default-Id",
                 [defaultName],
                 containerRuntime,
@@ -118,7 +118,7 @@ describe("Component Creation Tests", () => {
         it("Invalid global component", async () => {
             let success: boolean = true;
             // Create component A that is not in the global registry.
-            const context: LocalComponentContext = new LocalComponentContext(
+            const context: LocalFluidDataStoreContext = new LocalFluidDataStoreContext(
                 "A-Id",
                 [componentAName],
                 containerRuntime,
@@ -139,7 +139,7 @@ describe("Component Creation Tests", () => {
         it("Valid subcomponent from the global component", async () => {
             let success: boolean = true;
             // Create component A that is in the registry of the default component.
-            const contextA: LocalComponentContext = new LocalComponentContext(
+            const contextA: LocalFluidDataStoreContext = new LocalFluidDataStoreContext(
                 "A-Id",
                 [defaultName, componentAName],
                 containerRuntime,
@@ -160,7 +160,7 @@ describe("Component Creation Tests", () => {
         it("Invalid subcomponent from the global component", async () => {
             let success: boolean = true;
             // Create component B that is in not the registry of the default component.
-            const contextB: LocalComponentContext = new LocalComponentContext(
+            const contextB: LocalFluidDataStoreContext = new LocalFluidDataStoreContext(
                 "B-Id",
                 [defaultName, componentBName],
                 containerRuntime,
@@ -181,7 +181,7 @@ describe("Component Creation Tests", () => {
         it("Valid subcomponent at depth 2", async () => {
             let success: boolean = true;
             // Create component B that is in the registry of component A (which is at depth 2).
-            const contextB: LocalComponentContext = new LocalComponentContext(
+            const contextB: LocalFluidDataStoreContext = new LocalFluidDataStoreContext(
                 "B-Id",
                 [defaultName, componentAName, componentBName],
                 containerRuntime,
@@ -199,7 +199,7 @@ describe("Component Creation Tests", () => {
             assert.strictEqual(success, true);
 
             // Create component C that is in the registry of component A (which is at depth 2).
-            const contextC: LocalComponentContext = new LocalComponentContext(
+            const contextC: LocalFluidDataStoreContext = new LocalFluidDataStoreContext(
                 "C-Id",
                 [defaultName, componentAName, componentCName],
                 containerRuntime,
@@ -220,7 +220,7 @@ describe("Component Creation Tests", () => {
         it("Invalid subcomponent at depth 2", async () => {
             let success: boolean = true;
             // Create a fake component that is not in the registry of component A (which is at depth 2).
-            const contextFake: LocalComponentContext = new LocalComponentContext(
+            const contextFake: LocalFluidDataStoreContext = new LocalFluidDataStoreContext(
                 "fake-Id",
                 [defaultName, componentAName, "fake"],
                 containerRuntime,
@@ -241,7 +241,7 @@ describe("Component Creation Tests", () => {
         it("Invalid subcomponent at depth 3", async () => {
             let success: boolean = true;
             // Create a fake component that is not in the registry of component B (which is at depth 3).
-            const contextFake: LocalComponentContext = new LocalComponentContext(
+            const contextFake: LocalFluidDataStoreContext = new LocalFluidDataStoreContext(
                 "fake-Id",
                 [defaultName, componentAName, componentBName, "fake"],
                 containerRuntime,
@@ -262,7 +262,7 @@ describe("Component Creation Tests", () => {
         it("Subcomponent which is in the registry of the parent component", async () => {
             let success: boolean = true;
             // Create component C that is in parent's registry but not in the registry of component B.
-            const contextC: LocalComponentContext = new LocalComponentContext(
+            const contextC: LocalFluidDataStoreContext = new LocalFluidDataStoreContext(
                 "C-Id",
                 [defaultName, componentAName, componentBName, componentCName],
                 containerRuntime,

--- a/packages/runtime/runtime-definitions/src/componentContext.ts
+++ b/packages/runtime/runtime-definitions/src/componentContext.ts
@@ -54,7 +54,7 @@ export enum FlushMode {
 
 /**
  * A reduced set of functionality of IContainerRuntime that a component/component runtime will need
- * TODO: this should be merged into IComponentContext
+ * TODO: this should be merged into IFluidDataStoreContext
  */
 export interface IContainerRuntimeBase extends
     EventEmitter,
@@ -96,15 +96,15 @@ export interface IContainerRuntimeBase extends
     on(event: "leader" | "notleader", listener: () => void): this;
 
     /**
-     * Creates a new IComponentContext instance.  The caller completes construction of the the component by
-     * calling IComponentContext.bindRuntime() when the component is prepared to begin processing ops.
+     * Creates a new IFluidDataStoreContext instance.  The caller completes construction of the the component by
+     * calling IFluidDataStoreContext.bindRuntime() when the component is prepared to begin processing ops.
      *
      * @param pkg - Package path for the component to be created
      * @param props - Properties to be passed to the instantiateComponent thru the context
      *  @deprecated 0.16 Issue #1537 Properties should be passed directly to the component's initialization
      *  or to the factory method rather than be stored in/passed from the context
      */
-    createComponentContext(pkg: string[], props?: any): IComponentContext;
+    createDataStoreContext(pkg: string[], props?: any): IFluidDataStoreContext;
 
     /**
      * @deprecated 0.16 Issue #1537
@@ -118,7 +118,7 @@ export interface IContainerRuntimeBase extends
      * Further change to the component create flow to split the local create vs remote instantiate make this deprecated.
      * @internal
      */
-    _createComponentWithProps(pkg: string | string[], props?: any, id?: string): Promise<IComponentRuntimeChannel>;
+    _createDataStoreWithProps(pkg: string | string[], props?: any, id?: string): Promise<IFluidDataStoreChannel>;
 
     /**
      * @deprecated
@@ -127,7 +127,7 @@ export interface IContainerRuntimeBase extends
      * @param pkg - Package name of the component. Optional and only required if specifying an explicit ID.
      * Remove once issue #1756 is closed
      */
-    createComponent(pkgOrId: string, pkg?: string | string[]): Promise<IComponentRuntimeChannel>;
+    createDataStore(pkgOrId: string, pkg?: string | string[]): Promise<IFluidDataStoreChannel>;
 
     /**
      * Get an absolute url for a provided container-relative request.
@@ -138,12 +138,12 @@ export interface IContainerRuntimeBase extends
 }
 
 /**
- * Minimal interface a component runtime need to provide for IComponentContext to bind to control
+ * Minimal interface a component runtime need to provide for IFluidDataStoreContext to bind to control
  *
  * Functionality include attach, snapshot, op/signal processing, request routes,
  * and connection state notifications
  */
-export interface IComponentRuntimeChannel extends
+export interface IFluidDataStoreChannel extends
     IComponentRouter,
     Partial<IProvideComponentRegistry>,
     IDisposable {
@@ -237,7 +237,7 @@ export interface ISummaryTracker {
  * Represents the context for the component. It is used by the component runtime to
  * get information and call functionality to the container.
  */
-export interface IComponentContext extends EventEmitter {
+export interface IFluidDataStoreContext extends EventEmitter {
     readonly documentId: string;
     readonly id: string;
     /**
@@ -327,11 +327,11 @@ export interface IComponentContext extends EventEmitter {
      * @param pkg - Package name of the component. Optional and only required if specifying an explicit ID.
      * @param props - Properties to be passed to the instantiateComponent through the context.
      */
-    createComponent(
+    createDataStore(
         pkgOrId: string | undefined,
         pkg?: string | string[],
         props?: any,
-    ): Promise<IComponentRuntimeChannel>;
+    ): Promise<IFluidDataStoreChannel>;
 
     /**
      * Create a new component using subregistries with fallback.
@@ -340,24 +340,24 @@ export interface IComponentContext extends EventEmitter {
      * @returns A promise for a component that will have been initialized. Caller is responsible
      * for attaching the component to the provided runtime's container such as by storing its handle
      */
-    createComponentWithRealizationFn(
+    createDataStoreWithRealizationFn(
         pkg: string,
-        realizationFn?: (context: IComponentContext) => void,
+        realizationFn?: (context: IFluidDataStoreContext) => void,
     ): Promise<IComponent & IComponentLoadable>;
 
     /**
      * Binds a runtime to the context.
      */
-    bindRuntime(componentRuntime: IComponentRuntimeChannel): void;
+    bindRuntime(componentRuntime: IFluidDataStoreChannel): void;
 
     /**
      * Register the runtime to the container
      * @param componentRuntime - runtime to attach
      */
-    bindToContext(componentRuntime: IComponentRuntimeChannel): void;
+    bindToContext(componentRuntime: IFluidDataStoreChannel): void;
 
     /**
-     * Call by IComponentRuntimeChannel, indicates that a channel is dirty and needs to be part of the summary.
+     * Call by IFluidDataStoreChannel, indicates that a channel is dirty and needs to be part of the summary.
      * @param address - The address of the channe that is dirty.
      */
     setChannelDirty(address: string): void;
@@ -371,15 +371,15 @@ export interface IComponentContext extends EventEmitter {
 }
 
 /**
- * Legacy API to be removed from IComponentContext
+ * Legacy API to be removed from IFluidDataStoreContext
  *
  * Moving out of the main interface to force compilation error.
  * But the implementation is still in place as a transition so user can case to
  * the legacy interface and use it temporary if changing their code take some time.
  */
-export interface IComponentContextLegacy extends IComponentContext {
+export interface IComponentContextLegacy extends IFluidDataStoreContext {
     /**
-     * @deprecated 0.18. Should call IComponentRuntimeChannel.request directly
+     * @deprecated 0.18. Should call IFluidDataStoreChannel.request directly
      * Make request to the component.
      * @param request - Request.
      */

--- a/packages/runtime/runtime-definitions/src/componentFactory.ts
+++ b/packages/runtime/runtime-definitions/src/componentFactory.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IComponentContext } from "./componentContext";
+import { IFluidDataStoreContext } from "./componentContext";
 
 declare module "@fluidframework/component-core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -32,5 +32,5 @@ export interface IComponentFactory extends IProvideComponentFactory {
      * Generates runtime for the component from the component context. Once created should be bound to the context.
      * @param context - Context for the component.
      */
-    instantiateComponent(context: IComponentContext): void;
+    instantiateComponent(context: IFluidDataStoreContext): void;
 }

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -39,14 +39,14 @@ import {
 } from "@fluidframework/protocol-definitions";
 import {
     IChannel,
-    IComponentRuntime,
+    IFluidDataStoreRuntime,
     IDeltaConnection,
     IDeltaHandler,
     IChannelStorageService,
     IChannelServices,
 } from "@fluidframework/component-runtime-definitions";
 import { ComponentSerializer, getNormalizedObjectStoragePathParts } from "@fluidframework/runtime-utils";
-import { IComponentRuntimeChannel } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreChannel } from "@fluidframework/runtime-definitions";
 import { v4 as uuid } from "uuid";
 import { MockDeltaManager } from "./mockDeltas";
 
@@ -117,9 +117,9 @@ export class MockContainerRuntime {
         protected readonly factory: MockContainerRuntimeFactory,
     ) {
         this.deltaManager = new MockDeltaManager();
-        // Set ComponentRuntime's deltaManager to ours so that they are in sync.
+        // Set FluidDataStoreRuntime's deltaManager to ours so that they are in sync.
         this.componentRuntime.deltaManager = this.deltaManager;
-        // ComponentRuntime already creates a clientId, reuse that so they are in sync.
+        // FluidDataStoreRuntime already creates a clientId, reuse that so they are in sync.
         this.clientId = this.componentRuntime.clientId;
     }
 
@@ -361,7 +361,7 @@ export class MockQuorum implements IQuorum, EventEmitter {
  * Mock implementation of IRuntime for testing that does nothing
  */
 export class MockComponentRuntime extends EventEmitter
-    implements IComponentRuntime, IComponentRuntimeChannel, IComponentHandleContext {
+    implements IFluidDataStoreRuntime, IFluidDataStoreChannel, IComponentHandleContext {
     public get IComponentHandleContext(): IComponentHandleContext { return this; }
     public get IComponentRouter() { return this; }
 

--- a/packages/runtime/test-runtime-utils/src/mocksForReconnection.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksForReconnection.ts
@@ -31,7 +31,7 @@ export class MockContainerRuntimeForReconnection extends MockContainerRuntime {
             this.clientSequenceNumber = 0;
             // We should get a new clientId on reconnection.
             this.clientId = uuid();
-            // Update the clientId in ComponentRuntime.
+            // Update the clientId in FluidDataStoreRuntime.
             this.componentRuntime.clientId = this.clientId;
             // On reconnection, ask the DDSs to resubmit pending messages.
             this.reSubmitMessages();

--- a/packages/test/end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -52,7 +52,7 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
         containerRuntime: IContainerRuntimeBase,
     ) => {
         const peerComponentRuntimeChannel = await (containerRuntime as IContainerRuntime)
-            .createComponentWithRealizationFn(["default"]);
+            .createDataStoreWithRealizationFn(["default"]);
         const peerComponent =
             (await peerComponentRuntimeChannel.request({ url: "/" })).value as ITestFluidComponent;
         return {

--- a/packages/test/end-to-end-tests/src/test/compat.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/compat.spec.ts
@@ -80,7 +80,7 @@ describe("loader/runtime compatibility", () => {
                     runtimeOptions,
                 );
                 if (!runtime.existing) {
-                    const componentRuntime = await runtime.createComponent("default", type);
+                    const componentRuntime = await runtime.createDataStore("default", type);
                     await componentRuntime.request({ url: "/" });
                     componentRuntime.bindToContext();
                 }
@@ -261,7 +261,7 @@ describe("loader/runtime compatibility", () => {
         });
     });
 
-    describe("new ContainerRuntime, old ComponentRuntime", function() {
+    describe("new ContainerRuntime, old FluidDataStoreRuntime", function() {
         beforeEach(async function() {
             this.deltaConnectionServer = LocalDeltaConnectionServer.create(
                 undefined,

--- a/packages/test/end-to-end-tests/src/test/componentHandle.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/componentHandle.spec.ts
@@ -85,7 +85,7 @@ describe("ComponentHandle", () => {
         const firstContainer = await createContainer();
         firstContainerComponent1 = await getComponent("default", firstContainer);
         firstContainerComponent2 =
-            await TestSharedComponentFactory.createComponent(firstContainerComponent1._context) as TestSharedComponent;
+            await TestSharedComponentFactory.createDataStore(firstContainerComponent1._context) as TestSharedComponent;
 
         const secondContainer = await createContainer();
         secondContainerComponent1 = await getComponent("default", secondContainer);
@@ -110,17 +110,20 @@ describe("ComponentHandle", () => {
         assert.equal(containerRuntime2.absolutePath, absolutePath, "The remote ContainerRuntime's path is incorrect");
     });
 
-    it("should generate the absolute path for ComponentRuntime correctly", () => {
-        // The expected absolute path for the ComponentRuntime.
+    it("should generate the absolute path for FluidDataStoreRuntime correctly", () => {
+        // The expected absolute path for the FluidDataStoreRuntime.
         const absolutePath = `/${firstContainerComponent1._runtime.id}`;
 
-        // Verify that the local client's ComponentRuntime has the correct absolute path.
+        // Verify that the local client's FluidDataStoreRuntime has the correct absolute path.
         const componentRuntime1 = firstContainerComponent1._runtime.IComponentHandleContext;
-        assert.equal(componentRuntime1.absolutePath, absolutePath, "The ComponentRuntime's path is incorrect");
+        assert.equal(componentRuntime1.absolutePath, absolutePath, "The FluidDataStoreRuntime's path is incorrect");
 
-        // Verify that the remote client's ComponentRuntime has the correct absolute path.
+        // Verify that the remote client's FluidDataStoreRuntime has the correct absolute path.
         const componentRuntime2 = secondContainerComponent1._runtime.IComponentHandleContext;
-        assert.equal(componentRuntime2.absolutePath, absolutePath, "The remote ComponentRuntime's path is incorrect");
+        assert.equal(
+            componentRuntime2.absolutePath,
+            absolutePath,
+            "The remote FluidDataStoreRuntime's path is incorrect");
     });
 
     it("can store and retrieve a DDS from handle within same component runtime", async () => {
@@ -166,7 +169,7 @@ describe("ComponentHandle", () => {
         // Verify that the local client's handle has the correct absolute path.
         assert.equal(sharedMapHandle.absolutePath, absolutePath, "The handle's path is incorrect");
 
-        // Add the handle to the root DDS of `firstContainerComponent1` so that the ComponentRuntime is different.
+        // Add the handle to the root DDS of `firstContainerComponent1` so that the FluidDataStoreRuntime is different.
         firstContainerComponent1._root.set("sharedMap", sharedMap.handle);
 
         await opProcessingController.process();
@@ -193,7 +196,7 @@ describe("ComponentHandle", () => {
         assert.equal(componentHandle.absolutePath, absolutePath, "The handle's absolutepath is not correct");
 
         // Add `firstContainerComponent2's` handle to the root DDS of `firstContainerComponent1` so that the
-        // ComponentRuntime is different.
+        // FluidDataStoreRuntime is different.
         firstContainerComponent1._root.set("component2", firstContainerComponent2.handle);
 
         await opProcessingController.process();

--- a/packages/test/end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
@@ -15,7 +15,7 @@ import {
     IConsensusOrderedCollection,
     waitAcquireAndComplete,
 } from "@fluidframework/ordered-collection";
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import {
     createLocalLoader,
@@ -26,7 +26,7 @@ import {
 } from "@fluidframework/test-utils";
 
 interface ISharedObjectConstructor<T> {
-    create(runtime: IComponentRuntime, id?: string): T;
+    create(runtime: IFluidDataStoreRuntime, id?: string): T;
 }
 
 function generate(

--- a/packages/test/end-to-end-tests/src/test/consensusRegisterCollectionEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/consensusRegisterCollectionEndToEndTests.spec.ts
@@ -13,7 +13,7 @@ import {
     IConsensusRegisterCollection,
     ReadPolicy,
 } from "@fluidframework/register-collection";
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import {
     createLocalLoader,
@@ -23,7 +23,7 @@ import {
 } from "@fluidframework/test-utils";
 
 interface ISharedObjectConstructor<T> {
-    create(runtime: IComponentRuntime, id?: string): T;
+    create(runtime: IFluidDataStoreRuntime, id?: string): T;
 }
 
 function generate(name: string, ctor: ISharedObjectConstructor<IConsensusRegisterCollection>) {

--- a/packages/test/end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -9,7 +9,7 @@ import { IFluidCodeDetails, IProxyLoaderFactory, AttachState } from "@fluidframe
 import { ConnectionState, Loader } from "@fluidframework/container-loader";
 import { IUrlResolver } from "@fluidframework/driver-definitions";
 import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
-import { IComponentContext, IComponentRuntimeChannel } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreContext, IFluidDataStoreChannel } from "@fluidframework/runtime-definitions";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import {
     LocalCodeLoader,
@@ -53,11 +53,11 @@ describe("Detached Container", () => {
     let loader: Loader;
 
     const createAndAttachComponent = (async (
-        componentContext: IComponentContext,
+        componentContext: IFluidDataStoreContext,
         componentId: string,
         type: string,
     ) => {
-        const doc = await componentContext.createComponent(componentId, type);
+        const doc = await componentContext.createDataStore(componentId, type);
         doc.bindToContext();
     });
 
@@ -304,7 +304,7 @@ describe("Detached Container", () => {
     it("Fire component attach ops during container attach", async () => {
         const testComponentType = "default";
         // eslint-disable-next-line prefer-const
-        let peerComponentRuntimeChannel: IComponentRuntimeChannel;
+        let peerComponentRuntimeChannel: IFluidDataStoreChannel;
         const defPromise = new Deferred();
         const container = await loader.createDetachedContainer(pkg);
         // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -325,7 +325,7 @@ describe("Detached Container", () => {
 
         const containerP = container.attach(request);
         peerComponentRuntimeChannel = await (component.context.containerRuntime as IContainerRuntime)
-            .createComponentWithRealizationFn([testComponentType]);
+            .createDataStoreWithRealizationFn([testComponentType]);
         // Fire attach op
         peerComponentRuntimeChannel.bindToContext();
         await containerP;

--- a/packages/test/end-to-end-tests/src/test/localLoader.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/localLoader.spec.ts
@@ -10,7 +10,7 @@ import { IFluidCodeDetails, ILoader } from "@fluidframework/container-definition
 import { Container } from "@fluidframework/container-loader";
 import { SharedCounter } from "@fluidframework/counter";
 import { IComponentFactory } from "@fluidframework/runtime-definitions";
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { SharedString } from "@fluidframework/sequence";
 import { LocalDeltaConnectionServer, ILocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import {
@@ -44,7 +44,7 @@ export class TestComponent extends PrimedComponent {
      * Expose the runtime for testing purposes.
      */
 
-    public runtime: IComponentRuntime;
+    public runtime: IFluidDataStoreRuntime;
 
     public constructor(props: ISharedComponentProps) {
         super(props);
@@ -117,7 +117,7 @@ describe("LocalLoader", () => {
         });
 
         it("opened", async () => {
-            assert(component instanceof TestComponent, "createComponent() must return the expected component type.");
+            assert(component instanceof TestComponent, "createDataStore() must return the expected component type.");
         });
 
         afterEach(async () => {

--- a/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
@@ -274,7 +274,7 @@ describe("Ops on Reconnect", () => {
 
             // Create component2 in the first container.
             const firstContainerComp2 =
-                await firstContainerComp1.context.createComponentWithRealizationFn(
+                await firstContainerComp1.context.createDataStoreWithRealizationFn(
                     "component2",
                 ) as unknown as ITestFluidComponent & IComponentLoadable;
 
@@ -379,7 +379,7 @@ describe("Ops on Reconnect", () => {
 
             // Create component2 in the first container.
             const firstContainerComp2 =
-                await firstContainerComp1.context.createComponentWithRealizationFn(
+                await firstContainerComp1.context.createDataStoreWithRealizationFn(
                     "component2",
                 ) as unknown as ITestFluidComponent & IComponentLoadable;
 

--- a/packages/test/end-to-end-tests/src/test/upgradeManager.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/upgradeManager.spec.ts
@@ -7,7 +7,7 @@ import * as assert from "assert";
 import { OpProcessingController, initializeLocalContainer, LocalCodeLoader } from "@fluidframework/test-utils";
 import { PrimedComponent, PrimedComponentFactory } from "@fluidframework/aqueduct";
 import { UpgradeManager } from "@fluidframework/base-host";
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { ICodeLoader, IFluidCodeDetails, IProxyLoaderFactory } from "@fluidframework/container-definitions";
 import { Container, Loader } from "@fluidframework/container-loader";
 import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
@@ -25,7 +25,7 @@ class TestComponent extends PrimedComponent {
         {},
     );
 
-    public get _runtime(): IComponentRuntime { return this.runtime; }
+    public get _runtime(): IFluidDataStoreRuntime { return this.runtime; }
     public get _root() { return this.root; }
 }
 

--- a/packages/test/test-utils/src/interfaces.ts
+++ b/packages/test/test-utils/src/interfaces.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { ISharedMap } from "@fluidframework/map";
-import { IComponentContext } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 
 declare module "@fluidframework/component-core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -20,7 +20,7 @@ export interface IProvideTestFluidComponent {
 
 export interface ITestFluidComponent extends IProvideTestFluidComponent {
     root: ISharedMap;
-    readonly runtime: IComponentRuntime;
-    readonly context: IComponentContext;
+    readonly runtime: IFluidDataStoreRuntime;
+    readonly context: IFluidDataStoreContext;
     getSharedObject<T = any>(id: string): Promise<T>;
 }

--- a/packages/test/test-utils/src/testFluidComponent.ts
+++ b/packages/test/test-utils/src/testFluidComponent.ts
@@ -4,21 +4,21 @@
  */
 
 import { IRequest, IResponse, IComponentHandle, IComponentLoadable } from "@fluidframework/component-core-interfaces";
-import { ComponentHandle, ComponentRuntime } from "@fluidframework/component-runtime";
+import { ComponentHandle, FluidDataStoreRuntime } from "@fluidframework/component-runtime";
 import { SharedMap, ISharedMap } from "@fluidframework/map";
-import { IComponentContext, IComponentFactory } from "@fluidframework/runtime-definitions";
-import { IComponentRuntime, IChannelFactory } from "@fluidframework/component-runtime-definitions";
+import { IFluidDataStoreContext, IComponentFactory } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreRuntime, IChannelFactory } from "@fluidframework/component-runtime-definitions";
 import { ITestFluidComponent } from "./interfaces";
 
 /**
  * A test component that will create a shared object for each key-value pair in the factoryEntries passed to load.
  * The shared objects can be retrieved by passing the key of the entry to getSharedObject.
- * It exposes the IComponentContext and IComponentRuntime.
+ * It exposes the IFluidDataStoreContext and IFluidDataStoreRuntime.
  */
 export class TestFluidComponent implements ITestFluidComponent, IComponentLoadable {
     public static async load(
-        runtime: IComponentRuntime,
-        context: IComponentContext,
+        runtime: IFluidDataStoreRuntime,
+        context: IFluidDataStoreContext,
         factoryEntries: Map<string, IChannelFactory>) {
         const component = new TestFluidComponent(runtime, context, factoryEntries);
         await component.initialize();
@@ -48,8 +48,8 @@ export class TestFluidComponent implements ITestFluidComponent, IComponentLoadab
      * a shared object is created which can be retrieved by calling getSharedObject() with the id;
      */
     constructor(
-        public readonly runtime: IComponentRuntime,
-        public readonly context: IComponentContext,
+        public readonly runtime: IFluidDataStoreRuntime,
+        public readonly context: IFluidDataStoreContext,
         private readonly factoryEntriesMap: Map<string, IChannelFactory>,
     ) {
         this.url = context.id;
@@ -130,7 +130,7 @@ export class TestFluidComponentFactory implements IComponentFactory {
      */
     constructor(private readonly factoryEntries: Iterable<[string | undefined, IChannelFactory]>) { }
 
-    public instantiateComponent(context: IComponentContext): void {
+    public instantiateComponent(context: IFluidDataStoreContext): void {
         const dataTypes = new Map<string, IChannelFactory>();
 
         // Add SharedMap's factory which will be used to create the root map.
@@ -143,7 +143,7 @@ export class TestFluidComponentFactory implements IComponentFactory {
             dataTypes.set(factory.type, factory);
         }
 
-        const runtime = ComponentRuntime.load(
+        const runtime = FluidDataStoreRuntime.load(
             context,
             dataTypes,
         );


### PR DESCRIPTION
Renaming the core constructs used for managing and creating components. The new conceptual layering looks like this:

ContainerRuntime -> FluidDataContext -> FluidDataRuntime is a FluidDataModelChannel -> FluidDataModel

You can think of DataModel as what we used to call a component, and what developers will create. The DataModelChannel is the projection of that DataModel into the data context, and what the container will interact with.

I went with the term DataModel as I think it captures the code + data grouping. 

Please take a look at the Breaking.md to get a good overview of these changes.