### PR TITLE
Rename component-core-interfaces in layer info

### DIFF
--- a/tools/build-tools/data/layerInfo.json
+++ b/tools/build-tools/data/layerInfo.json
@@ -6,7 +6,7 @@
                 "dotSameRank": true,
                 "packages": [
                     "@fluidframework/common-definitions",
-                    "@fluidframework/component-core-interfaces",
+                    "@fluidframework/core-interfaces",
                     "@fluidframework/gitresources"
                 ]
             },
@@ -24,7 +24,7 @@
                 ],
                 "deps": [
                     "Protocol-Definitions",
-                    "@fluidframework/component-core-interfaces"
+                    "@fluidframework/core-interfaces"
                 ]
             },
             "Container-Definitions": {
@@ -33,7 +33,7 @@
                 ],
                 "deps": [
                     "Driver-Definitions",
-                    "@fluidframework/component-core-interfaces"
+                    "@fluidframework/core-interfaces"
                 ]
             }
         }
@@ -121,7 +121,7 @@
                 ],
                 "deps": [
                     "Driver-Utils",
-                    "@fluidframework/component-core-interfaces"
+                    "@fluidframework/core-interfaces"
                 ]
             },
             "Loader": {


### PR DESCRIPTION
Need to produce a build that excludes component-core-interfaces that can be consumed in #3051 which renames the package to core-interfaces