### PR TITLE
Update common-utils dependency to 0.21.0-0 in server packages

### DIFF
--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -502,16 +502,16 @@
 			"integrity": "sha1-Ga3wP0vJQ/m+idtBbgJ0NFHiMDI="
 		},
 		"@fluidframework/common-utils": {
-			"version": "0.20.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
-			"integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+			"version": "0.21.0-34142",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.21.0-34142.tgz",
+			"integrity": "sha1-GQ8+4upIKGkYCKAvWUUuayEPz60=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"assert": "^2.0.0",
 				"buffer": "^5.6.0",
 				"debug": "^4.1.1",
 				"events": "^3.1.0",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.19",
 				"performance-now": "^2.1.0",
 				"sha.js": "^2.4.11"
 			},

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -45,7 +45,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/server-services": "^0.1010.0",
     "@fluidframework/server-services-core": "^0.1010.0",
     "@fluidframework/server-services-utils": "^0.1010.0",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -48,7 +48,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/gitresources": "^0.1010.0",
     "@fluidframework/protocol-base": "^0.1010.0",
     "@fluidframework/protocol-definitions": "^0.1010.0",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -49,7 +49,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/protocol-definitions": "^0.1010.0",
     "@fluidframework/server-lambdas": "^0.1010.0",
     "@fluidframework/server-memory-orderer": "^0.1010.0",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -26,7 +26,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/protocol-base": "^0.1010.0",
     "@fluidframework/protocol-definitions": "^0.1010.0",
     "@fluidframework/server-lambdas": "^0.1010.0",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -50,7 +50,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/gitresources": "^0.1010.0",
     "@fluidframework/protocol-definitions": "^0.1010.0",
     "assert": "^2.0.0",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -60,7 +60,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/gitresources": "^0.1010.0",
     "@fluidframework/protocol-definitions": "^0.1010.0",
     "@fluidframework/server-kafka-orderer": "^0.1010.0",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -48,7 +48,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/gitresources": "^0.1010.0",
     "@fluidframework/protocol-base": "^0.1010.0",
     "@fluidframework/protocol-definitions": "^0.1010.0",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -23,7 +23,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/gitresources": "^0.1010.0",
     "@fluidframework/protocol-definitions": "^0.1010.0",
     "@fluidframework/server-services-client": "^0.1010.0",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -23,7 +23,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/gitresources": "^0.1010.0",
     "@fluidframework/protocol-base": "^0.1010.0",
     "@fluidframework/protocol-definitions": "^0.1010.0",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@azure/event-hubs": "^1.0.8",
     "@azure/event-processor-host": "^1.0.6",
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/gitresources": "^0.1010.0",
     "@fluidframework/protocol-base": "^0.1010.0",
     "@fluidframework/protocol-definitions": "^0.1010.0",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -44,7 +44,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/gitresources": "^0.1010.0",
     "@fluidframework/protocol-base": "^0.1010.0",
     "@fluidframework/protocol-definitions": "^0.1010.0",

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -52,16 +52,16 @@
       "integrity": "sha1-Ga3wP0vJQ/m+idtBbgJ0NFHiMDI="
     },
     "@fluidframework/common-utils": {
-      "version": "0.20.0",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
-      "integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+      "version": "0.21.0-34142",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.21.0-34142.tgz",
+      "integrity": "sha1-GQ8+4upIKGkYCKAvWUUuayEPz60=",
       "requires": {
         "@fluidframework/common-definitions": "^0.18.1",
         "assert": "^2.0.0",
         "buffer": "^5.6.0",
         "debug": "^4.1.1",
         "events": "^3.1.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.19",
         "performance-now": "^2.1.0",
         "sha.js": "^2.4.11"
       }
@@ -99,6 +99,23 @@
         "@fluidframework/protocol-definitions": "^0.1010.0-33996",
         "assert": "^2.0.0",
         "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.20.0",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+          "integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "buffer": "^5.6.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.11",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/protocol-definitions": {
@@ -142,6 +159,23 @@
         "nconf": "^0.10.0",
         "semver": "^6.3.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.20.0",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+          "integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "buffer": "^5.6.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.11",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/server-local-server": {
@@ -157,6 +191,23 @@
         "@fluidframework/server-services-core": "^0.1010.0-33996",
         "@fluidframework/server-test-utils": "^0.1010.0-33996",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.20.0",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+          "integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "buffer": "^5.6.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.11",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/server-memory-orderer": {
@@ -181,6 +232,23 @@
         "moniker": "^0.1.2",
         "uuid": "^3.3.2",
         "ws": "^6.1.2"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.20.0",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+          "integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "buffer": "^5.6.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.11",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/server-services-client": {
@@ -198,6 +266,23 @@
         "jsonwebtoken": "^8.4.0",
         "sillyname": "0.1.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.20.0",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+          "integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "buffer": "^5.6.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.11",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/server-services-core": {
@@ -213,6 +298,23 @@
         "@types/node": "^10.17.24",
         "debug": "^4.1.1",
         "nconf": "^0.10.0"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.20.0",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+          "integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "buffer": "^5.6.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.11",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/server-services-shared": {
@@ -234,6 +336,23 @@
         "socket.io": "^2.2.0",
         "socket.io-redis": "^5.2.0",
         "winston": "^3.1.0"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.20.0",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+          "integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "buffer": "^5.6.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.11",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/server-services-utils": {
@@ -263,6 +382,23 @@
         "lodash": "^4.17.19",
         "string-hash": "^1.1.3",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.20.0",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.20.0.tgz",
+          "integrity": "sha1-ckXv/3nmO3t1IJJ5al6fySl5Lm8=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "buffer": "^5.6.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.11",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@microsoft/api-extractor": {

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -22,7 +22,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.20.0",
+    "@fluidframework/common-utils": "^0.21.0-0",
     "@fluidframework/gitresources": "^0.1010.0-0",
     "@fluidframework/protocol-base": "^0.1010.0-0",
     "@fluidframework/protocol-definitions": "^0.1010.0-0",


### PR DESCRIPTION
`node bumpversion.js -d @fluidframework/common-utils`

I'm pretty confused about the lock files.  They are locking the `common-utils` dependency to `0.20.0` which doesn't match the updated `package.json` dependencies. Build seems to work locally, I'm going to look a bit more into it.  I really expected the lock files to point to 0.21.0-xxxxx.
_[edit] Ok I think I get it - the packages in node_modules depend on 0.20.0 so this package-lock specifies that version. But packages in the source code depend on 0.21.0-0 so nose_modules/.../common-utils is at 0.21.0_xxxxx._

I will also need to do a follow-up change to force the lock files to update server dependencies to the version that is depending on `common-utils` `0.21` once this is in and a build is published.
_[edit] Actually this PR is only doing the server packages. I have to stage it this way to avoid ever having 2 different versions of `common-utils` referenced in a single release._