### PR TITLE
A little tweak to get the request logs as objects.

### DIFF
--- a/server/routerlicious/packages/routerlicious/src/alfred/app.ts
+++ b/server/routerlicious/packages/routerlicious/src/alfred/app.ts
@@ -55,7 +55,7 @@ export function create(
     const loggerFormat = config.get("logger:morganFormat");
     if (loggerFormat === "json") {
         app.use(morgan((tokens, req, res) => {
-            const logObject = {
+            const messageMetaData = {
                 method: tokens.method(req, res),
                 url: tokens.url(req, res),
                 status: tokens.status(req, res),
@@ -65,15 +65,7 @@ export function create(
                 serviceName: "alfred",
                 eventName: "http_requests",
              };
-             const message = [
-                logObject.method,
-                logObject.url,
-                logObject.status,
-                logObject.contentLength, "-",
-                logObject.responseTime, "ms",
-             ].join(" ");
-
-             winston.info(message, { logObject });
+             winston.info("request log generated", { messageMetaData });
              return undefined;
         }, { stream }));
     } else {

--- a/server/routerlicious/packages/routerlicious/src/alfred/utils.ts
+++ b/server/routerlicious/packages/routerlicious/src/alfred/utils.ts
@@ -11,3 +11,24 @@ import { Params } from "express-serve-static-core";
 export function getParam(params: Params, key: string) {
     return Array.isArray(params) ? undefined : params[key];
 }
+
+export function getTenantIdFromRequest(params: Params) {
+    if (getParam(params, "tenantId") !== undefined) {
+        return getParam(params, "tenantId");
+    }
+    if (getParam(params, "id") !== undefined) {
+        return getParam(params, "id");
+    }
+
+    return "-";
+}
+
+export function isValidJson(message: string) {
+    let item;
+    try {
+        item = JSON.parse(message);
+    } catch (e) {
+        return item;
+    }
+    return item;
+}

--- a/server/routerlicious/packages/routerlicious/src/alfred/utils.ts
+++ b/server/routerlicious/packages/routerlicious/src/alfred/utils.ts
@@ -13,11 +13,13 @@ export function getParam(params: Params, key: string) {
 }
 
 export function getTenantIdFromRequest(params: Params) {
-    if (getParam(params, "tenantId") !== undefined) {
-        return getParam(params, "tenantId");
+    const tenantId = getParam(params, "tenantId");
+    if (tenantId !== undefined) {
+        return tenantId;
     }
-    if (getParam(params, "id") !== undefined) {
-        return getParam(params, "id");
+    const id = getParam(params, "id");
+    if (id !== undefined) {
+        return id;
     }
 
     return "-";

--- a/server/routerlicious/packages/routerlicious/src/alfred/utils.ts
+++ b/server/routerlicious/packages/routerlicious/src/alfred/utils.ts
@@ -22,13 +22,3 @@ export function getTenantIdFromRequest(params: Params) {
 
     return "-";
 }
-
-export function isValidJson(message: string) {
-    let item;
-    try {
-        item = JSON.parse(message);
-    } catch (e) {
-        return item;
-    }
-    return item;
-}

--- a/server/routerlicious/packages/routerlicious/src/riddler/app.ts
+++ b/server/routerlicious/packages/routerlicious/src/riddler/app.ts
@@ -8,6 +8,8 @@ import * as bodyParser from "body-parser";
 import express from "express";
 import morgan from "morgan";
 import * as winston from "winston";
+// eslint-disable-next-line import/no-internal-modules
+import { getTenantIdFromRequest, isValidJson } from "../alfred/utils";
 import * as api from "./api";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
@@ -17,7 +19,12 @@ const split = require("split");
  * Basic stream logging interface for libraries that require a stream to pipe output to (re: Morgan)
  */
 const stream = split().on("data", (message) => {
-    winston.info(message);
+    const logObject = isValidJson(message);
+    if (logObject !== undefined) {
+        winston.info(message, { logObject });
+    } else {
+        winston.info(message);
+    }
 });
 
 export function create(
@@ -36,7 +43,23 @@ export function create(
 
     // View engine setup.
     app.set("view engine", "hjs");
-
+    if (loggerFormat === "json") {
+        app.use(morgan((tokens, req, res) => {
+            const requestLogObject = {
+                method: tokens.method(req, res),
+                url: tokens.url(req, res),
+                status: tokens.status(req, res),
+                contentLength: tokens.res(req, res, "content-length"),
+                responseTime: tokens["response-time"](req, res),
+                tenantId: getTenantIdFromRequest(req.params),
+                serviceName: "riddler",
+                eventName: "http_requests",
+             };
+             return JSON.stringify(requestLogObject);
+        }, { stream }));
+    } else {
+        app.use(morgan(loggerFormat, { stream }));
+    }
     app.use(morgan(loggerFormat, { stream }));
     app.use(bodyParser.json());
     app.use(bodyParser.urlencoded({ extended: false }));

--- a/server/routerlicious/packages/routerlicious/src/riddler/app.ts
+++ b/server/routerlicious/packages/routerlicious/src/riddler/app.ts
@@ -42,7 +42,7 @@ export function create(
     app.set("view engine", "hjs");
     if (loggerFormat === "json") {
         app.use(morgan((tokens, req, res) => {
-            const logObject = {
+            const messageMetaData = {
                 method: tokens.method(req, res),
                 url: tokens.url(req, res),
                 status: tokens.status(req, res),
@@ -52,16 +52,7 @@ export function create(
                 serviceName: "riddler",
                 eventName: "http_requests",
              };
-
-             const message = [
-                logObject.method,
-                logObject.url,
-                logObject.status,
-                logObject.contentLength, "-",
-                logObject.responseTime, "ms",
-             ].join(" ");
-
-             winston.info(message, { logObject });
+             winston.info("request log generated", { messageMetaData });
              return undefined;
         }));
     } else {


### PR DESCRIPTION
Currently the requests hitting alfred/riddler has been logged as plan text through morgan and winston. This change brings an option (configurable in routerlicious/config/config.json) to log the request info as a json object so that it is able to be collected in a structured form in any logging service