### PR TITLE
Concept reduction: NamedFluidDataStoreRegistryEntries

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -179,7 +179,7 @@ All renames are 1-1, and global case senstive and whole word find replace for al
 
             "ComponentRegistryEntry": "FluidDataStoreRegistryEntry",
             "NamedComponentRegistryEntry": "NamedFluidDataStoreRegistryEntry",
-            "NamedComponentRegistryEntries": "NamedFluidDataStoreRegistryEntries",
+            "NamedComponentRegistryEntries": "FluidDataStoreRegistryEntries",
             "ComponentRegistry": "FluidDataStoreRegistry",
             "ContainerRuntimeComponentRegistry": "ContainerRuntimeDataStoreRegistry"
         },

--- a/components/examples/diceroller/src/index.ts
+++ b/components/examples/diceroller/src/index.ts
@@ -7,9 +7,9 @@ import {
     ContainerRuntimeFactoryWithDefaultDataStore,
 } from "@fluidframework/aqueduct";
 
-import { DiceRoller, DiceRollerInstantiationFactory } from "./main";
+import { DiceRollerInstantiationFactory } from "./main";
 
-export { DiceRoller, DiceRollerInstantiationFactory } from "./main";
+export { DiceRollerInstantiationFactory } from "./main";
 
 /**
  * This does setup for the Container. The ContainerRuntimeFactoryWithDefaultDataStore also enables dynamic loading in
@@ -23,8 +23,8 @@ export { DiceRoller, DiceRollerInstantiationFactory } from "./main";
  * components.
  */
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    DiceRoller.ComponentName,
-    new Map([
-        [DiceRoller.ComponentName, Promise.resolve(DiceRollerInstantiationFactory)],
-    ]),
+    DiceRollerInstantiationFactory.type,
+    [
+        DiceRollerInstantiationFactory,
+    ],
 );

--- a/components/examples/diceroller/src/main.tsx
+++ b/components/examples/diceroller/src/main.tsx
@@ -69,8 +69,6 @@ const DiceRollerView: React.FC<IDiceRollerViewProps> = (props: IDiceRollerViewPr
  * The DiceRoller is our implementation of the IDiceRoller interface.
  */
 export class DiceRoller extends DataObject implements IDiceRoller, IFluidHTMLView {
-    public static get ComponentName() { return "@fluid-example/dice-roller"; }
-
     public get IFluidHTMLView() { return this; }
 
     /**
@@ -116,7 +114,7 @@ export class DiceRoller extends DataObject implements IDiceRoller, IFluidHTMLVie
  * To add a SharedSequence, SharedMap, or any other structure, put it in the array below.
  */
 export const DiceRollerInstantiationFactory = new DataObjectFactory(
-    DiceRoller.ComponentName,
+    "@fluid-example/dice-roller",
     DiceRoller,
     [],
     {},

--- a/components/examples/pond/src/index.tsx
+++ b/components/examples/pond/src/index.tsx
@@ -20,10 +20,6 @@ import {
 import { IComponentUserInformation } from "./interfaces";
 import { userInfoFactory } from "./providers";
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-const pkg = require("../package.json");
-export const PondName = pkg.name as string;
-
 /**
  * Basic Pond example using stock component classes.
  *
@@ -100,14 +96,14 @@ export class Pond extends DataObject implements IFluidHTMLView {
     public static getFactory() { return Pond.factory; }
 
     private static readonly factory = new DataObjectFactory(
-        PondName,
+        "@fluid-example/pond",
         Pond,
         [SharedDirectory.getFactory()],
         {},
-        new Map([
+        [
             Clicker.getFactory().registryEntry,
             ExampleUsingProviders.getFactory().registryEntry,
-        ]),
+        ],
     );
 }
 
@@ -115,9 +111,9 @@ export class Pond extends DataObject implements IFluidHTMLView {
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
     Pond.getFactory().type,
-    new Map([
+    [
         Pond.getFactory().registryEntry,
-    ]),
+    ],
     [
         {
             type: IComponentUserInformation,

--- a/components/examples/primitives/src/index.ts
+++ b/components/examples/primitives/src/index.ts
@@ -7,7 +7,6 @@ import {
     ContainerRuntimeFactoryWithDefaultDataStore,
 } from "@fluidframework/aqueduct";
 
-import { PrimitivesName } from "./main";
 import { PrimitivesInstantiationFactory } from "./primitivesInstantiationFactory";
 
 /**
@@ -22,8 +21,8 @@ import { PrimitivesInstantiationFactory } from "./primitivesInstantiationFactory
  * components.
  */
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    PrimitivesName,
-    new Map([
-        [PrimitivesName, Promise.resolve(PrimitivesInstantiationFactory)],
-    ]),
+    PrimitivesInstantiationFactory.type,
+    [
+        PrimitivesInstantiationFactory,
+    ],
 );

--- a/components/examples/primitives/src/main.tsx
+++ b/components/examples/primitives/src/main.tsx
@@ -12,10 +12,6 @@ import ReactDOM from "react-dom";
 import { SharedMap, IDirectory, IDirectoryValueChanged } from "@fluidframework/map";
 import { DdsCollectionComponent } from "./ddsCollection";
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-const pkg = require("../package.json");
-export const PrimitivesName = pkg.name as string;
-
 /**
  * Basic DDS examples using view interfaces and stock component classes.
  */

--- a/components/examples/primitives/src/primitivesInstantiationFactory.ts
+++ b/components/examples/primitives/src/primitivesInstantiationFactory.ts
@@ -5,14 +5,14 @@
 
 import { DataObjectFactory } from "@fluidframework/aqueduct";
 import { SharedMap } from "@fluidframework/map";
-import { PrimitivesCollection, PrimitivesName } from "./main";
+import { PrimitivesCollection } from "./main";
 
 /**
  * The DataObjectFactory declares the component and defines any additional distributed data structures.
  * To add a SharedSequence, SharedMap, or any other structure, put it in the array below.
  */
 export const PrimitivesInstantiationFactory = new DataObjectFactory(
-    PrimitivesName,
+    "@fluid-example/primitives",
     PrimitivesCollection,
     [
         SharedMap.getFactory(),

--- a/components/examples/simple-component-embed/src/index.tsx
+++ b/components/examples/simple-component-embed/src/index.tsx
@@ -58,8 +58,8 @@ export const SimpleComponentEmbedInstantiationFactory = new DataObjectFactory(
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
     SimpleComponentEmbedInstantiationFactory.type,
-    new Map([
+    [
         SimpleComponentEmbedInstantiationFactory.registryEntry,
         ClickerInstantiationFactory.registryEntry,
-    ]),
+    ],
 );

--- a/components/experimental/canvas/src/index.ts
+++ b/components/experimental/canvas/src/index.ts
@@ -10,12 +10,8 @@ import {
 import { Ink } from "@fluidframework/ink";
 import { Canvas } from "./canvas";
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-const pkg = require("../package.json");
-export const CanvasName = pkg.name as string;
-
 export const CanvasInstantiationFactory = new DataObjectFactory(
-    CanvasName,
+    "@fluid-example/canvas",
     Canvas,
     [
         Ink.getFactory(),
@@ -24,8 +20,8 @@ export const CanvasInstantiationFactory = new DataObjectFactory(
 );
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    CanvasName,
-    new Map([
-        [CanvasName, Promise.resolve(CanvasInstantiationFactory)],
-    ]),
+    CanvasInstantiationFactory.type,
+    [
+        CanvasInstantiationFactory,
+    ],
 );

--- a/components/experimental/codemirror/src/index.ts
+++ b/components/experimental/codemirror/src/index.ts
@@ -9,7 +9,7 @@
     IRuntimeFactory,
 } from "@fluidframework/container-definitions";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
-import { IFluidDataStoreFactory, FlushMode } from "@fluidframework/runtime-definitions";
+import { FlushMode } from "@fluidframework/runtime-definitions";
 import {
     deprecated_innerRequestHandler,
     buildRuntimeRequestHandler,
@@ -22,16 +22,12 @@ class CodeMirrorFactory implements IRuntimeFactory {
     public get IRuntimeFactory() { return this; }
 
     public async instantiateRuntime(context: IContainerContext): Promise<IRuntime> {
-        const registry = new Map<string, Promise<IFluidDataStoreFactory>>([
-            ["@fluid-example/smde", Promise.resolve(smde)],
-        ]);
-
         const defaultComponentId = "default";
-        const defaultComponent = "@fluid-example/smde";
+        const defaultComponent = smde.type;
 
         const runtime = await ContainerRuntime.load(
             context,
-            registry,
+            [smde],
             buildRuntimeRequestHandler(
                 defaultRouteRequestHandler(defaultComponentId),
                 deprecated_innerRequestHandler),

--- a/components/experimental/external-component-loader/src/externalComponentLoader.tsx
+++ b/components/experimental/external-component-loader/src/externalComponentLoader.tsx
@@ -9,6 +9,7 @@ import {
     IFluidLoadable,
     IFluidRouter,
 } from "@fluidframework/core-interfaces";
+import { RenamingFactoryAdapter } from "@fluidframework/container-runtime";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { UrlRegistry } from "./urlRegistry";
 
@@ -23,7 +24,7 @@ export class ExternalComponentLoader extends DataObject {
         ExternalComponentLoader,
         [],
         {},
-        [["url", Promise.resolve(new UrlRegistry())]],
+        [new RenamingFactoryAdapter("url", new UrlRegistry())],
     );
 
     public static getFactory() {

--- a/components/experimental/external-component-loader/src/index.ts
+++ b/components/experimental/external-component-loader/src/index.ts
@@ -7,8 +7,6 @@ import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqu
 import { WaterPark } from "./waterPark";
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    WaterPark.ComponentName,
-    new Map([
-        [WaterPark.ComponentName, Promise.resolve(WaterPark.getFactory())],
-    ]),
+    WaterPark.getFactory().type,
+    [WaterPark.getFactory()],
 );

--- a/components/experimental/external-component-loader/src/urlRegistry.ts
+++ b/components/experimental/external-component-loader/src/urlRegistry.ts
@@ -12,7 +12,6 @@ import {
     FluidDataStoreRegistryEntry,
     IFluidDataStoreRegistry,
 } from "@fluidframework/runtime-definitions";
-import { IFluidObject } from "@fluidframework/core-interfaces";
 import { WebCodeLoader, SemVerCdnCodeResolver } from "@fluidframework/web-code-loader";
 
 /**
@@ -48,7 +47,7 @@ export class UrlRegistry implements IFluidDataStoreRegistry {
         return this.urlRegistryMap.get(name);
     }
 
-    private async loadEntrypoint(name: string): Promise<IFluidObject | undefined> {
+    private async loadEntrypoint(name: string): Promise<FluidDataStoreRegistryEntry | undefined> {
         if (this.isUrl(name)) {
             if (!this.loadingPackages.has(name)) {
                 this.loadingPackages.set(name, this.loadPackage(name));
@@ -62,7 +61,7 @@ export class UrlRegistry implements IFluidDataStoreRegistry {
             },
         };
         const fluidModule = await this.webloader.load(codeDetails);
-        return fluidModule.fluidExport;
+        return fluidModule.fluidExport as FluidDataStoreRegistryEntry;
     }
 
     private async loadPackage(url: string): Promise<IFluidPackage> {

--- a/components/experimental/external-component-loader/src/waterPark.tsx
+++ b/components/experimental/external-component-loader/src/waterPark.tsx
@@ -73,16 +73,14 @@ export interface IWaterparkItem {
 export class WaterPark extends DataObject implements IFluidHTMLView {
     public get IFluidHTMLView() { return this; }
 
-    public static get ComponentName() { return "@fluid-example/waterpark"; }
-
     private static readonly factory = new DataObjectFactory(
-        WaterPark.ComponentName,
+        "@fluid-example/waterpark",
         WaterPark,
         [],
         {},
         [
-            [SpacesStorage.ComponentName, Promise.resolve(SpacesStorage.getFactory())],
-            [ExternalComponentLoader.ComponentName, Promise.resolve(ExternalComponentLoader.getFactory())],
+            SpacesStorage.getFactory(),
+            ExternalComponentLoader.getFactory(),
         ],
     );
 

--- a/components/experimental/image-gallery/src/index.tsx
+++ b/components/experimental/image-gallery/src/index.tsx
@@ -18,8 +18,6 @@ import "react-image-gallery/styles/css/image-gallery.css";
 import "./Styles.css";
 import { ISharedMap } from "@fluidframework/map";
 
-const imageGalleryName = "@fluid-example/image-gallery";
-
 export class ImageGalleryComponent extends DataObject implements IFluidHTMLView {
     public get IFluidHTMLView() { return this; }
 
@@ -99,15 +97,13 @@ export class ImageGalleryComponent extends DataObject implements IFluidHTMLView 
 }
 
 export const ImageGalleryInstantiationFactory = new DataObjectFactory(
-    imageGalleryName,
+    "@fluid-example/image-gallery",
     ImageGalleryComponent,
     [],
     {},
 );
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    imageGalleryName,
-    new Map([
-        [imageGalleryName, Promise.resolve(ImageGalleryInstantiationFactory)],
-    ]),
+    ImageGalleryInstantiationFactory.type,
+    [ImageGalleryInstantiationFactory],
 );

--- a/components/experimental/key-value-cache/src/index.ts
+++ b/components/experimental/key-value-cache/src/index.ts
@@ -32,10 +32,6 @@ import {
 } from "@fluidframework/request-handler";
 import { defaultRouteRequestHandler } from "@fluidframework/aqueduct";
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-const pkg = require("../package.json");
-export const ComponentName = pkg.name;
-
 export const IKeyValue: keyof IProvideKeyValue = "IKeyValue";
 
 export interface IProvideKeyValue {
@@ -136,15 +132,15 @@ export class KeyValueFactoryComponent implements IRuntimeFactory, IFluidDataStor
     public async instantiateRuntime(context: IContainerContext): Promise<IRuntime> {
         const runtime: ContainerRuntime = await ContainerRuntime.load(
             context,
-            new Map([[ComponentName, Promise.resolve(this)]]),
+            [this],
             buildRuntimeRequestHandler(
-                defaultRouteRequestHandler(ComponentName),
+                defaultRouteRequestHandler(this.type),
                 deprecated_innerRequestHandler,
             ),
         );
 
         if (!runtime.existing) {
-            await runtime.createRootDataStore(ComponentName, ComponentName);
+            await runtime.createRootDataStore(this.type, this.type);
         }
 
         return runtime;

--- a/components/experimental/monaco/src/index.ts
+++ b/components/experimental/monaco/src/index.ts
@@ -12,10 +12,8 @@ import { IProvideFluidDataStoreFactory } from "@fluidframework/runtime-definitio
 import * as sequence from "@fluidframework/sequence";
 import { MonacoRunner } from "./chaincode";
 
-const monacoName = "@fluid-example/monaco";
-
 const componentFactory = new DataObjectFactory(
-    monacoName,
+    "@fluid-example/monaco",
     MonacoRunner,
     [
         sequence.SharedString.getFactory(),
@@ -26,10 +24,8 @@ const componentFactory = new DataObjectFactory(
 );
 
 const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
-    monacoName,
-    new Map([
-        [monacoName, Promise.resolve(componentFactory)],
-    ]),
+    componentFactory.type,
+    [componentFactory],
 );
 
 export const fluidExport: IProvideFluidDataStoreFactory & IProvideRuntimeFactory = {

--- a/components/experimental/multiview/constellation-model/src/model.ts
+++ b/components/experimental/multiview/constellation-model/src/model.ts
@@ -19,8 +19,6 @@ const starListKey = "stars";
  * The Constellation is our implementation of the IConstellation interface.
  */
 export class Constellation extends DataObject implements IConstellation {
-    public static get ComponentName() { return "@fluid-example/constellation"; }
-
     private _stars: ICoordinate[] = [];
 
     public static getFactory() {
@@ -28,13 +26,11 @@ export class Constellation extends DataObject implements IConstellation {
     }
 
     private static readonly factory = new DataObjectFactory(
-        Constellation.ComponentName,
+        "@fluid-example/constellation",
         Constellation,
         [],
         {},
-        new Map([
-            Coordinate.getFactory().registryEntry,
-        ]),
+        [Coordinate.getFactory()],
     );
 
     protected async initializingFirstTime() {

--- a/components/experimental/multiview/container/src/container.tsx
+++ b/components/experimental/multiview/container/src/container.tsx
@@ -25,11 +25,6 @@ const triangleCoordinateComponentId2 = "triangle2";
 const triangleCoordinateComponentId3 = "triangle3";
 const constellationComponentId = "constellation";
 
-const registryEntries = new Map([
-    Coordinate.getFactory().registryEntry,
-    Constellation.getFactory().registryEntry,
-]);
-
 // Just a little helper, since we're going to create multiple coordinates.
 const createAndAttachCoordinate = async (runtime: IContainerRuntime, id: string) => {
     const simpleCoordinateComponentRuntime =
@@ -81,7 +76,14 @@ export class CoordinateContainerRuntimeFactory extends BaseContainerRuntimeFacto
     constructor() {
         // We'll use a MountableView so webpack-component-loader can display us,
         // and add our default view request handler.
-        super(registryEntries, [], [mountableViewRequestHandler(MountableView, [defaultViewRequestHandler])]);
+        super(
+            [
+                Coordinate.getFactory(),
+                Constellation.getFactory(),
+            ],
+            [],
+            [mountableViewRequestHandler(MountableView, [defaultViewRequestHandler])],
+        );
     }
 
     /**
@@ -109,7 +111,7 @@ export class CoordinateContainerRuntimeFactory extends BaseContainerRuntimeFacto
 
         // Create the constellation component
         const constellationComponent = await requestFluidObject<Constellation>(
-            await runtime.createRootDataStore(Constellation.ComponentName, constellationComponentId),
+            await runtime.createRootDataStore(Constellation.getFactory().type, constellationComponentId),
             constellationComponentId); // FOLLOW UP: This looks wrong, it should be empty string or slash
 
         // Add a few stars

--- a/components/experimental/musica/src/index.tsx
+++ b/components/experimental/musica/src/index.tsx
@@ -20,8 +20,6 @@ import { Player, NoteProperties } from "./Player";
 import { PianoUtility } from "./PianoUtility";
 import { DAW } from "./daw";
 
-const musicaName = "@fluid-example/musica";
-
 // TODO: Is this right?
 const audioContext = new AudioContext();
 
@@ -101,15 +99,13 @@ export class Musica extends DataObject implements IFluidHTMLView {
 }
 
 export const MusicaInstantiationFactory = new DataObjectFactory(
-    musicaName,
+    "@fluid-example/musica",
     Musica,
     [],
     {},
 );
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    musicaName,
-    new Map([
-        [musicaName, Promise.resolve(MusicaInstantiationFactory)],
-    ]),
+    MusicaInstantiationFactory.type,
+    [MusicaInstantiationFactory],
 );

--- a/components/experimental/prosemirror/src/index.ts
+++ b/components/experimental/prosemirror/src/index.ts
@@ -9,7 +9,7 @@ import {
     IRuntimeFactory,
 } from "@fluidframework/container-definitions";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
-import { IFluidDataStoreFactory, FlushMode } from "@fluidframework/runtime-definitions";
+import { FlushMode } from "@fluidframework/runtime-definitions";
 import {
     deprecated_innerRequestHandler,
     buildRuntimeRequestHandler,
@@ -17,21 +17,15 @@ import {
 import { defaultRouteRequestHandler } from "@fluidframework/aqueduct";
 import { fluidExport as smde } from "./prosemirror";
 
-const defaultComponent = smde.type;
-
 class ProseMirrorFactory implements IRuntimeFactory {
     public get IRuntimeFactory() { return this; }
 
     public async instantiateRuntime(context: IContainerContext): Promise<IRuntime> {
-        const registry = new Map<string, Promise<IFluidDataStoreFactory>>([
-            [defaultComponent, Promise.resolve(smde)],
-        ]);
-
         const defaultComponentId = "default";
 
         const runtime = await ContainerRuntime.load(
             context,
-            registry,
+            [smde],
             buildRuntimeRequestHandler(
                 defaultRouteRequestHandler(defaultComponentId),
                 deprecated_innerRequestHandler,
@@ -43,7 +37,7 @@ class ProseMirrorFactory implements IRuntimeFactory {
 
         // On first boot create the base component
         if (!runtime.existing) {
-            await runtime.createRootDataStore(defaultComponent, defaultComponentId);
+            await runtime.createRootDataStore(smde.type, defaultComponentId);
         }
 
         return runtime;

--- a/components/experimental/scribe/src/scribe.ts
+++ b/components/experimental/scribe/src/scribe.ts
@@ -459,15 +459,11 @@ class ScribeFactory implements IFluidDataStoreFactory, IRuntimeFactory {
     public get IRuntimeFactory() { return this; }
 
     public async instantiateRuntime(context: IContainerContext): Promise<IRuntime> {
-        const registry = new Map<string, Promise<IFluidDataStoreFactory>>([
-            [ScribeFactory.type, Promise.resolve(this)],
-        ]);
-
         const defaultComponentId = "default";
 
         const runtime = await ContainerRuntime.load(
             context,
-            registry,
+            [this],
             buildRuntimeRequestHandler(
                 defaultRouteRequestHandler(defaultComponentId),
                 deprecated_innerRequestHandler,

--- a/components/experimental/smde/src/index.ts
+++ b/components/experimental/smde/src/index.ts
@@ -9,7 +9,7 @@ import {
     IRuntimeFactory,
 } from "@fluidframework/container-definitions";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
-import { IFluidDataStoreFactory, FlushMode } from "@fluidframework/runtime-definitions";
+import { FlushMode } from "@fluidframework/runtime-definitions";
 import {
     deprecated_innerRequestHandler,
     buildRuntimeRequestHandler,
@@ -21,16 +21,12 @@ class SmdeContainerFactory implements IRuntimeFactory {
     public get IRuntimeFactory() { return this; }
 
     public async instantiateRuntime(context: IContainerContext): Promise<IRuntime> {
-        const registry = new Map<string, Promise<IFluidDataStoreFactory>>([
-            ["@fluid-example/smde", Promise.resolve(smde)],
-        ]);
-
         const defaultComponentId = "default";
-        const defaultComponent = "@fluid-example/smde";
+        const defaultComponent = smde.type;
 
         const runtime = await ContainerRuntime.load(
             context,
-            registry,
+            [smde],
             buildRuntimeRequestHandler(
                 defaultRouteRequestHandler(defaultComponentId),
                 deprecated_innerRequestHandler,

--- a/components/experimental/spaces/src/index.ts
+++ b/components/experimental/spaces/src/index.ts
@@ -11,6 +11,6 @@ export * from "./spacesView";
 export * from "./storage";
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    Spaces.ComponentName,
-    [[Spaces.ComponentName, Promise.resolve(Spaces.getFactory())]],
+    Spaces.getFactory().type,
+    [Spaces.getFactory()],
 );

--- a/components/experimental/spaces/src/spaces.tsx
+++ b/components/experimental/spaces/src/spaces.tsx
@@ -54,15 +54,13 @@ export class Spaces extends DataObject implements IFluidHTMLView {
     private storageComponent: SpacesStorage<ISpacesItem> | undefined;
     private baseUrl: string | undefined;
 
-    public static get ComponentName() { return "@fluid-example/spaces"; }
-
     private static readonly factory = new DataObjectFactory(
-        Spaces.ComponentName,
+        "@fluid-example/spaces",
         Spaces,
         [],
         {},
         [
-            [SpacesStorage.ComponentName, Promise.resolve(SpacesStorage.getFactory())],
+            SpacesStorage.getFactory(),
             ...spacesRegistryEntries,
         ],
     );

--- a/components/experimental/spaces/src/spacesItemMap.ts
+++ b/components/experimental/spaces/src/spacesItemMap.ts
@@ -5,7 +5,7 @@
 
 import { IFluidObject, IFluidHandle, IFluidLoadable } from "@fluidframework/core-interfaces";
 import { AsSerializable, Serializable } from "@fluidframework/datastore-definitions";
-import { NamedFluidDataStoreRegistryEntries } from "@fluidframework/runtime-definitions";
+import { FluidDataStoreRegistryEntries } from "@fluidframework/runtime-definitions";
 import { ReactViewAdapter } from "@fluidframework/view-adapters";
 import { fluidExport as cmfe } from "@fluid-example/codemirror/dist/codemirror";
 import { CollaborativeText } from "@fluid-example/collaborative-textarea";
@@ -101,13 +101,13 @@ export const spacesItemMap = new Map<string, ISpacesItemEntry>([
 ]);
 
 // This can go away if the item entries have a way to bring their own subregistries.
-export const spacesRegistryEntries: NamedFluidDataStoreRegistryEntries = new Map([
-    ClickerInstantiationFactory.registryEntry,
-    [cmfe.type, Promise.resolve(cmfe)],
-    [CollaborativeText.ComponentName, Promise.resolve(CollaborativeText.getFactory())],
-    [pmfe.type, Promise.resolve(pmfe)],
-    Coordinate.getFactory().registryEntry,
-]);
+export const spacesRegistryEntries: FluidDataStoreRegistryEntries = [
+    ClickerInstantiationFactory,
+    cmfe,
+    CollaborativeText.getFactory(),
+    pmfe,
+    Coordinate.getFactory(),
+];
 
 interface ITemplate {
     [type: string]: Layout[];

--- a/components/experimental/sudoku/src/fluidSudoku.tsx
+++ b/components/experimental/sudoku/src/fluidSudoku.tsx
@@ -15,8 +15,6 @@ import { SudokuView } from "./react/sudokuView";
 // eslint-disable-next-line import/no-unassigned-import
 import "./helpers/styles.css";
 
-export const FluidSudokuName = "FluidSudoku";
-
 /**
  * A collaborative Sudoku component built on the Fluid Framework.
  */
@@ -29,7 +27,7 @@ export class FluidSudoku extends DataObject implements IFluidHTMLView {
      * This is where you define all which Distributed Data Structures your component will use
      */
     private static readonly factory = new DataObjectFactory(
-        FluidSudokuName,
+        "FluidSudoku",
         FluidSudoku,
         [SharedMap.getFactory()],
         {}

--- a/components/experimental/sudoku/src/index.ts
+++ b/components/experimental/sudoku/src/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
-import { FluidSudoku, FluidSudokuName } from "./fluidSudoku";
+import { FluidSudoku } from "./fluidSudoku";
 import { ISudokuViewProps, SudokuView } from "./react/sudokuView";
 
 /**
@@ -16,8 +16,8 @@ import { ISudokuViewProps, SudokuView } from "./react/sudokuView";
  * 2. Map of string to factory for all components
  */
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    FluidSudokuName,
-    new Map([[FluidSudokuName, Promise.resolve(FluidSudoku.getFactory())]])
+    FluidSudoku.getFactory().type,
+    [FluidSudoku.getFactory()]
 );
 
-export { ISudokuViewProps, FluidSudoku, FluidSudokuName, SudokuView };
+export { ISudokuViewProps, FluidSudoku, SudokuView };

--- a/components/experimental/table-document/src/componentTypes.ts
+++ b/components/experimental/table-document/src/componentTypes.ts
@@ -1,8 +1,0 @@
-/*!
- * Copyright (c) Microsoft Corporation. All rights reserved.
- * Licensed under the MIT License.
- */
-
-export const TableDocumentType = "@fluid-example/table-document/TableDocument";
-
-export const TableSliceType = "@fluid-example/table-document/TableSlice";

--- a/components/experimental/table-document/src/document.ts
+++ b/components/experimental/table-document/src/document.ts
@@ -16,11 +16,12 @@ import {
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { IEvent } from "@fluidframework/common-definitions";
 import { CellRange } from "./cellrange";
-import { TableDocumentType } from "./componentTypes";
 import { ConfigKey } from "./configKey";
 import { debug } from "./debug";
 import { TableSlice } from "./slice";
 import { ITable, TableDocumentItem } from "./table";
+
+export const TableDocumentType = "@fluid-example/table-document/TableDocument";
 
 export interface ITableDocumentEvents extends IEvent {
     (event: "op",

--- a/components/experimental/table-document/src/index.ts
+++ b/components/experimental/table-document/src/index.ts
@@ -6,6 +6,5 @@
 export { TableDocument } from "./document";
 export { TableSlice } from "./slice";
 export { ITable } from "./table";
-export * from "./componentTypes";
 export { parseRange, colIndexToName } from "./cellrange";
 export * from "./interception";

--- a/components/experimental/table-document/src/slice.ts
+++ b/components/experimental/table-document/src/slice.ts
@@ -10,7 +10,6 @@ import { CellRange } from "./cellrange";
 import { ConfigKey } from "./configKey";
 import { TableDocument } from "./document";
 import { ITable, TableDocumentItem } from "./table";
-import { TableSliceType } from "./componentTypes";
 
 export interface ITableSliceConfig {
     docId: string;
@@ -25,7 +24,7 @@ export class TableSlice extends DataObject<{}, ITableSliceConfig> implements ITa
     public static getFactory() { return TableSlice.factory; }
 
     private static readonly factory = new DataObjectFactory(
-        TableSliceType,
+        "@fluid-example/table-document/TableSlice",
         TableSlice,
         [],
         {},

--- a/components/experimental/table-document/src/test/tableWithInterception.spec.ts
+++ b/components/experimental/table-document/src/test/tableWithInterception.spec.ts
@@ -11,7 +11,6 @@ import { LocalDeltaConnectionServer } from "@fluidframework/server-local-server"
 import { createLocalLoader, initializeLocalContainer } from "@fluidframework/test-utils";
 import { ITable } from "../table";
 import { TableDocument } from "../document";
-import { TableDocumentType } from "../componentTypes";
 import { createTableWithInterception } from "../interception";
 
 describe("Table Document with Interception", () => {
@@ -65,10 +64,8 @@ describe("Table Document with Interception", () => {
 
         beforeEach(async () => {
             const factory = new ContainerRuntimeFactoryWithDefaultDataStore(
-                TableDocumentType,
-                new Map([
-                    [TableDocumentType, Promise.resolve(TableDocument.getFactory())],
-                ]),
+                TableDocument.getFactory().type,
+                [TableDocument.getFactory()],
             );
 
             const deltaConnectionServer = LocalDeltaConnectionServer.create();

--- a/components/experimental/table-view/package.json
+++ b/components/experimental/table-view/package.json
@@ -36,6 +36,7 @@
     "webpack:dev": "webpack --env.development"
   },
   "dependencies": {
+    "@fluidframework/container-runtime": "^0.25.0",
     "@fluid-example/flow-util-lib": "^0.25.0",
     "@fluid-example/table-document": "^0.25.0",
     "@fluidframework/aqueduct": "^0.25.0",

--- a/components/experimental/table-view/src/runtime.ts
+++ b/components/experimental/table-view/src/runtime.ts
@@ -4,12 +4,16 @@
  */
 
 import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
+import { DelayLoadingFactoryAdapter } from "@fluidframework/container-runtime";
 import { tableViewType } from "./tableview";
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
     tableViewType,
-    new Map([
-        // eslint-disable-next-line max-len
-        [tableViewType, import(/* webpackChunkName: "table-view", webpackPreload: true */ "./tableview").then((m) => m.TableView.getFactory())],
-    ]),
+    [
+        new DelayLoadingFactoryAdapter(
+            tableViewType,
+            import(/* webpackChunkName: "table-view", webpackPreload: true */ "./tableview")
+                .then((m) => m.TableView.getFactory()),
+        ),
+    ],
 );

--- a/components/experimental/table-view/src/tableview.ts
+++ b/components/experimental/table-view/src/tableview.ts
@@ -8,6 +8,7 @@ import { TableDocument, TableDocumentType } from "@fluid-example/table-document"
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { IFluidHTMLOptions, IFluidHTMLView } from "@fluidframework/view-interfaces";
+import { DelayLoadingFactoryAdapter } from "@fluidframework/container-runtime";
 import { GridView } from "./grid";
 import * as styles from "./index.css";
 
@@ -105,5 +106,8 @@ const factory = new DataObjectFactory(
     [],
     {},
     [
-        [TableDocumentType, import("@fluid-example/table-document").then((m) => m.TableDocument.getFactory())],
+        new DelayLoadingFactoryAdapter(
+            TableDocumentType,
+            import("@fluid-example/table-document").then((m) => m.TableDocument.getFactory()),
+        ),
     ]);

--- a/components/experimental/todo/src/Todo/Todo.tsx
+++ b/components/experimental/todo/src/Todo/Todo.tsx
@@ -13,10 +13,6 @@ import ReactDOM from "react-dom";
 import { ITodoItemInitialState, TodoItem } from "../TodoItem/index";
 import { TodoView } from "./TodoView";
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-const pkg = require("../../package.json");
-export const TodoName = `${pkg.name as string}-todo`;
-
 /**
  * Todo base component.
  * Visually contains the following:

--- a/components/experimental/todo/src/Todo/todoInstantiationFactory.ts
+++ b/components/experimental/todo/src/Todo/todoInstantiationFactory.ts
@@ -10,11 +10,10 @@ import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 import { SharedString } from "@fluidframework/sequence";
 import { TodoItem } from "../TodoItem";
 
-import { TodoName } from "./Todo";
 import { Todo } from "./index";
 
 export const TodoInstantiationFactory: IFluidDataStoreFactory = new DataObjectFactory(
-    TodoName,
+    "@fluid-example/todo",
     Todo,
     [
         SharedMap.getFactory(),
@@ -22,7 +21,7 @@ export const TodoInstantiationFactory: IFluidDataStoreFactory = new DataObjectFa
         SharedCell.getFactory(),
     ],
     {},
-    new Map([
+    [
         TodoItem.getFactory().registryEntry,
-    ]),
+    ],
 );

--- a/components/experimental/todo/src/TodoItem/TodoItem.tsx
+++ b/components/experimental/todo/src/TodoItem/TodoItem.tsx
@@ -117,11 +117,11 @@ export class TodoItem extends DataObject<{}, ITodoItemInitialState> implements I
             SharedCell.getFactory(),
         ],
         {},
-        new Map([
+        [
             TextBoxInstantiationFactory.registryEntry,
             TextListInstantiationFactory.registryEntry,
             ClickerInstantiationFactory.registryEntry,
-        ]),
+        ],
     );
 
     // start IFluidHTMLView

--- a/components/experimental/todo/src/index.tsx
+++ b/components/experimental/todo/src/index.tsx
@@ -4,11 +4,9 @@
  */
 
 import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
-import { TodoInstantiationFactory, TodoName } from "./Todo";
+import { TodoInstantiationFactory } from "./Todo";
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    TodoName,
-    new Map([
-        [TodoName, Promise.resolve(TodoInstantiationFactory)],
-    ]),
+    TodoInstantiationFactory.type,
+    [TodoInstantiationFactory],
 );

--- a/components/experimental/vltava/src/components/vltava/vltava.tsx
+++ b/components/experimental/vltava/src/components/vltava/vltava.tsx
@@ -12,15 +12,13 @@ import ReactDOM from "react-dom";
 import { IVltavaDataModel, VltavaDataModel } from "./dataModel";
 import { VltavaView } from "./view";
 
-export const VltavaName = "vltava";
-
 /**
  * Vltava is an application experience
  */
 export class Vltava extends DataObject implements IFluidHTMLView {
     private dataModelInternal: IVltavaDataModel | undefined;
 
-    private static readonly factory = new DataObjectFactory(VltavaName, Vltava, [], {});
+    private static readonly factory = new DataObjectFactory("vltava", Vltava, [], {});
 
     public static getFactory() {
         return Vltava.factory;

--- a/components/experimental/vltava/src/index.ts
+++ b/components/experimental/vltava/src/index.ts
@@ -11,14 +11,13 @@ import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqu
 import { IFluidObject } from "@fluidframework/core-interfaces";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import {
-    LastEditedTrackerComponentName,
     LastEditedTrackerComponent,
     setupLastEditedTrackerForContainer,
 } from "@fluidframework/last-edited-experimental";
 import {
     IFluidDataStoreRegistry,
     IProvideFluidDataStoreFactory,
-    NamedFluidDataStoreRegistryEntries,
+    FluidDataStoreRegistryEntries,
 } from "@fluidframework/runtime-definitions";
 
 import {
@@ -26,7 +25,6 @@ import {
     AnchorName,
     TabsComponent,
     Vltava,
-    VltavaName,
 } from "./components";
 import {
     IComponentInternalRegistry,
@@ -69,7 +67,7 @@ export class InternalRegistry implements IFluidDataStoreRegistry, IComponentInte
 export class VltavaRuntimeFactory extends ContainerRuntimeFactoryWithDefaultDataStore {
     constructor(
         defaultComponentName: string,
-        registryEntries: NamedFluidDataStoreRegistryEntries,
+        registryEntries: FluidDataStoreRegistryEntries,
     ) {
         super(defaultComponentName, registryEntries);
     }
@@ -95,58 +93,53 @@ const generateFactory = () => {
     const containerComponentsDefinition: IInternalRegistryEntry[] = [
         {
             type: "clicker",
-            factory: Promise.resolve(ClickerInstantiationFactory),
+            factory: ClickerInstantiationFactory,
             capabilities: ["IFluidHTMLView", "IFluidLoadable"],
             friendlyName: "Clicker",
             fabricIconName: "NumberField",
         },
         {
             type: "tabs",
-            factory: Promise.resolve(TabsComponent.getFactory()),
+            factory: TabsComponent.getFactory(),
             capabilities: ["IFluidHTMLView", "IFluidLoadable"],
             friendlyName: "Tabs",
             fabricIconName: "BrowserTab",
         },
         {
             type: "spaces",
-            factory: Promise.resolve(Spaces.getFactory()),
+            factory: Spaces.getFactory(),
             capabilities: ["IFluidHTMLView", "IFluidLoadable"],
             friendlyName: "Spaces",
             fabricIconName: "SnapToGrid",
         },
         {
             type: "codemirror",
-            factory: Promise.resolve(cmfe),
+            factory: cmfe,
             capabilities: ["IFluidHTMLView", "IFluidLoadable"],
             friendlyName: "Codemirror",
             fabricIconName: "Code",
         },
         {
             type: "prosemirror",
-            factory: Promise.resolve(pmfe),
+            factory: pmfe,
             capabilities: ["IFluidHTMLView", "IFluidLoadable"],
             friendlyName: "Prosemirror",
             fabricIconName: "Edit",
         },
     ];
 
-    const containerComponents: [string, Promise<IProvideFluidDataStoreFactory>][] = [];
+    const containerComponents: IProvideFluidDataStoreFactory[] = [];
     containerComponentsDefinition.forEach((value) => {
-        containerComponents.push([value.type, value.factory]);
+        containerComponents.push(value.factory);
     });
 
     // The last edited tracker component provides container level tracking of last edits. This is the first
     // component that is loaded.
-    containerComponents.push(
-        [LastEditedTrackerComponentName, Promise.resolve(LastEditedTrackerComponent.getFactory())]);
+    containerComponents.push(LastEditedTrackerComponent.getFactory());
 
     // We don't want to include the default wrapper component in our list of available components
-    containerComponents.push([AnchorName, Promise.resolve(Anchor.getFactory())]);
-    containerComponents.push([VltavaName, Promise.resolve(Vltava.getFactory())]);
-
-    const containerRegistries: NamedFluidDataStoreRegistryEntries = [
-        ["", Promise.resolve(new InternalRegistry(containerComponentsDefinition))],
-    ];
+    containerComponents.push(Anchor.getFactory());
+    containerComponents.push(Vltava.getFactory());
 
     // TODO: You should be able to specify the default registry instead of just a list of components
     // and the default registry is already determined Issue:#1138
@@ -154,7 +147,6 @@ const generateFactory = () => {
         AnchorName,
         [
             ...containerComponents,
-            ...containerRegistries,
         ],
     );
 };

--- a/components/experimental/vltava/src/interfaces/componentInternalRegistry.ts
+++ b/components/experimental/vltava/src/interfaces/componentInternalRegistry.ts
@@ -30,7 +30,7 @@ export interface IComponentInternalRegistry extends IProvideComponentInternalReg
  */
 export interface IInternalRegistryEntry {
     type: string;
-    factory: Promise<IProvideFluidDataStoreFactory>;
+    factory: IProvideFluidDataStoreFactory;
     capabilities: (keyof (IFluidObject & IFluidObject))[];
     friendlyName: string;
     fabricIconName: string;

--- a/docs/tutorials/dice-roller-comments.tsx
+++ b/docs/tutorials/dice-roller-comments.tsx
@@ -34,10 +34,6 @@ export interface IDiceRoller extends EventEmitter {
  * Fluid component
  */
 export class DiceRoller extends PrimedComponent implements IDiceRoller, IFluidHTMLView {
-    public static get ComponentName() {
-        return "DiceRoller";
-    }
-
     public get IFluidHTMLView() { return this; }
 
     /**
@@ -45,7 +41,7 @@ export class DiceRoller extends PrimedComponent implements IDiceRoller, IFluidHT
      * dependencies of the component.
      */
     public static readonly factory = new PrimedComponentFactory(
-        DiceRoller.ComponentName,
+        "DiceRoller",
         DiceRoller,
         [],
         {},

--- a/examples/hosts/app-integration/container-views/src/component/model.ts
+++ b/examples/hosts/app-integration/container-views/src/component/model.ts
@@ -22,8 +22,6 @@ const diceValueKey = "diceValue";
  * The DiceRoller is our implementation of the IDiceRoller interface.
  */
 export class DiceRoller extends DataObject implements IDiceRoller, IFluidHTMLView {
-    public static get ComponentName() { return "@fluid-example/dice-roller"; }
-
     public get IFluidHTMLView() { return this; }
 
     /**
@@ -69,7 +67,7 @@ export class DiceRoller extends DataObject implements IDiceRoller, IFluidHTMLVie
  * To add a SharedSequence, SharedMap, or any other structure, put it in the array below.
  */
 export const DiceRollerInstantiationFactory = new DataObjectFactory(
-    DiceRoller.ComponentName,
+    "@fluid-example/dice-roller",
     DiceRoller,
     [],
     {},

--- a/examples/hosts/app-integration/container-views/src/container/containerRuntimeFactory.ts
+++ b/examples/hosts/app-integration/container-views/src/container/containerRuntimeFactory.ts
@@ -7,7 +7,7 @@ import {
     ContainerRuntimeFactoryWithDefaultDataStore,
 } from "@fluidframework/aqueduct";
 
-import { DiceRoller, DiceRollerInstantiationFactory } from "../component";
+import { DiceRollerInstantiationFactory } from "../component";
 
 /**
  * This does setup for the Container. The ContainerRuntimeFactoryWithDefaultDataStore also enables dynamic loading in
@@ -21,8 +21,6 @@ import { DiceRoller, DiceRollerInstantiationFactory } from "../component";
  * components.
  */
 export const DiceRollerContainerRuntimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
-    DiceRoller.ComponentName,
-    new Map([
-        [DiceRoller.ComponentName, Promise.resolve(DiceRollerInstantiationFactory)],
-    ]),
+    DiceRollerInstantiationFactory.type,
+    [DiceRollerInstantiationFactory],
 );

--- a/examples/hosts/app-integration/external-views/src/component/model.ts
+++ b/examples/hosts/app-integration/external-views/src/component/model.ts
@@ -17,8 +17,6 @@ const diceValueKey = "diceValue";
  * The DiceRoller is our implementation of the IDiceRoller interface.
  */
 export class DiceRoller extends DataObject implements IDiceRoller {
-    public static get ComponentName() { return "@fluid-example/dice-roller"; }
-
     /**
      * ComponentInitializingFirstTime is called only once, it is executed only by the first client to open the
      * component and all work will resolve before the view is presented to any user.
@@ -52,7 +50,7 @@ export class DiceRoller extends DataObject implements IDiceRoller {
  * To add a SharedSequence, SharedMap, or any other structure, put it in the array below.
  */
 export const DiceRollerInstantiationFactory = new DataObjectFactory(
-    DiceRoller.ComponentName,
+    "@fluid-example/dice-roller",
     DiceRoller,
     [],
     {},

--- a/examples/hosts/app-integration/external-views/src/container/containerRuntimeFactory.ts
+++ b/examples/hosts/app-integration/external-views/src/container/containerRuntimeFactory.ts
@@ -7,7 +7,7 @@ import {
     ContainerRuntimeFactoryWithDefaultDataStore,
 } from "@fluidframework/aqueduct";
 
-import { DiceRoller, DiceRollerInstantiationFactory } from "../component";
+import { DiceRollerInstantiationFactory } from "../component";
 
 /**
  * This does setup for the Container. The ContainerRuntimeFactoryWithDefaultDataStore also enables dynamic loading in
@@ -21,8 +21,6 @@ import { DiceRoller, DiceRollerInstantiationFactory } from "../component";
  * components.
  */
 export const DiceRollerContainerRuntimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
-    DiceRoller.ComponentName,
-    new Map([
-        [DiceRoller.ComponentName, Promise.resolve(DiceRollerInstantiationFactory)],
-    ]),
+    DiceRollerInstantiationFactory.type,
+    [DiceRollerInstantiationFactory],
 );

--- a/examples/hosts/draft-js/src/container.ts
+++ b/examples/hosts/draft-js/src/container.ts
@@ -20,6 +20,6 @@ import { DraftJsObject } from "./fluid-object";
  * FluidObjects.
  */
 export const DraftJsContainer = new ContainerRuntimeFactoryWithDefaultDataStore(
-    DraftJsObject.Name,
-    new Map([DraftJsObject.factory.registryEntry]),
+    DraftJsObject.factory.type,
+    [DraftJsObject.factory.registryEntry],
 );

--- a/examples/hosts/draft-js/src/fluid-object/index.tsx
+++ b/examples/hosts/draft-js/src/fluid-object/index.tsx
@@ -23,10 +23,8 @@ export class DraftJsObject extends DataObject implements IFluidHTMLView {
 
     public get IFluidHTMLView() { return this; }
 
-    public static get Name() { return "@fluid-example/draft-js"; }
-
     public static readonly factory = new DataObjectFactory(
-        DraftJsObject.Name,
+        "@fluid-example/draft-js",
         DraftJsObject,
         [SharedMap.getFactory(), SharedString.getFactory()],
         {},

--- a/packages/framework/aqueduct/src/componentFactories/primedComponentFactory.ts
+++ b/packages/framework/aqueduct/src/componentFactories/primedComponentFactory.ts
@@ -13,7 +13,7 @@ import {
     SharedMap,
 } from "@fluidframework/map";
 import {
-    NamedFluidDataStoreRegistryEntries,
+    FluidDataStoreRegistryEntries,
 } from "@fluidframework/runtime-definitions";
 import { IChannelFactory } from "@fluidframework/datastore-definitions";
 import { ComponentSymbolProvider } from "@fluidframework/synthesize";
@@ -40,7 +40,7 @@ export class DataObjectFactory<
         ctor: new (props: ISharedComponentProps<P>) => DataObject<P, S>,
         sharedObjects: readonly IChannelFactory[] = [],
         optionalProviders: ComponentSymbolProvider<P>,
-        registryEntries?: NamedFluidDataStoreRegistryEntries,
+        registryEntries?: FluidDataStoreRegistryEntries,
         onDemandInstantiation = true,
     ) {
         const mergedObjects = [...sharedObjects];

--- a/packages/framework/aqueduct/src/componentFactories/sharedComponentFactory.ts
+++ b/packages/framework/aqueduct/src/componentFactories/sharedComponentFactory.ts
@@ -11,8 +11,8 @@ import {
     IFluidDataStoreFactory,
     IFluidDataStoreRegistry,
     IProvideFluidDataStoreRegistry,
-    NamedFluidDataStoreRegistryEntries,
-    NamedFluidDataStoreRegistryEntry,
+    FluidDataStoreRegistryEntries,
+    FluidDataStoreRegistryEntry,
 } from "@fluidframework/runtime-definitions";
 import { IChannelFactory } from "@fluidframework/datastore-definitions";
 import {
@@ -47,7 +47,7 @@ export class PureDataObjectFactory<P extends IFluidObject, S = undefined> implem
         private readonly ctor: new (props: ISharedComponentProps<P>) => PureDataObject<P, S>,
         sharedObjects: readonly IChannelFactory[],
         private readonly optionalProviders: ComponentSymbolProvider<P>,
-        registryEntries?: NamedFluidDataStoreRegistryEntries,
+        registryEntries?: FluidDataStoreRegistryEntries,
         private readonly onDemandInstantiation = true,
     ) {
         if (registryEntries !== undefined) {
@@ -68,8 +68,8 @@ export class PureDataObjectFactory<P extends IFluidObject, S = undefined> implem
      * entries that differ only in this way into the same array.
      * @returns The NamedFluidDataStoreRegistryEntry
      */
-    public get registryEntry(): NamedFluidDataStoreRegistryEntry {
-        return [this.type, Promise.resolve(this)];
+    public get registryEntry(): FluidDataStoreRegistryEntry {
+        return this;
     }
 
     /**

--- a/packages/framework/aqueduct/src/containerRuntimeFactories/baseContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/containerRuntimeFactories/baseContainerRuntimeFactory.ts
@@ -19,7 +19,7 @@ import {
 import {
     IFluidDataStoreRegistry,
     IProvideFluidDataStoreRegistry,
-    NamedFluidDataStoreRegistryEntries,
+    FluidDataStoreRegistryEntries,
 } from "@fluidframework/runtime-definitions";
 import { DependencyContainer, DependencyContainerRegistry } from "@fluidframework/synthesize";
 
@@ -41,7 +41,7 @@ export class BaseContainerRuntimeFactory implements
      * @param requestHandlers - Request handlers for containers produced
      */
     constructor(
-        private readonly registryEntries: NamedFluidDataStoreRegistryEntries,
+        private readonly registryEntries: FluidDataStoreRegistryEntries,
         private readonly providerEntries: DependencyContainerRegistry = [],
         private readonly requestHandlers: RuntimeRequestHandler[] = [],
     ) {

--- a/packages/framework/aqueduct/src/containerRuntimeFactories/containerRuntimeFactoryWithDefaultComponent.ts
+++ b/packages/framework/aqueduct/src/containerRuntimeFactories/containerRuntimeFactoryWithDefaultComponent.ts
@@ -4,7 +4,7 @@
  */
 
 import { IFluidExportDefaultFactoryName } from "@fluidframework/framework-interfaces";
-import { NamedFluidDataStoreRegistryEntries } from "@fluidframework/runtime-definitions";
+import { FluidDataStoreRegistryEntries } from "@fluidframework/runtime-definitions";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { DependencyContainerRegistry } from "@fluidframework/synthesize";
 import { MountableView } from "@fluidframework/view-adapters";
@@ -29,7 +29,7 @@ export class ContainerRuntimeFactoryWithDefaultDataStore extends BaseContainerRu
 
     constructor(
         private readonly defaultComponentName: string,
-        registryEntries: NamedFluidDataStoreRegistryEntries,
+        registryEntries: FluidDataStoreRegistryEntries,
         providerEntries: DependencyContainerRegistry = [],
         requestHandlers: RuntimeRequestHandler[] = [],
     ) {

--- a/packages/framework/component-base/src/runtimefactory.ts
+++ b/packages/framework/component-base/src/runtimefactory.ts
@@ -13,7 +13,7 @@ import {
     deprecated_innerRequestHandler,
 } from "@fluidframework/request-handler";
 import {
-    NamedFluidDataStoreRegistryEntries,
+    FluidDataStoreRegistryEntries,
     IFluidDataStoreFactory,
     FlushMode,
 } from "@fluidframework/runtime-definitions";
@@ -21,7 +21,7 @@ import {
 const defaultComponentId = "" as const;
 
 export class RuntimeFactory implements IRuntimeFactory {
-    private readonly registry: NamedFluidDataStoreRegistryEntries;
+    private readonly registry: FluidDataStoreRegistryEntries;
 
     constructor(
         private readonly defaultComponent: IFluidDataStoreFactory,
@@ -32,9 +32,7 @@ export class RuntimeFactory implements IRuntimeFactory {
             (components.includes(defaultComponent)
                 ? components
                 : components.concat(defaultComponent)
-            ).map(
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                (factory) => [factory.type!, factory]) as NamedFluidDataStoreRegistryEntries;
+            ) as FluidDataStoreRegistryEntries;
     }
 
     public get IRuntimeFactory() { return this; }

--- a/packages/framework/component-base/src/sharedcomponentfactory.ts
+++ b/packages/framework/component-base/src/sharedcomponentfactory.ts
@@ -10,7 +10,7 @@ import {
     IFluidDataStoreContext,
     IFluidDataStoreFactory,
     IFluidDataStoreRegistry,
-    NamedFluidDataStoreRegistryEntries,
+    FluidDataStoreRegistryEntries,
 } from "@fluidframework/runtime-definitions";
 import {
     IFluidDataStoreRuntime,
@@ -35,9 +35,7 @@ export class PureDataObjectFactory<T extends PureDataObject> implements IFluidDa
     ) {
         if (components !== undefined) {
             this.IFluidDataStoreRegistry = new FluidDataStoreRegistry(
-                components.map(
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    (factory) => [factory.type!, factory]) as NamedFluidDataStoreRegistryEntries);
+                components as FluidDataStoreRegistryEntries);
         }
 
         this.ISharedObjectRegistry = new Map(

--- a/packages/framework/last-edited-experimental/src/lastEditedTrackerComponent.ts
+++ b/packages/framework/last-edited-experimental/src/lastEditedTrackerComponent.ts
@@ -9,9 +9,7 @@ import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { LastEditedTracker } from "./lastEditedTracker";
 import { IProvideFluidLastEditedTracker } from "./interfaces";
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-const pkg = require("../package.json");
-export const LastEditedTrackerComponentName = pkg.name as string;
+export const LastEditedTrackerComponentName = "@fluidframework/last-edited-experimental";
 
 /**
  * LastEditedTrackerComponent creates a LastEditedTracker that keeps track of the latest edits to the document.

--- a/packages/hosts/local-web-host/package.json
+++ b/packages/hosts/local-web-host/package.json
@@ -29,6 +29,7 @@
     "@fluidframework/base-host": "^0.25.0",
     "@fluidframework/container-definitions": "^0.25.0",
     "@fluidframework/container-loader": "^0.25.0",
+    "@fluidframework/container-runtime": "^0.25.0",
     "@fluidframework/core-interfaces": "^0.25.0",
     "@fluidframework/local-driver": "^0.25.0",
     "@fluidframework/runtime-definitions": "^0.25.0",

--- a/packages/hosts/local-web-host/src/index.ts
+++ b/packages/hosts/local-web-host/src/index.ts
@@ -19,6 +19,7 @@ import { IFluidObject } from "@fluidframework/core-interfaces";
 import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
 import { initializeContainerCode } from "@fluidframework/base-host";
 import { HTMLViewAdapter } from "@fluidframework/view-adapters";
+import { RenamingFactoryAdapter } from "@fluidframework/container-runtime";
 
 export async function createLocalContainerFactory(
     entryPoint: Partial<IProvideRuntimeFactory & IProvideFluidDataStoreFactory & IFluidModule>,
@@ -36,7 +37,7 @@ export async function createLocalContainerFactory(
             factory.IRuntimeFactory :
             new ContainerRuntimeFactoryWithDefaultDataStore(
                 "default",
-                [["default", Promise.resolve(factory.IFluidDataStoreFactory)]],
+                [new RenamingFactoryAdapter("default", factory.IFluidDataStoreFactory)],
             );
 
     const codeLoader: ICodeLoader = {

--- a/packages/runtime/client-api/src/api/codeLoader.ts
+++ b/packages/runtime/client-api/src/api/codeLoader.ts
@@ -20,7 +20,7 @@ import { ConsensusQueue } from "@fluidframework/ordered-collection";
 import {
     IFluidDataStoreContext,
     IFluidDataStoreFactory,
-    NamedFluidDataStoreRegistryEntries,
+    FluidDataStoreRegistryEntries,
 } from "@fluidframework/runtime-definitions";
 import * as sequence from "@fluidframework/sequence";
 import {
@@ -103,7 +103,7 @@ export class ChaincodeFactory implements IRuntimeFactory {
 
     constructor(
         private readonly runtimeOptions: IContainerRuntimeOptions,
-        private readonly registries: NamedFluidDataStoreRegistryEntries) {
+        private readonly registries: FluidDataStoreRegistryEntries) {
     }
 
     public async instantiateRuntime(context: IContainerContext): Promise<IRuntime> {
@@ -112,7 +112,7 @@ export class ChaincodeFactory implements IRuntimeFactory {
         const runtime: ContainerRuntime = await ContainerRuntime.load(
             context,
             [
-                [chaincode.type, Promise.resolve(chaincode)],
+                chaincode,
                 ...this.registries,
             ],
             buildRuntimeRequestHandler(
@@ -135,7 +135,7 @@ export class CodeLoader implements ICodeLoader {
 
     constructor(
         runtimeOptions: IContainerRuntimeOptions,
-        registries: NamedFluidDataStoreRegistryEntries = [],
+        registries: FluidDataStoreRegistryEntries = [],
     ) {
         this.fluidModule = {
             fluidExport: new ChaincodeFactory(

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -76,7 +76,7 @@ import {
     IEnvelope,
     IInboundSignalMessage,
     ISignalEnvelop,
-    NamedFluidDataStoreRegistryEntries,
+    FluidDataStoreRegistryEntries,
     SchedulerType,
     ISummaryTreeWithStats,
     ISummaryStats,
@@ -428,10 +428,10 @@ export const schedulerId = SchedulerType;
 
 // Wraps the provided list of packages and augments with some system level services.
 class ContainerRuntimeDataStoreRegistry extends FluidDataStoreRegistry {
-    constructor(namedEntries: NamedFluidDataStoreRegistryEntries) {
+    constructor(namedEntries: FluidDataStoreRegistryEntries) {
         super([
             ...namedEntries,
-            [schedulerId, Promise.resolve(new AgentSchedulerFactory())],
+            new AgentSchedulerFactory(),
         ]);
     }
 }
@@ -455,7 +455,7 @@ export class ContainerRuntime extends EventEmitter
      */
     public static async load(
         context: IContainerContext,
-        registryEntries: NamedFluidDataStoreRegistryEntries,
+        registryEntries: FluidDataStoreRegistryEntries,
         requestHandler?: (request: IRequest, runtime: IContainerRuntime) => Promise<IResponse>,
         runtimeOptions?: IContainerRuntimeOptions,
         containerScope: IFluidObject & IFluidObject = context.scope,

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -240,6 +240,7 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
             let registry: IFluidDataStoreRegistry | undefined = this._containerRuntime.IFluidDataStoreRegistry;
             let factory: IFluidDataStoreFactory | undefined;
             let lastPkg: string | undefined;
+            assert(packages.length !== 0, "No package information");
             for (const pkg of packages) {
                 if (!registry) {
                     return this.rejectDeferredRealize(`No registry for ${lastPkg} package`);

--- a/packages/runtime/container-runtime/src/dataStoreRegistry.ts
+++ b/packages/runtime/container-runtime/src/dataStoreRegistry.ts
@@ -2,19 +2,27 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+import assert from "assert";
 import {
     FluidDataStoreRegistryEntry,
     IFluidDataStoreRegistry,
-    NamedFluidDataStoreRegistryEntries,
+    FluidDataStoreRegistryEntries,
+    IFluidDataStoreContext,
+    IProvideFluidDataStoreRegistry,
+    IProvideFluidDataStoreFactory,
 } from "@fluidframework/runtime-definitions";
 
 export class FluidDataStoreRegistry implements IFluidDataStoreRegistry {
-    private readonly map: Map<string, Promise<FluidDataStoreRegistryEntry>>;
+    private readonly map: Map<string, FluidDataStoreRegistryEntry> = new Map();
 
     public get IFluidDataStoreRegistry() { return this; }
 
-    constructor(namedEntries: NamedFluidDataStoreRegistryEntries) {
-        this.map = new Map(namedEntries);
+    constructor(namedEntries: FluidDataStoreRegistryEntries) {
+        for (const factory of namedEntries) {
+            const type = factory.IFluidDataStoreFactory.type;
+            assert(this.map.has(type), `Duplicate type: ${type}`);
+            this.map.set(type, factory);
+        }
     }
 
     public async get(name: string): Promise<FluidDataStoreRegistryEntry | undefined> {
@@ -23,5 +31,63 @@ export class FluidDataStoreRegistry implements IFluidDataStoreRegistry {
         }
 
         return undefined;
+    }
+}
+
+/**
+ * An adapter that allows to delay load factory. It can be used in cases where type
+ * factory type is known upfront. Adapter validates that type supplied actually matches
+ * factory type. If you need to overwrite name, please use RenamingFactoryAdapter
+ */
+export class DelayLoadingFactoryAdapter implements FluidDataStoreRegistryEntry {
+    public constructor(
+        public readonly type: string,
+        private readonly factoryP: Promise<FluidDataStoreRegistryEntry>) {
+    }
+
+    public get IFluidDataStoreRegistry() { return this; }
+    public get IFluidDataStoreFactory() { return this; }
+
+    public async get(name: string): Promise<FluidDataStoreRegistryEntry | undefined> {
+        const factory = await this.factoryP;
+        assert(factory.IFluidDataStoreFactory.type === this.type);
+        if (factory.IFluidDataStoreRegistry === undefined) {
+            return undefined;
+        }
+        return factory.IFluidDataStoreRegistry.get(name);
+    }
+
+    public instantiateDataStore(context: IFluidDataStoreContext): void {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        this.factoryP.then((factory) => {
+            assert(factory.IFluidDataStoreFactory.type === this.type);
+            factory.IFluidDataStoreFactory.instantiateDataStore(context);
+        });
+    }
+}
+
+/**
+ * Takes existing factory, and produces another one like original, but with different name.
+ * It allows registry without any factory to be used, throws if attempt to create component
+ * with no factory happens.
+ */
+export class RenamingFactoryAdapter implements FluidDataStoreRegistryEntry {
+    public constructor(
+        public readonly type: string,
+        private readonly factory: Partial<IProvideFluidDataStoreRegistry & IProvideFluidDataStoreFactory>) {
+    }
+
+    public get IFluidDataStoreRegistry() { return this.factory.IFluidDataStoreRegistry; }
+    public get IFluidDataStoreFactory() { return this; }
+
+    public async get(name: string): Promise<FluidDataStoreRegistryEntry | undefined> {
+        return this.factory.IFluidDataStoreRegistry?.get(name);
+    }
+
+    public instantiateDataStore(context: IFluidDataStoreContext): void {
+        if (this.factory.IFluidDataStoreFactory === undefined) {
+            throw new Error(`RenamingFactoryAdapter with type=${this.type} does not have factory!`);
+        }
+        this.factory.IFluidDataStoreFactory.instantiateDataStore(context);
     }
 }

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -54,6 +54,7 @@ describe("Data Store Context Tests", () => {
         let containerRuntime: ContainerRuntime;
         beforeEach(async () => {
             const factory: IFluidDataStoreFactory = {
+                type: "factory",
                 get IFluidDataStoreFactory() { return factory; },
                 instantiateDataStore: (context: IFluidDataStoreContext) => { },
             };

--- a/packages/runtime/runtime-definitions/src/componentFactory.ts
+++ b/packages/runtime/runtime-definitions/src/componentFactory.ts
@@ -24,7 +24,7 @@ export interface IFluidDataStoreFactory extends IProvideFluidDataStoreFactory {
     /**
      * String that uniquely identifies the type of component created by this factory.
      */
-    type?: string;
+    type: string;
 
     /**
      * Generates runtime for the component from the component context. Once created should be bound to the context.

--- a/packages/runtime/runtime-definitions/src/componentRegistry.ts
+++ b/packages/runtime/runtime-definitions/src/componentRegistry.ts
@@ -14,16 +14,12 @@ declare module "@fluidframework/core-interfaces" {
  * A single registry entry that may be used to create components
  */
 export type FluidDataStoreRegistryEntry =
-    Readonly<Partial<IProvideFluidDataStoreRegistry & IProvideFluidDataStoreFactory>>;
-/**
- * An associated pair of an identifier and registry entry.  Registry entries
- * may be dynamically loaded.
- */
-export type NamedFluidDataStoreRegistryEntry = [string, Promise<FluidDataStoreRegistryEntry>];
+    Readonly<Partial<IProvideFluidDataStoreRegistry> & IProvideFluidDataStoreFactory>;
+
 /**
  * An iterable itentifier/registry entry pair list
  */
-export type NamedFluidDataStoreRegistryEntries = Iterable<NamedFluidDataStoreRegistryEntry>;
+export type FluidDataStoreRegistryEntries = Iterable<FluidDataStoreRegistryEntry>;
 
 export const IFluidDataStoreRegistry: keyof IProvideFluidDataStoreRegistry = "IFluidDataStoreRegistry";
 

--- a/packages/test/end-to-end-tests/src/test/compat.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/compat.spec.ts
@@ -73,10 +73,10 @@ describe("loader/runtime compatibility", () => {
 
             const containersP: Promise<Container | old.Container>[] = [
                 createContainer( // new everything
-                    { fluidExport: createRuntimeFactory(TestComponent.type, createPrimedComponentFactory()) },
+                    { fluidExport: createRuntimeFactory(createPrimedComponentFactory()) },
                     args.deltaConnectionServer),
                 createContainerWithOldLoader( // old loader, new container/component runtimes
-                    { fluidExport: createRuntimeFactory(TestComponent.type, createPrimedComponentFactory()) },
+                    { fluidExport: createRuntimeFactory(createPrimedComponentFactory()) },
                     args.deltaConnectionServer),
                 createContainerWithOldLoader( // old everything
                     { fluidExport: createOldRuntimeFactory(TestComponent.type, createOldPrimedComponentFactory()) },
@@ -85,7 +85,7 @@ describe("loader/runtime compatibility", () => {
                     { fluidExport: createOldRuntimeFactory(TestComponent.type, createOldPrimedComponentFactory()) },
                     args.deltaConnectionServer),
                 createContainer( // new loader/container runtime, old component runtime
-                    { fluidExport: createRuntimeFactory(TestComponent.type, createOldPrimedComponentFactory()) },
+                    { fluidExport: createRuntimeFactory(createOldPrimedComponentFactory()) },
                     args.deltaConnectionServer),
             ];
 

--- a/packages/test/end-to-end-tests/src/test/compatUtils.ts
+++ b/packages/test/end-to-end-tests/src/test/compatUtils.ts
@@ -100,11 +100,10 @@ export const createOldTestFluidComponentFactory = (registry?: ChannelFactoryRegi
 };
 
 export const createRuntimeFactory = (
-    type: string,
     componentFactory: IFluidDataStoreFactory | old.IFluidDataStoreFactory,
     runtimeOptions: IContainerRuntimeOptions = { initialSummarizerDelayMs: 0 },
 ): IRuntimeFactory => {
-    return new TestContainerRuntimeFactory(type, componentFactory as IFluidDataStoreFactory, runtimeOptions);
+    return new TestContainerRuntimeFactory(componentFactory as IFluidDataStoreFactory, runtimeOptions);
 };
 
 // TODO: once 0.25 is released this can import the old version of TestContainerRuntimeFactory used above
@@ -164,7 +163,6 @@ export const compatTest = (
         const makeTestContainer = async (registry?: ChannelFactoryRegistry) => createContainerWithOldLoader(
             {
                 fluidExport: createRuntimeFactory(
-                    TestComponent.type,
                     options.testFluidComponent
                         ? createTestFluidComponentFactory(registry)
                         : createPrimedComponentFactory(),
@@ -230,7 +228,6 @@ export const compatTest = (
         const makeTestContainer = async (registry: ChannelFactoryRegistry) => createContainer(
             {
                 fluidExport: createRuntimeFactory(
-                    OldTestComponent.type,
                     options.testFluidComponent
                         ? createOldTestFluidComponentFactory(registry)
                         : createOldPrimedComponentFactory(),

--- a/packages/test/end-to-end-tests/src/test/componentHandle.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/componentHandle.spec.ts
@@ -44,6 +44,12 @@ const TestSharedComponentFactory = new DataObjectFactory(
     [SharedMap.getFactory()],
     []);
 
+const TestDefaultSharedComponentFactory = new DataObjectFactory(
+    "default",
+    TestSharedComponent,
+    [SharedMap.getFactory()],
+    []);
+
 describe("FluidOjectHandle", () => {
     const id = "fluid-test://localhost/componentHandleTest";
     const codeDetails: IFluidCodeDetails = {
@@ -70,8 +76,8 @@ describe("FluidOjectHandle", () => {
             new ContainerRuntimeFactoryWithDefaultDataStore(
                 "default",
                 [
-                    ["default", Promise.resolve(TestSharedComponentFactory)],
-                    ["TestSharedComponent", Promise.resolve(TestSharedComponentFactory)],
+                    TestDefaultSharedComponentFactory,
+                    TestSharedComponentFactory,
                 ],
             );
 

--- a/packages/test/end-to-end-tests/src/test/contextReload.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/contextReload.spec.ts
@@ -109,7 +109,7 @@ describe("context reload", function() {
         const type = TestComponent.type;
         return new ContainerRuntimeFactoryWithDefaultDataStore(
             type,
-            [[type, Promise.resolve(new DataObjectFactory(type, component, [], {}))]],
+            [new DataObjectFactory(type, component, [], {})],
         );
     };
 

--- a/packages/test/end-to-end-tests/src/test/documentDirty.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/documentDirty.spec.ts
@@ -70,13 +70,14 @@ describe("Document Dirty", () => {
             [
                 [mapId, SharedMap.getFactory()],
             ],
+            "default",
         );
 
         const runtimeFactory =
             new ContainerRuntimeFactoryWithDefaultDataStore(
                 "default",
                 [
-                    ["default", Promise.resolve(factory)],
+                    factory,
                 ],
             );
 

--- a/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
@@ -60,21 +60,32 @@ describe("Ops on Reconnect", () => {
     }
 
     async function createContainer(): Promise<Container> {
-        const factory: TestFluidComponentFactory = new TestFluidComponentFactory(
+        const defaultFactory: TestFluidComponentFactory = new TestFluidComponentFactory(
             [
                 [map1Id, SharedMap.getFactory()],
                 [map2Id, SharedMap.getFactory()],
                 [directoryId, SharedDirectory.getFactory()],
                 [stringId, SharedString.getFactory()],
             ],
+            "default",
+        );
+
+        const component2Factory: TestFluidComponentFactory = new TestFluidComponentFactory(
+            [
+                [map1Id, SharedMap.getFactory()],
+                [map2Id, SharedMap.getFactory()],
+                [directoryId, SharedDirectory.getFactory()],
+                [stringId, SharedString.getFactory()],
+            ],
+            "component2",
         );
 
         const runtimeFactory =
             new ContainerRuntimeFactoryWithDefaultDataStore(
                 "default",
                 [
-                    ["default", Promise.resolve(factory)],
-                    ["component2", Promise.resolve(factory)],
+                    defaultFactory,
+                    component2Factory,
                 ],
             );
 

--- a/packages/test/service-load-test/src/loadTestComponent.ts
+++ b/packages/test/service-load-test/src/loadTestComponent.ts
@@ -29,7 +29,6 @@ export interface ILoadTest {
 const wait = async (timeMs: number) => new Promise((resolve) => setTimeout(resolve, timeMs));
 
 class LoadTestComponent extends DataObject implements ILoadTest {
-    public static ComponentName = "StressTestComponent";
     private opCount = 0;
     private sentCount = 0;
     private state: string = "not started";
@@ -128,13 +127,13 @@ class LoadTestComponent extends DataObject implements ILoadTest {
 }
 
 const LoadTestComponentInstantiationFactory = new DataObjectFactory(
-    LoadTestComponent.ComponentName,
+    "StressTestComponent",
     LoadTestComponent,
     [],
     {},
 );
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    LoadTestComponent.ComponentName,
-    new Map([[LoadTestComponent.ComponentName, Promise.resolve(LoadTestComponentInstantiationFactory)]]),
+    LoadTestComponentInstantiationFactory.type,
+    [LoadTestComponentInstantiationFactory],
 );

--- a/packages/test/test-utils/src/localCodeLoader.ts
+++ b/packages/test/test-utils/src/localCodeLoader.ts
@@ -11,6 +11,7 @@ import {
     IFluidCodeDetails,
 } from "@fluidframework/container-definitions";
 import { IProvideFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
+import { RenamingFactoryAdapter } from "@fluidframework/container-runtime";
 
 // Represents the entry point for a fluid container.
 export type fluidEntryPoint = Partial<IProvideRuntimeFactory & IProvideFluidDataStoreFactory & IFluidModule>;
@@ -63,11 +64,14 @@ export class LocalCodeLoader implements ICodeLoader {
         if (entryPoint === undefined) {
             throw new Error(`Cannot find package ${pkdId}`);
         }
-        const factory: Partial<IProvideRuntimeFactory & IProvideFluidDataStoreFactory> =
-            entryPoint.fluidExport ?? entryPoint;
+        const factory = entryPoint.fluidExport ?? entryPoint;
+
         const runtimeFactory: IProvideRuntimeFactory =
             factory.IRuntimeFactory ??
-            new ContainerRuntimeFactoryWithDefaultDataStore("default", [["default", Promise.resolve(factory)]]);
+            new ContainerRuntimeFactoryWithDefaultDataStore(
+                "default",
+                [new RenamingFactoryAdapter("default", factory)],
+            );
 
         const fluidModule: IFluidModule = { fluidExport: runtimeFactory };
         return fluidModule;

--- a/packages/test/test-utils/src/testContainerRuntimeFactory.ts
+++ b/packages/test/test-utils/src/testContainerRuntimeFactory.ts
@@ -16,7 +16,6 @@ export class TestContainerRuntimeFactory implements IRuntimeFactory {
     public get IRuntimeFactory() { return this; }
 
     constructor(
-        public type: string,
         public componentFactory: IFluidDataStoreFactory,
         public runtimeOptions: IContainerRuntimeOptions,
     ) {}
@@ -29,13 +28,13 @@ export class TestContainerRuntimeFactory implements IRuntimeFactory {
 
         const runtime = await ContainerRuntime.load(
             context,
-            [[this.type, Promise.resolve(this.componentFactory)]],
+            [this.componentFactory],
             async (req, rt) => builder.handleRequest(req, rt),
             this.runtimeOptions,
         );
 
         if (!runtime.existing) {
-            await runtime.createRootDataStore(this.type, "default");
+            await runtime.createRootDataStore(this.componentFactory.type, "default");
         }
 
         return runtime;

--- a/packages/test/test-utils/src/testFluidComponent.ts
+++ b/packages/test/test-utils/src/testFluidComponent.ts
@@ -125,9 +125,6 @@ export type ChannelFactoryRegistry = Iterable<[string | undefined, IChannelFacto
  *      sharedDir = testFluidComponent.getSharedObject<SharedDirectory>("sharedDirectory");
  */
 export class TestFluidComponentFactory implements IFluidDataStoreFactory {
-    public static readonly type = "TestFluidComponentFactory";
-    public readonly type = TestFluidComponentFactory.type;
-
     public get IFluidDataStoreFactory() { return this; }
 
     /**
@@ -136,7 +133,9 @@ export class TestFluidComponentFactory implements IFluidDataStoreFactory {
      * IChannelFactory. Entries with string ids are passed to the component so that it can create a shared object
      * for it.
      */
-    constructor(private readonly factoryEntries: ChannelFactoryRegistry) { }
+    constructor(
+        private readonly factoryEntries: ChannelFactoryRegistry,
+        public readonly type = "TestFluidComponentFactory") { }
 
     public instantiateDataStore(context: IFluidDataStoreContext): void {
         const dataTypes = new Map<string, IChannelFactory>();

--- a/packages/test/version-test-1/@fluid-internal/version-test-2/src/index.ts
+++ b/packages/test/version-test-1/@fluid-internal/version-test-2/src/index.ts
@@ -7,16 +7,12 @@ import {
     ContainerRuntimeFactoryWithDefaultDataStore,
 } from "@fluidframework/aqueduct";
 
-import { VersiontestInstantiationFactory } from "./main";
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
-const pkg = require("../package.json");
-const fluidPackageName = pkg.name as string;
+import { VersiontestInstantiationFactory1, VersiontestInstantiationFactory2 } from "./main";
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    fluidPackageName,
-    new Map([
-        [fluidPackageName, Promise.resolve(VersiontestInstantiationFactory)],
-        ["@fluid-internal/version-test-1", Promise.resolve(VersiontestInstantiationFactory)],
-    ]),
+    VersiontestInstantiationFactory2.type,
+    [
+        VersiontestInstantiationFactory1,
+        VersiontestInstantiationFactory2,
+    ],
 );

--- a/packages/test/version-test-1/@fluid-internal/version-test-2/src/main.tsx
+++ b/packages/test/version-test-1/@fluid-internal/version-test-2/src/main.tsx
@@ -15,7 +15,6 @@ import ReactDOM from "react-dom";
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
 const pkg = require("../package.json");
 const pkgversion = pkg.version as string;
-const versionTest2Name = pkg.name as string;
 
 export class VersionTest extends DataObject implements IFluidHTMLView {
     public get IFluidHTMLView() { return this; }
@@ -97,4 +96,5 @@ export class VersionTest extends DataObject implements IFluidHTMLView {
     }
 }
 
-export const VersiontestInstantiationFactory = new DataObjectFactory(versionTest2Name, VersionTest, [], {});
+export const VersiontestInstantiationFactory1 = new DataObjectFactory("@fluid-internal/version-test-1", VersionTest, [], {});
+export const VersiontestInstantiationFactory2 = new DataObjectFactory("@fluid-internal/version-test-2", VersionTest, [], {});

--- a/packages/test/version-test-1/src/index.ts
+++ b/packages/test/version-test-1/src/index.ts
@@ -7,15 +7,11 @@ import {
     ContainerRuntimeFactoryWithDefaultDataStore,
 } from "@fluidframework/aqueduct";
 
-import { VersiontestInstantiationFactory } from "./main";
-
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-const pkg = require("../package.json");
-const fluidPackageName = pkg.name as string;
+import { VersiontestInstantiationFactory1 } from "./main";
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    fluidPackageName,
-    new Map([
-        [fluidPackageName, Promise.resolve(VersiontestInstantiationFactory)],
-    ]),
+    VersiontestInstantiationFactory1.type,
+    [
+        VersiontestInstantiationFactory1,
+    ],
 );

--- a/packages/test/version-test-1/src/main.tsx
+++ b/packages/test/version-test-1/src/main.tsx
@@ -20,7 +20,6 @@ const signalKey = {
     upgradeHighPriority: "upgrade high priority",
     upgradeLowPriority: "upgrade low priority",
 };
-const versionTest1Name = pkg.name as string;
 
 export class VersionTest extends DataObject implements IFluidHTMLView {
     public get IFluidHTMLView() { return this; }
@@ -120,4 +119,7 @@ export class VersionTest extends DataObject implements IFluidHTMLView {
     }
 }
 
-export const VersiontestInstantiationFactory = new DataObjectFactory(versionTest1Name, VersionTest, [], {});
+export const VersiontestInstantiationFactory1 =
+    new DataObjectFactory("@fluid-internal/version-test-1", VersionTest, [], {});
+export const VersiontestInstantiationFactory2 =
+    new DataObjectFactory("@fluid-internal/version-test-2", VersionTest, [], {});

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -39,6 +39,7 @@
     "@fluidframework/file-driver": "^0.25.0",
     "@fluidframework/protocol-definitions": "^0.1010.0",
     "@fluidframework/replay-driver": "^0.25.0",
+    "@fluidframework/runtime-definitions": "^0.25.0",
     "@fluidframework/telemetry-utils": "^0.25.0"
   },
   "devDependencies": {

--- a/packages/tools/webpack-component-loader/src/loader.ts
+++ b/packages/tools/webpack-component-loader/src/loader.ts
@@ -24,6 +24,7 @@ import { IFluidMountableView } from "@fluidframework/view-interfaces";
 import { extractPackageIdentifierDetails, WebCodeLoader } from "@fluidframework/web-code-loader";
 import { IFluidObject } from "@fluidframework/core-interfaces";
 import { RequestParser } from "@fluidframework/runtime-utils";
+import { RenamingFactoryAdapter } from "@fluidframework/container-runtime";
 import { MultiUrlResolver } from "./multiResolver";
 import { getDocumentServiceFactory } from "./multiDocumentServiceFactory";
 
@@ -83,9 +84,9 @@ function wrapIfComponentPackage(packageJson: IFluidPackage, fluidModule: IFluidM
 
         const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
             packageJson.name,
-            new Map([
-                [packageJson.name, Promise.resolve(componentFactory)],
-            ]),
+            [
+                new RenamingFactoryAdapter(packageJson.name, componentFactory),
+            ],
         );
         return {
             fluidExport: {

--- a/tools/generator-fluid/app/index.js
+++ b/tools/generator-fluid/app/index.js
@@ -274,11 +274,11 @@ module.exports = class extends Generator {
     const variableStatement = file.getVariableStatement("fluidExport");
     const varDec = variableStatement.getDeclarations()[0];
     const initializer = `new ContainerRuntimeFactoryWithDefaultDataStore(
-        ${this._componentClassName()}.ComponentName,
-        new Map([
-            [${this._componentClassName()}.ComponentName, Promise.resolve(${this._componentClassName()}.factory)],
+        ${this._componentClassName()}.factory.type,
+        [
+            ${this._componentClassName()}.factory,
             // Add another component here to create it within the container
-        ]))`
+        ])`
     varDec.set({initializer});
 
     // Formatting is needed for this file because the above initializer set won't set the indent correctly

--- a/tools/generator-fluid/app/templates/src/component-simple.ts
+++ b/tools/generator-fluid/app/templates/src/component-simple.ts
@@ -10,8 +10,6 @@ const diceValueKey = "diceValue";
  * Fluid component
  */
 export class DiceRoller extends DataObject implements IFluidHTMLView {
-    public static get ComponentName() { return "dice-roller"; }
-
     public get IFluidHTMLView() { return this; }
 
     /**
@@ -19,7 +17,7 @@ export class DiceRoller extends DataObject implements IFluidHTMLView {
      * dependencies of the component.
      */
     public static readonly factory = new DataObjectFactory(
-        DiceRoller.ComponentName,
+        "dice-roller",
         DiceRoller,
         [],
         {},

--- a/tools/generator-fluid/app/templates/src/component-simple.tsx
+++ b/tools/generator-fluid/app/templates/src/component-simple.tsx
@@ -14,8 +14,6 @@ const diceValueKey = "diceValue";
  * Fluid component
  */
 export class DiceRoller extends DataObject implements IFluidHTMLView {
-    public static get ComponentName() { return "dice-roller"; }
-
     public get IFluidHTMLView() { return this; }
 
     /**
@@ -23,7 +21,7 @@ export class DiceRoller extends DataObject implements IFluidHTMLView {
      * dependencies of the component.
      */
     public static readonly factory = new DataObjectFactory(
-        DiceRoller.ComponentName,
+        "dice-roller",
         DiceRoller,
         [],
         {},

--- a/tools/generator-fluid/app/templates/src/component.ts
+++ b/tools/generator-fluid/app/templates/src/component.ts
@@ -14,8 +14,6 @@ const diceValueKey = "diceValue";
  * Fluid component
  */
 export class DiceRoller extends DataObject implements IDiceRoller, IFluidHTMLView {
-    public static get ComponentName() { return "dice-roller"; }
-
     public get IFluidHTMLView() { return this; }
 
     /**
@@ -23,7 +21,7 @@ export class DiceRoller extends DataObject implements IDiceRoller, IFluidHTMLVie
      * dependencies of the component.
      */
     public static readonly factory = new DataObjectFactory(
-        DiceRoller.ComponentName,
+        "dice-roller",
         DiceRoller,
         [],
         {},

--- a/tools/generator-fluid/app/templates/src/component.tsx
+++ b/tools/generator-fluid/app/templates/src/component.tsx
@@ -17,8 +17,6 @@ const diceValueKey = "diceValue";
  * Fluid component
  */
 export class DiceRoller extends DataObject implements IDiceRoller, IFluidHTMLView {
-    public static get ComponentName() { return "dice-roller"; }
-
     public get IFluidHTMLView() { return this; }
 
     /**
@@ -26,7 +24,7 @@ export class DiceRoller extends DataObject implements IDiceRoller, IFluidHTMLVie
      * dependencies of the component.
      */
     public static readonly factory = new DataObjectFactory(
-        DiceRoller.ComponentName,
+        "dice-roller",
         DiceRoller,
         [],
         {},

--- a/tools/generator-fluid/app/templates/src/index.ts
+++ b/tools/generator-fluid/app/templates/src/index.ts
@@ -8,8 +8,7 @@ export { DiceRoller };
  * as a component that can be created in the container.
  */
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    DiceRoller.ComponentName,
-    new Map([
-        [DiceRoller.ComponentName, Promise.resolve(DiceRoller.factory)],
-        // Add another component here to create it within the container
-    ]));
+    DiceRoller.factory.type,
+    // Add another component here to create it within the container
+    [DiceRoller.factory],
+);


### PR DESCRIPTION
An exploration into reduction of concepts: getting rid of NamedFluidDataStoreRegistryEntries, and replacing it with 
```
export type FluidDataStoreRegistryEntries = Iterable<FluidDataStoreRegistryEntry>;
```
Factories (IFluidDataStoreFactory) already contain type, which is used in this PR instead of separately passed in type name in NamedFluidDataStoreRegistryEntries. This allows usage of factories directly.
Pros:
- Most of the code does not need to know type names, factory / registry chains can be built using chaining factories only.
- In Aqueduct, where we use factory.createInstance() workflow it's paramount for factory.type to have actual name used to reach this factory from root.
- In general, it creates simpler workflow.

Cons:
- This makes it harder to give custom names, or have delay-loaded factories. To solve this, helpers (adapter classes) are added.
- At runtime level, it's probably better to separate concerns, i.e. factory to be nameless and some other structure (like NamedFluidDataStoreRegistryEntries) put names to factories/registries - this allows more flexibility (even though more verbose).

Some helper adapters are added to bridge gaps between proposed and new model:
- DelayLoadingFactoryAdapter - takes a type & promise to factory, and implements factory. Asserts that type of resolved factory matches type provided initially to adapter.
- RenamingFactoryAdapter - an adapter that takes existing factory and wraps it into another factory with new type. While I've added it, see my note about Aqueduct usage of factories above, this kind of adapter might be a fire hazard.

Note that this change preserves ability for nodes in factory/registry tree to have no factories. I.e. only nodes that are actually used needs to have factories.

This change also removes component names as a concept from most of our examples. factory.type is the proper way to get name if/when needed, but the goal of these changes is to reduce such cases to a minimum.

Removing (where I saw it) getting names from package.json. This is backward compat hazard and impacts negatively bundle sizes. While it's likely necessary evil for dynamic loading cases to have package.json content (hopefully stripped down to only few properties), our static examples should follow how we would approach problem in shipping code (like fluid preview), where referencing package.json would be flagged pretty quickly by perf hawks.

It will probably take me a while to go through test failures and figure out where and how I broke stuff, sharing to get feedback before going forward.

