### PR TITLE
Make test historian work with collections

### DIFF
--- a/server/routerlicious/packages/test-utils/src/testHistorian.ts
+++ b/server/routerlicious/packages/test-utils/src/testHistorian.ts
@@ -55,7 +55,7 @@ export class TestHistorian implements IHistorian {
         const blob = await this.blobs.findOne({ _id: sha });
         return {
             content: Buffer.from(blob.content, blob.encoding).toString("base64"),
-            encoding: blob.encoding,
+            encoding: "base64",
             sha: blob._id,
             size: blob.content.length,
             url: "",


### PR DESCRIPTION
Found that collections doesn't expect to have value field, so it was creating problems like even after uploading the summary local server we used to get ops from beginning. So removed value field.