### PR TITLE
Null attach snapshots

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -57,6 +57,7 @@ import { ContainerRuntime } from "./containerRuntime";
 const currentSnapshotFormatVersion = "0.1";
 
 const attributesBlobKey = ".component";
+
 function createAttributes(pkg: readonly string[]): IFluidDataStoreAttributes {
     const stringifiedPkg = JSON.stringify(pkg);
     return {

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -32,6 +32,7 @@ import {
     ISnapshotTree,
     ITree,
     ConnectionState,
+    ITreeEntry,
 } from "@fluidframework/protocol-definitions";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import {
@@ -54,6 +55,19 @@ import { ContainerRuntime } from "./containerRuntime";
 
 // Snapshot Format Version to be used in store attributes.
 const currentSnapshotFormatVersion = "0.1";
+
+const attributesBlobKey = ".component";
+function createAttributes(pkg: readonly string[]): IFluidDataStoreAttributes {
+    const stringifiedPkg = JSON.stringify(pkg);
+    return {
+        pkg: stringifiedPkg,
+        snapshotFormatVersion: currentSnapshotFormatVersion,
+    };
+}
+export function createAttributesBlob(pkg: readonly string[]): ITreeEntry {
+    const attributes = createAttributes(pkg);
+    return new BlobTreeEntry(attributesBlobKey, JSON.stringify(attributes));
+}
 
 /**
  * Added IFluidDataStoreAttributes similar to IChannelAttributes which will tell
@@ -361,17 +375,13 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
 
         const { pkg } = await this.getInitialSnapshotDetails();
 
-        const attributes: IFluidDataStoreAttributes = {
-            pkg: JSON.stringify(pkg),
-            snapshotFormatVersion: currentSnapshotFormatVersion,
-        };
-
         await this.realize();
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const entries = await this.channel!.snapshotInternal(fullTree);
 
-        entries.push(new BlobTreeEntry(".component", JSON.stringify(attributes)));
+        const attributesBlob = createAttributesBlob(pkg);
+        entries.push(attributesBlob);
 
         return { entries, id: null };
     }
@@ -383,23 +393,20 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
     private async summarizeInternal(fullTree: boolean): Promise<ISummarizeInternalResult> {
         const { pkg } = await this.getInitialSnapshotDetails();
 
-        const attributes: IFluidDataStoreAttributes = {
-            pkg: JSON.stringify(pkg),
-            snapshotFormatVersion: currentSnapshotFormatVersion,
-        };
-
         await this.realize();
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const channel = this.channel!;
         if (channel.summarize !== undefined) {
             const summary = await channel.summarize(fullTree);
-            addBlobToSummary(summary, ".component", JSON.stringify(attributes));
+            const attributes: IFluidDataStoreAttributes = createAttributes(pkg);
+            addBlobToSummary(summary, attributesBlobKey, JSON.stringify(attributes));
             return { ...summary, id: this.id };
         } else {
             // back-compat summarizerNode - remove this case
             const entries = await channel.snapshotInternal(fullTree);
-            entries.push(new BlobTreeEntry(".component", JSON.stringify(attributes)));
+            const attributesBlob = createAttributesBlob(pkg);
+            entries.push(attributesBlob);
             const summary = convertToSummaryTree({ entries, id: null });
             return { ...summary, id: this.id };
         }
@@ -642,10 +649,10 @@ export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
                 this.pending = loadedSummary.outstandingOps.concat(this.pending!);
             }
 
-            if (tree !== null && tree.blobs[".component"] !== undefined) {
+            if (tree !== null && tree.blobs[attributesBlobKey] !== undefined) {
                 // Need to rip through snapshot and use that to populate extraBlobs
                 const { pkg, snapshotFormatVersion } =
-                    await localReadAndParse<IFluidDataStoreAttributes>(tree.blobs[".component"]);
+                    await localReadAndParse<IFluidDataStoreAttributes>(tree.blobs[attributesBlobKey]);
 
                 let pkgFromSnapshot: string[];
                 // Use the snapshotFormatVersion to determine how the pkg is encoded in the snapshot.
@@ -676,6 +683,9 @@ export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
 }
 
 export class LocalFluidDataStoreContext extends FluidDataStoreContext {
+    // Package is required at time of creation for local data stores
+    protected pkg: readonly string[];
+
     constructor(
         id: string,
         pkg: string[],
@@ -697,6 +707,7 @@ export class LocalFluidDataStoreContext extends FluidDataStoreContext {
             BindState.NotBound,
             bindChannel,
             pkg);
+        this.pkg = pkg; // TODO: avoid setting twice
         this.attachListeners();
     }
 
@@ -712,23 +723,18 @@ export class LocalFluidDataStoreContext extends FluidDataStoreContext {
     }
 
     public generateAttachMessage(): IAttachMessage {
-        const attributes: IFluidDataStoreAttributes = {
-            pkg: JSON.stringify(this.pkg),
-            snapshotFormatVersion: currentSnapshotFormatVersion,
-        };
-
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const entries = this.channel!.getAttachSnapshot();
 
         const snapshot: ITree = { entries, id: null };
 
-        snapshot.entries.push(new BlobTreeEntry(".component", JSON.stringify(attributes)));
+        const attributesBlob = createAttributesBlob(this.pkg);
+        snapshot.entries.push(attributesBlob);
 
         const message: IAttachMessage = {
             id: this.id,
             snapshot,
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            type: this.pkg![this.pkg!.length - 1],
+            type: this.pkg[this.pkg.length - 1],
         };
 
         return message;
@@ -736,8 +742,7 @@ export class LocalFluidDataStoreContext extends FluidDataStoreContext {
 
     protected async getInitialSnapshotDetails(): Promise<ISnapshotDetails> {
         return {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            pkg: this.pkg!,
+            pkg: this.pkg,
             snapshot: undefined,
         };
     }

--- a/packages/runtime/runtime-definitions/src/protocol.ts
+++ b/packages/runtime/runtime-definitions/src/protocol.ts
@@ -62,3 +62,12 @@ export interface IAttachMessage {
      */
     snapshot: ITree;
 }
+
+/**
+ * This type should be used when reading an incoming attach op,
+ * but it should not be used when creating a new attach op.
+ * Older versions of attach messages could have null snapshots,
+ * so this gives correct typings for writing back-compat code.
+ */
+export type InboundAttachMessage = Omit<IAttachMessage, "snapshot">
+    & { snapshot: IAttachMessage["snapshot"] | null };

--- a/packages/test/snapshots/src/replayMultipleFiles.ts
+++ b/packages/test/snapshots/src/replayMultipleFiles.ts
@@ -5,10 +5,28 @@
 
 import assert from "assert";
 import fs from "fs";
+import nodePath from "path";
 import { ReplayArgs, ReplayTool } from "@fluid-internal/replay-tool";
 import { Deferred } from "@fluidframework/common-utils";
 
-const fileLocation: string = "content/snapshotTestContent";
+// Determine relative file locations
+function getFileLocations(): [string, string] {
+    // Correct if executing from working directory of package root
+    const origTestCollateralPath = "content/snapshotTestContent";
+    let testCollateralPath = origTestCollateralPath;
+    let workerPath = "./dist/replayWorker.js";
+    if (fs.existsSync(testCollateralPath)) {
+        assert(fs.existsSync(workerPath), `Cannot find worker js file: ${workerPath}`);
+        return [testCollateralPath, workerPath];
+    }
+    // Relative to this generated js file being executed
+    testCollateralPath = nodePath.join(__dirname, "..", testCollateralPath);
+    workerPath = nodePath.join(__dirname, "..", workerPath);
+    assert(fs.existsSync(testCollateralPath), `Cannot find test collateral path: ${origTestCollateralPath}`);
+    assert(fs.existsSync(workerPath), `Cannot find worker js file: ${workerPath}`);
+    return [testCollateralPath, workerPath];
+}
+const [fileLocation, workerLocation] = getFileLocations();
 
 const numberOfThreads = 4;
 
@@ -144,7 +162,7 @@ export async function processContent(mode: Mode, concurrently = true) {
         }
 
         await (async (workerData: IWorkerArgs) => limiter.addWork(async () => new Promise((resolve, reject) => {
-            const worker = new threads.Worker("./dist/replayWorker.js", { workerData });
+            const worker = new threads.Worker(workerLocation, { workerData });
 
             worker.on("message", (error: string) => {
                 if (mode === Mode.Compare) {


### PR DESCRIPTION
Added `InboundAttachMessage` type to handle null snapshots.

Use empty tree with only ".component" attributes blob when attach snapshot is missing.

Also fixes the snapshot tests so they can be ran from Debug Current Test vscode launch task. This is confined to the first commit.