### PR TITLE
Use URL instead of parse in container-loader utils

### DIFF
--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -25,7 +25,7 @@ export function parseUrl(url: string): IParsedUrl | undefined {
     const match = regex.exec(parsed.pathname);
 
     return (match?.length === 3)
-        ? { id: match[1], path: match[2], version: parsed.searchParams.get("version") }
+        ? { id: match[1], path: match[2], version: parsed.searchParams.get("version") ?? undefined }
         : undefined;
 }
 

--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -4,7 +4,6 @@
  */
 
 import { Buffer } from "buffer";
-import { parse } from "url";
 import { ISummaryTree, ISnapshotTree, SummaryType } from "@fluidframework/protocol-definitions";
 import uuid from "uuid";
 
@@ -20,13 +19,13 @@ export interface IParsedUrl {
 }
 
 export function parseUrl(url: string): IParsedUrl | undefined {
-    const parsed = parse(url, true);
+    const parsed = new URL(url);
 
     const regex = /^\/([^/]*\/[^/]*)(\/?.*)$/;
-    const match = regex.exec(parsed.pathname!);
+    const match = regex.exec(parsed.pathname);
 
     return (match?.length === 3)
-        ? { id: match[1], path: match[2], version: parsed.query.version as string }
+        ? { id: match[1], path: match[2], version: parsed.searchParams.get("version") }
         : undefined;
 }
 


### PR DESCRIPTION
Alternative to solve the untyped parse problem I mentioned in #3142, and a good change anyway since the legacy URL API is deprecated and requires a polyfill.

Opening as a separate change since I think this one is less likely to require debate.