### PR TITLE
MergeTree: Add 'UNLINK' maintenance event

### DIFF
--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1350,6 +1350,15 @@ export class MergeTree {
                                 // eslint-disable-next-line dot-notation
                                 console.log(`${this.getLongClientId(this.collabWindow.clientId)}: Zremove ${segment["text"]}; cli ${this.getLongClientId(segment.clientId)}`);
                             }
+
+                            // Notify maintenance event observers that the segment is being unlinked from the MergeTree.
+                            if (this.mergeTreeMaintenanceCallback) {
+                                this.mergeTreeMaintenanceCallback({
+                                    operation: MergeTreeMaintenanceType.UNLINK,
+                                    deltaSegments: [{ segment }],
+                                });
+                            }
+
                             segment.parent = undefined;
                         }
                         prevSegment = undefined;

--- a/packages/dds/merge-tree/src/mergeTreeDeltaCallback.ts
+++ b/packages/dds/merge-tree/src/mergeTreeDeltaCallback.ts
@@ -13,8 +13,18 @@ export type MergeTreeDeltaOperationType =
 
 // Note: Assigned negative integers to avoid clashing with MergeTreeDeltaType
 export const enum MergeTreeMaintenanceType {
-    APPEND = -1,
-    SPLIT = -2,
+    APPEND  = -1,
+    SPLIT   = -2,
+    /**
+     * Notification that a segment has been unlinked from the MergeTree.  This occurs during
+     * Zamboni when:
+     *
+     *    a) The minSeq has moved past the segment's removeSeq, in which case the segment
+     *       can no longer be referenced by incoming remote ops, and...
+     *
+     *    b) The segment's tracking collection is empty (e.g., not being tracked for undo/redo).
+     */
+    UNLINK  = -3,
 }
 
 export type MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationType | MergeTreeMaintenanceType;


### PR DESCRIPTION
As part of implementing undo/redo support for matrices, I need to retain cell data until it's no longer reachable by the undo stack.

My plan is to wait to recycle handles in the matrix's sparse storage until the corresponding segments have been unlinked from the row/col permutation vectors.

This leaves the cells for the row/cols in the storage so the values can be retrieved if needed, but publicly unreachable.  Once the undo for the row/col removal is discarded, the segment is removed from the tracking group, can be unlinked by zamboni, which will tell the matrix it's okay to clear the cells and recycle the handles.