### PR TITLE
Renamed classes in local-drivers from having `test` prefix to `local` prefix

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -8,6 +8,7 @@
 - [IComponentReactViewable deprecated](#IComponentReactViewable-deprecated)
 - [Forward Compat For Loader IComponent Interfaces](#Forward-Compat-For-Loader-IComponent-Interfaces)
 - [Add Undefined to getAbsoluteUrl return type](#Add-Undefined-to-getAbsoluteUrl-return-type)
+- [Renamed TestDeltaStorageService, TestDocumentDeltaConnection, TestDocumentService, TestDocumentServiceFactory and TestResolver](#Renamed-TestDeltaStorageService,-TestDocumentDeltaConnection,-TestDocumentService,-TestDocumentServiceFactory-and-TestResolver)
 
 ### Deprecated `path` from `IComponentHandleContext`
 Deprecated the `path` field from the interface `IComponentHandleContext`. This means that `IComponentHandle` will not have this going forward as well.
@@ -104,6 +105,14 @@ protected async componentHasInitialized() {
             .catch(console.error);
 }
 ```
+
+### Renamed TestDeltaStorageService, TestDocumentDeltaConnection, TestDocumentService, TestDocumentServiceFactory and TestResolver
+Renamed the following in "@fluidframework/local-driver" since these are used beyond testing:
+- `TestDeltaStorageService` -> `LocalDeltaStorageService`
+- `TestDocumentDeltaConnection` -> `LocalDocumentDeltaConnection`
+- `TestDocumentService` -> `LocalDocumentService`
+- `TestDocumentServiceFactory` -> `LocalDocumentServiceFactory`
+- `TestResolver` -> `LocalResolver`
 
 ## 0.21 Breaking Changes
 - [Removed `@fluidframework/local-test-utils`](#removed-`@fluidframework/local-test-utils`)

--- a/packages/drivers/local-driver/src/index.ts
+++ b/packages/drivers/local-driver/src/index.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-export * from "./testDeltaStorageService";
-export * from "./testDocumentDeltaConnection";
-export * from "./testDocumentService";
-export * from "./testDocumentServiceFactory";
-export * from "./testResolver";
+export * from "./localDeltaStorageService";
+export * from "./localDocumentDeltaConnection";
+export * from "./localDocumentService";
+export * from "./localDocumentServiceFactory";
+export * from "./localResolver";

--- a/packages/drivers/local-driver/src/localDeltaStorageService.ts
+++ b/packages/drivers/local-driver/src/localDeltaStorageService.ts
@@ -7,7 +7,7 @@ import * as api from "@fluidframework/driver-definitions";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { IDatabaseManager } from "@fluidframework/server-services-core";
 
-export class TestDeltaStorageService implements api.IDocumentDeltaStorageService {
+export class LocalDeltaStorageService implements api.IDocumentDeltaStorageService {
     constructor(
         private readonly tenantId: string,
         private readonly id: string,

--- a/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
+++ b/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
@@ -25,7 +25,7 @@ import { TestWebSocketServer } from "@fluidframework/server-test-utils";
 import { debug } from "./debug";
 
 const testProtocolVersions = ["^0.3.0", "^0.2.0", "^0.1.0"];
-export class TestDocumentDeltaConnection
+export class LocalDocumentDeltaConnection
     extends TypedEventEmitter<IDocumentDeltaConnectionEvents>
     implements IDocumentDeltaConnection {
     public static async create(
@@ -33,7 +33,7 @@ export class TestDocumentDeltaConnection
         id: string,
         token: string,
         client: IClient,
-        webSocketServer: core.IWebSocketServer): Promise<TestDocumentDeltaConnection> {
+        webSocketServer: core.IWebSocketServer): Promise<LocalDocumentDeltaConnection> {
         const socket = (webSocketServer as TestWebSocketServer).createConnection();
 
         const connectMessage: IConnect = {
@@ -109,7 +109,7 @@ export class TestDocumentDeltaConnection
             socket.emit("connect_document", connectMessage);
         });
 
-        const deltaConnection = new TestDocumentDeltaConnection(socket, id, connection);
+        const deltaConnection = new LocalDocumentDeltaConnection(socket, id, connection);
 
         return Promise.resolve(deltaConnection);
     }

--- a/packages/drivers/local-driver/src/localDocumentService.ts
+++ b/packages/drivers/local-driver/src/localDocumentService.ts
@@ -9,12 +9,12 @@ import * as socketStorage from "@fluidframework/routerlicious-driver";
 import { GitManager } from "@fluidframework/server-services-client";
 import { TestHistorian } from "@fluidframework/server-test-utils";
 import { ILocalDeltaConnectionServer } from "@fluidframework/server-local-server";
-import { TestDeltaStorageService, TestDocumentDeltaConnection } from "./";
+import { LocalDeltaStorageService, LocalDocumentDeltaConnection } from ".";
 
 /**
- * Basic implementation of a document service for testing.
+ * Basic implementation of a document service for local use.
  */
-export class TestDocumentService implements api.IDocumentService {
+export class LocalDocumentService implements api.IDocumentService {
     /**
      * @param localDeltaConnectionServer - delta connection server for ops
      * @param tokenProvider - token provider with a single token
@@ -27,11 +27,11 @@ export class TestDocumentService implements api.IDocumentService {
         private readonly tokenProvider: socketStorage.TokenProvider,
         private readonly tenantId: string,
         private readonly documentId: string,
-        private readonly documentDeltaConnectionsMap: Map<string, TestDocumentDeltaConnection>,
+        private readonly documentDeltaConnectionsMap: Map<string, LocalDocumentDeltaConnection>,
     ) { }
 
     /**
-     * Creates and returns a document storage service for testing.
+     * Creates and returns a document storage service for local use.
      */
     public async connectToStorage(): Promise<api.IDocumentStorageService> {
         return new socketStorage.DocumentStorageService(this.documentId,
@@ -39,22 +39,22 @@ export class TestDocumentService implements api.IDocumentService {
     }
 
     /**
-     * Creates and returns a delta storage service for testing.
+     * Creates and returns a delta storage service for local use.
      */
     public async connectToDeltaStorage(): Promise<api.IDocumentDeltaStorageService> {
-        return new TestDeltaStorageService(
+        return new LocalDeltaStorageService(
             this.tenantId,
             this.documentId,
             this.localDeltaConnectionServer.databaseManager);
     }
 
     /**
-     * Creates and returns a delta stream for testing.
+     * Creates and returns a delta stream for local use.
      * @param client - client data
      */
     public async connectToDeltaStream(
         client: IClient): Promise<api.IDocumentDeltaConnection> {
-        const documentDeltaConnection = await TestDocumentDeltaConnection.create(
+        const documentDeltaConnection = await LocalDocumentDeltaConnection.create(
             this.tenantId,
             this.documentId,
             this.tokenProvider.token,
@@ -91,20 +91,20 @@ export class TestDocumentService implements api.IDocumentService {
 }
 
 /**
- * Creates and returns a document service for testing.
+ * Creates and returns a document service for local use.
  * @param localDeltaConnectionServer - delta connection server for ops
  * @param tokenProvider - token provider with a single token
  * @param tenantId - ID of tenant
  * @param documentId - ID of document
  */
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
-export function createTestDocumentService(
+export function createLocalDocumentService(
     resolvedUrl: api.IResolvedUrl,
     localDeltaConnectionServer: ILocalDeltaConnectionServer,
     tokenProvider: socketStorage.TokenProvider,
     tenantId: string,
     documentId: string,
-    documentDeltaConnectionsMap: Map<string, TestDocumentDeltaConnection>): api.IDocumentService {
-    return new TestDocumentService(
+    documentDeltaConnectionsMap: Map<string, LocalDocumentDeltaConnection>): api.IDocumentService {
+    return new LocalDocumentService(
         resolvedUrl, localDeltaConnectionServer, tokenProvider, tenantId, documentId, documentDeltaConnectionsMap);
 }

--- a/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
+++ b/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
@@ -18,17 +18,17 @@ import {
     getQuorumValuesFromProtocolSummary,
 } from "@fluidframework/driver-utils";
 import { ISummaryTree, NackErrorType } from "@fluidframework/protocol-definitions";
-import { TestDocumentDeltaConnection } from "./testDocumentDeltaConnection";
-import { createTestDocumentService } from "./testDocumentService";
+import { LocalDocumentDeltaConnection } from "./localDocumentDeltaConnection";
+import { createLocalDocumentService } from "./localDocumentService";
 
 /**
- * Implementation of document service factory for testing.
+ * Implementation of document service factory for local use.
  */
-export class TestDocumentServiceFactory implements IDocumentServiceFactory {
+export class LocalDocumentServiceFactory implements IDocumentServiceFactory {
     public readonly protocolName = "fluid-test:";
 
-    // A map of clientId to TestDocumentService.
-    private readonly documentDeltaConnectionsMap: Map<string, TestDocumentDeltaConnection> = new Map();
+    // A map of clientId to LocalDocumentService.
+    private readonly documentDeltaConnectionsMap: Map<string, LocalDocumentDeltaConnection> = new Map();
 
     /**
      * @param localDeltaConnectionServer - delta connection server for ops
@@ -94,7 +94,7 @@ export class TestDocumentServiceFactory implements IDocumentServiceFactory {
 
         const tokenProvider = new TokenProvider(jwtToken);
 
-        return createTestDocumentService(
+        return createLocalDocumentService(
             resolvedUrl,
             this.localDeltaConnectionServer,
             tokenProvider,

--- a/packages/drivers/local-driver/src/localResolver.ts
+++ b/packages/drivers/local-driver/src/localResolver.ts
@@ -17,9 +17,9 @@ import { generateToken } from "@fluidframework/server-services-client";
 
 /**
  * Resolves URLs by providing fake URLs which succeed with the other
- * related test classes.
+ * related local classes.
  */
-export class TestResolver implements IUrlResolver {
+export class LocalResolver implements IUrlResolver {
     private readonly tenantId = "tenantId";
     private readonly tokenKey = "tokenKey";
 

--- a/packages/drivers/local-driver/src/test/localResolverTest.spec.ts
+++ b/packages/drivers/local-driver/src/test/localResolverTest.spec.ts
@@ -6,17 +6,17 @@
 import assert from "assert";
 import { CreateNewHeader, IFluidResolvedUrl } from "@fluidframework/driver-definitions";
 import { IRequest } from "@fluidframework/component-core-interfaces";
-import { TestResolver } from "../testResolver";
+import { LocalResolver } from "../localResolver";
 
 describe("Local Driver Resolver", () => {
-    const documentId = "testResolverTest";
-    let resolver: TestResolver;
+    const documentId = "localResolverTest";
+    let resolver: LocalResolver;
 
     describe("CreateNew Flow", () => {
         let request: IRequest;
 
         beforeEach(() => {
-            resolver = new TestResolver();
+            resolver = new LocalResolver();
             request = resolver.createCreateNewRequest(documentId);
         });
 
@@ -44,7 +44,7 @@ describe("Local Driver Resolver", () => {
 
     describe("Container Request Resolution", () => {
         beforeEach(() => {
-            resolver = new TestResolver();
+            resolver = new LocalResolver();
         });
 
         it("should successfully resolve request for a container url", async () => {

--- a/packages/hosts/local-web-host/src/index.ts
+++ b/packages/hosts/local-web-host/src/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { TestDocumentServiceFactory, TestResolver } from "@fluidframework/local-driver";
+import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
 import { LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { v4 as uuid } from "uuid";
 import {
@@ -23,10 +23,10 @@ import { HTMLViewAdapter } from "@fluidframework/view-adapters";
 export async function createLocalContainerFactory(
     entryPoint: Partial<IProvideRuntimeFactory & IProvideComponentFactory & IFluidModule>,
 ): Promise<() => Promise<Container>> {
-    const urlResolver = new TestResolver();
+    const urlResolver = new LocalResolver();
 
     const deltaConn = LocalDeltaConnectionServer.create();
-    const documentServiceFactory = new TestDocumentServiceFactory(deltaConn);
+    const documentServiceFactory = new LocalDocumentServiceFactory(deltaConn);
 
     const factory: Partial<IProvideRuntimeFactory & IProvideComponentFactory> =
         entryPoint.fluidExport ? entryPoint.fluidExport : entryPoint;

--- a/packages/test/end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -9,7 +9,7 @@ import { IFluidCodeDetails, IProxyLoaderFactory, AttachState } from "@fluidframe
 import { Loader } from "@fluidframework/container-loader";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { IUrlResolver } from "@fluidframework/driver-definitions";
-import { TestDocumentServiceFactory, TestResolver } from "@fluidframework/local-driver";
+import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import {
     LocalCodeLoader,
@@ -67,7 +67,7 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
             [mapId2, SharedMap.getFactory()],
         ]);
         const codeLoader = new LocalCodeLoader([[codeDetails, factory]]);
-        const documentServiceFactory = new TestDocumentServiceFactory(testDeltaConnectionServer);
+        const documentServiceFactory = new LocalDocumentServiceFactory(testDeltaConnectionServer);
         return new Loader(
             urlResolver,
             documentServiceFactory,
@@ -79,7 +79,7 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
 
     beforeEach(async () => {
         testDeltaConnectionServer = LocalDeltaConnectionServer.create();
-        const urlResolver = new TestResolver();
+        const urlResolver = new LocalResolver();
         request = urlResolver.createCreateNewRequest(documentId);
         loader = createTestLoader(urlResolver);
     });

--- a/packages/test/end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/container.spec.ts
@@ -15,7 +15,7 @@ import {
     IFluidResolvedUrl,
     IDocumentServiceFactory,
 } from "@fluidframework/driver-definitions";
-import { TestDocumentServiceFactory, TestResolver } from "@fluidframework/local-driver";
+import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { MockDocumentDeltaConnection } from "@fluid-internal/test-loader-utils";
 import { LocalCodeLoader } from "@fluidframework/test-utils";
@@ -25,7 +25,7 @@ describe("Container", () => {
     const testRequest: IRequest = { url: id };
 
     let testDeltaConnectionServer: ILocalDeltaConnectionServer;
-    let testResolver: TestResolver;
+    let localResolver: LocalResolver;
     let testResolved: IFluidResolvedUrl;
     let deltaConnection: MockDocumentDeltaConnection;
     let serviceFactory: Readonly<IDocumentServiceFactory>;
@@ -34,14 +34,14 @@ describe("Container", () => {
 
     beforeEach(async () => {
         testDeltaConnectionServer = LocalDeltaConnectionServer.create();
-        testResolver = new TestResolver();
-        testResolved = await testResolver.resolve(testRequest) as IFluidResolvedUrl;
-        serviceFactory = new TestDocumentServiceFactory(testDeltaConnectionServer);
+        localResolver = new LocalResolver();
+        testResolved = await localResolver.resolve(testRequest) as IFluidResolvedUrl;
+        serviceFactory = new LocalDocumentServiceFactory(testDeltaConnectionServer);
         codeLoader = new LocalCodeLoader([]);
         const options = {};
 
         loader = new Loader(
-            testResolver,
+            localResolver,
             serviceFactory,
             codeLoader,
             options,
@@ -62,7 +62,7 @@ describe("Container", () => {
                 loader,
                 testRequest,
                 testResolved,
-                testResolver);
+                localResolver);
             success = true;
         } catch (error) {
             success = false;
@@ -93,7 +93,7 @@ describe("Container", () => {
                 loader,
                 testRequest,
                 testResolved,
-                testResolver);
+                localResolver);
             assert.fail("Error expected");
         } catch (error) {
             const err = error as IGenericError;
@@ -124,7 +124,7 @@ describe("Container", () => {
                 loader,
                 testRequest,
                 testResolved,
-                testResolver);
+                localResolver);
             assert.fail("Error expected");
         } catch (error) {
             assert.strictEqual(error.errorType, ContainerErrorType.genericError, "Error is not a general error");
@@ -158,7 +158,7 @@ describe("Container", () => {
             loader,
             testRequest,
             testResolved,
-            testResolver);
+            localResolver);
         assert.strictEqual(container.connectionState, ConnectionState.Connecting,
             "Container should be in Connecting state");
         deltaConnection.disconnect();
@@ -191,7 +191,7 @@ describe("Container", () => {
             loader,
             testRequest,
             testResolved,
-            testResolver);
+            localResolver);
         container.on("error", () => {
             errorRaised = true;
         });
@@ -233,7 +233,7 @@ describe("Container", () => {
             loader,
             testRequest,
             testResolved,
-            testResolver);
+            localResolver);
         container.on("error", () => {
             assert.ok(false, "Error event should not be raised.");
         });
@@ -256,7 +256,7 @@ describe("Container", () => {
             loader,
             testRequest,
             testResolved,
-            testResolver);
+            localResolver);
         assert.strictEqual(container.id, "documentId", "Container's id should be set");
         assert.strictEqual(container.clientDetails.capabilities.interactive, true,
             "Client details should be set with interactive as true");

--- a/packages/test/end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -8,7 +8,7 @@ import { IRequest } from "@fluidframework/component-core-interfaces";
 import { IFluidCodeDetails, IProxyLoaderFactory, AttachState } from "@fluidframework/container-definitions";
 import { ConnectionState, Loader } from "@fluidframework/container-loader";
 import { IUrlResolver } from "@fluidframework/driver-definitions";
-import { TestDocumentServiceFactory, TestResolver } from "@fluidframework/local-driver";
+import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
 import { IComponentContext, IComponentRuntimeChannel } from "@fluidframework/runtime-definitions";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import {
@@ -74,7 +74,7 @@ describe("Detached Container", () => {
             [sparseMatrixId, SparseMatrix.getFactory()],
         ]);
         const codeLoader = new LocalCodeLoader([[pkg, factory]]);
-        const documentServiceFactory = new TestDocumentServiceFactory(testDeltaConnectionServer);
+        const documentServiceFactory = new LocalDocumentServiceFactory(testDeltaConnectionServer);
         return new Loader(
             urlResolver,
             documentServiceFactory,
@@ -86,7 +86,7 @@ describe("Detached Container", () => {
 
     beforeEach(async () => {
         testDeltaConnectionServer = LocalDeltaConnectionServer.create();
-        const urlResolver = new TestResolver();
+        const urlResolver = new LocalResolver();
         request = urlResolver.createCreateNewRequest(documentId);
         loader = createTestLoader(urlResolver);
     });
@@ -185,7 +185,7 @@ describe("Detached Container", () => {
         const subComponent1 = response1.value as ITestFluidComponent;
 
         // Now load the container from another loader.
-        const urlResolver2 = new TestResolver();
+        const urlResolver2 = new LocalResolver();
         const loader2 = createTestLoader(urlResolver2);
         // Create a new request url from the resolvedUrl of the first container.
         const requestUrl2 = await urlResolver2.getAbsoluteUrl(container.resolvedUrl, "");

--- a/packages/test/end-to-end-tests/src/test/documentDirty.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/documentDirty.spec.ts
@@ -7,7 +7,7 @@ import * as assert from "assert";
 import { ContainerRuntimeFactoryWithDefaultComponent } from "@fluidframework/aqueduct";
 import { IFluidCodeDetails, IProxyLoaderFactory } from "@fluidframework/container-definitions";
 import { Container, Loader } from "@fluidframework/container-loader";
-import { TestDocumentServiceFactory, TestResolver } from "@fluidframework/local-driver";
+import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
 import { SharedMap } from "@fluidframework/map";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import {
@@ -28,7 +28,7 @@ describe("Document Dirty", () => {
     };
 
     let deltaConnectionServer: ILocalDeltaConnectionServer;
-    let documentServiceFactory: TestDocumentServiceFactory;
+    let documentServiceFactory: LocalDocumentServiceFactory;
     let containerDeltaEventManager: DocumentDeltaEventManager;
     let container: Container;
     let containerComp: ITestFluidComponent;
@@ -80,7 +80,7 @@ describe("Document Dirty", () => {
                 ],
             );
 
-        const urlResolver = new TestResolver();
+        const urlResolver = new LocalResolver();
         const codeLoader = new LocalCodeLoader([[codeDetails, runtimeFactory]]);
 
         const loader = new Loader(
@@ -105,7 +105,7 @@ describe("Document Dirty", () => {
 
     beforeEach(async () => {
         deltaConnectionServer = LocalDeltaConnectionServer.create();
-        documentServiceFactory = new TestDocumentServiceFactory(deltaConnectionServer);
+        documentServiceFactory = new LocalDocumentServiceFactory(deltaConnectionServer);
 
         // Create the first container, component and DDSes.
         container = await createContainer();

--- a/packages/test/end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/error.spec.ts
@@ -24,7 +24,7 @@ import {
     invalidFileNameStatusCode,
     OdspErrorType,
 } from "@fluidframework/odsp-driver";
-import { TestDocumentServiceFactory, TestResolver } from "@fluidframework/local-driver";
+import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { LocalCodeLoader } from "@fluidframework/test-utils";
 
@@ -33,7 +33,7 @@ describe("Errors Types", () => {
     const testRequest: IRequest = { url: id };
 
     let testDeltaConnectionServer: ILocalDeltaConnectionServer;
-    let testResolver: TestResolver;
+    let localResolver: LocalResolver;
     let testResolved: IFluidResolvedUrl;
     let serviceFactory: IDocumentServiceFactory;
     let codeLoader: LocalCodeLoader;
@@ -42,15 +42,15 @@ describe("Errors Types", () => {
     it("GeneralError Test", async () => {
         // Setup
         testDeltaConnectionServer = LocalDeltaConnectionServer.create();
-        testResolver = new TestResolver();
-        testResolved = await testResolver.resolve(testRequest) as IFluidResolvedUrl;
-        serviceFactory = new TestDocumentServiceFactory(testDeltaConnectionServer);
+        localResolver = new LocalResolver();
+        testResolved = await localResolver.resolve(testRequest) as IFluidResolvedUrl;
+        serviceFactory = new LocalDocumentServiceFactory(testDeltaConnectionServer);
 
         codeLoader = new LocalCodeLoader([]);
         const options = {};
 
         loader = new Loader(
-            testResolver,
+            localResolver,
             serviceFactory,
             codeLoader,
             options,
@@ -78,7 +78,7 @@ describe("Errors Types", () => {
                 loader,
                 testRequest,
                 testResolved,
-                testResolver);
+                localResolver);
 
             assert.fail("Error expected");
         } catch (error) {

--- a/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
@@ -9,7 +9,7 @@ import { IComponentHandle, IComponentLoadable } from "@fluidframework/component-
 import { IFluidCodeDetails, IProxyLoaderFactory } from "@fluidframework/container-definitions";
 import { Container, Loader } from "@fluidframework/container-loader";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
-import { TestDocumentServiceFactory, TestResolver } from "@fluidframework/local-driver";
+import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
 import { SharedMap, SharedDirectory } from "@fluidframework/map";
 import { ISequencedDocumentMessage, ConnectionState } from "@fluidframework/protocol-definitions";
 import { IEnvelope, SchedulerType, FlushMode } from "@fluidframework/runtime-definitions";
@@ -40,7 +40,7 @@ describe("Ops on Reconnect", () => {
     };
 
     let deltaConnectionServer: ILocalDeltaConnectionServer;
-    let documentServiceFactory: TestDocumentServiceFactory;
+    let documentServiceFactory: LocalDocumentServiceFactory;
     let containerDeltaEventManager: DocumentDeltaEventManager;
     let firstContainer: Container;
     let firstContainerClientId: string;
@@ -77,7 +77,7 @@ describe("Ops on Reconnect", () => {
                 ],
             );
 
-        const urlResolver = new TestResolver();
+        const urlResolver = new LocalResolver();
         const codeLoader = new LocalCodeLoader([[codeDetails, runtimeFactory]]);
 
         const loader = new Loader(
@@ -141,7 +141,7 @@ describe("Ops on Reconnect", () => {
 
     beforeEach(async () => {
         deltaConnectionServer = LocalDeltaConnectionServer.create();
-        documentServiceFactory = new TestDocumentServiceFactory(deltaConnectionServer);
+        documentServiceFactory = new LocalDocumentServiceFactory(deltaConnectionServer);
 
         // Create the first container, component and DDSes.
         firstContainer = await createContainer();

--- a/packages/test/end-to-end-tests/src/test/upgradeManager.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/upgradeManager.spec.ts
@@ -10,7 +10,7 @@ import { UpgradeManager } from "@fluidframework/base-host";
 import { IComponentRuntime } from "@fluidframework/component-runtime-definitions";
 import { ICodeLoader, IFluidCodeDetails, IProxyLoaderFactory } from "@fluidframework/container-definitions";
 import { Container, Loader } from "@fluidframework/container-loader";
-import { TestDocumentServiceFactory, TestResolver } from "@fluidframework/local-driver";
+import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
 import { IComponentFactory } from "@fluidframework/runtime-definitions";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 
@@ -37,11 +37,11 @@ describe("UpgradeManager", () => {
     };
 
     let deltaConnectionServer: ILocalDeltaConnectionServer;
-    let documentServiceFactory: TestDocumentServiceFactory;
+    let documentServiceFactory: LocalDocumentServiceFactory;
     let containerDeltaEventManager: DocumentDeltaEventManager;
 
     async function createContainer(factory: IComponentFactory): Promise<Container> {
-        const urlResolver = new TestResolver();
+        const urlResolver = new LocalResolver();
         const codeLoader: ICodeLoader = new LocalCodeLoader([[codeDetails, factory]]);
         const loader = new Loader(
             urlResolver,
@@ -64,7 +64,7 @@ describe("UpgradeManager", () => {
 
     beforeEach(async () => {
         deltaConnectionServer = LocalDeltaConnectionServer.create();
-        documentServiceFactory = new TestDocumentServiceFactory(deltaConnectionServer);
+        documentServiceFactory = new LocalDocumentServiceFactory(deltaConnectionServer);
         containerDeltaEventManager = new DocumentDeltaEventManager(deltaConnectionServer);
     });
 

--- a/packages/test/test-utils/README.md
+++ b/packages/test/test-utils/README.md
@@ -34,7 +34,7 @@ export function createLocalLoader(
 ): ILoader;
 ```
 
-- It creates a `TestResolver` that it uses to resolve requests.
+- It creates a `LocalResolver` that it uses to resolve requests.
 - It creates a `LocalCodeLoader` using the `fluidEntryPoint` list to load Container code.
 - It creates a `DocumentServiceFactory` which serves as the driver layer between the container and the server.
 

--- a/packages/test/test-utils/src/localLoader.ts
+++ b/packages/test/test-utils/src/localLoader.ts
@@ -13,7 +13,7 @@ import {
     IProvideRuntimeFactory,
 } from "@fluidframework/container-definitions";
 import { Loader, Container } from "@fluidframework/container-loader";
-import { TestDocumentServiceFactory, TestResolver } from "@fluidframework/local-driver";
+import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
 import { ILocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { IProvideComponentFactory } from "@fluidframework/runtime-definitions";
 import { LocalCodeLoader } from "./localCodeLoader";
@@ -30,8 +30,8 @@ export function createLocalLoader(
     ]>,
     deltaConnectionServer: ILocalDeltaConnectionServer,
 ): ILoader {
-    const urlResolver = new TestResolver();
-    const documentServiceFactory = new TestDocumentServiceFactory(deltaConnectionServer);
+    const urlResolver = new LocalResolver();
+    const documentServiceFactory = new LocalDocumentServiceFactory(deltaConnectionServer);
     const codeLoader: ICodeLoader = new LocalCodeLoader(packageEntries);
 
     return new Loader(

--- a/packages/tools/webpack-component-loader/src/multiDocumentServiceFactory.ts
+++ b/packages/tools/webpack-component-loader/src/multiDocumentServiceFactory.ts
@@ -5,7 +5,7 @@
 
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { MultiDocumentServiceFactory } from "@fluidframework/driver-utils";
-import { TestDocumentServiceFactory } from "@fluidframework/local-driver";
+import { LocalDocumentServiceFactory } from "@fluidframework/local-driver";
 import { OdspDocumentServiceFactory } from "@fluidframework/odsp-driver";
 import { RouterliciousDocumentServiceFactory, DefaultErrorTracking } from "@fluidframework/routerlicious-driver";
 import { RouteOptions } from "./loader";
@@ -19,7 +19,7 @@ export function getDocumentServiceFactory(documentId: string, options: RouteOpti
     deltaConns.set(documentId, deltaConn);
 
     return MultiDocumentServiceFactory.create([
-        new TestDocumentServiceFactory(deltaConn),
+        new LocalDocumentServiceFactory(deltaConn),
         // TODO: web socket token
         new OdspDocumentServiceFactory(
             async () => options.mode === "spo" || options.mode === "spo-df" ? options.odspAccessToken : undefined,

--- a/packages/tools/webpack-component-loader/src/multiResolver.ts
+++ b/packages/tools/webpack-component-loader/src/multiResolver.ts
@@ -5,7 +5,7 @@
 
 import { IResolvedUrl, IUrlResolver } from "@fluidframework/driver-definitions";
 import { IRequest } from "@fluidframework/component-core-interfaces";
-import { TestResolver } from "@fluidframework/local-driver";
+import { LocalResolver } from "@fluidframework/local-driver";
 import { InsecureUrlResolver } from "@fluidframework/test-runtime-utils";
 // eslint-disable-next-line import/no-internal-modules
 import uuid from "uuid/v4";
@@ -66,7 +66,7 @@ function getUrlResolver(
                 { accessToken: options.odspAccessToken });
 
         default: // Local
-            return new TestResolver();
+            return new LocalResolver();
     }
 }
 
@@ -114,7 +114,7 @@ export class MultiUrlResolver implements IUrlResolver {
                     fileName);
 
             default: // Local
-                return (this.urlResolver as TestResolver).createCreateNewRequest(fileName);
+                return (this.urlResolver as LocalResolver).createCreateNewRequest(fileName);
         }
     }
 }


### PR DESCRIPTION
Renamed the following in `local-drivers` since these are used more widely than just testing, such as in `webpack-component-loader`:
- `TestDeltaStorageService` -> `LocalDeltaStorageService`
- `TestDocumentDeltaConnection` -> `LocalDocumentDeltaConnection`
- `TestDocumentService` -> `LocalDocumentService`
- `TestDocumentServiceFactory` -> `LocalDocumentServiceFactory`
- `TestResolver` -> `LocalResolver`

Fixes #2624 