### PR TITLE
Fix .fluidtoolrc lock to work even if file doesnt exist

### DIFF
--- a/packages/utils/tool-utils/src/fluidToolRC.ts
+++ b/packages/utils/tool-utils/src/fluidToolRC.ts
@@ -15,7 +15,7 @@ import { IOdspTokens } from "@fluidframework/odsp-utils";
 export interface IAsyncCache<TKey, TValue> {
     get(key: TKey): Promise<TValue | undefined>;
     save(key: TKey, value: TValue): Promise<void>;
-    lock<Result>(callback: () => Promise<Result>): Promise<Result>;
+    lock<T>(callback: () => Promise<T>): Promise<T>;
 }
 
 interface IResources {

--- a/packages/utils/tool-utils/src/fluidToolRC.ts
+++ b/packages/utils/tool-utils/src/fluidToolRC.ts
@@ -12,10 +12,10 @@ import util from "util";
 import { lock } from "proper-lockfile";
 import { IOdspTokens } from "@fluidframework/odsp-utils";
 
-export interface IAsyncCache<K, T> {
-    get(key: K): Promise<T | undefined>;
-    save(key: K, value: T): Promise<void>;
-    lock<T2>(callback: () => Promise<T2>): Promise<T2>;
+export interface IAsyncCache<TKey, TValue> {
+    get(key: TKey): Promise<TValue | undefined>;
+    save(key: TKey, value: TValue): Promise<void>;
+    lock<Result>(callback: () => Promise<Result>): Promise<Result>;
 }
 
 interface IResources {
@@ -48,5 +48,5 @@ export async function saveRC(rc: IResources) {
 
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export async function lockRC() {
-    return lock(getRCFileName());
+    return lock(getRCFileName(), { realpath: false });
 }

--- a/packages/utils/tool-utils/src/odspTokenManager.ts
+++ b/packages/utils/tool-utils/src/odspTokenManager.ts
@@ -102,7 +102,7 @@ export class OdspTokenManager {
                     return tokensFromCache;
                 }
             }
-            // check with lock
+            // check with lock, used to prevent concurrent auth attempts
             return this.tokenCache.lock(async () => {
                 return this.getTokensCore(
                     isPush, server, clientConfig, initialNavigator,


### PR DESCRIPTION
Current implementation with lock doesn't work if the ".fluidtoolrc" file doesn't already exist.

Documentation of proper-lockfile says that the file must already exist if `realpath` option is enabled, which it is by default.
https://www.npmjs.com/package/proper-lockfile#lockfile-options

Without realpath, I think symlinks should not work, but at least it should work if file doesn't already exist.  If we need this we might want to add that feature to proper-lockfile.  I was thinking it could perform realpath on the _directory_ only rather than the file itself and then join the file name back to the directory to support both realpath + file not already existing, but feels a little out of scope.