### PR TITLE
Don't Implement IComponent on Agent Schedule

### DIFF
--- a/packages/runtime/agent-scheduler/src/scheduler.ts
+++ b/packages/runtime/agent-scheduler/src/scheduler.ts
@@ -33,7 +33,7 @@ import { v4 as uuid } from "uuid";
 // Note: making sure this ID is unique and does not collide with storage provided clientID
 const UnattachedClientId = `${uuid()}_unattached`;
 
-class AgentScheduler extends EventEmitter implements IAgentScheduler, IComponent, IComponentRouter {
+class AgentScheduler extends EventEmitter implements IAgentScheduler, IComponentRouter {
     public static async load(runtime: IComponentRuntime, context: IComponentContext) {
         let root: ISharedMap;
         let scheduler: ConsensusRegisterCollection<string | null>;


### PR DESCRIPTION
Found during renaming. Implementing icomponent isn't ever necessary