### PR TITLE
[0.24.0 -> 0.25.0] Correct FluidObjectHandle spelling

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -203,7 +203,7 @@ All renames are 1-1, and global case senstive and whole word find replace for al
 
             "SharedObjectComponentHandle": "SharedObjectHandle",
             "RemoteComponentHandle": "RemoteFluidObjectHandle",
-            "ComponentHandle": "FluidOjectHandle",
+            "ComponentHandle": "FluidObjectHandle",
             "ComponentSerializer": "FluidSerializer",
 
             "ComponentHandleContext": "FluidHandleContext",

--- a/examples/data-objects/codemirror/src/codemirror.ts
+++ b/examples/data-objects/codemirror/src/codemirror.ts
@@ -11,7 +11,7 @@ import {
     IResponse,
     IFluidHandle,
 } from "@fluidframework/core-interfaces";
-import { FluidOjectHandle, FluidDataStoreRuntime } from "@fluidframework/datastore";
+import { FluidObjectHandle, FluidDataStoreRuntime } from "@fluidframework/datastore";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
 import {
     MergeTreeDeltaType,
@@ -225,7 +225,7 @@ export class CodeMirrorComponent
     ) {
         super();
         this.url = context.id;
-        this.innerHandle = new FluidOjectHandle(this, this.url, runtime.IFluidHandleContext);
+        this.innerHandle = new FluidObjectHandle(this, this.url, runtime.IFluidHandleContext);
     }
 
     public async request(request: IRequest): Promise<IResponse> {

--- a/examples/data-objects/image-collection/src/images.ts
+++ b/examples/data-objects/image-collection/src/images.ts
@@ -11,7 +11,7 @@ import {
     IRequest,
     IResponse,
 } from "@fluidframework/core-interfaces";
-import { FluidOjectHandle } from "@fluidframework/datastore";
+import { FluidObjectHandle } from "@fluidframework/datastore";
 import { IFluidObjectCollection } from "@fluidframework/framework-interfaces";
 import { ISharedDirectory, SharedDirectory } from "@fluidframework/map";
 import { IFluidDataStoreContext, IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
@@ -32,10 +32,10 @@ export class ImageComponent implements
     public minimumHeightInline?: number;
     public readonly canInline = true;
     public readonly preferInline = false;
-    public handle: FluidOjectHandle;
+    public handle: FluidObjectHandle;
 
     constructor(public imageUrl: string, public url: string, path: string, context: IFluidHandleContext) {
-        this.handle = new FluidOjectHandle(this, path, context);
+        this.handle = new FluidObjectHandle(this, path, context);
     }
 
     public render(elm: HTMLElement, options?: IFluidHTMLOptions): void {

--- a/examples/data-objects/math/src/mathComponent.ts
+++ b/examples/data-objects/math/src/mathComponent.ts
@@ -16,7 +16,7 @@ import {
     IResponse,
     IFluidHandle,
 } from "@fluidframework/core-interfaces";
-import { FluidOjectHandle } from "@fluidframework/datastore";
+import { FluidObjectHandle } from "@fluidframework/datastore";
 import {
     IFluidObjectCollection,
 } from "@fluidframework/framework-interfaces";
@@ -418,7 +418,7 @@ export class MathInstance extends EventEmitter implements IFluidLoadable, IFluid
     public get IFluidLoadable() { return this; }
     public get IFluidRouter() { return this; }
 
-    public handle: FluidOjectHandle;
+    public handle: FluidObjectHandle;
     public endMarker: IMathMarkerInst;
     public startMarker: MergeTree.Marker;
     public solnText = "x=0";
@@ -433,7 +433,7 @@ export class MathInstance extends EventEmitter implements IFluidLoadable, IFluid
         inCombinedText = false,
     ) {
         super();
-        this.handle = new FluidOjectHandle(this, leafId, context);
+        this.handle = new FluidObjectHandle(this, leafId, context);
         this.initialize(inCombinedText);
     }
 

--- a/examples/data-objects/progress-bars/src/progressBars.ts
+++ b/examples/data-objects/progress-bars/src/progressBars.ts
@@ -12,7 +12,7 @@ import {
     IRequest,
     IResponse,
 } from "@fluidframework/core-interfaces";
-import { FluidOjectHandle, FluidDataStoreRuntime } from "@fluidframework/datastore";
+import { FluidObjectHandle, FluidDataStoreRuntime } from "@fluidframework/datastore";
 import { IFluidObjectCollection } from "@fluidframework/framework-interfaces";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
 import { IFluidDataStoreRuntime, IChannelFactory } from "@fluidframework/datastore-definitions";
@@ -80,7 +80,7 @@ export class ProgressBar extends EventEmitter implements
     IFluidLoadable,
     IFluidHTMLView,
     IFluidRouter {
-    public handle: FluidOjectHandle;
+    public handle: FluidObjectHandle;
 
     constructor(
         public value: number,
@@ -90,7 +90,7 @@ export class ProgressBar extends EventEmitter implements
         private readonly collection: ProgressCollection,
     ) {
         super();
-        this.handle = new FluidOjectHandle(this, keyId, context);
+        this.handle = new FluidObjectHandle(this, keyId, context);
     }
 
     public get IFluidLoadable() { return this; }
@@ -135,7 +135,7 @@ export class ProgressCollection
     public get IFluidObjectCollection() { return this; }
 
     public url: string;
-    public handle: FluidOjectHandle;
+    public handle: FluidObjectHandle;
 
     private readonly progressBars = new Map<string, ProgressBar>();
     private root: ISharedMap;
@@ -144,7 +144,7 @@ export class ProgressCollection
         super();
 
         this.url = context.id;
-        this.handle = new FluidOjectHandle(this, "", this.runtime.IFluidHandleContext);
+        this.handle = new FluidObjectHandle(this, "", this.runtime.IFluidHandleContext);
     }
 
     public changeValue(key: string, newValue: number) {

--- a/examples/data-objects/prosemirror/src/prosemirror.ts
+++ b/examples/data-objects/prosemirror/src/prosemirror.ts
@@ -11,7 +11,7 @@ import {
     IResponse,
     IFluidHandle,
 } from "@fluidframework/core-interfaces";
-import { FluidOjectHandle, FluidDataStoreRuntime } from "@fluidframework/datastore";
+import { FluidObjectHandle, FluidDataStoreRuntime } from "@fluidframework/datastore";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
 import {
     IMergeTreeInsertMsg,
@@ -127,7 +127,7 @@ export class ProseMirror extends EventEmitter
         super();
 
         this.url = context.id;
-        this.innerHandle = new FluidOjectHandle(this, this.url, runtime.IFluidHandleContext);
+        this.innerHandle = new FluidObjectHandle(this, this.url, runtime.IFluidHandleContext);
     }
 
     public async request(request: IRequest): Promise<IResponse> {

--- a/examples/data-objects/scribe/src/scribe.ts
+++ b/examples/data-objects/scribe/src/scribe.ts
@@ -12,7 +12,7 @@ import {
     IResponse,
     IFluidHandle,
 } from "@fluidframework/core-interfaces";
-import { FluidDataStoreRuntime, FluidOjectHandle } from "@fluidframework/datastore";
+import { FluidDataStoreRuntime, FluidObjectHandle } from "@fluidframework/datastore";
 import {
     IContainerContext,
     IFluidCodeDetails,
@@ -408,7 +408,7 @@ export class Scribe
         super();
 
         this.url = context.id;
-        this.innerHandle = new FluidOjectHandle(this, this.url, this.runtime.IFluidHandleContext);
+        this.innerHandle = new FluidObjectHandle(this, this.url, this.runtime.IFluidHandleContext);
     }
 
     public async request(request: IRequest): Promise<IResponse> {

--- a/examples/data-objects/shared-text/src/component.ts
+++ b/examples/data-objects/shared-text/src/component.ts
@@ -20,7 +20,7 @@ import {
     IResponse,
     IFluidRouter,
 } from "@fluidframework/core-interfaces";
-import { FluidDataStoreRuntime, FluidOjectHandle } from "@fluidframework/datastore";
+import { FluidDataStoreRuntime, FluidObjectHandle } from "@fluidframework/datastore";
 import { Ink } from "@fluidframework/ink";
 import {
     ISharedMap,
@@ -89,7 +89,7 @@ export class SharedTextRunner
         private readonly context: IFluidDataStoreContext,
     ) {
         super();
-        this.innerHandle = new FluidOjectHandle(this, this.url, this.runtime.IFluidHandleContext);
+        this.innerHandle = new FluidObjectHandle(this, this.url, this.runtime.IFluidHandleContext);
     }
 
     public render(element: HTMLElement) {

--- a/examples/data-objects/smde/src/smde.ts
+++ b/examples/data-objects/smde/src/smde.ts
@@ -13,7 +13,7 @@ import {
     IResponse,
     IFluidHandle,
 } from "@fluidframework/core-interfaces";
-import { FluidDataStoreRuntime, FluidOjectHandle } from "@fluidframework/datastore";
+import { FluidDataStoreRuntime, FluidObjectHandle } from "@fluidframework/datastore";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
 import {
     MergeTreeDeltaType,
@@ -66,7 +66,7 @@ export class Smde extends EventEmitter implements
         super();
 
         this.url = context.id;
-        this.innerHandle = new FluidOjectHandle(this, this.url, this.runtime.IFluidHandleContext);
+        this.innerHandle = new FluidObjectHandle(this, this.url, this.runtime.IFluidHandleContext);
     }
 
     public async request(request: IRequest): Promise<IResponse> {

--- a/examples/data-objects/video-players/src/videoPlayers.ts
+++ b/examples/data-objects/video-players/src/videoPlayers.ts
@@ -11,7 +11,7 @@ import {
     IRequest,
     IResponse,
 } from "@fluidframework/core-interfaces";
-import { FluidOjectHandle } from "@fluidframework/datastore";
+import { FluidObjectHandle } from "@fluidframework/datastore";
 import * as ClientUI from "@fluid-example/client-ui-lib";
 import { IFluidObjectCollection } from "@fluidframework/framework-interfaces";
 import { SharedDirectory, ISharedDirectory } from "@fluidframework/map";
@@ -90,7 +90,7 @@ export class VideoPlayer implements
     public readonly canInline = true;
     public readonly preferInline = false;
     public readonly preferPersistentElement = true;
-    public handle: FluidOjectHandle;
+    public handle: FluidObjectHandle;
 
     constructor(
         public videoId: string,
@@ -100,7 +100,7 @@ export class VideoPlayer implements
         private readonly youTubeApi: YouTubeAPI,
         private readonly collection: VideoPlayerCollection,
     ) {
-        this.handle = new FluidOjectHandle(this, keyId, context);
+        this.handle = new FluidObjectHandle(this, keyId, context);
     }
 
     public heightInLines() {

--- a/packages/dds/shared-object-base/src/handle.ts
+++ b/packages/dds/shared-object-base/src/handle.ts
@@ -8,18 +8,18 @@ import {
     IRequest,
     IResponse,
 } from "@fluidframework/core-interfaces";
-import { FluidOjectHandle } from "@fluidframework/datastore";
+import { FluidObjectHandle } from "@fluidframework/datastore";
 import { ISharedObject } from "./types";
 
 /**
  * Component handle for shared object
  * This object is used for already loaded (in-memory) shared object
  * and is used only for serialization purposes.
- * De-serialization process goes through FluidOjectHandle and request flow:
+ * De-serialization process goes through FluidObjectHandle and request flow:
  * FluidDataStoreRuntime.request() recognizes requests in the form of '/<shared object id>'
  * and loads shared object.
  */
-export class SharedObjectHandle extends FluidOjectHandle<ISharedObject> {
+export class SharedObjectHandle extends FluidObjectHandle<ISharedObject> {
     /**
      * Whether services have been attached for the associated shared object.
      */

--- a/packages/framework/aqueduct/src/data-objects/blobHandle.ts
+++ b/packages/framework/aqueduct/src/data-objects/blobHandle.ts
@@ -16,7 +16,7 @@ import { ISharedDirectory } from "@fluidframework/map";
 /**
  * This class represents blob (long string)
  * This object is used only when creating (writing) new blob and serialization purposes.
- * De-serialization process goes through FluidOjectHandle and request flow:
+ * De-serialization process goes through FluidObjectHandle and request flow:
  * DataObject.request() recognizes requests in the form of `/blobs/<id>`
  * and loads blob.
  */

--- a/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
@@ -15,7 +15,7 @@ import {
 import { AsyncFluidObjectProvider, FluidObjectKey } from "@fluidframework/synthesize";
 import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
-import { FluidOjectHandle } from "@fluidframework/datastore";
+import { FluidObjectHandle } from "@fluidframework/datastore";
 import { IDirectory } from "@fluidframework/map";
 import { EventForwarder } from "@fluidframework/common-utils";
 import { IEvent } from "@fluidframework/common-definitions";
@@ -82,10 +82,10 @@ export abstract class PureDataObject<P extends IFluidObject = object, S = undefi
         this.context = props.context;
         this.providers = props.providers;
 
-        // Create a FluidOjectHandle with empty string as `path`. This is because reaching this PureDataObject is the
+        // Create a FluidObjectHandle with empty string as `path`. This is because reaching this PureDataObject is the
         // same as reaching its routeContext (FluidDataStoreRuntime) so there is so the relative path to it from the
         // routeContext is empty.
-        this.innerHandle = new FluidOjectHandle(this, "", this.runtime.IFluidHandleContext);
+        this.innerHandle = new FluidObjectHandle(this, "", this.runtime.IFluidHandleContext);
 
         // Container event handlers
         this.runtime.once("dispose", () => {

--- a/packages/framework/component-base/src/sharedcomponent.ts
+++ b/packages/framework/component-base/src/sharedcomponent.ts
@@ -17,7 +17,7 @@ import {
 import {
     IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
-import { FluidOjectHandle } from "@fluidframework/datastore";
+import { FluidObjectHandle } from "@fluidframework/datastore";
 import { ISharedObject } from "@fluidframework/shared-object-base";
 import { EventForwarder } from "@fluidframework/common-utils";
 import { IEvent } from "@fluidframework/common-definitions";
@@ -62,9 +62,9 @@ export abstract class PureDataObject<
     // #region IFluidLoadable
 
     public get handle(): IFluidHandle<this> {
-        // Lazily create the FluidOjectHandle when requested.
+        // Lazily create the FluidObjectHandle when requested.
         if (!this._handle) {
-            this._handle = new FluidOjectHandle(
+            this._handle = new FluidObjectHandle(
                 this,
                 "",
                 this.runtime.IFluidHandleContext);

--- a/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
+++ b/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
@@ -10,7 +10,7 @@ import {
     IFluidLoadable,
     IFluidHandleContext,
 } from "@fluidframework/core-interfaces";
-import { FluidOjectHandle } from "@fluidframework/datastore";
+import { FluidObjectHandle } from "@fluidframework/datastore";
 
 import { DependencyContainer } from "..";
 
@@ -30,7 +30,7 @@ const mockHandleContext: IFluidHandleContext = {
 class MockLoadable implements IFluidLoadable {
     public get IFluidLoadable() { return this; }
     public get url() { return "url123"; }
-    public get handle() { return new FluidOjectHandle(this, "", mockHandleContext); }
+    public get handle() { return new FluidObjectHandle(this, "", mockHandleContext); }
 }
 
 class MockFluidConfiguration implements IFluidConfiguration {

--- a/packages/runtime/agent-scheduler/src/scheduler.ts
+++ b/packages/runtime/agent-scheduler/src/scheduler.ts
@@ -13,7 +13,7 @@ import {
     IRequest,
     IResponse,
 } from "@fluidframework/core-interfaces";
-import { FluidDataStoreRuntime, FluidOjectHandle } from "@fluidframework/datastore";
+import { FluidDataStoreRuntime, FluidObjectHandle } from "@fluidframework/datastore";
 import { LoaderHeader, AttachState } from "@fluidframework/container-definitions";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
 import { ConsensusRegisterCollection } from "@fluidframework/register-collection";
@@ -93,7 +93,7 @@ class AgentScheduler extends EventEmitter implements IAgentScheduler, IFluidRout
         private readonly context: IFluidDataStoreContext,
         private readonly scheduler: ConsensusRegisterCollection<string | null>) {
         super();
-        this.innerHandle = new FluidOjectHandle(this, this.url, this.runtime.IFluidHandleContext);
+        this.innerHandle = new FluidObjectHandle(this, this.url, this.runtime.IFluidHandleContext);
     }
 
     public async request(request: IRequest): Promise<IResponse> {
@@ -404,7 +404,7 @@ export class TaskManager implements ITaskManager {
         private readonly scheduler: IAgentScheduler,
         private readonly runtime: IFluidDataStoreRuntime,
         private readonly context: IFluidDataStoreContext) {
-        this.innerHandle = new FluidOjectHandle(this, this.url, this.runtime.IFluidHandleContext);
+        this.innerHandle = new FluidObjectHandle(this, this.url, this.runtime.IFluidHandleContext);
     }
 
     public async request(request: IRequest): Promise<IResponse> {

--- a/packages/runtime/container-runtime/src/summarizerHandle.ts
+++ b/packages/runtime/container-runtime/src/summarizerHandle.ts
@@ -2,11 +2,11 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { FluidOjectHandle } from "@fluidframework/datastore";
+import { FluidObjectHandle } from "@fluidframework/datastore";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 
-// TODO #2425 Expose Summarizer handle as FluidOjectHandle w/ tests
-export class SummarizerHandle extends FluidOjectHandle {
+// TODO #2425 Expose Summarizer handle as FluidObjectHandle w/ tests
+export class SummarizerHandle extends FluidObjectHandle {
     public async get(): Promise<any> {
         throw Error("Do not try to get a summarizer object from the handle. Reference it directly.");
     }

--- a/packages/runtime/datastore/src/fluidHandle.ts
+++ b/packages/runtime/datastore/src/fluidHandle.ts
@@ -11,7 +11,7 @@ import {
 import { AttachState } from "@fluidframework/container-definitions";
 import { generateHandleContextPath } from "@fluidframework/runtime-utils";
 
-export class FluidOjectHandle<T extends IFluidObject = IFluidObject> implements IFluidHandle {
+export class FluidObjectHandle<T extends IFluidObject = IFluidObject> implements IFluidHandle {
     // This is used to break the recursion while attaching the graph. Also tells the attach state of the graph.
     private graphAttachState: AttachState = AttachState.Detached;
     private bound: Set<IFluidHandle> | undefined;
@@ -24,7 +24,7 @@ export class FluidOjectHandle<T extends IFluidObject = IFluidObject> implements 
     }
 
     /**
-     * Creates a new FluidOjectHandle.
+     * Creates a new FluidObjectHandle.
      * @param value - The IFluidObject object this handle is for.
      * @param path - The path to this handle relative to the routeContext.
      * @param routeContext - The parent IFluidHandleContext that has a route to this handle.

--- a/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
+++ b/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
@@ -12,8 +12,8 @@ import {
 } from "@fluidframework/core-interfaces";
 
 /**
- * This handle is used to dynamically load a data store on a remote client and is created on parsing a seralized
- * FluidOjectHandle.
+ * This handle is used to dynamically load a data store on a remote client and is created on parsing a serialized
+ * FluidObjectHandle.
  * This class is used to generate an IFluidHandle when de-serializing Fluid Data Store and SharedObject handles
  * that are stored in SharedObjects. The Data Store or SharedObject corresponding to the IFluidHandle can be
  * retrieved by calling `get` on it.

--- a/packages/test/end-to-end-tests/src/test/componentHandle.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/componentHandle.spec.ts
@@ -22,7 +22,7 @@ import {
 } from "@fluidframework/test-utils";
 
 /**
- * Test component that extends DataObject so that we can test the FluidOjectHandle created by PureDataObject.
+ * Test component that extends DataObject so that we can test the FluidObjectHandle created by PureDataObject.
  */
 class TestSharedComponent extends DataObject {
     public get _root() {
@@ -44,7 +44,7 @@ const TestSharedComponentFactory = new DataObjectFactory(
     [SharedMap.getFactory()],
     []);
 
-describe("FluidOjectHandle", () => {
+describe("FluidObjectHandle", () => {
     const id = "fluid-test://localhost/componentHandleTest";
     const codeDetails: IFluidCodeDetails = {
         package: "componentHandleTestPackage",

--- a/packages/test/test-utils/src/testFluidComponent.ts
+++ b/packages/test/test-utils/src/testFluidComponent.ts
@@ -4,7 +4,7 @@
  */
 
 import { IRequest, IResponse, IFluidHandle } from "@fluidframework/core-interfaces";
-import { FluidOjectHandle, FluidDataStoreRuntime } from "@fluidframework/datastore";
+import { FluidObjectHandle, FluidDataStoreRuntime } from "@fluidframework/datastore";
 import { SharedMap, ISharedMap } from "@fluidframework/map";
 import {
     IFluidDataStoreContext,
@@ -59,7 +59,7 @@ export class TestFluidComponent implements ITestFluidComponent {
         private readonly factoryEntriesMap: Map<string, IChannelFactory>,
     ) {
         this.url = context.id;
-        this.innerHandle = new FluidOjectHandle(this, "", runtime.IFluidHandleContext);
+        this.innerHandle = new FluidObjectHandle(this, "", runtime.IFluidHandleContext);
     }
 
     /**


### PR DESCRIPTION
Porting the FluidObjectHandle spelling fix from 0.24.0 to master. These changes originate from #3060