### PR TITLE
Examples a dev in layer-check

### DIFF
--- a/tools/build-tools/data/layerInfo.json
+++ b/tools/build-tools/data/layerInfo.json
@@ -172,6 +172,7 @@
             },
             "Examples": {
                 "dot": false,
+                "dev": true,
                 "dirs": [
                     "components/",
                     "examples/",


### PR DESCRIPTION
This will allow a bit more flexibility in what we put in our examples. It will also make it so that our Examples cannot be consumed by any of our client packages.