### PR TITLE
Exclude @fluidframework/component-core-interfaces from layer-check

### DIFF
--- a/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -23,7 +23,7 @@ function packageShouldBePrivate(name: string): boolean {
     if (name === "@fluid-internal/client-api") {
         return false;
     }
-    
+
     return (
         name === "root" || // minirepo roots
         name.startsWith("@fluid-internal"));
@@ -32,6 +32,11 @@ function packageShouldBePrivate(name: string): boolean {
 function packageShouldNotBePrivate(name: string): boolean {
     // See https://github.com/microsoft/FluidFramework/issues/2642
     if (name === "@fluidframework/server-gateway") {
+        return false;
+    }
+
+    // see https://github.com/microsoft/FluidFramework/issues/3054
+    if (name === "@fluidframework/component-core-interfaces") {
         return false;
     }
 


### PR DESCRIPTION
Need to produce a build that excludes component-core-interfaces that can be consumed in #3051 which renames the package to core-interfaces