### PR TITLE
Abstract out the container registry feed from the pipeline

### DIFF
--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -14,6 +14,10 @@ pr:
 pool:
   vmImage: 'ubuntu-latest'
 
+variables:
+- name: skipComponentGovernanceDetection
+  value: true
+
 steps:
 - task: UseNode@1
   displayName: Use Node 12.x

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -35,21 +35,29 @@ pr:
     - server/routerlicious/kubernetes/routerlicious
 
 variables:
-  skipComponentGovernanceDetection: true
-  pushImage: ${{
+- name: skipComponentGovernanceDetection
+  value: true
+- name: pushImage
+  value: ${{
     and(
-        ne(variables['Build.Reason'], 'PullRequest'),
-        eq(variables['Build.SourceBranch'], 'refs/heads/master')
+      ne(variables['Build.Reason'], 'PullRequest'),
+      eq(variables['Build.SourceBranch'], 'refs/heads/master')
     )}}
-  registry: prague.azurecr.io
-  containerName: prague-server
-  baseContainerName: $(containerName)-base
-  baseContainerTag: $(baseContainerName):$(Build.BuildNumber)
-  fullRunnerContainerTag: $(registry)/$(containerName):$(Build.BuildNumber)
-  ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-    testConfig: :full
-  ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-    testConfig: :ci
+- group: container-registry-info
+- name: containerName
+  value: fluid-server
+- name: baseContainerName
+  value: $(containerName)-base
+- name: baseContainerTag
+  value: $(baseContainerName):$(Build.BuildNumber)
+- name: fullRunnerContainerTag
+  value: $(containerRegistryUrl)/$(containerName):$(Build.BuildNumber)
+- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+  - name: testConfig
+    value: :full
+- ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+  - name: testConfig
+    value: :ci
 
 stages:
 - stage: build
@@ -195,7 +203,7 @@ stages:
           - task: Docker@2
             displayName: 'Docker Build - Runner'
             inputs:
-              containerRegistry: Fluid Azure Container Registry
+              containerRegistry: $(containerRegistryConnection)
               repository: $(containerName)
               command: build
               dockerFile: server/routerlicious/Dockerfile
@@ -207,7 +215,7 @@ stages:
           - task: Docker@2
             displayName: 'Docker Push - Runner'
             inputs:
-              containerRegistry: Fluid Azure Container Registry
+              containerRegistry: $(containerRegistryConnection)
               repository: $(containerName)
               command: push
               tags: |
@@ -250,6 +258,7 @@ stages:
         feeds:
         - name: https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/
           environment: fluid-feed
+          customEndPoint: Offnet Packages
           internal: false
         # only publish release bits
         - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}:

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -28,21 +28,25 @@ parameters:
 trigger: none
 
 variables:
-  skipComponentGovernanceDetection: true
-  pushImage: ${{
+- name: skipComponentGovernanceDetection
+  value: true
+- name: pushImage
+  value: ${{
     and(
       ne(variables['Build.Reason'], 'PullRequest'),
       eq(variables['Build.SourceBranch'], 'refs/heads/master')
     )}}
-  generateNotice: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
-  registry: prague.azurecr.io
-  baseContainerTag: ${{ parameters.containerName }}:$(Build.BuildNumber)
-  ${{ if eq(variables.pushImage, false) }}:
-    containerRegistry:
-    containerTag: $(baseContainerTag)
-  ${{ if eq(variables.pushImage, true) }}:
-    containerRegistry: Fluid Azure Container Registry
-    containerTag: $(registry)/$(baseContainerTag)
+- name: generateNotice
+  value: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
+- group: container-registry-info
+- name: baseContainerTag
+  value: ${{ parameters.containerName }}:$(Build.BuildNumber)
+- ${{ if eq(variables.pushImage, false) }}:
+  - name: containerTag
+    value: $(baseContainerTag)
+- ${{ if eq(variables.pushImage, true) }}:
+  - name: containerTag
+    value: $(containerRegistryUrl)/$(baseContainerTag)
 
 jobs:
   - job: build
@@ -81,7 +85,7 @@ jobs:
     - task: Docker@2
       displayName: Docker Build
       inputs:
-        containerRegistry: $(containerRegistry)
+        containerRegistry: $(containerRegistryConnection)
         repository: ${{ parameters.containerName }}
         command: build
         dockerFile: ${{ parameters.buildDirectory }}/Dockerfile
@@ -126,7 +130,7 @@ jobs:
       - task: Docker@2
         displayName: Docker Push
         inputs:
-          containerRegistry: $(containerRegistry)
+          containerRegistry: $(containerRegistryConnection)
           repository: ${{ parameters.containerName }}
           command: push
           tags: |

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -31,11 +31,7 @@ variables:
 - name: skipComponentGovernanceDetection
   value: true
 - name: pushImage
-  value: ${{
-    and(
-      ne(variables['Build.Reason'], 'PullRequest'),
-      eq(variables['Build.SourceBranch'], 'refs/heads/master')
-    )}}
+  value: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
 - name: generateNotice
   value: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
 - group: container-registry-info


### PR DESCRIPTION
Pass container registry information using variable group
Skip the injected component governance detection on repo policy check.
Fix missing customEndPoint to provide auth to publish to offnet feed for routerlicious pipeline
Rename routerlicious container image from prague-server to fluid-server  (docker-compose change will come later)