### PR TITLE
Support objects in MatchProperties

### DIFF
--- a/packages/dds/merge-tree/src/properties.ts
+++ b/packages/dds/merge-tree/src/properties.ts
@@ -70,6 +70,10 @@ export function matchProperties(a: PropertySet, b: PropertySet) {
             for (const key in a) {
                 if (b[key] === undefined) {
                     return false;
+                } else if(typeof b[key] === "object") {
+                    if (!matchProperties(a[key], b[key])) {
+                        return false;
+                    }
                 } else if (b[key] !== a[key]) {
                     return false;
                 }

--- a/packages/dds/merge-tree/src/test/properties.spec.ts
+++ b/packages/dds/merge-tree/src/test/properties.spec.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import assert from "assert";
 import { matchProperties } from "../properties";
 

--- a/packages/dds/merge-tree/src/test/properties.spec.ts
+++ b/packages/dds/merge-tree/src/test/properties.spec.ts
@@ -1,0 +1,31 @@
+import assert from "assert";
+import { matchProperties } from "../properties";
+
+describe("Properties", () => {
+    describe("matchProperties", ()=>{
+        it("simple properties match", ()=>{
+            assert(matchProperties({ a: "a" }, { a: "a" }));
+        });
+        it("simple properties don't match", ()=>{
+            assert(!matchProperties({ a: "a" }, { a: "b" }));
+        });
+        it("multiple simple properties match", ()=>{
+            assert(matchProperties({ a: "a", 1: 1 }, { a: "a", 1: 1 }));
+        });
+        it("multiple simple properties don't match", ()=>{
+            assert(!matchProperties({ a: "a", 1: 1 }, { a: "b", 1:2 }));
+        });
+        it("keys don't match", ()=>{
+            assert(!matchProperties({ a: "a" }, { b: "a" }));
+        });
+        it("extra key", ()=>{
+            assert(!matchProperties({ a: "a" }, { a: "a", b: "b" }));
+        });
+        it("complex properties match", ()=>{
+            assert(matchProperties({ c: { a: "a" } }, { c: { a: "a" } }));
+        });
+        it("complex properties don't match", ()=>{
+            assert(!matchProperties({ c: { a: "a" } }, { c: { a: "b" } }));
+        });
+    });
+});


### PR DESCRIPTION
Going with a simple fix to start. if we need to support a large number of values we'll want to introduce hashing, but that shouldn't be necessary yet.

fixes #2767