### PR TITLE
Migrate to unreachableCase in common-utils

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -4349,8 +4349,7 @@
 		"@types/minimist": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
-			"dev": true
+			"integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY="
 		},
 		"@types/mocha": {
 			"version": "5.2.7",
@@ -11800,12 +11799,14 @@
 			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
 		},
 		"hotloop": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/hotloop/-/hotloop-1.0.0.tgz",
-			"integrity": "sha512-qaHufAVlIpQsUWz86568pWT0QG6QpOwWyNo5aziH2KKpfFnBwsvmhPcXYsF5HC7loDCIpELIsl64GY0yBUMf1A==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/hotloop/-/hotloop-1.1.0.tgz",
+			"integrity": "sha512-vJ8qU6KJyE6hDCodoQerFIMfSDYGDbVw2NN82gf6cGvr53SN6kAsdYSFZm4q/5wd0lRy9pBN24Cbep00AY5v0A==",
 			"requires": {
 				"@types/benchmark": "^1.0.31",
-				"benchmark": "^2.1.4"
+				"@types/minimist": "^1.2.0",
+				"benchmark": "^2.1.4",
+				"minimist": "^1.2.5"
 			}
 		},
 		"hpack.js": {

--- a/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
+++ b/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from "assert";
-import { fromBase64ToUtf8 } from "@fluidframework/common-utils";
+import { fromBase64ToUtf8, unreachableCase } from "@fluidframework/common-utils";
 import {
     FileMode,
     ISequencedDocumentMessage,
@@ -17,7 +17,6 @@ import {
     IComponentRuntime,
     IChannelStorageService,
 } from "@fluidframework/component-runtime-definitions";
-import { unreachableCase } from "@fluidframework/runtime-utils";
 import { SharedObject } from "@fluidframework/shared-object-base";
 import { v4 as uuid } from "uuid";
 import {

--- a/packages/dds/register-collection/src/consensusRegisterCollection.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollection.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from "assert";
-import { fromBase64ToUtf8 } from "@fluidframework/common-utils";
+import { fromBase64ToUtf8, unreachableCase } from "@fluidframework/common-utils";
 import {
     FileMode,
     ISequencedDocumentMessage,
@@ -17,7 +17,6 @@ import {
     IComponentRuntime,
     IChannelStorageService,
 } from "@fluidframework/component-runtime-definitions";
-import { unreachableCase } from "@fluidframework/runtime-utils";
 import { SharedObject } from "@fluidframework/shared-object-base";
 import { ConsensusRegisterCollectionFactory } from "./consensusRegisterCollectionFactory";
 import { debug } from "./debug";

--- a/packages/runtime/component-runtime/src/componentRuntime.ts
+++ b/packages/runtime/component-runtime/src/componentRuntime.ts
@@ -24,6 +24,7 @@ import {
 } from "@fluidframework/container-definitions";
 import {
     Deferred,
+    unreachableCase,
 } from "@fluidframework/common-utils";
 import {
     ChildLogger,
@@ -47,7 +48,7 @@ import {
     IInboundSignalMessage,
     SchedulerType,
 } from "@fluidframework/runtime-definitions";
-import { generateHandleContextPath, unreachableCase } from "@fluidframework/runtime-utils";
+import { generateHandleContextPath } from "@fluidframework/runtime-utils";
 import { IChannel, IComponentRuntime, IChannelFactory } from "@fluidframework/component-runtime-definitions";
 import { v4 as uuid } from "uuid";
 import { IChannelContext, snapshotChannel } from "./channelContext";

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -33,6 +33,7 @@ import { IContainerRuntime, IContainerRuntimeDirtyable } from "@fluidframework/c
 import {
     Deferred,
     Trace,
+    unreachableCase,
 } from "@fluidframework/common-utils";
 import {
     ChildLogger,
@@ -77,7 +78,7 @@ import {
     NamedComponentRegistryEntries,
     SchedulerType,
 } from "@fluidframework/runtime-definitions";
-import { ComponentSerializer, SummaryTracker, unreachableCase, RequestParser } from "@fluidframework/runtime-utils";
+import { ComponentSerializer, SummaryTracker, RequestParser } from "@fluidframework/runtime-utils";
 import { v4 as uuid } from "uuid";
 import { ComponentContext, LocalComponentContext, RemotedComponentContext } from "./componentContext";
 import { ComponentHandleContext } from "./componentHandleContext";
@@ -1716,12 +1717,10 @@ implements IContainerRuntime, IContainerRuntimeDirtyable, IRuntime, ISummarizerR
             case ContainerMessageType.Attach:
                 this.submit(type, content, localOpMetadata);
                 break;
-            default:
-                unreachableCase(type);
-                break;
             case ContainerMessageType.ChunkedOp:
-                unreachableCase(type as never);
-                break;
+                throw new Error(`Unsupported ContainerMessageType ${ContainerMessageType.ChunkedOp}`);
+            default:
+                unreachableCase(type, `Unknown ContainerMessageType: ${type}`);
         }
     }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1718,7 +1718,7 @@ implements IContainerRuntime, IContainerRuntimeDirtyable, IRuntime, ISummarizerR
                 this.submit(type, content, localOpMetadata);
                 break;
             case ContainerMessageType.ChunkedOp:
-                throw new Error(`Unsupported ContainerMessageType ${ContainerMessageType.ChunkedOp}`);
+                throw new Error(`chunkedOp not expected here`);
             default:
                 unreachableCase(type, `Unknown ContainerMessageType: ${type}`);
         }

--- a/packages/runtime/runtime-utils/src/utils.ts
+++ b/packages/runtime/runtime-utils/src/utils.ts
@@ -7,7 +7,3 @@ import { ISerializedHandle } from "@fluidframework/component-core-interfaces";
 
 export const isSerializedHandle = (value: any): value is ISerializedHandle =>
     value?.type === "__fluid_handle__";
-
-export function unreachableCase(value: never): never {
-    throw new Error(`Unreachable Case: Type of ${value} is never`);
-}


### PR DESCRIPTION
I moved `unreachableCase` to `common-utils` and bumped the dependency version, now I'm updating usages to use that one.