### PR TITLE
Make SummarizeTimeout a performance event instead of error event

### DIFF
--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -544,7 +544,7 @@ export class RunningSummarizer implements IDisposable {
     }
 
     private summarizeTimerHandler(time: number, count: number) {
-        this.logger.sendErrorEvent({
+        this.logger.sendPerformanceEvent({
             eventName: "SummarizeTimeout",
             timeoutTime: time,
             timeoutCount: count,


### PR DESCRIPTION
fixes #3077 

This event shouldn't be an error now that we have dashboards and alerts in place.