### PR TITLE
Disposed unhandled exceptions in CRC / Agent scheduler

### DIFF
--- a/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
+++ b/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
@@ -341,11 +341,12 @@ export class ConsensusOrderedCollection<T = any>
     ): Promise<IConsensusOrderedCollectionValue<T> | undefined> {
         assert(this.isAttached());
 
-        return this.newAckBasedPromise((resolve) => {
+        return this.newAckBasedPromise<IConsensusOrderedCollectionValue<T>>((resolve) => {
             // Send the resolve function as the localOpMetadata. This will be provided back to us when the
             // op is ack'd.
             this.submitLocalMessage(message, resolve);
-        });
+        // If we fail due to runtime being disposed, it's better to return undefined then unhandled exception.
+        }).catch((error) => undefined);
     }
 
     private addCore(value: T) {

--- a/packages/dds/register-collection/src/consensusRegisterCollection.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollection.ts
@@ -150,11 +150,12 @@ export class ConsensusRegisterCollection<T>
             refSeq: this.runtime.deltaManager.lastSequenceNumber,
         };
 
-        return this.newAckBasedPromise((resolve) => {
+        return this.newAckBasedPromise<boolean>((resolve) => {
             // Send the resolve function as the localOpMetadata. This will be provided back to us when the
             // op is ack'd.
             this.submitLocalMessage(message, resolve);
-        });
+        // If we fail due to runtime being disposed, it's better to return false then unhandled exception.
+        }).catch((error) => false);
     }
 
     /**

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -297,13 +297,13 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
         return new Promise<T>((resolve, reject) => {
             rejectBecauseDispose =
                 () => reject(new Error("ComponentRuntime disposed while this ack-based Promise was pending"));
-            this.runtime.on("dispose", rejectBecauseDispose);
 
-            // Even in this case don't return, so the caller's executor can run
             if (this.runtime.disposed) {
-                reject("Preparing to wait for an op to be acked but ComponentRuntime has been disposed");
+                rejectBecauseDispose();
+                return;
             }
 
+            this.runtime.once("dispose", rejectBecauseDispose);
             executor(resolve, reject);
         }).finally(() => {
             // Note: rejectBecauseDispose will never be undefined here

--- a/packages/runtime/agent-scheduler/src/scheduler.ts
+++ b/packages/runtime/agent-scheduler/src/scheduler.ts
@@ -168,7 +168,7 @@ class AgentScheduler extends EventEmitter implements IAgentScheduler, IComponent
 
     private async registerCore(taskUrls: string[]): Promise<void> {
         if (taskUrls.length > 0) {
-            const registersP: Promise<boolean>[] = [];
+            const registersP: Promise<void>[] = [];
             for (const taskUrl of taskUrls) {
                 debug(`Registering ${taskUrl}`);
                 // tslint:disable no-null-keyword
@@ -194,7 +194,7 @@ class AgentScheduler extends EventEmitter implements IAgentScheduler, IComponent
 
     private async releaseCore(taskUrls: string[]) {
         if (taskUrls.length > 0) {
-            const releasesP: Promise<boolean>[] = [];
+            const releasesP: Promise<void>[] = [];
             for (const taskUrl of taskUrls) {
                 debug(`Releasing ${taskUrl}`);
                 // Remove from local map so that it can be picked later.
@@ -207,7 +207,7 @@ class AgentScheduler extends EventEmitter implements IAgentScheduler, IComponent
 
     private async clearTasks(taskUrls: string[]) {
         assert(this.isActive());
-        const clearP: Promise<boolean>[] = [];
+        const clearP: Promise<void>[] = [];
         for (const taskUrl of taskUrls) {
             debug(`Clearing ${taskUrl}`);
             clearP.push(this.writeCore(taskUrl, null));
@@ -219,8 +219,8 @@ class AgentScheduler extends EventEmitter implements IAgentScheduler, IComponent
         return this.scheduler.read(url);
     }
 
-    private async writeCore(key: string, clientId: string | null): Promise<boolean> {
-        return this.scheduler.write(key, clientId);
+    private async writeCore(key: string, clientId: string | null): Promise<void> {
+        await this.scheduler.write(key, clientId);
     }
 
     private initialize() {

--- a/packages/test/end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
@@ -272,8 +272,8 @@ function generate(
             await collection1.add("testValue");
 
             assert(waitRejected, "Closing the runtime while waiting should cause promise reject");
-            await assert.rejects(acquireAndComplete(collection2), "Acquiring when the runtime is disposed should fail");
-            await assert.rejects(collection2.add("anotherValue"), "Adding when the runtime is disposed should fail");
+            await acquireAndComplete(collection2);
+            await collection2.add("anotherValue");
             assert.equal(await acquireAndComplete(collection1), "testValue", "testValue should still be there");
         });
 


### PR DESCRIPTION
Closes #2734: QoS Report Unhandled Rejection: ComponentRuntime disposed while this ack-based Promise was pending

Writing flows are mostly fire-and-forget in CRC.
There is not much value in returning failure on closure of container, as it does not matter.
The only place where it matters (and API shape does not allow to swallow error) is waitAndAcquire() API, where expectation is clear that when it returns, it has to acquire an item.

The caller can't do much about these failures anyway, so there is not much benefit of propagating to users.

We also should consider other design. We can remove all pending op tracking (i.e. clear unacked ops) on disposal (it's good thing to do either way!) and simply rely on GC to cleanup any hanging promises, without need to rely on newAckBasedPromise. I feel it's cleaner design, as we keep adding catches for runtime disposed exceptions here and there without much benefit.