### PR TITLE
Add node types to container-loader

### DIFF
--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -80,6 +80,7 @@
     "@types/jwt-decode": "^2.2.1",
     "@types/lodash": "^4.14.118",
     "@types/mocha": "^5.2.5",
+    "@types/node": "^10.17.24",
     "@types/sinon": "^7.0.13",
     "@typescript-eslint/eslint-plugin": "~2.17.0",
     "@typescript-eslint/parser": "~2.17.0",

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -141,7 +141,7 @@ export class DeltaManager
 
     private inQuorum = false;
 
-    private updateSequenceNumberTimer: number | undefined;
+    private updateSequenceNumberTimer: ReturnType<typeof setTimeout> | undefined;
 
     // The minimum sequence number and last sequence number received from the server
     private minSequenceNumber: number = 0;

--- a/packages/loader/container-loader/tsconfig.json
+++ b/packages/loader/container-loader/tsconfig.json
@@ -8,7 +8,8 @@
         "rootDir": "./src",
         "outDir": "./dist",
         "types": [
-            "mocha"
+            "mocha",
+            "node",
         ]
     },
     "include": [


### PR DESCRIPTION
We aren't getting type checking on node functionality we're using in the container-loader package (e.g. url.parse).  This includes @types/node and does fixup for a timer type usage that was assuming window.setTimeout.