### PR TITLE
Move buffer type into common defs

### DIFF
--- a/common/lib/common-definitions/src/buffer.ts
+++ b/common/lib/common-definitions/src/buffer.ts
@@ -8,7 +8,7 @@
  * exposing the entirely of Node's typings.  This should match the public interface
  * of the browser implementation, so any changes made in one should be made in both.
  */
-declare class Buffer extends Uint8Array {
+export declare class Buffer extends Uint8Array {
     toString(encoding?: string): string;
     /**
      * @param value - string | ArrayBuffer

--- a/common/lib/common-definitions/src/buffer.ts
+++ b/common/lib/common-definitions/src/buffer.ts
@@ -1,0 +1,20 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Declare the subset of Buffer functionality we want to make available instead of
+ * exposing the entirely of Node's typings.  This should match the public interface
+ * of the browser implementation, so any changes made in one should be made in both.
+ */
+declare class Buffer extends Uint8Array {
+    toString(encoding?: string): string;
+    /**
+     * @param value - string | ArrayBuffer
+     * @param encodingOrOffset - string | number
+     * @param length - number
+     */
+    static from(value, encodingOrOffset?, length?): IsoBuffer;
+}
+export type IsoBuffer = Buffer;

--- a/common/lib/common-definitions/src/index.ts
+++ b/common/lib/common-definitions/src/index.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+export * from "./buffer";
 export * from "./disposable";
 export * from "./events";
 export * from "./logger";


### PR DESCRIPTION
#2450 
Move the IsoBuffer type declaration into common-definitions from common-utils.  Common-utils will then re-export the type, along with exporting the actual class.  This is needed because protocol-definitons depends on the IsoBuffer type, and cannot depend on common-utils due to the layer map.

Alternative of using the Uint8Array typing instead of IsoBuffer in protocol-definitons was not done because consumers calling toString() on IsoBuffer would then need to use a static helper.  Node Buffer does not already provide a static helper, and the Browser implementation depends on browser APIs, meaning we either need to write/ship additional code (not great) or blindly assume any provided UInt8Array is actually an IsoBuffer (not great)