### PR TITLE
Remove attach & chunked ops types from container.ts

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1371,6 +1371,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             case MessageType.Operation:
             case MessageType.RemoteHelp:
             case MessageType.Summarize:
+                break;
             default:
                 this.close(CreateContainerError(`Runtime can't send arbitrary message type: ${type}`));
                 return -1;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1371,11 +1371,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             case MessageType.Operation:
             case MessageType.RemoteHelp:
             case MessageType.Summarize:
-            // Back-compat: <= 0.21.0
-            // Legacy, to be removed in next version(s)
-            case "attach":
-            case "chunkedOp":
-                break;
             default:
                 this.close(CreateContainerError(`Runtime can't send arbitrary message type: ${type}`));
                 return -1;


### PR DESCRIPTION
Closes #2728
Switched OPs to current format only in 0.22
While loader version is never behind runtime version for fluid preview and all key hosts (Teams, OWA, etc.), it's likely prudent to wait for 0.24 release given that we expect 0.23 to be fast follow up release.
So I'll merge it once 0.23 is cut.
