### PR TITLE
Get rid of _createDataStore

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,11 +1,22 @@
 # Breaking changes
 
 ## 0.25 Breaking Changes
-- [Removed IComponentRuntime._createDataStoreWithProps](#Removed-IComponentRuntime._createDataStoreWithProps)
+- [IComponentContextLegacy is removed](#IComponentContextLegacy-is-removed)
+- [IComponentRuntime._createDataStoreWithProps() is removed](#IComponentRuntime._createDataStoreWithProps-is-removed)
+- [_createDataStore() APIs are removed](#_createDataStore-APIs-are-removed)
 
-### Removed IComponentRuntime._createDataStoreWithProps
+### IComponentContextLegacy is removed
+Deprecated in 0.18, removed. 
+
+### IComponentRuntime._createDataStoreWithProps is removed
 `IComponentRuntime._createDataStoreWithProps()` has been removed. Please use `IComponentRuntime.createDataStore()` if possible (returns IFluidRouter). Otherwise use `IComponentRuntime._createDataStore()`, which is identical to `_createDataStoreWithProps()` other than props argument that has been deprecated for many versions.
 If you need to pass props to data store, either use request() route to pass initial props directly, or to query fluid object to interact with it (pass props / call methods to configure object).
+
+### _createDataStore APIs are removed
+`IFluidDataStoreContext._createDataStore()` & `IContainerRuntimeBase._createDataStore()` are removed
+Please switch to using one of the following APIs:
+1. `IContainerRuntime.createRootDataStore()` - data store created that way is automatically bound to container. It will immediately be visible to remote clients (when/if container is attached). Such data stores are never garbage collected. Note that this API is on `IContainerRuntime` interface, which is not directly accessible to data stores. The intention is that only container owners are creating roots.
+2. `IContainerRuntimeBase.createDataStore()` - creates data store that is not bound to container. In order for this store to be bound to container (and thus be observable on remote clients), ensure that handle to it (or any of its objects / DDS) is stored into any other DDS that is already bound to container. In other words, newly created data store has to be reachable (there has to be a path) from some root data store in container. If, in future, such data store becomes unreachable from one of the roots, it will be garbage collected (implementation pending).
 
 ## 0.24 Breaking Changes
 This release only contains renames. There are no functional changes in this release. You should ensure you have integrated and validated up to release 0.23 before integrating this release.

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -2,14 +2,14 @@
 
 ## 0.25 Breaking Changes
 - [IComponentContextLegacy is removed](#IComponentContextLegacy-is-removed)
-- [IComponentRuntime._createDataStoreWithProps() is removed](#IComponentRuntime._createDataStoreWithProps-is-removed)
+- [IContainerRuntimeBase._createDataStoreWithProps() is removed](#IContainerRuntimeBase._createDataStoreWithProps-is-removed)
 - [_createDataStore() APIs are removed](#_createDataStore-APIs-are-removed)
 
 ### IComponentContextLegacy is removed
 Deprecated in 0.18, removed. 
 
-### IComponentRuntime._createDataStoreWithProps is removed
-`IComponentRuntime._createDataStoreWithProps()` has been removed. Please use `IComponentRuntime.createDataStore()` if possible (returns IFluidRouter). Otherwise use `IComponentRuntime._createDataStore()`, which is identical to `_createDataStoreWithProps()` other than props argument that has been deprecated for many versions.
+### IContainerRuntimeBase._createDataStoreWithProps is removed
+`IContainerRuntimeBase._createDataStoreWithProps()` has been removed. Please use `IContainerRuntimeBase.createDataStore()` (returns IFluidRouter).
 If you need to pass props to data store, either use request() route to pass initial props directly, or to query fluid object to interact with it (pass props / call methods to configure object).
 
 ### _createDataStore APIs are removed

--- a/components/examples/pond/src/index.tsx
+++ b/components/examples/pond/src/index.tsx
@@ -42,10 +42,10 @@ export class Pond extends DataObject implements IFluidHTMLView {
    * Do setup work here
    */
     protected async initializingFirstTime() {
-        const clickerComponent = await Clicker.getFactory()._createDataStore(this.context);
+        const clickerComponent = await Clicker.getFactory().createInstance(this.context);
         this.root.set(Clicker.ComponentName, clickerComponent.handle);
 
-        const clickerComponentUsingProvider = await ExampleUsingProviders.getFactory()._createDataStore(this.context);
+        const clickerComponentUsingProvider = await ExampleUsingProviders.getFactory().createInstance(this.context);
         this.root.set(ExampleUsingProviders.ComponentName, clickerComponentUsingProvider.handle);
     }
 

--- a/components/examples/pond/src/providers/userInfo.ts
+++ b/components/examples/pond/src/providers/userInfo.ts
@@ -8,6 +8,7 @@ import { EventEmitter } from "events";
 import {
     IFluidHandleContext,
     IFluidSerializer,
+    IFluidRouter,
 } from "@fluidframework/component-core-interfaces";
 import { IQuorum } from "@fluidframework/protocol-definitions";
 import { DependencyContainer } from "@fluidframework/synthesize";
@@ -72,6 +73,7 @@ export const userInfoFactory = async (dc: DependencyContainer) => {
         IFluidHandleContext,
         IFluidSerializer,
         IFluidDataStoreRegistry,
+        IFluidRouter,
     }, {});
     const containerRuntime = await s.IContainerRuntime;
     if (containerRuntime !== undefined) {

--- a/components/examples/simple-component-embed/src/index.tsx
+++ b/components/examples/simple-component-embed/src/index.tsx
@@ -24,7 +24,7 @@ export class SimpleComponentEmbed extends DataObject implements IFluidHTMLView {
    * but in this scenario we only want it to be created once.
    */
     protected async initializingFirstTime() {
-        const component = await this.createAndAttachDataStore(ClickerInstantiationFactory.type);
+        const component = await this.createFluidObject(ClickerInstantiationFactory.type);
         this.root.set("myEmbeddedCounter", component.handle);
     }
 

--- a/components/experimental/client-ui-lib/package.json
+++ b/components/experimental/client-ui-lib/package.json
@@ -59,6 +59,7 @@
     "@fluidframework/merge-tree": "^0.25.0",
     "@fluidframework/protocol-definitions": "^0.1010.0",
     "@fluidframework/runtime-definitions": "^0.25.0",
+    "@fluidframework/runtime-utils": "^0.25.0",
     "@fluidframework/sequence": "^0.25.0",
     "@fluidframework/undo-redo": "^0.25.0",
     "@fluidframework/view-adapters": "^0.25.0",

--- a/components/experimental/codemirror/src/codemirror.ts
+++ b/components/experimental/codemirror/src/codemirror.ts
@@ -155,7 +155,7 @@ class CodemirrorView implements IFluidHTMLView {
             this.updatingSequence = true;
 
             // eslint-disable-next-line max-len
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const doc = this.codeMirror!.getDoc();
             for (const range of ev.ranges) {
                 const segment = range.segment;

--- a/components/experimental/codemirror/src/index.ts
+++ b/components/experimental/codemirror/src/index.ts
@@ -50,11 +50,7 @@ class CodeMirrorFactory implements IRuntimeFactory {
 
         // On first boot create the base component
         if (!runtime.existing) {
-            await Promise.all([
-                runtime._createDataStore(defaultComponentId, defaultComponent).then((componentRuntime) => {
-                    componentRuntime.bindToContext();
-                }),
-            ]);
+            await runtime.createRootDataStore(defaultComponent, defaultComponentId);
         }
 
         return runtime;

--- a/components/experimental/external-component-loader/src/waterPark.tsx
+++ b/components/experimental/external-component-loader/src/waterPark.tsx
@@ -133,9 +133,9 @@ export class WaterPark extends DataObject implements IFluidHTMLView {
     }
 
     protected async initializingFirstTime() {
-        const storage = await this.createAndAttachDataStore(SpacesStorage.ComponentName);
+        const storage = await this.createFluidObject(SpacesStorage.ComponentName);
         this.root.set(storageKey, storage.handle);
-        const loader = await this.createAndAttachDataStore(ExternalComponentLoader.ComponentName);
+        const loader = await this.createFluidObject(ExternalComponentLoader.ComponentName);
         this.root.set(loaderKey, loader.handle);
     }
 

--- a/components/experimental/key-value-cache/src/index.ts
+++ b/components/experimental/key-value-cache/src/index.ts
@@ -161,8 +161,7 @@ export class KeyValueFactoryComponent implements IRuntimeFactory, IFluidDataStor
         );
 
         if (!runtime.existing) {
-            const created = await runtime._createDataStore(ComponentName, ComponentName);
-            created.bindToContext();
+            await runtime.createRootDataStore(ComponentName, ComponentName);
         }
 
         return runtime;

--- a/components/experimental/multiview/constellation-model/src/model.ts
+++ b/components/experimental/multiview/constellation-model/src/model.ts
@@ -63,7 +63,7 @@ export class Constellation extends DataObject implements IConstellation {
 
     public async addStar(x: number, y: number): Promise<void> {
         const starHandles = this.root.get<IFluidHandle<ICoordinate>[]>(starListKey);
-        const newStar: Coordinate = (await Coordinate.getFactory()._createDataStore(this.context)) as Coordinate;
+        const newStar: Coordinate = (await Coordinate.getFactory().createInstance(this.context)) as Coordinate;
         newStar.x = x;
         newStar.y = y;
         starHandles.push(newStar.handle);

--- a/components/experimental/multiview/container/src/container.tsx
+++ b/components/experimental/multiview/container/src/container.tsx
@@ -5,7 +5,7 @@
 
 import { BaseContainerRuntimeFactory, mountableViewRequestHandler } from "@fluidframework/aqueduct";
 import { RuntimeRequestHandler } from "@fluidframework/request-handler";
-import { RequestParser } from "@fluidframework/runtime-utils";
+import { RequestParser, requestFluidObject } from "@fluidframework/runtime-utils";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { MountableView } from "@fluidframework/view-adapters";
 import { Constellation } from "@fluid-example/multiview-constellation-model";
@@ -33,13 +33,8 @@ const registryEntries = new Map([
 // Just a little helper, since we're going to create multiple coordinates.
 const createAndAttachCoordinate = async (runtime: IContainerRuntime, id: string) => {
     const simpleCoordinateComponentRuntime =
-        await runtime._createDataStore(id, Coordinate.ComponentName);
-    const simpleResult = await simpleCoordinateComponentRuntime.request({ url: id });
-    if (simpleResult.status !== 200 || simpleResult.mimeType !== "fluid/object") {
-        throw new Error("Error in creating the coordinate model.");
-    }
-    simpleCoordinateComponentRuntime.bindToContext();
-    return simpleResult.value as ICoordinate;
+        await runtime.createRootDataStore(Coordinate.ComponentName, id);
+    return requestFluidObject<ICoordinate>(simpleCoordinateComponentRuntime, id);
 };
 
 // Just a little helper, since we're going to request multiple coordinates.
@@ -116,14 +111,9 @@ export class CoordinateContainerRuntimeFactory extends BaseContainerRuntimeFacto
         triangleCoordinate3.y = 60;
 
         // Create the constellation component
-        const constellationComponentRuntime =
-            await runtime._createDataStore(constellationComponentId, Constellation.ComponentName);
-        const constellationResult = await constellationComponentRuntime.request({ url: constellationComponentId });
-        if (constellationResult.status !== 200 || constellationResult.mimeType !== "fluid/object") {
-            throw new Error("Error in creating the constellation model.");
-        }
-        constellationComponentRuntime.bindToContext();
-        const constellationComponent = constellationResult.value as Constellation;
+        const constellationComponent = await requestFluidObject<Constellation>(
+            await runtime.createRootDataStore(Constellation.ComponentName, constellationComponentId),
+            constellationComponentId); // FOLLOW UP: This looks wrong, it should be empty string or slash
 
         // Add a few stars
         await constellationComponent.addStar(86, 74);

--- a/components/experimental/prosemirror/src/index.ts
+++ b/components/experimental/prosemirror/src/index.ts
@@ -50,11 +50,7 @@ class ProseMirrorFactory implements IRuntimeFactory {
 
         // On first boot create the base component
         if (!runtime.existing) {
-            await Promise.all([
-                runtime._createDataStore(defaultComponentId, defaultComponent).then((componentRuntime) => {
-                    componentRuntime.bindToContext();
-                }),
-            ]);
+            await runtime.createRootDataStore(defaultComponent, defaultComponentId);
         }
 
         return runtime;

--- a/components/experimental/scribe/src/scribe.ts
+++ b/components/experimental/scribe/src/scribe.ts
@@ -486,11 +486,7 @@ class ScribeFactory implements IFluidDataStoreFactory, IRuntimeFactory {
 
         // On first boot create the base component
         if (!runtime.existing) {
-            await Promise.all([
-                runtime._createDataStore(defaultComponentId, ScribeFactory.type).then((componentRuntime) => {
-                    componentRuntime.bindToContext();
-                }),
-            ]);
+            await runtime.createRootDataStore(ScribeFactory.type, defaultComponentId);
         }
 
         return runtime;

--- a/components/experimental/shared-text/src/index.ts
+++ b/components/experimental/shared-text/src/index.ts
@@ -137,10 +137,7 @@ class SharedTextFactoryComponent implements IFluidDataStoreFactory, IRuntimeFact
 
         // On first boot create the base component
         if (!runtime.existing) {
-            await Promise.all([
-                runtime._createDataStore(DefaultComponentName, SharedTextFactoryComponent.type)
-                    .then((componentRuntime) => componentRuntime.bindToContext()),
-            ]);
+            await runtime.createRootDataStore(SharedTextFactoryComponent.type, DefaultComponentName);
         }
 
         return runtime;

--- a/components/experimental/smde/src/index.ts
+++ b/components/experimental/smde/src/index.ts
@@ -49,11 +49,7 @@ class SmdeContainerFactory implements IRuntimeFactory {
 
         // On first boot create the base component
         if (!runtime.existing) {
-            await Promise.all([
-                runtime._createDataStore(defaultComponentId, defaultComponent).then((componentRuntime) => {
-                    componentRuntime.bindToContext();
-                }),
-            ]);
+            await runtime.createRootDataStore(defaultComponentId, defaultComponent);
         }
 
         return runtime;

--- a/components/experimental/spaces/src/spaces.tsx
+++ b/components/experimental/spaces/src/spaces.tsx
@@ -127,7 +127,7 @@ export class Spaces extends DataObject implements IFluidHTMLView {
 
     protected async initializingFirstTime() {
         const storageComponent =
-            await this.createAndAttachDataStore<SpacesStorage<ISpacesItem>>(SpacesStorage.ComponentName);
+            await this.createFluidObject<SpacesStorage<ISpacesItem>>(SpacesStorage.ComponentName);
         this.root.set(SpacesStorageKey, storageComponent.handle);
         // Set the saved template if there is a template query param
         const urlParams = new URLSearchParams(window.location.search);
@@ -184,8 +184,8 @@ export class Spaces extends DataObject implements IFluidHTMLView {
             throw new Error("Unknown item, can't add");
         }
 
-        // Don't really want to hand out createAndAttachDataStore here, see spacesItemMap.ts for more info.
-        const serializableObject = await itemMapEntry.create(this.createAndAttachDataStore.bind(this));
+        // Don't really want to hand out createFluidObject here, see spacesItemMap.ts for more info.
+        const serializableObject = await itemMapEntry.create(this.createFluidObject.bind(this));
         return this.storageComponent.addItem(
             {
                 serializableObject,

--- a/components/experimental/spaces/src/spacesItemMap.ts
+++ b/components/experimental/spaces/src/spacesItemMap.ts
@@ -25,8 +25,8 @@ interface ISingleHandleItem {
 }
 
 const createSingleHandleItem = (type: string) => {
-    return async (createAndAttachDataStore: ICreateAndAttachComponentFunction): Promise<ISingleHandleItem> => {
-        const component = await createAndAttachDataStore(type);
+    return async (createFluidObject: ICreateAndAttachComponentFunction): Promise<ISingleHandleItem> => {
+        const component = await createFluidObject(type);
         return {
             handle: component.handle,
         };
@@ -51,7 +51,7 @@ const getSliderCoordinateView = async (serializableObject: ISingleHandleItem) =>
 export interface ISpacesItemEntry<T extends Serializable = AsSerializable<any>> {
     // Would be better if items to bring their own subregistries, and their own ability to create components
     // This might be done by integrating these items with the Spaces subcomponent registry?
-    create: (createAndAttachDataStore: ICreateAndAttachComponentFunction) => Promise<T>;
+    create: (createFluidObject: ICreateAndAttachComponentFunction) => Promise<T>;
     getView: (serializableObject: T) => Promise<JSX.Element>;
     friendlyName: string;
     fabricIconName: string;

--- a/components/experimental/table-document/src/document.ts
+++ b/components/experimental/table-document/src/document.ts
@@ -76,7 +76,7 @@ export class TableDocument extends DataObject<{}, {}, ITableDocumentEvents> impl
         minCol: number,
         maxRow: number,
         maxCol: number): Promise<ITable> {
-        const component = await TableSlice.getFactory()._createDataStore(
+        const component = await TableSlice.getFactory().createInstance(
             this.context,
             { docId: this.runtime.id, name, minRow, minCol, maxRow, maxCol },
         ) as TableSlice;

--- a/components/experimental/table-view/src/tableview.ts
+++ b/components/experimental/table-view/src/tableview.ts
@@ -92,7 +92,7 @@ export class TableView extends DataObject implements IFluidHTMLView {
 
     protected async initializingFirstTime() {
         // Set up internal table doc
-        const doc = await TableDocument.getFactory()._createDataStore(this.context) as TableDocument;
+        const doc = await TableDocument.getFactory().createInstance(this.context) as TableDocument;
         this.root.set(innerDocKey, doc.handle);
         doc.insertRows(0, 5);
         doc.insertCols(0, 8);

--- a/components/experimental/todo/src/Todo/Todo.tsx
+++ b/components/experimental/todo/src/Todo/Todo.tsx
@@ -82,7 +82,7 @@ export class Todo extends DataObject implements IFluidHTMLView {
 
     public async addTodoItemComponent(props?: ITodoItemInitialState) {
         // Create a new todo item
-        const component = await TodoItem.getFactory()._createDataStore(this.context, props);
+        const component = await TodoItem.getFactory().createInstance(this.context, props);
 
         // Store the id of the component in our ids map so we can reference it later
         this.todoItemsMap.set(component.url, component.handle);

--- a/components/experimental/todo/src/TodoItem/TodoItem.tsx
+++ b/components/experimental/todo/src/TodoItem/TodoItem.tsx
@@ -173,19 +173,19 @@ export class TodoItem extends DataObject<{}, ITodoItemInitialState> implements I
         let component: IFluidLoadable;
         switch (type) {
             case "todo":
-                component = await TodoItem.getFactory()._createDataStore(
+                component = await TodoItem.getFactory().createInstance(
                     this.context,
                     { startingText: type },
                 );
                 break;
             case "clicker":
-                component = await ClickerInstantiationFactory._createDataStore(this.context);
+                component = await ClickerInstantiationFactory.createInstance(this.context);
                 break;
             case "textBox":
-                component = await TextBoxInstantiationFactory._createDataStore(this.context, type);
+                component = await TextBoxInstantiationFactory.createInstance(this.context, type);
                 break;
             case "textList":
-                component = await TextListInstantiationFactory._createDataStore(this.context);
+                component = await TextListInstantiationFactory.createInstance(this.context);
                 break;
             default:
         }

--- a/components/experimental/vltava/src/components/anchor/anchor.ts
+++ b/components/experimental/vltava/src/components/anchor/anchor.ts
@@ -48,10 +48,10 @@ export class Anchor extends DataObject implements IProvideFluidHTMLView, IProvid
     }
 
     protected async initializingFirstTime() {
-        const defaultComponent = await this.createAndAttachDataStore("vltava");
+        const defaultComponent = await this.createFluidObject("vltava");
         this.root.set(this.defaultComponentId, defaultComponent.handle);
 
-        const lastEditedComponent = await this.createAndAttachDataStore(LastEditedTrackerComponentName);
+        const lastEditedComponent = await this.createFluidObject(LastEditedTrackerComponentName);
         this.root.set(this.lastEditedComponentId, lastEditedComponent.handle);
     }
 

--- a/components/experimental/vltava/src/components/tabs/dataModel.ts
+++ b/components/experimental/vltava/src/components/tabs/dataModel.ts
@@ -43,7 +43,7 @@ export class TabsDataModel extends EventEmitter implements ITabsDataModel {
     constructor(
         public root: ISharedDirectory,
         private readonly internalRegistry: IComponentInternalRegistry,
-        private readonly createAndAttachDataStore: <T extends IFluidObject & IFluidLoadable>
+        private readonly createFluidObject: <T extends IFluidObject & IFluidLoadable>
             (pkg: string) => Promise<T>,
         private readonly getFluidObjectFromDirectory: <T extends IFluidObject & IFluidLoadable>(
             id: string,
@@ -75,7 +75,7 @@ export class TabsDataModel extends EventEmitter implements ITabsDataModel {
 
     public async createTab(type: string): Promise<string> {
         const newKey = uuid();
-        const component = await this.createAndAttachDataStore<IFluidObject & IFluidLoadable>(type);
+        const component = await this.createFluidObject<IFluidObject & IFluidLoadable>(type);
         this.tabs.set(newKey, {
             type,
             handleOrId: component.handle,

--- a/components/experimental/vltava/src/components/tabs/tabs.tsx
+++ b/components/experimental/vltava/src/components/tabs/tabs.tsx
@@ -47,7 +47,7 @@ export class TabsComponent extends DataObject implements IFluidHTMLView {
             new TabsDataModel(
                 this.root,
                 registryDetails,
-                this.createAndAttachDataStore.bind(this),
+                this.createFluidObject.bind(this),
                 this.getFluidObjectFromDirectory.bind(this),
             );
     }

--- a/components/experimental/vltava/src/components/vltava/vltava.tsx
+++ b/components/experimental/vltava/src/components/vltava/vltava.tsx
@@ -37,7 +37,7 @@ export class Vltava extends DataObject implements IFluidHTMLView {
     public get IFluidHTMLView() { return this; }
 
     protected async initializingFirstTime() {
-        const tabsComponent = await this.createAndAttachDataStore("tabs");
+        const tabsComponent = await this.createFluidObject("tabs");
         this.root.set("tabs-component-id", tabsComponent.handle);
     }
 

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -589,60 +589,60 @@
 			}
 		},
 		"@fluidframework/agent-scheduler": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/agent-scheduler/-/agent-scheduler-0.24.0.tgz",
-			"integrity": "sha1-9HsEo5rBW8hsGU4FXYrn4XVpuKs=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/agent-scheduler/-/agent-scheduler-0.24.1.tgz",
+			"integrity": "sha1-xyXalZXlzhPrhht52TaW/tBuuxQ=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/component-runtime": "^0.24.0",
-				"@fluidframework/component-runtime-definitions": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.24.0",
-				"@fluidframework/map": "^0.24.0",
-				"@fluidframework/register-collection": "^0.24.0",
-				"@fluidframework/runtime-definitions": "^0.24.0",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/component-runtime": "^0.24.1",
+				"@fluidframework/component-runtime-definitions": "^0.24.1",
+				"@fluidframework/container-definitions": "^0.24.1",
+				"@fluidframework/map": "^0.24.1",
+				"@fluidframework/register-collection": "^0.24.1",
+				"@fluidframework/runtime-definitions": "^0.24.1",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/aqueduct/-/aqueduct-0.24.0.tgz",
-			"integrity": "sha1-Uo1NrqHX86hKZogPMBY/UoVXTgk=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/aqueduct/-/aqueduct-0.24.1.tgz",
+			"integrity": "sha1-UFHwpEA0sDnljm+CCqR2YfP1kTw=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.21.0",
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/component-runtime": "^0.24.0",
-				"@fluidframework/component-runtime-definitions": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.24.0",
-				"@fluidframework/container-runtime": "^0.24.0",
-				"@fluidframework/container-runtime-definitions": "^0.24.0",
-				"@fluidframework/framework-interfaces": "^0.24.0",
-				"@fluidframework/map": "^0.24.0",
-				"@fluidframework/request-handler": "^0.24.0",
-				"@fluidframework/runtime-definitions": "^0.24.0",
-				"@fluidframework/runtime-utils": "^0.24.0",
-				"@fluidframework/synthesize": "^0.24.0",
-				"@fluidframework/view-adapters": "^0.24.0",
-				"@fluidframework/view-interfaces": "^0.24.0",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/component-runtime": "^0.24.1",
+				"@fluidframework/component-runtime-definitions": "^0.24.1",
+				"@fluidframework/container-definitions": "^0.24.1",
+				"@fluidframework/container-runtime": "^0.24.1",
+				"@fluidframework/container-runtime-definitions": "^0.24.1",
+				"@fluidframework/framework-interfaces": "^0.24.1",
+				"@fluidframework/map": "^0.24.1",
+				"@fluidframework/request-handler": "^0.24.1",
+				"@fluidframework/runtime-definitions": "^0.24.1",
+				"@fluidframework/runtime-utils": "^0.24.1",
+				"@fluidframework/synthesize": "^0.24.1",
+				"@fluidframework/view-adapters": "^0.24.1",
+				"@fluidframework/view-interfaces": "^0.24.1",
 				"uuid": "^3.3.2"
 			}
 		},
 		"@fluidframework/base-host": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/base-host/-/base-host-0.24.0.tgz",
-			"integrity": "sha1-uShUmZYeFzHrZcYn7WifF0efA3A=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/base-host/-/base-host-0.24.1.tgz",
+			"integrity": "sha1-qyvdyUa5ZCnTwtZ3/KJEslWDwLE=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.21.0",
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.24.0",
-				"@fluidframework/container-loader": "^0.24.0",
-				"@fluidframework/driver-definitions": "^0.24.0",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/container-definitions": "^0.24.1",
+				"@fluidframework/container-loader": "^0.24.1",
+				"@fluidframework/driver-definitions": "^0.24.1",
 				"@fluidframework/protocol-base": "^0.1010.0",
 				"@fluidframework/protocol-definitions": "^0.1010.0",
-				"@fluidframework/telemetry-utils": "^0.24.0",
-				"@fluidframework/web-code-loader": "^0.24.0"
+				"@fluidframework/telemetry-utils": "^0.24.1",
+				"@fluidframework/web-code-loader": "^0.24.1"
 			}
 		},
 		"@fluidframework/build-common": {
@@ -703,72 +703,72 @@
 			}
 		},
 		"@fluidframework/component-core-interfaces": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/component-core-interfaces/-/component-core-interfaces-0.24.0.tgz",
-			"integrity": "sha1-HvcTWGP/8JPUSxF3BsX9Meg+39w="
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/component-core-interfaces/-/component-core-interfaces-0.24.1.tgz",
+			"integrity": "sha1-bjQ0k/CG0NOxe6GgveTCn1Dat3w="
 		},
 		"@fluidframework/component-runtime": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/component-runtime/-/component-runtime-0.24.0.tgz",
-			"integrity": "sha1-w8sFTTpETQiIAZCiYwGhjCyoSok=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/component-runtime/-/component-runtime-0.24.1.tgz",
+			"integrity": "sha1-0bONI/lYg1Ooq+J0rVpwKOFayEM=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.21.0",
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/component-runtime-definitions": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.24.0",
-				"@fluidframework/container-utils": "^0.24.0",
-				"@fluidframework/driver-definitions": "^0.24.0",
-				"@fluidframework/driver-utils": "^0.24.0",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/component-runtime-definitions": "^0.24.1",
+				"@fluidframework/container-definitions": "^0.24.1",
+				"@fluidframework/container-utils": "^0.24.1",
+				"@fluidframework/driver-definitions": "^0.24.1",
+				"@fluidframework/driver-utils": "^0.24.1",
 				"@fluidframework/protocol-base": "^0.1010.0",
 				"@fluidframework/protocol-definitions": "^0.1010.0",
-				"@fluidframework/runtime-definitions": "^0.24.0",
-				"@fluidframework/runtime-utils": "^0.24.0",
-				"@fluidframework/telemetry-utils": "^0.24.0",
+				"@fluidframework/runtime-definitions": "^0.24.1",
+				"@fluidframework/runtime-utils": "^0.24.1",
+				"@fluidframework/telemetry-utils": "^0.24.1",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
 			}
 		},
 		"@fluidframework/component-runtime-definitions": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/component-runtime-definitions/-/component-runtime-definitions-0.24.0.tgz",
-			"integrity": "sha1-qSdGfmInAxgjWlNcqd8JLGD8QOc=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/component-runtime-definitions/-/component-runtime-definitions-0.24.1.tgz",
+			"integrity": "sha1-5d1tyDu6aRMtRvrdTfaQ1kaccWQ=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.24.0",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/container-definitions": "^0.24.1",
 				"@fluidframework/protocol-definitions": "^0.1010.0",
-				"@fluidframework/runtime-definitions": "^0.24.0",
+				"@fluidframework/runtime-definitions": "^0.24.1",
 				"@types/node": "^10.17.24"
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-definitions/-/container-definitions-0.24.0.tgz",
-			"integrity": "sha1-ki6KgUuXZvy+fbTXP01tYcj4tCY=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-definitions/-/container-definitions-0.24.1.tgz",
+			"integrity": "sha1-CVVNm07A6C3jIKgmTEM4j6Q8+00=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/driver-definitions": "^0.24.0",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/driver-definitions": "^0.24.1",
 				"@fluidframework/protocol-definitions": "^0.1010.0"
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-loader/-/container-loader-0.24.0.tgz",
-			"integrity": "sha1-E2dcwmfXkkO52n0H5096NSbvltI=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-loader/-/container-loader-0.24.1.tgz",
+			"integrity": "sha1-vzTnk7TdCRJ5hvjKeLLF/68r4TY=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.21.0",
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.24.0",
-				"@fluidframework/container-utils": "^0.24.0",
-				"@fluidframework/driver-definitions": "^0.24.0",
-				"@fluidframework/driver-utils": "^0.24.0",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/container-definitions": "^0.24.1",
+				"@fluidframework/container-utils": "^0.24.1",
+				"@fluidframework/driver-definitions": "^0.24.1",
+				"@fluidframework/driver-utils": "^0.24.1",
 				"@fluidframework/protocol-base": "^0.1010.0",
 				"@fluidframework/protocol-definitions": "^0.1010.0",
-				"@fluidframework/telemetry-utils": "^0.24.0",
+				"@fluidframework/telemetry-utils": "^0.24.1",
 				"@types/double-ended-queue": "^2.1.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -779,25 +779,25 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-runtime/-/container-runtime-0.24.0.tgz",
-			"integrity": "sha1-BxgvFmNXP1pua8Mho0fOMRMExAI=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-runtime/-/container-runtime-0.24.1.tgz",
+			"integrity": "sha1-XkyF4woa3NbpVTlvEAOoSu6vz5k=",
 			"requires": {
-				"@fluidframework/agent-scheduler": "^0.24.0",
+				"@fluidframework/agent-scheduler": "^0.24.1",
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.21.0",
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/component-runtime": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.24.0",
-				"@fluidframework/container-runtime-definitions": "^0.24.0",
-				"@fluidframework/container-utils": "^0.24.0",
-				"@fluidframework/driver-definitions": "^0.24.0",
-				"@fluidframework/driver-utils": "^0.24.0",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/component-runtime": "^0.24.1",
+				"@fluidframework/container-definitions": "^0.24.1",
+				"@fluidframework/container-runtime-definitions": "^0.24.1",
+				"@fluidframework/container-utils": "^0.24.1",
+				"@fluidframework/driver-definitions": "^0.24.1",
+				"@fluidframework/driver-utils": "^0.24.1",
 				"@fluidframework/protocol-base": "^0.1010.0",
 				"@fluidframework/protocol-definitions": "^0.1010.0",
-				"@fluidframework/runtime-definitions": "^0.24.0",
-				"@fluidframework/runtime-utils": "^0.24.0",
-				"@fluidframework/telemetry-utils": "^0.24.0",
+				"@fluidframework/runtime-definitions": "^0.24.1",
+				"@fluidframework/runtime-utils": "^0.24.1",
+				"@fluidframework/telemetry-utils": "^0.24.1",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/node": "^10.17.24",
@@ -809,37 +809,37 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.24.0.tgz",
-			"integrity": "sha1-GX1QIui71io7QyFj7Uuts4ZMS+Y=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.24.1.tgz",
+			"integrity": "sha1-RM2U0EC6lstrrARmg4yCZBDw69k=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.24.0",
-				"@fluidframework/driver-definitions": "^0.24.0",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/container-definitions": "^0.24.1",
+				"@fluidframework/driver-definitions": "^0.24.1",
 				"@fluidframework/protocol-definitions": "^0.1010.0",
-				"@fluidframework/runtime-definitions": "^0.24.0",
+				"@fluidframework/runtime-definitions": "^0.24.1",
 				"@types/node": "^10.17.24"
 			}
 		},
 		"@fluidframework/container-utils": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-utils/-/container-utils-0.24.0.tgz",
-			"integrity": "sha1-3gQuMCsCAMUVE3uWe8qA8tbiY1U=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-utils/-/container-utils-0.24.1.tgz",
+			"integrity": "sha1-Y7BbCpuzPi7VUBN0FikzexR5nto=",
 			"requires": {
-				"@fluidframework/container-definitions": "^0.24.0",
-				"@fluidframework/telemetry-utils": "^0.24.0",
+				"@fluidframework/container-definitions": "^0.24.1",
+				"@fluidframework/telemetry-utils": "^0.24.1",
 				"performance-now": "^2.1.0",
 				"uuid": "^3.3.2"
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-base/-/driver-base-0.24.0.tgz",
-			"integrity": "sha1-/DJr5RgTZIh9nN6jBeHSVgmU+ds=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-base/-/driver-base-0.24.1.tgz",
+			"integrity": "sha1-oIZwC5G4dQyV0/4jDqkgtVW2mrY=",
 			"requires": {
 				"@fluidframework/common-utils": "^0.21.0",
-				"@fluidframework/driver-definitions": "^0.24.0",
-				"@fluidframework/driver-utils": "^0.24.0",
+				"@fluidframework/driver-definitions": "^0.24.1",
+				"@fluidframework/driver-utils": "^0.24.1",
 				"@fluidframework/protocol-definitions": "^0.1010.0",
 				"@types/debug": "^4.1.5",
 				"@types/node": "^10.17.24",
@@ -848,29 +848,29 @@
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-definitions/-/driver-definitions-0.24.0.tgz",
-			"integrity": "sha1-U/U8FgIWTwroXTA2SGUWHfogDkw=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-definitions/-/driver-definitions-0.24.1.tgz",
+			"integrity": "sha1-SmW/EijpnzpPdyQQwIbYk/b1onY=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
-				"@fluidframework/component-core-interfaces": "^0.24.0",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
 				"@fluidframework/protocol-definitions": "^0.1010.0",
 				"buffer": "^5.6.0"
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-utils/-/driver-utils-0.24.0.tgz",
-			"integrity": "sha1-BwuKSa2shYOeqhTg4nZqyh++fd4=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-utils/-/driver-utils-0.24.1.tgz",
+			"integrity": "sha1-cWuEkFDyeOnZX5h+J/2UB1XCgPQ=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.21.0",
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/driver-definitions": "^0.24.0",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/driver-definitions": "^0.24.1",
 				"@fluidframework/gitresources": "^0.1010.0",
 				"@fluidframework/protocol-base": "^0.1010.0",
 				"@fluidframework/protocol-definitions": "^0.1010.0",
-				"@fluidframework/telemetry-utils": "^0.24.0"
+				"@fluidframework/telemetry-utils": "^0.24.1"
 			}
 		},
 		"@fluidframework/eslint-config-fluid": {
@@ -891,11 +891,11 @@
 			}
 		},
 		"@fluidframework/framework-interfaces": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/framework-interfaces/-/framework-interfaces-0.24.0.tgz",
-			"integrity": "sha1-OEXQIcIJDYRg8qu+DcHK6ViqhvA=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/framework-interfaces/-/framework-interfaces-0.24.1.tgz",
+			"integrity": "sha1-ut5oZgQVcenzLvDM5Sz5SCACeFM=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.24.0"
+				"@fluidframework/component-core-interfaces": "^0.24.1"
 			}
 		},
 		"@fluidframework/gitresources": {
@@ -904,17 +904,17 @@
 			"integrity": "sha1-k5NFaWWqvLbSgl2dkz09fguAWfA="
 		},
 		"@fluidframework/local-driver": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/local-driver/-/local-driver-0.24.0.tgz",
-			"integrity": "sha1-e6SA4Nj0AlfnelI5gg5hI4COqwU=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/local-driver/-/local-driver-0.24.1.tgz",
+			"integrity": "sha1-I5mhMFmC1H5PBFjPcaL8ay4ktPA=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.21.0",
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/driver-definitions": "^0.24.0",
-				"@fluidframework/driver-utils": "^0.24.0",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/driver-definitions": "^0.24.1",
+				"@fluidframework/driver-utils": "^0.24.1",
 				"@fluidframework/protocol-definitions": "^0.1010.0",
-				"@fluidframework/routerlicious-driver": "^0.24.0",
+				"@fluidframework/routerlicious-driver": "^0.24.1",
 				"@fluidframework/server-local-server": "^0.1010.0",
 				"@fluidframework/server-services-client": "^0.1010.0",
 				"@fluidframework/server-services-core": "^0.1010.0",
@@ -924,18 +924,18 @@
 			}
 		},
 		"@fluidframework/map": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/map/-/map-0.24.0.tgz",
-			"integrity": "sha1-3Vu5dsuwHIn34HlVHmYiezr5ilM=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/map/-/map-0.24.1.tgz",
+			"integrity": "sha1-jW8Br2bmd4TAzCMTa4vE8RKxFog=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.21.0",
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/component-runtime-definitions": "^0.24.0",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/component-runtime-definitions": "^0.24.1",
 				"@fluidframework/protocol-base": "^0.1010.0",
 				"@fluidframework/protocol-definitions": "^0.1010.0",
-				"@fluidframework/runtime-utils": "^0.24.0",
-				"@fluidframework/shared-object-base": "^0.24.0",
+				"@fluidframework/runtime-utils": "^0.24.1",
+				"@fluidframework/shared-object-base": "^0.24.1",
 				"debug": "^4.1.1"
 			}
 		},
@@ -978,39 +978,39 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/register-collection/-/register-collection-0.24.0.tgz",
-			"integrity": "sha1-KVDe+AdborUvOkQrbJ2/uUTMIqs=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/register-collection/-/register-collection-0.24.1.tgz",
+			"integrity": "sha1-YjxkRHgt3v4sodNw53wZxVt01Gw=",
 			"requires": {
 				"@fluidframework/common-utils": "^0.21.0",
-				"@fluidframework/component-runtime-definitions": "^0.24.0",
+				"@fluidframework/component-runtime-definitions": "^0.24.1",
 				"@fluidframework/protocol-definitions": "^0.1010.0",
-				"@fluidframework/runtime-utils": "^0.24.0",
-				"@fluidframework/shared-object-base": "^0.24.0",
+				"@fluidframework/runtime-utils": "^0.24.1",
+				"@fluidframework/shared-object-base": "^0.24.1",
 				"debug": "^4.1.1"
 			}
 		},
 		"@fluidframework/request-handler": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/request-handler/-/request-handler-0.24.0.tgz",
-			"integrity": "sha1-6cp+F9x0RMndPdniMXLD2Cl4JLs=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/request-handler/-/request-handler-0.24.1.tgz",
+			"integrity": "sha1-TSDtpeaav7Uz2HlV2EdxRro8cVI=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/container-runtime-definitions": "^0.24.0",
-				"@fluidframework/runtime-definitions": "^0.24.0",
-				"@fluidframework/runtime-utils": "^0.24.0"
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/container-runtime-definitions": "^0.24.1",
+				"@fluidframework/runtime-definitions": "^0.24.1",
+				"@fluidframework/runtime-utils": "^0.24.1"
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.24.0.tgz",
-			"integrity": "sha1-qrAxtJwOeNiRzY0SbAvGQ6CGCRE=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.24.1.tgz",
+			"integrity": "sha1-hGMaLm8BsLU2JLkN5rmUWL/jzaw=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.21.0",
-				"@fluidframework/driver-base": "^0.24.0",
-				"@fluidframework/driver-definitions": "^0.24.0",
-				"@fluidframework/driver-utils": "^0.24.0",
+				"@fluidframework/driver-base": "^0.24.1",
+				"@fluidframework/driver-definitions": "^0.24.1",
+				"@fluidframework/driver-utils": "^0.24.1",
 				"@fluidframework/gitresources": "^0.1010.0",
 				"@fluidframework/protocol-base": "^0.1010.0",
 				"@fluidframework/protocol-definitions": "^0.1010.0",
@@ -1024,27 +1024,27 @@
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/runtime-definitions/-/runtime-definitions-0.24.0.tgz",
-			"integrity": "sha1-eHsa/a9fozUI4qp3hsYesVvrZI0=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/runtime-definitions/-/runtime-definitions-0.24.1.tgz",
+			"integrity": "sha1-Ox5GsmGmyRupSePGzKZMUMPlsgA=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.24.0",
-				"@fluidframework/driver-definitions": "^0.24.0",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/container-definitions": "^0.24.1",
+				"@fluidframework/driver-definitions": "^0.24.1",
 				"@fluidframework/protocol-definitions": "^0.1010.0",
 				"@types/node": "^10.17.24"
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/runtime-utils/-/runtime-utils-0.24.0.tgz",
-			"integrity": "sha1-HQtefGPElR2OF4bkhSU2qE1othM=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/runtime-utils/-/runtime-utils-0.24.1.tgz",
+			"integrity": "sha1-VqoiQ5G0axDL1Zo/kVgpw2jO3Kw=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/component-runtime-definitions": "^0.24.0",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/component-runtime-definitions": "^0.24.1",
 				"@fluidframework/protocol-definitions": "^0.1010.0",
-				"@fluidframework/runtime-definitions": "^0.24.0"
+				"@fluidframework/runtime-definitions": "^0.24.1"
 			}
 		},
 		"@fluidframework/server-lambdas": {
@@ -1165,19 +1165,19 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/shared-object-base/-/shared-object-base-0.24.0.tgz",
-			"integrity": "sha1-n3EOVY83/jsl4qB2ITautzgQQuI=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/shared-object-base/-/shared-object-base-0.24.1.tgz",
+			"integrity": "sha1-T11JKerFdrALOc9cShKVFSfqZGE=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.21.0",
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/component-runtime": "^0.24.0",
-				"@fluidframework/component-runtime-definitions": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.24.0",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/component-runtime": "^0.24.1",
+				"@fluidframework/component-runtime-definitions": "^0.24.1",
+				"@fluidframework/container-definitions": "^0.24.1",
 				"@fluidframework/protocol-definitions": "^0.1010.0",
-				"@fluidframework/runtime-utils": "^0.24.0",
-				"@fluidframework/telemetry-utils": "^0.24.0",
+				"@fluidframework/runtime-utils": "^0.24.1",
+				"@fluidframework/telemetry-utils": "^0.24.1",
 				"@types/debug": "^4.1.5",
 				"@types/node": "^10.17.24",
 				"debug": "^4.1.1",
@@ -1185,17 +1185,17 @@
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/synthesize/-/synthesize-0.24.0.tgz",
-			"integrity": "sha1-HSFKYpAv12VL/8rLCbbM2hnupn8=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/synthesize/-/synthesize-0.24.1.tgz",
+			"integrity": "sha1-G2x4pfnpuKGjwQvXvoH1v/zTN1k=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.24.0"
+				"@fluidframework/component-core-interfaces": "^0.24.1"
 			}
 		},
 		"@fluidframework/telemetry-utils": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/telemetry-utils/-/telemetry-utils-0.24.0.tgz",
-			"integrity": "sha1-TKG6ClZj6rjg1m4QUJHGONeYYKU=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/telemetry-utils/-/telemetry-utils-0.24.1.tgz",
+			"integrity": "sha1-vr+hsrKdUbLQP9gjchwR3Pfchp4=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.21.0",
@@ -1211,30 +1211,30 @@
 			"dev": true
 		},
 		"@fluidframework/view-adapters": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/view-adapters/-/view-adapters-0.24.0.tgz",
-			"integrity": "sha1-UR4LwzoCzGu88R4eT3ZPl+9K3ms=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/view-adapters/-/view-adapters-0.24.1.tgz",
+			"integrity": "sha1-MJ5tlRgRktNh7Cum9KbAx4lZWC0=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/view-interfaces": "^0.24.0",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/view-interfaces": "^0.24.1",
 				"react": "^16.10.2",
 				"react-dom": "^16.10.2"
 			}
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/view-interfaces/-/view-interfaces-0.24.0.tgz",
-			"integrity": "sha1-NG+RvDlYfuGN19fGFvznqOqHXlY=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/view-interfaces/-/view-interfaces-0.24.1.tgz",
+			"integrity": "sha1-teYeeec4Z3j/A5BNgucBqVD+SNQ=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.24.0"
+				"@fluidframework/component-core-interfaces": "^0.24.1"
 			}
 		},
 		"@fluidframework/web-code-loader": {
-			"version": "0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/web-code-loader/-/web-code-loader-0.24.0.tgz",
-			"integrity": "sha1-v5aQlQmr8yqOin4trBUSwtSUahc=",
+			"version": "0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/web-code-loader/-/web-code-loader-0.24.1.tgz",
+			"integrity": "sha1-nPThP7c/+bf8OpSFSDiFaKBmVhg=",
 			"requires": {
-				"@fluidframework/container-definitions": "^0.24.0",
+				"@fluidframework/container-definitions": "^0.24.1",
 				"@types/node": "^10.17.24",
 				"isomorphic-fetch": "^2.2.1"
 			}
@@ -15427,55 +15427,55 @@
 			}
 		},
 		"old-aqueduct": {
-			"version": "npm:@fluidframework/aqueduct@0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/aqueduct/-/aqueduct-0.24.0.tgz",
-			"integrity": "sha1-Uo1NrqHX86hKZogPMBY/UoVXTgk=",
+			"version": "npm:@fluidframework/aqueduct@0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/aqueduct/-/aqueduct-0.24.1.tgz",
+			"integrity": "sha1-UFHwpEA0sDnljm+CCqR2YfP1kTw=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.21.0",
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/component-runtime": "^0.24.0",
-				"@fluidframework/component-runtime-definitions": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.24.0",
-				"@fluidframework/container-runtime": "^0.24.0",
-				"@fluidframework/container-runtime-definitions": "^0.24.0",
-				"@fluidframework/framework-interfaces": "^0.24.0",
-				"@fluidframework/map": "^0.24.0",
-				"@fluidframework/request-handler": "^0.24.0",
-				"@fluidframework/runtime-definitions": "^0.24.0",
-				"@fluidframework/runtime-utils": "^0.24.0",
-				"@fluidframework/synthesize": "^0.24.0",
-				"@fluidframework/view-adapters": "^0.24.0",
-				"@fluidframework/view-interfaces": "^0.24.0",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/component-runtime": "^0.24.1",
+				"@fluidframework/component-runtime-definitions": "^0.24.1",
+				"@fluidframework/container-definitions": "^0.24.1",
+				"@fluidframework/container-runtime": "^0.24.1",
+				"@fluidframework/container-runtime-definitions": "^0.24.1",
+				"@fluidframework/framework-interfaces": "^0.24.1",
+				"@fluidframework/map": "^0.24.1",
+				"@fluidframework/request-handler": "^0.24.1",
+				"@fluidframework/runtime-definitions": "^0.24.1",
+				"@fluidframework/runtime-utils": "^0.24.1",
+				"@fluidframework/synthesize": "^0.24.1",
+				"@fluidframework/view-adapters": "^0.24.1",
+				"@fluidframework/view-interfaces": "^0.24.1",
 				"uuid": "^3.3.2"
 			}
 		},
 		"old-container-definitions": {
-			"version": "npm:@fluidframework/container-definitions@0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-definitions/-/container-definitions-0.24.0.tgz",
-			"integrity": "sha1-ki6KgUuXZvy+fbTXP01tYcj4tCY=",
+			"version": "npm:@fluidframework/container-definitions@0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-definitions/-/container-definitions-0.24.1.tgz",
+			"integrity": "sha1-CVVNm07A6C3jIKgmTEM4j6Q8+00=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/driver-definitions": "^0.24.0",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/driver-definitions": "^0.24.1",
 				"@fluidframework/protocol-definitions": "^0.1010.0"
 			}
 		},
 		"old-container-loader": {
-			"version": "npm:@fluidframework/container-loader@0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-loader/-/container-loader-0.24.0.tgz",
-			"integrity": "sha1-E2dcwmfXkkO52n0H5096NSbvltI=",
+			"version": "npm:@fluidframework/container-loader@0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-loader/-/container-loader-0.24.1.tgz",
+			"integrity": "sha1-vzTnk7TdCRJ5hvjKeLLF/68r4TY=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.21.0",
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.24.0",
-				"@fluidframework/container-utils": "^0.24.0",
-				"@fluidframework/driver-definitions": "^0.24.0",
-				"@fluidframework/driver-utils": "^0.24.0",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/container-definitions": "^0.24.1",
+				"@fluidframework/container-utils": "^0.24.1",
+				"@fluidframework/driver-definitions": "^0.24.1",
+				"@fluidframework/driver-utils": "^0.24.1",
 				"@fluidframework/protocol-base": "^0.1010.0",
 				"@fluidframework/protocol-definitions": "^0.1010.0",
-				"@fluidframework/telemetry-utils": "^0.24.0",
+				"@fluidframework/telemetry-utils": "^0.24.1",
 				"@types/double-ended-queue": "^2.1.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -15486,25 +15486,25 @@
 			}
 		},
 		"old-container-runtime": {
-			"version": "npm:@fluidframework/container-runtime@0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-runtime/-/container-runtime-0.24.0.tgz",
-			"integrity": "sha1-BxgvFmNXP1pua8Mho0fOMRMExAI=",
+			"version": "npm:@fluidframework/container-runtime@0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-runtime/-/container-runtime-0.24.1.tgz",
+			"integrity": "sha1-XkyF4woa3NbpVTlvEAOoSu6vz5k=",
 			"requires": {
-				"@fluidframework/agent-scheduler": "^0.24.0",
+				"@fluidframework/agent-scheduler": "^0.24.1",
 				"@fluidframework/common-definitions": "^0.18.1",
 				"@fluidframework/common-utils": "^0.21.0",
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/component-runtime": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.24.0",
-				"@fluidframework/container-runtime-definitions": "^0.24.0",
-				"@fluidframework/container-utils": "^0.24.0",
-				"@fluidframework/driver-definitions": "^0.24.0",
-				"@fluidframework/driver-utils": "^0.24.0",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/component-runtime": "^0.24.1",
+				"@fluidframework/container-definitions": "^0.24.1",
+				"@fluidframework/container-runtime-definitions": "^0.24.1",
+				"@fluidframework/container-utils": "^0.24.1",
+				"@fluidframework/driver-definitions": "^0.24.1",
+				"@fluidframework/driver-utils": "^0.24.1",
 				"@fluidframework/protocol-base": "^0.1010.0",
 				"@fluidframework/protocol-definitions": "^0.1010.0",
-				"@fluidframework/runtime-definitions": "^0.24.0",
-				"@fluidframework/runtime-utils": "^0.24.0",
-				"@fluidframework/telemetry-utils": "^0.24.0",
+				"@fluidframework/runtime-definitions": "^0.24.1",
+				"@fluidframework/runtime-utils": "^0.24.1",
+				"@fluidframework/telemetry-utils": "^0.24.1",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/node": "^10.17.24",
@@ -15516,45 +15516,45 @@
 			}
 		},
 		"old-request-handler": {
-			"version": "npm:@fluidframework/request-handler@0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/request-handler/-/request-handler-0.24.0.tgz",
-			"integrity": "sha1-6cp+F9x0RMndPdniMXLD2Cl4JLs=",
+			"version": "npm:@fluidframework/request-handler@0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/request-handler/-/request-handler-0.24.1.tgz",
+			"integrity": "sha1-TSDtpeaav7Uz2HlV2EdxRro8cVI=",
 			"requires": {
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/container-runtime-definitions": "^0.24.0",
-				"@fluidframework/runtime-definitions": "^0.24.0",
-				"@fluidframework/runtime-utils": "^0.24.0"
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/container-runtime-definitions": "^0.24.1",
+				"@fluidframework/runtime-definitions": "^0.24.1",
+				"@fluidframework/runtime-utils": "^0.24.1"
 			}
 		},
 		"old-runtime-definitions": {
-			"version": "npm:@fluidframework/runtime-definitions@0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/runtime-definitions/-/runtime-definitions-0.24.0.tgz",
-			"integrity": "sha1-eHsa/a9fozUI4qp3hsYesVvrZI0=",
+			"version": "npm:@fluidframework/runtime-definitions@0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/runtime-definitions/-/runtime-definitions-0.24.1.tgz",
+			"integrity": "sha1-Ox5GsmGmyRupSePGzKZMUMPlsgA=",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.18.1",
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.24.0",
-				"@fluidframework/driver-definitions": "^0.24.0",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/container-definitions": "^0.24.1",
+				"@fluidframework/driver-definitions": "^0.24.1",
 				"@fluidframework/protocol-definitions": "^0.1010.0",
 				"@types/node": "^10.17.24"
 			}
 		},
 		"old-test-utils": {
-			"version": "npm:@fluidframework/test-utils@0.24.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/test-utils/-/test-utils-0.24.0.tgz",
-			"integrity": "sha1-KOMv/1n3RBJrhAHxSrXx8MbQImg=",
+			"version": "npm:@fluidframework/test-utils@0.24.1",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/test-utils/-/test-utils-0.24.1.tgz",
+			"integrity": "sha1-slKCC7w2cv/ga3fYOuieWLD7vsY=",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.24.0",
-				"@fluidframework/base-host": "^0.24.0",
-				"@fluidframework/component-core-interfaces": "^0.24.0",
-				"@fluidframework/component-runtime": "^0.24.0",
-				"@fluidframework/component-runtime-definitions": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.24.0",
-				"@fluidframework/container-loader": "^0.24.0",
-				"@fluidframework/local-driver": "^0.24.0",
-				"@fluidframework/map": "^0.24.0",
+				"@fluidframework/aqueduct": "^0.24.1",
+				"@fluidframework/base-host": "^0.24.1",
+				"@fluidframework/component-core-interfaces": "^0.24.1",
+				"@fluidframework/component-runtime": "^0.24.1",
+				"@fluidframework/component-runtime-definitions": "^0.24.1",
+				"@fluidframework/container-definitions": "^0.24.1",
+				"@fluidframework/container-loader": "^0.24.1",
+				"@fluidframework/local-driver": "^0.24.1",
+				"@fluidframework/map": "^0.24.1",
 				"@fluidframework/protocol-definitions": "^0.1010.0",
-				"@fluidframework/runtime-definitions": "^0.24.0",
+				"@fluidframework/runtime-definitions": "^0.24.1",
 				"@fluidframework/server-local-server": "^0.1010.0"
 			}
 		},

--- a/packages/framework/aqueduct/src/componentFactories/sharedComponentFactory.ts
+++ b/packages/framework/aqueduct/src/componentFactories/sharedComponentFactory.ts
@@ -134,7 +134,7 @@ export class PureDataObjectFactory<P extends IFluidObject, S = undefined> implem
     }
 
     /**
-     * Implementation of IFluidDataStoreFactory's _createDataStore method that also exposes an initial
+     * Implementation of IFluidDataStoreFactory's createInstance method that also exposes an initial
      * state argument.  Only specific factory instances are intended to take initial state.
      * @param context - The component context being used to create the component
      * (the created component will have its own new context created as well)
@@ -142,7 +142,7 @@ export class PureDataObjectFactory<P extends IFluidObject, S = undefined> implem
      * @returns A promise for a component that will have been initialized. Caller is responsible
      * for attaching the component to the provided runtime's container such as by storing its handle
      */
-    public async _createDataStore(
+    public async createInstance(
         context: IFluidDataStoreContext,
         initialState?: S,
     ): Promise<IFluidObject & IFluidLoadable> {

--- a/packages/framework/aqueduct/src/components/primedComponent.ts
+++ b/packages/framework/aqueduct/src/components/primedComponent.ts
@@ -13,6 +13,7 @@ import { ISharedDirectory, MapFactory, SharedDirectory } from "@fluidframework/m
 import { ITaskManager, SchedulerType } from "@fluidframework/runtime-definitions";
 import { v4 as uuid } from "uuid";
 import { IEvent } from "@fluidframework/common-definitions";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { BlobHandle } from "./blobHandle";
 import { PureDataObject } from "./sharedComponent";
 
@@ -97,13 +98,9 @@ export abstract class DataObject<P extends IFluidObject = object, S = undefined,
      */
     protected async initializeInternal(props?: any): Promise<void> {
         // Initialize task manager.
-        const request = {
-            headers: [[true]],
-            url: `/${SchedulerType}`,
-        };
-
-        this.internalTaskManager =
-            await this.asFluidObject<ITaskManager>(this.context.containerRuntime.request(request));
+        this.internalTaskManager = await requestFluidObject<ITaskManager>(
+            this.context.containerRuntime,
+            `/${SchedulerType}`);
 
         if (!this.runtime.existing) {
             // Create a root directory and register it before calling initializingFirstTime

--- a/packages/framework/aqueduct/src/containerRuntimeFactories/containerRuntimeFactoryWithDefaultComponent.ts
+++ b/packages/framework/aqueduct/src/containerRuntimeFactories/containerRuntimeFactoryWithDefaultComponent.ts
@@ -50,13 +50,12 @@ export class ContainerRuntimeFactoryWithDefaultDataStore extends BaseContainerRu
      * {@inheritDoc BaseContainerRuntimeFactory.containerInitializingFirstTime}
      */
     protected async containerInitializingFirstTime(runtime: IContainerRuntime) {
-        const componentRuntime = await runtime._createDataStore(
-            ContainerRuntimeFactoryWithDefaultDataStore.defaultComponentId,
+        const router = await runtime.createRootDataStore(
             this.defaultComponentName,
+            ContainerRuntimeFactoryWithDefaultDataStore.defaultComponentId,
         );
         // We need to request the component before attaching to ensure it
         // runs through its entire instantiation flow.
-        await componentRuntime.request({ url: "/" });
-        componentRuntime.bindToContext();
+        await router.request({ url: "/" });
     }
 }

--- a/packages/framework/component-base/src/runtimefactory.ts
+++ b/packages/framework/component-base/src/runtimefactory.ts
@@ -73,11 +73,7 @@ export class RuntimeFactory implements IRuntimeFactory {
 
         // On first boot create the base component
         if (!runtime.existing && this.defaultComponent.type) {
-            await runtime
-                ._createDataStore(defaultComponentId, this.defaultComponent.type)
-                .then((componentRuntime) => {
-                    componentRuntime.bindToContext();
-                });
+            await runtime.createRootDataStore(this.defaultComponent.type, defaultComponentId);
         }
 
         return runtime;

--- a/packages/runtime/client-api/src/api/codeLoader.ts
+++ b/packages/runtime/client-api/src/api/codeLoader.ts
@@ -24,7 +24,6 @@ import {
     IFluidDataStoreFactory,
     NamedFluidDataStoreRegistryEntries,
 } from "@fluidframework/runtime-definitions";
-import { CreateContainerError } from "@fluidframework/container-utils";
 import * as sequence from "@fluidframework/sequence";
 import { Document } from "./document";
 
@@ -133,13 +132,7 @@ export class ChaincodeFactory implements IRuntimeFactory {
 
         // On first boot create the base component
         if (!runtime.existing) {
-            runtime._createDataStore(rootMapId, "@fluid-internal/client-api")
-                .then((componentRuntime) => {
-                    componentRuntime.bindToContext();
-                })
-                .catch((error: any) => {
-                    context.closeFn(CreateContainerError(error));
-                });
+            await runtime.createRootDataStore("@fluid-internal/client-api", rootMapId);
         }
 
         return runtime;

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -40,13 +40,11 @@ import {
     IFluidDataStoreChannel,
     IAttachMessage,
     IFluidDataStoreContext,
-    IComponentContextLegacy,
     IFluidDataStoreFactory,
     IFluidDataStoreRegistry,
     IInboundSignalMessage,
 } from "@fluidframework/runtime-definitions";
 import { SummaryTracker } from "@fluidframework/runtime-utils";
-import { v4 as uuid } from "uuid";
 import { ContainerRuntime } from "./containerRuntime";
 
 // Snapshot Format Version to be used in component attributes.
@@ -77,7 +75,6 @@ interface ComponentMessage {
  */
 export abstract class FluidDataStoreContext extends EventEmitter implements
     IFluidDataStoreContext,
-    IComponentContextLegacy,
     IDisposable {
     public get documentId(): string {
         return this._containerRuntime.id;
@@ -205,25 +202,6 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
                     error);
             });
         }
-    }
-
-    /**
-     * @deprecated
-     * Remove once issue #1756 is closed
-     */
-    public async _createDataStore(
-        pkgOrId: string | undefined,
-        pkg?: string,
-    ): Promise<IFluidDataStoreChannel> {
-        // pkgOrId can't be undefined if pkg is undefined
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const pkgName = pkg ?? pkgOrId!;
-        assert(pkgName);
-        const id = pkg ? (pkgOrId ?? uuid()) : uuid();
-
-        const packagePath: string[] = await this.composeSubpackagePath(pkgName);
-
-        return this.containerRuntime._createDataStore(id, packagePath);
     }
 
     public async createDataStoreWithRealizationFn(
@@ -530,7 +508,7 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
      * @returns A list of packages to the subpackage destination if found,
      * otherwise the original subpackage
      */
-    protected async composeSubpackagePath(subpackage: string): Promise<string[]> {
+    public async composeSubpackagePath(subpackage: string): Promise<string[]> {
         const details = await this.getInitialSnapshotDetails();
         let packagePath: string[] = [...details.pkg];
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -429,6 +429,7 @@ export class ContainerRuntime extends EventEmitter
     implements IContainerRuntime, IContainerRuntimeDirtyable, IRuntime, ISummarizerRuntime {
     public get IContainerRuntime() { return this; }
     public get IContainerRuntimeDirtyable() { return this; }
+    public get IFluidRouter() { return this; }
 
     /**
      * Load the components from a snapshot and returns the runtime.
@@ -469,10 +470,7 @@ export class ContainerRuntime extends EventEmitter
 
         // Create all internal components in first load.
         if (!context.existing) {
-            await runtime._createDataStore(schedulerId, schedulerId)
-                .then((componentRuntime) => {
-                    componentRuntime.bindToContext();
-                });
+            await runtime.createRootDataStore(schedulerId, schedulerId);
         }
 
         runtime.subscribeToLeadership();
@@ -1137,16 +1135,6 @@ export class ContainerRuntime extends EventEmitter
                 this.setFlushMode(savedFlushMode);
             }
         }
-    }
-
-    /**
-     * @deprecated
-     * Remove once issue #1756 is closed
-     */
-    public async _createDataStore(idOrPkg: string, maybePkg: string | string[]) {
-        const id = maybePkg === undefined ? uuid() : idOrPkg;
-        const pkg = maybePkg === undefined ? idOrPkg : maybePkg;
-        return this._createComponentContext(Array.isArray(pkg) ? pkg : [pkg], id).realize();
     }
 
     public async createDataStore(pkg: string | string[]): Promise<IFluidRouter> {

--- a/packages/runtime/runtime-definitions/src/componentContext.ts
+++ b/packages/runtime/runtime-definitions/src/componentContext.ts
@@ -59,6 +59,7 @@ export interface IContainerRuntimeBase extends
     EventEmitter,
     IProvideFluidHandleContext,
     IProvideFluidSerializer,
+    IFluidRouter,
     /* TODO: Used by spaces. we should switch to IoC to provide the global registry */
     IProvideFluidDataStoreRegistry {
 
@@ -93,15 +94,6 @@ export interface IContainerRuntimeBase extends
     on(event: "op", listener: (message: ISequencedDocumentMessage) => void): this;
     on(event: "signal", listener: (message: IInboundSignalMessage, local: boolean) => void): this;
     on(event: "leader" | "notleader", listener: () => void): this;
-
-    /**
-     * @deprecated
-     * Creates a new component.
-     * @param pkgOrId - Package name if a second parameter is not provided. Otherwise an explicit ID.
-     * @param pkg - Package name of the component. Optional and only required if specifying an explicit ID.
-     * Remove once issue #1756 is closed
-     */
-    _createDataStore(pkgOrId: string, pkg?: string | string[]): Promise<IFluidDataStoreChannel>;
 
     /**
      * Creates data store. Returns router of data store. Data store is not bound to container,
@@ -302,20 +294,6 @@ export interface IFluidDataStoreContext extends EventEmitter {
     submitSignal(type: string, content: any): void;
 
     /**
-     * @deprecated 0.16 Issue #1537, issue #1756 Components
-     *      should be created using IFluidDataStoreFactory methods instead
-     * Creates a new component by using subregistries.
-     * @param pkgOrId - Package name if a second parameter is not provided. Otherwise an explicit ID.
-     *                  ID is being deprecated, so prefer passing undefined instead (the runtime will
-     *                  generate an ID in this case).
-     * @param pkg - Package name of the component. Optional and only required if specifying an explicit ID.
-     */
-    _createDataStore(
-        pkgOrId: string | undefined,
-        pkg?: string | string[],
-    ): Promise<IFluidDataStoreChannel>;
-
-    /**
      * Create a new component using subregistries with fallback.
      * @param pkg - Package name of the component
      * @param realizationFn - Optional function to call to realize the component over the context default
@@ -350,20 +328,13 @@ export interface IFluidDataStoreContext extends EventEmitter {
      * @param relativeUrl - A relative request within the container
      */
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
-}
 
-/**
- * Legacy API to be removed from IFluidDataStoreContext
- *
- * Moving out of the main interface to force compilation error.
- * But the implementation is still in place as a transition so user can case to
- * the legacy interface and use it temporary if changing their code take some time.
- */
-export interface IComponentContextLegacy extends IFluidDataStoreContext {
     /**
-     * @deprecated 0.18. Should call IFluidDataStoreChannel.request directly
-     * Make request to the component.
-     * @param request - Request.
+     * Take a package name and transform it into a path that can be used to find it
+     * from this context, such as by looking into subregistries
+     * @param subpackage - The subpackage to find in this context
+     * @returns A list of packages to the subpackage destination if found,
+     * otherwise the original subpackage
      */
-    request(request: IRequest): Promise<IResponse>;
+    composeSubpackagePath(subpackage: string): Promise<string[]>;
 }

--- a/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
+++ b/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
@@ -8,7 +8,7 @@ import assert from "assert";
     IFluidRouter,
 } from "@fluidframework/component-core-interfaces";
 
-export async function requestFluidObject<T extends IFluidObject = IFluidObject>(
+export async function requestFluidObject<T = IFluidObject>(
     router: IFluidRouter, url: string): Promise<T>
 {
     const request = await router.request({ url });

--- a/packages/test/end-to-end-tests/package.json
+++ b/packages/test/end-to-end-tests/package.json
@@ -81,6 +81,7 @@
     "@fluidframework/register-collection": "^0.25.0",
     "@fluidframework/request-handler": "^0.25.0",
     "@fluidframework/runtime-definitions": "^0.25.0",
+    "@fluidframework/runtime-utils": "^0.25.0",
     "@fluidframework/sequence": "^0.25.0",
     "@fluidframework/server-local-server": "^0.1010.0",
     "@fluidframework/shared-object-base": "^0.25.0",

--- a/packages/test/end-to-end-tests/src/test/compat.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/compat.spec.ts
@@ -80,9 +80,7 @@ describe("loader/runtime compatibility", () => {
                     runtimeOptions,
                 );
                 if (!runtime.existing) {
-                    const componentRuntime = await runtime._createDataStore("default", type);
-                    await componentRuntime.request({ url: "/" });
-                    componentRuntime.bindToContext();
+                    await runtime.createRootDataStore(type, "default");
                 }
                 return runtime;
             },

--- a/packages/test/end-to-end-tests/src/test/componentHandle.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/componentHandle.spec.ts
@@ -85,7 +85,7 @@ describe("FluidOjectHandle", () => {
         const firstContainer = await createContainer();
         firstContainerComponent1 = await requestFluidObject("default", firstContainer);
         firstContainerComponent2 =
-            await TestSharedComponentFactory._createDataStore(firstContainerComponent1._context) as TestSharedComponent;
+            await TestSharedComponentFactory.createInstance(firstContainerComponent1._context) as TestSharedComponent;
 
         const secondContainer = await createContainer();
         secondContainerComponent1 = await requestFluidObject("default", secondContainer);

--- a/packages/test/end-to-end-tests/src/test/localLoader.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/localLoader.spec.ts
@@ -117,7 +117,7 @@ describe("LocalLoader", () => {
         });
 
         it("opened", async () => {
-            assert(component instanceof TestComponent, "_createDataStore() must return the expected component type.");
+            assert(component instanceof TestComponent, "requestFluidObject() must return the expected component type.");
         });
 
         afterEach(async () => {

--- a/packages/test/test-utils/src/interfaces.ts
+++ b/packages/test/test-utils/src/interfaces.ts
@@ -6,6 +6,7 @@
 import { IFluidDataStoreRuntime } from "@fluidframework/component-runtime-definitions";
 import { ISharedMap } from "@fluidframework/map";
 import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
+import { IFluidLoadable } from "@fluidframework/component-core-interfaces";
 
 declare module "@fluidframework/component-core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -18,7 +19,7 @@ export interface IProvideTestFluidComponent {
     readonly ITestFluidComponent: ITestFluidComponent;
 }
 
-export interface ITestFluidComponent extends IProvideTestFluidComponent {
+export interface ITestFluidComponent extends IProvideTestFluidComponent, IFluidLoadable {
     root: ISharedMap;
     readonly runtime: IFluidDataStoreRuntime;
     readonly context: IFluidDataStoreContext;


### PR DESCRIPTION
API is deleted from IFluidDataStoreContext & IContainerRuntimeBase.

Also some renames:
PureDataObject.createAndAttachDataStore -> createFluidObject
PureDataObjectFactory._createDataStore -> createInstance
