### PR TITLE
Fix for build breaks in master after release/0.22 was published and the pacakage versions were updated

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -589,102 +589,62 @@
 			}
 		},
 		"@fluidframework/agent-scheduler": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/agent-scheduler/-/agent-scheduler-0.21.1.tgz",
-			"integrity": "sha1-fwB7VS6ibKBjG27scG1qFd/Cngw=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/agent-scheduler/-/agent-scheduler-0.22.0.tgz",
+			"integrity": "sha1-mM+BZXbqtvTyqqN856Rd2/L5ods=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/component-runtime": "^0.21.1",
-				"@fluidframework/component-runtime-definitions": "^0.21.1",
-				"@fluidframework/container-definitions": "^0.21.1",
-				"@fluidframework/map": "^0.21.1",
-				"@fluidframework/register-collection": "^0.21.1",
-				"@fluidframework/runtime-definitions": "^0.21.1",
-				"@fluidframework/shared-object-base": "^0.21.1",
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/component-runtime": "^0.22.0",
+				"@fluidframework/component-runtime-definitions": "^0.22.0",
+				"@fluidframework/container-definitions": "^0.22.0",
+				"@fluidframework/map": "^0.22.0",
+				"@fluidframework/register-collection": "^0.22.0",
+				"@fluidframework/runtime-definitions": "^0.22.0",
+				"@fluidframework/shared-object-base": "^0.22.0",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/aqueduct/-/aqueduct-0.21.1.tgz",
-			"integrity": "sha1-+vw3K78oPMJIsjm1Qr0LEcLNXTg=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/aqueduct/-/aqueduct-0.22.0.tgz",
+			"integrity": "sha1-IRahd4r0Y9QjsJISsEki/Oy+RAQ=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.20.0",
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/component-runtime": "^0.21.1",
-				"@fluidframework/component-runtime-definitions": "^0.21.1",
-				"@fluidframework/container-definitions": "^0.21.1",
-				"@fluidframework/container-runtime": "^0.21.1",
-				"@fluidframework/container-runtime-definitions": "^0.21.1",
-				"@fluidframework/framework-interfaces": "^0.21.1",
-				"@fluidframework/map": "^0.21.1",
-				"@fluidframework/runtime-definitions": "^0.21.1",
-				"@fluidframework/shared-object-base": "^0.21.1",
-				"@fluidframework/synthesize": "^0.21.1",
-				"@fluidframework/view-adapters": "^0.21.1",
-				"@fluidframework/view-interfaces": "^0.21.1",
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/component-runtime": "^0.22.0",
+				"@fluidframework/component-runtime-definitions": "^0.22.0",
+				"@fluidframework/container-definitions": "^0.22.0",
+				"@fluidframework/container-runtime": "^0.22.0",
+				"@fluidframework/container-runtime-definitions": "^0.22.0",
+				"@fluidframework/framework-interfaces": "^0.22.0",
+				"@fluidframework/map": "^0.22.0",
+				"@fluidframework/request-handler": "^0.22.0",
+				"@fluidframework/runtime-definitions": "^0.22.0",
+				"@fluidframework/runtime-utils": "^0.22.0",
+				"@fluidframework/shared-object-base": "^0.22.0",
+				"@fluidframework/synthesize": "^0.22.0",
+				"@fluidframework/view-adapters": "^0.22.0",
+				"@fluidframework/view-interfaces": "^0.22.0",
 				"uuid": "^3.3.2"
 			}
 		},
 		"@fluidframework/base-host": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/base-host/-/base-host-0.21.1.tgz",
-			"integrity": "sha1-enSprJANwwKF+TRq10rMi3OOWMo=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/base-host/-/base-host-0.22.0.tgz",
+			"integrity": "sha1-FcGJ9HPtKmVgcTn5Pte7LUBRBl4=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.20.0",
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/container-definitions": "^0.21.1",
-				"@fluidframework/container-loader": "^0.21.1",
-				"@fluidframework/driver-definitions": "^0.21.1",
-				"@fluidframework/protocol-base": "^0.1008.0",
-				"@fluidframework/protocol-definitions": "^0.1008.0",
-				"@fluidframework/web-code-loader": "^0.21.1"
-			},
-			"dependencies": {
-				"@fluidframework/gitresources": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/gitresources/-/gitresources-0.1008.0.tgz",
-					"integrity": "sha1-pYdGVZvMFDsmKgv/xiHbjMMKi/Y="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-base/-/protocol-base-0.1008.0.tgz",
-					"integrity": "sha1-8pmULYHkd/zum0nHG36Ul1pvV/8=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/gitresources": "^0.1008.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.11"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1008.0.tgz",
-					"integrity": "sha1-E89ZDcx+XDsSDOr19r4mRJQD7yA=",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.18.1",
-						"buffer": "^4.3.0"
-					}
-				},
-				"buffer": {
-					"version": "4.9.2",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				}
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/container-definitions": "^0.22.0",
+				"@fluidframework/container-loader": "^0.22.0",
+				"@fluidframework/driver-definitions": "^0.22.0",
+				"@fluidframework/protocol-base": "^0.1009.0",
+				"@fluidframework/protocol-definitions": "^0.1009.0",
+				"@fluidframework/telemetry-utils": "^0.22.0",
+				"@fluidframework/web-code-loader": "^0.22.0"
 			}
 		},
 		"@fluidframework/build-common": {
@@ -739,234 +699,102 @@
 			}
 		},
 		"@fluidframework/component-core-interfaces": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/component-core-interfaces/-/component-core-interfaces-0.21.1.tgz",
-			"integrity": "sha1-jBQep+jx9PwuwEbI6NI8Hcyxugg="
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/component-core-interfaces/-/component-core-interfaces-0.22.0.tgz",
+			"integrity": "sha1-rEeYqlOESZ6YNtANWzkGlQl3t6k="
 		},
 		"@fluidframework/component-runtime": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/component-runtime/-/component-runtime-0.21.1.tgz",
-			"integrity": "sha1-SP/2YQVodRqDYYNtLrxpDkpmxHc=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/component-runtime/-/component-runtime-0.22.0.tgz",
+			"integrity": "sha1-6vjWpQmjXWG5x34SPuN6dy0aZp0=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.20.0",
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/component-runtime-definitions": "^0.21.1",
-				"@fluidframework/container-definitions": "^0.21.1",
-				"@fluidframework/driver-definitions": "^0.21.1",
-				"@fluidframework/driver-utils": "^0.21.1",
-				"@fluidframework/protocol-base": "^0.1008.0",
-				"@fluidframework/protocol-definitions": "^0.1008.0",
-				"@fluidframework/runtime-definitions": "^0.21.1",
-				"@fluidframework/runtime-utils": "^0.21.1",
-				"@fluidframework/shared-object-base": "^0.21.1",
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/component-runtime-definitions": "^0.22.0",
+				"@fluidframework/container-definitions": "^0.22.0",
+				"@fluidframework/container-utils": "^0.22.0",
+				"@fluidframework/driver-definitions": "^0.22.0",
+				"@fluidframework/driver-utils": "^0.22.0",
+				"@fluidframework/protocol-base": "^0.1009.0",
+				"@fluidframework/protocol-definitions": "^0.1009.0",
+				"@fluidframework/runtime-definitions": "^0.22.0",
+				"@fluidframework/runtime-utils": "^0.22.0",
+				"@fluidframework/shared-object-base": "^0.22.0",
+				"@fluidframework/telemetry-utils": "^0.22.0",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
-			},
-			"dependencies": {
-				"@fluidframework/gitresources": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/gitresources/-/gitresources-0.1008.0.tgz",
-					"integrity": "sha1-pYdGVZvMFDsmKgv/xiHbjMMKi/Y="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-base/-/protocol-base-0.1008.0.tgz",
-					"integrity": "sha1-8pmULYHkd/zum0nHG36Ul1pvV/8=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/gitresources": "^0.1008.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.11"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1008.0.tgz",
-					"integrity": "sha1-E89ZDcx+XDsSDOr19r4mRJQD7yA=",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.18.1",
-						"buffer": "^4.3.0"
-					}
-				},
-				"buffer": {
-					"version": "4.9.2",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				}
 			}
 		},
 		"@fluidframework/component-runtime-definitions": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/component-runtime-definitions/-/component-runtime-definitions-0.21.1.tgz",
-			"integrity": "sha1-6GobmhCyNdoq15xb4hJtkpgHk70=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/component-runtime-definitions/-/component-runtime-definitions-0.22.0.tgz",
+			"integrity": "sha1-FGYSfbj6SHrZc/tINJp7aN0UQE8=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/container-definitions": "^0.21.1",
-				"@fluidframework/protocol-definitions": "^0.1008.0",
-				"@fluidframework/runtime-definitions": "^0.21.1",
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/container-definitions": "^0.22.0",
+				"@fluidframework/protocol-definitions": "^0.1009.0",
+				"@fluidframework/runtime-definitions": "^0.22.0",
 				"@types/node": "^10.17.24"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1008.0.tgz",
-					"integrity": "sha1-E89ZDcx+XDsSDOr19r4mRJQD7yA=",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.18.1",
-						"buffer": "^4.3.0"
-					}
-				},
-				"buffer": {
-					"version": "4.9.2",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				}
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-definitions/-/container-definitions-0.21.1.tgz",
-			"integrity": "sha1-bD558KLgP+1ixPa8m9QPeALmSLs=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-definitions/-/container-definitions-0.22.0.tgz",
+			"integrity": "sha1-ahuuXsWEixbcxLHR+Rh0b44G4xw=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/driver-definitions": "^0.21.1",
-				"@fluidframework/protocol-definitions": "^0.1008.0"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1008.0.tgz",
-					"integrity": "sha1-E89ZDcx+XDsSDOr19r4mRJQD7yA=",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.18.1",
-						"buffer": "^4.3.0"
-					}
-				},
-				"buffer": {
-					"version": "4.9.2",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				}
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/driver-definitions": "^0.22.0",
+				"@fluidframework/protocol-definitions": "^0.1009.0"
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-loader/-/container-loader-0.21.1.tgz",
-			"integrity": "sha1-Rc3SHxYbR97OeA0/77kNjhgdcOk=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-loader/-/container-loader-0.22.0.tgz",
+			"integrity": "sha1-QYn8kvSqrN6P7uJQMGBw6PIL3RA=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.20.0",
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/container-definitions": "^0.21.1",
-				"@fluidframework/driver-definitions": "^0.21.1",
-				"@fluidframework/driver-utils": "^0.21.1",
-				"@fluidframework/protocol-base": "^0.1008.0",
-				"@fluidframework/protocol-definitions": "^0.1008.0",
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/container-definitions": "^0.22.0",
+				"@fluidframework/container-utils": "^0.22.0",
+				"@fluidframework/driver-definitions": "^0.22.0",
+				"@fluidframework/driver-utils": "^0.22.0",
+				"@fluidframework/protocol-base": "^0.1009.0",
+				"@fluidframework/protocol-definitions": "^0.1009.0",
+				"@fluidframework/telemetry-utils": "^0.22.0",
 				"@types/double-ended-queue": "^2.1.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
 				"jwt-decode": "^2.2.0",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.19",
 				"performance-now": "^2.1.0",
 				"uuid": "^3.3.2"
-			},
-			"dependencies": {
-				"@fluidframework/gitresources": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/gitresources/-/gitresources-0.1008.0.tgz",
-					"integrity": "sha1-pYdGVZvMFDsmKgv/xiHbjMMKi/Y="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-base/-/protocol-base-0.1008.0.tgz",
-					"integrity": "sha1-8pmULYHkd/zum0nHG36Ul1pvV/8=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/gitresources": "^0.1008.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.11"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1008.0.tgz",
-					"integrity": "sha1-E89ZDcx+XDsSDOr19r4mRJQD7yA=",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.18.1",
-						"buffer": "^4.3.0"
-					}
-				},
-				"buffer": {
-					"version": "4.9.2",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				}
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-runtime/-/container-runtime-0.21.1.tgz",
-			"integrity": "sha1-e1p0MSrK90L+R+mFgHyNz9vv2TU=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-runtime/-/container-runtime-0.22.0.tgz",
+			"integrity": "sha1-2sF78gMzHrd643Nj+HQrNAzpb/8=",
 			"requires": {
-				"@fluidframework/agent-scheduler": "^0.21.1",
+				"@fluidframework/agent-scheduler": "^0.22.0",
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.20.0",
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/component-runtime": "^0.21.1",
-				"@fluidframework/container-definitions": "^0.21.1",
-				"@fluidframework/container-runtime-definitions": "^0.21.1",
-				"@fluidframework/driver-definitions": "^0.21.1",
-				"@fluidframework/driver-utils": "^0.21.1",
-				"@fluidframework/protocol-base": "^0.1008.0",
-				"@fluidframework/protocol-definitions": "^0.1008.0",
-				"@fluidframework/runtime-definitions": "^0.21.1",
-				"@fluidframework/runtime-utils": "^0.21.1",
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/component-runtime": "^0.22.0",
+				"@fluidframework/container-definitions": "^0.22.0",
+				"@fluidframework/container-runtime-definitions": "^0.22.0",
+				"@fluidframework/container-utils": "^0.22.0",
+				"@fluidframework/driver-definitions": "^0.22.0",
+				"@fluidframework/driver-utils": "^0.22.0",
+				"@fluidframework/protocol-base": "^0.1009.0",
+				"@fluidframework/protocol-definitions": "^0.1009.0",
+				"@fluidframework/runtime-definitions": "^0.22.0",
+				"@fluidframework/runtime-utils": "^0.22.0",
+				"@fluidframework/telemetry-utils": "^0.22.0",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/node": "^10.17.24",
@@ -975,226 +803,71 @@
 				"double-ended-queue": "^2.1.0-0",
 				"performance-now": "^2.1.0",
 				"uuid": "^3.3.2"
-			},
-			"dependencies": {
-				"@fluidframework/gitresources": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/gitresources/-/gitresources-0.1008.0.tgz",
-					"integrity": "sha1-pYdGVZvMFDsmKgv/xiHbjMMKi/Y="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-base/-/protocol-base-0.1008.0.tgz",
-					"integrity": "sha1-8pmULYHkd/zum0nHG36Ul1pvV/8=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/gitresources": "^0.1008.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.11"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1008.0.tgz",
-					"integrity": "sha1-E89ZDcx+XDsSDOr19r4mRJQD7yA=",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.18.1",
-						"buffer": "^4.3.0"
-					}
-				},
-				"buffer": {
-					"version": "4.9.2",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				}
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.21.1.tgz",
-			"integrity": "sha1-FJISaHhnDxCp2KseZltw11idpmg=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.22.0.tgz",
+			"integrity": "sha1-jeY3Yce84KSz8wL2loctANt1mGA=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/container-definitions": "^0.21.1",
-				"@fluidframework/driver-definitions": "^0.21.1",
-				"@fluidframework/protocol-definitions": "^0.1008.0",
-				"@fluidframework/runtime-definitions": "^0.21.1",
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/container-definitions": "^0.22.0",
+				"@fluidframework/driver-definitions": "^0.22.0",
+				"@fluidframework/protocol-definitions": "^0.1009.0",
+				"@fluidframework/runtime-definitions": "^0.22.0",
 				"@types/node": "^10.17.24"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1008.0.tgz",
-					"integrity": "sha1-E89ZDcx+XDsSDOr19r4mRJQD7yA=",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.18.1",
-						"buffer": "^4.3.0"
-					}
-				},
-				"buffer": {
-					"version": "4.9.2",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				}
+			}
+		},
+		"@fluidframework/container-utils": {
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-utils/-/container-utils-0.22.0.tgz",
+			"integrity": "sha1-slz1/hPp42xTaTN5NZ6dUbIa3s0=",
+			"requires": {
+				"@fluidframework/container-definitions": "^0.22.0",
+				"@fluidframework/telemetry-utils": "^0.22.0",
+				"performance-now": "^2.1.0",
+				"uuid": "^3.3.2"
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-base/-/driver-base-0.21.1.tgz",
-			"integrity": "sha1-rGU4R5LI/EsI4VUyWJotLtMBH+U=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-base/-/driver-base-0.22.0.tgz",
+			"integrity": "sha1-dBODkp1V/oDTVQEbFGyqNoSk2gI=",
 			"requires": {
 				"@fluidframework/common-utils": "^0.20.0",
-				"@fluidframework/driver-definitions": "^0.21.1",
-				"@fluidframework/driver-utils": "^0.21.1",
-				"@fluidframework/protocol-definitions": "^0.1008.0",
+				"@fluidframework/driver-definitions": "^0.22.0",
+				"@fluidframework/driver-utils": "^0.22.0",
+				"@fluidframework/protocol-definitions": "^0.1009.0",
 				"@types/debug": "^4.1.5",
 				"@types/node": "^10.17.24",
 				"@types/socket.io-client": "^1.4.32",
 				"debug": "^4.1.1"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1008.0.tgz",
-					"integrity": "sha1-E89ZDcx+XDsSDOr19r4mRJQD7yA=",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.18.1",
-						"buffer": "^4.3.0"
-					}
-				},
-				"buffer": {
-					"version": "4.9.2",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				}
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-definitions/-/driver-definitions-0.21.1.tgz",
-			"integrity": "sha1-2TGSyiZam1Sw/jaT0vQiQu2jI9M=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-definitions/-/driver-definitions-0.22.0.tgz",
+			"integrity": "sha1-5yC6TGv203fsOzlTxFRE8RuLGVs=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/protocol-definitions": "^0.1008.0",
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/protocol-definitions": "^0.1009.0",
 				"buffer": "^5.6.0"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1008.0.tgz",
-					"integrity": "sha1-E89ZDcx+XDsSDOr19r4mRJQD7yA=",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.18.1",
-						"buffer": "^4.3.0"
-					},
-					"dependencies": {
-						"buffer": {
-							"version": "4.9.2",
-							"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-							"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-							"requires": {
-								"base64-js": "^1.0.2",
-								"ieee754": "^1.1.4",
-								"isarray": "^1.0.0"
-							}
-						}
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				}
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-utils/-/driver-utils-0.21.1.tgz",
-			"integrity": "sha1-20ce+TJddxBd/uqOih97NdRXVGk=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-utils/-/driver-utils-0.22.0.tgz",
+			"integrity": "sha1-XPu0N37cJFXx4FfwRcnZOH9de5s=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.20.0",
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/container-definitions": "^0.21.1",
-				"@fluidframework/driver-definitions": "^0.21.1",
-				"@fluidframework/gitresources": "^0.1008.0",
-				"@fluidframework/protocol-base": "^0.1008.0",
-				"@fluidframework/protocol-definitions": "^0.1008.0"
-			},
-			"dependencies": {
-				"@fluidframework/gitresources": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/gitresources/-/gitresources-0.1008.0.tgz",
-					"integrity": "sha1-pYdGVZvMFDsmKgv/xiHbjMMKi/Y="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-base/-/protocol-base-0.1008.0.tgz",
-					"integrity": "sha1-8pmULYHkd/zum0nHG36Ul1pvV/8=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/gitresources": "^0.1008.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.11"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1008.0.tgz",
-					"integrity": "sha1-E89ZDcx+XDsSDOr19r4mRJQD7yA=",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.18.1",
-						"buffer": "^4.3.0"
-					}
-				},
-				"buffer": {
-					"version": "4.9.2",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				}
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/driver-definitions": "^0.22.0",
+				"@fluidframework/gitresources": "^0.1009.0",
+				"@fluidframework/protocol-base": "^0.1009.0",
+				"@fluidframework/protocol-definitions": "^0.1009.0",
+				"@fluidframework/telemetry-utils": "^0.22.0"
 			}
 		},
 		"@fluidframework/eslint-config-fluid": {
@@ -1215,11 +888,11 @@
 			}
 		},
 		"@fluidframework/framework-interfaces": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/framework-interfaces/-/framework-interfaces-0.21.1.tgz",
-			"integrity": "sha1-ucof5omHtkX0JKxuDskeXPW+uRE=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/framework-interfaces/-/framework-interfaces-0.22.0.tgz",
+			"integrity": "sha1-yrKBO+jn5/Y/sK95PD4nGLfQZpA=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.21.1"
+				"@fluidframework/component-core-interfaces": "^0.22.0"
 			}
 		},
 		"@fluidframework/gitresources": {
@@ -1228,240 +901,38 @@
 			"integrity": "sha1-DrHHoNxQmh6Gi7vEVL/hxF7BFqA="
 		},
 		"@fluidframework/local-driver": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/local-driver/-/local-driver-0.21.1.tgz",
-			"integrity": "sha1-gOF7UzCwAM4FrUs4wSdtiHUpcJI=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/local-driver/-/local-driver-0.22.0.tgz",
+			"integrity": "sha1-vFWrMl8icJyo0BCyETfC2bZFrfg=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.20.0",
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/container-definitions": "^0.21.1",
-				"@fluidframework/driver-definitions": "^0.21.1",
-				"@fluidframework/driver-utils": "^0.21.1",
-				"@fluidframework/protocol-definitions": "^0.1008.0",
-				"@fluidframework/routerlicious-driver": "^0.21.1",
-				"@fluidframework/server-local-server": "^0.1008.0",
-				"@fluidframework/server-services-client": "^0.1008.0",
-				"@fluidframework/server-services-core": "^0.1008.0",
-				"@fluidframework/server-test-utils": "^0.1008.0",
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/driver-definitions": "^0.22.0",
+				"@fluidframework/driver-utils": "^0.22.0",
+				"@fluidframework/protocol-definitions": "^0.1009.0",
+				"@fluidframework/routerlicious-driver": "^0.22.0",
+				"@fluidframework/server-local-server": "^0.1009.0",
+				"@fluidframework/server-services-client": "^0.1009.0",
+				"@fluidframework/server-services-core": "^0.1009.0",
+				"@fluidframework/server-test-utils": "^0.1009.0",
 				"debug": "^4.1.1"
-			},
-			"dependencies": {
-				"@fluidframework/gitresources": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/gitresources/-/gitresources-0.1008.0.tgz",
-					"integrity": "sha1-pYdGVZvMFDsmKgv/xiHbjMMKi/Y="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-base/-/protocol-base-0.1008.0.tgz",
-					"integrity": "sha1-8pmULYHkd/zum0nHG36Ul1pvV/8=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/gitresources": "^0.1008.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.11"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1008.0.tgz",
-					"integrity": "sha1-E89ZDcx+XDsSDOr19r4mRJQD7yA=",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.18.1",
-						"buffer": "^4.3.0"
-					}
-				},
-				"@fluidframework/server-lambdas": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/server-lambdas/-/server-lambdas-0.1008.0.tgz",
-					"integrity": "sha1-LfhSFo1nLQtsfEWFC0fc+4yx6eI=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/gitresources": "^0.1008.0",
-						"@fluidframework/protocol-base": "^0.1008.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"@fluidframework/server-services-client": "^0.1008.0",
-						"@fluidframework/server-services-core": "^0.1008.0",
-						"@types/semver": "^6.0.1",
-						"async": "^2.6.1",
-						"double-ended-queue": "^2.1.0-0",
-						"json-stringify-safe": "^5.0.1",
-						"jsonwebtoken": "^8.4.0",
-						"lodash": "^4.17.11",
-						"nconf": "^0.10.0",
-						"semver": "^6.3.0",
-						"uuid": "^3.3.2"
-					}
-				},
-				"@fluidframework/server-local-server": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/server-local-server/-/server-local-server-0.1008.0.tgz",
-					"integrity": "sha1-AZu/h6dxsFxoc7xmQIfVidBGHAE=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"@fluidframework/server-lambdas": "^0.1008.0",
-						"@fluidframework/server-memory-orderer": "^0.1008.0",
-						"@fluidframework/server-services-client": "^0.1008.0",
-						"@fluidframework/server-services-core": "^0.1008.0",
-						"@fluidframework/server-test-utils": "^0.1008.0"
-					}
-				},
-				"@fluidframework/server-memory-orderer": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1008.0.tgz",
-					"integrity": "sha1-6bMSBObt5pDx4yiEJ4YXdUYwLUE=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/protocol-base": "^0.1008.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"@fluidframework/server-lambdas": "^0.1008.0",
-						"@fluidframework/server-services-client": "^0.1008.0",
-						"@fluidframework/server-services-core": "^0.1008.0",
-						"@types/debug": "^4.1.5",
-						"@types/double-ended-queue": "^2.1.0",
-						"@types/lodash": "^4.14.118",
-						"@types/node": "^10.17.24",
-						"@types/ws": "^6.0.1",
-						"debug": "^4.1.1",
-						"double-ended-queue": "^2.1.0-0",
-						"lodash": "^4.17.11",
-						"moniker": "^0.1.2",
-						"uuid": "^3.3.2",
-						"ws": "^6.1.2"
-					}
-				},
-				"@fluidframework/server-services-client": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/server-services-client/-/server-services-client-0.1008.0.tgz",
-					"integrity": "sha1-j6V6UpVBkWmiML/IbEtZ4pdRSjg=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/gitresources": "^0.1008.0",
-						"@fluidframework/protocol-base": "^0.1008.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"@types/node": "^10.17.24",
-						"axios": "^0.18.0",
-						"debug": "^4.1.1",
-						"jsonwebtoken": "^8.4.0",
-						"sillyname": "0.1.0",
-						"uuid": "^3.3.2"
-					}
-				},
-				"@fluidframework/server-services-core": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/server-services-core/-/server-services-core-0.1008.0.tgz",
-					"integrity": "sha1-7pp7verks+Fvq7WnurTxfB3PoGg=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/gitresources": "^0.1008.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"@fluidframework/server-services-client": "^0.1008.0",
-						"@types/nconf": "^0.0.37",
-						"@types/node": "^10.17.24",
-						"debug": "^4.1.1",
-						"nconf": "^0.10.0"
-					}
-				},
-				"@fluidframework/server-test-utils": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/server-test-utils/-/server-test-utils-0.1008.0.tgz",
-					"integrity": "sha1-X+s5cMvGQF/LNEpiJy4HrWM02s0=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/gitresources": "^0.1008.0",
-						"@fluidframework/protocol-base": "^0.1008.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"@fluidframework/server-services-client": "^0.1008.0",
-						"@fluidframework/server-services-core": "^0.1008.0",
-						"debug": "^4.1.1",
-						"lodash": "^4.17.11",
-						"moniker": "^0.1.2",
-						"string-hash": "^1.1.3",
-						"uuid": "^3.3.2"
-					}
-				},
-				"buffer": {
-					"version": "4.9.2",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				}
 			}
 		},
 		"@fluidframework/map": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/map/-/map-0.21.1.tgz",
-			"integrity": "sha1-3+Gd1LmCqLTxQUpAqpTzSdszJeQ=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/map/-/map-0.22.0.tgz",
+			"integrity": "sha1-uq8aocwFyKFWfC7I+FE0BeptkdI=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.20.0",
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/component-runtime-definitions": "^0.21.1",
-				"@fluidframework/protocol-base": "^0.1008.0",
-				"@fluidframework/protocol-definitions": "^0.1008.0",
-				"@fluidframework/runtime-utils": "^0.21.1",
-				"@fluidframework/shared-object-base": "^0.21.1",
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/component-runtime-definitions": "^0.22.0",
+				"@fluidframework/protocol-base": "^0.1009.0",
+				"@fluidframework/protocol-definitions": "^0.1009.0",
+				"@fluidframework/runtime-utils": "^0.22.0",
+				"@fluidframework/shared-object-base": "^0.22.0",
 				"debug": "^4.1.1"
-			},
-			"dependencies": {
-				"@fluidframework/gitresources": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/gitresources/-/gitresources-0.1008.0.tgz",
-					"integrity": "sha1-pYdGVZvMFDsmKgv/xiHbjMMKi/Y="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-base/-/protocol-base-0.1008.0.tgz",
-					"integrity": "sha1-8pmULYHkd/zum0nHG36Ul1pvV/8=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/gitresources": "^0.1008.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.11"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1008.0.tgz",
-					"integrity": "sha1-E89ZDcx+XDsSDOr19r4mRJQD7yA=",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.18.1",
-						"buffer": "^4.3.0"
-					}
-				},
-				"buffer": {
-					"version": "4.9.2",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				}
 			}
 		},
 		"@fluidframework/protocol-base": {
@@ -1503,201 +974,73 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/register-collection/-/register-collection-0.21.1.tgz",
-			"integrity": "sha1-JW1CZccVLxbrrZifUB+yEsRsDLg=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/register-collection/-/register-collection-0.22.0.tgz",
+			"integrity": "sha1-FsIHgkiJrSi1KYAWlQtqL68TKrU=",
 			"requires": {
 				"@fluidframework/common-utils": "^0.20.0",
-				"@fluidframework/component-runtime-definitions": "^0.21.1",
-				"@fluidframework/protocol-definitions": "^0.1008.0",
-				"@fluidframework/runtime-utils": "^0.21.1",
-				"@fluidframework/shared-object-base": "^0.21.1",
+				"@fluidframework/component-runtime-definitions": "^0.22.0",
+				"@fluidframework/protocol-definitions": "^0.1009.0",
+				"@fluidframework/runtime-utils": "^0.22.0",
+				"@fluidframework/shared-object-base": "^0.22.0",
 				"debug": "^4.1.1"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1008.0.tgz",
-					"integrity": "sha1-E89ZDcx+XDsSDOr19r4mRJQD7yA=",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.18.1",
-						"buffer": "^4.3.0"
-					}
-				},
-				"buffer": {
-					"version": "4.9.2",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				}
+			}
+		},
+		"@fluidframework/request-handler": {
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/request-handler/-/request-handler-0.22.0.tgz",
+			"integrity": "sha1-f5oaUqHqOQb0P0t2BhgwyLZnys8=",
+			"requires": {
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/container-runtime-definitions": "^0.22.0",
+				"@fluidframework/runtime-definitions": "^0.22.0",
+				"@fluidframework/runtime-utils": "^0.22.0"
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.21.1.tgz",
-			"integrity": "sha1-W2Ekl+wmqgh3DyCqOD/cduV+P7g=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.22.0.tgz",
+			"integrity": "sha1-kXbdPCLbrONK/smUmWrNiYpqu3I=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.20.0",
-				"@fluidframework/container-definitions": "^0.21.1",
-				"@fluidframework/driver-base": "^0.21.1",
-				"@fluidframework/driver-definitions": "^0.21.1",
-				"@fluidframework/driver-utils": "^0.21.1",
-				"@fluidframework/gitresources": "^0.1008.0",
-				"@fluidframework/protocol-base": "^0.1008.0",
-				"@fluidframework/protocol-definitions": "^0.1008.0",
-				"@fluidframework/server-services-client": "^0.1008.0",
+				"@fluidframework/driver-base": "^0.22.0",
+				"@fluidframework/driver-definitions": "^0.22.0",
+				"@fluidframework/driver-utils": "^0.22.0",
+				"@fluidframework/gitresources": "^0.1009.0",
+				"@fluidframework/protocol-base": "^0.1009.0",
+				"@fluidframework/protocol-definitions": "^0.1009.0",
+				"@fluidframework/server-services-client": "^0.1009.0",
 				"axios": "^0.18.0",
 				"debug": "^4.1.1",
 				"isomorphic-ws": "^4.0.1",
 				"jwt-decode": "^2.2.0",
 				"socket.io-client": "^2.1.1",
 				"ws": "^6.1.2"
-			},
-			"dependencies": {
-				"@fluidframework/gitresources": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/gitresources/-/gitresources-0.1008.0.tgz",
-					"integrity": "sha1-pYdGVZvMFDsmKgv/xiHbjMMKi/Y="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-base/-/protocol-base-0.1008.0.tgz",
-					"integrity": "sha1-8pmULYHkd/zum0nHG36Ul1pvV/8=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/gitresources": "^0.1008.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.11"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1008.0.tgz",
-					"integrity": "sha1-E89ZDcx+XDsSDOr19r4mRJQD7yA=",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.18.1",
-						"buffer": "^4.3.0"
-					}
-				},
-				"@fluidframework/server-services-client": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/server-services-client/-/server-services-client-0.1008.0.tgz",
-					"integrity": "sha1-j6V6UpVBkWmiML/IbEtZ4pdRSjg=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/gitresources": "^0.1008.0",
-						"@fluidframework/protocol-base": "^0.1008.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"@types/node": "^10.17.24",
-						"axios": "^0.18.0",
-						"debug": "^4.1.1",
-						"jsonwebtoken": "^8.4.0",
-						"sillyname": "0.1.0",
-						"uuid": "^3.3.2"
-					}
-				},
-				"buffer": {
-					"version": "4.9.2",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				}
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/runtime-definitions/-/runtime-definitions-0.21.1.tgz",
-			"integrity": "sha1-8eT5iyY47LxXMU89nMqBs2bFYKE=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/runtime-definitions/-/runtime-definitions-0.22.0.tgz",
+			"integrity": "sha1-NRydf9Mdq6lupNWiUvwQWrl7qnE=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/container-definitions": "^0.21.1",
-				"@fluidframework/driver-definitions": "^0.21.1",
-				"@fluidframework/protocol-definitions": "^0.1008.0",
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/container-definitions": "^0.22.0",
+				"@fluidframework/driver-definitions": "^0.22.0",
+				"@fluidframework/protocol-definitions": "^0.1009.0",
 				"@types/node": "^10.17.24"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1008.0.tgz",
-					"integrity": "sha1-E89ZDcx+XDsSDOr19r4mRJQD7yA=",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.18.1",
-						"buffer": "^4.3.0"
-					}
-				},
-				"buffer": {
-					"version": "4.9.2",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				}
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/runtime-utils/-/runtime-utils-0.21.1.tgz",
-			"integrity": "sha1-uHOK8dlafuFi6i//stWPheVx0gY=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/runtime-utils/-/runtime-utils-0.22.0.tgz",
+			"integrity": "sha1-wcQUnMZXAacDFf5xw/5b0mfhtYE=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/component-runtime-definitions": "^0.21.1",
-				"@fluidframework/protocol-definitions": "^0.1008.0",
-				"@fluidframework/runtime-definitions": "^0.21.1"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1008.0.tgz",
-					"integrity": "sha1-E89ZDcx+XDsSDOr19r4mRJQD7yA=",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.18.1",
-						"buffer": "^4.3.0"
-					}
-				},
-				"buffer": {
-					"version": "4.9.2",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				}
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/component-runtime-definitions": "^0.22.0",
+				"@fluidframework/protocol-definitions": "^0.1009.0",
+				"@fluidframework/runtime-definitions": "^0.22.0"
 			}
 		},
 		"@fluidframework/server-lambdas": {
@@ -1818,54 +1161,42 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/shared-object-base/-/shared-object-base-0.21.1.tgz",
-			"integrity": "sha1-NbsqaeDoxuY0+mI21YQuQRoGHOI=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/shared-object-base/-/shared-object-base-0.22.0.tgz",
+			"integrity": "sha1-k14UI0VqKXnkZgXPEq5GMQO5n/g=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.20.0",
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/component-runtime-definitions": "^0.21.1",
-				"@fluidframework/container-definitions": "^0.21.1",
-				"@fluidframework/protocol-definitions": "^0.1008.0",
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/component-runtime-definitions": "^0.22.0",
+				"@fluidframework/container-definitions": "^0.22.0",
+				"@fluidframework/protocol-definitions": "^0.1009.0",
+				"@fluidframework/runtime-utils": "^0.22.0",
+				"@fluidframework/telemetry-utils": "^0.22.0",
 				"@types/debug": "^4.1.5",
 				"@types/node": "^10.17.24",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1008.0.tgz",
-					"integrity": "sha1-E89ZDcx+XDsSDOr19r4mRJQD7yA=",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.18.1",
-						"buffer": "^4.3.0"
-					}
-				},
-				"buffer": {
-					"version": "4.9.2",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				}
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/synthesize/-/synthesize-0.21.1.tgz",
-			"integrity": "sha1-M88owDEoBqvwfLxG/pLBGZ0i76A=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/synthesize/-/synthesize-0.22.0.tgz",
+			"integrity": "sha1-FFN9q2d8SnvJvJ/FIAigtTJSk0s=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.21.1"
+				"@fluidframework/component-core-interfaces": "^0.22.0"
+			}
+		},
+		"@fluidframework/telemetry-utils": {
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/telemetry-utils/-/telemetry-utils-0.22.0.tgz",
+			"integrity": "sha1-TLHOIhNEncgEI8ZmWLcef44UV/o=",
+			"requires": {
+				"@fluidframework/common-definitions": "^0.18.1",
+				"@fluidframework/common-utils": "^0.20.0",
+				"debug": "^4.1.1",
+				"events": "^3.1.0",
+				"performance-now": "^2.1.0"
 			}
 		},
 		"@fluidframework/test-tools": {
@@ -1875,30 +1206,30 @@
 			"dev": true
 		},
 		"@fluidframework/view-adapters": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/view-adapters/-/view-adapters-0.21.1.tgz",
-			"integrity": "sha1-Q2AsPDbgzagou8SHUOu3MXkBDH4=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/view-adapters/-/view-adapters-0.22.0.tgz",
+			"integrity": "sha1-Ae72OCT3d8PLbrrRMInRywiL/xk=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/view-interfaces": "^0.21.1",
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/view-interfaces": "^0.22.0",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			}
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/view-interfaces/-/view-interfaces-0.21.1.tgz",
-			"integrity": "sha1-mFpyYuGCOEy7ECi5VAEqhzTeSW4=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/view-interfaces/-/view-interfaces-0.22.0.tgz",
+			"integrity": "sha1-76YdT1qUTA0aelX9wB4IpADCtU0=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.21.1"
+				"@fluidframework/component-core-interfaces": "^0.22.0"
 			}
 		},
 		"@fluidframework/web-code-loader": {
-			"version": "0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/web-code-loader/-/web-code-loader-0.21.1.tgz",
-			"integrity": "sha1-Pv0WyL1wIe0LmSZgOG3xUp9R9qY=",
+			"version": "0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/web-code-loader/-/web-code-loader-0.22.0.tgz",
+			"integrity": "sha1-1TFxV1Bz+svABBCQX7uyUaoDQqU=",
 			"requires": {
-				"@fluidframework/container-definitions": "^0.21.1",
+				"@fluidframework/container-definitions": "^0.22.0",
 				"@types/node": "^10.17.24",
 				"isomorphic-fetch": "^2.2.1"
 			}
@@ -15715,148 +15046,85 @@
 			}
 		},
 		"old-aqueduct": {
-			"version": "npm:@fluidframework/aqueduct@0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/aqueduct/-/aqueduct-0.21.1.tgz",
-			"integrity": "sha1-+vw3K78oPMJIsjm1Qr0LEcLNXTg=",
+			"version": "npm:@fluidframework/aqueduct@0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/aqueduct/-/aqueduct-0.22.0.tgz",
+			"integrity": "sha1-IRahd4r0Y9QjsJISsEki/Oy+RAQ=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.20.0",
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/component-runtime": "^0.21.1",
-				"@fluidframework/component-runtime-definitions": "^0.21.1",
-				"@fluidframework/container-definitions": "^0.21.1",
-				"@fluidframework/container-runtime": "^0.21.1",
-				"@fluidframework/container-runtime-definitions": "^0.21.1",
-				"@fluidframework/framework-interfaces": "^0.21.1",
-				"@fluidframework/map": "^0.21.1",
-				"@fluidframework/runtime-definitions": "^0.21.1",
-				"@fluidframework/shared-object-base": "^0.21.1",
-				"@fluidframework/synthesize": "^0.21.1",
-				"@fluidframework/view-adapters": "^0.21.1",
-				"@fluidframework/view-interfaces": "^0.21.1",
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/component-runtime": "^0.22.0",
+				"@fluidframework/component-runtime-definitions": "^0.22.0",
+				"@fluidframework/container-definitions": "^0.22.0",
+				"@fluidframework/container-runtime": "^0.22.0",
+				"@fluidframework/container-runtime-definitions": "^0.22.0",
+				"@fluidframework/framework-interfaces": "^0.22.0",
+				"@fluidframework/map": "^0.22.0",
+				"@fluidframework/request-handler": "^0.22.0",
+				"@fluidframework/runtime-definitions": "^0.22.0",
+				"@fluidframework/runtime-utils": "^0.22.0",
+				"@fluidframework/shared-object-base": "^0.22.0",
+				"@fluidframework/synthesize": "^0.22.0",
+				"@fluidframework/view-adapters": "^0.22.0",
+				"@fluidframework/view-interfaces": "^0.22.0",
 				"uuid": "^3.3.2"
 			}
 		},
 		"old-container-definitions": {
-			"version": "npm:@fluidframework/container-definitions@0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-definitions/-/container-definitions-0.21.1.tgz",
-			"integrity": "sha1-bD558KLgP+1ixPa8m9QPeALmSLs=",
+			"version": "npm:@fluidframework/container-definitions@0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-definitions/-/container-definitions-0.22.0.tgz",
+			"integrity": "sha1-ahuuXsWEixbcxLHR+Rh0b44G4xw=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/driver-definitions": "^0.21.1",
-				"@fluidframework/protocol-definitions": "^0.1008.0"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1008.0.tgz",
-					"integrity": "sha1-E89ZDcx+XDsSDOr19r4mRJQD7yA=",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.18.1",
-						"buffer": "^4.3.0"
-					}
-				},
-				"buffer": {
-					"version": "4.9.2",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				}
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/driver-definitions": "^0.22.0",
+				"@fluidframework/protocol-definitions": "^0.1009.0"
 			}
 		},
 		"old-container-loader": {
-			"version": "npm:@fluidframework/container-loader@0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-loader/-/container-loader-0.21.1.tgz",
-			"integrity": "sha1-Rc3SHxYbR97OeA0/77kNjhgdcOk=",
+			"version": "npm:@fluidframework/container-loader@0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-loader/-/container-loader-0.22.0.tgz",
+			"integrity": "sha1-QYn8kvSqrN6P7uJQMGBw6PIL3RA=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.20.0",
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/container-definitions": "^0.21.1",
-				"@fluidframework/driver-definitions": "^0.21.1",
-				"@fluidframework/driver-utils": "^0.21.1",
-				"@fluidframework/protocol-base": "^0.1008.0",
-				"@fluidframework/protocol-definitions": "^0.1008.0",
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/container-definitions": "^0.22.0",
+				"@fluidframework/container-utils": "^0.22.0",
+				"@fluidframework/driver-definitions": "^0.22.0",
+				"@fluidframework/driver-utils": "^0.22.0",
+				"@fluidframework/protocol-base": "^0.1009.0",
+				"@fluidframework/protocol-definitions": "^0.1009.0",
+				"@fluidframework/telemetry-utils": "^0.22.0",
 				"@types/double-ended-queue": "^2.1.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
 				"jwt-decode": "^2.2.0",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.19",
 				"performance-now": "^2.1.0",
 				"uuid": "^3.3.2"
-			},
-			"dependencies": {
-				"@fluidframework/gitresources": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/gitresources/-/gitresources-0.1008.0.tgz",
-					"integrity": "sha1-pYdGVZvMFDsmKgv/xiHbjMMKi/Y="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-base/-/protocol-base-0.1008.0.tgz",
-					"integrity": "sha1-8pmULYHkd/zum0nHG36Ul1pvV/8=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/gitresources": "^0.1008.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.11"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1008.0.tgz",
-					"integrity": "sha1-E89ZDcx+XDsSDOr19r4mRJQD7yA=",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.18.1",
-						"buffer": "^4.3.0"
-					}
-				},
-				"buffer": {
-					"version": "4.9.2",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				}
 			}
 		},
 		"old-container-runtime": {
-			"version": "npm:@fluidframework/container-runtime@0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-runtime/-/container-runtime-0.21.1.tgz",
-			"integrity": "sha1-e1p0MSrK90L+R+mFgHyNz9vv2TU=",
+			"version": "npm:@fluidframework/container-runtime@0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-runtime/-/container-runtime-0.22.0.tgz",
+			"integrity": "sha1-2sF78gMzHrd643Nj+HQrNAzpb/8=",
 			"requires": {
-				"@fluidframework/agent-scheduler": "^0.21.1",
+				"@fluidframework/agent-scheduler": "^0.22.0",
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.20.0",
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/component-runtime": "^0.21.1",
-				"@fluidframework/container-definitions": "^0.21.1",
-				"@fluidframework/container-runtime-definitions": "^0.21.1",
-				"@fluidframework/driver-definitions": "^0.21.1",
-				"@fluidframework/driver-utils": "^0.21.1",
-				"@fluidframework/protocol-base": "^0.1008.0",
-				"@fluidframework/protocol-definitions": "^0.1008.0",
-				"@fluidframework/runtime-definitions": "^0.21.1",
-				"@fluidframework/runtime-utils": "^0.21.1",
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/component-runtime": "^0.22.0",
+				"@fluidframework/container-definitions": "^0.22.0",
+				"@fluidframework/container-runtime-definitions": "^0.22.0",
+				"@fluidframework/container-utils": "^0.22.0",
+				"@fluidframework/driver-definitions": "^0.22.0",
+				"@fluidframework/driver-utils": "^0.22.0",
+				"@fluidframework/protocol-base": "^0.1009.0",
+				"@fluidframework/protocol-definitions": "^0.1009.0",
+				"@fluidframework/runtime-definitions": "^0.22.0",
+				"@fluidframework/runtime-utils": "^0.22.0",
+				"@fluidframework/telemetry-utils": "^0.22.0",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/node": "^10.17.24",
@@ -15865,265 +15133,50 @@
 				"double-ended-queue": "^2.1.0-0",
 				"performance-now": "^2.1.0",
 				"uuid": "^3.3.2"
-			},
-			"dependencies": {
-				"@fluidframework/gitresources": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/gitresources/-/gitresources-0.1008.0.tgz",
-					"integrity": "sha1-pYdGVZvMFDsmKgv/xiHbjMMKi/Y="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-base/-/protocol-base-0.1008.0.tgz",
-					"integrity": "sha1-8pmULYHkd/zum0nHG36Ul1pvV/8=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/gitresources": "^0.1008.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.11"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1008.0.tgz",
-					"integrity": "sha1-E89ZDcx+XDsSDOr19r4mRJQD7yA=",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.18.1",
-						"buffer": "^4.3.0"
-					}
-				},
-				"buffer": {
-					"version": "4.9.2",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				}
+			}
+		},
+		"old-request-handler": {
+			"version": "npm:@fluidframework/request-handler@0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/request-handler/-/request-handler-0.22.0.tgz",
+			"integrity": "sha1-f5oaUqHqOQb0P0t2BhgwyLZnys8=",
+			"requires": {
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/container-runtime-definitions": "^0.22.0",
+				"@fluidframework/runtime-definitions": "^0.22.0",
+				"@fluidframework/runtime-utils": "^0.22.0"
 			}
 		},
 		"old-runtime-definitions": {
-			"version": "npm:@fluidframework/runtime-definitions@0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/runtime-definitions/-/runtime-definitions-0.21.1.tgz",
-			"integrity": "sha1-8eT5iyY47LxXMU89nMqBs2bFYKE=",
+			"version": "npm:@fluidframework/runtime-definitions@0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/runtime-definitions/-/runtime-definitions-0.22.0.tgz",
+			"integrity": "sha1-NRydf9Mdq6lupNWiUvwQWrl7qnE=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/container-definitions": "^0.21.1",
-				"@fluidframework/driver-definitions": "^0.21.1",
-				"@fluidframework/protocol-definitions": "^0.1008.0",
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/container-definitions": "^0.22.0",
+				"@fluidframework/driver-definitions": "^0.22.0",
+				"@fluidframework/protocol-definitions": "^0.1009.0",
 				"@types/node": "^10.17.24"
-			},
-			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1008.0.tgz",
-					"integrity": "sha1-E89ZDcx+XDsSDOr19r4mRJQD7yA=",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.18.1",
-						"buffer": "^4.3.0"
-					}
-				},
-				"buffer": {
-					"version": "4.9.2",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				}
 			}
 		},
 		"old-test-utils": {
-			"version": "npm:@fluidframework/test-utils@0.21.1",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/test-utils/-/test-utils-0.21.1.tgz",
-			"integrity": "sha1-3SNVzZTEejIVE/ON0cU/8bT831E=",
+			"version": "npm:@fluidframework/test-utils@0.22.0",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/test-utils/-/test-utils-0.22.0.tgz",
+			"integrity": "sha1-a0y6v4blnHWGHmCVUbxBQrGftKU=",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.21.1",
-				"@fluidframework/base-host": "^0.21.1",
-				"@fluidframework/component-core-interfaces": "^0.21.1",
-				"@fluidframework/component-runtime": "^0.21.1",
-				"@fluidframework/component-runtime-definitions": "^0.21.1",
-				"@fluidframework/container-definitions": "^0.21.1",
-				"@fluidframework/container-loader": "^0.21.1",
-				"@fluidframework/local-driver": "^0.21.1",
-				"@fluidframework/map": "^0.21.1",
-				"@fluidframework/runtime-definitions": "^0.21.1",
-				"@fluidframework/server-local-server": "^0.1008.0",
-				"@fluidframework/shared-object-base": "^0.21.1"
-			},
-			"dependencies": {
-				"@fluidframework/gitresources": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/gitresources/-/gitresources-0.1008.0.tgz",
-					"integrity": "sha1-pYdGVZvMFDsmKgv/xiHbjMMKi/Y="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-base/-/protocol-base-0.1008.0.tgz",
-					"integrity": "sha1-8pmULYHkd/zum0nHG36Ul1pvV/8=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/gitresources": "^0.1008.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.11"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1008.0.tgz",
-					"integrity": "sha1-E89ZDcx+XDsSDOr19r4mRJQD7yA=",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.18.1",
-						"buffer": "^4.3.0"
-					}
-				},
-				"@fluidframework/server-lambdas": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/server-lambdas/-/server-lambdas-0.1008.0.tgz",
-					"integrity": "sha1-LfhSFo1nLQtsfEWFC0fc+4yx6eI=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/gitresources": "^0.1008.0",
-						"@fluidframework/protocol-base": "^0.1008.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"@fluidframework/server-services-client": "^0.1008.0",
-						"@fluidframework/server-services-core": "^0.1008.0",
-						"@types/semver": "^6.0.1",
-						"async": "^2.6.1",
-						"double-ended-queue": "^2.1.0-0",
-						"json-stringify-safe": "^5.0.1",
-						"jsonwebtoken": "^8.4.0",
-						"lodash": "^4.17.11",
-						"nconf": "^0.10.0",
-						"semver": "^6.3.0",
-						"uuid": "^3.3.2"
-					}
-				},
-				"@fluidframework/server-local-server": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/server-local-server/-/server-local-server-0.1008.0.tgz",
-					"integrity": "sha1-AZu/h6dxsFxoc7xmQIfVidBGHAE=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"@fluidframework/server-lambdas": "^0.1008.0",
-						"@fluidframework/server-memory-orderer": "^0.1008.0",
-						"@fluidframework/server-services-client": "^0.1008.0",
-						"@fluidframework/server-services-core": "^0.1008.0",
-						"@fluidframework/server-test-utils": "^0.1008.0"
-					}
-				},
-				"@fluidframework/server-memory-orderer": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1008.0.tgz",
-					"integrity": "sha1-6bMSBObt5pDx4yiEJ4YXdUYwLUE=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/protocol-base": "^0.1008.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"@fluidframework/server-lambdas": "^0.1008.0",
-						"@fluidframework/server-services-client": "^0.1008.0",
-						"@fluidframework/server-services-core": "^0.1008.0",
-						"@types/debug": "^4.1.5",
-						"@types/double-ended-queue": "^2.1.0",
-						"@types/lodash": "^4.14.118",
-						"@types/node": "^10.17.24",
-						"@types/ws": "^6.0.1",
-						"debug": "^4.1.1",
-						"double-ended-queue": "^2.1.0-0",
-						"lodash": "^4.17.11",
-						"moniker": "^0.1.2",
-						"uuid": "^3.3.2",
-						"ws": "^6.1.2"
-					}
-				},
-				"@fluidframework/server-services-client": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/server-services-client/-/server-services-client-0.1008.0.tgz",
-					"integrity": "sha1-j6V6UpVBkWmiML/IbEtZ4pdRSjg=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/gitresources": "^0.1008.0",
-						"@fluidframework/protocol-base": "^0.1008.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"@types/node": "^10.17.24",
-						"axios": "^0.18.0",
-						"debug": "^4.1.1",
-						"jsonwebtoken": "^8.4.0",
-						"sillyname": "0.1.0",
-						"uuid": "^3.3.2"
-					}
-				},
-				"@fluidframework/server-services-core": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/server-services-core/-/server-services-core-0.1008.0.tgz",
-					"integrity": "sha1-7pp7verks+Fvq7WnurTxfB3PoGg=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/gitresources": "^0.1008.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"@fluidframework/server-services-client": "^0.1008.0",
-						"@types/nconf": "^0.0.37",
-						"@types/node": "^10.17.24",
-						"debug": "^4.1.1",
-						"nconf": "^0.10.0"
-					}
-				},
-				"@fluidframework/server-test-utils": {
-					"version": "0.1008.0",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/server-test-utils/-/server-test-utils-0.1008.0.tgz",
-					"integrity": "sha1-X+s5cMvGQF/LNEpiJy4HrWM02s0=",
-					"requires": {
-						"@fluidframework/common-utils": "^0.20.0",
-						"@fluidframework/gitresources": "^0.1008.0",
-						"@fluidframework/protocol-base": "^0.1008.0",
-						"@fluidframework/protocol-definitions": "^0.1008.0",
-						"@fluidframework/server-services-client": "^0.1008.0",
-						"@fluidframework/server-services-core": "^0.1008.0",
-						"debug": "^4.1.1",
-						"lodash": "^4.17.11",
-						"moniker": "^0.1.2",
-						"string-hash": "^1.1.3",
-						"uuid": "^3.3.2"
-					}
-				},
-				"buffer": {
-					"version": "4.9.2",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				}
+				"@fluidframework/aqueduct": "^0.22.0",
+				"@fluidframework/base-host": "^0.22.0",
+				"@fluidframework/component-core-interfaces": "^0.22.0",
+				"@fluidframework/component-runtime": "^0.22.0",
+				"@fluidframework/component-runtime-definitions": "^0.22.0",
+				"@fluidframework/container-definitions": "^0.22.0",
+				"@fluidframework/container-loader": "^0.22.0",
+				"@fluidframework/local-driver": "^0.22.0",
+				"@fluidframework/map": "^0.22.0",
+				"@fluidframework/protocol-definitions": "^0.1009.0",
+				"@fluidframework/runtime-definitions": "^0.22.0",
+				"@fluidframework/server-local-server": "^0.1009.0",
+				"@fluidframework/shared-object-base": "^0.22.0"
 			}
 		},
 		"on-finished": {

--- a/packages/test/end-to-end-tests/package.json
+++ b/packages/test/end-to-end-tests/package.json
@@ -110,6 +110,7 @@
     "old-container-definitions": "npm:@fluidframework/container-definitions@^0.22.0",
     "old-container-loader": "npm:@fluidframework/container-loader@^0.22.0",
     "old-container-runtime": "npm:@fluidframework/container-runtime@^0.22.0",
+    "old-request-handler": "npm:@fluidframework/request-handler@^0.22.0",
     "old-runtime-definitions": "npm:@fluidframework/runtime-definitions@^0.22.0",
     "old-test-utils": "npm:@fluidframework/test-utils@^0.22.0",
     "rimraf": "^2.6.2",

--- a/packages/test/end-to-end-tests/src/test/compat.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/compat.spec.ts
@@ -94,13 +94,18 @@ describe("loader/runtime compatibility", () => {
         componentFactory: IComponentFactory | old.IComponentFactory,
         runtimeOptions: old.IContainerRuntimeOptions = { initialSummarizerDelayMs: 0 },
     ): old.IRuntimeFactory => {
+        const builder = new old.RuntimeRequestHandlerBuilder();
+        builder.pushHandler(
+            old.componentRuntimeRequestHandler,
+            old.defaultComponentRuntimeRequestHandler("default"));
+
         return {
             get IRuntimeFactory() { return this; },
             instantiateRuntime: async (context: old.IContainerContext) => {
                 const runtime = await old.ContainerRuntime.load(
                     context,
                     [[type, Promise.resolve(componentFactory as old.IComponentFactory)]],
-                    [old.componentRuntimeRequestHandler, old.defaultComponentRuntimeRequestHandler("default")],
+                    async (req,rt) => builder.handleRequest(req,rt),
                     runtimeOptions,
                 );
                 if (!runtime.existing) {

--- a/packages/test/end-to-end-tests/src/test/oldVersion.ts
+++ b/packages/test/end-to-end-tests/src/test/oldVersion.ts
@@ -12,7 +12,8 @@ export {
 } from "old-aqueduct";
 export { IContainerContext, IFluidModule, IRuntimeFactory } from "old-container-definitions";
 export { Container } from "old-container-loader";
-export { componentRuntimeRequestHandler, ContainerRuntime, IContainerRuntimeOptions } from "old-container-runtime";
+export { ContainerRuntime, IContainerRuntimeOptions } from "old-container-runtime";
+export { componentRuntimeRequestHandler, RuntimeRequestHandlerBuilder } from "old-request-handler";
 export { IComponentFactory } from "old-runtime-definitions";
 export { createLocalLoader, initializeLocalContainer } from "old-test-utils";
 /* eslint-enable import/no-extraneous-dependencies */


### PR DESCRIPTION
With the release of release/0.22.x, there are a couple of build breaks in compat tests. Fixed these and also updated lerna-package-lock.json which doesn't seem to have been updated by bump-version tool.