### PR TITLE
removed FluidDataStoreContext.createdProps

### DIFF
--- a/packages/framework/aqueduct/src/components/sharedComponent.ts
+++ b/packages/framework/aqueduct/src/components/sharedComponent.ts
@@ -100,7 +100,7 @@ export abstract class PureDataObject<P extends IFluidObject = object, S = undefi
     public async initialize(initialState?: S): Promise<void> {
         // We want to ensure if this gets called more than once it only executes the initialize code once.
         if (!this.initializeP) {
-            this.initializeP = this.initializeInternal(this.context.createProps as S ?? initialState);
+            this.initializeP = this.initializeInternal(initialState);
         }
 
         await this.initializeP;

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -620,10 +620,6 @@ export class LocalFluidDataStoreContext extends FluidDataStoreContext {
         scope: IFluidObject & IFluidObject,
         summaryTracker: SummaryTracker,
         bindComponent: (componentRuntime: IFluidDataStoreChannel) => void,
-        /**
-         * @deprecated 0.16 Issue #1635 Use the IFluidDataStoreFactory creation methods instead to specify initial state
-         */
-        public readonly createProps?: any,
     ) {
         super(runtime, id, false, storage, scope, summaryTracker, BindState.NotBound, bindComponent, pkg);
         this.attachListeners();

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1165,7 +1165,7 @@ export class ContainerRuntime extends EventEmitter
             this.containerScope,
             this.summaryTracker.createOrGetChild(id, this.deltaManager.lastSequenceNumber),
             (cr: IFluidDataStoreChannel) => this.bindComponent(cr),
-            undefined);
+        );
 
         const deferred = new Deferred<FluidDataStoreContext>();
         this.contextsDeferred.set(id, deferred);
@@ -1191,7 +1191,7 @@ export class ContainerRuntime extends EventEmitter
             this.containerScope,
             this.summaryTracker.createOrGetChild(id, this.deltaManager.lastSequenceNumber),
             (cr: IFluidDataStoreChannel) => this.bindComponent(cr),
-            undefined /* #1635: Remove LocalFluidDataStoreContext createProps */);
+        );
 
         const deferred = new Deferred<FluidDataStoreContext>();
         this.contextsDeferred.set(id, deferred);

--- a/packages/runtime/runtime-definitions/src/componentContext.ts
+++ b/packages/runtime/runtime-definitions/src/componentContext.ts
@@ -259,11 +259,6 @@ export interface IFluidDataStoreContext extends EventEmitter {
     readonly snapshotFn: (message: string) => Promise<void>;
 
     /**
-     * @deprecated 0.16 Issue #1635 Use the IFluidDataStoreFactory creation methods instead to specify initial state
-     */
-    readonly createProps?: any;
-
-    /**
      * Ambient services provided with the context
      */
     readonly scope: IFluidObject & IFluidObject;


### PR DESCRIPTION
It is not used directly in Fluid Preview, and back compat is covered by earlier note of removal of _createDataStoreWithProps