### PR TITLE
update layercheck

### DIFF
--- a/tools/build-tools/data/layerInfo.json
+++ b/tools/build-tools/data/layerInfo.json
@@ -170,13 +170,12 @@
                     "Runtime"
                 ]
             },
-            "Component": {
+            "Examples": {
                 "dot": false,
                 "dirs": [
-                    "packages/components/",
                     "components/",
-                    "packages/agents/",
-                    "packages/server/tools-core"
+                    "examples/",
+                    "packages/agents/"
                 ],
                 "deps": [
                     "Framework"
@@ -211,8 +210,7 @@
                     "@fluidframework/webpack-component-loader"
                 ],
                 "dirs": [
-                    "packages/test/",
-                    "examples/hosts/"
+                    "packages/test/"
                 ]
             }
         }


### PR DESCRIPTION
updating layercheck to reflect our new example structure

`/examples/apps` -> new apps
`/examples/hosts` -> other apps that are not with the new pattern. node-host/literate-host/iframe-host
`/examples/containers` -> move everything from `/components` here. We can port them to apps 


@curtisman , does renaming `Components` to `Examples` break anything I'm not thinking about?