### PR TITLE
Disable automatic context reload on code proposal

### DIFF
--- a/packages/framework/aqueduct/src/containerRuntimeFactories/baseContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/containerRuntimeFactories/baseContainerRuntimeFactory.ts
@@ -79,11 +79,11 @@ export class BaseContainerRuntimeFactory implements
 
         if (!runtime.existing) {
             // If it's the first time through.
-            await this.containerInitializingFirstTime(runtime);
+            await this.containerInitializingFirstTime(runtime, context);
         }
 
         // This always gets called at the end of initialize on first time or from existing.
-        await this.containerHasInitialized(runtime);
+        await this.containerHasInitialized(runtime, context);
 
         return runtime;
     }
@@ -93,12 +93,12 @@ export class BaseContainerRuntimeFactory implements
      * is created. This likely includes creating any initial components that are expected to be there at the outset.
      * @param runtime - The container runtime for the container being initialized
      */
-    protected async containerInitializingFirstTime(runtime: IContainerRuntime) { }
+    protected async containerInitializingFirstTime(runtime: IContainerRuntime, context: IContainerContext) { }
 
     /**
      * Subclasses may override containerHasInitialized to perform any steps after the container has initialized.
      * This likely includes loading any components that are expected to be there at the outset.
      * @param runtime - The container runtime for the container being initialized
      */
-    protected async containerHasInitialized(runtime: IContainerRuntime) { }
+    protected async containerHasInitialized(runtime: IContainerRuntime, context: IContainerContext) { }
 }

--- a/packages/loader/container-definitions/src/loader.ts
+++ b/packages/loader/container-definitions/src/loader.ts
@@ -72,7 +72,7 @@ export interface ICodeAllowList {
 export interface IContainerEvents extends IEvent {
     (event: "readonly", listener: (readonly: boolean) => void): void;
     (event: "connected", listener: (clientId: string) => void);
-    (event: "contextChanged", listener: (codeDetails: IFluidCodeDetails) => void);
+    (event: "codeChanged" | "contextChanged", listener: (codeDetails: IFluidCodeDetails) => void);
     (event: "disconnected" | "joining" | "attaching" | "attached", listener: () => void);
     (event: "closed", listener: (error?: ICriticalContainerError) => void);
     (event: "warning", listener: (error: ContainerWarning) => void);


### PR DESCRIPTION
This change disable automatic context reload by default. For the detached container we don't need this initial context reload. This will allow containers to take ownership of when and if to reload on the context on code proposal.