### PR TITLE
Container getAbsoluteUrl return undefined when not attached

### DIFF
--- a/packages/loader/container-definitions/src/loader.ts
+++ b/packages/loader/container-definitions/src/loader.ts
@@ -106,10 +106,12 @@ export interface IContainer extends IEventProvider<IContainerEvents> {
 
     /**
      * Get an absolute url for a provided container-relative request.
+     * If the container is not attached, this will return undefined.
+     *
      * @param relativeUrl - A relative request within the container
      *
      */
-    getAbsoluteUrl(relativeUrl: string): Promise<string>;
+    getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
 }
 
 export interface ILoader {

--- a/packages/loader/container-definitions/src/runtime.ts
+++ b/packages/loader/container-definitions/src/runtime.ts
@@ -140,7 +140,7 @@ export interface IContainerContext extends IMessageScheduler, IDisposable {
      *
      * TODO: Optional for backwards compatibility. Make non-optional in version 0.19
      */
-    getAbsoluteUrl?(relativeUrl: string): Promise<string>;
+    getAbsoluteUrl?(relativeUrl: string): Promise<string | undefined>;
 
     /**
      * Indicates the attachment state of the container to a host service.

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -506,7 +506,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             ensureFluidResolvedUrl(resolvedUrl);
             this._resolvedUrl = resolvedUrl;
             const url = await this.getAbsoluteUrl("");
-            assert(url, "Container url undefined");
+            assert(url !== undefined, "Container url undefined");
             this.originalRequest = { url };
             this._canReconnect = !(request.headers?.[LoaderHeader.reconnect] === false);
             const parsedUrl = parseUrl(resolvedUrl.url);
@@ -665,13 +665,10 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     }
 
     public async getAbsoluteUrl(relativeUrl: string): Promise<string | undefined> {
-        if (this.attachState !== AttachState.Attached) {
+        if (this.resolvedUrl === undefined) {
             return undefined;
         }
 
-        if (this.resolvedUrl === undefined) {
-            throw new Error("Container not attached to storage");
-        }
         // TODO: Remove support for legacy requestUrl in 0.20
         const legacyResolver = this.urlResolver as {
             requestUrl?(resolvedUrl: IResolvedUrl, request: IRequest): Promise<IResponse>;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -663,7 +663,11 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         return this.context!.hasNullRuntime();
     }
 
-    public async getAbsoluteUrl(relativeUrl: string): Promise<string> {
+    public async getAbsoluteUrl(relativeUrl: string): Promise<string | undefined> {
+        if (this.attachState !== AttachState.Attached) {
+            return undefined;
+        }
+
         if (this.resolvedUrl === undefined) {
             throw new Error("Container not attached to storage");
         }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -506,6 +506,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             ensureFluidResolvedUrl(resolvedUrl);
             this._resolvedUrl = resolvedUrl;
             const url = await this.getAbsoluteUrl("");
+            assert(url, "Container url undefined");
             this.originalRequest = { url };
             this._canReconnect = !(request.headers?.[LoaderHeader.reconnect] === false);
             const parsedUrl = parseUrl(resolvedUrl.url);

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -286,7 +286,7 @@ export class ContainerContext implements IContainerContext {
         return this.runtime! instanceof NullRuntime;
     }
 
-    public async getAbsoluteUrl?(relativeUrl: string): Promise<string> {
+    public async getAbsoluteUrl?(relativeUrl: string): Promise<string | undefined> {
         return this.container.getAbsoluteUrl(relativeUrl);
     }
 


### PR DESCRIPTION
For got a case in #2591 related to #2794 