### PR TITLE
Remove createComponent

### DIFF
--- a/packages/runtime/runtime-definitions/src/componentFactory.ts
+++ b/packages/runtime/runtime-definitions/src/componentFactory.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { IComponent, IComponentLoadable } from "@fluidframework/component-core-interfaces";
 import { IComponentContext } from "./componentContext";
 
 declare module "@fluidframework/component-core-interfaces" {
@@ -27,15 +26,6 @@ export interface IComponentFactory extends IProvideComponentFactory {
      * String that uniquely identifies the type of component created by this factory.
      */
     type?: string;
-
-    /**
-     * Create a component described by the factory
-     * @param context - The component context being used to create the component
-     * (the created component will have its own new context created as well)
-     * @returns A promise for a component that will have been initialized. Caller is responsible
-     * for attaching the component to the provided runtime's container such as by storing its handle
-     */
-    createComponent?(context: IComponentContext): Promise<IComponent & IComponentLoadable>;
 
     /**
      * Generates runtime for the component from the component context. Once created should be bound to the context.


### PR DESCRIPTION
Not used.
Not implemented by anyone and not used anywhere 
It's shape is also wrong- it returns IComponent & IComponentLoadable, when in reality it needs to return IComponentRuntimeChannel.