### PR TITLE
add additional layer-check deps to Examples

### DIFF
--- a/tools/build-tools/data/layerInfo.json
+++ b/tools/build-tools/data/layerInfo.json
@@ -178,7 +178,10 @@
                     "packages/agents/"
                 ],
                 "deps": [
-                    "Framework"
+                    "Framework",
+                    "Driver",
+                    "Routerlicious-Driver",
+                    "Test"
                 ]
             },
             "Build": {


### PR DESCRIPTION
Since we are moving things back to Examples we need to ensure it has the correct layer check deps.

I plan on moving `get-tinylicious-container` here too as well as `get-session-storage-container` which is in PR. This is why we need the Driver deps.