### PR TITLE
Add vsts-npm-auth command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ git clone https://github.com/microsoft/FluidFramework.git
 cd FluidFramework
 ```
 
-Run the following to build the client packages:
+Run the following to build the client packages.  Note that the first command is an auth helper to obtain tokens for the required package repository, and only works on a Windows machine:
 
 ```shell
+npx --package vsts-npm-auth@latest vsts-npm-auth -config .npmrc
 npm install
 npm run build:fast
 ```


### PR DESCRIPTION
On cloning FluidFramework from scratch, I was getting errors doing "npm install".  After some digging, I found that I needed to run `npx --package vsts-npm-auth@latest vsts-npm-auth -config .npmrc`.

I think it would be helpful to have this step in the README...