### PR TITLE
App integration with static-linked code

### DIFF
--- a/examples/hosts/app-integration/container-views/src/app/app.ts
+++ b/examples/hosts/app-integration/container-views/src/app/app.ts
@@ -8,6 +8,7 @@ import { Container } from "@fluidframework/container-loader";
 import { getTinyliciousContainer } from "@fluidframework/get-tinylicious-container";
 import { HTMLViewAdapter } from "@fluidframework/view-adapters";
 import { IComponentMountableView } from "@fluidframework/view-interfaces";
+import { DiceRollerContainerRuntimeFactory } from "../container";
 
 // I'm choosing to put the docId in the hash just for my own convenience.  There should be no requirements on the
 // page's URL format deeper in the system.
@@ -61,14 +62,8 @@ async function mountDefaultComponentFromContainer(container: Container): Promise
 
 // Just a helper function to kick things off.  Making it async allows us to use await.
 async function start(): Promise<void> {
-    // The format of the code proposal will be the contents of our package.json, which has a special "fluid" section
-    // describing the code to load.
-    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
-    const packageJson = require("../../package.json");
-
-    // If you'd prefer to load the container bundle yourself (rather than relying on the codeLoader), pass the
-    // entrypoint to the module as the third param below (e.g. window["main"]).
-    const container = await getTinyliciousContainer(documentId, packageJson);
+    // Get the container to use.  Associate the data with the provided documentId, and run the provided code within.
+    const container = await getTinyliciousContainer(documentId, DiceRollerContainerRuntimeFactory);
     await mountDefaultComponentFromContainer(container);
     // Setting "fluidStarted" is just for our test automation
     // eslint-disable-next-line dot-notation

--- a/examples/hosts/app-integration/container-views/src/container/containerRuntimeFactory.ts
+++ b/examples/hosts/app-integration/container-views/src/container/containerRuntimeFactory.ts
@@ -26,4 +26,3 @@ export const DiceRollerContainerRuntimeFactory = new ContainerRuntimeFactoryWith
         [DiceRoller.ComponentName, Promise.resolve(DiceRollerInstantiationFactory)],
     ]),
 );
-export const fluidExport = DiceRollerContainerRuntimeFactory;

--- a/examples/hosts/app-integration/container-views/src/container/containerRuntimeFactory.ts
+++ b/examples/hosts/app-integration/container-views/src/container/containerRuntimeFactory.ts
@@ -20,9 +20,10 @@ import { DiceRoller, DiceRollerInstantiationFactory } from "../component";
  * In this example, we are only registering a single component, but more complex examples will register multiple
  * components.
  */
-export const fluidExport = new ContainerRuntimeFactoryWithDefaultComponent(
+export const DiceRollerContainerRuntimeFactory = new ContainerRuntimeFactoryWithDefaultComponent(
     DiceRoller.ComponentName,
     new Map([
         [DiceRoller.ComponentName, Promise.resolve(DiceRollerInstantiationFactory)],
     ]),
 );
+export const fluidExport = DiceRollerContainerRuntimeFactory;

--- a/examples/hosts/app-integration/container-views/webpack.config.js
+++ b/examples/hosts/app-integration/container-views/webpack.config.js
@@ -13,7 +13,6 @@ module.exports = env => {
 
     return merge({
         entry: {
-            main: "./src/container/index.ts",
             app: "./src/app/app.ts"
         },
         resolve: {

--- a/examples/hosts/app-integration/external-views/src/app/app.ts
+++ b/examples/hosts/app-integration/external-views/src/app/app.ts
@@ -8,6 +8,7 @@ import { getTinyliciousContainer } from "@fluidframework/get-tinylicious-contain
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { IDiceRoller } from "../component";
+import { DiceRollerContainerRuntimeFactory } from "../container";
 import { PrettyDiceRollerView } from "./views";
 
 // I'm choosing to put the docId in the hash just for my own convenience.  There should be no requirements on the
@@ -43,14 +44,8 @@ async function renderPrettyDiceRoller(diceRoller: IDiceRoller) {
 
 // Just a helper function to kick things off.  Making it async allows us to use await.
 async function start(): Promise<void> {
-    // The format of the code proposal will be the contents of our package.json, which has a special "fluid" section
-    // describing the code to load.
-    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
-    const packageJson = require("../../package.json");
-
-    // If you'd prefer to load the container bundle yourself (rather than relying on the codeLoader), pass the
-    // entrypoint to the module as the third param below (e.g. window["main"]).
-    const container = await getTinyliciousContainer(documentId, packageJson);
+    // Get the container to use.  Associate the data with the provided documentId, and run the provided code within.
+    const container = await getTinyliciousContainer(documentId, DiceRollerContainerRuntimeFactory);
     const diceRoller = await getDiceRollerFromContainer(container);
     await renderPrettyDiceRoller(diceRoller);
     // Setting "fluidStarted" is just for our test automation

--- a/examples/hosts/app-integration/external-views/src/container/containerRuntimeFactory.ts
+++ b/examples/hosts/app-integration/external-views/src/container/containerRuntimeFactory.ts
@@ -26,4 +26,3 @@ export const DiceRollerContainerRuntimeFactory = new ContainerRuntimeFactoryWith
         [DiceRoller.ComponentName, Promise.resolve(DiceRollerInstantiationFactory)],
     ]),
 );
-export const fluidExport = DiceRollerContainerRuntimeFactory;

--- a/examples/hosts/app-integration/external-views/src/container/containerRuntimeFactory.ts
+++ b/examples/hosts/app-integration/external-views/src/container/containerRuntimeFactory.ts
@@ -20,9 +20,10 @@ import { DiceRoller, DiceRollerInstantiationFactory } from "../component";
  * In this example, we are only registering a single component, but more complex examples will register multiple
  * components.
  */
-export const fluidExport = new ContainerRuntimeFactoryWithDefaultComponent(
+export const DiceRollerContainerRuntimeFactory = new ContainerRuntimeFactoryWithDefaultComponent(
     DiceRoller.ComponentName,
     new Map([
         [DiceRoller.ComponentName, Promise.resolve(DiceRollerInstantiationFactory)],
     ]),
 );
+export const fluidExport = DiceRollerContainerRuntimeFactory;

--- a/examples/hosts/app-integration/external-views/webpack.config.js
+++ b/examples/hosts/app-integration/external-views/webpack.config.js
@@ -13,7 +13,6 @@ module.exports = env => {
 
     return merge({
         entry: {
-            main: "./src/container/index.ts",
             app: "./src/app/app.ts"
         },
         resolve: {

--- a/packages/tools/get-tinylicious-container/package.json
+++ b/packages/tools/get-tinylicious-container/package.json
@@ -31,7 +31,6 @@
     "@fluidframework/driver-definitions": "^0.23.0",
     "@fluidframework/protocol-definitions": "^0.1009.0",
     "@fluidframework/routerlicious-driver": "^0.23.0",
-    "@fluidframework/web-code-loader": "^0.23.0",
     "jsonwebtoken": "^8.4.0",
     "uuid": "^3.3.2"
   },

--- a/packages/tools/get-tinylicious-container/src/getTinyliciousContainer.ts
+++ b/packages/tools/get-tinylicious-container/src/getTinyliciousContainer.ts
@@ -96,6 +96,8 @@ export async function getTinyliciousContainer(
     // The InsecureTinyliciousUrlResolver expects the url of the request to be the documentId.
     const container = await loader.resolve({ url: documentId });
 
+    // We're not actually using the code proposal here, but the Container will only give us a NullRuntime if there's
+    // no proposal.  So we make a fake proposal, using initializeContainerCode to ensure it only happens once.
     await initializeContainerCode(container, { package: "", config: {} });
 
     // If we're loading from ops, the context might be in the middle of reloading.  Check for that case and wait

--- a/packages/tools/get-tinylicious-container/src/getTinyliciousContainer.ts
+++ b/packages/tools/get-tinylicious-container/src/getTinyliciousContainer.ts
@@ -61,11 +61,9 @@ class InsecureTinyliciousUrlResolver implements IUrlResolver {
 }
 
 /**
- * Connect to the Tinylicious service and retrieve a Container, or if it does not already exist then create a new
- * Container and propose the given code.
+ * Connect to the Tinylicious service and retrieve a Container with the given ID running the given code.
  * @param documentId - The document id to retrieve or create
- * @param packageJson - The package that will be proposed as the code proposal
- * @param fluidModule - Optionally, seed the codeLoader with an in-memory entrypoint for that proposal
+ * @param containerRuntimeFactory - The container factory to be loaded in the container
  */
 export async function getTinyliciousContainer(
     documentId: string,
@@ -81,6 +79,8 @@ export async function getTinyliciousContainer(
 
     const urlResolver = new InsecureTinyliciousUrlResolver();
 
+    // To bypass proposal-based loading, we need a codeLoader that will return our already-in-memory container factory.
+    // The expected format of that response is an IFluidModule with a fluidExport.
     const module = { fluidExport: containerRuntimeFactory };
     const codeLoader = { load: async () => module };
 

--- a/packages/tools/get-tinylicious-container/src/getTinyliciousContainer.ts
+++ b/packages/tools/get-tinylicious-container/src/getTinyliciousContainer.ts
@@ -6,12 +6,7 @@
 import { initializeContainerCode } from "@fluidframework/base-host";
 import { IRequest } from "@fluidframework/component-core-interfaces";
 import {
-    IFluidModule,
-    IFluidPackage,
-    IFluidCodeDetails,
-    IFluidCodeResolver,
-    IResolvedFluidCodeDetails,
-    isFluidPackage,
+    IRuntimeFactory,
 } from "@fluidframework/container-definitions";
 import { Container, Loader } from "@fluidframework/container-loader";
 import {
@@ -21,7 +16,6 @@ import {
 } from "@fluidframework/driver-definitions";
 import { ITokenClaims } from "@fluidframework/protocol-definitions";
 import { RouterliciousDocumentServiceFactory, DefaultErrorTracking } from "@fluidframework/routerlicious-driver";
-import { extractPackageIdentifierDetails, WebCodeLoader } from "@fluidframework/web-code-loader";
 import jwt from "jsonwebtoken";
 import { v4 as uuid } from "uuid";
 
@@ -66,26 +60,6 @@ class InsecureTinyliciousUrlResolver implements IUrlResolver {
     }
 }
 
-// The code resolver's job is basically to take a list of relative URLs (embedded in the IFluidCodeDetails) and
-// convert them to URLs that will find the correct scripts relative to the app (which is the context in which the code
-// will be loaded).  So maybe the URLs can stay relative, or maybe they'll be converted to absolute URLs against a
-// base URL (like a CDN or something).  In this case, we assume any relative URLs are hosted from the same server
-// running the app, and as a result none of the relative URLs need to be converted.
-class WebpackCodeResolver implements IFluidCodeResolver {
-    async resolveCodeDetails(details: IFluidCodeDetails): Promise<IResolvedFluidCodeDetails> {
-        if (typeof details.package === "string" || !isFluidPackage(details.package)) {
-            throw new Error("Not a fluid package");
-        }
-        const parse = extractPackageIdentifierDetails(details.package);
-        return {
-            config: details.config,
-            package: details.package,
-            resolvedPackage: details.package,
-            resolvedPackageCacheId: parse.fullId,
-        };
-    }
-}
-
 /**
  * Connect to the Tinylicious service and retrieve a Container, or if it does not already exist then create a new
  * Container and propose the given code.
@@ -95,8 +69,7 @@ class WebpackCodeResolver implements IFluidCodeResolver {
  */
 export async function getTinyliciousContainer(
     documentId: string,
-    packageJson: IFluidPackage,
-    fluidModule?: IFluidModule,
+    containerRuntimeFactory: IRuntimeFactory,
 ): Promise<Container> {
     const documentServiceFactory = new RouterliciousDocumentServiceFactory(
         false,
@@ -108,18 +81,8 @@ export async function getTinyliciousContainer(
 
     const urlResolver = new InsecureTinyliciousUrlResolver();
 
-    const codeResolver = new WebpackCodeResolver();
-    const codeLoader = new WebCodeLoader(codeResolver);
-
-    const codeDetails: IFluidCodeDetails = {
-        package: packageJson,
-        config: {},
-    };
-    // Optionally, we can seed the codeLoader with a module we loaded ourselves.  If we don't seed, the codeLoader
-    // is supposed to bring it in.
-    if (fluidModule !== undefined) {
-        await codeLoader.seedModule(codeDetails, fluidModule);
-    }
+    const module = { fluidExport: containerRuntimeFactory };
+    const codeLoader = { load: async () => module };
 
     const loader = new Loader(
         urlResolver,
@@ -133,7 +96,7 @@ export async function getTinyliciousContainer(
     // The InsecureTinyliciousUrlResolver expects the url of the request to be the documentId.
     const container = await loader.resolve({ url: documentId });
 
-    await initializeContainerCode(container, codeDetails);
+    await initializeContainerCode(container, { package: "", config: {} });
 
     // If we're loading from ops, the context might be in the middle of reloading.  Check for that case and wait
     // for the contextChanged event to avoid returning before that reload completes.


### PR DESCRIPTION
Raising as a draft to get some feedback about this point on the spectrum.

Currently, the app-integration samples are doing dynamic code loading, with a legit code proposal using the package.json of the container package.  It bundles the container package separately from the app package and relies on the webpack-dev-server serving it up for dynamically including later.  This approach is kind of nice because it's demonstrating dynamic code loading, but it also includes some bad practices (like including the package.json) and introduces extra concepts like container code hosting and bundling strategies that probably detract from the first few lessons we want to teach.

This draft PR is demonstrating an alternative where the app developer would just directly pass in their `IRuntimeFactory`, and we would short-circuit the proposal and loading flows to just always load that code.  This simplifies usage/bundling/hosting, but punts on introducing the concept of a real code proposal for now.  It's closer to the prototype I showed a couple weeks ago from the consumption side (though the Loader and codeLoader are still present in the underlying implementation here).

So would love your thoughts on whether this balance of concepts/simplicity feels better than the current state, dial it back, go further, etc.  I personally prefer it, but then again I would love to fully externalize the code loading and not just for learning :)