### PR TITLE
SPO Custom error codes

### DIFF
--- a/packages/drivers/odsp-driver/src/odspError.ts
+++ b/packages/drivers/odsp-driver/src/odspError.ts
@@ -103,6 +103,11 @@ export function createOdspNetworkError(
             error = new NetworkErrorBasic(errorMessage, DriverErrorType.offlineError, true);
             break;
         case fetchFailureStatusCode:
+            error = new NetworkErrorBasic(errorMessage, DriverErrorType.fetchFailure, false);
+            break;
+        case fetchIncorrectResponse:
+            error = new NetworkErrorBasic(errorMessage, DriverErrorType.incorrectServerResponse, false);
+            break;
         default:
             error = createGenericNetworkError(errorMessage, true, retryAfterSeconds, statusCode);
     }

--- a/packages/loader/driver-definitions/src/driverError.ts
+++ b/packages/loader/driver-definitions/src/driverError.ts
@@ -49,6 +49,19 @@ export enum DriverErrorType {
      * That might be indication of some component error - components should not generate ops in readonly mode.
      */
     writeError = "writeError",
+
+    /**
+     * Generic fetch failure.
+     * Most of such failures are due to client being offline, or DNS is not reachable, such errors map to
+     * DriverErrorType.offlineError. Anything else that can't be diagnose as likely offline maps to this error.
+     * This can also indicate no response from server.
+     */
+    fetchFailure = "fetchFailure",
+
+    /**
+     * Unexpected response from server. Either JSON is malformed, or some required properties are missing
+     */
+    incorrectServerResponse = "incorrectServerResponse",
 }
 
 /**
@@ -82,7 +95,9 @@ export interface IDriverBasicError extends IDriverErrorBase {
         | DriverErrorType.fileNotFoundOrAccessDeniedError
         | DriverErrorType.offlineError
         | DriverErrorType.unsupportedClientProtocolVersion
-        | DriverErrorType.writeError;
+        | DriverErrorType.writeError
+        | DriverErrorType.fetchFailure
+        | DriverErrorType.incorrectServerResponse;
     readonly statusCode?: number;
 }
 


### PR DESCRIPTION
We use some custom error codes (in the range of 709-712).for internal…purposes.

They should not leak outside of SPO driver, i.e. we should not use createGenericNetworkError() which exposes them as statusCode property, which confuses consumers.