### PR TITLE
Update Location of Tinylicious storage due to MacOS bug

### DIFF
--- a/server/tinylicious/config.json
+++ b/server/tinylicious/config.json
@@ -31,10 +31,10 @@
             "scribeDeltas": "scribeDeltas"
         }
     },
-    "storage": "/var/lib/tinylicious",
+    "storage": "/var/tmp/tinylicious",
     "db": {
         "inMemory": true,
-        "path": "/var/lib/db"
+        "path": "/var/tmp/db"
     },
     "error": {
         "track": false,


### PR DESCRIPTION
Not much more detail... Tinylicious stopped working for a bunch of mac users and this seems to be the culprit. I haven't found any literature on this.

Triggered by isomorphic git attempting to mkdir in /var/lib

{ [Error: EACCES: permission denied, mkdir '/var/lib/test']
  errno: -13,
  code: 'EACCES',
  syscall: 'mkdir',
  path: '/var/lib/test' }