### PR TITLE
Remove the term component from dds packages (other than cell)

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -355,7 +355,7 @@ The `createValueType()` method on `SharedMap` and `SharedDirectory` was deprecat
 isLocal api is removed from the repo. It is now replaced with isAttached which tells that the entity is attached or getting attached to storage. So its meaning is opposite to isLocal.
 
 ### register/attach api renames on handles, components and dds
-Register on dds and attach on component runtime is renamed to bindToContext(). attach on handles is renamed to attachGraph().
+Register on dds and attach on data store runtime is renamed to bindToContext(). attach on handles is renamed to attachGraph().
 
 ### Error handling changes
 ErrorType enum has been broken into 3 distinct enums / layers:

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -225,7 +225,7 @@ example:
 ``` typescript
     const builder = new RuntimeRequestHandlerBuilder();
     builder.pushHandler(...this.requestHandlers);
-    builder.pushHandler(componentRuntimeRequestHandler);
+    builder.pushHandler(dataStoreRuntimeRequestHandler);
 
     const runtime = await ContainerRuntime.load(
         context,

--- a/docs/docs/compatibility.md
+++ b/docs/docs/compatibility.md
@@ -71,7 +71,7 @@ Within the Fluid Framework, the runtime consists of a few parts:
    components, the component-level runtime code and container-level runtime code depend on each other through the APIs
    defined in runtime-definitions.  For reference, this boundary occurs between the `IComponentContext`
    (container-level) and the `IDatastoreRuntime` (component-level).  Fluid tries to keep the container runtime backwards
-   compatible with the component runtime by at least 1 version.
+   compatible with the data store runtime by at least 1 version.
 3. The distributed data structures code: typically developers can build components consisting of the Fluid Framework
    provided set of distributed data structures.  There is a registry of DDS factories within each component that
    instruct how to load the DDS code, but this code is meant to be statically loaded with the component.  Developers can
@@ -84,9 +84,9 @@ our own container-level runtime code can load our own component-level runtime co
 
 Specific interfaces to monitor:
 
-- `IContainerRuntime` - interfaces container runtime to loaded component runtime
-- `IComponentContext` - interfaces component context to loaded component runtime
-- `IDatastoreRuntime` - interfaces loaded component runtime to its context
+- `IContainerRuntime` - interfaces container runtime to loaded data store runtime
+- `IComponentContext` - interfaces component context to loaded data store runtime
+- `IDatastoreRuntime` - interfaces loaded data store runtime to its context
 
 ## Guidelines for compatible contributions
 

--- a/docs/docs/compatibility.md
+++ b/docs/docs/compatibility.md
@@ -86,7 +86,7 @@ Specific interfaces to monitor:
 
 - `IContainerRuntime` - interfaces container runtime to loaded data store runtime
 - `IFluidDataStoreContext` - interfaces component context to loaded data store runtime
-- `IDatastoreRuntime` - interfaces loaded data store runtime to its context
+- `IFluidDataStoreRuntime` - interfaces loaded data store runtime to its context
 
 ## Guidelines for compatible contributions
 

--- a/docs/docs/compatibility.md
+++ b/docs/docs/compatibility.md
@@ -85,7 +85,7 @@ our own container-level runtime code can load our own component-level runtime co
 Specific interfaces to monitor:
 
 - `IContainerRuntime` - interfaces container runtime to loaded data store runtime
-- `IComponentContext` - interfaces component context to loaded data store runtime
+- `IFluidDataStoreContext` - interfaces component context to loaded data store runtime
 - `IDatastoreRuntime` - interfaces loaded data store runtime to its context
 
 ## Guidelines for compatible contributions

--- a/packages/dds/cell/src/cell.ts
+++ b/packages/dds/cell/src/cell.ts
@@ -57,7 +57,7 @@ export class SharedCell<T extends Serializable = any> extends SharedObject<IShar
     /**
      * Create a new shared cell
      *
-     * @param runtime - component runtime the new shared map belongs to
+     * @param runtime - data store runtime the new shared map belongs to
      * @param id - optional name of the shared map
      * @returns newly create shared map (but not attached yet)
      */
@@ -94,7 +94,7 @@ export class SharedCell<T extends Serializable = any> extends SharedObject<IShar
      * Constructs a new shared cell. If the object is non-local an id and service interfaces will
      * be provided
      *
-     * @param runtime - component runtime the shared map belongs to
+     * @param runtime - data store runtime the shared map belongs to
      * @param id - optional name of the shared map
      */
     constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes) {

--- a/packages/dds/cell/src/test/cell.spec.ts
+++ b/packages/dds/cell/src/test/cell.spec.ts
@@ -61,7 +61,7 @@ describe("Cell", () => {
 
     describe("SharedCell op processing in local state", () => {
         it("should correctly process a set operation sent in local state", async () => {
-            // Set the component runtime to local.
+            // Set the data store runtime to local.
             componentRuntime.local = true;
 
             // Set a value in local state.

--- a/packages/dds/counter/src/counter.ts
+++ b/packages/dds/counter/src/counter.ts
@@ -46,7 +46,7 @@ export class SharedCounter extends SharedObject<ISharedCounterEvents> implements
     /**
      * Create a new shared counter
      *
-     * @param runtime - component runtime the new shared counter belongs to
+     * @param runtime - data store runtime the new shared counter belongs to
      * @param id - optional name of the shared counter
      * @returns newly create shared counter (but not attached yet)
      */

--- a/packages/dds/counter/src/counter.ts
+++ b/packages/dds/counter/src/counter.ts
@@ -55,7 +55,7 @@ export class SharedCounter extends SharedObject<ISharedCounterEvents> implements
     }
 
     /**
-     * Get a factory for SharedCounter to register with the component.
+     * Get a factory for SharedCounter to register with the data store.
      *
      * @returns a factory that creates and load SharedCounter
      */

--- a/packages/dds/counter/src/test/counter.spec.ts
+++ b/packages/dds/counter/src/test/counter.spec.ts
@@ -17,13 +17,13 @@ import { ISharedCounter, SharedCounter } from "..";
 
 describe("SharedCounter", () => {
     let testCounter: ISharedCounter;
-    let componentRuntime: MockFluidDataStoreRuntime;
+    let dataStoreRuntime: MockFluidDataStoreRuntime;
     let factory: IChannelFactory;
 
     beforeEach(async () => {
-        componentRuntime = new MockFluidDataStoreRuntime();
+        dataStoreRuntime = new MockFluidDataStoreRuntime();
         factory = SharedCounter.getFactory();
-        testCounter = factory.create(componentRuntime, "counter") as ISharedCounter;
+        testCounter = factory.create(dataStoreRuntime, "counter") as ISharedCounter;
     });
 
     describe("SharedCounter in local state", () => {
@@ -74,7 +74,7 @@ describe("SharedCounter", () => {
 
                 // Load a new SharedCounter from the snapshot of the first one.
                 const services = MockSharedObjectServices.createFromTree(testCounter.snapshot());
-                const testCounter2 = factory.create(componentRuntime, "counter2") as SharedCounter;
+                const testCounter2 = factory.create(dataStoreRuntime, "counter2") as SharedCounter;
                 await testCounter2.load("branchId", services);
 
                 // Verify that the new SharedCounter has the correct value.
@@ -91,8 +91,8 @@ describe("SharedCounter", () => {
             containerRuntimeFactory = new MockContainerRuntimeFactory();
 
             // Connect the first SharedCounter.
-            componentRuntime.local = false;
-            const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime);
+            dataStoreRuntime.local = false;
+            const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
             const services1 = {
                 deltaConnection: containerRuntime1.createDeltaConnection(),
                 objectStorage: new MockStorage(),
@@ -100,14 +100,14 @@ describe("SharedCounter", () => {
             testCounter.connect(services1);
 
             // Create and connect a second SharedCounter.
-            const componentRuntime2 = new MockFluidDataStoreRuntime();
-            const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+            const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
             const services2 = {
                 deltaConnection: containerRuntime2.createDeltaConnection(),
                 objectStorage: new MockStorage(),
             };
 
-            testCounter2 = factory.create(componentRuntime, "counter2") as SharedCounter;
+            testCounter2 = factory.create(dataStoreRuntime, "counter2") as SharedCounter;
             testCounter2.connect(services2);
         });
 
@@ -167,8 +167,8 @@ describe("SharedCounter", () => {
             containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
 
             // Connect the first SharedCounter.
-            componentRuntime.local = false;
-            containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime);
+            dataStoreRuntime.local = false;
+            containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
             const services1 = {
                 deltaConnection: containerRuntime1.createDeltaConnection(),
                 objectStorage: new MockStorage(),
@@ -176,14 +176,14 @@ describe("SharedCounter", () => {
             testCounter.connect(services1);
 
             // Create and connect a second SharedCounter.
-            const componentRuntime2 = new MockFluidDataStoreRuntime();
-            containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+            containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
             const services2 = {
                 deltaConnection: containerRuntime2.createDeltaConnection(),
                 objectStorage: new MockStorage(),
             };
 
-            testCounter2 = factory.create(componentRuntime, "counter2") as SharedCounter;
+            testCounter2 = factory.create(dataStoreRuntime, "counter2") as SharedCounter;
             testCounter2.connect(services2);
         });
 

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -381,7 +381,7 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
     }
 
     /**
-     * Get a factory for SharedDirectory to register with the component.
+     * Get a factory for SharedDirectory to register with the data store.
      *
      * @returns A factory that creates and load SharedDirectory
      */

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -372,7 +372,7 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
     /**
      * Create a new shared directory
      *
-     * @param runtime - Component runtime the new shared directory belongs to
+     * @param runtime - Data store runtime the new shared directory belongs to
      * @param id - Optional name of the shared directory
      * @returns Newly create shared directory (but not attached yet)
      */
@@ -420,7 +420,7 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
      * Constructs a new shared directory. If the object is non-local an id and service interfaces will
      * be provided.
      * @param id - String identifier for the SharedDirectory
-     * @param runtime - Component runtime
+     * @param runtime - Data store runtime
      * @param type - Type identifier
      */
     constructor(
@@ -954,7 +954,7 @@ class SubDirectory implements IDirectory {
     /**
      * Constructor.
      * @param directory - Reference back to the SharedDirectory to perform operations
-     * @param runtime - The component runtime this directory is associated with
+     * @param runtime - The data store runtime this directory is associated with
      * @param absolutePath - The absolute path of this IDirectory
      */
     constructor(

--- a/packages/dds/map/src/localValues.ts
+++ b/packages/dds/map/src/localValues.ts
@@ -42,8 +42,8 @@ export interface ILocalValue {
 
     /**
      * Retrieve the serialized form of the value stored within.
-     * @param serializer - Component runtime's serializer
-     * @param context - Component runtime's handle context
+     * @param serializer - Data store runtime's serializer
+     * @param context - Data store runtime's handle context
      * @param bind - Container type's handle
      * @returns The serialized form of the contained value
      */

--- a/packages/dds/map/src/map.ts
+++ b/packages/dds/map/src/map.ts
@@ -112,7 +112,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
     }
 
     /**
-   * Get a factory for SharedMap to register with the component.
+   * Get a factory for SharedMap to register with the data store.
    * @returns A factory that creates and load SharedMap
    */
     public static getFactory(): IChannelFactory {

--- a/packages/dds/map/src/map.ts
+++ b/packages/dds/map/src/map.ts
@@ -103,7 +103,7 @@ export class MapFactory implements IChannelFactory {
 export class SharedMap extends SharedObject<ISharedMapEvents> implements ISharedMap {
     /**
    * Create a new shared map.
-   * @param runtime - Component runtime the new shared map belongs to
+   * @param runtime - Data store runtime the new shared map belongs to
    * @param id - Optional name of the shared map
    * @returns Newly create shared map (but not attached yet)
    */
@@ -132,7 +132,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
     /**
    * Create a new SharedMap.
    * @param id - String identifier
-   * @param runtime - Component runtime
+   * @param runtime - Data store runtime
    * @param attributes - The attributes for the map
    */
     constructor(

--- a/packages/dds/map/src/mapKernel.ts
+++ b/packages/dds/map/src/mapKernel.ts
@@ -179,7 +179,7 @@ export class MapKernel implements IValueTypeCreator {
 
     /**
      * Create a new shared map kernel.
-     * @param runtime - The component runtime the shared object using the kernel will be associated with
+     * @param runtime - The data store runtime the shared object using the kernel will be associated with
      * @param handle - The handle of the shared object using the kernel
      * @param submitMessage - A callback to submit a message through the shared object
      * @param isAttached - To query whether the shared object should generate ops

--- a/packages/dds/map/src/test/directory.spec.ts
+++ b/packages/dds/map/src/test/directory.spec.ts
@@ -37,17 +37,17 @@ function serialize(directory: SharedDirectory): string {
 describe("Directory", () => {
     let directory: SharedDirectory;
     let mapFactory: MapFactory;
-    let componentRuntime: MockFluidDataStoreRuntime;
+    let dataStoreRuntime: MockFluidDataStoreRuntime;
 
     beforeEach(async () => {
-        componentRuntime = new MockFluidDataStoreRuntime();
+        dataStoreRuntime = new MockFluidDataStoreRuntime();
         mapFactory = new MapFactory();
-        directory = new SharedDirectory("directory", componentRuntime, DirectoryFactory.Attributes);
+        directory = new SharedDirectory("directory", dataStoreRuntime, DirectoryFactory.Attributes);
     });
 
     describe("SharedDirectory in local state", () => {
         beforeEach(() => {
-            componentRuntime.local = true;
+            dataStoreRuntime.local = true;
         });
 
         it("Can create a new directory", () => {
@@ -104,7 +104,7 @@ describe("Directory", () => {
                 directory.set("first", "second");
                 directory.set("third", "fourth");
                 directory.set("fifth", "sixth");
-                const subMap = mapFactory.create(componentRuntime, "subMap");
+                const subMap = mapFactory.create(dataStoreRuntime, "subMap");
                 directory.set("object", subMap.handle);
 
                 const subMapHandleUrl = subMap.handle.absolutePath;
@@ -119,7 +119,7 @@ describe("Directory", () => {
                 directory.set("first", "second");
                 directory.set("third", "fourth");
                 directory.set("fifth", "sixth");
-                const subMap = mapFactory.create(componentRuntime, "subMap");
+                const subMap = mapFactory.create(dataStoreRuntime, "subMap");
                 directory.set("object", subMap.handle);
                 const nestedDirectory = directory.createSubDirectory("nested");
                 nestedDirectory.set("deepKey1", "deepValue1");
@@ -139,7 +139,7 @@ describe("Directory", () => {
                 directory.set("third", "fourth");
                 directory.set("fifth", undefined);
                 assert.ok(directory.has("fifth"));
-                const subMap = mapFactory.create(componentRuntime, "subMap");
+                const subMap = mapFactory.create(dataStoreRuntime, "subMap");
                 directory.set("object", subMap.handle);
                 const nestedDirectory = directory.createSubDirectory("nested");
                 nestedDirectory.set("deepKey1", "deepValue1");
@@ -296,7 +296,7 @@ describe("Directory", () => {
                 assert((tree.entries[1].value as IBlob).contents.length >= 1024);
                 assert((tree.entries[2].value as IBlob).contents.length <= 200);
 
-                const directory2 = new SharedDirectory("test", componentRuntime, DirectoryFactory.Attributes);
+                const directory2 = new SharedDirectory("test", dataStoreRuntime, DirectoryFactory.Attributes);
                 const storage = MockSharedObjectServices.createFromTree(tree);
                 await directory2.load("branchId", storage);
 
@@ -323,7 +323,7 @@ describe("Directory", () => {
          */
         it("should correctly process a set operation sent in local state", async () => {
             // Set the data store runtime to local.
-            componentRuntime.local = true;
+            dataStoreRuntime.local = true;
 
             // Set a key in local state.
             const key = "testKey";
@@ -332,17 +332,17 @@ describe("Directory", () => {
 
             // Load a new SharedDirectory in connected state from the snapshot of the first one.
             const containerRuntimeFactory = new MockContainerRuntimeFactory();
-            const componentRuntime2 = new MockFluidDataStoreRuntime();
-            const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+            const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
             const services2 = MockSharedObjectServices.createFromTree(directory.snapshot());
             services2.deltaConnection = containerRuntime2.createDeltaConnection();
 
-            const directory2 = new SharedDirectory("directory2", componentRuntime2, DirectoryFactory.Attributes);
+            const directory2 = new SharedDirectory("directory2", dataStoreRuntime2, DirectoryFactory.Attributes);
             await directory2.load("branchId", services2);
 
             // Now connect the first SharedDirectory
-            componentRuntime.local = false;
-            const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime);
+            dataStoreRuntime.local = false;
+            const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
             const services1 = {
                 deltaConnection: containerRuntime1.createDeltaConnection(),
                 objectStorage: new MockStorage(undefined),
@@ -367,7 +367,7 @@ describe("Directory", () => {
 
         it("should correctly process a sub directory operation sent in local state", async () => {
             // Set the data store runtime to local.
-            componentRuntime.local = true;
+            dataStoreRuntime.local = true;
 
             // Create a sub directory in local state.
             const subDirName = "testSubDir";
@@ -375,17 +375,17 @@ describe("Directory", () => {
 
             // Load a new SharedDirectory in connected state from the snapshot of the first one.
             const containerRuntimeFactory = new MockContainerRuntimeFactory();
-            const componentRuntime2 = new MockFluidDataStoreRuntime();
-            const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+            const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
             const services2 = MockSharedObjectServices.createFromTree(directory.snapshot());
             services2.deltaConnection = containerRuntime2.createDeltaConnection();
 
-            const directory2 = new SharedDirectory("directory2", componentRuntime2, DirectoryFactory.Attributes);
+            const directory2 = new SharedDirectory("directory2", dataStoreRuntime2, DirectoryFactory.Attributes);
             await directory2.load("branchId", services2);
 
             // Now connect the first SharedDirectory
-            componentRuntime.local = false;
-            const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime);
+            dataStoreRuntime.local = false;
+            const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
             const services1 = {
                 deltaConnection: containerRuntime1.createDeltaConnection(),
                 objectStorage: new MockStorage(undefined),
@@ -417,7 +417,7 @@ describe("Directory", () => {
         beforeEach(async () => {
             // Connect the first directory
             containerRuntimeFactory = new MockContainerRuntimeFactory();
-            const containerRuntime = containerRuntimeFactory.createContainerRuntime(componentRuntime);
+            const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
             const services = {
                 deltaConnection: containerRuntime.createDeltaConnection(),
                 objectStorage: new MockStorage(undefined),
@@ -425,9 +425,9 @@ describe("Directory", () => {
             directory.connect(services);
 
             // Create and connect a second directory
-            const componentRuntime2 = new MockFluidDataStoreRuntime();
-            directory2 = new SharedDirectory("directory2", componentRuntime2, DirectoryFactory.Attributes);
-            const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+            directory2 = new SharedDirectory("directory2", dataStoreRuntime2, DirectoryFactory.Attributes);
+            const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
             const services2 = {
                 deltaConnection: containerRuntime2.createDeltaConnection(),
                 objectStorage: new MockStorage(undefined),

--- a/packages/dds/map/src/test/directory.spec.ts
+++ b/packages/dds/map/src/test/directory.spec.ts
@@ -322,7 +322,7 @@ describe("Directory", () => {
          *   same key.
          */
         it("should correctly process a set operation sent in local state", async () => {
-            // Set the component runtime to local.
+            // Set the data store runtime to local.
             componentRuntime.local = true;
 
             // Set a key in local state.
@@ -366,7 +366,7 @@ describe("Directory", () => {
         });
 
         it("should correctly process a sub directory operation sent in local state", async () => {
-            // Set the component runtime to local.
+            // Set the data store runtime to local.
             componentRuntime.local = true;
 
             // Create a sub directory in local state.

--- a/packages/dds/map/src/test/map.spec.ts
+++ b/packages/dds/map/src/test/map.spec.ts
@@ -233,7 +233,7 @@ describe("Map", () => {
          *   when it gets a remote op with the same key, it ignores it as it has a pending set with the same key.
          */
         it("should correctly process a set operation sent in local state", async () => {
-            // Set the component runtime to local.
+            // Set the data store runtime to local.
             componentRuntime.local = true;
 
             // Set a key in local state.

--- a/packages/dds/map/src/test/map.spec.ts
+++ b/packages/dds/map/src/test/map.spec.ts
@@ -17,17 +17,17 @@ import { MapFactory, SharedMap } from "../map";
 describe("Map", () => {
     let map: SharedMap;
     let factory: MapFactory;
-    let componentRuntime: MockFluidDataStoreRuntime;
+    let dataStoreRuntime: MockFluidDataStoreRuntime;
 
     beforeEach(async () => {
-        componentRuntime = new MockFluidDataStoreRuntime();
+        dataStoreRuntime = new MockFluidDataStoreRuntime();
         factory = new MapFactory();
-        map = new SharedMap("testMap", componentRuntime, MapFactory.Attributes);
+        map = new SharedMap("testMap", dataStoreRuntime, MapFactory.Attributes);
     });
 
     describe("SharedMap in local state", () => {
         beforeEach(() => {
-            componentRuntime.local = true;
+            dataStoreRuntime.local = true;
         });
 
         it("Can create a new map", () => {
@@ -70,7 +70,7 @@ describe("Map", () => {
                 map.set("first", "second");
                 map.set("third", "fourth");
                 map.set("fifth", "sixth");
-                const subMap = factory.create(componentRuntime, "subMap");
+                const subMap = factory.create(dataStoreRuntime, "subMap");
                 map.set("object", subMap.handle);
 
                 const parsed = map.getSerializableStorage();
@@ -91,7 +91,7 @@ describe("Map", () => {
                 map.set("third", "fourth");
                 map.set("fifth", undefined);
                 assert.ok(map.has("fifth"));
-                const subMap = factory.create(componentRuntime, "subMap");
+                const subMap = factory.create(dataStoreRuntime, "subMap");
                 map.set("object", subMap.handle);
 
                 const parsed = map.getSerializableStorage();
@@ -108,8 +108,8 @@ describe("Map", () => {
             });
 
             it("Should serialize an object with nested handles", async () => {
-                const subMap = factory.create(componentRuntime, "subMap");
-                const subMap2 = factory.create(componentRuntime, "subMap2");
+                const subMap = factory.create(dataStoreRuntime, "subMap");
+                const subMap2 = factory.create(dataStoreRuntime, "subMap2");
                 const containingObject = {
                     subMapHandle: subMap.handle,
                     nestedObj: {
@@ -137,7 +137,7 @@ describe("Map", () => {
 
                 const services = new MockSharedObjectServices({ header: content });
                 const loadedMap = await factory.load(
-                    componentRuntime, "mapId", services, "branchId", factory.attributes,
+                    dataStoreRuntime, "mapId", services, "branchId", factory.attributes,
                 );
                 assert(loadedMap.get("key") === "value");
             });
@@ -161,7 +161,7 @@ describe("Map", () => {
 
                 const services = new MockSharedObjectServices({ header: content });
                 const loadedMap = await factory.load(
-                    componentRuntime, "mapId", services, "branchId", factory.attributes,
+                    dataStoreRuntime, "mapId", services, "branchId", factory.attributes,
                 );
                 assert(loadedMap.get("key") === "value");
             });
@@ -211,7 +211,7 @@ describe("Map", () => {
                     blob0: content2,
                 });
                 const loadedMap = await factory.load(
-                    componentRuntime, "mapId", services, "branchId", factory.attributes,
+                    dataStoreRuntime, "mapId", services, "branchId", factory.attributes,
                 );
                 assert(loadedMap.get("key") === "value");
                 assert(loadedMap.get("longValue") === longString);
@@ -234,7 +234,7 @@ describe("Map", () => {
          */
         it("should correctly process a set operation sent in local state", async () => {
             // Set the data store runtime to local.
-            componentRuntime.local = true;
+            dataStoreRuntime.local = true;
 
             // Set a key in local state.
             const key = "testKey";
@@ -243,17 +243,17 @@ describe("Map", () => {
 
             // Load a new SharedMap in connected state from the snapshot of the first one.
             const containerRuntimeFactory = new MockContainerRuntimeFactory();
-            const componentRuntime2 = new MockFluidDataStoreRuntime();
-            const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+            const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
             const services2 = MockSharedObjectServices.createFromTree(map.snapshot());
             services2.deltaConnection = containerRuntime2.createDeltaConnection();
 
-            const map2 = new SharedMap("testMap2", componentRuntime2, MapFactory.Attributes);
+            const map2 = new SharedMap("testMap2", dataStoreRuntime2, MapFactory.Attributes);
             await map2.load("branchId", services2);
 
             // Now connect the first SharedMap
-            componentRuntime.local = false;
-            const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime);
+            dataStoreRuntime.local = false;
+            const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
             const services1 = {
                 deltaConnection: containerRuntime1.createDeltaConnection(),
                 objectStorage: new MockStorage(undefined),
@@ -284,7 +284,7 @@ describe("Map", () => {
         beforeEach(async () => {
             // Connect the first map
             containerRuntimeFactory = new MockContainerRuntimeFactory();
-            const containerRuntime = containerRuntimeFactory.createContainerRuntime(componentRuntime);
+            const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
             const services = {
                 deltaConnection: containerRuntime.createDeltaConnection(),
                 objectStorage: new MockStorage(undefined),
@@ -292,9 +292,9 @@ describe("Map", () => {
             map.connect(services);
 
             // Create and connect a second map
-            const componentRuntime2 = new MockFluidDataStoreRuntime();
-            map2 = new SharedMap("testMap2", componentRuntime2, MapFactory.Attributes);
-            const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+            map2 = new SharedMap("testMap2", dataStoreRuntime2, MapFactory.Attributes);
+            const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
             const services2 = {
                 deltaConnection: containerRuntime2.createDeltaConnection(),
                 objectStorage: new MockStorage(undefined),
@@ -352,7 +352,7 @@ describe("Map", () => {
             });
 
             it("Should be able to set a shared object handle as a key", () => {
-                const subMap = factory.create(componentRuntime, "subMap");
+                const subMap = factory.create(dataStoreRuntime, "subMap");
                 map.set("test", subMap.handle);
 
                 containerRuntimeFactory.processAllMessages();
@@ -370,8 +370,8 @@ describe("Map", () => {
             });
 
             it("Should be able to set and retrieve a plain object with nested handles", async () => {
-                const subMap = factory.create(componentRuntime, "subMap");
-                const subMap2 = factory.create(componentRuntime, "subMap2");
+                const subMap = factory.create(dataStoreRuntime, "subMap");
+                const subMap2 = factory.create(dataStoreRuntime, "subMap2");
                 const containingObject = {
                     subMapHandle: subMap.handle,
                     nestedObj: {

--- a/packages/dds/map/src/test/reconnection.spec.ts
+++ b/packages/dds/map/src/test/reconnection.spec.ts
@@ -25,23 +25,23 @@ describe("Reconnection", () => {
             containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
 
             // Create the first SharedMap.
-            const componentRuntime1 = new MockFluidDataStoreRuntime();
-            containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime1);
+            const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
+            containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
             const services1 = {
                 deltaConnection: containerRuntime1.createDeltaConnection(),
                 objectStorage: new MockStorage(),
             };
-            map1 = new SharedMap("shared-map-1", componentRuntime1, MapFactory.Attributes);
+            map1 = new SharedMap("shared-map-1", dataStoreRuntime1, MapFactory.Attributes);
             map1.connect(services1);
 
             // Create the second SharedMap.
-            const componentRuntime2 = new MockFluidDataStoreRuntime();
-            containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+            containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
             const services2 = {
                 deltaConnection: containerRuntime2.createDeltaConnection(),
                 objectStorage: new MockStorage(),
             };
-            map2 = new SharedMap("shared-map-2", componentRuntime2, MapFactory.Attributes);
+            map2 = new SharedMap("shared-map-2", dataStoreRuntime2, MapFactory.Attributes);
             map2.connect(services2);
         });
 
@@ -127,23 +127,23 @@ describe("Reconnection", () => {
             containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
 
             // Create the first SharedDirectory.
-            const componentRuntime1 = new MockFluidDataStoreRuntime();
-            containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime1);
+            const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
+            containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
             const services1 = {
                 deltaConnection: containerRuntime1.createDeltaConnection(),
                 objectStorage: new MockStorage(),
             };
-            directory1 = new SharedDirectory("shared-directory-1", componentRuntime1, DirectoryFactory.Attributes);
+            directory1 = new SharedDirectory("shared-directory-1", dataStoreRuntime1, DirectoryFactory.Attributes);
             directory1.connect(services1);
 
             // Create the second SharedDirectory.
-            const componentRuntime2 = new MockFluidDataStoreRuntime();
-            containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+            containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
             const services2 = {
                 deltaConnection: containerRuntime2.createDeltaConnection(),
                 objectStorage: new MockStorage(),
             };
-            directory2 = new SharedDirectory("shared-directory-2", componentRuntime2, DirectoryFactory.Attributes);
+            directory2 = new SharedDirectory("shared-directory-2", dataStoreRuntime2, DirectoryFactory.Attributes);
             directory2.connect(services2);
         });
 

--- a/packages/dds/matrix/test/matrix.big.spec.ts
+++ b/packages/dds/matrix/test/matrix.big.spec.ts
@@ -27,12 +27,12 @@ async function snapshot<T extends Serializable>(matrix: SharedMatrix<T>) {
     // Create a snapshot
     const objectStorage = new MockStorage(matrix.snapshot());
 
-    // Create a local ComponentRuntime since we only want to load the snapshot for a local client.
-    const componentRuntime = new MockFluidDataStoreRuntime();
-    componentRuntime.local = true;
+    // Create a local DataStoreRuntime since we only want to load the snapshot for a local client.
+    const dataStoreRuntime = new MockFluidDataStoreRuntime();
+    dataStoreRuntime.local = true;
 
     // Load the snapshot into a newly created 2nd SharedMatrix.
-    const matrix2 = new SharedMatrix<T>(componentRuntime, `load(${matrix.id})`, SharedMatrixFactory.Attributes);
+    const matrix2 = new SharedMatrix<T>(dataStoreRuntime, `load(${matrix.id})`, SharedMatrixFactory.Attributes);
     await matrix2.load(/*branchId: */ null as any, {
         deltaConnection: new MockEmptyDeltaConnection(),
         objectStorage
@@ -50,30 +50,30 @@ describe("Big Matrix", function () {
     describe(`Excel-size matrix (${Const.excelMaxRows}x${Const.excelMaxCols})`, () => {
         let matrix1: SharedMatrix;
         let matrix2: SharedMatrix;
-        let componentRuntime1: MockFluidDataStoreRuntime;
+        let dataStoreRuntime1: MockFluidDataStoreRuntime;
         let containterRuntimeFactory: MockContainerRuntimeFactory;
 
         beforeEach(async () => {
             containterRuntimeFactory = new MockContainerRuntimeFactory();
 
             // Create and connect the first SharedMatrix.
-            componentRuntime1 = new MockFluidDataStoreRuntime();
-            const containerRuntime1 = containterRuntimeFactory.createContainerRuntime(componentRuntime1);
+            dataStoreRuntime1 = new MockFluidDataStoreRuntime();
+            const containerRuntime1 = containterRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
             const services1: IChannelServices = {
                 deltaConnection: containerRuntime1.createDeltaConnection(),
                 objectStorage: new MockStorage(),
             };
-            matrix1 = new SharedMatrix(componentRuntime1, "matrix1", SharedMatrixFactory.Attributes);
+            matrix1 = new SharedMatrix(dataStoreRuntime1, "matrix1", SharedMatrixFactory.Attributes);
             matrix1.connect(services1);
 
             // Create and connect the second SharedMatrix.
-            const componentRuntime2 = new MockFluidDataStoreRuntime();
-            const containerRuntime2 = containterRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+            const containerRuntime2 = containterRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
             const services2: IChannelServices = {
                 deltaConnection: containerRuntime2.createDeltaConnection(),
                 objectStorage: new MockStorage(),
             };
-            matrix2 = new SharedMatrix(componentRuntime2, "matrix2", SharedMatrixFactory.Attributes);
+            matrix2 = new SharedMatrix(dataStoreRuntime2, "matrix2", SharedMatrixFactory.Attributes);
             matrix2.connect(services2);
         });
 
@@ -129,9 +129,9 @@ describe("Big Matrix", function () {
 
         beforeEach(async () => {
             // Create a SharedMatrix in local state.
-            const componentRuntime = new MockFluidDataStoreRuntime();
-            componentRuntime.local = true;
-            matrix = new SharedMatrix(componentRuntime, "matrix1", SharedMatrixFactory.Attributes);
+            const dataStoreRuntime = new MockFluidDataStoreRuntime();
+            dataStoreRuntime.local = true;
+            matrix = new SharedMatrix(dataStoreRuntime, "matrix1", SharedMatrixFactory.Attributes);
         });
 
         it("snapshot", async () => {

--- a/packages/dds/matrix/test/matrix.spec.ts
+++ b/packages/dds/matrix/test/matrix.spec.ts
@@ -21,7 +21,7 @@ import { TestConsumer } from "./testconsumer";
 
 describe("Matrix", () => {
     describe("local client", () => {
-        let componentRuntime: MockFluidDataStoreRuntime;
+        let dataStoreRuntime: MockFluidDataStoreRuntime;
         let matrix: SharedMatrix<number>;
         let consumer: TestConsumer<undefined | null | number>;     // Test IMatrixConsumer that builds a copy of `matrix` via observed events.
 
@@ -31,12 +31,12 @@ describe("Matrix", () => {
             // Create a snapshot
             const objectStorage = new MockStorage(matrix.snapshot());
 
-            // Create a local ComponentRuntime since we only want to load the snapshot for a local client.
-            const componentRuntime = new MockFluidDataStoreRuntime();
-            componentRuntime.local = true;
+            // Create a local DataStoreRuntime since we only want to load the snapshot for a local client.
+            const dataStoreRuntime = new MockFluidDataStoreRuntime();
+            dataStoreRuntime.local = true;
 
             // Load the snapshot into a newly created 2nd SharedMatrix.
-            const matrix2 = new SharedMatrix<T>(componentRuntime, `load(${matrix.id})`, SharedMatrixFactory.Attributes);
+            const matrix2 = new SharedMatrix<T>(dataStoreRuntime, `load(${matrix.id})`, SharedMatrixFactory.Attributes);
             await matrix2.load(/*branchId: */ null as any, {
                 deltaConnection: new MockEmptyDeltaConnection(),
                 objectStorage
@@ -59,8 +59,8 @@ describe("Matrix", () => {
         }
 
         beforeEach(async () => {
-            componentRuntime = new MockFluidDataStoreRuntime();
-            matrix = new SharedMatrix(componentRuntime, "matrix1", SharedMatrixFactory.Attributes);
+            dataStoreRuntime = new MockFluidDataStoreRuntime();
+            matrix = new SharedMatrix(dataStoreRuntime, "matrix1", SharedMatrixFactory.Attributes);
 
             // Attach a new IMatrixConsumer
             consumer = new TestConsumer(matrix);
@@ -358,24 +358,24 @@ describe("Matrix", () => {
             containterRuntimeFactory = new MockContainerRuntimeFactory();
 
             // Create and connect the first SharedMatrix.
-            const componentRuntime1 = new MockFluidDataStoreRuntime();
-            const containerRuntime1 = containterRuntimeFactory.createContainerRuntime(componentRuntime1);
+            const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
+            const containerRuntime1 = containterRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
             const services1: IChannelServices = {
                 deltaConnection: containerRuntime1.createDeltaConnection(),
                 objectStorage: new MockStorage(),
             };
-            matrix1 = new SharedMatrix(componentRuntime1, "matrix1", SharedMatrixFactory.Attributes);
+            matrix1 = new SharedMatrix(dataStoreRuntime1, "matrix1", SharedMatrixFactory.Attributes);
             matrix1.connect(services1);
             consumer1 = new TestConsumer(matrix1);
 
             // Create and connect the second SharedMatrix.
-            const componentRuntime2 = new MockFluidDataStoreRuntime();
-            const containerRuntime2 = containterRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+            const containerRuntime2 = containterRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
             const services2: IChannelServices = {
                 deltaConnection: containerRuntime2.createDeltaConnection(),
                 objectStorage: new MockStorage(),
             };
-            matrix2 = new SharedMatrix(componentRuntime2, "matrix2", SharedMatrixFactory.Attributes);
+            matrix2 = new SharedMatrix(dataStoreRuntime2, "matrix2", SharedMatrixFactory.Attributes);
             matrix2.connect(services2);
             consumer2 = new TestConsumer(matrix2);
         });
@@ -700,24 +700,24 @@ describe("Matrix", () => {
             containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
 
             // Create and connect the first SharedMatrix.
-            const componentRuntime1 = new MockFluidDataStoreRuntime();
-            containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime1);
+            const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
+            containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
             const services1: IChannelServices = {
                 deltaConnection: containerRuntime1.createDeltaConnection(),
                 objectStorage: new MockStorage(),
             };
-            matrix1 = new SharedMatrix(componentRuntime1, "matrix1", SharedMatrixFactory.Attributes);
+            matrix1 = new SharedMatrix(dataStoreRuntime1, "matrix1", SharedMatrixFactory.Attributes);
             matrix1.connect(services1);
             consumer1 = new TestConsumer(matrix1);
 
             // Create and connect the second SharedMatrix.
-            const componentRuntime2 = new MockFluidDataStoreRuntime();
-            containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+            containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
             const services2: IChannelServices = {
                 deltaConnection: containerRuntime2.createDeltaConnection(),
                 objectStorage: new MockStorage(),
             };
-            matrix2 = new SharedMatrix(componentRuntime2, "matrix2", SharedMatrixFactory.Attributes);
+            matrix2 = new SharedMatrix(dataStoreRuntime2, "matrix2", SharedMatrixFactory.Attributes);
             matrix2.connect(services2);
             consumer2 = new TestConsumer(matrix2);
         });

--- a/packages/dds/matrix/test/matrix.stress.spec.ts
+++ b/packages/dds/matrix/test/matrix.stress.spec.ts
@@ -76,14 +76,14 @@ describe("Matrix", () => {
 
                 // Create matrices for this stress run.
                 for (let i = 0; i < numClients; i++) {
-                    const componentRuntimeN = new MockFluidDataStoreRuntime();
-                    const containerRuntimeN = containerRuntimeFactory.createContainerRuntime(componentRuntimeN);
+                    const dataStoreRuntimeN = new MockFluidDataStoreRuntime();
+                    const containerRuntimeN = containerRuntimeFactory.createContainerRuntime(dataStoreRuntimeN);
                     const servicesN: IChannelServices = {
                         deltaConnection: containerRuntimeN.createDeltaConnection(),
                         objectStorage: new MockStorage(),
                     };
 
-                    const matrixN = new SharedMatrix(componentRuntimeN, `matrix-${i}`, SharedMatrixFactory.Attributes);
+                    const matrixN = new SharedMatrix(dataStoreRuntimeN, `matrix-${i}`, SharedMatrixFactory.Attributes);
                     matrixN.connect(servicesN);
 
                     matrices.push(matrixN);

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -896,7 +896,7 @@ export class Client {
 
         // Catch up to latest MSN, if we have not had a chance to do it.
         // Required for case where FluidDataStoreRuntime.attachChannel()
-        // generates snapshot right after loading component.
+        // generates snapshot right after loading data store.
 
         this.updateSeqNumbers(minSeq, deltaManager.lastSequenceNumber);
 

--- a/packages/dds/merge-tree/src/ops.ts
+++ b/packages/dds/merge-tree/src/ops.ts
@@ -25,10 +25,6 @@ export interface IMarkerDef {
     refType?: ReferenceType;
 }
 
-export interface IComponentDef {
-    url: string;
-}
-
 // Note: Assigned positive integers to avoid clashing with MergeTreeMaintenanceType
 export const enum MergeTreeDeltaType {
     INSERT = 0,

--- a/packages/dds/ordered-collection/src/consensusQueue.ts
+++ b/packages/dds/ordered-collection/src/consensusQueue.ts
@@ -47,7 +47,7 @@ export class ConsensusQueue<T = any> extends ConsensusOrderedCollection<T> {
     }
 
     /**
-     * Get a factory for ConsensusQueue to register with the component.
+     * Get a factory for ConsensusQueue to register with the data store.
      *
      * @returns a factory that creates and load ConsensusQueue
      */

--- a/packages/dds/ordered-collection/src/consensusQueue.ts
+++ b/packages/dds/ordered-collection/src/consensusQueue.ts
@@ -38,7 +38,7 @@ export class ConsensusQueue<T = any> extends ConsensusOrderedCollection<T> {
     /**
      * Create a new consensus queue
      *
-     * @param runtime - component runtime the new consensus queue belongs to
+     * @param runtime - data store runtime the new consensus queue belongs to
      * @param id - optional name of theconsensus queue
      * @returns newly create consensus queue (but not attached yet)
      */

--- a/packages/dds/ordered-collection/src/test/consensusOrderedCollection.spec.ts
+++ b/packages/dds/ordered-collection/src/test/consensusOrderedCollection.spec.ts
@@ -71,8 +71,8 @@ describe("ConsensusOrderedCollection", () => {
 
                 const acquiredValue = await removeItem();
                 assert.strictEqual(acquiredValue.absolutePath, handle.absolutePath);
-                const component = await handle.get();
-                assert.strictEqual(component.url, testCollection.url);
+                const dataStore = await handle.get();
+                assert.strictEqual(dataStore.url, testCollection.url);
 
                 assert.strictEqual(await removeItem(), undefined);
             });
@@ -174,15 +174,15 @@ describe("ConsensusOrderedCollection", () => {
         generate([1, 2], [1, 2],
             () => {
                 containerRuntimeFactory = new MockContainerRuntimeFactory();
-                const componentRuntime = new MockFluidDataStoreRuntime();
-                const containerRuntime = containerRuntimeFactory.createContainerRuntime(componentRuntime);
+                const dataStoreRuntime = new MockFluidDataStoreRuntime();
+                const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
                 const services: IChannelServices = {
                     deltaConnection: containerRuntime.createDeltaConnection(),
                     objectStorage: new MockStorage(),
                 };
 
                 counter++;
-                const testCollection = factory.create(componentRuntime, `consensus-ordered-collection_${counter}`);
+                const testCollection = factory.create(dataStoreRuntime, `consensus-ordered-collection_${counter}`);
                 testCollection.connect(services);
                 return testCollection;
             },
@@ -200,7 +200,7 @@ describe("ConsensusOrderedCollection", () => {
 
         async function createConsensusOrderedCollection(
             id: string,
-            componentRuntime: MockFluidDataStoreRuntime,
+            dataStoreRuntime: MockFluidDataStoreRuntime,
             deltaConnection: IDeltaConnection,
         ): Promise<IConsensusOrderedCollection> {
             const services: IChannelServices = {
@@ -208,7 +208,7 @@ describe("ConsensusOrderedCollection", () => {
                 objectStorage: new MockStorage(),
             };
 
-            const consensusOrderedCollection = factory.create(componentRuntime, id);
+            const consensusOrderedCollection = factory.create(dataStoreRuntime, id);
             consensusOrderedCollection.connect(services);
             return consensusOrderedCollection;
         }
@@ -217,22 +217,22 @@ describe("ConsensusOrderedCollection", () => {
             containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
 
             // Create first ConsensusOrderedCollection
-            const componentRuntime1 = new MockFluidDataStoreRuntime();
-            containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime1);
+            const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
+            containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
             const deltaConnection1 = containerRuntime1.createDeltaConnection();
             testCollection1 = await createConsensusOrderedCollection(
                 "consensus-ordered-collection1",
-                componentRuntime1,
+                dataStoreRuntime1,
                 deltaConnection1,
             );
 
             // Create second ConsensusOrderedCollection
-            const componentRuntime2 = new MockFluidDataStoreRuntime();
-            containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+            containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
             const deltaConnection2 = containerRuntime2.createDeltaConnection();
             testCollection2 = await createConsensusOrderedCollection(
                 "consensus-ordered-collection2",
-                componentRuntime2,
+                dataStoreRuntime2,
                 deltaConnection2,
             );
         });

--- a/packages/dds/register-collection/src/consensusRegisterCollection.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollection.ts
@@ -96,7 +96,7 @@ export class ConsensusRegisterCollection<T>
     /**
      * Create a new consensus register collection
      *
-     * @param runtime - component runtime the new consensus register collection belongs to
+     * @param runtime - data store runtime the new consensus register collection belongs to
      * @param id - optional name of the consensus register collection
      * @returns newly create consensus register collection (but not attached yet)
      */

--- a/packages/dds/register-collection/src/consensusRegisterCollection.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollection.ts
@@ -105,7 +105,7 @@ export class ConsensusRegisterCollection<T>
     }
 
     /**
-     * Get a factory for ConsensusRegisterCollection to register with the component.
+     * Get a factory for ConsensusRegisterCollection to register with the data store.
      *
      * @returns a factory that creates and load ConsensusRegisterCollection
      */

--- a/packages/dds/register-collection/src/test/consensusRegisterCollection.spec.ts
+++ b/packages/dds/register-collection/src/test/consensusRegisterCollection.spec.ts
@@ -24,22 +24,22 @@ import { IConsensusRegisterCollection } from "../interfaces";
 describe("ConsensusRegisterCollection", () => {
     const crcFactory = new ConsensusRegisterCollectionFactory();
     describe("Api", () => {
-        const componentId = "consensus-register-collection";
+        const dataStoreId = "consensus-register-collection";
         let crc: IConsensusRegisterCollection;
-        let componentRuntime: MockFluidDataStoreRuntime;
+        let dataStoreRuntime: MockFluidDataStoreRuntime;
         let services: IChannelServices;
         let containerRuntimeFactory: MockContainerRuntimeFactory;
 
         beforeEach(() => {
-            componentRuntime = new MockFluidDataStoreRuntime();
+            dataStoreRuntime = new MockFluidDataStoreRuntime();
             containerRuntimeFactory = new MockContainerRuntimeFactory();
-            const containerRuntime = containerRuntimeFactory.createContainerRuntime(componentRuntime);
+            const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
             services = {
                 deltaConnection: containerRuntime.createDeltaConnection(),
                 objectStorage: new MockStorage(),
             };
 
-            crc = crcFactory.create(componentRuntime, componentId);
+            crc = crcFactory.create(dataStoreRuntime, dataStoreId);
         });
 
         describe("Attached, connected", () => {
@@ -130,8 +130,8 @@ describe("ConsensusRegisterCollection", () => {
                 const tree: ITree = buildTree(expectedSerialization);
                 services.objectStorage = new MockStorage(tree);
                 const loadedCrc = await crcFactory.load(
-                    componentRuntime,
-                    componentId,
+                    dataStoreRuntime,
+                    dataStoreId,
                     services,
                     "master",
                     ConsensusRegisterCollectionFactory.Attributes,
@@ -143,8 +143,8 @@ describe("ConsensusRegisterCollection", () => {
                 const tree: ITree = buildTree(legacySharedObjectSerialization);
                 services.objectStorage = new MockStorage(tree);
                 await assert.rejects(crcFactory.load(
-                    componentRuntime,
-                    componentId,
+                    dataStoreRuntime,
+                    dataStoreId,
                     services,
                     "master",
                     ConsensusRegisterCollectionFactory.Attributes,
@@ -166,16 +166,16 @@ describe("ConsensusRegisterCollection", () => {
             containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
 
             // Create first ConsensusOrderedCollection
-            const componentRuntime1 = new MockFluidDataStoreRuntime();
-            containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime1);
+            const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
+            containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
             deltaConnection1 = containerRuntime1.createDeltaConnection();
-            testCollection1 = crcFactory.create(componentRuntime1, "consenses-register-collection1");
+            testCollection1 = crcFactory.create(dataStoreRuntime1, "consenses-register-collection1");
 
             // Create second ConsensusOrderedCollection
-            const componentRuntime2 = new MockFluidDataStoreRuntime();
-            containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+            containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
             deltaConnection2 = containerRuntime2.createDeltaConnection();
-            testCollection2 = crcFactory.create(componentRuntime2, "consenses-register-collection2");
+            testCollection2 = crcFactory.create(dataStoreRuntime2, "consenses-register-collection2");
         });
 
         describe("Object not connected", () => {

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -121,17 +121,17 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
     private messagesSinceMSNChange: ISequencedDocumentMessage[] = [];
     private readonly intervalMapKernel: MapKernel;
     constructor(
-        private readonly componentRuntime: IFluidDataStoreRuntime,
+        private readonly dataStoreRuntime: IFluidDataStoreRuntime,
         public id: string,
         attributes: IChannelAttributes,
         public readonly segmentFromSpec: (spec: MergeTree.IJSONSegment) => MergeTree.ISegment,
     ) {
-        super(id, componentRuntime, attributes);
+        super(id, dataStoreRuntime, attributes);
 
         this.client = new MergeTree.Client(
             segmentFromSpec,
             ChildLogger.create(this.logger, "SharedSegmentSequence.MergeTreeClient"),
-            componentRuntime.options);
+            dataStoreRuntime.options);
 
         super.on("newListener", (event) => {
             switch (event) {
@@ -513,7 +513,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
                 .catch((error) => {
                     this.loadFinished(error);
                 });
-            if (this.componentRuntime.options?.sequenceInitializeFromHeaderOnly !== true) {
+            if (this.dataStoreRuntime.options?.sequenceInitializeFromHeaderOnly !== true) {
                 // if we not doing parital load, await the catch up ops,
                 // and the finalization of the load
                 await loadCatchUpOps;

--- a/packages/dds/sequence/src/sharedIntervalCollection.ts
+++ b/packages/dds/sequence/src/sharedIntervalCollection.ts
@@ -84,7 +84,7 @@ export class SharedIntervalCollection<TInterval extends ISerializableInterval = 
     /**
      * Create a SharedIntervalCollection
      *
-     * @param runtime - component runtime the new shared map belongs to
+     * @param runtime - data store runtime the new shared map belongs to
      * @param id - optional name of the shared map
      * @returns newly create shared map (but not attached yet)
      */

--- a/packages/dds/sequence/src/sharedIntervalCollection.ts
+++ b/packages/dds/sequence/src/sharedIntervalCollection.ts
@@ -93,7 +93,7 @@ export class SharedIntervalCollection<TInterval extends ISerializableInterval = 
     }
 
     /**
-     * Get a factory for SharedIntervalCollection to register with the component.
+     * Get a factory for SharedIntervalCollection to register with the data store.
      *
      * @returns a factory that creates and load SharedIntervalCollection
      */

--- a/packages/dds/sequence/src/sharedNumberSequence.ts
+++ b/packages/dds/sequence/src/sharedNumberSequence.ts
@@ -11,7 +11,7 @@ export class SharedNumberSequence extends SharedSequence<number> {
     /**
      * Create a new shared number sequence
      *
-     * @param runtime - component runtime the new shared number sequence belongs to
+     * @param runtime - data store runtime the new shared number sequence belongs to
      * @param id - optional name of the shared number sequence
      * @returns newly create shared number sequence (but not attached yet)
      */

--- a/packages/dds/sequence/src/sharedNumberSequence.ts
+++ b/packages/dds/sequence/src/sharedNumberSequence.ts
@@ -21,7 +21,7 @@ export class SharedNumberSequence extends SharedSequence<number> {
     }
 
     /**
-     * Get a factory for SharedNumberSequence to register with the component.
+     * Get a factory for SharedNumberSequence to register with the data store.
      *
      * @returns a factory that creates and load SharedNumberSequence
      */

--- a/packages/dds/sequence/src/sharedObjectSequence.ts
+++ b/packages/dds/sequence/src/sharedObjectSequence.ts
@@ -20,7 +20,7 @@ export class SharedObjectSequence<T> extends SharedSequence<T> {
     }
 
     /**
-     * Get a factory for SharedObjectSequence to register with the component.
+     * Get a factory for SharedObjectSequence to register with the data store.
      *
      * @returns a factory that creates and load SharedObjectSequence
      */

--- a/packages/dds/sequence/src/sharedObjectSequence.ts
+++ b/packages/dds/sequence/src/sharedObjectSequence.ts
@@ -11,7 +11,7 @@ export class SharedObjectSequence<T> extends SharedSequence<T> {
     /**
      * Create a new shared object sequence
      *
-     * @param runtime - component runtime the new shared object sequence belongs to
+     * @param runtime - data store runtime the new shared object sequence belongs to
      * @param id - optional name of the shared object sequence
      * @returns newly create shared object sequence (but not attached yet)
      */

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -22,7 +22,7 @@ export interface IProvideSharedString {
 }
 
 /**
- * Component interface describing access methods on a SharedString
+ * Fluid object interface describing access methods on a SharedString
  */
 export interface ISharedString extends SharedSegmentSequence<SharedStringSegment>, IProvideSharedString {
     insertText(pos: number, text: string, props?: MergeTree.PropertySet);
@@ -47,7 +47,7 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
     }
 
     /**
-     * Get a factory for SharedString to register with the component.
+     * Get a factory for SharedString to register with the data store.
      *
      * @returns a factory that creates and load SharedString
      */
@@ -214,7 +214,7 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
         return this.mergeTreeTextHelper.getText(segmentWindow.currentSeq, segmentWindow.clientId, "", start, end);
     }
     /**
-     * Adds spaces for markers and components, so that position calculations account for them
+     * Adds spaces for markers and handles, so that position calculations account for them
      */
     public getTextWithPlaceholders() {
         const segmentWindow = this.client.getCollabWindow();

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -38,7 +38,7 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
     /**
      * Create a new shared string
      *
-     * @param runtime - component runtime the new shared string belongs to
+     * @param runtime - data store runtime the new shared string belongs to
      * @param id - optional name of the shared string
      * @returns newly create shared string (but not attached yet)
      */

--- a/packages/dds/sequence/src/sparsematrix.ts
+++ b/packages/dds/sequence/src/sparsematrix.ts
@@ -201,7 +201,7 @@ export class SparseMatrix extends SharedSegmentSequence<MatrixSegment> {
     }
 
     /**
-     * Get a factory for SharedMap to register with the component.
+     * Get a factory for SharedMap to register with the data store.
      *
      * @returns a factory that creates and load SharedMap
      */

--- a/packages/dds/sequence/src/sparsematrix.ts
+++ b/packages/dds/sequence/src/sparsematrix.ts
@@ -192,7 +192,7 @@ export class SparseMatrix extends SharedSegmentSequence<MatrixSegment> {
     /**
      * Create a new sparse matrix
      *
-     * @param runtime - component runtime the new sparse matrix belongs to
+     * @param runtime - data store runtime the new sparse matrix belongs to
      * @param id - optional name of the sparse matrix
      * @returns newly create sparse matrix (but not attached yet)
      */

--- a/packages/dds/sequence/src/test/generateSharedStrings.ts
+++ b/packages/dds/sequence/src/test/generateSharedStrings.ts
@@ -24,13 +24,13 @@ export const supportedVersions = new Map<string, any>([
 export function* generateStrings(): Generator<[string, SharedString]> {
     for (const [version, options] of supportedVersions) {
         const documentId = "fakeId";
-        const componentRuntime: mocks.MockFluidDataStoreRuntime = new mocks.MockFluidDataStoreRuntime();
+        const dataStoreRuntime: mocks.MockFluidDataStoreRuntime = new mocks.MockFluidDataStoreRuntime();
         for (const key of Object.keys(options)) {
-            componentRuntime.options[key] = options[key];
+            dataStoreRuntime.options[key] = options[key];
         }
         const insertText = "text";
 
-        let sharedString = new SharedString(componentRuntime, documentId, SharedStringFactory.Attributes);
+        let sharedString = new SharedString(dataStoreRuntime, documentId, SharedStringFactory.Attributes);
         sharedString.initializeLocal();
         // Small enough so snapshot won't have body
         for (let i = 0; i < (Snapshot.sizeOfFirstChunk / insertText.length) / 2; ++i) {
@@ -39,7 +39,7 @@ export function* generateStrings(): Generator<[string, SharedString]> {
 
         yield [`${version}/headerOnly`, sharedString];
 
-        sharedString = new SharedString(componentRuntime, documentId, SharedStringFactory.Attributes);
+        sharedString = new SharedString(dataStoreRuntime, documentId, SharedStringFactory.Attributes);
         sharedString.initializeLocal();
         // Big enough that snapshot will have body
         for (let i = 0; i < (Snapshot.sizeOfFirstChunk / insertText.length) * 2; ++i) {
@@ -48,7 +48,7 @@ export function* generateStrings(): Generator<[string, SharedString]> {
 
         yield [`${version}/headerAndBody`, sharedString];
 
-        sharedString = new SharedString(componentRuntime, documentId, SharedStringFactory.Attributes);
+        sharedString = new SharedString(dataStoreRuntime, documentId, SharedStringFactory.Attributes);
         sharedString.initializeLocal();
         // Very big sharedString
         for (let i = 0; i < Snapshot.sizeOfFirstChunk; ++i) {
@@ -57,7 +57,7 @@ export function* generateStrings(): Generator<[string, SharedString]> {
 
         yield [`${version}/largeBody`, sharedString];
 
-        sharedString = new SharedString(componentRuntime, documentId, SharedStringFactory.Attributes);
+        sharedString = new SharedString(dataStoreRuntime, documentId, SharedStringFactory.Attributes);
         sharedString.initializeLocal();
         // SharedString with markers
         for (let i = 0; i < (Snapshot.sizeOfFirstChunk / insertText.length) * 2; ++i) {
@@ -74,7 +74,7 @@ export function* generateStrings(): Generator<[string, SharedString]> {
 
         yield [`${version}/withMarkers`, sharedString];
 
-        sharedString = new SharedString(componentRuntime, documentId, SharedStringFactory.Attributes);
+        sharedString = new SharedString(dataStoreRuntime, documentId, SharedStringFactory.Attributes);
         sharedString.initializeLocal();
         // SharedString with annotations
         for (let i = 0; i < (Snapshot.sizeOfFirstChunk / insertText.length) * 2; ++i) {
@@ -86,7 +86,7 @@ export function* generateStrings(): Generator<[string, SharedString]> {
 
         yield [`${version}/withAnnotations`, sharedString];
 
-        sharedString = new SharedString(componentRuntime, documentId, SharedStringFactory.Attributes);
+        sharedString = new SharedString(dataStoreRuntime, documentId, SharedStringFactory.Attributes);
         sharedString.initializeLocal();
         // Very big sharedString
         for (let i = 0; i < Snapshot.sizeOfFirstChunk; ++i) {

--- a/packages/dds/sequence/src/test/partialLoad.spec.ts
+++ b/packages/dds/sequence/src/test/partialLoad.spec.ts
@@ -46,23 +46,23 @@ function generateSnapshotTree(
     containerRuntimeFactory: MockContainerRuntimeFactory,
     options: any = {},
 ): [SharedString, ITree] {
-    const componentRuntime1 = new MockFluidDataStoreRuntime();
-    componentRuntime1.options = options;
+    const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
+    dataStoreRuntime1.options = options;
     // Connect the first SharedString.
-    const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime1);
+    const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
     const services1: IChannelServices = {
         deltaConnection: containerRuntime1.createDeltaConnection(),
         objectStorage: new MockStorage(),
     };
-    const sharedString = new SharedString(componentRuntime1, "shared-string", SharedStringFactory.Attributes);
+    const sharedString = new SharedString(dataStoreRuntime1, "shared-string", SharedStringFactory.Attributes);
     sharedString.initializeLocal();
     sharedString.connect(services1);
 
     // Create and connect a second SharedString.
-    const componentRuntime2 = new MockFluidDataStoreRuntime();
-    componentRuntime2.options = options;
-    const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
-    const sharedString2 = new SharedString(componentRuntime2, "shared-string", SharedStringFactory.Attributes);
+    const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+    dataStoreRuntime2.options = options;
+    const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
+    const sharedString2 = new SharedString(dataStoreRuntime2, "shared-string", SharedStringFactory.Attributes);
     const services2: IChannelServices = {
         deltaConnection: containerRuntime2.createDeltaConnection(),
         objectStorage: new MockStorage(),
@@ -86,15 +86,15 @@ describe("SharedString Partial Load", () => {
         const options = { mergeTreeSnapshotChunkSize };
         const [remoteSharedString, snapshotTree] = generateSnapshotTree(containerRuntimeFactory, options);
 
-        const localComponentRuntime = new MockFluidDataStoreRuntime();
-        localComponentRuntime.options = options;
-        const localContainerRuntime = containerRuntimeFactory.createContainerRuntime(localComponentRuntime);
+        const localDataStoreRuntime = new MockFluidDataStoreRuntime();
+        localDataStoreRuntime.options = options;
+        const localContainerRuntime = containerRuntimeFactory.createContainerRuntime(localDataStoreRuntime);
         const localServices = {
             deltaConnection: localContainerRuntime.createDeltaConnection(),
             objectStorage: new MockStorage(snapshotTree),
         };
         const localSharedString =
-            new SharedString(localComponentRuntime, "shared-string", SharedStringFactory.Attributes);
+            new SharedString(localDataStoreRuntime, "shared-string", SharedStringFactory.Attributes);
 
         // eslint-disable-next-line no-null/no-null
         await localSharedString.load(null, localServices);
@@ -107,15 +107,15 @@ describe("SharedString Partial Load", () => {
         const options = { newMergeTreeSnapshotFormat: true, mergeTreeSnapshotChunkSize };
         const [remoteSharedString, snapshotTree] = generateSnapshotTree(containerRuntimeFactory, options);
 
-        const localComponentRuntime = new MockFluidDataStoreRuntime();
-        localComponentRuntime.options = options;
-        const localContainerRuntime = containerRuntimeFactory.createContainerRuntime(localComponentRuntime);
+        const localDataStoreRuntime = new MockFluidDataStoreRuntime();
+        localDataStoreRuntime.options = options;
+        const localContainerRuntime = containerRuntimeFactory.createContainerRuntime(localDataStoreRuntime);
         const localServices = {
             deltaConnection: localContainerRuntime.createDeltaConnection(),
             objectStorage: new MockStorage(snapshotTree),
         };
         const localSharedString =
-            new SharedString(localComponentRuntime, "shared-string", SharedStringFactory.Attributes);
+            new SharedString(localDataStoreRuntime, "shared-string", SharedStringFactory.Attributes);
 
         // eslint-disable-next-line no-null/no-null
         await localSharedString.load(null, localServices);
@@ -132,15 +132,15 @@ describe("SharedString Partial Load", () => {
         };
         const [remoteSharedString, snapshotTree] = generateSnapshotTree(containerRuntimeFactory, options);
 
-        const localComponentRuntime = new MockFluidDataStoreRuntime();
-        localComponentRuntime.options = options;
-        const localContainerRuntime = containerRuntimeFactory.createContainerRuntime(localComponentRuntime);
+        const localDataStoreRuntime = new MockFluidDataStoreRuntime();
+        localDataStoreRuntime.options = options;
+        const localContainerRuntime = containerRuntimeFactory.createContainerRuntime(localDataStoreRuntime);
         const localServices = {
             deltaConnection: localContainerRuntime.createDeltaConnection(),
             objectStorage: new MockStorage(snapshotTree),
         };
         const localSharedString =
-            new SharedString(localComponentRuntime, "shared-string", SharedStringFactory.Attributes);
+            new SharedString(localDataStoreRuntime, "shared-string", SharedStringFactory.Attributes);
 
         // eslint-disable-next-line no-null/no-null
         await localSharedString.load(null, localServices);
@@ -148,7 +148,7 @@ describe("SharedString Partial Load", () => {
         assert.notEqual(localSharedString.getText(), remoteSharedString.getText());
 
         await localSharedString.loaded;
-        localComponentRuntime.deltaManager.lastSequenceNumber = localSharedString.getCurrentSeq();
+        localDataStoreRuntime.deltaManager.lastSequenceNumber = localSharedString.getCurrentSeq();
 
         assert.equal(localSharedString.getText(), remoteSharedString.getText());
     });
@@ -162,23 +162,23 @@ describe("SharedString Partial Load", () => {
         };
         const [remoteSharedString, snapshotTree] = generateSnapshotTree(containerRuntimeFactory, options);
 
-        const localComponentRuntime = new MockFluidDataStoreRuntime();
-        localComponentRuntime.options = options;
-        const localContainerRuntime = containerRuntimeFactory.createContainerRuntime(localComponentRuntime);
+        const localDataStoreRuntime = new MockFluidDataStoreRuntime();
+        localDataStoreRuntime.options = options;
+        const localContainerRuntime = containerRuntimeFactory.createContainerRuntime(localDataStoreRuntime);
         const localServices = {
             deltaConnection: localContainerRuntime.createDeltaConnection(),
             objectStorage: new MockStorage(snapshotTree),
         };
         const localSharedString =
-            new SharedString(localComponentRuntime, "shared-string", SharedStringFactory.Attributes);
+            new SharedString(localDataStoreRuntime, "shared-string", SharedStringFactory.Attributes);
 
         // eslint-disable-next-line no-null/no-null
         await localSharedString.load(null, localServices);
 
-        localComponentRuntime.deltaManager.lastSequenceNumber =
+        localDataStoreRuntime.deltaManager.lastSequenceNumber =
             containerRuntimeFactory.sequenceNumber;
 
-        localComponentRuntime.deltaManager.minimumSequenceNumber =
+        localDataStoreRuntime.deltaManager.minimumSequenceNumber =
             containerRuntimeFactory.getMinSeq();
 
         assert.notEqual(localSharedString.getText(), remoteSharedString.getText());
@@ -207,23 +207,23 @@ describe("SharedString Partial Load", () => {
         };
         const [remoteSharedString, snapshotTree] = generateSnapshotTree(containerRuntimeFactory, options);
 
-        const localComponentRuntime = new MockFluidDataStoreRuntime();
-        localComponentRuntime.options = options;
-        const localContainerRuntime = containerRuntimeFactory.createContainerRuntime(localComponentRuntime);
+        const localDataStoreRuntime = new MockFluidDataStoreRuntime();
+        localDataStoreRuntime.options = options;
+        const localContainerRuntime = containerRuntimeFactory.createContainerRuntime(localDataStoreRuntime);
         const localServices = {
             deltaConnection: localContainerRuntime.createDeltaConnection(),
             objectStorage: new MockStorage(snapshotTree),
         };
         const localSharedString =
-            new SharedString(localComponentRuntime, "shared-string", SharedStringFactory.Attributes);
+            new SharedString(localDataStoreRuntime, "shared-string", SharedStringFactory.Attributes);
 
         // eslint-disable-next-line no-null/no-null
         await localSharedString.load(null, localServices);
 
-        localComponentRuntime.deltaManager.lastSequenceNumber =
+        localDataStoreRuntime.deltaManager.lastSequenceNumber =
             containerRuntimeFactory.sequenceNumber;
 
-        localComponentRuntime.deltaManager.minimumSequenceNumber =
+        localDataStoreRuntime.deltaManager.minimumSequenceNumber =
             containerRuntimeFactory.getMinSeq();
 
         assert.notEqual(localSharedString.getText(), remoteSharedString.getText());
@@ -249,23 +249,23 @@ describe("SharedString Partial Load", () => {
         };
         const [remoteSharedString, snapshotTree] = generateSnapshotTree(containerRuntimeFactory, options);
 
-        const localComponentRuntime = new MockFluidDataStoreRuntime();
-        localComponentRuntime.options = options;
-        const localContainerRuntime = containerRuntimeFactory.createContainerRuntime(localComponentRuntime);
+        const localDataStoreRuntime = new MockFluidDataStoreRuntime();
+        localDataStoreRuntime.options = options;
+        const localContainerRuntime = containerRuntimeFactory.createContainerRuntime(localDataStoreRuntime);
         const localServices = {
             deltaConnection: localContainerRuntime.createDeltaConnection(),
             objectStorage: new MockStorage(snapshotTree),
         };
         const localSharedString =
-            new SharedString(localComponentRuntime, "shared-string", SharedStringFactory.Attributes);
+            new SharedString(localDataStoreRuntime, "shared-string", SharedStringFactory.Attributes);
 
         // eslint-disable-next-line no-null/no-null
         await localSharedString.load(null, localServices);
 
-        localComponentRuntime.deltaManager.lastSequenceNumber =
+        localDataStoreRuntime.deltaManager.lastSequenceNumber =
             containerRuntimeFactory.sequenceNumber;
 
-        localComponentRuntime.deltaManager.minimumSequenceNumber =
+        localDataStoreRuntime.deltaManager.minimumSequenceNumber =
             containerRuntimeFactory.getMinSeq();
 
         assert.notEqual(localSharedString.getText(), remoteSharedString.getText());

--- a/packages/dds/sequence/src/test/sharedNumberSequence.spec.ts
+++ b/packages/dds/sequence/src/test/sharedNumberSequence.spec.ts
@@ -11,10 +11,10 @@ describe("SharedNumberSequence", () => {
     const documentId = "fakeId";
     let sharedNumberSequence: SharedNumberSequence;
     beforeEach(() => {
-        const componentRuntime = new MockFluidDataStoreRuntime();
+        const dataStoreRuntime = new MockFluidDataStoreRuntime();
         sharedNumberSequence =
-            new SharedNumberSequence(componentRuntime, documentId, SharedNumberSequenceFactory.Attributes);
-        componentRuntime.bindToContext();
+            new SharedNumberSequence(dataStoreRuntime, documentId, SharedNumberSequenceFactory.Attributes);
+        dataStoreRuntime.bindToContext();
     });
 
     describe("getItems", () => {

--- a/packages/dds/sequence/src/test/sharedString.spec.ts
+++ b/packages/dds/sequence/src/test/sharedString.spec.ts
@@ -27,16 +27,16 @@ import { SharedStringFactory } from "../sequenceFactory";
 
 describe("SharedString", () => {
     let sharedString: SharedString;
-    let componentRuntime1: MockFluidDataStoreRuntime;
+    let dataStoreRuntime1: MockFluidDataStoreRuntime;
 
     beforeEach(() => {
-        componentRuntime1 = new MockFluidDataStoreRuntime();
-        sharedString = new SharedString(componentRuntime1, "shared-string-1", SharedStringFactory.Attributes);
+        dataStoreRuntime1 = new MockFluidDataStoreRuntime();
+        sharedString = new SharedString(dataStoreRuntime1, "shared-string-1", SharedStringFactory.Attributes);
     });
 
     describe("SharedString in local state", () => {
         beforeEach(() => {
-            componentRuntime1.local = true;
+            dataStoreRuntime1.local = true;
         });
 
         // Creates a new SharedString and loads it from the passed snaphost tree.
@@ -45,9 +45,9 @@ describe("SharedString", () => {
                 deltaConnection: new MockEmptyDeltaConnection(),
                 objectStorage: new MockStorage(tree),
             };
-            const componentRuntime2 = new MockFluidDataStoreRuntime();
+            const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
             const sharedString2 = new SharedString(
-                componentRuntime2,
+                dataStoreRuntime2,
                 "shared-string-2",
                 SharedStringFactory.Attributes);
             // eslint-disable-next-line no-null/no-null
@@ -223,7 +223,7 @@ describe("SharedString", () => {
     describe("SharedString op processing in local state", () => {
         it("should correctly process operations sent in local state", async () => {
             // Set the data store runtime to local.
-            componentRuntime1.local = true;
+            dataStoreRuntime1.local = true;
 
             // Initialize the shared string so that it is completely loaded before we take a snapshot.
             sharedString.initializeLocal();
@@ -234,21 +234,21 @@ describe("SharedString", () => {
 
             // Load a new Ink in connected state from the snapshot of the first one.
             const containerRuntimeFactory = new MockContainerRuntimeFactory();
-            const componentRuntime2 = new MockFluidDataStoreRuntime();
-            const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+            const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
             const services2: IChannelServices = {
                 deltaConnection: containerRuntime2.createDeltaConnection(),
                 objectStorage: new MockStorage(sharedString.snapshot()),
             };
 
             const sharedString2 =
-                new SharedString(componentRuntime2, "shared-string-2", SharedStringFactory.Attributes);
+                new SharedString(dataStoreRuntime2, "shared-string-2", SharedStringFactory.Attributes);
             // eslint-disable-next-line no-null/no-null
             await sharedString2.load(null, services2);
 
             // Now connect the first Ink
-            componentRuntime1.local = false;
-            const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime1);
+            dataStoreRuntime1.local = false;
+            const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
             const services1 = {
                 deltaConnection: containerRuntime1.createDeltaConnection(),
                 objectStorage: new MockStorage(undefined),
@@ -279,8 +279,8 @@ describe("SharedString", () => {
             containerRuntimeFactory = new MockContainerRuntimeFactory();
 
             // Connect the first SharedString.
-            componentRuntime1.local = false;
-            const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime1);
+            dataStoreRuntime1.local = false;
+            const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
             const services1 = {
                 deltaConnection: containerRuntime1.createDeltaConnection(),
                 objectStorage: new MockStorage(),
@@ -289,14 +289,14 @@ describe("SharedString", () => {
             sharedString.connect(services1);
 
             // Create and connect a second SharedString.
-            const componentRuntime2 = new MockFluidDataStoreRuntime();
-            const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+            const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+            const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
             const services2 = {
                 deltaConnection: containerRuntime2.createDeltaConnection(),
                 objectStorage: new MockStorage(),
             };
 
-            sharedString2 = new SharedString(componentRuntime2, "shared-string-2", SharedStringFactory.Attributes);
+            sharedString2 = new SharedString(dataStoreRuntime2, "shared-string-2", SharedStringFactory.Attributes);
             sharedString2.initializeLocal();
             sharedString2.connect(services2);
         });
@@ -465,7 +465,7 @@ describe("SharedString", () => {
             containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
 
             // Connect the first SharedString.
-            containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime1);
+            containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
             const services1: IChannelServices = {
                 deltaConnection: containerRuntime1.createDeltaConnection(),
                 objectStorage: new MockStorage(),

--- a/packages/dds/sequence/src/test/sharedString.spec.ts
+++ b/packages/dds/sequence/src/test/sharedString.spec.ts
@@ -222,7 +222,7 @@ describe("SharedString", () => {
 
     describe("SharedString op processing in local state", () => {
         it("should correctly process operations sent in local state", async () => {
-            // Set the component runtime to local.
+            // Set the data store runtime to local.
             componentRuntime1.local = true;
 
             // Initialize the shared string so that it is completely loaded before we take a snapshot.

--- a/packages/dds/sequence/src/test/snapshotVersion.spec.ts
+++ b/packages/dds/sequence/src/test/snapshotVersion.spec.ts
@@ -35,13 +35,13 @@ describe("SharedString Snapshot Version", () => {
             // load snapshot into sharedString
             const documentId = "fakeId";
             const containerRuntimeFactory = new MockContainerRuntimeFactory();
-            const componentRuntime = new MockFluidDataStoreRuntime();
-            const containerRuntime = containerRuntimeFactory.createContainerRuntime(componentRuntime);
+            const dataStoreRuntime = new MockFluidDataStoreRuntime();
+            const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
             const services = {
                 deltaConnection: containerRuntime.createDeltaConnection(),
                 objectStorage: new MockStorage(oldsnap),
             };
-            const sharedString = new SharedString(componentRuntime, documentId, SharedStringFactory.Attributes);
+            const sharedString = new SharedString(dataStoreRuntime, documentId, SharedStringFactory.Attributes);
             // eslint-disable-next-line no-null/no-null
             await sharedString.load(null/* branchId */, services);
             await sharedString.loaded;

--- a/packages/dds/sequence/src/test/sparseMatrix.spec.ts
+++ b/packages/dds/sequence/src/test/sparseMatrix.spec.ts
@@ -30,12 +30,12 @@ describe("SparseMatrix", () => {
     };
 
     describe("local state", () => {
-        let componentRuntime: MockFluidDataStoreRuntime;
+        let dataStoreRuntime: MockFluidDataStoreRuntime;
         let matrix: SparseMatrix;
 
         before(async () => {
-            componentRuntime = new MockFluidDataStoreRuntime();
-            matrix = new SparseMatrix(componentRuntime, "matrix", SparseMatrixFactory.Attributes);
+            dataStoreRuntime = new MockFluidDataStoreRuntime();
+            matrix = new SparseMatrix(dataStoreRuntime, "matrix", SparseMatrixFactory.Attributes);
         });
 
         const expect = async (expected: readonly (readonly any[])[]) => {
@@ -139,24 +139,24 @@ describe("SparseMatrix", () => {
                 containerRuntimeFactory = new MockContainerRuntimeFactory();
 
                 // Create and connect the first SparseMatrix.
-                const componentRuntime1 = new MockFluidDataStoreRuntime();
-                const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(componentRuntime1);
+                const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
+                const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
                 const services1: IChannelServices = {
                     deltaConnection: containerRuntime1.createDeltaConnection(),
                     objectStorage: new MockStorage(),
                 };
-                matrix1 = new SparseMatrix(componentRuntime1, "matrix1", SparseMatrixFactory.Attributes);
+                matrix1 = new SparseMatrix(dataStoreRuntime1, "matrix1", SparseMatrixFactory.Attributes);
                 matrix1.initializeLocal();
                 matrix1.connect(services1);
 
                 // Create and connect the second SparseMatrix.
-                const componentRuntime2 = new MockFluidDataStoreRuntime();
-                const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(componentRuntime2);
+                const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+                const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
                 const services2: IChannelServices = {
                     deltaConnection: containerRuntime2.createDeltaConnection(),
                     objectStorage: new MockStorage(),
                 };
-                matrix2 = new SparseMatrix(componentRuntime2, "matrix2", SparseMatrixFactory.Attributes);
+                matrix2 = new SparseMatrix(dataStoreRuntime2, "matrix2", SparseMatrixFactory.Attributes);
                 matrix2.initializeLocal();
                 matrix2.connect(services2);
             });
@@ -265,26 +265,26 @@ describe("SparseMatrix", () => {
                 containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
 
                 // Create and connect the first SharedMatrix.
-                const componentRuntime1 = new MockFluidDataStoreRuntime();
+                const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
                 containerRuntime1 = (containerRuntimeFactory as MockContainerRuntimeFactoryForReconnection).
-                    createContainerRuntime(componentRuntime1);
+                    createContainerRuntime(dataStoreRuntime1);
                 const services1: IChannelServices = {
                     deltaConnection: containerRuntime1.createDeltaConnection(),
                     objectStorage: new MockStorage(),
                 };
-                matrix1 = new SparseMatrix(componentRuntime1, "matrix", SparseMatrixFactory.Attributes);
+                matrix1 = new SparseMatrix(dataStoreRuntime1, "matrix", SparseMatrixFactory.Attributes);
                 matrix1.initializeLocal();
                 matrix1.connect(services1);
 
                 // Create and connect the second SharedMatrix.
-                const componentRuntime2 = new MockFluidDataStoreRuntime();
+                const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
                 containerRuntime2 = (containerRuntimeFactory as MockContainerRuntimeFactoryForReconnection).
-                    createContainerRuntime(componentRuntime2);
+                    createContainerRuntime(dataStoreRuntime2);
                 const services2: IChannelServices = {
                     deltaConnection: containerRuntime2.createDeltaConnection(),
                     objectStorage: new MockStorage(),
                 };
-                matrix2 = new SparseMatrix(componentRuntime2, "matrix2", SparseMatrixFactory.Attributes);
+                matrix2 = new SparseMatrix(dataStoreRuntime2, "matrix2", SparseMatrixFactory.Attributes);
                 matrix2.initializeLocal();
                 matrix2.connect(services2);
             });

--- a/packages/dds/shared-object-base/src/types.ts
+++ b/packages/dds/shared-object-base/src/types.ts
@@ -29,7 +29,7 @@ export interface ISharedObjectEvents extends IErrorEvent {
 export interface ISharedObject<TEvent extends ISharedObjectEvents = ISharedObjectEvents>
     extends IProvideSharedObject, IChannel, IEventProvider<TEvent> {
     /**
-     * Binds the given shared object to its containing component runtime, causing it to attach once
+     * Binds the given shared object to its containing data store runtime, causing it to attach once
      * the runtime attaches.
      */
     bindToContext(): void;

--- a/packages/dds/shared-object-base/src/utils.ts
+++ b/packages/dds/shared-object-base/src/utils.ts
@@ -35,7 +35,7 @@ export function serializeHandles(
 
 /**
  * Given a mostly-plain object that may have handle objects embedded within, will return a fully-plain object
- * where any embedded IComponentHandles have been replaced with a serializable form.
+ * where any embedded IFluidObjectHandles have been replaced with a serializable form.
  *
  * The original `input` object is not mutated.  This method will shallowly clones all objects in the path from
  * the root to any replaced handles.  (If no handles are found, returns the original object.)

--- a/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
+++ b/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
@@ -42,7 +42,7 @@ export class SharedSummaryBlock extends SharedObject implements ISharedSummaryBl
     /**
      * Create a new shared summary block
      *
-     * @param runtime - component runtime the new shared summary block belongs to.
+     * @param runtime - data store runtime the new shared summary block belongs to.
      * @param id - optional name of the shared summary block.
      * @returns newly created shared summary block (but not attached yet).
      */
@@ -69,7 +69,7 @@ export class SharedSummaryBlock extends SharedObject implements ISharedSummaryBl
      * be provided.
      *
      * @param id - optional name of the shared summary block.
-     * @param runtime - component runtime thee object belongs to.
+     * @param runtime - data store runtime thee object belongs to.
      * @param attributes - The attributes for the object.
      */
     constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes) {

--- a/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
+++ b/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
@@ -51,7 +51,7 @@ export class SharedSummaryBlock extends SharedObject implements ISharedSummaryBl
     }
 
     /**
-     * Get a factory for SharedSummaryBlock to register with the component.
+     * Get a factory for SharedSummaryBlock to register with the data store.
      *
      * @returns a factory that creates and loads SharedSummaryBlock.
      */

--- a/packages/dds/shared-summary-block/src/test/sharedSummaryBlock.spec.ts
+++ b/packages/dds/shared-summary-block/src/test/sharedSummaryBlock.spec.ts
@@ -17,16 +17,16 @@ interface ITestInterface {
 }
 
 describe("SharedSummaryBlock", () => {
-    let componentRuntime: MockFluidDataStoreRuntime;
+    let dataStoreRuntime: MockFluidDataStoreRuntime;
     let factory: SharedSummaryBlockFactory;
     let sharedSummaryBlock: ISharedSummaryBlock;
 
     beforeEach(async () => {
-        componentRuntime = new MockFluidDataStoreRuntime();
+        dataStoreRuntime = new MockFluidDataStoreRuntime();
         // We only want to test local state of the DDS.
-        componentRuntime.local = true;
+        dataStoreRuntime.local = true;
         factory = new SharedSummaryBlockFactory();
-        sharedSummaryBlock = factory.create(componentRuntime, "root") as ISharedSummaryBlock;
+        sharedSummaryBlock = factory.create(dataStoreRuntime, "root") as ISharedSummaryBlock;
     });
 
     describe("Api", () => {
@@ -93,7 +93,7 @@ describe("SharedSummaryBlock", () => {
 
             // Load another object from the snapshot and ensure that it has loaded the data from the original object.
             const sharedSummaryBlock2 = await factory.load(
-                componentRuntime, "mapId", services, "branchId", factory.attributes,
+                dataStoreRuntime, "mapId", services, "branchId", factory.attributes,
             ) as ISharedSummaryBlock;
             assert.equal(sharedSummaryBlock2.get(key1), value1);
             assert.equal(sharedSummaryBlock2.get(key2), value2);

--- a/packages/framework/aqueduct/src/componentFactories/sharedComponentFactory.ts
+++ b/packages/framework/aqueduct/src/componentFactories/sharedComponentFactory.ts
@@ -75,7 +75,7 @@ export class PureDataObjectFactory<P extends IFluidObject, S = undefined> implem
     /**
      * This is where we do component setup.
      *
-     * @param context - component context used to load a component runtime
+     * @param context - component context used to load a data store runtime
      */
     public instantiateDataStore(context: IFluidDataStoreContext): void {
         this.instantiateComponentWithInitialState(context, undefined);
@@ -83,7 +83,7 @@ export class PureDataObjectFactory<P extends IFluidObject, S = undefined> implem
 
     /**
      * Private method for component instantiation that exposes initial state
-     * @param context - Component context used to load a component runtime
+     * @param context - Component context used to load a data store runtime
      * @param initialState  - The initial state to provide the created component
      */
     private instantiateComponentWithInitialState(
@@ -118,8 +118,8 @@ export class PureDataObjectFactory<P extends IFluidObject, S = undefined> implem
 
     /**
      * Instantiate and initialize the component object
-     * @param runtime - component runtime created for the component context
-     * @param context - component context used to load a component runtime
+     * @param runtime - data store runtime created for the component context
+     * @param context - component context used to load a data store runtime
      */
     private async instantiateInstance(
         runtime: FluidDataStoreRuntime,

--- a/packages/framework/aqueduct/src/components/sharedComponent.ts
+++ b/packages/framework/aqueduct/src/components/sharedComponent.ts
@@ -219,7 +219,7 @@ export abstract class PureDataObject<P extends IFluidObject = object, S = undefi
 
     /**
      * Called the first time the component is initialized (new creations with a new
-     * component runtime)
+     * data store runtime)
      *
      * @param props - Optional props to be passed in on create
      * @deprecated 0.16 Issue #1635 Initial props should be provided through a factory override
@@ -228,7 +228,7 @@ export abstract class PureDataObject<P extends IFluidObject = object, S = undefi
 
     /**
      * Called every time but the first time the component is initialized (creations
-     * with an existing component runtime)
+     * with an existing data store runtime)
      */
     protected async initializingFromExisting(): Promise<void> { }
 

--- a/packages/framework/aqueduct/src/containerRuntimeFactories/baseContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/containerRuntimeFactories/baseContainerRuntimeFactory.ts
@@ -12,7 +12,7 @@ import {
     IContainerRuntime,
 } from "@fluidframework/container-runtime-definitions";
 import {
-    RuntimeRequestHandler, RuntimeRequestHandlerBuilder, componentRuntimeRequestHandler,
+    RuntimeRequestHandler, RuntimeRequestHandlerBuilder, dataStoreRuntimeRequestHandler,
 } from "@fluidframework/request-handler";
 import {
     IFluidDataStoreRegistry,
@@ -65,7 +65,7 @@ export class BaseContainerRuntimeFactory implements
 
         const builder = new RuntimeRequestHandlerBuilder();
         builder.pushHandler(...this.requestHandlers);
-        builder.pushHandler(componentRuntimeRequestHandler);
+        builder.pushHandler(dataStoreRuntimeRequestHandler);
 
         const runtime = await ContainerRuntime.load(
             context,

--- a/packages/framework/aqueduct/src/requestHandlers/requestHandlers.ts
+++ b/packages/framework/aqueduct/src/requestHandlers/requestHandlers.ts
@@ -5,7 +5,7 @@
 
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { IFluidMountableViewClass } from "@fluidframework/view-interfaces";
-import { RuntimeRequestHandler, componentRuntimeRequestHandler } from "@fluidframework/request-handler";
+import { RuntimeRequestHandler, dataStoreRuntimeRequestHandler } from "@fluidframework/request-handler";
 import { RequestParser } from "@fluidframework/runtime-utils";
 
 /**
@@ -52,7 +52,7 @@ export const defaultDataStoreRuntimeRequestHandler: (defaultComponentId: string)
     (defaultComponentId: string) => {
         return async (request: RequestParser, runtime: IContainerRuntime) => {
             if (request.pathParts.length === 0) {
-                return componentRuntimeRequestHandler(
+                return dataStoreRuntimeRequestHandler(
                     new RequestParser({
                         url: defaultComponentId,
                         headers: request.headers,

--- a/packages/framework/aqueduct/src/utils/attachUtils.ts
+++ b/packages/framework/aqueduct/src/utils/attachUtils.ts
@@ -6,13 +6,13 @@
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { AttachState } from "@fluidframework/container-definitions";
 
-export async function waitForAttach(componentRuntime: IFluidDataStoreRuntime): Promise<void> {
-    if (componentRuntime.attachState === AttachState.Attached) {
+export async function waitForAttach(dataStoreRuntime: IFluidDataStoreRuntime): Promise<void> {
+    if (dataStoreRuntime.attachState === AttachState.Attached) {
         return;
     }
 
     return new Promise((resolve) => {
-        componentRuntime.once(
+        dataStoreRuntime.once(
             "attached",
             () => {
                 Promise.resolve().then(() => resolve()).catch(() => { });

--- a/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
@@ -87,9 +87,9 @@ describe("Shared Directory with Interception", () => {
         }
 
         beforeEach(() => {
-            const componentRuntime = new MockFluidDataStoreRuntime();
-            sharedDirectory = new SharedDirectory(documentId, componentRuntime, DirectoryFactory.Attributes);
-            componentRuntime.bindToContext();
+            const dataStoreRuntime = new MockFluidDataStoreRuntime();
+            sharedDirectory = new SharedDirectory(documentId, dataStoreRuntime, DirectoryFactory.Attributes);
+            dataStoreRuntime.bindToContext();
 
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             componentContext = { containerRuntime: { orderSequentially } } as IFluidDataStoreContext;

--- a/packages/framework/dds-interceptions/src/test/sharedMapWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedMapWithInterception.spec.ts
@@ -31,9 +31,9 @@ describe("Shared Map with Interception", () => {
         }
 
         beforeEach(() => {
-            const componentRuntime = new MockFluidDataStoreRuntime();
-            sharedMap = new SharedMap(documentId, componentRuntime, MapFactory.Attributes);
-            componentRuntime.bindToContext();
+            const dataStoreRuntime = new MockFluidDataStoreRuntime();
+            sharedMap = new SharedMap(documentId, dataStoreRuntime, MapFactory.Attributes);
+            dataStoreRuntime.bindToContext();
 
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             componentContext = { containerRuntime: { orderSequentially } } as IFluidDataStoreContext;

--- a/packages/framework/dds-interceptions/src/test/sharedStringWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedStringWithInterception.spec.ts
@@ -43,9 +43,9 @@ describe("Shared String with Interception", () => {
         }
 
         beforeEach(() => {
-            const componentRuntime = new MockFluidDataStoreRuntime();
-            sharedString = new SharedString(componentRuntime, documentId, SharedStringFactory.Attributes);
-            componentRuntime.bindToContext();
+            const dataStoreRuntime = new MockFluidDataStoreRuntime();
+            sharedString = new SharedString(dataStoreRuntime, documentId, SharedStringFactory.Attributes);
+            dataStoreRuntime.bindToContext();
 
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             componentContext = { containerRuntime: { orderSequentially } } as IFluidDataStoreContext;

--- a/packages/framework/react/src/helpers/generateComponentSchema.ts
+++ b/packages/framework/react/src/helpers/generateComponentSchema.ts
@@ -17,7 +17,7 @@ import {
  * Identifies which values within the Fluid and view states match
  * The view and Fluid matching map identify if the value in the respective states
  * needs a converter or not
- * @param runtime - The component runtime used to create the SharedMap objects
+ * @param runtime - The data store runtime used to create the SharedMap objects
  * @param fluidToView - The fluid to view state conversion mapping
  * @param viewToFluid - The view to fluid conversion state mapping
  * */

--- a/packages/framework/react/src/helpers/rootCallbackListener.ts
+++ b/packages/framework/react/src/helpers/rootCallbackListener.ts
@@ -24,7 +24,7 @@ import { ISyncedState } from "..";
  * @param fluidComponentMap - A map of component handle paths to their respective components
  * @param syncedStateId - Unique ID for this synced component's state
  * @param syncedState - The shared map this component's synced state is stored on
- * @param runtime - The component runtime
+ * @param runtime - The data store runtime
  * @param state - The current view state
  * @param setState - Callback to update the react view state
  * @param fluidToView - A map of the Fluid state values that need conversion to their view state counterparts and the

--- a/packages/framework/react/src/helpers/setFluidState.ts
+++ b/packages/framework/react/src/helpers/setFluidState.ts
@@ -17,7 +17,7 @@ import {
  * Store the Fluid state onto the shared synced state
  * @param syncedStateId - Unique ID to use for storing the component's synced state in the map
  * @param syncedState - The shared map that will be used to store the synced state
- * @param runtime - The component runtime
+ * @param runtime - The data store runtime
  * @param componentMap - A map of component handle paths to their respective components
  * @param fluidToView - A map of the Fluid state values that need conversion to their view state counterparts and the
  * respective converters

--- a/packages/framework/react/src/helpers/updateStateAndComponentMap.ts
+++ b/packages/framework/react/src/helpers/updateStateAndComponentMap.ts
@@ -25,7 +25,7 @@ import { ISyncedState } from "..";
  * @param isSyncedStateUpdate - Is the update from a local state update or from one triggered by the synced state
  * @param syncedStateId - Unique ID for this synced component's state
  * @param syncedState - The shared map this component's synced state is stored on
- * @param runtime - The component runtime
+ * @param runtime - The data store runtime
  * @param viewState - The current view state
  * @param setState - Callback to update the react view state
  * @param syncedStateCallback - The callback that will be triggered when the synced state value for the components

--- a/packages/framework/react/src/interface.ts
+++ b/packages/framework/react/src/interface.ts
@@ -269,7 +269,7 @@ export type FluidComponentMap = Map<string, IFluidComponent>;
  */
 export interface IFluidDataProps {
     /**
-     * The Fluid component runtime passed in from component initialization
+     * The Fluid data store runtime passed in from component initialization
      */
     runtime: IFluidDataStoreRuntime;
     /**

--- a/packages/framework/request-handler/src/requestHandlers.ts
+++ b/packages/framework/request-handler/src/requestHandlers.ts
@@ -15,7 +15,7 @@ import { RequestParser } from "@fluidframework/runtime-utils";
 export type RuntimeRequestHandler = (request: RequestParser, runtime: IContainerRuntime)
     => Promise<IResponse | undefined>;
 
-export const componentRuntimeRequestHandler: RuntimeRequestHandler =
+export const dataStoreRuntimeRequestHandler: RuntimeRequestHandler =
     async (request: RequestParser, runtime: IContainerRuntime) => {
         if (request.pathParts.length > 0) {
             let wait: boolean | undefined;

--- a/packages/framework/request-handler/src/test/requestHandlers.spec.ts
+++ b/packages/framework/request-handler/src/test/requestHandlers.spec.ts
@@ -8,14 +8,14 @@ import assert from "assert";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { IFluidDataStoreChannel } from "@fluidframework/runtime-definitions";
 import { RequestParser } from "@fluidframework/runtime-utils";
-import { componentRuntimeRequestHandler, createComponentResponse } from "../requestHandlers";
+import { dataStoreRuntimeRequestHandler, createComponentResponse } from "../requestHandlers";
 
 describe("RequestParser", () => {
-    describe("componentRuntimeRequestHandler", () => {
+    describe("dataStoreRuntimeRequestHandler", () => {
         it("Empty request", async () => {
             const requestParser = new RequestParser({ url: "/" });
             const runtime: IContainerRuntime = {} as IContainerRuntime;
-            const response = await componentRuntimeRequestHandler(requestParser, runtime);
+            const response = await dataStoreRuntimeRequestHandler(requestParser, runtime);
             assert.equal(response, undefined);
         });
 
@@ -33,7 +33,7 @@ describe("RequestParser", () => {
                     } as IFluidDataStoreChannel);
                 },
             } as IContainerRuntime;
-            const response = await componentRuntimeRequestHandler(requestParser, runtime);
+            const response = await dataStoreRuntimeRequestHandler(requestParser, runtime);
             assert.notEqual(response, undefined);
         });
 
@@ -51,7 +51,7 @@ describe("RequestParser", () => {
                     } as IFluidDataStoreChannel);
                 },
             } as IContainerRuntime;
-            const response = await componentRuntimeRequestHandler(requestParser, runtime);
+            const response = await dataStoreRuntimeRequestHandler(requestParser, runtime);
             assert.notEqual(response, undefined);
         });
 
@@ -69,7 +69,7 @@ describe("RequestParser", () => {
                     } as IFluidDataStoreChannel);
                 },
             } as IContainerRuntime;
-            const response = await componentRuntimeRequestHandler(requestParser, runtime);
+            const response = await dataStoreRuntimeRequestHandler(requestParser, runtime);
             assert.notEqual(response, undefined);
         });
     });

--- a/packages/framework/undo-redo/src/test/sequenceHandler.spec.ts
+++ b/packages/framework/undo-redo/src/test/sequenceHandler.spec.ts
@@ -47,17 +47,17 @@ describe("SharedSegmentSequenceUndoRedoHandler", () => {
     let undoRedoStack: UndoRedoStackManager;
 
     beforeEach(() => {
-        const componentRuntime = new MockFluidDataStoreRuntime();
-        componentRuntime.bindToContext();
+        const dataStoreRuntime = new MockFluidDataStoreRuntime();
+        dataStoreRuntime.bindToContext();
 
         containerRuntimeFactory = new MockContainerRuntimeFactory();
-        const containerRuntime = containerRuntimeFactory.createContainerRuntime(componentRuntime);
+        const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
         const services = {
             deltaConnection: containerRuntime.createDeltaConnection(),
             objectStorage: new MockStorage(undefined),
         };
 
-        sharedString = new SharedString(componentRuntime, documentId, SharedStringFactory.Attributes);
+        sharedString = new SharedString(dataStoreRuntime, documentId, SharedStringFactory.Attributes);
         sharedString.initializeLocal();
         sharedString.bindToContext();
         sharedString.connect(services);

--- a/packages/loader/container-loader/README.md
+++ b/packages/loader/container-loader/README.md
@@ -20,7 +20,7 @@ Please see specific sections for more details on these states and events - this 
 
 ## Expectations from container runtime and components implementers
 1. Respect ["readonly" state](#Readonly-states). In this state container runtime (and components) should not allow changes to local state, as these changes will be lost on container being closed.
-2. Maintain Ops in flight until observed they are acknowledged by server. Resubmit any lost Ops on reconnection. This is done by DDSs in stock implementations of container & component runtimes provided by Fluid Framework
+2. Maintain Ops in flight until observed they are acknowledged by server. Resubmit any lost Ops on reconnection. This is done by DDSs in stock implementations of container & data store runtimes provided by Fluid Framework
 3. Respect "["disconnected" and "connected"](#Connectivity-events) states and do not not submit Ops when disconnected.
 4. Respect ["dispose"](#Closure) event and treat it as combination of "readonly" and "disconnected" states. I.e. it should be fully operatable (render content), but not allow edits. This is equivalent to "closed" event on container for hosts, but is broader (includes container's code version upgrades).
 

--- a/packages/runtime/component-runtime/src/componentRuntime.ts
+++ b/packages/runtime/component-runtime/src/componentRuntime.ts
@@ -75,10 +75,10 @@ export interface ISharedObjectRegistry {
 export class FluidDataStoreRuntime extends EventEmitter implements IFluidDataStoreChannel,
     IFluidDataStoreRuntime, IFluidHandleContext {
     /**
-     * Loads the component runtime
+     * Loads the data store runtime
      * @param context - The component context
      * @param sharedObjectRegistry - The registry of shared objects used by this component
-     * @param activeCallback - The callback called when the component runtime in active
+     * @param activeCallback - The callback called when the data store runtime in active
      * @param componentRegistry - The registry of components created and used by this component
      */
     public static load(

--- a/packages/runtime/component-runtime/src/componentRuntime.ts
+++ b/packages/runtime/component-runtime/src/componentRuntime.ts
@@ -609,7 +609,7 @@ export class FluidDataStoreRuntime extends EventEmitter implements IFluidDataSto
     }
 
     /**
-     * Attach channel should only be called after the componentRuntime has been attached
+     * Attach channel should only be called after the dataStoreRuntime has been attached
      */
     private attachChannel(channel: IChannel): void {
         this.verifyNotClosed();

--- a/packages/runtime/component-runtime/src/localChannelContext.ts
+++ b/packages/runtime/component-runtime/src/localChannelContext.ts
@@ -14,7 +14,7 @@ import { IFluidDataStoreContext, ISummarizeResult } from "@fluidframework/runtim
 import { convertToSummaryTree } from "@fluidframework/runtime-utils";
 import { createServiceEndpoints, IChannelContext, snapshotChannel } from "./channelContext";
 import { ChannelDeltaConnection } from "./channelDeltaConnection";
-import { ISharedObjectRegistry } from "./componentRuntime";
+import { ISharedObjectRegistry } from "./dataStoreRuntime";
 
 /**
  * Channel context for a locally created channel

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -76,7 +76,7 @@ interface ComponentMessage {
 }
 
 /**
- * Represents the context for the component. This context is passed to the component runtime.
+ * Represents the context for the component. This context is passed to the data store runtime.
  */
 export abstract class FluidDataStoreContext extends EventEmitter implements
     IFluidDataStoreContext,

--- a/packages/runtime/container-runtime/src/componentContext.ts
+++ b/packages/runtime/container-runtime/src/componentContext.ts
@@ -160,11 +160,11 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
         return this._attachState;
     }
 
-    public readonly bindToContext: (componentRuntime: IFluidDataStoreChannel) => void;
-    protected componentRuntime: IFluidDataStoreChannel | undefined;
+    public readonly bindToContext: (dataStoreRuntime: IFluidDataStoreChannel) => void;
+    protected dataStoreRuntime: IFluidDataStoreChannel | undefined;
     private loaded = false;
     protected pending: ISequencedDocumentMessage[] | undefined = [];
-    private componentRuntimeDeferred: Deferred<IFluidDataStoreChannel> | undefined;
+    private dataStoreRuntimeDeferred: Deferred<IFluidDataStoreChannel> | undefined;
     private _baseSnapshot: ISnapshotTree | undefined;
     protected _attachState: AttachState;
     protected readonly summarizerNode: ISummarizerNode;
@@ -178,17 +178,17 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
         public readonly summaryTracker: SummaryTracker,
         createSummarizerNode: CreateChildSummarizerNodeFn,
         private bindState: BindState,
-        bindComponent: (componentRuntime: IFluidDataStoreChannel) => void,
+        bindComponent: (dataStoreRuntime: IFluidDataStoreChannel) => void,
         protected pkg?: readonly string[],
     ) {
         super();
 
         this._attachState = existing ? AttachState.Attached : AttachState.Detached;
 
-        this.bindToContext = (componentRuntime: IFluidDataStoreChannel) => {
+        this.bindToContext = (dataStoreRuntime: IFluidDataStoreChannel) => {
             assert(this.bindState === BindState.NotBound);
             this.bindState = BindState.Binding;
-            bindComponent(componentRuntime);
+            bindComponent(dataStoreRuntime);
             this.bindState = BindState.Bound;
         };
 
@@ -203,8 +203,8 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
         this._disposed = true;
 
         // Dispose any pending runtime after it gets fulfilled
-        if (this.componentRuntimeDeferred) {
-            this.componentRuntimeDeferred.promise.then((runtime) => {
+        if (this.dataStoreRuntimeDeferred) {
+            this.dataStoreRuntimeDeferred.promise.then((runtime) => {
                 runtime.dispose();
             }).catch((error) => {
                 this._containerRuntime.logger.sendErrorEvent(
@@ -220,16 +220,16 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
         // Mark it as such, so that if it ever reaches telemetry pipeline, it has a chance to remove it.
         (error as any).containsPII = true;
 
-        // This is always called with a componentRuntimeDeferred in realize();
+        // This is always called with a dataStoreRuntimeDeferred in realize();
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const deferred = this.componentRuntimeDeferred!;
+        const deferred = this.dataStoreRuntimeDeferred!;
         deferred.reject(error);
         return deferred.promise;
     }
 
     public async realize(): Promise<IFluidDataStoreChannel> {
-        if (!this.componentRuntimeDeferred) {
-            this.componentRuntimeDeferred = new Deferred<IFluidDataStoreChannel>();
+        if (!this.dataStoreRuntimeDeferred) {
+            this.dataStoreRuntimeDeferred = new Deferred<IFluidDataStoreChannel>();
             const details = await this.getInitialSnapshotDetails();
             // Base snapshot is the baseline where pending ops are applied to.
             // It is important that this be in sync with the pending ops, and also
@@ -256,22 +256,22 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
                 return this.rejectDeferredRealize(`Can't find factory for ${lastPkg} package`);
             }
             // During this call we will invoke the instantiate method - which will call back into us
-            // via the bindRuntime call to resolve componentRuntimeDeferred
+            // via the bindRuntime call to resolve dataStoreRuntimeDeferred
             factory.instantiateDataStore(this);
         }
 
-        return this.componentRuntimeDeferred.promise;
+        return this.dataStoreRuntimeDeferred.promise;
     }
 
     public async realizeWithFn(
         realizationFn: (context: IFluidDataStoreContext) => void,
     ): Promise<IFluidDataStoreChannel> {
-        if (!this.componentRuntimeDeferred) {
-            this.componentRuntimeDeferred = new Deferred<IFluidDataStoreChannel>();
+        if (!this.dataStoreRuntimeDeferred) {
+            this.dataStoreRuntimeDeferred = new Deferred<IFluidDataStoreChannel>();
             realizationFn(this);
         }
 
-        return this.componentRuntimeDeferred.promise;
+        return this.dataStoreRuntimeDeferred.promise;
     }
 
     /**
@@ -291,7 +291,7 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
         assert(this.connected === connected);
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const runtime: IFluidDataStoreChannel = this.componentRuntime!;
+        const runtime: IFluidDataStoreChannel = this.dataStoreRuntime!;
 
         // Back-compat: supporting <= 0.16 components
         if (runtime.setConnectionState) {
@@ -318,7 +318,7 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
 
         if (this.loaded) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            return this.componentRuntime!.process(message, local, localOpMetadata);
+            return this.dataStoreRuntime!.process(message, local, localOpMetadata);
         } else {
             assert(!local, "local component is not loaded");
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -335,7 +335,7 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
         }
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.componentRuntime!.processSignal(message, local);
+        this.dataStoreRuntime!.processSignal(message, local);
     }
 
     public getQuorum(): IQuorum {
@@ -372,7 +372,7 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
         await this.realize();
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const entries = await this.componentRuntime!.snapshotInternal(fullTree);
+        const entries = await this.dataStoreRuntime!.snapshotInternal(fullTree);
 
         entries.push(new BlobTreeEntry(".component", JSON.stringify(componentAttributes)));
 
@@ -394,14 +394,14 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
         await this.realize();
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const componentRuntime = this.componentRuntime!;
-        if (componentRuntime.summarize !== undefined) {
-            const summary = await componentRuntime.summarize(fullTree);
+        const dataStoreRuntime = this.dataStoreRuntime!;
+        if (dataStoreRuntime.summarize !== undefined) {
+            const summary = await dataStoreRuntime.summarize(fullTree);
             addBlobToSummary(summary, ".component", JSON.stringify(componentAttributes));
             return { ...summary, id: this.id };
         } else {
             // back-compat summarizerNode - remove this case
-            const entries = await componentRuntime.snapshotInternal(fullTree);
+            const entries = await dataStoreRuntime.snapshotInternal(fullTree);
             entries.push(new BlobTreeEntry(".component", JSON.stringify(componentAttributes)));
             const summary = convertToSummaryTree({ entries, id: null });
             return { ...summary, id: this.id };
@@ -418,7 +418,7 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
 
     public submitMessage(type: string, content: any, localOpMetadata: unknown): void {
         this.verifyNotClosed();
-        assert(this.componentRuntime);
+        assert(this.dataStoreRuntime);
         const componentContent: ComponentMessage = {
             content,
             type,
@@ -460,7 +460,7 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
 
     public submitSignal(type: string, content: any) {
         this.verifyNotClosed();
-        assert(this.componentRuntime);
+        assert(this.dataStoreRuntime);
         return this._containerRuntime.submitComponentSignal(this.id, type, content);
     }
 
@@ -484,15 +484,15 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
         }
     }
 
-    public bindRuntime(componentRuntime: IFluidDataStoreChannel) {
-        if (this.componentRuntime) {
+    public bindRuntime(dataStoreRuntime: IFluidDataStoreChannel) {
+        if (this.dataStoreRuntime) {
             throw new Error("runtime already bound");
         }
 
         // If this FluidDataStoreContext was created via `IContainerRuntime.createDataStoreContext`, the
-        // `componentRuntimeDeferred` promise hasn't yet been initialized.  Do so now.
-        if (!this.componentRuntimeDeferred) {
-            this.componentRuntimeDeferred = new Deferred();
+        // `dataStoreRuntimeDeferred` promise hasn't yet been initialized.  Do so now.
+        if (!this.dataStoreRuntimeDeferred) {
+            this.dataStoreRuntimeDeferred = new Deferred();
         }
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -501,7 +501,7 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
         if (pending.length > 0) {
             // Apply all pending ops
             for (const op of pending) {
-                componentRuntime.process(op, false, undefined /* localOpMetadata */);
+                dataStoreRuntime.process(op, false, undefined /* localOpMetadata */);
             }
         }
 
@@ -509,14 +509,14 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
 
         // And now mark the runtime active
         this.loaded = true;
-        this.componentRuntime = componentRuntime;
+        this.dataStoreRuntime = dataStoreRuntime;
 
         // Freeze the package path to ensure that someone doesn't modify it when it is
         // returned in packagePath().
         Object.freeze(this.pkg);
 
         // And notify the pending promise it is now available
-        this.componentRuntimeDeferred.resolve(this.componentRuntime);
+        this.dataStoreRuntimeDeferred.resolve(this.dataStoreRuntime);
 
         // notify the runtime if they want to propagate up. Used for logging.
         this.containerRuntime.notifyDataStoreInstantiated(this);
@@ -549,7 +549,7 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
         // Look for the package entry in our sub-registry. If we find the entry, we need to add our path
         // to the packagePath. If not, look into the global registry and the packagePath becomes just the
         // passed package.
-        if (await this.componentRuntime?.IFluidDataStoreRegistry?.get(subpackage)) {
+        if (await this.dataStoreRuntime?.IFluidDataStoreRegistry?.get(subpackage)) {
             packagePath.push(subpackage);
         } else {
             if (!(await this._containerRuntime.IFluidDataStoreRegistry.get(subpackage))) {
@@ -567,9 +567,9 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
     protected abstract getInitialSnapshotDetails(): Promise<ISnapshotDetails>;
 
     public reSubmit(contents: any, localOpMetadata: unknown) {
-        assert(this.componentRuntime, "FluidDataStoreRuntime must exist when resubmitting ops");
+        assert(this.dataStoreRuntime, "FluidDataStoreRuntime must exist when resubmitting ops");
         const innerContents = contents as ComponentMessage;
-        this.componentRuntime.reSubmit(innerContents.type, innerContents.content, localOpMetadata);
+        this.dataStoreRuntime.reSubmit(innerContents.type, innerContents.content, localOpMetadata);
     }
 
     private verifyNotClosed() {
@@ -686,7 +686,7 @@ export class LocalFluidDataStoreContext extends FluidDataStoreContext {
         scope: IFluidObject & IFluidObject,
         summaryTracker: SummaryTracker,
         createSummarizerNode: CreateChildSummarizerNodeFn,
-        bindComponent: (componentRuntime: IFluidDataStoreChannel) => void,
+        bindComponent: (dataStoreRuntime: IFluidDataStoreChannel) => void,
     ) {
         super(
             runtime,
@@ -720,7 +720,7 @@ export class LocalFluidDataStoreContext extends FluidDataStoreContext {
         };
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const entries = this.componentRuntime!.getAttachSnapshot();
+        const entries = this.dataStoreRuntime!.getAttachSnapshot();
 
         const snapshot: ITree = { entries, id: null };
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1441,12 +1441,12 @@ export class ContainerRuntime extends EventEmitter
         componentContext.process(transformed, local, localMessageMetadata);
     }
 
-    private bindComponent(componentRuntime: IFluidDataStoreChannel): void {
+    private bindComponent(dataStoreRuntime: IFluidDataStoreChannel): void {
         this.verifyNotClosed();
-        assert(this.notBoundedComponentContexts.has(componentRuntime.id),
+        assert(this.notBoundedComponentContexts.has(dataStoreRuntime.id),
             "Component to be binded should be in not bounded set");
-        this.notBoundedComponentContexts.delete(componentRuntime.id);
-        const context = this.getContext(componentRuntime.id) as LocalFluidDataStoreContext;
+        this.notBoundedComponentContexts.delete(dataStoreRuntime.id);
+        const context = this.getContext(dataStoreRuntime.id) as LocalFluidDataStoreContext;
         // If the container is detached, we don't need to send OP or add to pending attach because
         // we will summarize it while uploading the create new summary and make it known to other
         // clients but we do need to submit op if container forced us to do so.
@@ -1454,12 +1454,12 @@ export class ContainerRuntime extends EventEmitter
             context.emit("attaching");
             const message = context.generateAttachMessage();
 
-            this.pendingAttach.set(componentRuntime.id, message);
+            this.pendingAttach.set(dataStoreRuntime.id, message);
             this.submit(ContainerMessageType.Attach, message);
         }
 
         // Resolve the deferred so other local components can access it.
-        const deferred = this.getContextDeferred(componentRuntime.id);
+        const deferred = this.getContextDeferred(dataStoreRuntime.id);
         deferred.resolve(context);
     }
 

--- a/packages/runtime/runtime-definitions/README.md
+++ b/packages/runtime/runtime-definitions/README.md
@@ -1,6 +1,6 @@
 # @fluidframework/runtime-definitions
 
-Contains handshake interfaces for communication between the container runtime layer and the component runtime layer.
+Contains handshake interfaces for communication between the container runtime layer and the data store runtime layer.
 
 - `IComponentRuntimeChannel` includes the minimal set of data and functionalities that are needed by the ContainerRuntime to bind and control a ComponentRuntime, including attach, snapshot, op/signal processing, request routes, and connection state notifications.
 - `IComponentContext` includes data and function provided by the container layer and used by the component layer for information about the container, to send ops and signals, component creation, etc.

--- a/packages/runtime/runtime-definitions/src/componentContext.ts
+++ b/packages/runtime/runtime-definitions/src/componentContext.ts
@@ -52,7 +52,7 @@ export enum FlushMode {
 }
 
 /**
- * A reduced set of functionality of IContainerRuntime that a component/component runtime will need
+ * A reduced set of functionality of IContainerRuntime that a component/data store runtime will need
  * TODO: this should be merged into IFluidDataStoreContext
  */
 export interface IContainerRuntimeBase extends
@@ -125,7 +125,7 @@ export interface IContainerRuntimeBase extends
 }
 
 /**
- * Minimal interface a component runtime need to provide for IFluidDataStoreContext to bind to control
+ * Minimal interface a data store runtime need to provide for IFluidDataStoreContext to bind to control
  *
  * Functionality include attach, snapshot, op/signal processing, request routes,
  * and connection state notifications
@@ -234,7 +234,7 @@ export interface ISummaryTracker {
 export type CreateChildSummarizerNodeFn = (summarizeInternal: SummarizeInternalFn) => ISummarizerNode;
 
 /**
- * Represents the context for the component. It is used by the component runtime to
+ * Represents the context for the component. It is used by the data store runtime to
  * get information and call functionality to the container.
  */
 export interface IFluidDataStoreContext extends EventEmitter {
@@ -291,7 +291,7 @@ export interface IFluidDataStoreContext extends EventEmitter {
     getAudience(): IAudience;
 
     /**
-     * Report error in that happend in the component runtime layer to the container runtime layer
+     * Report error in that happend in the data store runtime layer to the container runtime layer
      * @param err - the error object.
      */
     raiseContainerWarning(warning: ContainerWarning): void;

--- a/packages/runtime/runtime-definitions/src/componentContext.ts
+++ b/packages/runtime/runtime-definitions/src/componentContext.ts
@@ -316,13 +316,13 @@ export interface IFluidDataStoreContext extends EventEmitter {
     /**
      * Binds a runtime to the context.
      */
-    bindRuntime(componentRuntime: IFluidDataStoreChannel): void;
+    bindRuntime(dataStoreRuntime: IFluidDataStoreChannel): void;
 
     /**
      * Register the runtime to the container
-     * @param componentRuntime - runtime to attach
+     * @param dataStoreRuntime - runtime to attach
      */
-    bindToContext(componentRuntime: IFluidDataStoreChannel): void;
+    bindToContext(dataStoreRuntime: IFluidDataStoreChannel): void;
 
     /**
      * Call by IFluidDataStoreChannel, indicates that a channel is dirty and needs to be part of the summary.

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -112,14 +112,14 @@ export class MockContainerRuntime {
     protected readonly pendingMessages: IMockContainerRuntimePendingMessage[] = [];
 
     constructor(
-        protected readonly componentRuntime: MockFluidDataStoreRuntime,
+        protected readonly dataStoreRuntime: MockFluidDataStoreRuntime,
         protected readonly factory: MockContainerRuntimeFactory,
     ) {
         this.deltaManager = new MockDeltaManager();
         // Set FluidDataStoreRuntime's deltaManager to ours so that they are in sync.
-        this.componentRuntime.deltaManager = this.deltaManager;
+        this.dataStoreRuntime.deltaManager = this.deltaManager;
         // FluidDataStoreRuntime already creates a clientId, reuse that so they are in sync.
-        this.clientId = this.componentRuntime.clientId;
+        this.clientId = this.dataStoreRuntime.clientId;
     }
 
     public createDeltaConnection(): MockDeltaConnection {
@@ -209,9 +209,9 @@ export class MockContainerRuntimeFactory {
         return minSeq ? minSeq : 0;
     }
 
-    public createContainerRuntime(componentRuntime: MockFluidDataStoreRuntime): MockContainerRuntime {
+    public createContainerRuntime(dataStoreRuntime: MockFluidDataStoreRuntime): MockContainerRuntime {
         const containerRuntime =
-            new MockContainerRuntime(componentRuntime, this);
+            new MockContainerRuntime(dataStoreRuntime, this);
         this.runtimes.push(containerRuntime);
         return containerRuntime;
     }

--- a/packages/runtime/test-runtime-utils/src/mocksForReconnection.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksForReconnection.ts
@@ -32,7 +32,7 @@ export class MockContainerRuntimeForReconnection extends MockContainerRuntime {
             // We should get a new clientId on reconnection.
             this.clientId = uuid();
             // Update the clientId in FluidDataStoreRuntime.
-            this.componentRuntime.clientId = this.clientId;
+            this.dataStoreRuntime.clientId = this.clientId;
             // On reconnection, ask the DDSs to resubmit pending messages.
             this.reSubmitMessages();
         } else {
@@ -50,9 +50,9 @@ export class MockContainerRuntimeForReconnection extends MockContainerRuntime {
     private _connected = true;
 
     constructor(
-        componentRuntime: MockFluidDataStoreRuntime,
+        dataStoreRuntime: MockFluidDataStoreRuntime,
         factory: MockContainerRuntimeFactoryForReconnection) {
-        super(componentRuntime, factory);
+        super(dataStoreRuntime, factory);
     }
 
     public submit(messageContent: any, localOpMetadata: unknown) {
@@ -81,8 +81,8 @@ export class MockContainerRuntimeForReconnection extends MockContainerRuntime {
  * Specalized implementation of MockContainerRuntimeFactory for testing ops during reconnection.
  */
 export class MockContainerRuntimeFactoryForReconnection extends MockContainerRuntimeFactory {
-    public createContainerRuntime(componentRuntime: MockFluidDataStoreRuntime): MockContainerRuntimeForReconnection {
-        const containerRuntime = new MockContainerRuntimeForReconnection(componentRuntime, this);
+    public createContainerRuntime(dataStoreRuntime: MockFluidDataStoreRuntime): MockContainerRuntimeForReconnection {
+        const containerRuntime = new MockContainerRuntimeForReconnection(dataStoreRuntime, this);
         this.runtimes.push(containerRuntime);
         return containerRuntime;
     }

--- a/packages/test/end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -532,7 +532,7 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
             assert.strictEqual(componentRuntimeAttachState, AttachState.Detached,
                 "Should be fire from Detached state for runtime");
             assert.strictEqual(defaultComponent.runtime.attachState, AttachState.Attaching,
-                "Component runtime should be attaching at this stage");
+                "Data store runtime should be attaching at this stage");
             componentRuntimeAttachState = AttachState.Attaching;
         });
 
@@ -540,14 +540,14 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
             assert.strictEqual(componentRuntimeAttachState, AttachState.Attaching,
                 "Should be fire from attaching state for runtime");
             assert.strictEqual(defaultComponent.runtime.attachState, AttachState.Attached,
-                "Component runtime should be attached at this stage");
+                "Data store runtime should be attached at this stage");
             componentRuntimeAttachState = AttachState.Attached;
         });
         await container.attach(request);
         assert.strictEqual(componentContextAttachState, AttachState.Attached,
             "Component context should end up in attached state");
         assert.strictEqual(componentRuntimeAttachState, AttachState.Attached,
-            "Component runtime should end up in attached state");
+            "Data store runtime should end up in attached state");
     });
 
     it("Attach events on not bounded components", async () => {

--- a/packages/test/end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -511,7 +511,7 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
         const { container, defaultComponent } =
             await createDetachedContainerAndGetRootComponent();
         let componentContextAttachState = AttachState.Detached;
-        let componentRuntimeAttachState = AttachState.Detached;
+        let dataStoreRuntimeAttachState = AttachState.Detached;
         defaultComponent.context.once("attaching", () => {
             assert.strictEqual(componentContextAttachState, AttachState.Detached,
                 "Should be fire from Detached state for context");
@@ -529,24 +529,24 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
         });
 
         defaultComponent.runtime.once("attaching", () => {
-            assert.strictEqual(componentRuntimeAttachState, AttachState.Detached,
+            assert.strictEqual(dataStoreRuntimeAttachState, AttachState.Detached,
                 "Should be fire from Detached state for runtime");
             assert.strictEqual(defaultComponent.runtime.attachState, AttachState.Attaching,
                 "Data store runtime should be attaching at this stage");
-            componentRuntimeAttachState = AttachState.Attaching;
+            dataStoreRuntimeAttachState = AttachState.Attaching;
         });
 
         defaultComponent.runtime.once("attached", () => {
-            assert.strictEqual(componentRuntimeAttachState, AttachState.Attaching,
+            assert.strictEqual(dataStoreRuntimeAttachState, AttachState.Attaching,
                 "Should be fire from attaching state for runtime");
             assert.strictEqual(defaultComponent.runtime.attachState, AttachState.Attached,
                 "Data store runtime should be attached at this stage");
-            componentRuntimeAttachState = AttachState.Attached;
+            dataStoreRuntimeAttachState = AttachState.Attached;
         });
         await container.attach(request);
         assert.strictEqual(componentContextAttachState, AttachState.Attached,
             "Component context should end up in attached state");
-        assert.strictEqual(componentRuntimeAttachState, AttachState.Attached,
+        assert.strictEqual(dataStoreRuntimeAttachState, AttachState.Attached,
             "Data store runtime should end up in attached state");
     });
 

--- a/packages/test/end-to-end-tests/src/test/compat.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/compat.spec.ts
@@ -24,7 +24,7 @@ import {
 import { ISummaryConfiguration } from "@fluidframework/protocol-definitions";
 import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
-import { componentRuntimeRequestHandler, RuntimeRequestHandlerBuilder } from "@fluidframework/request-handler";
+import { dataStoreRuntimeRequestHandler, RuntimeRequestHandlerBuilder } from "@fluidframework/request-handler";
 import { createLocalLoader, OpProcessingController, initializeLocalContainer } from "@fluidframework/test-utils";
 import * as old from "./oldVersion";
 
@@ -67,7 +67,7 @@ describe("loader/runtime compatibility", () => {
     ): IRuntimeFactory => {
         const builder = new RuntimeRequestHandlerBuilder();
         builder.pushHandler(
-            componentRuntimeRequestHandler,
+            dataStoreRuntimeRequestHandler,
             defaultDataStoreRuntimeRequestHandler("default"));
 
         return {
@@ -94,7 +94,7 @@ describe("loader/runtime compatibility", () => {
     ): old.IRuntimeFactory => {
         const builder = new old.RuntimeRequestHandlerBuilder();
         builder.pushHandler(
-            old.componentRuntimeRequestHandler,
+            old.dataStoreRuntimeRequestHandler,
             old.defaultDataStoreRuntimeRequestHandler("default"));
 
         return {
@@ -107,9 +107,9 @@ describe("loader/runtime compatibility", () => {
                     runtimeOptions,
                 );
                 if (!runtime.existing) {
-                    const componentRuntime = await runtime.createComponent("default", type);
-                    await componentRuntime.request({ url: "/" });
-                    componentRuntime.bindToContext();
+                    const dataStoreRuntime = await runtime.createComponent("default", type);
+                    await dataStoreRuntime.request({ url: "/" });
+                    dataStoreRuntime.bindToContext();
                 }
                 return runtime;
             },

--- a/packages/test/end-to-end-tests/src/test/compat.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/compat.spec.ts
@@ -181,16 +181,16 @@ describe("loader/runtime compatibility", () => {
                 createContainer( // new everything
                     { fluidExport: createRuntimeFactory(TestComponent.type, createComponentFactory()) },
                     this.deltaConnectionServer),
-                createContainerWithOldLoader( // old loader, new container/component runtimes
+                createContainerWithOldLoader( // old loader, new container/data store runtimes
                     { fluidExport: createRuntimeFactory(TestComponent.type, createComponentFactory()) },
                     this.deltaConnectionServer),
                 createContainerWithOldLoader( // old everything
                     { fluidExport: createOldRuntimeFactory(TestComponent.type, createOldComponentFactory()) },
                     this.deltaConnectionServer),
-                createContainer( // new loader, old container/component runtimes
+                createContainer( // new loader, old container/data store runtimes
                     { fluidExport: createOldRuntimeFactory(TestComponent.type, createOldComponentFactory()) },
                     this.deltaConnectionServer),
-                createContainer( // new loader/container runtime, old component runtime
+                createContainer( // new loader/container runtime, old data store runtime
                     { fluidExport: createRuntimeFactory(TestComponent.type, createOldComponentFactory()) },
                     this.deltaConnectionServer),
             ];

--- a/packages/test/end-to-end-tests/src/test/componentHandle.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/componentHandle.spec.ts
@@ -115,13 +115,13 @@ describe("FluidOjectHandle", () => {
         const absolutePath = `/${firstContainerComponent1._runtime.id}`;
 
         // Verify that the local client's FluidDataStoreRuntime has the correct absolute path.
-        const componentRuntime1 = firstContainerComponent1._runtime.IFluidHandleContext;
-        assert.equal(componentRuntime1.absolutePath, absolutePath, "The FluidDataStoreRuntime's path is incorrect");
+        const dataStoreRuntime1 = firstContainerComponent1._runtime.IFluidHandleContext;
+        assert.equal(dataStoreRuntime1.absolutePath, absolutePath, "The FluidDataStoreRuntime's path is incorrect");
 
         // Verify that the remote client's FluidDataStoreRuntime has the correct absolute path.
-        const componentRuntime2 = secondContainerComponent1._runtime.IFluidHandleContext;
+        const dataStoreRuntime2 = secondContainerComponent1._runtime.IFluidHandleContext;
         assert.equal(
-            componentRuntime2.absolutePath,
+            dataStoreRuntime2.absolutePath,
             absolutePath,
             "The remote FluidDataStoreRuntime's path is incorrect");
     });

--- a/packages/test/end-to-end-tests/src/test/componentHandle.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/componentHandle.spec.ts
@@ -126,7 +126,7 @@ describe("FluidOjectHandle", () => {
             "The remote FluidDataStoreRuntime's path is incorrect");
     });
 
-    it("can store and retrieve a DDS from handle within same component runtime", async () => {
+    it("can store and retrieve a DDS from handle within same data store runtime", async () => {
         // Create a new SharedMap in `firstContainerComponent1` and set a value.
         const sharedMap = SharedMap.create(firstContainerComponent1._runtime);
         sharedMap.set("key1", "value1");
@@ -156,7 +156,7 @@ describe("FluidOjectHandle", () => {
         assert.equal(remoteSharedMap.get("key1"), "value1", "The map does not have the value that was set");
     });
 
-    it("can store and retrieve a DDS from handle in different component runtime", async () => {
+    it("can store and retrieve a DDS from handle in different data store runtime", async () => {
         // Create a new SharedMap in `firstContainerComponent2` and set a value.
         const sharedMap = SharedMap.create(firstContainerComponent2._runtime);
         sharedMap.set("key1", "value1");
@@ -186,7 +186,7 @@ describe("FluidOjectHandle", () => {
         assert.equal(remoteSharedMap.get("key1"), "value1", "The map does not have the value that was set");
     });
 
-    it("can store and retrieve a PureDataObject from handle in different component runtime", async () => {
+    it("can store and retrieve a PureDataObject from handle in different data store runtime", async () => {
         // The expected absolute path.
         const absolutePath = `/${firstContainerComponent2._runtime.id}`;
 

--- a/packages/test/end-to-end-tests/src/test/localTestSignals.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/localTestSignals.spec.ts
@@ -56,7 +56,7 @@ describe("TestSignals", () => {
     });
 
     describe("Attach signal Handlers on Both Clients", () => {
-        it("Validate component runtime signals", async () => {
+        it("Validate data store runtime signals", async () => {
             let user1SignalReceivedCount = 0;
             let user2SignalReceivedCount = 0;
 
@@ -151,15 +151,15 @@ describe("TestSignals", () => {
         await opProcessingController.process();
         assert.equal(user1HostSignalReceivedCount, 1, "client 1 did not receive signal on host runtime");
         assert.equal(user2HostSignalReceivedCount, 1, "client 2 did not receive signal on host runtime");
-        assert.equal(user1CompSignalReceivedCount, 0, "client 1 should not receive signal on component runtime");
-        assert.equal(user2CompSignalReceivedCount, 0, "client 2 should not receive signal on component runtime");
+        assert.equal(user1CompSignalReceivedCount, 0, "client 1 should not receive signal on data store runtime");
+        assert.equal(user2CompSignalReceivedCount, 0, "client 2 should not receive signal on data store runtime");
 
         user2ComponentRuntime.submitSignal("TestSignal", true);
         await opProcessingController.process();
         assert.equal(user1HostSignalReceivedCount, 1, "client 1 should not receive signal on host runtime");
         assert.equal(user2HostSignalReceivedCount, 1, "client 2 should not receive signal on host runtime");
-        assert.equal(user1CompSignalReceivedCount, 1, "client 1 did not receive signal on component runtime");
-        assert.equal(user2CompSignalReceivedCount, 1, "client 2 did not receive signal on component runtime");
+        assert.equal(user1CompSignalReceivedCount, 1, "client 1 did not receive signal on data store runtime");
+        assert.equal(user2CompSignalReceivedCount, 1, "client 2 did not receive signal on data store runtime");
     });
 
     afterEach(async () => {

--- a/packages/test/end-to-end-tests/src/test/oldVersion.ts
+++ b/packages/test/end-to-end-tests/src/test/oldVersion.ts
@@ -13,7 +13,10 @@ export {
 export { IContainerContext, IFluidModule, IRuntimeFactory } from "old-container-definitions";
 export { Container } from "old-container-loader";
 export { ContainerRuntime, IContainerRuntimeOptions } from "old-container-runtime";
-export { componentRuntimeRequestHandler, RuntimeRequestHandlerBuilder } from "old-request-handler";
+export {
+    componentRuntimeRequestHandler as dataStoreRuntimeRequestHandler,
+    RuntimeRequestHandlerBuilder,
+} from "old-request-handler";
 export { IFluidDataStoreFactory } from "old-runtime-definitions";
 export { createLocalLoader, initializeLocalContainer } from "old-test-utils";
 /* eslint-enable import/no-extraneous-dependencies */

--- a/packages/test/test-utils/src/testFluidComponent.ts
+++ b/packages/test/test-utils/src/testFluidComponent.ts
@@ -47,7 +47,7 @@ export class TestFluidComponent implements ITestFluidComponent {
 
     /**
      * Creates a new TestFluidComponent.
-     * @param runtime - The component runtime.
+     * @param runtime - The data store runtime.
      * @param context - The componet context.
      * @param factoryEntries - A list of id to IChannelFactory mapping. For each item in the list,
      * a shared object is created which can be retrieved by calling getSharedObject() with the id;
@@ -106,12 +106,12 @@ export class TestFluidComponent implements ITestFluidComponent {
 }
 
 /**
- * Creates a factory for a TestFluidComponent with the given object factory entries. It creates a component runtime
+ * Creates a factory for a TestFluidComponent with the given object factory entries. It creates a data store runtime
  * with the object factories in the entry list. All the entries with an id other than undefined are passed to the
  * component so that it can create a shared object for each.
  *
  * For example, the following will create a component that creates and loads a SharedString and SharedDirectory. It
- * will add SparseMatrix to the component runtime's factory so that it can be created later.
+ * will add SparseMatrix to the data store runtime's factory so that it can be created later.
  *      new TestFluidComponentFactory([
  *          [ "sharedString", SharedString.getFactory() ],
  *          [ "sharedDirectory", SharedDirectory.getFactory() ],
@@ -130,7 +130,7 @@ export class TestFluidComponentFactory implements IFluidDataStoreFactory {
 
     /**
      * Creates a new TestFluidComponentFactory.
-     * @param factoryEntries - A list of id to IChannelFactory mapping. It creates a component runtime with each
+     * @param factoryEntries - A list of id to IChannelFactory mapping. It creates a data store runtime with each
      * IChannelFactory. Entries with string ids are passed to the component so that it can create a shared object
      * for it.
      */
@@ -143,7 +143,7 @@ export class TestFluidComponentFactory implements IFluidDataStoreFactory {
         const sharedMapFactory = SharedMap.getFactory();
         dataTypes.set(sharedMapFactory.type, sharedMapFactory);
 
-        // Add the object factories to the list to be sent to component runtime.
+        // Add the object factories to the list to be sent to data store runtime.
         for (const entry of this.factoryEntries) {
             const factory = entry[1];
             dataTypes.set(factory.type, factory);


### PR DESCRIPTION
Also renamed `componentRuntimeRequestHandler` to `dataStoreRuntimeRequestHandler`
Delete unused `IComponentDef` from `merge-tree/src/ops.ts`

Fixes #3030, #3028, #3027, #3026, #3025, #3024, #3023, #3022, #3021