### PR TITLE
Add tenantId & documentId as messageMetaData for several logs

### DIFF
--- a/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
+++ b/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
@@ -155,6 +155,7 @@ export class LocalDeltaConnectionServer implements ILocalDeltaConnectionServer {
             const queuedMessages: ISequencedDocumentMessage[] = [];
             const queuedContents: IContentMessage[] = [];
             const queuedSignals: ISignalMessage[] = [];
+
             const earlyOpHandler = (docId: string, msgs: ISequencedDocumentMessage[]) => {
                 this.logger.info(`Queued early ops: ${msgs.length}`);
                 queuedMessages.push(...msgs);

--- a/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
+++ b/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
@@ -155,21 +155,21 @@ export class LocalDeltaConnectionServer implements ILocalDeltaConnectionServer {
             const queuedMessages: ISequencedDocumentMessage[] = [];
             const queuedContents: IContentMessage[] = [];
             const queuedSignals: ISignalMessage[] = [];
-
+            const messageMetaData = { documentId, tenantId };
             const earlyOpHandler = (docId: string, msgs: ISequencedDocumentMessage[]) => {
-                this.logger.info(`Queued early ops: ${msgs.length}`);
+                this.logger.info(`Queued early ops: ${msgs.length}`, { messageMetaData });
                 queuedMessages.push(...msgs);
             };
             socket.on("op", earlyOpHandler);
 
             const earlyContentHandler = (msg: IContentMessage) => {
-                this.logger.info("Queued early contents");
+                this.logger.info("Queued early contents", { messageMetaData });
                 queuedContents.push(msg);
             };
             socket.on("op-content", earlyContentHandler);
 
             const earlySignalHandler = (msg: ISignalMessage) => {
-                this.logger.info("Queued early signals");
+                this.logger.info("Queued early signals", { messageMetaData });
                 queuedSignals.push(msg);
             };
             socket.on("signal", earlySignalHandler);

--- a/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
+++ b/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
@@ -155,21 +155,20 @@ export class LocalDeltaConnectionServer implements ILocalDeltaConnectionServer {
             const queuedMessages: ISequencedDocumentMessage[] = [];
             const queuedContents: IContentMessage[] = [];
             const queuedSignals: ISignalMessage[] = [];
-            const messageMetaData = { documentId, tenantId };
             const earlyOpHandler = (docId: string, msgs: ISequencedDocumentMessage[]) => {
-                this.logger.info(`Queued early ops: ${msgs.length}`, { messageMetaData });
+                this.logger.info(`Queued early ops: ${msgs.length}`);
                 queuedMessages.push(...msgs);
             };
             socket.on("op", earlyOpHandler);
 
             const earlyContentHandler = (msg: IContentMessage) => {
-                this.logger.info("Queued early contents", { messageMetaData });
+                this.logger.info("Queued early contents");
                 queuedContents.push(msg);
             };
             socket.on("op-content", earlyContentHandler);
 
             const earlySignalHandler = (msg: ISignalMessage) => {
-                this.logger.info("Queued early signals", { messageMetaData });
+                this.logger.info("Queued early signals");
                 queuedSignals.push(msg);
             };
             socket.on("signal", earlySignalHandler);

--- a/server/routerlicious/packages/routerlicious/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious/src/alfred/runnerFactory.ts
@@ -52,8 +52,8 @@ export class OrdererManager implements core.IOrdererManager {
     public async getOrderer(tenantId: string, documentId: string): Promise<core.IOrderer> {
         const tenant = await this.tenantManager.getTenant(tenantId);
 
-        winston.info(tenant.orderer);
-        winston.info(tenant.orderer.url);
+        const messageMetaData = { documentId, tenantId };
+        winston.info(`tenant orderer: ${JSON.stringify(tenant.orderer)}`, { messageMetaData });
 
         if (tenant.orderer.url !== this.ordererUrl) {
             return Promise.reject("Invalid ordering service endpoint");

--- a/server/routerlicious/packages/services-shared/src/storage.ts
+++ b/server/routerlicious/packages/services-shared/src/storage.ts
@@ -91,8 +91,9 @@ export class DocumentStorage implements IDocumentStorage {
             gitManager.getTree(handle, false),
         ]);
 
-        winston.info(JSON.stringify(protocolTree));
-        winston.info(JSON.stringify(appSummaryTree));
+        const messageMetaData = { documentId, tenantId };
+        winston.info(`protocolTree ${JSON.stringify(protocolTree)}`, { messageMetaData });
+        winston.info(`appSummaryTree ${JSON.stringify(appSummaryTree)}`, { messageMetaData });
 
         // Combine the app summary with .protocol
         const newTreeEntries = mergeAppAndProtocolTree(appSummaryTree, protocolTree);
@@ -112,8 +113,7 @@ export class DocumentStorage implements IDocumentStorage {
         const commit = await gitManager.createCommit(commitParams);
         await gitManager.createRef(documentId, commit.sha);
 
-        winston.info(JSON.stringify(documentId));
-        winston.info(JSON.stringify(commit.sha));
+        winston.info(`commit sha: ${JSON.stringify(commit.sha)}`, { messageMetaData });
 
         const scribe: IScribe = {
             logOffset: -1,


### PR DESCRIPTION
Just several spots missing from previous change to added tenantId & documentId as messageMetaData