### PR TITLE
Remove from Fluid Debugger ability to run from ops.

### DIFF
--- a/packages/drivers/debugger/src/fluidDebugger.ts
+++ b/packages/drivers/debugger/src/fluidDebugger.ts
@@ -11,7 +11,7 @@ import { DebuggerUI } from "./fluidDebuggerUi";
 export namespace FluidDebugger {
     /**
      * Creates document service wrapper that pops up Debugger window and allows user to play ops one by one.
-     * User can chose to start with any snapshot, or no snapshot.
+     * User can chose to start with any snapshot
      * If pop-ups are disabled, we continue without debugger.
      * @param documentService - original document service to use to fetch ops / snapshots.
      */

--- a/packages/drivers/debugger/src/fluidDebuggerController.ts
+++ b/packages/drivers/debugger/src/fluidDebuggerController.ts
@@ -16,7 +16,6 @@ import {
 import {
     FileSnapshotReader,
     IFileSnapshot,
-    OpStorage,
     ReadDocumentStorageServiceBase,
     ReplayController,
     SnapshotStorage,
@@ -84,12 +83,7 @@ export class DebugReplayController extends ReplayController implements IDebugger
         this.startSeqDeferred.resolve(DebugReplayController.WindowClosedSeq);
     }
 
-    public async onVersionSelection(version?: IVersion) {
-        if (version === undefined) {
-            this.resolveStorage(0, new OpStorage());
-            return;
-        }
-
+    public async onVersionSelection(version: IVersion) {
         if (!this.documentStorageService) {
             throw new Error("onVersionSelection: no storage");
         }
@@ -189,7 +183,7 @@ export class DebugReplayController extends ReplayController implements IDebugger
         assert(!this.documentStorageService);
         this.documentStorageService = documentStorageService;
 
-        // User can chose "no snapshot" or "file" at any moment in time!
+        // User can chose "file" at any moment in time!
         if (!this.isSelectionMade()) {
             this.versions = await documentStorageService.getVersions("", 50);
             if (!this.isSelectionMade()) {
@@ -197,15 +191,6 @@ export class DebugReplayController extends ReplayController implements IDebugger
                 this.ui.updateVersionText(this.versionCount);
             }
         }
-
-        /* Short circuit for when we have no versions
-        we do not want to use it to leave ability for user to close window and use real storage.
-        if (!this.isSelectionMade() && this.versions.length === 0) {
-            this.text1.textContent = "";
-            this.resolveStorage(0, new OpStorage());
-            return true;
-        }
-        */
 
         this.versionCount = this.versions.length;
 
@@ -315,7 +300,7 @@ export class DebugReplayController extends ReplayController implements IDebugger
     protected resolveStorage(
         seq: number,
         storage: ReadDocumentStorageServiceBase,
-        version?: IVersion | string) {
+        version: IVersion | string) {
         assert(!this.isSelectionMade());
         assert(storage);
         this.storage = storage;

--- a/packages/drivers/debugger/src/fluidDebuggerUi.ts
+++ b/packages/drivers/debugger/src/fluidDebuggerUi.ts
@@ -28,7 +28,7 @@ export interface IDebuggerUI {
      * if file does not exist, has wrong name of wrong format.
      * @param version - version, file name, or undefined if playing ops.
      */
-    versionSelected(seqNumber: number, version?: IVersion | string): void;
+    versionSelected(seqNumber: number, version: IVersion | string): void;
 
     /**
      * Called by controller in response to new ops being downloaded
@@ -65,7 +65,7 @@ export interface IDebuggerController {
 
     /**
      * Called by UI layer when debugger window is closed by user
-     * If called before user makes selection of snapshot/file/no snapshot, original
+     * If called before user makes selection of snapshot/file, original
      * document service is returned to loader (instead of debugger service) and normal document load continues.
      */
     onClose(): void;
@@ -75,7 +75,7 @@ export interface IDebuggerController {
      * On successful load, versionSelected() is called.
      * @param version - Version, undefined (playing ops)
      */
-    onVersionSelection(version?: IVersion): void;
+    onVersionSelection(version: IVersion): void;
 
     /**
      * UI Layer notifies about selection of version to continue.
@@ -98,7 +98,6 @@ const debuggerWindowHtml =
 Please select snapshot or file to start with<br/>
 Close debugger window to proceed to live document<br/><br/>
 <select style='width:250px' id='selector'>
-<option>No snapshot</option>
 </select>
 &nbsp; &nbsp; &nbsp;
 <button id='buttonVers' style='width:60px'>Go</button><br/>
@@ -186,7 +185,7 @@ export class DebuggerUI {
         buttonVers.onclick = () => {
             // Accounting for "no snapshots"
             const index = this.selector!.selectedIndex;
-            controller.onVersionSelection(index === 0 ? undefined : this.versions[index - 1]);
+            controller.onVersionSelection(this.versions[index]);
         };
 
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
@@ -219,18 +218,15 @@ export class DebuggerUI {
 
     public updateVersion(index: number, version: IVersion, seqNumber: number) {
         if (this.selector) {
-            const option = this.selector[index + 1] as HTMLOptionElement;
+            const option = this.selector[index] as HTMLOptionElement;
             option.text = `${option.text},  seq = ${seqNumber}`;
-            // Accounting for "no snapshots"
-            this.selector[index + 1] = option;
+            this.selector[index] = option;
         }
     }
 
-    public versionSelected(seqNumber: number, version?: IVersion | string) {
+    public versionSelected(seqNumber: number, version: IVersion | string) {
         let text: string;
-        if (version === undefined) {
-            text = "Playing from seq# 0";
-        } else if (typeof version === "string") {
+        if (typeof version === "string") {
             text = `Playing ${version} file`;
         } else {
             text = `Playing from ${version.id}, seq# ${seqNumber}`;

--- a/packages/drivers/debugger/src/fluidDebuggerUi.ts
+++ b/packages/drivers/debugger/src/fluidDebuggerUi.ts
@@ -183,7 +183,6 @@ export class DebuggerUI {
         this.versionText = doc.getElementById("versionText") as HTMLDivElement;
 
         buttonVers.onclick = () => {
-            // Accounting for "no snapshots"
             const index = this.selector!.selectedIndex;
             controller.onVersionSelection(this.versions[index]);
         };


### PR DESCRIPTION
This option no longer works given Detached container flow.