### PR TITLE
Trigger docs deployments when the docs builds complete

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -11,7 +11,7 @@ variables:
   - name: latestPipeline
     value: ${{ or(
       eq(variables['Build.SourceBranchName'], 'master'),
-      eq(variables['Build.SourceBranchName'], 'api-pipeline')
+      eq(variables['Build.SourceBranchName'], 'pipeline')
       )}}
   - name: n1Branch
     value: ${{ join('/refs/heads/release/', variables['N1_BRANCH']) }}
@@ -38,7 +38,7 @@ trigger:
     include:
     - release/*
     - master
-    - docs/api-pipeline # for testing
+    - docs/pipeline # for testing
   paths:
     exclude:
     - packages

--- a/tools/pipelines/deploy-docs.yml
+++ b/tools/pipelines/deploy-docs.yml
@@ -14,7 +14,7 @@ variables:
   - name: latestPipeline
     value: ${{ or(
       eq(variables['Build.SourceBranchName'], 'master'),
-      eq(variables['Build.SourceBranchName'], 'api-pipeline')
+      eq(variables['Build.SourceBranchName'], 'pipeline')
       )}}
   - name: n1Pipeline
     value: ${{ eq(variables['Build.SourceBranchName'], variables['N1_BRANCH']) }}
@@ -27,12 +27,12 @@ resources:
   pipelines:
   - pipeline: docs
     source: build-docs
-    trigger: true
-#      branches:
-#        include:
-#        - release/*
-#        - master
-#        - docs/api-pipeline # for testing
+    trigger:
+      branches:
+        include:
+        - release/*
+        - master
+        - docs/pipeline # for testing
 
 # no branch and PR triggers
 trigger: none


### PR DESCRIPTION
This change should enable the deploy-docs pipeline to start whenever the corresponding build-docs pipeline completes on a per-branch basis. 