### PR TITLE
BuildTools: Add --info parameter for the layer graph info path

### DIFF
--- a/tools/build-tools/src/layerCheck/layerCheck.ts
+++ b/tools/build-tools/src/layerCheck/layerCheck.ts
@@ -17,6 +17,7 @@ function printUsage() {
 Usage: fluid-layer-check <options>
 Options:
      --dot <path>     Generate *.dot for GraphViz
+     --info <path>    Path to the layer graph json file
      --md             Generate PACKAGES.md file for human consumption
 ${commonOptionString}
 `);
@@ -26,6 +27,7 @@ const packagesMdFileName: string = "PACKAGES.md";
 
 let dotGraphFilePath: string | undefined;
 let writePackagesMd: boolean = false;
+let layerInfoPath: string | undefined;
 
 function parseOptions(argv: string[]) {
     let error = false;
@@ -62,6 +64,16 @@ function parseOptions(argv: string[]) {
             continue;
         }
 
+        if (arg === "--info") {
+            if (i !== process.argv.length - 1) {
+                layerInfoPath = path.resolve(process.argv[++i]);
+                continue;
+            }
+            console.error("ERROR: Missing argument for --info");
+            error = true;
+            break;
+        }
+
         console.error(`ERROR: Invalid arguments ${arg}`);
         error = true;
         break;
@@ -85,7 +97,7 @@ async function main() {
     timer.time("Package scan completed");
 
     try {
-        const layerGraph = LayerGraph.load(resolvedRoot, packages);
+        const layerGraph = LayerGraph.load(resolvedRoot, packages, layerInfoPath);
 
         // Write human-readable package list organized by layer
         if (writePackagesMd) {

--- a/tools/build-tools/src/layerCheck/layerGraph.ts
+++ b/tools/build-tools/src/layerCheck/layerGraph.ts
@@ -92,7 +92,7 @@ class LayerNode extends BaseNode {
         if (this.packages.size < 2) {
             return `\n    ${nodes.join("\n    ")}`;
         }
-        const sameRank = this.dotSameRank? "\n      rank=\"same\"": "";
+        const sameRank = this.dotSameRank ? "\n      rank=\"same\"" : "";
         return `
     subgraph cluster_${this.dotName} {
       label = "${this.dotName}"${sameRank}
@@ -137,7 +137,7 @@ class GroupNode extends BaseNode {
         // default to true
         return this.groupInfo.dot ?? true;
     }
-    
+
     private get dotSameRank() {
         // default to false
         return this.groupInfo.dotSameRank ?? false;
@@ -155,7 +155,7 @@ class GroupNode extends BaseNode {
     }
 
     public generateDotSubgraph() {
-        const sameRank = this.dotSameRank? "\n    rank=\"same\"": "";
+        const sameRank = this.dotSameRank ? "\n    rank=\"same\"" : "";
         const subGraphs = this.layerNodes.map(layerNode => layerNode.generateDotSubgraph()).join("");
         if (!this.dotGroup) {
             return subGraphs;
@@ -390,7 +390,7 @@ export class LayerGraph {
             return true;
         });
         const dotGraph =
-`strict digraph G { graph [ newrank=true; ranksep=2; compound=true ]; ${this.groupNodes.map(group => group.generateDotSubgraph()).join("")}
+            `strict digraph G { graph [ newrank=true; ranksep=2; compound=true ]; ${this.groupNodes.map(group => group.generateDotSubgraph()).join("")}
   ${dotEdges.join("\n  ")}
 }`;
         return dotGraph;
@@ -428,18 +428,18 @@ export class LayerGraph {
         // Move this root from childrenToVisit to orderedChildren if present
         // This will create at least one new root (i.e. it has no unvisited dependencies)
         allLayers
-        .forEach((l) => {
-            const foundIdx = l.childrenToVisit.findIndex((child) => child?.name === root.node.name);
-            if (foundIdx >= 0) {
-                l.orderedChildren.push(l.childrenToVisit[foundIdx]!);
-                l.childrenToVisit[foundIdx] = undefined;
-            }
-        });
+            .forEach((l) => {
+                const foundIdx = l.childrenToVisit.findIndex((child) => child?.name === root.node.name);
+                if (foundIdx >= 0) {
+                    l.orderedChildren.push(l.childrenToVisit[foundIdx]!);
+                    l.childrenToVisit[foundIdx] = undefined;
+                }
+            });
 
         // Recurse for every layer with no more unvisited dependencies itself (i.e. now a root itself)
         allLayers
-        .filter((l) => l.childrenToVisit.every((c) => !c)) // Also accepts empty childrenToVisit
-        .forEach((newRoot) => this.traverseSubgraph(newRoot, allLayers, orderedLayers));
+            .filter((l) => l.childrenToVisit.every((c) => !c)) // Also accepts empty childrenToVisit
+            .forEach((newRoot) => this.traverseSubgraph(newRoot, allLayers, orderedLayers));
     }
 
     /**
@@ -468,8 +468,8 @@ export class LayerGraph {
         // Take any "roots" (layers with no child dependencies) and traverse those subgraphs,
         // building up orderedLayers as we go
         layers
-        .filter((l) => l.childrenToVisit.length === 0)
-        .forEach((root) => this.traverseSubgraph(root, layers, orderedLayers));
+            .filter((l) => l.childrenToVisit.length === 0)
+            .forEach((root) => this.traverseSubgraph(root, layers, orderedLayers));
 
         return orderedLayers;
     }
@@ -505,7 +505,7 @@ export class LayerGraph {
         assert(packageCount === this.packageNodeMap.size, "ERROR: Did not find all packages while traversing layers");
 
         const packagesMdContents: string =
-`# Package Layers
+            `# Package Layers
 
 [//]: <> (This file is generated, please don't edit it manually!)
 
@@ -518,7 +518,7 @@ ${lines.join(newline)}
     }
 
     public static load(root: string, packages: Packages, info?: string) {
-        const layerInfoFile = require(info?? path.join(__dirname, "..", "..", "data", "layerInfo.json"));
+        const layerInfoFile = require(info ?? path.join(__dirname, "..", "..", "data", "layerInfo.json"));
         return new LayerGraph(root, layerInfoFile, packages);
     }
 };

--- a/tools/build-tools/src/layerCheck/layerGraph.ts
+++ b/tools/build-tools/src/layerCheck/layerGraph.ts
@@ -517,8 +517,8 @@ ${lines.join(newline)}
         return packagesMdContents;
     }
 
-    public static load(root: string, packages: Packages) {
-        const layerInfoFile = require(path.join(__dirname, "..", "..", "data", "layerInfo.json"));
+    public static load(root: string, packages: Packages, info?: string) {
+        const layerInfoFile = require(info?? path.join(__dirname, "..", "..", "data", "layerInfo.json"));
         return new LayerGraph(root, layerInfoFile, packages);
     }
 };


### PR DESCRIPTION
This will allow us to move the data file out of the package, so that updating it doesn't need to update the package itself.