### PR TITLE
Add new APIs to create components.

### DIFF
--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -4,7 +4,9 @@
  */
 
 import {
-    IComponent, IFluidObject,
+    IComponent,
+    IFluidObject,
+    IComponentRouter,
 } from "@fluidframework/component-core-interfaces";
 import {
     IAudience,
@@ -103,6 +105,18 @@ export interface IContainerRuntime extends
         pkg: string[],
         realizationFn?: (context: IComponentContext) => void,
     ): Promise<IComponentRuntimeChannel>;
+
+    /**
+     * Creates root data store in container. Such store is automatically bound to container, and thus is
+     * attached to storage when/if container is attached to storage. Such stores are never garbage collected
+     * and can be found / loaded by name.
+     * Majority of data stores in container should not be roots, and should be reachable (directly or indirectly)
+     * through one of the roots.
+     * @param pkg - Package name of the data store factory
+     * @param rootDataStoreId - data store ID. IDs naming space is global in container. If collision on name occurs,
+     * it results in container corruption - loading this file after that will always result in error.
+     */
+    createRootDataStore(pkg: string | string[], rootDataStoreId: string): Promise<IComponentRouter>;
 
     /**
      * Returns the current quorum.

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -9,6 +9,7 @@ import { AgentSchedulerFactory } from "@fluidframework/agent-scheduler";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import {
     IComponent,
+    IComponentRouter,
     IComponentHandleContext,
     IComponentSerializer,
     IRequest,
@@ -1145,6 +1146,17 @@ implements IContainerRuntime, IContainerRuntimeDirtyable, IRuntime, ISummarizerR
         const id = maybePkg === undefined ? uuid() : idOrPkg;
         const pkg = maybePkg === undefined ? idOrPkg : maybePkg;
         return this._createComponentWithProps(pkg, undefined, id);
+    }
+
+    public async _createComponent(pkg: string | string[]): Promise<IComponentRouter> {
+        return this._createComponentContext(Array.isArray(pkg) ? pkg : [pkg]).realize();
+    }
+
+    public async createRootComponent(pkg: string | string[], rootComponentId: string): Promise<IComponentRouter> {
+        const context = this._createComponentContext(Array.isArray(pkg) ? pkg : [pkg], rootComponentId);
+        const component = await context.realize();
+        component.bindToContext();
+        return component;
     }
 
     public async _createComponentWithProps(pkg: string | string[], props?: any, id?: string):

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1148,12 +1148,12 @@ implements IContainerRuntime, IContainerRuntimeDirtyable, IRuntime, ISummarizerR
         return this._createComponentWithProps(pkg, undefined, id);
     }
 
-    public async _createComponent(pkg: string | string[]): Promise<IComponentRouter> {
+    public async createDataStore(pkg: string | string[]): Promise<IComponentRouter> {
         return this._createComponentContext(Array.isArray(pkg) ? pkg : [pkg]).realize();
     }
 
-    public async createRootComponent(pkg: string | string[], rootComponentId: string): Promise<IComponentRouter> {
-        const context = this._createComponentContext(Array.isArray(pkg) ? pkg : [pkg], rootComponentId);
+    public async createRootDataStore(pkg: string | string[], rootDataStoreId: string): Promise<IComponentRouter> {
+        const context = this._createComponentContext(Array.isArray(pkg) ? pkg : [pkg], rootDataStoreId);
         const component = await context.realize();
         component.bindToContext();
         return component;

--- a/packages/runtime/runtime-definitions/src/componentContext.ts
+++ b/packages/runtime/runtime-definitions/src/componentContext.ts
@@ -119,24 +119,13 @@ export interface IContainerRuntimeBase extends
     createComponent(pkgOrId: string, pkg?: string | string[]): Promise<IComponentRuntimeChannel>;
 
     /**
-     * Creates component. Returned component is not bound to container. Component in such state is not
-     * persisted to storage (file). Storing a handle to this component (or any of its parts, like DDS) into
-     * already attached DDS (or non-attached DDS that will eventually gets attached to storage) will result
-     * in this component being attached to storage.
-     * @param pkg - Package name of the component
+     * Creates data store. Returns router of data store. Data store is not bound to container,
+     * store in such state is not persisted to storage (file). Storing a handle to this store
+     * (or any of its parts, like DDS) into already attached DDS (or non-attached DDS that will eventually
+     * gets attached to storage) will result in this store being attached to storage.
+     * @param pkg - Package name of the data store factory
      */
-    _createComponent(pkg: string | string[]): Promise<IComponentRouter>;
-    /**
-     * Creates root component in container. Such component is automatically bound to container, and thus is
-     * attached to storage when/if container is attached to storage. Such components are never garbage collected
-     * and can be found / loaded by name.
-     * Majority of components in container should not be roots, and should be reachable (directly or indirectly)
-     * through one of the roots.
-     * @param pkg - Package name of the component
-     * @param rootComponentId - component ID. IDs naming space is global in container. If collision on name occurs,
-     * it results in container corruption - loading this file after that will always result in error.
-     */
-    createRootComponent(pkg: string | string[], rootComponentId: string): Promise<IComponentRouter>;
+    createDataStore(pkg: string | string[]): Promise<IComponentRouter>;
 
     /**
      * Get an absolute url for a provided container-relative request.

--- a/packages/runtime/runtime-definitions/src/componentContext.ts
+++ b/packages/runtime/runtime-definitions/src/componentContext.ts
@@ -119,6 +119,26 @@ export interface IContainerRuntimeBase extends
     createComponent(pkgOrId: string, pkg?: string | string[]): Promise<IComponentRuntimeChannel>;
 
     /**
+     * Creates component. Returned component is not bound to container. Component in such state is not
+     * persisted to storage (file). Storing a handle to this component (or any of its parts, like DDS) into
+     * already attached DDS (or non-attached DDS that will eventually gets attached to storage) will result
+     * in this component being attached to storage.
+     * @param pkg - Package name of the component
+     */
+    _createComponent(pkg: string | string[]): Promise<IComponentRouter>;
+    /**
+     * Creates root component in container. Such component is automatically bound to container, and thus is
+     * attached to storage when/if container is attached to storage. Such components are never garbage collected
+     * and can be found / loaded by name.
+     * Majority of components in container should not be roots, and should be reachable (directly or indirectly)
+     * through one of the roots.
+     * @param pkg - Package name of the component
+     * @param rootComponentId - component ID. IDs naming space is global in container. If collision on name occurs,
+     * it results in container corruption - loading this file after that will always result in error.
+     */
+    createRootComponent(pkg: string | string[], rootComponentId: string): Promise<IComponentRouter>;
+
+    /**
      * Get an absolute url for a provided container-relative request.
      * Returns undefined if the container or component isn't attached to storage.
      * @param relativeUrl - A relative request within the container


### PR DESCRIPTION
All existing APIs will eventually consolidate around these APIs.
This change is primarily here to "seed" backward compatibility train.
Note that in the future I expect us to re-access "root" part of the question.
Also _createComponent() will eventually be renamed not to have underscore, but it will take many releases (due to existing name conflict).