### PR TITLE
Optimize rdkafka rebalance

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
@@ -10,9 +10,9 @@ import {
     IPartition,
     IPartitionWithEpoch,
     IPartitionLambdaFactory,
+    ILogger,
 } from "@fluidframework/server-services-core";
 import { Provider } from "nconf";
-import * as winston from "winston";
 import { Partition } from "./partition";
 
 /**
@@ -27,7 +27,8 @@ export class PartitionManager extends EventEmitter {
     constructor(
         private readonly factory: IPartitionLambdaFactory,
         private readonly consumer: IConsumer,
-        private readonly config: Provider) {
+        private readonly config: Provider,
+        private readonly logger?: ILogger) {
         super();
 
         // Place new Kafka messages into our processing queue
@@ -68,7 +69,8 @@ export class PartitionManager extends EventEmitter {
 
     private process(message: IQueuedMessage) {
         if (this.isRebalancing) {
-            winston.info(`Ignoring ${message.topic}:${message.partition}@${message.offset} due to pending rebalance`);
+            this.logger?.info(
+                `Ignoring ${message.topic}:${message.partition}@${message.offset} due to pending rebalance`);
             return;
         }
 
@@ -83,33 +85,62 @@ export class PartitionManager extends EventEmitter {
         partition.process(message);
     }
 
+    /**
+     * Called when rebalancing starts
+     * Note: The consumer may decide to only emit "rebalanced" if it wants to skip closing existing partitions
+     * @param partitions Assigned partitions before the rebalance
+     */
     private rebalancing(partitions: IPartition[]) {
-        winston.info("rebalancing", partitions);
+        this.logger?.info(`Rebalancing partitions: ${JSON.stringify(partitions)}`);
+
         this.isRebalancing = true;
 
         for (const [id, partition] of this.partitions) {
-            winston.info(`Stopping partition ${id} due to rebalancing`);
+            this.logger?.info(`Closing partition ${id} due to rebalancing`);
             partition.close();
         }
 
         this.partitions.clear();
     }
 
+    /**
+     * Called when rebalanced occurs
+     * @param partitions Assigned partitions after the rebalance.
+     * May contain partitions that have been previously assigned to this consumer
+     */
     private rebalanced(partitions: IPartitionWithEpoch[]) {
         this.isRebalancing = false;
 
-        this.partitions.clear();
+        const partitionsMap = new Map(partitions.map((partition) => [partition.partition, partition]));
 
+        // close and remove existing partitions that are no longer assigned
+        const existingPartitions = Array.from(this.partitions);
+        for (const [id, partition] of existingPartitions) {
+            if (!partitionsMap.has(id)) {
+                this.logger?.info(`Closing partition ${id} due to rebalancing`);
+                partition.close();
+                this.partitions.delete(id);
+            }
+        }
+
+        // create new partitions
         for (const partition of partitions) {
+            if (this.partitions.has(partition.partition)) {
+                // this partition already exists
+                // it must have existed before the rebalance
+                continue;
+            }
+
             // eslint-disable-next-line max-len
-            winston.info(`Creating ${partition.topic}: Partition ${partition.partition}, Epoch ${partition.leaderEpoch}, Offset ${partition.offset} due to rebalance`);
+            this.logger?.info(`Creating ${partition.topic}: Partition ${partition.partition}, Epoch ${partition.leaderEpoch}, Offset ${partition.offset} due to rebalance`);
 
             const newPartition = new Partition(
                 partition.partition,
                 partition.leaderEpoch,
                 this.factory,
                 this.consumer,
-                this.config);
+                this.config,
+                this.logger);
 
             // Listen for error events to know when the partition has stopped processing due to an error
             newPartition.on("error", (error, restart) => {

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -32,7 +32,7 @@ export class KafkaRunner implements IRunner {
             this.deferred.reject(error);
         });
 
-        this.partitionManager = new PartitionManager(this.factory, this.consumer, this.config);
+        this.partitionManager = new PartitionManager(this.factory, this.consumer, this.config, winston);
         this.partitionManager.on("error", (error, restart) => {
             this.deferred.reject(error);
         });

--- a/server/routerlicious/packages/services/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services/src/rdkafkaConsumer.ts
@@ -98,7 +98,7 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 				// a rebalance occurred while we were committing
 				// we can resubmit the commit if we still own the partition
 				shouldRetryCommit =
-					this.optimizedRebalance && err.message.includes("Specified group generation id is not valid");
+					this.optimizedRebalance && err.code === kafka.CODES.ERRORS.ERR_ILLEGAL_GENERATION;
 			}
 
 			for (const offset of offsets) {

--- a/server/routerlicious/packages/services/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services/src/rdkafkaConsumer.ts
@@ -93,14 +93,12 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 			let shouldRetryCommit = false;
 
 			if (err) {
+				this.emit("error", err);
+
 				// a rebalance occurred while we were committing
 				// we can resubmit the commit if we still own the partition
 				shouldRetryCommit =
 					this.optimizedRebalance && err.message.includes("Specified group generation id is not valid");
-
-				if (!shouldRetryCommit) {
-					this.emit("error", err);
-				}
 			}
 
 			for (const offset of offsets) {


### PR DESCRIPTION
- Update `RdkafkaConsumer` to support "optimized" rebalancing. Optimized rebalancing means that it will keep partitions opened if they are still assigned after a rebalance. Opt in via the `optimizedRebalance` property.
- Use `ILogger` instead of `winston` in `PartitionManager` & `Partition` classes
- Allow consumers to only emit `rebalanced`, which allows existing partitions to remain open