### PR TITLE
Emit Ink clear operation after clearing the data

### DIFF
--- a/packages/dds/ink/src/ink.ts
+++ b/packages/dds/ink/src/ink.ts
@@ -200,8 +200,8 @@ export class Ink extends SharedObject<IInkEvents> implements IInk {
      * @param operation - The operation object
      */
     private executeClearOperation(operation: IClearOperation): void {
-        this.emit("clear", operation);
         this.inkData.clear();
+        this.emit("clear", operation);
     }
 
     /**


### PR DESCRIPTION
It was emitting before clearing the ink data, which was causing issues in the canvas example app since it redraws when clear is emitted.
All the other emits already occur after changing ink data.