### PR TITLE
Fix build breaks coming when bumping common-utils dependency to 0.21.0

### DIFF
--- a/common/lib/common-utils/src/index.ts
+++ b/common/lib/common-utils/src/index.ts
@@ -10,6 +10,7 @@ export * from "./disposal";
 export * from "./eventForwarder";
 export * from "./hashFile";
 export * from "./heap";
+export * from "./logger";
 export * from "./promiseCache";
 export * from "./promises";
 export * from "./rangeTracker";

--- a/common/lib/common-utils/src/packageVersion.ts
+++ b/common/lib/common-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/common-utils";
-export const pkgVersion = "0.21.0-0";
+export const pkgVersion = "0.21.0";

--- a/common/lib/common-utils/src/packageVersion.ts
+++ b/common/lib/common-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/common-utils";
-export const pkgVersion = "0.21.0";
+export const pkgVersion = "0.21.0-0";

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -4,7 +4,7 @@
  */
 
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
-import { PerformanceEvent } from "@fluidframework/common-utils";
+import { PerformanceEvent } from "@fluidframework/telemetry-utils";
 import { IOdspSnapshot } from "./contracts";
 import { getQueryString } from "./getQueryString";
 import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth";


### PR DESCRIPTION
Prerequisite for https://github.com/microsoft/FluidFramework/pull/2880
