### PR TITLE
Update common-utils dependency to 0.21.0 in client and server packages

### DIFF
--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/common-utils",
-  "version": "0.21.0",
+  "version": "0.21.0-0",
   "description": "Collection of utility functions for Fluid",
   "repository": "microsoft/FluidFramework",
   "license": "MIT",

--- a/common/lib/common-utils/src/index.ts
+++ b/common/lib/common-utils/src/index.ts
@@ -10,6 +10,7 @@ export * from "./disposal";
 export * from "./eventForwarder";
 export * from "./hashFile";
 export * from "./heap";
+export * from "./logger";
 export * from "./promiseCache";
 export * from "./promises";
 export * from "./rangeTracker";

--- a/common/lib/common-utils/src/packageVersion.ts
+++ b/common/lib/common-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/common-utils";
-export const pkgVersion = "0.21.0";
+export const pkgVersion = "0.21.0-0";

--- a/components/experimental/client-ui-lib/package.json
+++ b/components/experimental/client-ui-lib/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@fluid-example/search-menu": "^0.23.0",
     "@fluid-internal/client-api": "^0.23.0",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/component-runtime-definitions": "^0.23.0",
     "@fluidframework/container-definitions": "^0.23.0",

--- a/components/experimental/shared-text/package.json
+++ b/components/experimental/shared-text/package.json
@@ -47,7 +47,7 @@
     "@fluid-example/video-players": "^0.23.0",
     "@fluid-internal/client-api": "^0.23.0",
     "@fluidframework/cell": "^0.23.0",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/component-runtime": "^0.23.0",
     "@fluidframework/component-runtime-definitions": "^0.23.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -628,6 +628,23 @@
 				"@fluidframework/view-adapters": "^0.22.1",
 				"@fluidframework/view-interfaces": "^0.22.1",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.20.0",
+					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+					"integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.18.1",
+						"assert": "^2.0.0",
+						"buffer": "^5.6.0",
+						"debug": "^4.1.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.11",
+						"performance-now": "^2.1.0",
+						"sha.js": "^2.4.11"
+					}
+				}
 			}
 		},
 		"@fluidframework/base-host": {
@@ -733,16 +750,16 @@
 			"integrity": "sha1-Ga3wP0vJQ/m+idtBbgJ0NFHiMDI="
 		},
 		"@fluidframework/common-utils": {
-			"version": "0.20.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
-			"integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+			"version": "0.21.0-33984",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.21.0-33984.tgz",
+			"integrity": "sha1-iMPH0mSrhT51L5osme4TYQbFLNk=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"assert": "^2.0.0",
 				"buffer": "^5.6.0",
 				"debug": "^4.1.1",
 				"events": "^3.1.0",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.19",
 				"performance-now": "^2.1.0",
 				"sha.js": "^2.4.11"
 			}
@@ -1499,6 +1516,23 @@
 				"@fluidframework/protocol-definitions": "^0.1010.0-33996",
 				"assert": "^2.0.0",
 				"lodash": "^4.17.19"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.20.0",
+					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+					"integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.18.1",
+						"assert": "^2.0.0",
+						"buffer": "^5.6.0",
+						"debug": "^4.1.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.11",
+						"performance-now": "^2.1.0",
+						"sha.js": "^2.4.11"
+					}
+				}
 			}
 		},
 		"@fluidframework/protocol-definitions": {
@@ -1757,6 +1791,21 @@
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.20.0",
+					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+					"integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.18.1",
+						"assert": "^2.0.0",
+						"buffer": "^5.6.0",
+						"debug": "^4.1.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.11",
+						"performance-now": "^2.1.0",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -1801,6 +1850,23 @@
 				"moniker": "^0.1.2",
 				"uuid": "^3.3.2",
 				"ws": "^6.1.2"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.20.0",
+					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+					"integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.18.1",
+						"assert": "^2.0.0",
+						"buffer": "^5.6.0",
+						"debug": "^4.1.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.11",
+						"performance-now": "^2.1.0",
+						"sha.js": "^2.4.11"
+					}
+				}
 			}
 		},
 		"@fluidframework/server-services-client": {
@@ -1818,6 +1884,23 @@
 				"jsonwebtoken": "^8.4.0",
 				"sillyname": "0.1.0",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.20.0",
+					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+					"integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.18.1",
+						"assert": "^2.0.0",
+						"buffer": "^5.6.0",
+						"debug": "^4.1.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.11",
+						"performance-now": "^2.1.0",
+						"sha.js": "^2.4.11"
+					}
+				}
 			}
 		},
 		"@fluidframework/server-services-core": {
@@ -1833,6 +1916,23 @@
 				"@types/node": "^10.17.24",
 				"debug": "^4.1.1",
 				"nconf": "^0.10.0"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.20.0",
+					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+					"integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.18.1",
+						"assert": "^2.0.0",
+						"buffer": "^5.6.0",
+						"debug": "^4.1.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.11",
+						"performance-now": "^2.1.0",
+						"sha.js": "^2.4.11"
+					}
+				}
 			}
 		},
 		"@fluidframework/server-test-utils": {
@@ -1850,6 +1950,23 @@
 				"lodash": "^4.17.19",
 				"string-hash": "^1.1.3",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.20.0",
+					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+					"integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.18.1",
+						"assert": "^2.0.0",
+						"buffer": "^5.6.0",
+						"debug": "^4.1.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.11",
+						"performance-now": "^2.1.0",
+						"sha.js": "^2.4.11"
+					}
+				}
 			}
 		},
 		"@fluidframework/shared-object-base": {
@@ -1915,6 +2032,23 @@
 				"debug": "^4.1.1",
 				"events": "^3.1.0",
 				"performance-now": "^2.1.0"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.20.0",
+					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+					"integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.18.1",
+						"assert": "^2.0.0",
+						"buffer": "^5.6.0",
+						"debug": "^4.1.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.11",
+						"performance-now": "^2.1.0",
+						"sha.js": "^2.4.11"
+					}
+				}
 			}
 		},
 		"@fluidframework/test-tools": {
@@ -16161,6 +16295,23 @@
 				"@fluidframework/view-adapters": "^0.22.1",
 				"@fluidframework/view-interfaces": "^0.22.1",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.20.0",
+					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+					"integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.18.1",
+						"assert": "^2.0.0",
+						"buffer": "^5.6.0",
+						"debug": "^4.1.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.11",
+						"performance-now": "^2.1.0",
+						"sha.js": "^2.4.11"
+					}
+				}
 			}
 		},
 		"old-container-definitions": {

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -50,7 +50,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/component-runtime-definitions": "^0.23.0",
     "@fluidframework/protocol-definitions": "^0.1010.0-0",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -48,7 +48,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/component-runtime-definitions": "^0.23.0",
     "@fluidframework/protocol-definitions": "^0.1010.0-0",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -50,7 +50,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-runtime-definitions": "^0.23.0",
     "@fluidframework/protocol-definitions": "^0.1010.0-0",
     "@fluidframework/shared-object-base": "^0.23.0",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.18.1",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/component-runtime-definitions": "^0.23.0",
     "@fluidframework/protocol-base": "^0.1010.0-0",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.18.1",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/component-runtime-definitions": "^0.23.0",
     "@fluidframework/container-utils": "^0.23.0",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.18.1",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/component-runtime-definitions": "^0.23.0",
     "@fluidframework/protocol-definitions": "^0.1010.0-0",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -50,7 +50,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-runtime-definitions": "^0.23.0",
     "@fluidframework/protocol-definitions": "^0.1010.0-0",
     "@fluidframework/runtime-utils": "^0.23.0",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -50,7 +50,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-runtime-definitions": "^0.23.0",
     "@fluidframework/protocol-definitions": "^0.1010.0-0",
     "@fluidframework/runtime-utils": "^0.23.0",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.18.1",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/component-runtime-definitions": "^0.23.0",
     "@fluidframework/map": "^0.23.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.18.1",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/component-runtime": "^0.23.0",
     "@fluidframework/component-runtime-definitions": "^0.23.0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -52,7 +52,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-runtime-definitions": "^0.23.0",
     "@fluidframework/protocol-definitions": "^0.1010.0-0",
     "@fluidframework/shared-object-base": "^0.23.0"

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -26,7 +26,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/driver-definitions": "^0.23.0",
     "@fluidframework/driver-utils": "^0.23.0",
     "@fluidframework/protocol-definitions": "^0.1010.0-0",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -27,7 +27,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/driver-definitions": "^0.23.0",
     "@fluidframework/driver-utils": "^0.23.0",
     "@fluidframework/protocol-definitions": "^0.1010.0-0",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.18.1",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/driver-definitions": "^0.23.0",
     "@fluidframework/driver-utils": "^0.23.0",
     "@fluidframework/protocol-base": "^0.1010.0-0",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -28,7 +28,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/driver-definitions": "^0.23.0",
     "@fluidframework/odsp-driver": "^0.23.0"

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.18.1",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/driver-definitions": "^0.23.0",
     "@fluidframework/driver-utils": "^0.23.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.18.1",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/driver-definitions": "^0.23.0",
     "@fluidframework/driver-utils": "^0.23.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.18.1",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/driver-base": "^0.23.0",
     "@fluidframework/driver-definitions": "^0.23.0",

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -4,7 +4,7 @@
  */
 
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
-import { PerformanceEvent } from "@fluidframework/common-utils";
+import { PerformanceEvent } from "@fluidframework/telemetry-utils";
 import { IOdspSnapshot } from "./contracts";
 import { getQueryString } from "./getQueryString";
 import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth";

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.18.1",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/driver-definitions": "^0.23.0",
     "@fluidframework/driver-utils": "^0.23.0",
     "@fluidframework/protocol-base": "^0.1010.0-0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.18.1",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/driver-base": "^0.23.0",
     "@fluidframework/driver-definitions": "^0.23.0",
     "@fluidframework/driver-utils": "^0.23.0",

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -26,7 +26,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/driver-definitions": "^0.23.0",
     "@types/debug": "^4.1.5",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.18.1",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/component-runtime": "^0.23.0",
     "@fluidframework/component-runtime-definitions": "^0.23.0",

--- a/packages/framework/component-base/package.json
+++ b/packages/framework/component-base/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.18.1",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/component-runtime": "^0.23.0",
     "@fluidframework/component-runtime-definitions": "^0.23.0",

--- a/packages/framework/react/package.json
+++ b/packages/framework/react/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.23.0",
     "@fluidframework/common-definitions": "^0.18.1",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/component-runtime-definitions": "^0.23.0",
     "@fluidframework/counter": "^0.23.0",

--- a/packages/hosts/base-host/package.json
+++ b/packages/hosts/base-host/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.18.1",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/container-definitions": "^0.23.0",
     "@fluidframework/container-loader": "^0.23.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.18.1",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/container-definitions": "^0.23.0",
     "@fluidframework/container-utils": "^0.23.0",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.18.1",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/driver-definitions": "^0.23.0",
     "@fluidframework/gitresources": "^0.1010.0-0",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -25,7 +25,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/driver-definitions": "^0.23.0",
     "@fluidframework/protocol-definitions": "^0.1010.0-0"
   },

--- a/packages/runtime/client-api/package.json
+++ b/packages/runtime/client-api/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@fluidframework/cell": "^0.23.0",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/component-runtime": "^0.23.0",
     "@fluidframework/container-definitions": "^0.23.0",

--- a/packages/runtime/component-runtime/package.json
+++ b/packages/runtime/component-runtime/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.18.1",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/component-runtime-definitions": "^0.23.0",
     "@fluidframework/container-definitions": "^0.23.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@fluidframework/agent-scheduler": "^0.23.0",
     "@fluidframework/common-definitions": "^0.18.1",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/component-runtime": "^0.23.0",
     "@fluidframework/container-definitions": "^0.23.0",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.18.1",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/component-runtime-definitions": "^0.23.0",
     "@fluidframework/container-definitions": "^0.23.0",

--- a/packages/test/end-to-end-tests/package.json
+++ b/packages/test/end-to-end-tests/package.json
@@ -56,7 +56,7 @@
     "@fluidframework/base-host": "^0.23.0",
     "@fluidframework/build-common": "^0.18.0",
     "@fluidframework/cell": "^0.23.0",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/component-runtime": "^0.23.0",
     "@fluidframework/component-runtime-definitions": "^0.23.0",

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@fluid-internal/test-loader-utils": "^0.23.0",
     "@fluidframework/build-common": "^0.18.0",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/container-loader": "^0.23.0",
     "@fluidframework/container-runtime": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.18.0",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@fluid-internal/replay-tool": "^0.23.0",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/protocol-definitions": "^0.1010.0-0"
   },
   "devDependencies": {

--- a/packages/test/version-test-1/package.json
+++ b/packages/test/version-test-1/package.json
@@ -37,7 +37,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/test-tools": "^0.1.0",
     "@fluidframework/webpack-component-loader": "^0.23.0",
     "@types/jest": "22.2.3",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -25,7 +25,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-runtime": "^0.23.0",
     "@fluidframework/container-runtime": "^0.23.0",
     "@fluidframework/driver-definitions": "^0.23.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@fluid-internal/client-api": "^0.23.0",
     "@fluidframework/common-definitions": "^0.18.1",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/container-definitions": "^0.23.0",
     "@fluidframework/container-loader": "^0.23.0",

--- a/packages/tools/webpack-component-loader/package.json
+++ b/packages/tools/webpack-component-loader/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.23.0",
     "@fluidframework/base-host": "^0.23.0",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/container-definitions": "^0.23.0",
     "@fluidframework/container-loader": "^0.23.0",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.18.1",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "debug": "^4.1.1",
     "events": "^3.1.0",
     "performance-now": "^2.1.0"

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -502,16 +502,16 @@
 			"integrity": "sha1-Ga3wP0vJQ/m+idtBbgJ0NFHiMDI="
 		},
 		"@fluidframework/common-utils": {
-			"version": "0.20.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
-			"integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+			"version": "0.21.0-33984",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.21.0-33984.tgz",
+			"integrity": "sha1-iMPH0mSrhT51L5osme4TYQbFLNk=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"assert": "^2.0.0",
 				"buffer": "^5.6.0",
 				"debug": "^4.1.1",
 				"events": "^3.1.0",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.19",
 				"performance-now": "^2.1.0",
 				"sha.js": "^2.4.11"
 			},

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -45,7 +45,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/server-services": "^0.1010.0",
     "@fluidframework/server-services-core": "^0.1010.0",
     "@fluidframework/server-services-utils": "^0.1010.0",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -48,7 +48,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/gitresources": "^0.1010.0",
     "@fluidframework/protocol-base": "^0.1010.0",
     "@fluidframework/protocol-definitions": "^0.1010.0",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -49,7 +49,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/protocol-definitions": "^0.1010.0",
     "@fluidframework/server-lambdas": "^0.1010.0",
     "@fluidframework/server-memory-orderer": "^0.1010.0",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -26,7 +26,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/protocol-base": "^0.1010.0",
     "@fluidframework/protocol-definitions": "^0.1010.0",
     "@fluidframework/server-lambdas": "^0.1010.0",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -50,7 +50,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/gitresources": "^0.1010.0",
     "@fluidframework/protocol-definitions": "^0.1010.0",
     "assert": "^2.0.0",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -60,7 +60,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/gitresources": "^0.1010.0",
     "@fluidframework/protocol-definitions": "^0.1010.0",
     "@fluidframework/server-kafka-orderer": "^0.1010.0",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -48,7 +48,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/gitresources": "^0.1010.0",
     "@fluidframework/protocol-base": "^0.1010.0",
     "@fluidframework/protocol-definitions": "^0.1010.0",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -23,7 +23,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/gitresources": "^0.1010.0",
     "@fluidframework/protocol-definitions": "^0.1010.0",
     "@fluidframework/server-services-client": "^0.1010.0",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -23,7 +23,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/gitresources": "^0.1010.0",
     "@fluidframework/protocol-base": "^0.1010.0",
     "@fluidframework/protocol-definitions": "^0.1010.0",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@azure/event-hubs": "^1.0.8",
     "@azure/event-processor-host": "^1.0.6",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/gitresources": "^0.1010.0",
     "@fluidframework/protocol-base": "^0.1010.0",
     "@fluidframework/protocol-definitions": "^0.1010.0",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -44,7 +44,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/gitresources": "^0.1010.0",
     "@fluidframework/protocol-base": "^0.1010.0",
     "@fluidframework/protocol-definitions": "^0.1010.0",

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -52,16 +52,16 @@
       "integrity": "sha1-Ga3wP0vJQ/m+idtBbgJ0NFHiMDI="
     },
     "@fluidframework/common-utils": {
-      "version": "0.20.0",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
-      "integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+      "version": "0.21.0-33984",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.21.0-33984.tgz",
+      "integrity": "sha1-iMPH0mSrhT51L5osme4TYQbFLNk=",
       "requires": {
         "@fluidframework/common-definitions": "^0.18.1",
         "assert": "^2.0.0",
         "buffer": "^5.6.0",
         "debug": "^4.1.1",
         "events": "^3.1.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.19",
         "performance-now": "^2.1.0",
         "sha.js": "^2.4.11"
       }
@@ -142,6 +142,23 @@
         "nconf": "^0.10.0",
         "semver": "^6.3.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.20.0",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+          "integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "buffer": "^5.6.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.11",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/server-local-server": {
@@ -181,6 +198,23 @@
         "moniker": "^0.1.2",
         "uuid": "^3.3.2",
         "ws": "^6.1.2"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.20.0",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+          "integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "buffer": "^5.6.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.11",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/server-services-client": {
@@ -198,6 +232,23 @@
         "jsonwebtoken": "^8.4.0",
         "sillyname": "0.1.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.20.0",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+          "integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "buffer": "^5.6.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.11",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/server-services-core": {
@@ -213,6 +264,23 @@
         "@types/node": "^10.17.24",
         "debug": "^4.1.1",
         "nconf": "^0.10.0"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.20.0",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+          "integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "buffer": "^5.6.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.11",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/server-services-shared": {
@@ -234,6 +302,23 @@
         "socket.io": "^2.2.0",
         "socket.io-redis": "^5.2.0",
         "winston": "^3.1.0"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.20.0",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+          "integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "buffer": "^5.6.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.11",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/server-services-utils": {
@@ -263,6 +348,23 @@
         "lodash": "^4.17.19",
         "string-hash": "^1.1.3",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.20.0",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+          "integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "buffer": "^5.6.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.11",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@microsoft/api-extractor": {

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -22,7 +22,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/gitresources": "^0.1010.0-0",
     "@fluidframework/protocol-base": "^0.1010.0-0",
     "@fluidframework/protocol-definitions": "^0.1010.0-0",


### PR DESCRIPTION
- `node bumpversion.js -d @fluidframework/common-utils`
- Switch version in common-utils/package.json to pre-release 0.21.0-0 <-- Is this correct, or do I leave it as-is and just let the pre-release packages be pulled in from the build share? I needed this for local testing.
- Fix build breaks and validate using --symlink:full option with fluid-build (Pulled into separate PR #2882)

I need to do some double-checking on package.json's, especially given the recent server dependency bump from Navin.