### PR TITLE
createaComponent APIs

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -3,12 +3,35 @@
 ## 0.23 Breaking Changes
 - [Removed `collaborating` event on IComponentRuntime](#Removed-`collaborating`-event-on-IComponentRuntime)
 - [ISharedObjectFactory rename](#ISharedObjectFactory)
+- [createComponent API renames and deletions](#createComponent-API-renames-and-deletions)
 
 ### Removed `collaborating` event on IComponentRuntime
 Component Runtime no longer fires the collaborating event on attaching. Now it fires `attaching` event.
 
 ### ISharedObjectFactory
 `ISharedObjectFactory` renamed to `IChannelFactory` and moved from `@fluidframework/shared-object-base` to `@fluidframework/component-runtime-definitions`
+
+## createComponent API renames and deletions
+Deprecated APIs:
+1. IContainerRuntime:
+    - createComponentWithRealizationFn() - not used
+2. IContainerRuntimeBase:
+    - createComponent() - switch to _createComponent
+    - getComponentRuntime() is gone. getComponentById() is its replacement, but it returns IComponent, not IComponentRuntimeChannel.
+2. IContainerContext:
+   - createComponent() - switch to IContainerRuntimeBase._createComponent
+   - createComponentWithRealizationFn() - not used
+   - realizeWithFn() - not used
+
+IContainerRuntimeBase._createComponent() is the only APIs to create components. It takes now different args:
+- package path
+- attach (boolean) - indicates if components needs to be attached to container as part of its creation creation
+- id of component (optional, to be removed in future once we have aliases and named components)
+
+Initial props are gone from runtime layer. They have been deprecated for many versions.
+If you need to pass props on component creation, please either use SharedComponentFactory / PrimedComponentFactory, or copy/borrow pattern (IInitializeSharedObject) from there.
+
+Note that there is no way any more to get to IComponentRuntimeChannel or IComponentContext directly, unless component itself choses to expose this info. These interfaces are private communication channel between container and component runtime. _createComponent() and getComponentById() both return components, which is result of doing default request against component runtime. getComponentById() allows to overwrite default request argument.
 
 ## 0.22 Breaking Changes
 - [Deprecated `path` from `IComponentHandleContext`](#Deprecated-`path`-from-`IComponentHandleContext`)

--- a/components/examples/simple-component-embed/src/index.tsx
+++ b/components/examples/simple-component-embed/src/index.tsx
@@ -24,7 +24,7 @@ export class SimpleComponentEmbed extends PrimedComponent implements IComponentH
    * but in this scenario we only want it to be created once.
    */
     protected async componentInitializingFirstTime() {
-        const component = await this.createAndAttachComponent(ClickerInstantiationFactory.type);
+        const component = await this.createComponent(ClickerInstantiationFactory.type);
         this.root.set("myEmbeddedCounter", component.handle);
     }
 

--- a/components/examples/simple-component-embed/src/index.tsx
+++ b/components/examples/simple-component-embed/src/index.tsx
@@ -7,6 +7,7 @@ import {
     ContainerRuntimeFactoryWithDefaultComponent,
     PrimedComponent,
     PrimedComponentFactory,
+    createComponentHelper,
 } from "@fluidframework/aqueduct";
 import { ClickerInstantiationFactory, Clicker } from "@fluid-example/clicker";
 import { IComponentHTMLView } from "@fluidframework/view-interfaces";
@@ -24,7 +25,7 @@ export class SimpleComponentEmbed extends PrimedComponent implements IComponentH
    * but in this scenario we only want it to be created once.
    */
     protected async componentInitializingFirstTime() {
-        const component = await this.createComponent(ClickerInstantiationFactory.type);
+        const component = await createComponentHelper(ClickerInstantiationFactory.type, this.context);
         this.root.set("myEmbeddedCounter", component.handle);
     }
 

--- a/components/experimental/client-ui-lib/src/controls/flowView.ts
+++ b/components/experimental/client-ui-lib/src/controls/flowView.ts
@@ -4523,7 +4523,7 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
     public insertComponentNew(prefix: string, chaincode: string, inline = false) {
         const id = `${prefix}-${Date.now()}`;
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.collabDocument.context.createComponent(id, chaincode).then((doc) => doc.bindToContext());
+        this.collabDocument.context._createComponentWithProps(chaincode, true, undefined, id);
         const props = {
             crefTest: {
                 layout: { inline },

--- a/components/experimental/client-ui-lib/src/controls/flowView.ts
+++ b/components/experimental/client-ui-lib/src/controls/flowView.ts
@@ -4523,7 +4523,7 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
     public insertComponentNew(prefix: string, chaincode: string, inline = false) {
         const id = `${prefix}-${Date.now()}`;
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.collabDocument.context._createComponentWithProps(chaincode, true, undefined, id);
+        this.collabDocument.context._createComponentWithProps(chaincode, true, id);
         const props = {
             crefTest: {
                 layout: { inline },

--- a/components/experimental/client-ui-lib/src/controls/flowView.ts
+++ b/components/experimental/client-ui-lib/src/controls/flowView.ts
@@ -4523,7 +4523,7 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
     public insertComponentNew(prefix: string, chaincode: string, inline = false) {
         const id = `${prefix}-${Date.now()}`;
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.collabDocument.context._createComponentWithProps(chaincode, true, id);
+        this.collabDocument.context._createComponent(chaincode, true, id);
         const props = {
             crefTest: {
                 layout: { inline },

--- a/components/experimental/client-ui-lib/src/controls/flowView.ts
+++ b/components/experimental/client-ui-lib/src/controls/flowView.ts
@@ -4523,7 +4523,7 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
     public insertComponentNew(prefix: string, chaincode: string, inline = false) {
         const id = `${prefix}-${Date.now()}`;
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.collabDocument.context._createComponent(chaincode, true, id);
+        this.collabDocument.context.containerRuntime._createComponent(chaincode, true, id);
         const props = {
             crefTest: {
                 layout: { inline },

--- a/components/experimental/codemirror/src/index.ts
+++ b/components/experimental/codemirror/src/index.ts
@@ -52,7 +52,6 @@ class CodeMirrorFactory implements IRuntimeFactory {
         if (!runtime.existing) {
             const componentRuntime = await runtime._createComponentWithProps(
                 defaultComponent,
-                undefined,
                 defaultComponentId);
             componentRuntime.bindToContext();
         }

--- a/components/experimental/codemirror/src/index.ts
+++ b/components/experimental/codemirror/src/index.ts
@@ -50,11 +50,11 @@ class CodeMirrorFactory implements IRuntimeFactory {
 
         // On first boot create the base component
         if (!runtime.existing) {
-            await Promise.all([
-                runtime.createComponent(defaultComponentId, defaultComponent).then((componentRuntime) => {
-                    componentRuntime.bindToContext();
-                }),
-            ]);
+            const componentRuntime = await runtime._createComponentWithProps(
+                defaultComponent,
+                undefined,
+                defaultComponentId);
+            componentRuntime.bindToContext();
         }
 
         return runtime;

--- a/components/experimental/codemirror/src/index.ts
+++ b/components/experimental/codemirror/src/index.ts
@@ -38,9 +38,10 @@ class CodeMirrorFactory implements IRuntimeFactory {
                 const componentId = requestUrl
                     ? requestUrl.substr(0, trailingSlash === -1 ? requestUrl.length : trailingSlash)
                     : defaultComponentId;
-                const component = await containerRuntime.getComponentRuntime(componentId, true);
-
-                return component.request({ url: trailingSlash === -1 ? "" : requestUrl.substr(trailingSlash + 1) });
+                return containerRuntime.getComponentById(
+                    componentId,
+                    { url: trailingSlash === -1 ? "" : requestUrl.substr(trailingSlash + 1) },
+                    true);
             },
 
             { generateSummaries: true });
@@ -50,10 +51,7 @@ class CodeMirrorFactory implements IRuntimeFactory {
 
         // On first boot create the base component
         if (!runtime.existing) {
-            const componentRuntime = await runtime._createComponentWithProps(
-                defaultComponent,
-                defaultComponentId);
-            componentRuntime.bindToContext();
+            await runtime._createComponent(defaultComponent, true, defaultComponentId);
         }
 
         return runtime;

--- a/components/experimental/external-component-loader/src/externalComponentLoader.tsx
+++ b/components/experimental/external-component-loader/src/externalComponentLoader.tsx
@@ -47,22 +47,24 @@ export class ExternalComponentLoader extends PrimedComponent {
         let componentRuntime: IComponentRuntimeChannel;
         const id = uuid();
         if (pkgReg?.IComponentDefaultFactoryName !== undefined) {
-            componentRuntime = await this.context.containerRuntime.createComponent(
-                id,
+            componentRuntime = await this.context.containerRuntime._createComponentWithProps(
                 [
                     ...this.context.packagePath,
                     "url",
                     componentUrl,
                     pkgReg.IComponentDefaultFactoryName.getDefaultFactoryName(),
-                ]);
+                ],
+                undefined,
+                id);
         } else if (pkgReg?.IComponentFactory !== undefined) {
-            componentRuntime = await this.context.containerRuntime.createComponent(
-                id,
+            componentRuntime = await this.context.containerRuntime._createComponentWithProps(
                 [
                     ...this.context.packagePath,
                     "url",
                     componentUrl,
-                ]);
+                ],
+                undefined,
+                id);
         } else {
             throw new Error(`${componentUrl} is not a factory, and does not provide default component name`);
         }

--- a/components/experimental/external-component-loader/src/externalComponentLoader.tsx
+++ b/components/experimental/external-component-loader/src/externalComponentLoader.tsx
@@ -54,7 +54,6 @@ export class ExternalComponentLoader extends PrimedComponent {
                     componentUrl,
                     pkgReg.IComponentDefaultFactoryName.getDefaultFactoryName(),
                 ],
-                undefined,
                 id);
         } else if (pkgReg?.IComponentFactory !== undefined) {
             componentRuntime = await this.context.containerRuntime._createComponentWithProps(
@@ -63,7 +62,6 @@ export class ExternalComponentLoader extends PrimedComponent {
                     "url",
                     componentUrl,
                 ],
-                undefined,
                 id);
         } else {
             throw new Error(`${componentUrl} is not a factory, and does not provide default component name`);

--- a/components/experimental/external-component-loader/src/waterPark.tsx
+++ b/components/experimental/external-component-loader/src/waterPark.tsx
@@ -133,9 +133,9 @@ export class WaterPark extends PrimedComponent implements IComponentHTMLView {
     }
 
     protected async componentInitializingFirstTime() {
-        const storage = await this.createAndAttachComponent(SpacesStorage.ComponentName);
+        const storage = await this.createComponent(SpacesStorage.ComponentName);
         this.root.set(storageKey, storage.handle);
-        const loader = await this.createAndAttachComponent(ExternalComponentLoader.ComponentName);
+        const loader = await this.createComponent(ExternalComponentLoader.ComponentName);
         this.root.set(loaderKey, loader.handle);
     }
 

--- a/components/experimental/external-component-loader/src/waterPark.tsx
+++ b/components/experimental/external-component-loader/src/waterPark.tsx
@@ -3,7 +3,7 @@
 * Licensed under the MIT License.
 */
 
-import { PrimedComponent, PrimedComponentFactory } from "@fluidframework/aqueduct";
+import { createComponentHelper, PrimedComponent, PrimedComponentFactory } from "@fluidframework/aqueduct";
 import {
     IComponentHandle,
     IRequest,
@@ -133,9 +133,9 @@ export class WaterPark extends PrimedComponent implements IComponentHTMLView {
     }
 
     protected async componentInitializingFirstTime() {
-        const storage = await this.createComponent(SpacesStorage.ComponentName);
+        const storage = await createComponentHelper(SpacesStorage.ComponentName, this.context);
         this.root.set(storageKey, storage.handle);
-        const loader = await this.createComponent(ExternalComponentLoader.ComponentName);
+        const loader = await createComponentHelper(ExternalComponentLoader.ComponentName, this.context);
         this.root.set(loaderKey, loader.handle);
     }
 

--- a/components/experimental/image-collection/src/images.ts
+++ b/components/experimental/image-collection/src/images.ts
@@ -63,8 +63,8 @@ export class ImageCollection extends SharedComponent<ISharedDirectory> implement
 
     public static getFactory(): IComponentFactory { return ImageCollection.factory; }
 
-    public static create(parentContext: IComponentContext, props?: any) {
-        return ImageCollection.factory.create(parentContext, props);
+    public static create(parentContext: IComponentContext) {
+        return ImageCollection.factory.create(parentContext);
     }
 
     public create() { this.initialize(); }

--- a/components/experimental/key-value-cache/src/index.ts
+++ b/components/experimental/key-value-cache/src/index.ts
@@ -161,7 +161,7 @@ export class KeyValueFactoryComponent implements IRuntimeFactory, IComponentFact
         );
 
         if (!runtime.existing) {
-            const created = await runtime.createComponent(ComponentName, ComponentName);
+            const created = await runtime._createComponentWithProps(ComponentName, undefined, ComponentName);
             created.bindToContext();
         }
 

--- a/components/experimental/key-value-cache/src/index.ts
+++ b/components/experimental/key-value-cache/src/index.ts
@@ -161,7 +161,7 @@ export class KeyValueFactoryComponent implements IRuntimeFactory, IComponentFact
         );
 
         if (!runtime.existing) {
-            const created = await runtime._createComponentWithProps(ComponentName, undefined, ComponentName);
+            const created = await runtime._createComponentWithProps(ComponentName, ComponentName);
             created.bindToContext();
         }
 

--- a/components/experimental/key-value-cache/src/index.ts
+++ b/components/experimental/key-value-cache/src/index.ts
@@ -132,8 +132,7 @@ export class KeyValueFactoryComponent implements IRuntimeFactory, IComponentFact
             : ComponentName;
 
         const pathForComponent = trailingSlash !== -1 ? requestUrl.substr(trailingSlash) : requestUrl;
-        const component = await runtime.getComponentRuntime(componentId, true);
-        return component.request({ url: pathForComponent });
+        return runtime.getComponentById(componentId, { url: pathForComponent }, true);
     }
 
     public instantiateComponent(context: IComponentContext): void {
@@ -161,8 +160,7 @@ export class KeyValueFactoryComponent implements IRuntimeFactory, IComponentFact
         );
 
         if (!runtime.existing) {
-            const created = await runtime._createComponentWithProps(ComponentName, ComponentName);
-            created.bindToContext();
+            await runtime._createComponent(ComponentName, true, ComponentName);
         }
 
         return runtime;

--- a/components/experimental/math/src/mathComponent.ts
+++ b/components/experimental/math/src/mathComponent.ts
@@ -504,8 +504,8 @@ export class MathCollection extends SharedComponent<ISharedDirectory> implements
 
     public static getFactory(): IComponentFactory { return MathCollection.factory; }
 
-    public static create(parentContext: IComponentContext, props?: any) {
-        return MathCollection.factory.create(parentContext, props);
+    public static create(parentContext: IComponentContext) {
+        return MathCollection.factory.create(parentContext);
     }
 
     public create() {

--- a/components/experimental/multiview/container/src/container.tsx
+++ b/components/experimental/multiview/container/src/container.tsx
@@ -30,7 +30,7 @@ const registryEntries = new Map([
 // Just a little helper, since we're going to create multiple coordinates.
 const createAndAttachCoordinate = async (runtime: IContainerRuntime, id: string) => {
     const simpleCoordinateComponentRuntime =
-        await runtime.createComponent(id, Coordinate.ComponentName);
+        await runtime._createComponentWithProps(Coordinate.ComponentName, undefined, id);
     const simpleResult = await simpleCoordinateComponentRuntime.request({ url: id });
     if (simpleResult.status !== 200 || simpleResult.mimeType !== "fluid/component") {
         throw new Error("Error in creating the default option picker model.");

--- a/components/experimental/multiview/container/src/container.tsx
+++ b/components/experimental/multiview/container/src/container.tsx
@@ -30,7 +30,7 @@ const registryEntries = new Map([
 // Just a little helper, since we're going to create multiple coordinates.
 const createAndAttachCoordinate = async (runtime: IContainerRuntime, id: string) => {
     const simpleCoordinateComponentRuntime =
-        await runtime._createComponentWithProps(Coordinate.ComponentName, undefined, id);
+        await runtime._createComponentWithProps(Coordinate.ComponentName, id);
     const simpleResult = await simpleCoordinateComponentRuntime.request({ url: id });
     if (simpleResult.status !== 200 || simpleResult.mimeType !== "fluid/component") {
         throw new Error("Error in creating the default option picker model.");

--- a/components/experimental/multiview/container/src/container.tsx
+++ b/components/experimental/multiview/container/src/container.tsx
@@ -29,14 +29,8 @@ const registryEntries = new Map([
 
 // Just a little helper, since we're going to create multiple coordinates.
 const createAndAttachCoordinate = async (runtime: IContainerRuntime, id: string) => {
-    const simpleCoordinateComponentRuntime =
-        await runtime._createComponentWithProps(Coordinate.ComponentName, id);
-    const simpleResult = await simpleCoordinateComponentRuntime.request({ url: id });
-    if (simpleResult.status !== 200 || simpleResult.mimeType !== "fluid/component") {
-        throw new Error("Error in creating the default option picker model.");
-    }
-    simpleCoordinateComponentRuntime.bindToContext();
-    return simpleResult.value as ICoordinate;
+    const component = await runtime._createComponent(Coordinate.ComponentName, true, id);
+    return component as any as ICoordinate;
 };
 
 // Just a little helper, since we're going to request multiple coordinates.

--- a/components/experimental/prosemirror/src/index.ts
+++ b/components/experimental/prosemirror/src/index.ts
@@ -52,7 +52,6 @@ class ProseMirrorFactory implements IRuntimeFactory {
         if (!runtime.existing) {
             const componentRuntime = await runtime._createComponentWithProps(
                 defaultComponent,
-                undefined,
                 defaultComponentId);
             componentRuntime.bindToContext();
         }

--- a/components/experimental/prosemirror/src/index.ts
+++ b/components/experimental/prosemirror/src/index.ts
@@ -39,9 +39,10 @@ class ProseMirrorFactory implements IRuntimeFactory {
                 const componentId = requestUrl
                     ? requestUrl.substr(0, trailingSlash === -1 ? requestUrl.length : trailingSlash)
                     : defaultComponentId;
-                const component = await containerRuntime.getComponentRuntime(componentId, true);
-
-                return component.request({ url: trailingSlash === -1 ? "" : requestUrl.substr(trailingSlash + 1) });
+                return containerRuntime.getComponentById(
+                    componentId,
+                    { url: trailingSlash === -1 ? "" : requestUrl.substr(trailingSlash + 1) },
+                    true);
             },
             { generateSummaries: true });
 
@@ -50,10 +51,7 @@ class ProseMirrorFactory implements IRuntimeFactory {
 
         // On first boot create the base component
         if (!runtime.existing) {
-            const componentRuntime = await runtime._createComponentWithProps(
-                defaultComponent,
-                defaultComponentId);
-            componentRuntime.bindToContext();
+            await runtime._createComponent(defaultComponent, true, defaultComponentId);
         }
 
         return runtime;

--- a/components/experimental/prosemirror/src/index.ts
+++ b/components/experimental/prosemirror/src/index.ts
@@ -50,11 +50,11 @@ class ProseMirrorFactory implements IRuntimeFactory {
 
         // On first boot create the base component
         if (!runtime.existing) {
-            await Promise.all([
-                runtime.createComponent(defaultComponentId, defaultComponent).then((componentRuntime) => {
-                    componentRuntime.bindToContext();
-                }),
-            ]);
+            const componentRuntime = await runtime._createComponentWithProps(
+                defaultComponent,
+                undefined,
+                defaultComponentId);
+            componentRuntime.bindToContext();
         }
 
         return runtime;

--- a/components/experimental/scribe/src/scribe.ts
+++ b/components/experimental/scribe/src/scribe.ts
@@ -478,18 +478,16 @@ class ScribeFactory implements IComponentFactory, IRuntimeFactory {
                 const componentId = requestUrl
                     ? requestUrl.substr(0, trailingSlash === -1 ? requestUrl.length : trailingSlash)
                     : defaultComponentId;
-                const component = await containerRuntime.getComponentRuntime(componentId, true);
-
-                return component.request({ url: trailingSlash === -1 ? "" : requestUrl.substr(trailingSlash + 1) });
+                return containerRuntime.getComponentById(
+                    componentId,
+                    { url: trailingSlash === -1 ? "" : requestUrl.substr(trailingSlash + 1) },
+                    true);
             },
             { generateSummaries: true });
 
         // On first boot create the base component
         if (!runtime.existing) {
-            const componentRuntime = await runtime._createComponentWithProps(
-                ScribeFactory.type,
-                defaultComponentId);
-            componentRuntime.bindToContext();
+            await runtime._createComponent(ScribeFactory.type, true, defaultComponentId);
         }
 
         return runtime;

--- a/components/experimental/scribe/src/scribe.ts
+++ b/components/experimental/scribe/src/scribe.ts
@@ -488,7 +488,6 @@ class ScribeFactory implements IComponentFactory, IRuntimeFactory {
         if (!runtime.existing) {
             const componentRuntime = await runtime._createComponentWithProps(
                 ScribeFactory.type,
-                undefined,
                 defaultComponentId);
             componentRuntime.bindToContext();
         }

--- a/components/experimental/scribe/src/scribe.ts
+++ b/components/experimental/scribe/src/scribe.ts
@@ -486,11 +486,11 @@ class ScribeFactory implements IComponentFactory, IRuntimeFactory {
 
         // On first boot create the base component
         if (!runtime.existing) {
-            await Promise.all([
-                runtime.createComponent(defaultComponentId, ScribeFactory.type).then((componentRuntime) => {
-                    componentRuntime.bindToContext();
-                }),
-            ]);
+            const componentRuntime = await runtime._createComponentWithProps(
+                ScribeFactory.type,
+                undefined,
+                defaultComponentId);
+            componentRuntime.bindToContext();
         }
 
         return runtime;

--- a/components/experimental/shared-text/src/component.ts
+++ b/components/experimental/shared-text/src/component.ts
@@ -152,10 +152,10 @@ export class SharedTextRunner
 
             const containerRuntime = this.context.containerRuntime;
             const [progressBars, math, videoPlayers, images] = await Promise.all([
-                getHandle(containerRuntime._createComponentWithProps("@fluid-example/progress-bars")),
-                getHandle(containerRuntime._createComponentWithProps("@fluid-example/math")),
-                getHandle(containerRuntime._createComponentWithProps("@fluid-example/video-players")),
-                getHandle(containerRuntime._createComponentWithProps("@fluid-example/image-collection")),
+                getHandle(containerRuntime._createComponentWithProps("@fluid-example/progress-bars", false)),
+                getHandle(containerRuntime._createComponentWithProps("@fluid-example/math", false)),
+                getHandle(containerRuntime._createComponentWithProps("@fluid-example/video-players", false)),
+                getHandle(containerRuntime._createComponentWithProps("@fluid-example/image-collection", false)),
             ]);
 
             this.rootView.set("progressBars", progressBars);

--- a/components/experimental/shared-text/src/component.ts
+++ b/components/experimental/shared-text/src/component.ts
@@ -28,7 +28,6 @@ import {
 } from "@fluidframework/map";
 import * as MergeTree from "@fluidframework/merge-tree";
 import {
-    IComponentRuntimeChannel,
     IComponentContext,
     ITask,
     ITaskManager,
@@ -49,15 +48,8 @@ const debug = registerDebug("fluid:shared-text");
 /**
  * Helper function to retrieve the handle for the default component route
  */
-async function getHandle(runtimeP: Promise<IComponentRuntimeChannel>): Promise<IComponentHandle> {
-    const runtime = await runtimeP;
-    const request = await runtime.request({ url: "" });
-
-    if (request.status !== 200 || request.mimeType !== "fluid/component") {
-        return Promise.reject("Not found");
-    }
-
-    const component = request.value as IFluidObject & IComponent;
+async function getHandle(componentP: Promise<IComponent>): Promise<IComponentHandle> {
+    const component = await componentP;
     return component.IComponentLoadable.handle;
 }
 
@@ -152,10 +144,10 @@ export class SharedTextRunner
 
             const containerRuntime = this.context.containerRuntime;
             const [progressBars, math, videoPlayers, images] = await Promise.all([
-                getHandle(containerRuntime._createComponentWithProps("@fluid-example/progress-bars")),
-                getHandle(containerRuntime._createComponentWithProps("@fluid-example/math")),
-                getHandle(containerRuntime._createComponentWithProps("@fluid-example/video-players")),
-                getHandle(containerRuntime._createComponentWithProps("@fluid-example/image-collection")),
+                getHandle(containerRuntime._createComponent("@fluid-example/progress-bars", false)),
+                getHandle(containerRuntime._createComponent("@fluid-example/math", false)),
+                getHandle(containerRuntime._createComponent("@fluid-example/video-players", false)),
+                getHandle(containerRuntime._createComponent("@fluid-example/image-collection", false)),
             ]);
 
             this.rootView.set("progressBars", progressBars);

--- a/components/experimental/shared-text/src/component.ts
+++ b/components/experimental/shared-text/src/component.ts
@@ -152,10 +152,10 @@ export class SharedTextRunner
 
             const containerRuntime = this.context.containerRuntime;
             const [progressBars, math, videoPlayers, images] = await Promise.all([
-                getHandle(containerRuntime._createComponentWithProps("@fluid-example/progress-bars", false)),
-                getHandle(containerRuntime._createComponentWithProps("@fluid-example/math", false)),
-                getHandle(containerRuntime._createComponentWithProps("@fluid-example/video-players", false)),
-                getHandle(containerRuntime._createComponentWithProps("@fluid-example/image-collection", false)),
+                getHandle(containerRuntime._createComponentWithProps("@fluid-example/progress-bars")),
+                getHandle(containerRuntime._createComponentWithProps("@fluid-example/math")),
+                getHandle(containerRuntime._createComponentWithProps("@fluid-example/video-players")),
+                getHandle(containerRuntime._createComponentWithProps("@fluid-example/image-collection")),
             ]);
 
             this.rootView.set("progressBars", progressBars);

--- a/components/experimental/shared-text/src/index.ts
+++ b/components/experimental/shared-text/src/index.ts
@@ -137,10 +137,11 @@ class SharedTextFactoryComponent implements IComponentFactory, IRuntimeFactory {
 
         // On first boot create the base component
         if (!runtime.existing) {
-            await Promise.all([
-                runtime.createComponent(DefaultComponentName, SharedTextFactoryComponent.type)
-                    .then((componentRuntime) => componentRuntime.bindToContext()),
-            ]);
+            const componentRuntime = await runtime._createComponentWithProps(
+                SharedTextFactoryComponent.type,
+                undefined,
+                DefaultComponentName);
+            componentRuntime.bindToContext();
         }
 
         return runtime;

--- a/components/experimental/shared-text/src/index.ts
+++ b/components/experimental/shared-text/src/index.ts
@@ -106,13 +106,13 @@ class SharedTextFactoryComponent implements IComponentFactory, IRuntimeFactory {
         const componentId = requestUrl
             ? requestUrl.substr(0, trailingSlash === -1 ? requestUrl.length : trailingSlash)
             : "text";
-        const component = await runtime.getComponentRuntime(componentId, true);
-
-        return component.request(
+        return runtime.getComponentById(
+            componentId,
             {
                 headers: request.headers,
                 url: trailingSlash === -1 ? "" : requestUrl.substr(trailingSlash + 1),
-            });
+            },
+            true);
     }
 
     public instantiateComponent(context: IComponentContext): void {
@@ -137,10 +137,7 @@ class SharedTextFactoryComponent implements IComponentFactory, IRuntimeFactory {
 
         // On first boot create the base component
         if (!runtime.existing) {
-            const componentRuntime = await runtime._createComponentWithProps(
-                SharedTextFactoryComponent.type,
-                DefaultComponentName);
-            componentRuntime.bindToContext();
+            await runtime._createComponent(SharedTextFactoryComponent.type, true, DefaultComponentName);
         }
 
         return runtime;

--- a/components/experimental/shared-text/src/index.ts
+++ b/components/experimental/shared-text/src/index.ts
@@ -139,7 +139,6 @@ class SharedTextFactoryComponent implements IComponentFactory, IRuntimeFactory {
         if (!runtime.existing) {
             const componentRuntime = await runtime._createComponentWithProps(
                 SharedTextFactoryComponent.type,
-                undefined,
                 DefaultComponentName);
             componentRuntime.bindToContext();
         }

--- a/components/experimental/smde/src/index.ts
+++ b/components/experimental/smde/src/index.ts
@@ -49,11 +49,11 @@ class SmdeContainerFactory implements IRuntimeFactory {
 
         // On first boot create the base component
         if (!runtime.existing) {
-            await Promise.all([
-                runtime.createComponent(defaultComponentId, defaultComponent).then((componentRuntime) => {
-                    componentRuntime.bindToContext();
-                }),
-            ]);
+            const componentRuntime = await runtime._createComponentWithProps(
+                defaultComponent,
+                undefined,
+                defaultComponentId);
+            componentRuntime.bindToContext();
         }
 
         return runtime;

--- a/components/experimental/smde/src/index.ts
+++ b/components/experimental/smde/src/index.ts
@@ -38,9 +38,10 @@ class SmdeContainerFactory implements IRuntimeFactory {
                 const componentId = requestUrl
                     ? requestUrl.substr(0, trailingSlash === -1 ? requestUrl.length : trailingSlash)
                     : defaultComponentId;
-                const component = await containerRuntime.getComponentRuntime(componentId, true);
-
-                return component.request({ url: trailingSlash === -1 ? "" : requestUrl.substr(trailingSlash + 1) });
+                return containerRuntime.getComponentById(
+                    componentId,
+                    { url: trailingSlash === -1 ? "" : requestUrl.substr(trailingSlash + 1) },
+                    true);
             },
             { generateSummaries: true });
 
@@ -49,10 +50,7 @@ class SmdeContainerFactory implements IRuntimeFactory {
 
         // On first boot create the base component
         if (!runtime.existing) {
-            const componentRuntime = await runtime._createComponentWithProps(
-                defaultComponent,
-                defaultComponentId);
-            componentRuntime.bindToContext();
+            await runtime._createComponent(defaultComponent, true, defaultComponentId);
         }
 
         return runtime;

--- a/components/experimental/smde/src/index.ts
+++ b/components/experimental/smde/src/index.ts
@@ -51,7 +51,6 @@ class SmdeContainerFactory implements IRuntimeFactory {
         if (!runtime.existing) {
             const componentRuntime = await runtime._createComponentWithProps(
                 defaultComponent,
-                undefined,
                 defaultComponentId);
             componentRuntime.bindToContext();
         }

--- a/components/experimental/spaces/src/spaces.tsx
+++ b/components/experimental/spaces/src/spaces.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { Layout } from "react-grid-layout";
 import {
+    createComponentHelper,
     PrimedComponent,
     PrimedComponentFactory,
 } from "@fluidframework/aqueduct";
@@ -127,7 +128,7 @@ export class Spaces extends PrimedComponent implements IComponentHTMLView {
 
     protected async componentInitializingFirstTime() {
         const storageComponent =
-            await this.createComponent<SpacesStorage<ISpacesItem>>(SpacesStorage.ComponentName);
+            await createComponentHelper<SpacesStorage<ISpacesItem>>(SpacesStorage.ComponentName, this.context);
         this.root.set(SpacesStorageKey, storageComponent.handle);
         // Set the saved template if there is a template query param
         const urlParams = new URLSearchParams(window.location.search);
@@ -185,7 +186,8 @@ export class Spaces extends PrimedComponent implements IComponentHTMLView {
         }
 
         // Don't really want to hand out createComponent here, see spacesItemMap.ts for more info.
-        const serializableObject = await itemMapEntry.create(this.createComponent.bind(this));
+        const serializableObject = await itemMapEntry.create(
+            async (pkg: string, props?: any) => createComponentHelper(pkg, this.context, props));
         return this.storageComponent.addItem(
             {
                 serializableObject,

--- a/components/experimental/spaces/src/spaces.tsx
+++ b/components/experimental/spaces/src/spaces.tsx
@@ -127,7 +127,7 @@ export class Spaces extends PrimedComponent implements IComponentHTMLView {
 
     protected async componentInitializingFirstTime() {
         const storageComponent =
-            await this.createAndAttachComponent<SpacesStorage<ISpacesItem>>(SpacesStorage.ComponentName);
+            await this.createComponent<SpacesStorage<ISpacesItem>>(SpacesStorage.ComponentName);
         this.root.set(SpacesStorageKey, storageComponent.handle);
         // Set the saved template if there is a template query param
         const urlParams = new URLSearchParams(window.location.search);
@@ -184,8 +184,8 @@ export class Spaces extends PrimedComponent implements IComponentHTMLView {
             throw new Error("Unknown item, can't add");
         }
 
-        // Don't really want to hand out createAndAttachComponent here, see spacesItemMap.ts for more info.
-        const serializableObject = await itemMapEntry.create(this.createAndAttachComponent.bind(this));
+        // Don't really want to hand out createComponent here, see spacesItemMap.ts for more info.
+        const serializableObject = await itemMapEntry.create(this.createComponent.bind(this));
         return this.storageComponent.addItem(
             {
                 serializableObject,

--- a/components/experimental/spaces/src/spacesItemMap.ts
+++ b/components/experimental/spaces/src/spacesItemMap.ts
@@ -17,7 +17,7 @@ import { ClickerInstantiationFactory } from "@fluid-example/clicker";
 import * as React from "react";
 import { Layout } from "react-grid-layout";
 
-export type ICreateAndAttachComponentFunction =
+export type ICreateComponentFunction =
     <T extends IFluidObject & IComponentLoadable>(pkg: string, props?: any) => Promise<T>;
 
 interface ISingleHandleItem {
@@ -25,8 +25,8 @@ interface ISingleHandleItem {
 }
 
 const createSingleHandleItem = (type: string) => {
-    return async (createAndAttachComponent: ICreateAndAttachComponentFunction): Promise<ISingleHandleItem> => {
-        const component = await createAndAttachComponent(type);
+    return async (createComponent: ICreateComponentFunction): Promise<ISingleHandleItem> => {
+        const component = await createComponent(type);
         return {
             handle: component.handle,
         };
@@ -51,7 +51,7 @@ const getSliderCoordinateView = async (serializableObject: ISingleHandleItem) =>
 export interface ISpacesItemEntry<T extends Serializable = AsSerializable<any>> {
     // Would be better if items to bring their own subregistries, and their own ability to create components
     // This might be done by integrating these items with the Spaces subcomponent registry?
-    create: (createAndAttachComponent: ICreateAndAttachComponentFunction) => Promise<T>;
+    create: (createComponent: ICreateComponentFunction) => Promise<T>;
     getView: (serializableObject: T) => Promise<JSX.Element>;
     friendlyName: string;
     fabricIconName: string;

--- a/components/experimental/table-document/src/slice.ts
+++ b/components/experimental/table-document/src/slice.ts
@@ -24,7 +24,7 @@ export interface ITableSliceConfig {
 export class TableSlice extends PrimedComponent<{}, ITableSliceConfig> implements ITable {
     public static getFactory() { return TableSlice.factory; }
 
-    private static readonly factory = new PrimedComponentFactory(
+    private static readonly factory = new PrimedComponentFactory<{}, ITableSliceConfig>(
         TableSliceType,
         TableSlice,
         [],

--- a/components/experimental/todo/src/TextBox/textBoxInstantiationFactory.ts
+++ b/components/experimental/todo/src/TextBox/textBoxInstantiationFactory.ts
@@ -5,10 +5,11 @@
 
 import { PrimedComponentFactory } from "@fluidframework/aqueduct";
 import { SharedString } from "@fluidframework/sequence";
+import { TodoItemSupportedComponents } from "../TodoItem/supportedComponent";
 import { TextBoxName } from "./TextBox";
 import { TextBox } from "./index";
 
-export const TextBoxInstantiationFactory = new PrimedComponentFactory(
+export const TextBoxInstantiationFactory = new PrimedComponentFactory<{}, TodoItemSupportedComponents>(
     TextBoxName,
     TextBox,
     [

--- a/components/experimental/todo/src/TodoItem/TodoItem.tsx
+++ b/components/experimental/todo/src/TodoItem/TodoItem.tsx
@@ -109,7 +109,7 @@ export class TodoItem extends PrimedComponent<{}, ITodoItemInitialState> impleme
 
     public static getFactory() { return TodoItem.factory; }
 
-    private static readonly factory = new PrimedComponentFactory(
+    private static readonly factory = new PrimedComponentFactory<{}, ITodoItemInitialState>(
         TodoItemName,
         TodoItem,
         [

--- a/components/experimental/video-players/src/videoPlayers.ts
+++ b/components/experimental/video-players/src/videoPlayers.ts
@@ -157,8 +157,8 @@ export class VideoPlayerCollection extends SharedComponent<ISharedDirectory> imp
 
     public static getFactory(): IComponentFactory { return VideoPlayerCollection.factory; }
 
-    public static create(parentContext: IComponentContext, props?: any) {
-        return VideoPlayerCollection.factory.create(parentContext, props);
+    public static create(parentContext: IComponentContext) {
+        return VideoPlayerCollection.factory.create(parentContext);
     }
 
     // TODO: either better error handling is needed here, or create() should be async

--- a/components/experimental/vltava/src/components/anchor/anchor.ts
+++ b/components/experimental/vltava/src/components/anchor/anchor.ts
@@ -48,10 +48,10 @@ export class Anchor extends PrimedComponent implements IProvideComponentHTMLView
     }
 
     protected async componentInitializingFirstTime() {
-        const defaultComponent = await this.createAndAttachComponent("vltava");
+        const defaultComponent = await this.createComponent("vltava");
         this.root.set(this.defaultComponentId, defaultComponent.handle);
 
-        const lastEditedComponent = await this.createAndAttachComponent(LastEditedTrackerComponentName);
+        const lastEditedComponent = await this.createComponent(LastEditedTrackerComponentName);
         this.root.set(this.lastEditedComponentId, lastEditedComponent.handle);
     }
 

--- a/components/experimental/vltava/src/components/anchor/anchor.ts
+++ b/components/experimental/vltava/src/components/anchor/anchor.ts
@@ -4,7 +4,7 @@
  */
 
 import { IComponentHandle } from "@fluidframework/component-core-interfaces";
-import { PrimedComponent, PrimedComponentFactory } from "@fluidframework/aqueduct";
+import { createComponentHelper, PrimedComponent, PrimedComponentFactory } from "@fluidframework/aqueduct";
 import {
     IComponentLastEditedTracker,
     IProvideComponentLastEditedTracker,
@@ -48,10 +48,10 @@ export class Anchor extends PrimedComponent implements IProvideComponentHTMLView
     }
 
     protected async componentInitializingFirstTime() {
-        const defaultComponent = await this.createComponent("vltava");
+        const defaultComponent = await createComponentHelper("vltava", this.context);
         this.root.set(this.defaultComponentId, defaultComponent.handle);
 
-        const lastEditedComponent = await this.createComponent(LastEditedTrackerComponentName);
+        const lastEditedComponent = await createComponentHelper(LastEditedTrackerComponentName, this.context);
         this.root.set(this.lastEditedComponentId, lastEditedComponent.handle);
     }
 

--- a/components/experimental/vltava/src/components/tabs/dataModel.ts
+++ b/components/experimental/vltava/src/components/tabs/dataModel.ts
@@ -43,7 +43,7 @@ export class TabsDataModel extends EventEmitter implements ITabsDataModel {
     constructor(
         public root: ISharedDirectory,
         private readonly internalRegistry: IComponentInternalRegistry,
-        private readonly createAndAttachComponent: <T extends IFluidObject & IComponentLoadable>
+        private readonly createComponent: <T extends IFluidObject & IComponentLoadable>
             (pkg: string, props?: any) => Promise<T>,
         private readonly getComponentFromDirectory: <T extends IFluidObject & IComponentLoadable>(
             id: string,
@@ -75,7 +75,7 @@ export class TabsDataModel extends EventEmitter implements ITabsDataModel {
 
     public async createTab(type: string): Promise<string> {
         const newKey = uuid();
-        const component = await this.createAndAttachComponent<IFluidObject & IComponentLoadable>(type);
+        const component = await this.createComponent<IFluidObject & IComponentLoadable>(type);
         this.tabs.set(newKey, {
             type,
             handleOrId: component.handle,

--- a/components/experimental/vltava/src/components/tabs/tabs.tsx
+++ b/components/experimental/vltava/src/components/tabs/tabs.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { PrimedComponent, PrimedComponentFactory } from "@fluidframework/aqueduct";
+import { createComponentHelper, PrimedComponent, PrimedComponentFactory } from "@fluidframework/aqueduct";
 import { IFluidObject } from "@fluidframework/component-core-interfaces";
 import { IComponentHTMLView } from "@fluidframework/view-interfaces";
 
@@ -47,7 +47,7 @@ export class TabsComponent extends PrimedComponent implements IComponentHTMLView
             new TabsDataModel(
                 this.root,
                 registryDetails,
-                this.createComponent.bind(this),
+                async (pkg: string, props?: any) => createComponentHelper(pkg, this.context, props),
                 this.getComponentFromDirectory.bind(this),
             );
     }

--- a/components/experimental/vltava/src/components/tabs/tabs.tsx
+++ b/components/experimental/vltava/src/components/tabs/tabs.tsx
@@ -47,7 +47,7 @@ export class TabsComponent extends PrimedComponent implements IComponentHTMLView
             new TabsDataModel(
                 this.root,
                 registryDetails,
-                this.createAndAttachComponent.bind(this),
+                this.createComponent.bind(this),
                 this.getComponentFromDirectory.bind(this),
             );
     }

--- a/components/experimental/vltava/src/components/vltava/vltava.tsx
+++ b/components/experimental/vltava/src/components/vltava/vltava.tsx
@@ -37,7 +37,7 @@ export class Vltava extends PrimedComponent implements IComponentHTMLView {
     public get IComponentHTMLView() { return this; }
 
     protected async componentInitializingFirstTime() {
-        const tabsComponent = await this.createAndAttachComponent("tabs");
+        const tabsComponent = await this.createComponent("tabs");
         this.root.set("tabs-component-id", tabsComponent.handle);
     }
 

--- a/components/experimental/vltava/src/components/vltava/vltava.tsx
+++ b/components/experimental/vltava/src/components/vltava/vltava.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { PrimedComponent, PrimedComponentFactory } from "@fluidframework/aqueduct";
+import { createComponentHelper, PrimedComponent, PrimedComponentFactory } from "@fluidframework/aqueduct";
 import { IComponentHTMLView } from "@fluidframework/view-interfaces";
 
 import React from "react";
@@ -37,7 +37,7 @@ export class Vltava extends PrimedComponent implements IComponentHTMLView {
     public get IComponentHTMLView() { return this; }
 
     protected async componentInitializingFirstTime() {
-        const tabsComponent = await this.createComponent("tabs");
+        const tabsComponent = await createComponentHelper("tabs", this.context);
         this.root.set("tabs-component-id", tabsComponent.handle);
     }
 

--- a/components/experimental/webflow/README.md
+++ b/components/experimental/webflow/README.md
@@ -24,7 +24,7 @@ To host an instance of the Editor, your Fluid component will need to create an i
 example, this is done in host/host.ts:
 
 ```ts
-    const docP = this.createComponent<FlowDocument>(this.docId, FlowDocument.type);
+    const docP = createComponentHelper<FlowDocument>(FlowDocument.type, this.context);
 ```
 
 On subsequent loads, you'll want to open the same flow document:

--- a/components/experimental/webflow/README.md
+++ b/components/experimental/webflow/README.md
@@ -24,7 +24,7 @@ To host an instance of the Editor, your Fluid component will need to create an i
 example, this is done in host/host.ts:
 
 ```ts
-    const docP = this.createAndAttachComponent<FlowDocument>(this.docId, FlowDocument.type);
+    const docP = this.createComponent<FlowDocument>(this.docId, FlowDocument.type);
 ```
 
 On subsequent loads, you'll want to open the same flow document:

--- a/components/experimental/webflow/src/document/index.ts
+++ b/components/experimental/webflow/src/document/index.ts
@@ -139,8 +139,8 @@ export class FlowDocument extends SharedComponent<ISharedDirectory, IFlowDocumen
 
     public static getFactory(): IComponentFactory { return FlowDocument.factory; }
 
-    public static create(parentContext: IComponentContext, props?: any) {
-        return FlowDocument.factory.create(parentContext, props);
+    public static create(parentContext: IComponentContext) {
+        return FlowDocument.factory.create(parentContext);
     }
 
     private get sharedString() { return this.maybeSharedString; }

--- a/components/experimental/webflow/src/host/index.ts
+++ b/components/experimental/webflow/src/host/index.ts
@@ -23,8 +23,8 @@ export class WebFlow extends SharedComponent<ISharedDirectory> implements ICompo
 
     public static getFactory(): IComponentFactory { return WebFlow.factory; }
 
-    public static create(parentContext: IComponentContext, props?: any) {
-        return WebFlow.factory.create(parentContext, props);
+    public static create(parentContext: IComponentContext) {
+        return WebFlow.factory.create(parentContext);
     }
 
     public create() {

--- a/docs/tutorials/dice-roller.md
+++ b/docs/tutorials/dice-roller.md
@@ -72,7 +72,7 @@ behavior as well as additional helpers to make component development easier.
 
 1. Setup a `root` [SharedDirectory](../api/map.shareddirectory.md) (a Distributed Data Structure) that we can use to
    store collaborative content and other distributed data structures.
-2. Provide `this.createAndAttachComponent(...)` and `this.getComponent(...)` functions for easier creation and access
+2. Provide `this.createComponent(...)` and `this.getComponent(...)` functions for easier creation and access
    to other components.
 3. Provide the following setup overrides
    - `componentInitializingFirstTime()` - only called the first time a component is initialized

--- a/packages/framework/aqueduct/src/componentFactories/sharedComponentFactory.ts
+++ b/packages/framework/aqueduct/src/componentFactories/sharedComponentFactory.ts
@@ -135,6 +135,6 @@ export class SharedComponentFactory<P extends IComponent, S = undefined> impleme
         context: IComponentContext,
         initialState?: S,
     ): Promise<IComponent & IComponentLoadable> {
-        return createComponentHelper<S>(this.type, context, initialState);
+        return createComponentHelper<IComponent & IComponentLoadable, S>(this.type, context, initialState);
     }
 }

--- a/packages/framework/aqueduct/src/componentFactories/sharedComponentFactory.ts
+++ b/packages/framework/aqueduct/src/componentFactories/sharedComponentFactory.ts
@@ -139,7 +139,7 @@ export class SharedComponentFactory<P extends IComponent, S = undefined> impleme
             throw new Error("undefined type member");
         }
 
-        const component = await context._createComponentWithProps(
+        const component = await context._createComponent(
             this.type,
             false,
         );

--- a/packages/framework/aqueduct/src/componentFactories/sharedComponentFactory.ts
+++ b/packages/framework/aqueduct/src/componentFactories/sharedComponentFactory.ts
@@ -23,7 +23,7 @@ import {
 import {
     ISharedComponentProps,
     SharedComponent,
-    IInitializeSharedObject,
+    createComponentHelper,
 } from "../components";
 
 /**
@@ -135,21 +135,6 @@ export class SharedComponentFactory<P extends IComponent, S = undefined> impleme
         context: IComponentContext,
         initialState?: S,
     ): Promise<IComponent & IComponentLoadable> {
-        if (this.type === "") {
-            throw new Error("undefined type member");
-        }
-
-        const component = await context._createComponent(
-            this.type,
-            false,
-        );
-
-        const init: IInitializeSharedObject<S> | undefined = (component as any).IInitializeSharedObject;
-        if (init === undefined) {
-            throw new Error("Can't find IInitializeSharedObject");
-        }
-        await init.initializingComponentOnCreation(initialState);
-
-        return component;
+        return createComponentHelper<S>(this.type, context, false, initialState);
     }
 }

--- a/packages/framework/aqueduct/src/componentFactories/sharedComponentFactory.ts
+++ b/packages/framework/aqueduct/src/componentFactories/sharedComponentFactory.ts
@@ -142,7 +142,6 @@ export class SharedComponentFactory<P extends IComponent, S = undefined> impleme
         const component = await context._createComponentWithProps(
             this.type,
             false,
-            initialState,
         );
 
         const init: IInitializeSharedObject<S> | undefined = (component as any).IInitializeSharedObject;

--- a/packages/framework/aqueduct/src/componentFactories/sharedComponentFactory.ts
+++ b/packages/framework/aqueduct/src/componentFactories/sharedComponentFactory.ts
@@ -135,6 +135,6 @@ export class SharedComponentFactory<P extends IComponent, S = undefined> impleme
         context: IComponentContext,
         initialState?: S,
     ): Promise<IComponent & IComponentLoadable> {
-        return createComponentHelper<S>(this.type, context, false, initialState);
+        return createComponentHelper<S>(this.type, context, initialState);
     }
 }

--- a/packages/framework/aqueduct/src/components/index.ts
+++ b/packages/framework/aqueduct/src/components/index.ts
@@ -9,4 +9,5 @@ export {
     ISharedComponentProps,
     SharedComponent,
     IInitializeSharedObject,
+    createComponentHelper,
 } from "./sharedComponent";

--- a/packages/framework/aqueduct/src/components/index.ts
+++ b/packages/framework/aqueduct/src/components/index.ts
@@ -8,4 +8,5 @@ export { PrimedComponent } from "./primedComponent";
 export {
     ISharedComponentProps,
     SharedComponent,
+    IInitializeSharedObject,
 } from "./sharedComponent";

--- a/packages/framework/aqueduct/src/components/primedComponent.ts
+++ b/packages/framework/aqueduct/src/components/primedComponent.ts
@@ -105,7 +105,7 @@ export abstract class PrimedComponent<P extends IComponent = object, S = undefin
         this.internalTaskManager = await this.asComponent<ITaskManager>(this.context.containerRuntime.request(request));
 
         if (!this.runtime.existing) {
-            // Create a root directory and register it before calling componentInitializingFirstTime
+            // Create a root directory and register it
             this.internalRoot = SharedDirectory.create(this.runtime, this.rootDirectoryId);
             this.internalRoot.bindToContext();
         } else {
@@ -116,8 +116,7 @@ export abstract class PrimedComponent<P extends IComponent = object, S = undefin
             // PrimedComponent which used a SharedMap.  Since SharedMap and SharedDirectory are compatible unless
             // SharedDirectory-only commands are used on SharedMap, this will mostly just work for compatibility.
             if (this.internalRoot.attributes.type === MapFactory.Type) {
-                this.runtime.logger.send({
-                    category: "generic",
+                this.runtime.logger.sendTelemetryEvent({
                     eventName: "MapPrimedComponent",
                     message: "Legacy document, SharedMap is masquerading as SharedDirectory in PrimedComponent",
                 });

--- a/packages/framework/aqueduct/src/components/primedComponent.ts
+++ b/packages/framework/aqueduct/src/components/primedComponent.ts
@@ -95,7 +95,7 @@ export abstract class PrimedComponent<P extends IComponent = object, S = undefin
      * Initializes internal objects and calls initialization overrides.
      * Caller is responsible for ensuring this is only invoked once.
      */
-    protected async initializeInternal(props?: any): Promise<void> {
+    protected async initializeInternal(): Promise<void> {
         // Initialize task manager.
         const request = {
             headers: [[true]],
@@ -108,7 +108,6 @@ export abstract class PrimedComponent<P extends IComponent = object, S = undefin
             // Create a root directory and register it before calling componentInitializingFirstTime
             this.internalRoot = SharedDirectory.create(this.runtime, this.rootDirectoryId);
             this.internalRoot.bindToContext();
-            await this.componentInitializingFirstTime(props);
         } else {
             // Component has a root directory so we just need to set it before calling componentInitializingFromExisting
             this.internalRoot = await this.runtime.getChannel(this.rootDirectoryId) as ISharedDirectory;
@@ -123,12 +122,9 @@ export abstract class PrimedComponent<P extends IComponent = object, S = undefin
                     message: "Legacy document, SharedMap is masquerading as SharedDirectory in PrimedComponent",
                 });
             }
-
-            await this.componentInitializingFromExisting();
         }
 
-        // This always gets called at the end of initialize on FirstTime or from existing.
-        await this.componentHasInitialized();
+        return super.initializeInternal();
     }
 
     protected getUninitializedErrorString(item: string) {

--- a/packages/framework/aqueduct/src/components/sharedComponent.ts
+++ b/packages/framework/aqueduct/src/components/sharedComponent.ts
@@ -186,7 +186,7 @@ export abstract class SharedComponent<P extends IComponent = object, S = undefin
     protected async createAndAttachComponent<T extends IComponent & IComponentLoadable>(
         pkg: string, props?: any,
     ): Promise<T> {
-        return this.context._createComponentWithProps(pkg, true, props) as Promise<T>;
+        return this.context._createComponent(pkg, true, props) as Promise<T>;
     }
 
     /**

--- a/packages/framework/aqueduct/src/components/sharedComponent.ts
+++ b/packages/framework/aqueduct/src/components/sharedComponent.ts
@@ -35,7 +35,6 @@ export interface IInitializeSharedObject<S> {
 export async function createComponentHelper<S>(
     type: string,
     context: IComponentContext,
-    attach: boolean,
     initialState?: S,
 ): Promise<IComponent & IComponentLoadable> {
     if (type === "") {
@@ -43,12 +42,12 @@ export async function createComponentHelper<S>(
     }
 
     // ComponentContext.composeSubpackagePath() was used before to construct path.
-    // Is this correct way of doing things?
+    // Is this correct way of doing
     const path = context.packagePath.concat(type);
 
     const component = await context.containerRuntime._createComponent(
         path,
-        attach,
+        false,
     );
 
     const init: IInitializeSharedObject<S> | undefined = (component as any).IInitializeSharedObject;
@@ -206,15 +205,15 @@ export abstract class SharedComponent<P extends IComponent = object, S = undefin
     }
 
     /**
-     * Calls create, initialize, and attach on a new component with random generated ID
+     * Calls create, and initialize on a new component with random generated ID
      *
      * @param pkg - package name for the new component
      * @param props - optional props to be passed in
      */
-    protected async createAndAttachComponent<T extends IComponent & IComponentLoadable>(
+    protected async createComponent<T extends IComponent & IComponentLoadable>(
         pkg: string, props?: S,
     ): Promise<T> {
-        return createComponentHelper<S>(pkg, this.context, true, props) as Promise<T>;
+        return createComponentHelper<S>(pkg, this.context, props) as Promise<T>;
     }
 
     /**

--- a/packages/framework/aqueduct/src/containerRuntimeFactories/containerRuntimeFactoryWithDefaultComponent.ts
+++ b/packages/framework/aqueduct/src/containerRuntimeFactories/containerRuntimeFactoryWithDefaultComponent.ts
@@ -50,9 +50,10 @@ export class ContainerRuntimeFactoryWithDefaultComponent extends BaseContainerRu
      * {@inheritDoc BaseContainerRuntimeFactory.containerInitializingFirstTime}
      */
     protected async containerInitializingFirstTime(runtime: IContainerRuntime) {
-        const componentRuntime = await runtime.createComponent(
-            ContainerRuntimeFactoryWithDefaultComponent.defaultComponentId,
+        const componentRuntime = await runtime._createComponentWithProps(
             this.defaultComponentName,
+            undefined,
+            ContainerRuntimeFactoryWithDefaultComponent.defaultComponentId,
         );
         // We need to request the component before attaching to ensure it
         // runs through its entire instantiation flow.

--- a/packages/framework/aqueduct/src/containerRuntimeFactories/containerRuntimeFactoryWithDefaultComponent.ts
+++ b/packages/framework/aqueduct/src/containerRuntimeFactories/containerRuntimeFactoryWithDefaultComponent.ts
@@ -50,13 +50,10 @@ export class ContainerRuntimeFactoryWithDefaultComponent extends BaseContainerRu
      * {@inheritDoc BaseContainerRuntimeFactory.containerInitializingFirstTime}
      */
     protected async containerInitializingFirstTime(runtime: IContainerRuntime) {
-        const componentRuntime = await runtime._createComponentWithProps(
+        await runtime._createComponent(
             this.defaultComponentName,
+            true,
             ContainerRuntimeFactoryWithDefaultComponent.defaultComponentId,
         );
-        // We need to request the component before attaching to ensure it
-        // runs through its entire instantiation flow.
-        await componentRuntime.request({ url: "/" });
-        componentRuntime.bindToContext();
     }
 }

--- a/packages/framework/aqueduct/src/containerRuntimeFactories/containerRuntimeFactoryWithDefaultComponent.ts
+++ b/packages/framework/aqueduct/src/containerRuntimeFactories/containerRuntimeFactoryWithDefaultComponent.ts
@@ -52,7 +52,6 @@ export class ContainerRuntimeFactoryWithDefaultComponent extends BaseContainerRu
     protected async containerInitializingFirstTime(runtime: IContainerRuntime) {
         const componentRuntime = await runtime._createComponentWithProps(
             this.defaultComponentName,
-            undefined,
             ContainerRuntimeFactoryWithDefaultComponent.defaultComponentId,
         );
         // We need to request the component before attaching to ensure it

--- a/packages/framework/component-base/src/runtimefactory.ts
+++ b/packages/framework/component-base/src/runtimefactory.ts
@@ -73,11 +73,9 @@ export class RuntimeFactory implements IRuntimeFactory {
 
         // On first boot create the base component
         if (!runtime.existing && this.defaultComponent.type) {
-            await runtime
-                .createComponent(defaultComponentId, this.defaultComponent.type)
-                .then((componentRuntime) => {
-                    componentRuntime.bindToContext();
-                });
+            const componentRuntime = await runtime
+                ._createComponentWithProps(this.defaultComponent.type, undefined, defaultComponentId);
+            componentRuntime.bindToContext();
         }
 
         return runtime;

--- a/packages/framework/component-base/src/runtimefactory.ts
+++ b/packages/framework/component-base/src/runtimefactory.ts
@@ -57,9 +57,7 @@ export class RuntimeFactory implements IRuntimeFactory {
                 remainingUrl = "";
             }
 
-            const component = await containerRuntime.getComponentRuntime(componentId, true);
-
-            return component.request({ url: remainingUrl });
+            return containerRuntime.getComponentById(componentId, { url: remainingUrl }, true);
         });
 
         const runtime = await ContainerRuntime.load(
@@ -73,9 +71,7 @@ export class RuntimeFactory implements IRuntimeFactory {
 
         // On first boot create the base component
         if (!runtime.existing && this.defaultComponent.type) {
-            const componentRuntime = await runtime
-                ._createComponentWithProps(this.defaultComponent.type, defaultComponentId);
-            componentRuntime.bindToContext();
+            await runtime._createComponent(this.defaultComponent.type, true, defaultComponentId);
         }
 
         return runtime;

--- a/packages/framework/component-base/src/runtimefactory.ts
+++ b/packages/framework/component-base/src/runtimefactory.ts
@@ -74,7 +74,7 @@ export class RuntimeFactory implements IRuntimeFactory {
         // On first boot create the base component
         if (!runtime.existing && this.defaultComponent.type) {
             const componentRuntime = await runtime
-                ._createComponentWithProps(this.defaultComponent.type, undefined, defaultComponentId);
+                ._createComponentWithProps(this.defaultComponent.type, defaultComponentId);
             componentRuntime.bindToContext();
         }
 

--- a/packages/framework/component-base/src/sharedcomponent.ts
+++ b/packages/framework/component-base/src/sharedcomponent.ts
@@ -80,6 +80,6 @@ export abstract class SharedComponent<
 
     // #endregion IComponentLoadable
 
-    public abstract create(props?: any);
+    public abstract create();
     public abstract async load();
 }

--- a/packages/framework/component-base/src/sharedcomponentfactory.ts
+++ b/packages/framework/component-base/src/sharedcomponentfactory.ts
@@ -58,20 +58,17 @@ export class SharedComponentFactory<T extends SharedComponent> implements ICompo
             // If the instance has not yet been resolved, await it now.  Once the instance is
             // resolved, we replace the value of `instance` with the resolved component, at which
             // point we begin processing requests synchronously.
-            if ("then" in instance) {
-                instance = await instance;
-            }
+            instance = await instance;
 
             return instance.request(request);
         });
     }
 
-    public create(parentContext: IComponentContext, props?: any) {
+    public create(parentContext: IComponentContext) {
         const { containerRuntime, packagePath } = parentContext;
 
         const childContext = containerRuntime.createComponentContext(
-            packagePath.concat(this.type),
-            props);
+            packagePath.concat(this.type));
 
         return this.createCore(childContext, this.createRuntime(childContext));
     }
@@ -84,10 +81,10 @@ export class SharedComponentFactory<T extends SharedComponent> implements ICompo
             : this.createCore(context, runtime);
     }
 
-    private createCore(context: IComponentContext, runtime: IComponentRuntime, props?: any) {
+    private createCore(context: IComponentContext, runtime: IComponentRuntime) {
         const root = runtime.createChannel("root", this.root.type) as ISharedObject;
         const instance = new this.ctor(context, runtime, root);
-        instance.create(props);
+        instance.create();
         root.bindToContext();
         return instance;
     }

--- a/packages/framework/request-handler/src/requestHandlers.ts
+++ b/packages/framework/request-handler/src/requestHandlers.ts
@@ -23,11 +23,11 @@ export const componentRuntimeRequestHandler: RuntimeRequestHandler =
                 wait = request.headers.wait;
             }
 
-            const component = await runtime.getComponentRuntime(request.pathParts[0], wait);
             const subRequest = request.createSubRequest(1);
-            if (subRequest !== undefined) {
-                return component.request(subRequest);
-            }
+            return runtime.getComponentById(
+                request.pathParts[0],
+                subRequest ?? { url: "/" },
+                wait);
         }
         return undefined;
     };

--- a/packages/framework/request-handler/src/test/requestHandlers.spec.ts
+++ b/packages/framework/request-handler/src/test/requestHandlers.spec.ts
@@ -6,8 +6,8 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 import assert from "assert";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
-import { IComponentRuntimeChannel } from "@fluidframework/runtime-definitions";
 import { RequestParser } from "@fluidframework/runtime-utils";
+import { IResponse } from "@fluidframework/component-core-interfaces";
 import { componentRuntimeRequestHandler, createComponentResponse } from "../requestHandlers";
 
 describe("RequestParser", () => {
@@ -21,55 +21,40 @@ describe("RequestParser", () => {
 
         it("Component request without wait", async () => {
             const requestParser = new RequestParser({ url: "/componentId" });
-            const runtime: IContainerRuntime = {
-                getComponentRuntime: async (id, wait): Promise<IComponentRuntimeChannel> => {
+            const runtime = {
+                getComponentById: async (id, request, wait): Promise<IResponse> => {
                     assert.equal(id, "componentId");
                     assert.equal(wait, undefined);
-                    return Promise.resolve<IComponentRuntimeChannel>({
-                        request: async (r) => {
-                            assert.equal(r.url, "");
-                            return Promise.resolve(createComponentResponse({}));
-                        },
-                    } as IComponentRuntimeChannel);
+                    return Promise.resolve(createComponentResponse({}));
                 },
-            } as IContainerRuntime;
-            const response = await componentRuntimeRequestHandler(requestParser, runtime);
+            };
+            const response = await componentRuntimeRequestHandler(requestParser, runtime as any as IContainerRuntime);
             assert.notEqual(response, undefined);
         });
 
         it("Component request with wait", async () => {
             const requestParser = new RequestParser({ url: "/componentId", headers: { wait: true } });
-            const runtime: IContainerRuntime = {
-                getComponentRuntime: async (id, wait): Promise<IComponentRuntimeChannel> => {
+            const runtime = {
+                getComponentById: async (id, request, wait): Promise<IResponse> => {
                     assert.equal(id, "componentId");
                     assert.equal(wait, true);
-                    return Promise.resolve<IComponentRuntimeChannel>({
-                        request: async (r) => {
-                            assert.equal(r.url, "");
-                            return Promise.resolve(createComponentResponse({}));
-                        },
-                    } as IComponentRuntimeChannel);
+                    return Promise.resolve(createComponentResponse({}));
                 },
-            } as IContainerRuntime;
-            const response = await componentRuntimeRequestHandler(requestParser, runtime);
+            };
+            const response = await componentRuntimeRequestHandler(requestParser, runtime as any as IContainerRuntime);
             assert.notEqual(response, undefined);
         });
 
         it("Component request with sub route", async () => {
             const requestParser = new RequestParser({ url: "/componentId/route", headers: { wait: true } });
-            const runtime: IContainerRuntime = {
-                getComponentRuntime: async (id, wait): Promise<IComponentRuntimeChannel> => {
+            const runtime = {
+                getComponentById: async (id, request, wait): Promise<IResponse> => {
                     assert.equal(id, "componentId");
                     assert.equal(wait, true);
-                    return Promise.resolve<IComponentRuntimeChannel>({
-                        request: async (r) => {
-                            assert.equal(r.url, "route");
-                            return Promise.resolve(createComponentResponse({}));
-                        },
-                    } as IComponentRuntimeChannel);
+                    return Promise.resolve(createComponentResponse({}));
                 },
-            } as IContainerRuntime;
-            const response = await componentRuntimeRequestHandler(requestParser, runtime);
+            };
+            const response = await componentRuntimeRequestHandler(requestParser, runtime as any as IContainerRuntime);
             assert.notEqual(response, undefined);
         });
     });

--- a/packages/runtime/client-api/src/api/codeLoader.ts
+++ b/packages/runtime/client-api/src/api/codeLoader.ts
@@ -135,7 +135,6 @@ export class ChaincodeFactory implements IRuntimeFactory {
         if (!runtime.existing) {
             const componentRuntime = await runtime._createComponentWithProps(
                 "@fluid-internal/client-api",
-                undefined,
                 rootComponentId);
             componentRuntime.bindToContext();
         }

--- a/packages/runtime/client-api/src/api/codeLoader.ts
+++ b/packages/runtime/client-api/src/api/codeLoader.ts
@@ -110,8 +110,10 @@ export class ChaincodeFactory implements IRuntimeFactory {
 
         const componentId = trimmed !== "" ? trimmed : rootComponentId;
 
-        const component = await runtime.getComponentRuntime(componentId, true);
-        return component.request({ url: trimmed.substr(1 + trimmed.length) });
+        return runtime.getComponentById(
+            componentId,
+            { url: trimmed.substr(1 + trimmed.length) },
+            true);
     }
 
     constructor(
@@ -133,10 +135,7 @@ export class ChaincodeFactory implements IRuntimeFactory {
 
         // On first boot create the base component
         if (!runtime.existing) {
-            const componentRuntime = await runtime._createComponentWithProps(
-                "@fluid-internal/client-api",
-                rootComponentId);
-            componentRuntime.bindToContext();
+            await runtime._createComponent("@fluid-internal/client-api", true, rootComponentId);
         }
 
         return runtime;

--- a/packages/runtime/client-api/src/api/codeLoader.ts
+++ b/packages/runtime/client-api/src/api/codeLoader.ts
@@ -24,11 +24,11 @@ import {
     IComponentFactory,
     NamedComponentRegistryEntries,
 } from "@fluidframework/runtime-definitions";
-import { CreateContainerError } from "@fluidframework/container-utils";
 import * as sequence from "@fluidframework/sequence";
 import { Document } from "./document";
 
 const rootMapId = "root";
+const rootComponentId = "root";
 const insightsMapId = "insights";
 
 export class Chaincode implements IComponentFactory {
@@ -108,7 +108,7 @@ export class ChaincodeFactory implements IRuntimeFactory {
             .substr(1)
             .substr(0, !request.url.includes("/", 1) ? request.url.length : request.url.indexOf("/"));
 
-        const componentId = trimmed !== "" ? trimmed : rootMapId;
+        const componentId = trimmed !== "" ? trimmed : rootComponentId;
 
         const component = await runtime.getComponentRuntime(componentId, true);
         return component.request({ url: trimmed.substr(1 + trimmed.length) });
@@ -133,13 +133,11 @@ export class ChaincodeFactory implements IRuntimeFactory {
 
         // On first boot create the base component
         if (!runtime.existing) {
-            runtime.createComponent(rootMapId, "@fluid-internal/client-api")
-                .then((componentRuntime) => {
-                    componentRuntime.bindToContext();
-                })
-                .catch((error: any) => {
-                    context.closeFn(CreateContainerError(error));
-                });
+            const componentRuntime = await runtime._createComponentWithProps(
+                "@fluid-internal/client-api",
+                undefined,
+                rootComponentId);
+            componentRuntime.bindToContext();
         }
 
         return runtime;

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -93,18 +93,6 @@ export interface IContainerRuntime extends
     getComponentRuntime(id: string, wait?: boolean): Promise<IComponentRuntimeChannel>;
 
     /**
-     * Creates a new component using an optional realization function.  This API does not allow specifying
-     * the component's id and instead generates a uuid.  Consumers must save another reference to the
-     * component, such as the handle.
-     * @param pkg - Package name of the component
-     * @param realizationFn - Optional function to call to realize the component over the context default
-     */
-    createComponentWithRealizationFn(
-        pkg: string[],
-        realizationFn?: (context: IComponentContext) => void,
-    ): Promise<IComponentRuntimeChannel>;
-
-    /**
      * Returns the current quorum.
      */
     getQuorum(): IQuorum;

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -4,7 +4,10 @@
  */
 
 import {
-    IComponent, IFluidObject,
+    IComponent,
+    IResponse,
+    IFluidObject,
+    IRequest,
 } from "@fluidframework/component-core-interfaces";
 import {
     IAudience,
@@ -25,7 +28,6 @@ import {
 import {
     FlushMode,
     IContainerRuntimeBase,
-    IComponentRuntimeChannel,
     IComponentContext,
     IInboundSignalMessage,
 } from "@fluidframework/runtime-definitions";
@@ -90,7 +92,7 @@ export interface IContainerRuntime extends
      * @param id - Id supplied during creating the component.
      * @param wait - True if you want to wait for it.
      */
-    getComponentRuntime(id: string, wait?: boolean): Promise<IComponentRuntimeChannel>;
+    getComponentById(id: string, request: IRequest, wait?: boolean): Promise<IResponse>;
 
     /**
      * Returns the current quorum.

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -207,28 +207,18 @@ export abstract class ComponentContext extends EventEmitter implements
         }
     }
 
-    public async _createComponentWithProps(
+    public async _createComponent(
         pkg: string,
         attach,
         id?: string,
     ): Promise<IComponent & IComponentLoadable> {
         const packagePath = await this.composeSubpackagePath(pkg);
 
-        const componentRuntime = await this.containerRuntime._createComponentWithProps(
+        return  this.containerRuntime._createComponent(
             packagePath,
+            attach,
             id,
         );
-
-        if (attach) {
-            componentRuntime.bindToContext();
-        }
-
-        const response = await componentRuntime.request({ url: "/" });
-        if (response.status !== 200 || response.mimeType !== "fluid/component") {
-            throw new Error("Failed to create component");
-        }
-
-        return response.value;
     }
 
     private async rejectDeferredRealize(reason: string) {

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -481,7 +481,7 @@ export abstract class ComponentContext extends EventEmitter implements
      * @returns A list of packages to the subpackage destination if found,
      * otherwise the original subpackage
      */
-    protected async composeSubpackagePath(subpackage: string): Promise<string[]> {
+    public async composeSubpackagePath(subpackage: string): Promise<string[]> {
         const details = await this.getInitialSnapshotDetails();
         let packagePath: string[] = [...details.pkg];
 

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -210,14 +210,12 @@ export abstract class ComponentContext extends EventEmitter implements
     public async _createComponentWithProps(
         pkg: string,
         attach,
-        initialState?: any,
         id?: string,
     ): Promise<IComponent & IComponentLoadable> {
         const packagePath = await this.composeSubpackagePath(pkg);
 
         const componentRuntime = await this.containerRuntime._createComponentWithProps(
             packagePath,
-            initialState,
             id,
         );
 
@@ -639,10 +637,6 @@ export class LocalComponentContext extends ComponentContext {
         scope: IComponent & IFluidObject,
         summaryTracker: SummaryTracker,
         bindComponent: (componentRuntime: IComponentRuntimeChannel) => void,
-        /**
-         * @deprecated 0.16 Issue #1635 Use the IComponentFactory creation methods instead to specify initial state
-         */
-        public readonly createProps?: any,
     ) {
         super(runtime, id, false, storage, scope, summaryTracker, BindState.NotBound, bindComponent, pkg);
         this.attachListeners();

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -8,7 +8,6 @@ import EventEmitter from "events";
 import { IDisposable } from "@fluidframework/common-definitions";
 import {
     IComponent,
-    IComponentLoadable,
     IRequest,
     IResponse,
     IFluidObject,
@@ -205,20 +204,6 @@ export abstract class ComponentContext extends EventEmitter implements
                     error);
             });
         }
-    }
-
-    public async _createComponent(
-        pkg: string,
-        attach,
-        id?: string,
-    ): Promise<IComponent & IComponentLoadable> {
-        const packagePath = await this.composeSubpackagePath(pkg);
-
-        return  this.containerRuntime._createComponent(
-            packagePath,
-            attach,
-            id,
-        );
     }
 
     private async rejectDeferredRealize(reason: string) {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -468,7 +468,7 @@ implements IContainerRuntime, IContainerRuntimeDirtyable, IRuntime, ISummarizerR
 
         // Create all internal components in first load.
         if (!context.existing) {
-            const componentRuntime = await runtime._createComponentWithProps(schedulerId, undefined, schedulerId);
+            const componentRuntime = await runtime._createComponentWithProps(schedulerId, schedulerId);
             componentRuntime.bindToContext();
         }
 
@@ -1093,16 +1093,16 @@ implements IContainerRuntime, IContainerRuntimeDirtyable, IRuntime, ISummarizerR
         }
     }
 
-    public async _createComponentWithProps(pkg: string | string[], props?: any, id?: string):
+    public async _createComponentWithProps(pkg: string | string[], id?: string):
         Promise<IComponentRuntimeChannel> {
-        return this._createComponentContext(Array.isArray(pkg) ? pkg : [pkg], props, id).realize();
+        return this._createComponentContext(Array.isArray(pkg) ? pkg : [pkg], id).realize();
     }
 
-    public createComponentContext(pkg: string[], props?: any): IComponentContext {
-        return this._createComponentContext(pkg, props);
+    public createComponentContext(pkg: string[]): IComponentContext {
+        return this._createComponentContext(pkg);
     }
 
-    private _createComponentContext(pkg: string[], props?: any, id = uuid()) {
+    private _createComponentContext(pkg: string[], id = uuid()) {
         this.verifyNotClosed();
 
         assert(!this.contexts.has(id), "Creating component with existing ID");
@@ -1114,8 +1114,7 @@ implements IContainerRuntime, IContainerRuntimeDirtyable, IRuntime, ISummarizerR
             this.storage,
             this.containerScope,
             this.summaryTracker.createOrGetChild(id, this.deltaManager.lastSequenceNumber),
-            (cr: IComponentRuntimeChannel) => this.bindComponent(cr),
-            props);
+            (cr: IComponentRuntimeChannel) => this.bindComponent(cr));
 
         const deferred = new Deferred<ComponentContext>();
         this.contextsDeferred.set(id, deferred);

--- a/packages/runtime/runtime-definitions/src/componentContext.ts
+++ b/packages/runtime/runtime-definitions/src/componentContext.ts
@@ -100,25 +100,19 @@ export interface IContainerRuntimeBase extends
      * calling IComponentContext.bindRuntime() when the component is prepared to begin processing ops.
      *
      * @param pkg - Package path for the component to be created
-     * @param props - Properties to be passed to the instantiateComponent thru the context
-     *  @deprecated 0.16 Issue #1537 Properties should be passed directly to the component's initialization
-     *  or to the factory method rather than be stored in/passed from the context
      */
     createComponentContext(pkg: string[]): IComponentContext;
 
     /**
-     * @deprecated 0.16 Issue #1537
-     *  Properties should be passed to the component factory method rather than to the runtime
-     * Creates a new component with props
+     * Creates a new component
      * @param pkg - Package name of the component
-     * @param props - properties to be passed to the instantiateComponent thru the context
      * @param id - Only supplied if the component is explicitly passing its ID, only used for default components
      * @remarks
      * Only used by aqueduct PrimedComponent to pass param to the instantiateComponent function thru the context.
      * Further change to the component create flow to split the local create vs remote instantiate make this deprecated.
      * @internal
      */
-    _createComponentWithProps(pkg: string | string[], id?: string): Promise<IComponentRuntimeChannel>;
+    _createComponent(pkg: string | string[], attach: boolean, id?: string): Promise<IComponent & IComponentLoadable>;
 
     /**
      * Get an absolute url for a provided container-relative request.
@@ -311,7 +305,7 @@ export interface IComponentContext extends EventEmitter {
      * @returns A promise for a component that will have been initialized. Caller is responsible
      * for attaching the component to the provided runtime's container such as by storing its handle
      */
-    _createComponentWithProps(
+    _createComponent(
         pkg: string,
         attach: boolean,
         id?: string,

--- a/packages/runtime/runtime-definitions/src/componentContext.ts
+++ b/packages/runtime/runtime-definitions/src/componentContext.ts
@@ -104,7 +104,7 @@ export interface IContainerRuntimeBase extends
      *  @deprecated 0.16 Issue #1537 Properties should be passed directly to the component's initialization
      *  or to the factory method rather than be stored in/passed from the context
      */
-    createComponentContext(pkg: string[], props?: any): IComponentContext;
+    createComponentContext(pkg: string[]): IComponentContext;
 
     /**
      * @deprecated 0.16 Issue #1537
@@ -118,7 +118,7 @@ export interface IContainerRuntimeBase extends
      * Further change to the component create flow to split the local create vs remote instantiate make this deprecated.
      * @internal
      */
-    _createComponentWithProps(pkg: string | string[], props?: any, id?: string): Promise<IComponentRuntimeChannel>;
+    _createComponentWithProps(pkg: string | string[], id?: string): Promise<IComponentRuntimeChannel>;
 
     /**
      * Get an absolute url for a provided container-relative request.
@@ -264,11 +264,6 @@ export interface IComponentContext extends EventEmitter {
     readonly snapshotFn: (message: string) => Promise<void>;
 
     /**
-     * @deprecated 0.16 Issue #1635 Use the IComponentFactory creation methods instead to specify initial state
-     */
-    readonly createProps?: any;
-
-    /**
      * Ambient services provided with the context
      */
     readonly scope: IComponent & IFluidObject;
@@ -319,7 +314,6 @@ export interface IComponentContext extends EventEmitter {
     _createComponentWithProps(
         pkg: string,
         attach: boolean,
-        initialState?: any,
         id?: string,
     ): Promise<IComponent & IComponentLoadable>;
 

--- a/packages/runtime/runtime-definitions/src/componentContext.ts
+++ b/packages/runtime/runtime-definitions/src/componentContext.ts
@@ -321,6 +321,15 @@ export interface IComponentContext extends EventEmitter {
      * @param relativeUrl - A relative request within the container
      */
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
+
+    /**
+     * Take a package name and transform it into a path that can be used to find it
+     * from container, such as by looking into subregistries
+     * @param subpackage - The subpackage to find in this context
+     * @returns A list of packages to the subpackage destination if found,
+     * otherwise the original subpackage
+     */
+    composeSubpackagePath(subpackage: string): Promise<string[]>;
 }
 
 /**

--- a/packages/runtime/runtime-definitions/src/componentContext.ts
+++ b/packages/runtime/runtime-definitions/src/componentContext.ts
@@ -299,19 +299,6 @@ export interface IComponentContext extends EventEmitter {
     submitSignal(type: string, content: any): void;
 
     /**
-     * Create a new component using subregistries with fallback.
-     * @param pkg - Package name of the component
-     * @param realizationFn - Optional function to call to realize the component over the context default
-     * @returns A promise for a component that will have been initialized. Caller is responsible
-     * for attaching the component to the provided runtime's container such as by storing its handle
-     */
-    _createComponent(
-        pkg: string,
-        attach: boolean,
-        id?: string,
-    ): Promise<IComponent & IComponentLoadable>;
-
-    /**
      * Binds a runtime to the context.
      */
     bindRuntime(componentRuntime: IComponentRuntimeChannel): void;

--- a/packages/runtime/runtime-definitions/src/componentContext.ts
+++ b/packages/runtime/runtime-definitions/src/componentContext.ts
@@ -121,15 +121,6 @@ export interface IContainerRuntimeBase extends
     _createComponentWithProps(pkg: string | string[], props?: any, id?: string): Promise<IComponentRuntimeChannel>;
 
     /**
-     * @deprecated
-     * Creates a new component.
-     * @param pkgOrId - Package name if a second parameter is not provided. Otherwise an explicit ID.
-     * @param pkg - Package name of the component. Optional and only required if specifying an explicit ID.
-     * Remove once issue #1756 is closed
-     */
-    createComponent(pkgOrId: string, pkg?: string | string[]): Promise<IComponentRuntimeChannel>;
-
-    /**
      * Get an absolute url for a provided container-relative request.
      * Returns undefined if the container or component isn't attached to storage.
      * @param relativeUrl - A relative request within the container
@@ -319,30 +310,17 @@ export interface IComponentContext extends EventEmitter {
     submitSignal(type: string, content: any): void;
 
     /**
-     * @deprecated 0.16 Issue #1537, issue #1756 Components should be created using IComponentFactory methods instead
-     * Creates a new component by using subregistries.
-     * @param pkgOrId - Package name if a second parameter is not provided. Otherwise an explicit ID.
-     *                  ID is being deprecated, so prefer passing undefined instead (the runtime will
-     *                  generate an ID in this case).
-     * @param pkg - Package name of the component. Optional and only required if specifying an explicit ID.
-     * @param props - Properties to be passed to the instantiateComponent through the context.
-     */
-    createComponent(
-        pkgOrId: string | undefined,
-        pkg?: string | string[],
-        props?: any,
-    ): Promise<IComponentRuntimeChannel>;
-
-    /**
      * Create a new component using subregistries with fallback.
      * @param pkg - Package name of the component
      * @param realizationFn - Optional function to call to realize the component over the context default
      * @returns A promise for a component that will have been initialized. Caller is responsible
      * for attaching the component to the provided runtime's container such as by storing its handle
      */
-    createComponentWithRealizationFn(
+    _createComponentWithProps(
         pkg: string,
-        realizationFn?: (context: IComponentContext) => void,
+        attach: boolean,
+        initialState?: any,
+        id?: string,
     ): Promise<IComponent & IComponentLoadable>;
 
     /**

--- a/packages/test/end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -17,7 +17,7 @@ import {
     TestFluidComponent,
 } from "@fluidframework/test-utils";
 import { SharedObject } from "@fluidframework/shared-object-base";
-import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
+import { IContainerRuntimeBase, IComponentRuntimeChannel } from "@fluidframework/runtime-definitions";
 import { SharedMap } from "@fluidframework/map";
 
 describe(`Attach/Bind Api Tests For Attached Container`, () => {
@@ -50,12 +50,10 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
     const createPeerComponent = async (
         containerRuntime: IContainerRuntimeBase,
     ) => {
-        const peerComponentRuntimeChannel = await containerRuntime._createComponentWithProps(["default"]);
-        const peerComponent =
-            (await peerComponentRuntimeChannel.request({ url: "/" })).value as ITestFluidComponent;
+        const peerComponent = await containerRuntime._createComponent(["default"], false) as any as ITestFluidComponent;
         return {
             peerComponent,
-            peerComponentRuntimeChannel,
+            peerComponentRuntimeChannel: peerComponent.runtime as any as IComponentRuntimeChannel,
         };
     };
 

--- a/packages/test/end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -7,7 +7,6 @@ import assert from "assert";
 import { IRequest } from "@fluidframework/component-core-interfaces";
 import { IFluidCodeDetails, IProxyLoaderFactory, AttachState } from "@fluidframework/container-definitions";
 import { Loader } from "@fluidframework/container-loader";
-import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { IUrlResolver } from "@fluidframework/driver-definitions";
 import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
@@ -51,8 +50,7 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
     const createPeerComponent = async (
         containerRuntime: IContainerRuntimeBase,
     ) => {
-        const peerComponentRuntimeChannel = await (containerRuntime as IContainerRuntime)
-            .createComponentWithRealizationFn(["default"]);
+        const peerComponentRuntimeChannel = await containerRuntime._createComponentWithProps(["default"]);
         const peerComponent =
             (await peerComponentRuntimeChannel.request({ url: "/" })).value as ITestFluidComponent;
         return {

--- a/packages/test/end-to-end-tests/src/test/compat.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/compat.spec.ts
@@ -80,9 +80,9 @@ describe("loader/runtime compatibility", () => {
                     runtimeOptions,
                 );
                 if (!runtime.existing) {
-                    const componentRuntime = await runtime.createComponent("default", type);
-                    await componentRuntime.request({ url: "/" });
+                    const componentRuntime = await runtime._createComponentWithProps(type, undefined, "default");
                     componentRuntime.bindToContext();
+                    await componentRuntime.request({ url: "/" });
                 }
                 return runtime;
             },
@@ -109,7 +109,7 @@ describe("loader/runtime compatibility", () => {
                     runtimeOptions,
                 );
                 if (!runtime.existing) {
-                    const componentRuntime = await runtime.createComponent("default", type);
+                    const componentRuntime = await runtime._createComponentWithProps(type, undefined, "default");
                     await componentRuntime.request({ url: "/" });
                     componentRuntime.bindToContext();
                 }

--- a/packages/test/end-to-end-tests/src/test/compat.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/compat.spec.ts
@@ -80,7 +80,7 @@ describe("loader/runtime compatibility", () => {
                     runtimeOptions,
                 );
                 if (!runtime.existing) {
-                    const componentRuntime = await runtime._createComponentWithProps(type, undefined, "default");
+                    const componentRuntime = await runtime._createComponentWithProps(type, "default");
                     componentRuntime.bindToContext();
                     await componentRuntime.request({ url: "/" });
                 }
@@ -109,7 +109,7 @@ describe("loader/runtime compatibility", () => {
                     runtimeOptions,
                 );
                 if (!runtime.existing) {
-                    const componentRuntime = await runtime._createComponentWithProps(type, undefined, "default");
+                    const componentRuntime = await runtime._createComponentWithProps(type, "default");
                     await componentRuntime.request({ url: "/" });
                     componentRuntime.bindToContext();
                 }

--- a/packages/test/end-to-end-tests/src/test/compat.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/compat.spec.ts
@@ -80,9 +80,7 @@ describe("loader/runtime compatibility", () => {
                     runtimeOptions,
                 );
                 if (!runtime.existing) {
-                    const componentRuntime = await runtime._createComponentWithProps(type, "default");
-                    componentRuntime.bindToContext();
-                    await componentRuntime.request({ url: "/" });
+                    await runtime._createComponent(type, true, "default");
                 }
                 return runtime;
             },
@@ -109,9 +107,7 @@ describe("loader/runtime compatibility", () => {
                     runtimeOptions,
                 );
                 if (!runtime.existing) {
-                    const componentRuntime = await runtime._createComponentWithProps(type, "default");
-                    await componentRuntime.request({ url: "/" });
-                    componentRuntime.bindToContext();
+                    await runtime._createComponent(type, true, "default");
                 }
                 return runtime;
             },

--- a/packages/test/end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -56,7 +56,7 @@ describe("Detached Container", () => {
         componentId: string,
         type: string,
     ) => {
-        return componentContext._createComponent(type, true, componentId);
+        return componentContext.containerRuntime._createComponent(type, true, componentId);
     });
 
     function createTestLoader(urlResolver: IUrlResolver): Loader {

--- a/packages/test/end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -22,7 +22,6 @@ import { Deferred } from "@fluidframework/common-utils";
 import { SharedString, SparseMatrix } from "@fluidframework/sequence";
 import { Ink, IColor } from "@fluidframework/ink";
 import { SharedMatrix } from "@fluidframework/matrix";
-import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { ConsensusRegisterCollection } from "@fluidframework/register-collection";
 import { SharedCell } from "@fluidframework/cell";
 import { ConsensusQueue } from "@fluidframework/ordered-collection";
@@ -57,8 +56,7 @@ describe("Detached Container", () => {
         componentId: string,
         type: string,
     ) => {
-        const doc = await componentContext.createComponent(componentId, type);
-        doc.bindToContext();
+        return componentContext._createComponentWithProps(type, true, undefined, componentId);
     });
 
     function createTestLoader(urlResolver: IUrlResolver): Loader {
@@ -324,8 +322,8 @@ describe("Detached Container", () => {
         const component = response.value as ITestFluidComponent;
 
         const containerP = container.attach(request);
-        peerComponentRuntimeChannel = await (component.context.containerRuntime as IContainerRuntime)
-            .createComponentWithRealizationFn([testComponentType]);
+        peerComponentRuntimeChannel =
+            await component.context.containerRuntime._createComponentWithProps([testComponentType]);
         // Fire attach op
         peerComponentRuntimeChannel.bindToContext();
         await containerP;

--- a/packages/test/end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -56,7 +56,7 @@ describe("Detached Container", () => {
         componentId: string,
         type: string,
     ) => {
-        return componentContext._createComponentWithProps(type, true, undefined, componentId);
+        return componentContext._createComponentWithProps(type, true, componentId);
     });
 
     function createTestLoader(urlResolver: IUrlResolver): Loader {

--- a/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
@@ -274,7 +274,7 @@ describe("Ops on Reconnect", () => {
 
             // Create component2 in the first container.
             const firstContainerComp2 =
-                await firstContainerComp1.context._createComponentWithProps(
+                await firstContainerComp1.context._createComponent(
                     "component2",
                     false,
                 ) as unknown as ITestFluidComponent & IComponentLoadable;
@@ -380,7 +380,7 @@ describe("Ops on Reconnect", () => {
 
             // Create component2 in the first container.
             const firstContainerComp2 =
-                await firstContainerComp1.context._createComponentWithProps(
+                await firstContainerComp1.context._createComponent(
                     "component2",
                     false,
                 ) as unknown as ITestFluidComponent & IComponentLoadable;

--- a/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
@@ -274,8 +274,9 @@ describe("Ops on Reconnect", () => {
 
             // Create component2 in the first container.
             const firstContainerComp2 =
-                await firstContainerComp1.context.createComponentWithRealizationFn(
+                await firstContainerComp1.context._createComponentWithProps(
                     "component2",
+                    false,
                 ) as unknown as ITestFluidComponent & IComponentLoadable;
 
             // Get the maps in component2.
@@ -379,8 +380,9 @@ describe("Ops on Reconnect", () => {
 
             // Create component2 in the first container.
             const firstContainerComp2 =
-                await firstContainerComp1.context.createComponentWithRealizationFn(
+                await firstContainerComp1.context._createComponentWithProps(
                     "component2",
+                    false,
                 ) as unknown as ITestFluidComponent & IComponentLoadable;
 
             // Get the maps in component2.

--- a/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
@@ -274,7 +274,7 @@ describe("Ops on Reconnect", () => {
 
             // Create component2 in the first container.
             const firstContainerComp2 =
-                await firstContainerComp1.context._createComponent(
+                await firstContainerComp1.context.containerRuntime._createComponent(
                     "component2",
                     false,
                 ) as unknown as ITestFluidComponent & IComponentLoadable;
@@ -380,7 +380,7 @@ describe("Ops on Reconnect", () => {
 
             // Create component2 in the first container.
             const firstContainerComp2 =
-                await firstContainerComp1.context._createComponent(
+                await firstContainerComp1.context.containerRuntime._createComponent(
                     "component2",
                     false,
                 ) as unknown as ITestFluidComponent & IComponentLoadable;


### PR DESCRIPTION
Key items:
1. remove IComponentContext APIs: createComponent(), createComponentWithRealizationFn(), realizeWithFn().
2. Remove IContainerRuntimeBase APIs: createComponentWithRealizationFn(). createComponent()
3. IComponentContext._createComponentWithProps() (and similar one on IContainerRuntimeBase) is the only path to create components, now takes more args: package, initial props, attach, id.
   In the future, ID would be gone.

With these changes, we follow single path of realizing components, which means side-effects of realize() call are applicable to all loading paths .
This is important, as features can rely on this path, like co-loading components (future).

What needs to be done before check-in:
1. Back-compat needs to be built in
2. _createComponentWithProps is not ideal name, ideally we call it createComponent(), but need to think through back compat given it will 