### PR TITLE
Implement get content for test historian

### DIFF
--- a/server/routerlicious/packages/memory-orderer/src/localOrdererSetup.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrdererSetup.ts
@@ -56,7 +56,7 @@ export class LocalOrdererSetup implements ILocalOrdererSetup {
         }
 
         const content = await this.gitManager.getContent(existingRef.object.sha, ".protocol/attributes");
-        const attributes = JSON.parse(Buffer.from(content.content, content.encoding).toString()) as IDocumentAttributes;
+        const attributes = JSON.parse(Buffer.from(content.content, "base64").toString()) as IDocumentAttributes;
 
         return attributes.sequenceNumber;
     }

--- a/server/routerlicious/packages/test-utils/src/testHistorian.ts
+++ b/server/routerlicious/packages/test-utils/src/testHistorian.ts
@@ -73,9 +73,13 @@ export class TestHistorian implements IHistorian {
         };
     }
 
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    public getContent(path: string, ref: string): Promise<any> {
-        throw new Error("Not Supported");
+    public async getContent(path: string, ref: string): Promise<any> {
+        const tree = await this.getTree(ref, true);
+        for (const entry of tree.tree) {
+            if (entry.path === path) {
+                return this.getBlob(entry.sha);
+            }
+        }
     }
 
     public async getCommits(sha: string, count: number): Promise<git.ICommitDetails[]> {


### PR DESCRIPTION
Issue: https://github.com/microsoft/FluidFramework/issues/2792
Scribe lambda request for IDcoumentAttributes by calling this api. Because it not implemented we couldn't get the seq no for the document.