### PR TITLE
Add forEachCell to Shared Matrix

### DIFF
--- a/components/experimental/table-view/package.json
+++ b/components/experimental/table-view/package.json
@@ -41,7 +41,7 @@
     "@fluidframework/aqueduct": "^0.23.0",
     "@fluidframework/component-core-interfaces": "^0.23.0",
     "@fluidframework/view-interfaces": "^0.23.0",
-    "@tiny-calc/micro": "0.0.0-alpha.0"
+    "@tiny-calc/micro": "0.0.0-alpha.5"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.18.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -4063,17 +4063,17 @@
 			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
 		},
 		"@tiny-calc/micro": {
-			"version": "0.0.0-alpha.0",
-			"resolved": "https://registry.npmjs.org/@tiny-calc/micro/-/micro-0.0.0-alpha.0.tgz",
-			"integrity": "sha512-Ffilh08i2oej2jIQ2FAKwOnfgZ9dUZJuAz3m6cOOivZ/BEX+id3Jtz4LAdN6iGynub5YWxoi6jPRvypkA4sntQ==",
+			"version": "0.0.0-alpha.5",
+			"resolved": "https://registry.npmjs.org/@tiny-calc/micro/-/micro-0.0.0-alpha.5.tgz",
+			"integrity": "sha512-ldmINj6PDn5SaeIT9STO/P1O2rhPZjSkIoWUaXjfuBAEcE5bflwh5+WTFShofJcpnaCVpGannXuDS0+qn6Ctfg==",
 			"requires": {
-				"@tiny-calc/nano": "0.0.0-alpha.0"
+				"@tiny-calc/nano": "0.0.0-alpha.5"
 			}
 		},
 		"@tiny-calc/nano": {
-			"version": "0.0.0-alpha.0",
-			"resolved": "https://registry.npmjs.org/@tiny-calc/nano/-/nano-0.0.0-alpha.0.tgz",
-			"integrity": "sha512-pUhl3lMnK8+w/xbly5Pcfulon2VNHVwDMDnk+MCIdbrssubXHqPLQ14L4vP+cXJbX48lOgvv6AO1OIhOiSF3oA=="
+			"version": "0.0.0-alpha.5",
+			"resolved": "https://registry.npmjs.org/@tiny-calc/nano/-/nano-0.0.0-alpha.5.tgz",
+			"integrity": "sha512-Hs37tz9ZtvK21/5s4tjt5RBa/PFHKYS0AzvdxiXuSd3+AKQN2ygxw7uwD9j0DIG9qONddg1vIASO77JIGyZzyw=="
 		},
 		"@types/anymatch": {
 			"version": "1.3.1",
@@ -4349,8 +4349,7 @@
 		"@types/minimist": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
-			"dev": true
+			"integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY="
 		},
 		"@types/mocha": {
 			"version": "5.2.7",
@@ -11800,12 +11799,14 @@
 			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
 		},
 		"hotloop": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/hotloop/-/hotloop-1.0.0.tgz",
-			"integrity": "sha512-qaHufAVlIpQsUWz86568pWT0QG6QpOwWyNo5aziH2KKpfFnBwsvmhPcXYsF5HC7loDCIpELIsl64GY0yBUMf1A==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/hotloop/-/hotloop-1.1.0.tgz",
+			"integrity": "sha512-vJ8qU6KJyE6hDCodoQerFIMfSDYGDbVw2NN82gf6cGvr53SN6kAsdYSFZm4q/5wd0lRy9pBN24Cbep00AY5v0A==",
 			"requires": {
 				"@types/benchmark": "^1.0.31",
-				"benchmark": "^2.1.4"
+				"@types/minimist": "^1.2.0",
+				"benchmark": "^2.1.4",
+				"minimist": "^1.2.5"
 			}
 		},
 		"hpack.js": {

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/runtime-utils": "^0.23.0",
     "@fluidframework/shared-object-base": "^0.23.0",
     "@fluidframework/telemetry-utils": "^0.23.0",
-    "@tiny-calc/nano": "0.0.0-alpha.0",
+    "@tiny-calc/nano": "0.0.0-alpha.5",
     "debug": "^4.1.1",
     "tslib": "^1.10.0"
   },

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -172,7 +172,10 @@ export class SharedMatrix<T extends Serializable = Serializable>
                     }
                 }
                 else {
-                    callback(this.cells.getCell(rowHandle, colHandle), row, col);
+                    const content = this.cells.getCell(rowHandle, colHandle);
+                    if (content !== undefined || includeEmpty) {
+                        callback(content, row, col);
+                    }
                 }
             }
         }

--- a/packages/dds/matrix/test/matrix.spec.ts
+++ b/packages/dds/matrix/test/matrix.spec.ts
@@ -16,7 +16,7 @@ import {
     MockStorage,
 } from "@fluidframework/test-runtime-utils";
 import { SharedMatrix, SharedMatrixFactory } from "../src";
-import { fill, check, insertFragmented, extract, expectSize } from "./utils";
+import { fill, check, insertFragmented, extract, expectSize, checkValue } from "./utils";
 import { TestConsumer } from "./testconsumer";
 
 describe("Matrix", () => {
@@ -216,6 +216,34 @@ describe("Matrix", () => {
                 matrix.insertCols(0, 256);
                 fill(matrix, /* row: */ 0, /* col: */ 0, /* rowCount: */ 16, /* colCount: */ 16);
                 check(matrix, /* row: */ 0, /* col: */ 0, /* rowCount: */ 16, /* colCount: */ 16);
+            });
+
+            it("forEach 16x16", () => {
+                matrix.insertRows(0, 16);
+                matrix.insertCols(0, 16);
+                fill(matrix, /* row: */ 0, /* col: */ 0, /* rowCount: */ 16, /* colCount: */ 16);
+                matrix.forEachCell((v, row, col) => {
+                    checkValue(matrix, v, row, col, /* row: */ 0, /* rowCount: */ 16);
+                })
+            });
+
+            it("forEach 16x16 empty with blanks skipped", () => {
+                matrix.insertRows(0, 16);
+                matrix.insertCols(0, 16);
+                matrix.forEachCell(() => {
+                    assert.fail();
+                });
+            });
+
+            it("forEach 16x16 empty with blanks", () => {
+                matrix.insertRows(0, 16);
+                matrix.insertCols(0, 16);
+                let count = 0;
+                matrix.forEachCell((v) => {
+                    assert.equal(v, undefined);
+                    count++;
+                }, { includeEmpty: true });
+                assert.equal(count, 16*16);
             });
         });
 

--- a/packages/dds/matrix/test/matrix.spec.ts
+++ b/packages/dds/matrix/test/matrix.spec.ts
@@ -243,13 +243,13 @@ describe("Matrix", () => {
                     assert.equal(v, undefined);
                     count++;
                 }, { includeEmpty: true });
-                assert.equal(count, 16*16);
+                assert.equal(count, 16 * 16);
             });
 
             it("forEachCell 16x16 empty with 1 cell", () => {
                 matrix.insertRows(0, 16);
                 matrix.insertCols(0, 16);
-                matrix.setCell(0,0, -42);
+                matrix.setCell(0, 0, -42);
                 let count = 0;
                 matrix.forEachCell((v) => {
                     assert.equal(v, -42);
@@ -261,13 +261,13 @@ describe("Matrix", () => {
             it("forEachCell 16x16 empty with 1 cell and blanks", () => {
                 matrix.insertRows(0, 16);
                 matrix.insertCols(0, 16);
-                matrix.setCell(0,0, -42);
+                matrix.setCell(0, 0, -42);
                 let count = 0;
                 matrix.forEachCell((v, r, c) => {
                     assert.equal(v, r === 0 && c === 0 ? -42 : undefined);
                     count++;
                 }, { includeEmpty: true });
-                assert.equal(count, 16*16);
+                assert.equal(count, 16 * 16);
             });
         });
 
@@ -276,6 +276,18 @@ describe("Matrix", () => {
                 insertFragmented(matrix, 16, 16);
                 fill(matrix, /* row: */ 0, /* col: */ 0, /* rowCount: */ 16, /* colCount: */ 16);
                 check(matrix, /* row: */ 0, /* col: */ 0, /* rowCount: */ 16, /* colCount: */ 16);
+            });
+        });
+
+        describe("annotations", () => {
+            it("read/write 16x16", () => {
+                matrix.insertRows(0, 256);
+                matrix.insertCols(0, 256);
+                matrix.setAnnotation(0, 0, -42);
+                assert.equal(matrix.getAnnotation(0, 0), -42);
+                matrix.setCell(0, 0, 1);
+                // Setting a cell should clear existing annotation.
+                assert.equal(matrix.getAnnotation(0, 0), undefined);
             });
         });
 

--- a/packages/dds/matrix/test/matrix.spec.ts
+++ b/packages/dds/matrix/test/matrix.spec.ts
@@ -227,7 +227,7 @@ describe("Matrix", () => {
                 })
             });
 
-            it("forEach 16x16 empty with blanks skipped", () => {
+            it("forEachCell 16x16 empty with blanks skipped", () => {
                 matrix.insertRows(0, 16);
                 matrix.insertCols(0, 16);
                 matrix.forEachCell(() => {
@@ -235,12 +235,36 @@ describe("Matrix", () => {
                 });
             });
 
-            it("forEach 16x16 empty with blanks", () => {
+            it("forEachCell 16x16 empty with blanks", () => {
                 matrix.insertRows(0, 16);
                 matrix.insertCols(0, 16);
                 let count = 0;
                 matrix.forEachCell((v) => {
                     assert.equal(v, undefined);
+                    count++;
+                }, { includeEmpty: true });
+                assert.equal(count, 16*16);
+            });
+
+            it("forEachCell 16x16 empty with 1 cell", () => {
+                matrix.insertRows(0, 16);
+                matrix.insertCols(0, 16);
+                matrix.setCell(0,0, -42);
+                let count = 0;
+                matrix.forEachCell((v) => {
+                    assert.equal(v, -42);
+                    count++;
+                });
+                assert.equal(count, 1);
+            });
+
+            it("forEachCell 16x16 empty with 1 cell and blanks", () => {
+                matrix.insertRows(0, 16);
+                matrix.insertCols(0, 16);
+                matrix.setCell(0,0, -42);
+                let count = 0;
+                matrix.forEachCell((v, r, c) => {
+                    assert.equal(v, r === 0 && c === 0 ? -42 : undefined);
                     count++;
                 }, { includeEmpty: true });
                 assert.equal(count, 16*16);

--- a/packages/dds/matrix/test/utils.ts
+++ b/packages/dds/matrix/test/utils.ts
@@ -74,6 +74,18 @@ export function check<T extends IArray2D<U>, U>(
     return matrix;
 }
 
+export function checkValue<T extends IArray2D<U>, U>(
+    matrix: T,
+    test: unknown,
+    r: number,
+    c: number,
+    rowStart = 0,
+    rowCount = matrix.rowCount - rowStart,
+    value = (row: number, col: number) => row * rowCount + col
+) {
+    assert.equal(test, value(r, c) as any);
+}
+
 /**
  * Extracts the contents of the given `SharedMatrix` as a jagged 2D array.  This is convenient for
  * comparing matrices via `assert.deepEqual()`.


### PR DESCRIPTION
Adding `forEachCell`.

Adding in-memory annotations that are cleared on each `setCell`.