### PR TITLE
 Renamed webpack-component-loader -> webpack-fluid-loader in layerInfo.json in prep for the rename in the repo

### DIFF
--- a/tools/build-tools/data/layerInfo.json
+++ b/tools/build-tools/data/layerInfo.json
@@ -211,7 +211,7 @@
                     "@fluidframework/local-web-host",
                     "@fluidframework/local-driver",
                     "@fluidframework/test-runtime-utils",
-                    "@fluidframework/webpack-component-loader"
+                    "@fluidframework/webpack-fluid-loader"
                 ],
                 "dirs": [
                     "packages/test/"


### PR DESCRIPTION
A followup PR #3137 will update the packages in client repo to use the new package name.