### PR TITLE
0.24: Use explicit return type to fix package

### DIFF
--- a/packages/hosts/base-host/src/host.ts
+++ b/packages/hosts/base-host/src/host.ts
@@ -9,7 +9,7 @@ import {
     IProxyLoaderFactory,
     IFluidModule,
 } from "@fluidframework/container-definitions";
-import { Loader } from "@fluidframework/container-loader";
+import { Loader, Container } from "@fluidframework/container-loader";
 import { WebCodeLoader } from "@fluidframework/web-code-loader";
 import { IBaseHostConfig } from "./hostConfig";
 import { initializeContainerCode } from "./initializeContainerCode";
@@ -67,7 +67,7 @@ export class BaseHost {
         return this.loaderP;
     }
 
-    public async initializeContainer(url: string, codeDetails?: IFluidCodeDetails) {
+    public async initializeContainer(url: string, codeDetails?: IFluidCodeDetails): Promise<Container> {
         const loader = await this.getLoader();
         const container = await loader.resolve({ url });
 


### PR DESCRIPTION
The generated package is using a local path, rather than a package path for the implicit return type. Hoping making the return type explicit will fix the issue.

From host.d.ts in the package:
`initializeContainer(url: string, codeDetails?: IFluidCodeDetails): Promise<import("../../../loader/container-loader/dist").Container>;`

It should be:
`initializeContainer(url: string, codeDetails?: IFluidCodeDetails): Promise<import("@fluidframework/container-loader").Container>;`