### PR TITLE
Disable GitHub actions on push and switch to Main pool

### DIFF
--- a/.github/workflows/azure-static-web-apps-polite-pebble-004dbbb10.yml
+++ b/.github/workflows/azure-static-web-apps-polite-pebble-004dbbb10.yml
@@ -1,18 +1,7 @@
 name: Azure Static Web Apps CI/CD
 
 on:
-  # push:
-  #   branches:
-  #     - docs/hugo
-  # pull_request:
-  #   types: [opened, synchronize, reopened, closed]
-  #   branches:
-  #     - docs/hugo
-  #     - main
-  #     - master
   repository_dispatch:
-    # all types
-  # workflow_dispatch:
     # all types
 
 jobs:

--- a/.github/workflows/azure-static-web-apps-polite-pebble-004dbbb10.yml
+++ b/.github/workflows/azure-static-web-apps-polite-pebble-004dbbb10.yml
@@ -1,16 +1,18 @@
 name: Azure Static Web Apps CI/CD
 
 on:
-  push:
-    branches:
-      - docs/hugo
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    branches:
-      - docs/hugo
+  # push:
+  #   branches:
+  #     - docs/hugo
+  # pull_request:
+  #   types: [opened, synchronize, reopened, closed]
+  #   branches:
+  #     - docs/hugo
+  #     - main
+  #     - master
   repository_dispatch:
     # all types
-  workflow_dispatch:
+  # workflow_dispatch:
     # all types
 
 jobs:

--- a/tools/pipelines/build-docs-latest.yml
+++ b/tools/pipelines/build-docs-latest.yml
@@ -54,7 +54,7 @@ resources:
 stages:
 - stage: build
   displayName: 'Build docs'
-  pool: Default
+  pool: Main
   jobs:
   - job:
     displayName: Component Detection


### PR DESCRIPTION
This will reduce noise in the actions until we merge to main.