### PR TITLE
Renamed MemoryOrdererMnaager -> LocalOrdererManager in local-server

### DIFF
--- a/server/routerlicious/packages/local-server/src/index.ts
+++ b/server/routerlicious/packages/local-server/src/index.ts
@@ -4,4 +4,5 @@
  */
 
 export * from "./localDeltaConnectionServer";
+export * from "./localOrdererManager";
 export * from "./localWebSocketServer";

--- a/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
+++ b/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
@@ -35,7 +35,7 @@ import {
     TestTenantManager,
 } from "@fluidframework/server-test-utils";
 import { LocalWebSocketServer } from "./localWebSocketServer";
-import { MemoryOrdererManager } from "./memoryOrdererManager";
+import { LocalOrdererManager } from "./localOrdererManager";
 
 /**
  * Items needed for handling deltas.
@@ -87,7 +87,7 @@ export class LocalDeltaConnectionServer implements ILocalDeltaConnectionServer {
 
         const logger = DebugLogger.create("fluid-server:LocalDeltaConnectionServer");
 
-        const ordererManager = new MemoryOrdererManager(
+        const ordererManager = new LocalOrdererManager(
             testStorage,
             databaseManager,
             testTenantManager,
@@ -121,7 +121,7 @@ export class LocalDeltaConnectionServer implements ILocalDeltaConnectionServer {
     private constructor(
         public webSocketServer: LocalWebSocketServer,
         public databaseManager: IDatabaseManager,
-        private readonly ordererManager: MemoryOrdererManager,
+        private readonly ordererManager: LocalOrdererManager,
         public testDbFactory: ITestDbFactory,
         public documentStorage: IDocumentStorage,
         private readonly logger: ILogger) { }

--- a/server/routerlicious/packages/local-server/src/localOrdererManager.ts
+++ b/server/routerlicious/packages/local-server/src/localOrdererManager.ts
@@ -16,7 +16,7 @@ import {
     ITenantManager,
 } from "@fluidframework/server-services-core";
 
-export class MemoryOrdererManager implements IOrdererManager {
+export class LocalOrdererManager implements IOrdererManager {
     private readonly map = new Map<string, Promise<IOrderer>>();
 
     constructor(


### PR DESCRIPTION
Renamed `MemoryOrdererManager` to `LocalOrdererManager` and exported it.

In a follow up change, I will update Tinylicious to use this.