### PR TITLE
Get draft-js tests building and running, remove chunks

### DIFF
--- a/examples/apps/draft-js/jest-puppeteer.config.js
+++ b/examples/apps/draft-js/jest-puppeteer.config.js
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+module.exports = {
+  server: {
+    command: `npm run start:test -- --no-live-reload --port ${process.env["PORT"]}`,
+    port: process.env["PORT"],
+    launchTimeout:10000,
+    usedPortAction: 'error'
+  },
+  launch: {
+    args: ['--no-sandbox', '--disable-setuid-sandbox'], // https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#setting-up-chrome-linux-sandbox
+    dumpio: process.env.FLUID_TEST_VERBOSE !== undefined // output browser console to cmd line
+    // slowMo: 500, // slows down process for easier viewing
+    // headless: false, // run in the browser
+  },
+};

--- a/examples/apps/draft-js/jest.config.js
+++ b/examples/apps/draft-js/jest.config.js
@@ -1,0 +1,23 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Get the test port from the global map and set it in env for this test
+const testTools = require("@fluidframework/test-tools");
+const { name } = require("./package.json");
+
+mappedPort = testTools.getTestPort(name);
+process.env["PORT"] = mappedPort;
+
+module.exports = {
+  preset: "jest-puppeteer",
+  globals: {
+    PATH: `http://localhost:${mappedPort}`
+  },
+  testMatch: ["**/?(*.)+(spec|test).[t]s"],
+  testPathIgnorePatterns: ['/node_modules/', 'dist'],
+  transform: {
+    "^.+\\.ts?$": "ts-jest"
+  },
+};

--- a/examples/apps/draft-js/package.json
+++ b/examples/apps/draft-js/package.json
@@ -23,6 +23,9 @@
     "start": "webpack-dev-server",
     "start:server": "tinylicious",
     "start:test": "webpack-dev-server --config webpack.test.js",
+    "test": "npm run test:jest",
+    "test:jest": "jest",
+    "test:jest:verbose": "cross-env FLUID_TEST_VERBOSE=1 jest",
     "tsc": "tsc",
     "tsfmt": "tsfmt --verify",
     "tsfmt:fix": "tsfmt --replace",
@@ -48,8 +51,13 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.18.0",
     "@fluidframework/eslint-config-fluid": "^0.18.0",
+    "@fluidframework/test-tools": "^0.1.0",
     "@types/draft-js": "^0.10.34",
+    "@types/expect-puppeteer": "2.2.1",
+    "@types/jest": "22.2.3",
+    "@types/jest-environment-puppeteer": "2.2.0",
     "@types/node": "^10.17.24",
+    "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",
     "@typescript-eslint/eslint-plugin": "~2.17.0",
@@ -65,8 +73,13 @@
     "eslint-plugin-react": "~7.18.0",
     "eslint-plugin-unicorn": "~15.0.1",
     "html-webpack-plugin": "^4.3.0",
+    "jest": "^24.9.0",
+    "jest-junit": "^10.0.0",
+    "jest-puppeteer": "^4.3.0",
+    "puppeteer": "^1.20.0",
     "rimraf": "^2.6.2",
     "style-loader": "^1.0.0",
+    "ts-jest": "24.1.0",
     "ts-loader": "^6.1.2",
     "typescript": "~3.7.4",
     "typescript-formatter": "7.1.0",
@@ -84,5 +97,9 @@
         "library": "main"
       }
     }
+  },
+  "jest-junit": {
+    "outputDirectory": "nyc",
+    "outputName": "jest-junit-report.xml"
   }
 }

--- a/examples/apps/draft-js/tests/draftjs.test.ts
+++ b/examples/apps/draft-js/tests/draftjs.test.ts
@@ -1,0 +1,23 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { globals } from "../jest.config";
+
+describe("draft-js", () => {
+    beforeAll(async () => {
+        // Wait for the page to load first before running any tests
+        // so this time isn't attributed to the first test
+        await page.goto(globals.PATH, { waitUntil: "load", timeout: 0 });
+    }, 45000);
+
+    beforeEach(async () => {
+        await page.goto(globals.PATH, { waitUntil: "load" });
+        await page.waitFor(() => window["fluidStarted"]);
+    });
+
+    it("loads and the starting text is present", async () => {
+        await expect(page).toMatch("starting text");
+    });
+});

--- a/examples/apps/draft-js/tests/index.tsx
+++ b/examples/apps/draft-js/tests/index.tsx
@@ -6,8 +6,12 @@
 import { getSessionStorageContainer } from "@fluidframework/get-session-storage-container";
 import { getDefaultObjectFromContainer } from "@fluidframework/aqueduct";
 
-import { DraftJsContainer } from "../src/container";
-import { DraftJsObject } from "../src/fluid-object";
+import React from "react";
+import ReactDOM from "react-dom";
+
+import { FluidDraftJsContainer } from "../src/container";
+import { FluidDraftJsObject } from "../src/fluid-object";
+import { FluidDraftJsView } from "../src/view";
 
 // Since this is a single page fluid application we are generating a new document id
 // if one was not provided
@@ -25,13 +29,15 @@ const documentId = window.location.hash.substring(1);
 async function createContainerAndRenderInElement(element: HTMLElement, createNewFlag: boolean) {
     // The SessionStorage Container is an in-memory Fluid container that uses the local browser SessionStorage
     // to store ops.
-    const container = await getSessionStorageContainer(documentId, DraftJsContainer, createNewFlag);
+    const container = await getSessionStorageContainer(documentId, FluidDraftJsContainer, createNewFlag);
 
     // Get the Default Object from the Container
-    const defaultObject = await getDefaultObjectFromContainer<DraftJsObject>(container);
+    const defaultObject = await getDefaultObjectFromContainer<FluidDraftJsObject>(container);
 
-    // For now we will just reach into the FluidObject to render it
-    defaultObject.render(element);
+    // Render the content using ReactDOM
+    ReactDOM.render(
+        <FluidDraftJsView model={defaultObject} />,
+        document.getElementById("content"));
 
     // Setting "fluidStarted" is just for our test automation
     // eslint-disable-next-line dot-notation

--- a/examples/apps/draft-js/tsconfig.json
+++ b/examples/apps/draft-js/tsconfig.json
@@ -8,7 +8,8 @@
         "strictNullChecks": false,
         "module": "esnext",
         "outDir": "dist",
-        "jsx": "react"
+        "jsx": "react",
+        "types": ["react", "react-dom", "jest", "puppeteer", "jest-environment-puppeteer", "expect-puppeteer"]
     },
     "include": [
         "src/**/*"

--- a/examples/apps/draft-js/webpack.config.js
+++ b/examples/apps/draft-js/webpack.config.js
@@ -41,7 +41,6 @@ module.exports = env => {
         plugins: [
             new HtmlWebpackPlugin({
                 template: "./public/index.html",
-                chunks: ["app"],
             }),
             // new CleanWebpackPlugin(),
         ],

--- a/examples/apps/spaces/webpack.config.js
+++ b/examples/apps/spaces/webpack.config.js
@@ -54,7 +54,6 @@ module.exports = (env) => {
         plugins: [
             new HtmlWebpackPlugin({
                 template: "./public/index.html",
-                chunks: ["app"],
             }),
         ],
     }, isProduction

--- a/examples/hosts/app-integration/container-views/webpack.config.js
+++ b/examples/hosts/app-integration/container-views/webpack.config.js
@@ -36,7 +36,6 @@ module.exports = env => {
         plugins: [
             new HtmlWebpackPlugin({
                 template: "./src/app/index.html",
-                chunks: ["app"],
             }),
             // new CleanWebpackPlugin(),
         ],


### PR DESCRIPTION
Was looking at our test directory setups for the app samples and noticed draft-js didn't have a test running.  This adds one.