### PR TITLE
Remove I prefix from odsp-utils type names

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -26,6 +26,7 @@ Temporarily exposed on IContainerRuntimeBase. The intent is to remove it altoget
 
 ### odsp-utils Changes
 To support additional authentication scenarios, the signature and/or name of a few auth-related functions was modified.
+Several type names were also changed to remove the I prefix since these types are data types, not interfaces to be implemented.
 
 ## 0.24 Breaking Changes
 This release only contains renames. There are no functional changes in this release. You should ensure you have integrated and validated up to release 0.23 before integrating this release.
@@ -170,7 +171,7 @@ All renames are 1-1, and global case senstive and whole word find replace for al
 ## 0.23 Breaking Changes
 - [Removed `collaborating` event on IComponentRuntime](#Removed-`collaborating`-event-on-IComponentRuntime)
 - [ISharedObjectFactory rename](#ISharedObjectFactory)
-- [odsp-utils - Minor renames and signature changes](#odsp-utils-Changes)
+- [LocalSessionStorageDbFactory moved to @fluidframework/local-driver](LocalSessionStorageDbFactory-moved-to-@fluidframework/local-driver)
 
 ### Removed `collaborating` event on IComponentRuntime
 Component Runtime no longer fires the collaborating event on attaching. Now it fires `attaching` event.
@@ -178,8 +179,8 @@ Component Runtime no longer fires the collaborating event on attaching. Now it f
 ### ISharedObjectFactory
 `ISharedObjectFactory` renamed to `IChannelFactory` and moved from `@fluidframework/shared-object-base` to `@fluidframework/component-runtime-definitions`
 
-### odsp-utils Changes
-
+### LocalSessionStorageDbFactory moved to @fluidframework/local-driver
+Previously, `LocalSessionStorageDbFactory` was part of the `@fluidframework/webpack-component-loader` package.  It has been moved to the `@fluidframework/local-driver` package.
 
 ## 0.22 Breaking Changes
 - [Deprecated `path` from `IComponentHandleContext`](#Deprecated-`path`-from-`IComponentHandleContext`)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -170,7 +170,7 @@ All renames are 1-1, and global case senstive and whole word find replace for al
 ## 0.23 Breaking Changes
 - [Removed `collaborating` event on IComponentRuntime](#Removed-`collaborating`-event-on-IComponentRuntime)
 - [ISharedObjectFactory rename](#ISharedObjectFactory)
-- [LocalSessionStorageDbFactory moved to @fluidframework/local-driver](LocalSessionStorageDbFactory-moved-to-@fluidframework/local-driver)
+- [odsp-utils - Minor renames and signature changes](#odsp-utils-Changes)
 
 ### Removed `collaborating` event on IComponentRuntime
 Component Runtime no longer fires the collaborating event on attaching. Now it fires `attaching` event.
@@ -178,8 +178,8 @@ Component Runtime no longer fires the collaborating event on attaching. Now it f
 ### ISharedObjectFactory
 `ISharedObjectFactory` renamed to `IChannelFactory` and moved from `@fluidframework/shared-object-base` to `@fluidframework/component-runtime-definitions`
 
-### LocalSessionStorageDbFactory moved to @fluidframework/local-driver
-Previously, `LocalSessionStorageDbFactory` was part of the `@fluidframework/webpack-component-loader` package.  It has been moved to the `@fluidframework/local-driver` package.
+### odsp-utils Changes
+
 
 ## 0.22 Breaking Changes
 - [Deprecated `path` from `IComponentHandleContext`](#Deprecated-`path`-from-`IComponentHandleContext`)

--- a/packages/tools/fetch-tool/src/fluidFetchInit.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchInit.ts
@@ -10,7 +10,7 @@ import { configurableUrlResolver } from "@fluidframework/driver-utils";
 import { FluidAppOdspUrlResolver } from "@fluidframework/fluidapp-odsp-urlresolver";
 import * as odsp from "@fluidframework/odsp-driver";
 import { OdspUrlResolver } from "@fluidframework/odsp-urlresolver";
-import { IClientConfig, IOdspAuthRequestInfo } from "@fluidframework/odsp-utils";
+import { OAuthClientConfig, OdspAuthRequestInfo } from "@fluidframework/odsp-utils";
 import * as r11s from "@fluidframework/routerlicious-driver";
 import { RouterliciousUrlResolver } from "@fluidframework/routerlicious-urlresolver";
 import { getMicrosoftConfiguration } from "@fluidframework/tool-utils";
@@ -32,7 +32,7 @@ export const fluidFetchWebNavigator = (url: string) => {
 async function initializeODSPCore(
     odspResolvedUrl: odsp.IOdspResolvedUrl,
     server: string,
-    clientConfig: IClientConfig,
+    clientConfig: OAuthClientConfig,
 ) {
     const { driveId, itemId } = odspResolvedUrl;
 
@@ -56,7 +56,7 @@ async function initializeODSPCore(
 
     const getStorageTokenStub = async (siteUrl: string, refresh: boolean) => {
         return resolveWrapper(
-            async (authRequestInfo: IOdspAuthRequestInfo) => {
+            async (authRequestInfo: OdspAuthRequestInfo) => {
                 if ((refresh || !authRequestInfo.accessToken) && authRequestInfo.refreshTokenFn) {
                     return authRequestInfo.refreshTokenFn();
                 }

--- a/packages/tools/fetch-tool/src/fluidFetchSharePoint.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchSharePoint.ts
@@ -6,10 +6,10 @@
 import {
     getChildrenByDriveItem,
     getDriveItemByServerRelativePath,
-    IClientConfig,
+    OAuthClientConfig,
     IOdspDriveItem,
     getOdspRefreshTokenFn,
-    IOdspAuthRequestInfo,
+    OdspAuthRequestInfo,
 } from "@fluidframework/odsp-utils";
 import {
     getMicrosoftConfiguration,
@@ -21,9 +21,9 @@ import { fluidFetchWebNavigator } from "./fluidFetchInit";
 import { getForceTokenReauth } from "./fluidFetchArgs";
 
 export async function resolveWrapper<T>(
-    callback: (authRequestInfo: IOdspAuthRequestInfo) => Promise<T>,
+    callback: (authRequestInfo: OdspAuthRequestInfo) => Promise<T>,
     server: string,
-    clientConfig: IClientConfig,
+    clientConfig: OAuthClientConfig,
     forceTokenReauth = false,
 ): Promise<T> {
     try {
@@ -64,7 +64,7 @@ export async function resolveWrapper<T>(
 export async function resolveDriveItemByServerRelativePath(
     server: string,
     serverRelativePath: string,
-    clientConfig: IClientConfig,
+    clientConfig: OAuthClientConfig,
 ) {
     return resolveWrapper<IOdspDriveItem>(
         // eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -80,7 +80,7 @@ export async function resolveDriveItemByServerRelativePath(
 async function resolveChildrenByDriveItem(
     server: string,
     folderDriveItem: IOdspDriveItem,
-    clientConfig: IClientConfig,
+    clientConfig: OAuthClientConfig,
 ) {
     return resolveWrapper<IOdspDriveItem[]>(
         // eslint-disable-next-line @typescript-eslint/promise-function-async

--- a/packages/tools/fetch-tool/src/fluidFetchSharePoint.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchSharePoint.ts
@@ -7,7 +7,7 @@ import {
     getChildrenByDriveItem,
     getDriveItemByServerRelativePath,
     OAuthClientConfig,
-    IOdspDriveItem,
+    OdspDriveItem,
     getOdspRefreshTokenFn,
     OdspAuthRequestInfo,
 } from "@fluidframework/odsp-utils";
@@ -66,7 +66,7 @@ export async function resolveDriveItemByServerRelativePath(
     serverRelativePath: string,
     clientConfig: OAuthClientConfig,
 ) {
-    return resolveWrapper<IOdspDriveItem>(
+    return resolveWrapper<OdspDriveItem>(
         // eslint-disable-next-line @typescript-eslint/promise-function-async
         (authRequestInfo) => getDriveItemByServerRelativePath(
             server,
@@ -79,10 +79,10 @@ export async function resolveDriveItemByServerRelativePath(
 
 async function resolveChildrenByDriveItem(
     server: string,
-    folderDriveItem: IOdspDriveItem,
+    folderDriveItem: OdspDriveItem,
     clientConfig: OAuthClientConfig,
 ) {
-    return resolveWrapper<IOdspDriveItem[]>(
+    return resolveWrapper<OdspDriveItem[]>(
         // eslint-disable-next-line @typescript-eslint/promise-function-async
         (authRequestInfo) => getChildrenByDriveItem(folderDriveItem, server, authRequestInfo),
         server, clientConfig);
@@ -93,8 +93,8 @@ export async function getSharepointFiles(server: string, serverRelativePath: str
 
     const fileInfo = await resolveDriveItemByServerRelativePath(server, serverRelativePath, clientConfig);
     console.log(fileInfo);
-    const pendingFolder: { path: string, folder: IOdspDriveItem }[] = [];
-    const files: IOdspDriveItem[] = [];
+    const pendingFolder: { path: string, folder: OdspDriveItem }[] = [];
+    const files: OdspDriveItem[] = [];
     if (fileInfo.isFolder) {
         pendingFolder.push({ path: serverRelativePath, folder: fileInfo });
     } else {

--- a/packages/tools/webpack-component-loader/src/odspUrlResolver.ts
+++ b/packages/tools/webpack-component-loader/src/odspUrlResolver.ts
@@ -7,7 +7,7 @@ import { IUrlResolver, IResolvedUrl } from "@fluidframework/driver-definitions";
 import { IRequest } from "@fluidframework/component-core-interfaces";
 import { OdspDriverUrlResolver, createOdspUrl } from "@fluidframework/odsp-driver";
 import {
-    IOdspAuthRequestInfo,
+    OdspAuthRequestInfo,
     getDriveItemByRootFileName,
 } from "@fluidframework/odsp-utils";
 
@@ -16,7 +16,7 @@ export class OdspUrlResolver implements IUrlResolver {
 
     constructor(
         private readonly server: string,
-        private readonly authRequestInfo: IOdspAuthRequestInfo,
+        private readonly authRequestInfo: OdspAuthRequestInfo,
     ) { }
 
     public async resolve(request: IRequest): Promise<IResolvedUrl> {

--- a/packages/tools/webpack-component-loader/src/routes.ts
+++ b/packages/tools/webpack-component-loader/src/routes.ts
@@ -9,7 +9,7 @@ import express from "express";
 import moniker from "moniker";
 import nconf from "nconf";
 import WebpackDevServer from "webpack-dev-server";
-import { IOdspTokens, getServer } from "@fluidframework/odsp-utils";
+import { OdspTokens, getServer } from "@fluidframework/odsp-utils";
 import {
     getMicrosoftConfiguration,
     OdspTokenManager,
@@ -124,7 +124,7 @@ export const after = (app: express.Application, server: WebpackDevServer, baseDi
                     await tokenManager.getOdspTokens(
                         options.server,
                         getMicrosoftConfiguration(),
-                        buildTokenConfig(res, async (tokens: IOdspTokens) => {
+                        buildTokenConfig(res, async (tokens: OdspTokens) => {
                             options.odspAccessToken = tokens.accessToken;
                             return originalUrl;
                         }),
@@ -137,7 +137,7 @@ export const after = (app: express.Application, server: WebpackDevServer, baseDi
                 await tokenManager.getPushTokens(
                     options.server,
                     getMicrosoftConfiguration(),
-                    buildTokenConfig(res, async (tokens: IOdspTokens) => {
+                    buildTokenConfig(res, async (tokens: OdspTokens) => {
                         options.pushAccessToken = tokens.accessToken;
                         return originalUrl;
                     }),
@@ -161,7 +161,7 @@ export const after = (app: express.Application, server: WebpackDevServer, baseDi
         await tokenManager.getOdspTokens(
             options.server,
             getMicrosoftConfiguration(),
-            buildTokenConfig(res, async (tokens: IOdspTokens) => {
+            buildTokenConfig(res, async (tokens: OdspTokens) => {
                 options.odspAccessToken = tokens.accessToken;
                 return `${getThisOrigin(options)}/pushLogin`;
             }),

--- a/packages/utils/odsp-utils/src/odspAuth.ts
+++ b/packages/utils/odsp-utils/src/odspAuth.ts
@@ -4,20 +4,20 @@
  */
 
 import { AxiosRequestConfig } from "axios";
-import { IRequestResult, createErrorFromResponse, unauthPostAsync } from "./odspRequest";
+import { OdspRequestResult, createErrorFromResponse, unauthPostAsync } from "./odspRequest";
 import { getSharepointTenant } from "./odspUtils";
 
-export interface IOdspTokens {
+export interface OdspTokens {
     accessToken: string;
     refreshToken: string;
 }
 
-export interface IClientConfig {
+export interface OAuthClientConfig {
     clientId: string;
     clientSecret: string;
 }
 
-export interface IOdspAuthRequestInfo {
+export interface OdspAuthRequestInfo {
     accessToken: string;
     refreshTokenFn?: () => Promise<string>,
 }
@@ -52,7 +52,7 @@ export function getFetchTokenUrl(server: string): string {
 export function getLoginPageUrl(
     isPush: boolean,
     server: string,
-    clientConfig: IClientConfig,
+    clientConfig: OAuthClientConfig,
     scope: string,
     odspAuthRedirectUri: string,
 ) {
@@ -64,11 +64,11 @@ export function getLoginPageUrl(
         + `&redirect_uri=${odspAuthRedirectUri}`;
 }
 
-export const getOdspRefreshTokenFn = (server: string, clientConfig: IClientConfig, tokens: IOdspTokens) =>
+export const getOdspRefreshTokenFn = (server: string, clientConfig: OAuthClientConfig, tokens: OdspTokens) =>
     getRefreshTokenFn(getOdspScope(server), server, clientConfig, tokens);
-export const getPushRefreshTokenFn = (server: string, clientConfig: IClientConfig, tokens: IOdspTokens) =>
+export const getPushRefreshTokenFn = (server: string, clientConfig: OAuthClientConfig, tokens: OdspTokens) =>
     getRefreshTokenFn(pushScope, server, clientConfig, tokens);
-export const getRefreshTokenFn = (scope: string, server: string, clientConfig: IClientConfig, tokens: IOdspTokens) =>
+export const getRefreshTokenFn = (scope: string, server: string, clientConfig: OAuthClientConfig, tokens: OdspTokens) =>
     async () => {
         await refreshTokens(server, scope, clientConfig, tokens);
         return tokens.accessToken;
@@ -84,9 +84,9 @@ export const getRefreshTokenFn = (scope: string, server: string, clientConfig: I
 export async function fetchTokens(
     server: string,
     scope: string,
-    clientConfig: IClientConfig,
+    clientConfig: OAuthClientConfig,
     credentials: TokenRequestCredentials,
-): Promise<IOdspTokens> {
+): Promise<OdspTokens> {
     const body: TokenRequestBody = {
         scope,
         client_id: clientConfig.clientId,
@@ -116,8 +116,8 @@ export async function fetchTokens(
 export async function refreshTokens(
     server: string,
     scope: string,
-    clientConfig: IClientConfig,
-    tokens: IOdspTokens,
+    clientConfig: OAuthClientConfig,
+    tokens: OdspTokens,
 ): Promise<void> {
     // Clear out the old tokens while awaiting the new tokens
     const refresh_token = tokens.refreshToken;
@@ -140,9 +140,9 @@ export async function refreshTokens(
  * and retrying with a refreshed token if necessary.
  */
 export async function authRequestWithRetry(
-    authRequestInfo: IOdspAuthRequestInfo,
+    authRequestInfo: OdspAuthRequestInfo,
     requestCallback: (config: AxiosRequestConfig) => Promise<any>,
-): Promise<IRequestResult> {
+): Promise<OdspRequestResult> {
     const createConfig = (token) => ({ headers: { Authorization: `Bearer ${token}` } });
 
     const result = await requestCallback(createConfig(authRequestInfo.accessToken));

--- a/packages/utils/odsp-utils/src/odspDrives.ts
+++ b/packages/utils/odsp-utils/src/odspDrives.ts
@@ -10,18 +10,18 @@ import {
     putAsync,
 } from "./odspRequest";
 
-interface IOdspUser {
+interface OdspUser {
     displayName: string;
     email?: string;
     id?: string;
 }
 
-interface IOdspGroup {
+interface OdspGroup {
     displayName: string;
     email?: string;
 }
 
-interface IOdspDriveQuota {
+interface OdspDriveQuota {
     deleted: number;
     fileCount: number;
     remaining: number;
@@ -30,12 +30,12 @@ interface IOdspDriveQuota {
     used: number;
 }
 
-interface IOdspEntity {
-    user?: IOdspUser;
-    group?: IOdspGroup;
+interface OdspEntity {
+    user?: OdspUser;
+    group?: OdspGroup;
 }
 
-interface IOdspDriveInfo {
+interface OdspDriveInfo {
     id: string;
     createdDateTime: string;
     description: string;
@@ -43,13 +43,13 @@ interface IOdspDriveInfo {
     lastModifiedDateTime: string;
     name: string;
     webUrl: string;
-    createdBy: IOdspEntity;
-    lastModifiedBy: IOdspEntity;
-    owner: IOdspEntity;
-    quota: IOdspDriveQuota;
+    createdBy: OdspEntity;
+    lastModifiedBy: OdspEntity;
+    owner: OdspEntity;
+    quota: OdspDriveQuota;
 }
 
-export interface IOdspDriveItem {
+export interface OdspDriveItem {
     path: string;
     name: string;
     drive: string;
@@ -63,7 +63,7 @@ export async function getDriveItemByRootFileName(
     path: string,
     authRequestInfo: OdspAuthRequestInfo,
     create: boolean,
-): Promise<IOdspDriveItem> {
+): Promise<OdspDriveItem> {
     const accountPath = account ? `/${account}` : "";
     const getDriveItemUrl = `https://${server}${accountPath}/_api/v2.1/drive/root:${path}:`;
     return getDriveItem(getDriveItemUrl, authRequestInfo, create);
@@ -74,7 +74,7 @@ export async function getDriveItemByServerRelativePath(
     serverRelativePath: string,
     authRequestInfo: OdspAuthRequestInfo,
     create: boolean,
-): Promise<IOdspDriveItem> {
+): Promise<OdspDriveItem> {
     let account = "";
     const pathParts = serverRelativePath.split("/");
     if (serverRelativePath.startsWith("/")) {
@@ -100,10 +100,10 @@ export async function getDriveItemByServerRelativePath(
 }
 
 export async function getChildrenByDriveItem(
-    driveItem: IOdspDriveItem,
+    driveItem: OdspDriveItem,
     server: string,
     authRequestInfo: OdspAuthRequestInfo,
-): Promise<IOdspDriveItem[]> {
+): Promise<OdspDriveItem[]> {
     if (!driveItem.isFolder) { return []; }
     let url = `https://${server}/_api/v2.1/drives/${driveItem.drive}/items/${driveItem.item}/children`;
     let children: any[] = [];
@@ -123,7 +123,7 @@ async function getDriveItem(
     getDriveItemUrl: string,
     authRequestInfo: OdspAuthRequestInfo,
     create: boolean,
-): Promise<IOdspDriveItem> {
+): Promise<OdspDriveItem> {
     let getDriveItemResult = await getAsync(getDriveItemUrl, authRequestInfo);
     if (getDriveItemResult.status !== 200) {
         if (!create) {
@@ -165,17 +165,17 @@ async function getDrives(
     server: string,
     account: string,
     authRequestInfo: OdspAuthRequestInfo,
-): Promise<IOdspDriveInfo[]> {
+): Promise<OdspDriveInfo[]> {
     const accountPath = account ? `/${account}` : "";
     const getDriveUrl = `https://${server}${accountPath}/_api/v2.1/drives`;
     const getDriveResult = await getAsync(getDriveUrl, authRequestInfo);
     if (getDriveResult.status !== 200) {
         throw createErrorFromResponse("Failed to get drives.", getDriveResult);
     }
-    return getDriveResult.data.value as IOdspDriveInfo[];
+    return getDriveResult.data.value as OdspDriveInfo[];
 }
 
-function toIODSPDriveItem(parsedDriveItemBody: any): IOdspDriveItem {
+function toIODSPDriveItem(parsedDriveItemBody: any): OdspDriveItem {
     const path = parsedDriveItemBody.parentReference.path ?
         parsedDriveItemBody.parentReference.path.split("root:")[1] : "/";
     return {

--- a/packages/utils/odsp-utils/src/odspDrives.ts
+++ b/packages/utils/odsp-utils/src/odspDrives.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IOdspAuthRequestInfo } from "./odspAuth";
+import { OdspAuthRequestInfo } from "./odspAuth";
 import {
     getAsync,
     createErrorFromResponse,
@@ -61,7 +61,7 @@ export async function getDriveItemByRootFileName(
     server: string,
     account: string,
     path: string,
-    authRequestInfo: IOdspAuthRequestInfo,
+    authRequestInfo: OdspAuthRequestInfo,
     create: boolean,
 ): Promise<IOdspDriveItem> {
     const accountPath = account ? `/${account}` : "";
@@ -72,7 +72,7 @@ export async function getDriveItemByRootFileName(
 export async function getDriveItemByServerRelativePath(
     server: string,
     serverRelativePath: string,
-    authRequestInfo: IOdspAuthRequestInfo,
+    authRequestInfo: OdspAuthRequestInfo,
     create: boolean,
 ): Promise<IOdspDriveItem> {
     let account = "";
@@ -102,7 +102,7 @@ export async function getDriveItemByServerRelativePath(
 export async function getChildrenByDriveItem(
     driveItem: IOdspDriveItem,
     server: string,
-    authRequestInfo: IOdspAuthRequestInfo,
+    authRequestInfo: OdspAuthRequestInfo,
 ): Promise<IOdspDriveItem[]> {
     if (!driveItem.isFolder) { return []; }
     let url = `https://${server}/_api/v2.1/drives/${driveItem.drive}/items/${driveItem.item}/children`;
@@ -121,7 +121,7 @@ export async function getChildrenByDriveItem(
 
 async function getDriveItem(
     getDriveItemUrl: string,
-    authRequestInfo: IOdspAuthRequestInfo,
+    authRequestInfo: OdspAuthRequestInfo,
     create: boolean,
 ): Promise<IOdspDriveItem> {
     let getDriveItemResult = await getAsync(getDriveItemUrl, authRequestInfo);
@@ -149,7 +149,7 @@ async function getDriveId(
     server: string,
     account: string,
     library: string,
-    authRequestInfo: IOdspAuthRequestInfo,
+    authRequestInfo: OdspAuthRequestInfo,
 ): Promise<string> {
     const drives = await getDrives(server, account, authRequestInfo);
     const accountPath = account ? `/${account}` : "";
@@ -164,7 +164,7 @@ async function getDriveId(
 async function getDrives(
     server: string,
     account: string,
-    authRequestInfo: IOdspAuthRequestInfo,
+    authRequestInfo: OdspAuthRequestInfo,
 ): Promise<IOdspDriveInfo[]> {
     const accountPath = account ? `/${account}` : "";
     const getDriveUrl = `https://${server}${accountPath}/_api/v2.1/drives`;

--- a/packages/utils/odsp-utils/src/odspRequest.ts
+++ b/packages/utils/odsp-utils/src/odspRequest.ts
@@ -5,55 +5,55 @@
 
 import Axios, { AxiosResponse, AxiosRequestConfig } from "axios";
 import {
-    IOdspAuthRequestInfo,
+    OdspAuthRequestInfo,
     authRequestWithRetry,
 } from "./odspAuth";
 
-export interface IRequestResult {
+export interface OdspRequestResult {
     href: string | undefined;
     status: number;
     data: any;
 }
 
-export type RequestResultError = Error & { requestResult?: IRequestResult };
+export type RequestResultError = Error & { requestResult?: OdspRequestResult };
 
 export async function getAsync(
     url: string,
-    authRequestInfo: IOdspAuthRequestInfo,
-): Promise<IRequestResult> {
+    authRequestInfo: OdspAuthRequestInfo,
+): Promise<OdspRequestResult> {
     return authRequest(authRequestInfo, async (config) => Axios.get(url, config));
 }
 
 export async function putAsync(
     url: string,
-    authRequestInfo: IOdspAuthRequestInfo,
-): Promise<IRequestResult> {
+    authRequestInfo: OdspAuthRequestInfo,
+): Promise<OdspRequestResult> {
     return authRequest(authRequestInfo, async (config) => Axios.put(url, undefined, config));
 }
 
 export async function postAsync(
     url: string,
     body: any,
-    authRequestInfo: IOdspAuthRequestInfo,
-): Promise<IRequestResult> {
+    authRequestInfo: OdspAuthRequestInfo,
+): Promise<OdspRequestResult> {
     return authRequest(authRequestInfo, async (config) => Axios.post(url, body, config));
 }
 
-export async function unauthPostAsync(url: string, body: any): Promise<IRequestResult> {
+export async function unauthPostAsync(url: string, body: any): Promise<OdspRequestResult> {
     return safeRequestCore(async () => Axios.post(url, body));
 }
 
 async function authRequest(
-    authRequestInfo: IOdspAuthRequestInfo,
+    authRequestInfo: OdspAuthRequestInfo,
     requestCallback: (config: AxiosRequestConfig) => Promise<any>,
-): Promise<IRequestResult> {
+): Promise<OdspRequestResult> {
     return authRequestWithRetry(
         authRequestInfo,
         async (config) => safeRequestCore(async () => requestCallback(config)),
     );
 }
 
-async function safeRequestCore(requestCallback: () => Promise<AxiosResponse>): Promise<IRequestResult> {
+async function safeRequestCore(requestCallback: () => Promise<AxiosResponse>): Promise<OdspRequestResult> {
     let response: AxiosResponse;
     try {
         response = await requestCallback();
@@ -67,7 +67,7 @@ async function safeRequestCore(requestCallback: () => Promise<AxiosResponse>): P
     return { href: response.config.url, status: response.status, data: response.data };
 }
 
-export function createErrorFromResponse(message: string, requestResult: IRequestResult): RequestResultError {
+export function createErrorFromResponse(message: string, requestResult: OdspRequestResult): RequestResultError {
     const error: RequestResultError = Error(message);
     error.requestResult = requestResult;
     return error;

--- a/packages/utils/tool-utils/src/fluidToolRC.ts
+++ b/packages/utils/tool-utils/src/fluidToolRC.ts
@@ -10,7 +10,7 @@ import os from "os";
 import path from "path";
 import util from "util";
 import { lock } from "proper-lockfile";
-import { IOdspTokens } from "@fluidframework/odsp-utils";
+import { OdspTokens } from "@fluidframework/odsp-utils";
 
 export interface IAsyncCache<TKey, TValue> {
     get(key: TKey): Promise<TValue | undefined>;
@@ -19,8 +19,8 @@ export interface IAsyncCache<TKey, TValue> {
 }
 
 interface IResources {
-    tokens?: { [key: string]: IOdspTokens };
-    pushTokens?: IOdspTokens;
+    tokens?: { [key: string]: OdspTokens };
+    pushTokens?: OdspTokens;
 }
 
 const getRCFileName = () => path.join(os.homedir(), ".fluidtoolrc");

--- a/packages/utils/tool-utils/src/odspTokenManager.ts
+++ b/packages/utils/tool-utils/src/odspTokenManager.ts
@@ -6,7 +6,7 @@
 import { unreachableCase } from "@fluidframework/common-utils";
 import {
     OdspTokens,
-    OdspClientConfig,
+    OAuthClientConfig,
     fetchTokens,
     refreshTokens,
     getOdspScope,
@@ -21,7 +21,7 @@ const odspAuthRedirectPort = 7000;
 const odspAuthRedirectOrigin = `http://localhost:${odspAuthRedirectPort}`;
 const odspAuthRedirectUri = new URL("/auth/callback", odspAuthRedirectOrigin).href;
 
-export const getMicrosoftConfiguration = (): OdspClientConfig => ({
+export const getMicrosoftConfiguration = (): OAuthClientConfig => ({
     get clientId() {
         if (!process.env.login__microsoft__clientId) {
             throw new Error("Client ID environment variable not set: login__microsoft__clientId.");
@@ -57,7 +57,7 @@ export class OdspTokenManager {
 
     public async getOdspTokens(
         server: string,
-        clientConfig: OdspClientConfig,
+        clientConfig: OAuthClientConfig,
         tokenConfig: OdspTokenConfig,
         forceRefresh = false,
         forceReauth = false,
@@ -74,7 +74,7 @@ export class OdspTokenManager {
 
     public async getPushTokens(
         server: string,
-        clientConfig: OdspClientConfig,
+        clientConfig: OAuthClientConfig,
         tokenConfig: OdspTokenConfig,
         forceRefresh = false,
         forceReauth = false,
@@ -91,7 +91,7 @@ export class OdspTokenManager {
     private async getTokens(
         isPush: boolean,
         server: string,
-        clientConfig: OdspClientConfig,
+        clientConfig: OAuthClientConfig,
         tokenConfig: OdspTokenConfig,
         forceRefresh: boolean,
         forceReauth: boolean,
@@ -124,7 +124,7 @@ export class OdspTokenManager {
     private async getTokensCore(
         isPush: boolean,
         server: string,
-        clientConfig: OdspClientConfig,
+        clientConfig: OAuthClientConfig,
         tokenConfig: OdspTokenConfig,
         forceRefresh,
         forceReauth,
@@ -186,7 +186,7 @@ export class OdspTokenManager {
     private async acquireTokensWithPassword(
         server: string,
         scope: string,
-        clientConfig: OdspClientConfig,
+        clientConfig: OAuthClientConfig,
         username: string,
         password: string,
     ): Promise<OdspTokens> {
@@ -201,7 +201,7 @@ export class OdspTokenManager {
     private async acquireTokensViaBrowserLogin(
         loginPageUrl: string,
         server: string,
-        clientConfig: OdspClientConfig,
+        clientConfig: OAuthClientConfig,
         scope: string,
         navigator: (url: string) => void,
         redirectUriCallback?: (tokens: OdspTokens) => Promise<string>,

--- a/server/gateway/src/gatewayUrlResolver.ts
+++ b/server/gateway/src/gatewayUrlResolver.ts
@@ -6,7 +6,7 @@
 import { IFluidCodeDetails } from "@fluidframework/container-definitions";
 import { IFluidResolvedUrl } from "@fluidframework/driver-definitions";
 import { configurableUrlResolver } from "@fluidframework/driver-utils";
-import { IClientConfig } from "@fluidframework/odsp-utils";
+import { IClientConfig as OAuthClientConfig } from "@fluidframework/odsp-utils"; // renamed like so in odsp-utils 0.25
 import { ScopeType } from "@fluidframework/protocol-definitions";
 import { IAlfredUser, RouterliciousUrlResolver } from "@fluidframework/routerlicious-urlresolver";
 import { IAlfredTenant, IGitCache } from "@fluidframework/server-services-client";
@@ -33,7 +33,7 @@ export function resolveUrl(
 ): [Promise<IFluidResolvedUrl>, Promise<undefined | FullTree>] {
     if (isSpoTenant(tenantId)) {
         const microsoftConfiguration = config.get("login:microsoft");
-        const clientConfig: IClientConfig = {
+        const clientConfig: OAuthClientConfig = {
             clientId: microsoftConfiguration.clientId,
             clientSecret: microsoftConfiguration.secret,
         };

--- a/server/gateway/src/odspUtils.ts
+++ b/server/gateway/src/odspUtils.ts
@@ -8,8 +8,8 @@ import { OdspDriverUrlResolver } from "@fluidframework/odsp-driver";
 import {
     getDriveItemByRootFileName,
     getOdspRefreshTokenFn,
-    IClientConfig,
-    IOdspTokens,
+    IClientConfig as OAuthClientConfig, // renamed like so in odsp-utils 0.25
+    IOdspTokens as OdspTokens, // renamed like so in odsp-utils 0.25
 } from "@fluidframework/odsp-utils";
 
 const spoTenants = new Map<string, string>([
@@ -39,8 +39,8 @@ export function isSpoServer(server: string) {
 export async function spoGetResolvedUrl(
     tenantId: string,
     id: string,
-    serverTokens: { [server: string]: IOdspTokens } | undefined,
-    clientConfig: IClientConfig) {
+    serverTokens: { [server: string]: OdspTokens } | undefined,
+    clientConfig: OAuthClientConfig) {
     const server = getSpoServer(tenantId);
     if (server === undefined) {
         return Promise.reject(`Invalid SPO tenantId ${tenantId}`);


### PR DESCRIPTION
These types are all data types not meant to be implemented, even though we're using the `interface` keyword to declare them. So renaming to remove the `I` (and use slightly different names in some cases).