### PR TITLE
Detached container flow in webpack-component-loader

### DIFF
--- a/components/experimental/client-ui-lib/src/controls/flowContainer.ts
+++ b/components/experimental/client-ui-lib/src/controls/flowContainer.ts
@@ -38,6 +38,7 @@ export class FlowContainer extends ui.Component {
 
     constructor(
         element: HTMLDivElement,
+        private readonly id: string,
         private readonly collabDocument: api.Document,
         private readonly sharedString: Sequence.SharedString,
         private readonly overlayInkMap: ISharedMap,
@@ -52,8 +53,8 @@ export class FlowContainer extends ui.Component {
         const titleDiv = document.createElement("div");
         titleDiv.id = "title-bar";
         this.title = new Title(titleDiv);
-        this.title.setTitle(this.collabDocument.id);
-        this.title.setBackgroundColor(this.collabDocument.id);
+        this.title.setTitle(this.id);
+        this.title.setBackgroundColor(this.id);
 
         // Status bar at the bottom
         const statusDiv = document.createElement("div");
@@ -135,9 +136,9 @@ export class FlowContainer extends ui.Component {
         });
 
         // For now only allow one level deep of branching
-        this.status.addButton("Versions", `/sharedText/${this.collabDocument.id}/commits`, false);
+        this.status.addButton("Versions", `/sharedText/${this.id}/commits`, false);
         if (!this.collabDocument.parentBranch) {
-            this.status.addButton("Branch", `/sharedText/${this.collabDocument.id}/fork`, true);
+            this.status.addButton("Branch", `/sharedText/${this.id}/fork`, true);
         }
 
         // Add children to the panel once we have both

--- a/components/experimental/client-ui-lib/src/controls/flowContainer.ts
+++ b/components/experimental/client-ui-lib/src/controls/flowContainer.ts
@@ -39,7 +39,7 @@ export class FlowContainer extends ui.Component {
     // api.Document should not be used. It should be removed after #2915 is fixed.
     constructor(
         element: HTMLDivElement,
-        private readonly id: string,
+        title: string,
         private readonly collabDocument: api.Document,
         private readonly sharedString: Sequence.SharedString,
         private readonly overlayInkMap: ISharedMap,
@@ -54,8 +54,8 @@ export class FlowContainer extends ui.Component {
         const titleDiv = document.createElement("div");
         titleDiv.id = "title-bar";
         this.title = new Title(titleDiv);
-        this.title.setTitle(this.id);
-        this.title.setBackgroundColor(this.id);
+        this.title.setTitle(title);
+        this.title.setBackgroundColor(title);
 
         // Status bar at the bottom
         const statusDiv = document.createElement("div");
@@ -137,9 +137,9 @@ export class FlowContainer extends ui.Component {
         });
 
         // For now only allow one level deep of branching
-        this.status.addButton("Versions", `/sharedText/${this.id}/commits`, false);
+        this.status.addButton("Versions", `/sharedText/${this.collabDocument.id}/commits`, false);
         if (!this.collabDocument.parentBranch) {
-            this.status.addButton("Branch", `/sharedText/${this.id}/fork`, true);
+            this.status.addButton("Branch", `/sharedText/${this.collabDocument.id}/fork`, true);
         }
 
         // Add children to the panel once we have both

--- a/components/experimental/client-ui-lib/src/controls/flowContainer.ts
+++ b/components/experimental/client-ui-lib/src/controls/flowContainer.ts
@@ -36,6 +36,7 @@ export class FlowContainer extends ui.Component {
     private layerCache: { [key: string]: Layer } = {};
     private activeLayers: { [key: string]: IOverlayLayerStatus } = {};
 
+    // api.Document should not be used. It should be removed after #2915 is fixed.
     constructor(
         element: HTMLDivElement,
         private readonly id: string,

--- a/components/experimental/shared-text/src/component.ts
+++ b/components/experimental/shared-text/src/component.ts
@@ -242,6 +242,7 @@ export class SharedTextRunner
         const container = new controls.FlowContainer(
             containerDiv,
             sharedTextId,
+            // API.Document should not be used here. This should be removed once #2915 is fixed.
             new API.Document(
                 this.runtime,
                 this.context,

--- a/components/experimental/shared-text/src/component.ts
+++ b/components/experimental/shared-text/src/component.ts
@@ -83,6 +83,7 @@ export class SharedTextRunner
     private collabDoc: Document;
     private taskManager: ITaskManager;
     private uiInitialized = false;
+    private readonly title: string = "Shared Text";
 
     private constructor(
         private readonly runtime: FluidDataStoreRuntime,
@@ -171,9 +172,6 @@ export class SharedTextRunner
             this.rootView.set("flowContainerMap", flowContainerMap.handle);
 
             insights.set(newString.id, this.collabDoc.createMap().handle);
-
-            // Set the an id for this component that is used to display UI.
-            this.rootView.set("sharedTextId", "SharedText");
         }
 
         debug(`collabDoc loaded ${this.runtime.id} - ${performanceNow()}`);
@@ -238,10 +236,9 @@ export class SharedTextRunner
         containerDiv.id = "flow-container";
         containerDiv.style.touchAction = "none";
         containerDiv.style.overflow = "hidden";
-        const sharedTextId = this.rootView.get("sharedTextId");
         const container = new controls.FlowContainer(
             containerDiv,
-            sharedTextId,
+            this.title,
             // API.Document should not be used here. This should be removed once #2915 is fixed.
             new API.Document(
                 this.runtime,

--- a/components/experimental/shared-text/src/component.ts
+++ b/components/experimental/shared-text/src/component.ts
@@ -171,6 +171,9 @@ export class SharedTextRunner
             this.rootView.set("flowContainerMap", flowContainerMap.handle);
 
             insights.set(newString.id, this.collabDoc.createMap().handle);
+
+            // Set the an id for this component that is used to display UI.
+            this.rootView.set("sharedTextId", "SharedText");
         }
 
         debug(`collabDoc loaded ${this.runtime.id} - ${performanceNow()}`);
@@ -235,8 +238,10 @@ export class SharedTextRunner
         containerDiv.id = "flow-container";
         containerDiv.style.touchAction = "none";
         containerDiv.style.overflow = "hidden";
+        const sharedTextId = this.rootView.get("sharedTextId");
         const container = new controls.FlowContainer(
             containerDiv,
+            sharedTextId,
             new API.Document(
                 this.runtime,
                 this.context,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -732,12 +732,12 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             term: this._deltaManager.referenceTerm,
         };
 
+        this._existing = true;
+
         await this.loadContext(attributes, snapshot, previousContextState);
 
         this.deltaManager.inbound.systemResume();
         this.deltaManager.inboundSignal.systemResume();
-
-        this._existing = true;
     }
 
     private async snapshotCore(tagMessage: string, fullTree: boolean = false) {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -720,6 +720,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         const blobs = new Map();
         if (previousContextState.snapshot !== undefined) {
             snapshot = await buildSnapshotTree(previousContextState.snapshot.entries, blobs);
+            this._existing = true;
         }
 
         if (blobs.size > 0) {
@@ -731,8 +732,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             sequenceNumber: this._deltaManager.lastSequenceNumber,
             term: this._deltaManager.referenceTerm,
         };
-
-        this._existing = true;
 
         await this.loadContext(attributes, snapshot, previousContextState);
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -935,8 +935,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         this.loaded = true;
 
         // Propagate current connection state through the system.
-        const connected = this.connectionState === ConnectionState.Connected;
-        assert(!connected || this._deltaManager.connectionMode === "read");
         this.propagateConnectionState();
 
         if (!pause) {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -720,6 +720,18 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         const blobs = new Map();
         if (previousContextState.snapshot !== undefined) {
             snapshot = await buildSnapshotTree(previousContextState.snapshot.entries, blobs);
+
+            /**
+             * Should be removed / updated after issue #2914 is fixed.
+             * There are currently two scenarios where this is called:
+             * 1. When a new code proposal is accepted - This should be set to true before `this.loadContext` is
+             * called which creates and loads the ContainerRuntime. This is because for "read" mode clients this
+             * flag is false which causes ContainerRuntime to create the internal compoents again.
+             * 2. When the first client connects in "write" mode - This happens when a clent does not create the
+             * Container in detached mode. In this case, when the code proposal is accepted, we come here and we
+             * need to create the internal components in ContainerRuntime.
+             * Once we move to using detached container everywhere, this can move outside this block.
+             */
             this._existing = true;
         }
 

--- a/packages/test/version-test-1/tests/contextReload.test.ts
+++ b/packages/test/version-test-1/tests/contextReload.test.ts
@@ -24,16 +24,16 @@ describe("context reload", () => {
         }
 
         const text = "fluid is really great!!!";
-        await expect(page).toFill("#sbs-left .titleInput", text);
-        await expect(page).toFill("#sbs-left input.cdn", `${globals.PATH}/file`);
-        await expect(await page.$eval("#sbs-left input.cdn", (el) => (el as HTMLInputElement).value)).toBe(`${globals.PATH}/file`);
+        await expect(page).toFill("#sbs-right .titleInput", text);
+        await expect(page).toFill("#sbs-right input.cdn", `${globals.PATH}/file`);
+        await expect(await page.$eval("#sbs-right input.cdn", (el) => (el as HTMLInputElement).value)).toBe(`${globals.PATH}/file`);
 
-        const upgrade = await page.$("#sbs-left button.upgrade");
+        const upgrade = await page.$("#sbs-right button.upgrade");
         upgrade && await upgrade.click();
 
         await page.waitForSelector("button.diceRoller");
-        await expect(await getTitleValue("left")).toEqual(await getTitleValue("right"));
-        await expect(await getTitleValue("left")).toEqual(text);
+        await expect(await getTitleValue("right")).toEqual(await getTitleValue("left"));
+        await expect(await getTitleValue("right")).toEqual(text);
     })
 
     it("has a dice roller on the new version", async () => {
@@ -41,16 +41,16 @@ describe("context reload", () => {
             return await page.$eval(`#sbs-${div} .diceValue`, (el) => (el as HTMLDivElement).innerText);
         }
 
-        await expect(page).toFill("#sbs-left input.cdn", `${globals.PATH}/file`);
-        await expect(await page.$eval("#sbs-left input.cdn", (el) => (el as HTMLInputElement).value)).toBe(`${globals.PATH}/file`);
+        await expect(page).toFill("#sbs-right input.cdn", `${globals.PATH}/file`);
+        await expect(await page.$eval("#sbs-right input.cdn", (el) => (el as HTMLInputElement).value)).toBe(`${globals.PATH}/file`);
 
-        const upgrade = await page.$("#sbs-left button.upgrade");
+        const upgrade = await page.$("#sbs-right button.upgrade");
         upgrade && await upgrade.click();
 
         await page.waitForSelector("button.diceRoller");
         await expect(page).toClick("button.diceRoller", { text: "Roll" });
 
-        await expect(await getDiceValue("left")).toEqual(await getDiceValue("right"));
+        await expect(await getDiceValue("right")).toEqual(await getDiceValue("left"));
     });
 
     it("is followed by an immediate summary", async () => {
@@ -68,10 +68,10 @@ describe("context reload", () => {
             }
         });
 
-        await expect(page).toFill("#sbs-left input.cdn", `${globals.PATH}/file`);
-        await expect(await page.$eval("#sbs-left input.cdn", (el) => (el as HTMLInputElement).value)).toBe(`${globals.PATH}/file`);
+        await expect(page).toFill("#sbs-right input.cdn", `${globals.PATH}/file`);
+        await expect(await page.$eval("#sbs-right input.cdn", (el) => (el as HTMLInputElement).value)).toBe(`${globals.PATH}/file`);
 
-        const upgrade = await page.$("#sbs-left button.upgrade");
+        const upgrade = await page.$("#sbs-right button.upgrade");
         upgrade && await upgrade.click();
 
         await summMessage.promise;

--- a/packages/tools/webpack-component-loader/README.md
+++ b/packages/tools/webpack-component-loader/README.md
@@ -25,12 +25,12 @@ The following environment variables can be defined when running webpack-dev-serv
 | `spo-df` | Use SharePoint DogFood server with your personal OneDrive for storage |
 | `spo` | Use SharePoint server with your personal OneDrive for storage |
 
-### Detached Container
-In all modes you can start with a detached container by appending #manualAttach to the url.
+### Manually attach the container
+In all modes you can start a detached container that you can later attach by appending `/manualCreate` to the url. For example - http://localhost:8080/manualCreate.
+
+You can interact with the component and do any number of operations before clicking the attach buttom to attach the container.
 
 If in side by side mode, only one side will be visible until attached.
-
-Clicking the attach buttom will attach the container, and remove #manualAttach from the url.
 
 ## Connecting to a remote server
 

--- a/packages/tools/webpack-component-loader/README.md
+++ b/packages/tools/webpack-component-loader/README.md
@@ -26,9 +26,10 @@ The following environment variables can be defined when running webpack-dev-serv
 | `spo` | Use SharePoint server with your personal OneDrive for storage |
 
 ### Manually attach the container
-In all modes you can start a detached container that you can later attach by appending `/manualCreate` to the url. For example - http://localhost:8080/manualCreate.
 
-You can interact with the component and do any number of operations before clicking the attach buttom to attach the container.
+In all modes you can start a detached container that you can later attach by appending `/manualAttach` to the url. For example - http://localhost:8080/manualAttach.
+
+You can interact with the component and do any number of operations before clicking the `Attach Container` button to attach the container.
 
 If in side by side mode, only one side will be visible until attached.
 

--- a/packages/tools/webpack-component-loader/README.md
+++ b/packages/tools/webpack-component-loader/README.md
@@ -28,11 +28,9 @@ The following environment variables can be defined when running webpack-dev-serv
 ### Detached Container
 In all modes you can start with a detached container by appending #manualAttach to the url.
 
-If in side by side mode, only one side will be visable until attached.
+If in side by side mode, only one side will be visible until attached.
 
 Clicking the attach buttom will attach the container, and remove #manualAttach from the url.
-
-To use the detach flow for spo-df, you need to provide driveId also. eg. --env.driveId value
 
 ## Connecting to a remote server
 

--- a/packages/tools/webpack-component-loader/package.json
+++ b/packages/tools/webpack-component-loader/package.json
@@ -7,6 +7,9 @@
   "author": "Microsoft",
   "main": "dist/index.js",
   "module": "lib/index.js",
+  "browser": {
+    "moniker": "@fluidframework/server-services-client/dist/dockerNames.js"
+  },
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "concurrently npm:build:compile npm:lint",
@@ -52,7 +55,6 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.25.0",
-    "@fluidframework/base-host": "^0.25.0",
     "@fluidframework/common-utils": "^0.21.0",
     "@fluidframework/container-definitions": "^0.25.0",
     "@fluidframework/container-loader": "^0.25.0",

--- a/packages/tools/webpack-component-loader/src/loader.ts
+++ b/packages/tools/webpack-component-loader/src/loader.ts
@@ -208,7 +208,7 @@ export async function start(
          * Create a new `documentId`, a new Loader and a new detached container.
          */
         if (!container1.existing) {
-            console.log(`Document with id ${documentId} not found. Falling back to creating a new document.`);
+            console.warn(`Document with id ${documentId} not found. Falling back to creating a new document.`);
             container1.close();
 
             documentId = moniker.choose();

--- a/packages/tools/webpack-component-loader/src/loader.ts
+++ b/packages/tools/webpack-component-loader/src/loader.ts
@@ -137,10 +137,7 @@ class WebpackCodeResolver implements IFluidCodeResolver {
 }
 
 /**
- * Create a loader and return it.
- * @param hostConfig - Config specifying the resolver/factory to be used.
- * @param pkg - A resolved package with cdn links.
- * @param scriptIds - The script tags the chaincode are attached to the view with.
+ * Create a loader with WebCodeLoader and return it.
  */
 async function createWebLoader(
     documentId: string,

--- a/packages/tools/webpack-component-loader/src/loader.ts
+++ b/packages/tools/webpack-component-loader/src/loader.ts
@@ -302,7 +302,7 @@ async function attachContainer(
     urlResolver: MultiUrlResolver,
     documentId: string,
     url: string,
-    div: HTMLDivElement,
+    div: HTMLDivElement | undefined,
     manualAttach: boolean,
 ) {
     // This is called once loading is complete to replace the url in the address bar with the new `url`.
@@ -315,6 +315,7 @@ async function attachContainer(
     const attachUrl = await urlResolver.createRequestForCreateNew(documentId);
 
     if (manualAttach) {
+        // Create an "Attach Container" button that the user can click when they want to attach the container.
         const attachDiv = document.createElement("div");
         const attachButton = document.createElement("button");
         attachButton.innerText = "Attach Container";
@@ -324,16 +325,23 @@ async function attachContainer(
         attachButton.onclick = () => {
             container.attach(attachUrl)
                 .then(() => {
-                    div.innerText = "";
                     attachDiv.remove();
                     replaceUrl();
+
+                    if (div) {
+                        div.innerText = "";
+                    }
+
                     attached.resolve();
                 }, (error) => {
                     console.error(error);
                 });
         };
 
-        div.innerText = "Waiting for container attach";
+        // If we are in side-by-side mode, we need to display the following message in the right div passed here.
+        if (div) {
+            div.innerText = "Waiting for container attach";
+        }
     } else {
         await container.attach(attachUrl);
         replaceUrl();

--- a/packages/tools/webpack-component-loader/src/multiResolver.ts
+++ b/packages/tools/webpack-component-loader/src/multiResolver.ts
@@ -96,9 +96,9 @@ export class MultiUrlResolver implements IUrlResolver {
         return this.urlResolver.resolve(request);
     }
 
-    public createRequestForCreateNew(
+    public async createRequestForCreateNew(
         fileName: string,
-    ): IRequest {
+    ): Promise<IRequest> {
         switch (this.options.mode) {
             case "r11s":
             case "docker":
@@ -107,11 +107,8 @@ export class MultiUrlResolver implements IUrlResolver {
 
             case "spo":
             case "spo-df":
-                return (this.urlResolver as OdspUrlResolver).createCreateNewRequest(
-                    `https://${this.options.server}`,
-                    this.options.driveId,
-                    "/r11s/",
-                    fileName);
+                const request = await (this.urlResolver as OdspUrlResolver).createCreateNewRequest(fileName);
+                return request;
 
             default: // Local
                 return (this.urlResolver as LocalResolver).createCreateNewRequest(fileName);

--- a/packages/tools/webpack-component-loader/src/multiResolver.ts
+++ b/packages/tools/webpack-component-loader/src/multiResolver.ts
@@ -107,8 +107,7 @@ export class MultiUrlResolver implements IUrlResolver {
 
             case "spo":
             case "spo-df":
-                const request = await (this.urlResolver as OdspUrlResolver).createCreateNewRequest(fileName);
-                return request;
+                return (this.urlResolver as OdspUrlResolver).createCreateNewRequest(fileName);
 
             default: // Local
                 return (this.urlResolver as LocalResolver).createCreateNewRequest(fileName);

--- a/packages/tools/webpack-component-loader/src/multiResolver.ts
+++ b/packages/tools/webpack-component-loader/src/multiResolver.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { IResolvedUrl, IUrlResolver } from "@fluidframework/driver-definitions";
+import { parse } from "url";
+import { IFluidResolvedUrl, IResolvedUrl, IUrlResolver } from "@fluidframework/driver-definitions";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { LocalResolver } from "@fluidframework/local-driver";
 import { InsecureUrlResolver } from "@fluidframework/test-runtime-utils";
@@ -25,10 +26,7 @@ export const tinyliciousUrls = {
     storageUrl: "http://localhost:3000",
 };
 
-function getUrlResolver(
-    documentId: string,
-    options: RouteOptions,
-): IUrlResolver {
+function getUrlResolver(options: RouteOptions): IUrlResolver {
     switch (options.mode) {
         case "docker":
             return new InsecureUrlResolver(
@@ -79,9 +77,8 @@ export class MultiUrlResolver implements IUrlResolver {
     private readonly urlResolver: IUrlResolver;
     constructor(
         private readonly rawUrl: string,
-        private readonly documentId: string,
         private readonly options: RouteOptions) {
-        this.urlResolver = getUrlResolver(documentId, options);
+        this.urlResolver = getUrlResolver(options);
     }
 
     async getAbsoluteUrl(resolvedUrl: IResolvedUrl, relativeUrl: string): Promise<string> {
@@ -89,7 +86,14 @@ export class MultiUrlResolver implements IUrlResolver {
         if (url.startsWith("/")) {
             url = url.substr(1);
         }
-        return `${this.rawUrl}/${this.documentId}/${url}`;
+        const fluidResolvedUrl = resolvedUrl as IFluidResolvedUrl;
+
+        const parsedUrl = parse(fluidResolvedUrl.url);
+        if (parsedUrl.pathname === undefined) {
+            throw new Error("Url should contain tenant and docId!!");
+        }
+        const [, , documentId] = parsedUrl.pathname.split("/");
+        return `${this.rawUrl}/${documentId}/${url}`;
     }
 
     async resolve(request: IRequest): Promise<IResolvedUrl | undefined> {

--- a/packages/tools/webpack-component-loader/src/odspUrlResolver.ts
+++ b/packages/tools/webpack-component-loader/src/odspUrlResolver.ts
@@ -55,7 +55,15 @@ export class OdspUrlResolver implements IUrlResolver {
         return this.driverUrlResolver.getAbsoluteUrl(resolvedUrl, relativeUrl);
     }
 
-    public createCreateNewRequest(siteUrl: string, driveId: string, filePath: string, fileName: string): IRequest {
-        return this.driverUrlResolver.createCreateNewRequest(siteUrl, driveId, filePath, fileName);
+    public async createCreateNewRequest(fileName: string): Promise<IRequest> {
+        const filePath = "/r11s/";
+        const driveItem = await getDriveItemByRootFileName(
+            this.server,
+            "",
+            filePath,
+            this.authRequestInfo,
+            true);
+        return this.driverUrlResolver.createCreateNewRequest(
+            `https://${this.server}`, driveItem.drive, filePath, fileName);
     }
 }

--- a/packages/tools/webpack-component-loader/src/odspUrlResolver.ts
+++ b/packages/tools/webpack-component-loader/src/odspUrlResolver.ts
@@ -62,7 +62,7 @@ export class OdspUrlResolver implements IUrlResolver {
             "",
             filePath,
             this.authRequestInfo,
-            true);
+            false);
         return this.driverUrlResolver.createCreateNewRequest(
             `https://${this.server}`, driveItem.drive, filePath, fileName);
     }

--- a/packages/tools/webpack-component-loader/src/routes.ts
+++ b/packages/tools/webpack-component-loader/src/routes.ts
@@ -29,7 +29,7 @@ const getThisOrigin = (options: RouteOptions): string => `http://localhost:${opt
 
 export const before = async (app: express.Application) => {
     app.get("/getclientsidewebparts", async (req, res) => res.send(await createManifestResponse()));
-    app.get("/", (req, res) => res.redirect(`/createNew`));
+    app.get("/", (req, res) => res.redirect(`/autoCreate`));
 };
 
 export const after = (app: express.Application, server: WebpackDevServer, baseDir: string, env: RouteOptions) => {

--- a/packages/tools/webpack-component-loader/src/routes.ts
+++ b/packages/tools/webpack-component-loader/src/routes.ts
@@ -6,7 +6,6 @@
 import fs from "fs";
 import path from "path";
 import express from "express";
-import moniker from "moniker";
 import nconf from "nconf";
 import WebpackDevServer from "webpack-dev-server";
 import { IOdspTokens, getServer } from "@fluidframework/odsp-utils";
@@ -30,7 +29,7 @@ const getThisOrigin = (options: RouteOptions): string => `http://localhost:${opt
 
 export const before = async (app: express.Application) => {
     app.get("/getclientsidewebparts", async (req, res) => res.send(await createManifestResponse()));
-    app.get("/", (req, res) => res.redirect(`/${moniker.choose()}`));
+    app.get("/", (req, res) => res.redirect(`/createNew`));
 };
 
 export const after = (app: express.Application, server: WebpackDevServer, baseDir: string, env: RouteOptions) => {


### PR DESCRIPTION
Updated webpack-component-loader to use detached container flow. There are a few things to note in this change:
- On navigating to localhost:&lt;port>, webpack-component-loader uses the detached container flow.
- On navigating to a url which has the document id (say localhost:&lt;port>/&lt;documentId>, it tries to load the container with id &lt;documentId>. However, if the container does not already exist, it reloads the page with the detached container flow.
This is so that we do not use the flow where we create an attached container.
- Updated the odspUrlResolver's `createCreateNewRequest` method to get the `driveId` automatically rather than being passed as a parameter to npm start. Since detached container is now the default flow, it might be a pain to find and pass the `driveId` every time we want to run the webpack in `spo` or `spo-df` mode.
- Removed BaseHost from webpack-component-loader.
- Removed the following check in `Container::load` method because in case of local server, when the second container loads, it is it in "write" mode and is already connected (the join message is part of the initial messages when we establish the connection):
   ```
   const connected = this.connectionState === ConnectionState.Connected;
   assert(!connected || this._deltaManager.connectionMode === "read");
   ```

Fixes #2838 