### PR TITLE
wrap node-rdkafka import within try catch

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -10,7 +10,7 @@ services:
             - NODE_ENV=development
         restart: always
     alfred:
-        image: prague.azurecr.io/prague-server:26869
+        image: prague.azurecr.io/prague-server:33553
         ports:
             - "3003:3000"
         command: node packages/routerlicious/dist/alfred/www.js
@@ -19,42 +19,42 @@ services:
             - NODE_ENV=development
         restart: always
     deli:
-        image: prague.azurecr.io/prague-server:26869
+        image: prague.azurecr.io/prague-server:33553
         command: node packages/routerlicious/dist/kafka-service/index.js deli /usr/src/server/packages/routerlicious/dist/deli/index.js
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
         restart: always
     scriptorium:
-        image: prague.azurecr.io/prague-server:26869
+        image: prague.azurecr.io/prague-server:33553
         command: node packages/routerlicious/dist/kafka-service/index.js scriptorium /usr/src/server/packages/routerlicious/dist/scriptorium/index.js
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
         restart: always
     copier:
-        image: prague.azurecr.io/prague-server:26869
+        image: prague.azurecr.io/prague-server:33553
         command: node packages/routerlicious/dist/kafka-service/index.js copier /usr/src/server/packages/routerlicious/dist/copier/index.js
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
         restart: always
     scribe:
-        image: prague.azurecr.io/prague-server:26869
+        image: prague.azurecr.io/prague-server:33553
         command: node packages/routerlicious/dist/kafka-service/index.js scribe /usr/src/server/packages/routerlicious/dist/scribe/index.js
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
         restart: always
     foreman:
-        image: prague.azurecr.io/prague-server:26869
+        image: prague.azurecr.io/prague-server:33553
         command: node packages/routerlicious/dist/kafka-service/index.js foreman /usr/src/server/packages/routerlicious/dist/foreman/index.js
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
         restart: always
     routemaster:
-        image: prague.azurecr.io/prague-server:26869
+        image: prague.azurecr.io/prague-server:33553
         command: node packages/routerlicious/dist/kafka-service/index.js routemaster /usr/src/server/packages/lambdas-driver/dist/document-router/index.js
         environment:
             - DEBUG=fluid:*
@@ -62,7 +62,7 @@ services:
             - documentLambda=/usr/src/server/packages/routerlicious/dist/routemaster/index.js
         restart: always
     riddler:
-        image: prague.azurecr.io/prague-server:26869
+        image: prague.azurecr.io/prague-server:33553
         ports:
             - "5000:5000"
         command: node packages/routerlicious/dist/riddler/www.js

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -1787,6 +1787,14 @@
 				"resolve": "1.8.1",
 				"source-map": "~0.6.1",
 				"typescript": "~3.7.2"
+			},
+			"dependencies": {
+				"typescript": {
+					"version": "3.7.5",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+					"integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+					"dev": true
+				}
 			}
 		},
 		"@microsoft/api-extractor-model": {
@@ -15505,9 +15513,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.7.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-			"integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"typescript-formatter": {

--- a/server/routerlicious/package-lock.json
+++ b/server/routerlicious/package-lock.json
@@ -1645,6 +1645,14 @@
         "resolve": "1.8.1",
         "source-map": "~0.6.1",
         "typescript": "~3.7.2"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "3.7.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+          "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+          "dev": true
+        }
       }
     },
     "@microsoft/api-extractor-model": {
@@ -9064,9 +9072,9 @@
       }
     },
     "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "uglify-js": {

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -81,6 +81,6 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "run-script-os": "^1.0.7",
-    "typescript": "~3.7.4"
+    "typescript": "~3.8.2"
   }
 }

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -36,7 +36,7 @@
     "eslint-plugin-react": "~7.18.0",
     "eslint-plugin-unicorn": "~15.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~3.7.4",
+    "typescript": "~3.8.2",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-react": "~7.18.0",
     "eslint-plugin-unicorn": "~15.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~3.7.4",
+    "typescript": "~3.8.2",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -79,7 +79,7 @@
     "mocha": "^8.0.1",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~3.7.4",
+    "typescript": "~3.8.2",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -90,7 +90,7 @@
     "mocha": "^8.0.1",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~3.7.4",
+    "typescript": "~3.8.2",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0"
   }

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -82,7 +82,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "ts-loader": "^6.1.2",
-    "typescript": "~3.7.4",
+    "typescript": "~3.8.2",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11"

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -60,7 +60,7 @@
     "eslint-plugin-react": "~7.18.0",
     "eslint-plugin-unicorn": "~15.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~3.7.4",
+    "typescript": "~3.8.2",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -81,7 +81,7 @@
     "mocha-junit-reporter": "^1.18.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~3.7.4",
+    "typescript": "~3.8.2",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/protocol-definitions/package.json
+++ b/server/routerlicious/packages/protocol-definitions/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-react": "~7.18.0",
     "eslint-plugin-unicorn": "~15.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~3.7.4",
+    "typescript": "~3.8.2",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -144,7 +144,7 @@
     "supertest": "^3.1.0",
     "thread-loader": "^1.2.0",
     "ts-loader": "^6.1.2",
-    "typescript": "~3.7.4",
+    "typescript": "~3.8.2",
     "typescript-formatter": "7.1.0",
     "url-loader": "^2.1.0"
   }

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -81,7 +81,7 @@
     "mocha-junit-reporter": "^1.18.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~3.7.4",
+    "typescript": "~3.8.2",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-react": "~7.18.0",
     "eslint-plugin-unicorn": "~15.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~3.7.4",
+    "typescript": "~3.8.2",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-react": "~7.18.0",
     "eslint-plugin-unicorn": "~15.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~3.7.4",
+    "typescript": "~3.8.2",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-react": "~7.18.0",
     "eslint-plugin-unicorn": "~15.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~3.7.4",
+    "typescript": "~3.8.2",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -73,7 +73,7 @@
     "eslint-plugin-react": "~7.18.0",
     "eslint-plugin-unicorn": "~15.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~3.7.4",
+    "typescript": "~3.8.2",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services/src/rdkafkaBase.ts
+++ b/server/routerlicious/packages/services/src/rdkafkaBase.ts
@@ -4,7 +4,15 @@
  */
 
 import { EventEmitter } from "events";
-import * as kafka from "node-rdkafka";
+import type * as kafkaTypes from "node-rdkafka";
+import { tryImport } from "./tryImport";
+
+// The native dependency of node-rdkafka throws an error when installing in one enviroment (e.g., macOS) and running
+// inside another (e.g., docker ubuntu). The issue only occurs because we volume mount code directly into docker
+// for local dev flow. Using a pre-built image works fine (https://github.com/Blizzard/node-rdkafka/issues/315).
+// Because of this limitation, currently we cannot use node-rdkafka in local dev flow. So locally kafka config should
+// always point to kafka-node library. Production code can use either one of those.
+const kafka = tryImport("node-rdkafka");
 
 export interface IKafkaEndpoints {
 	kafka: string[];
@@ -47,7 +55,7 @@ export abstract class RdkafkaBase extends EventEmitter {
 			"metadata.broker.list": this.endpoints.kafka.join(","),
 		});
 
-		const newTopic: kafka.NewTopic = {
+		const newTopic: kafkaTypes.NewTopic = {
 			topic: this.topic,
 			num_partitions: this.numberOfPartitions,
 			replication_factor: this.replicationFactor,

--- a/server/routerlicious/packages/services/src/rdkafkaBase.ts
+++ b/server/routerlicious/packages/services/src/rdkafkaBase.ts
@@ -7,7 +7,7 @@ import { EventEmitter } from "events";
 import type * as kafkaTypes from "node-rdkafka";
 import { tryImport } from "./tryImport";
 
-// The native dependency of node-rdkafka throws an error when installing in one enviroment (e.g., macOS) and running
+// The native dependency of node-rdkafka throws an error when installing in one environment (e.g., macOS) and running
 // inside another (e.g., docker ubuntu). The issue only occurs because we volume mount code directly into docker
 // for local dev flow. Using a pre-built image works fine (https://github.com/Blizzard/node-rdkafka/issues/315).
 // Because of this limitation, currently we cannot use node-rdkafka in local dev flow. So locally kafka config should

--- a/server/routerlicious/packages/services/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services/src/rdkafkaConsumer.ts
@@ -3,18 +3,21 @@
  * Licensed under the MIT License.
  */
 
-import * as kafka from "node-rdkafka";
+import type * as kafkaTypes from "node-rdkafka";
 
 import { Deferred } from "@fluidframework/common-utils";
 import { IConsumer, IPartition, IPartitionWithEpoch, IQueuedMessage } from "@fluidframework/server-services-core";
 import { ZookeeperClient } from "./zookeeperClient";
 import { IKafkaEndpoints, RdkafkaBase } from "./rdkafkaBase";
+import { tryImport } from "./tryImport";
+
+const kafka = tryImport("node-rdkafka");
 
 /**
  * Kafka consumer using the node-rdkafka library
  */
 export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
-	private consumer?: kafka.KafkaConsumer;
+	private consumer?: kafkaTypes.KafkaConsumer;
 	private zooKeeperClient?: ZookeeperClient;
 
 	private isRebalancing = true;
@@ -66,7 +69,7 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 			this.emit("disconnected");
 		});
 
-		this.consumer.on("data", (message: kafka.Message) => {
+		this.consumer.on("data", (message: kafkaTypes.Message) => {
 			this.emit("data", message as IQueuedMessage);
 		});
 

--- a/server/routerlicious/packages/services/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services/src/rdkafkaProducer.ts
@@ -3,19 +3,21 @@
  * Licensed under the MIT License.
  */
 
-import * as kafka from "node-rdkafka";
-
+import type * as kafkaTypes from "node-rdkafka";
 import { BoxcarType, IBoxcarMessage, IPendingBoxcar, IProducer } from "@fluidframework/server-services-core";
 
 import { IKafkaEndpoints, RdkafkaBase } from "./rdkafkaBase";
 import { PendingBoxcar, MaxBatchSize } from "./pendingBoxcar";
+import { tryImport } from "./tryImport";
+
+const kafka = tryImport("node-rdkafka");
 
 /**
  * Kafka producer using the node-rdkafka library
  */
 export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 	private readonly messages = new Map<string, IPendingBoxcar[]>();
-	private producer?: kafka.Producer;
+	private producer?: kafkaTypes.Producer;
 	private sendPending?: NodeJS.Immediate;
 	private connecting = false;
 	private connected = false;

--- a/server/routerlicious/packages/services/src/tryImport.ts
+++ b/server/routerlicious/packages/services/src/tryImport.ts
@@ -1,0 +1,15 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Imports a module inside a try-catch block and swallows the error if import fails.
+export function tryImport(packageName: string) {
+    let module;
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+        module = require(packageName);
+    } catch (e) {
+    }
+    return module;
+}

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -82,7 +82,7 @@
     "mocha-junit-reporter": "^1.18.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~3.7.4",
+    "typescript": "~3.8.2",
     "typescript-formatter": "7.1.0"
   }
 }


### PR DESCRIPTION
The native dependency of node-rdkafka throws an error when installing in one environment (e.g., macOS) and running
inside another (e.g., docker ubuntu). The issue only occurs because we volume mount code directly into docker
for local dev flow. Using a pre-built image works fine (https://github.com/Blizzard/node-rdkafka/issues/315).
Because of this limitation, currently we cannot use node-rdkafka in local dev flow. So locally kafka config should
always point to kafka-node library. Production code can use either one of those.