### PR TITLE
Demonstrate replacing IFluidObject with unknown and using queryObject fn for feature detection

### DIFF
--- a/examples/data-objects/client-ui-lib/src/controls/flowView.ts
+++ b/examples/data-objects/client-ui-lib/src/controls/flowView.ts
@@ -7,6 +7,7 @@ import * as SearchMenu from "@fluid-example/search-menu";
 import * as api from "@fluid-internal/client-api";
 import { performanceNow } from "@fluidframework/common-utils";
 import {
+    queryObject,
     IFluidObject,
     IFluidHandle,
     IFluidLoadable,
@@ -4523,7 +4524,7 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
     public async insertComponentNew(prefix: string, chaincode: string, inline = false) {
         const router = await this.collabDocument.context.containerRuntime.createDataStore(chaincode);
         const object = await requestFluidObject(router, "");
-        const loadable = object.IFluidLoadable;
+        const loadable = queryObject(object).IFluidLoadable;
 
         const props = {
             crefTest: {
@@ -4588,7 +4589,7 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
     public insertNewCollectionComponent(collection: IFluidObjectCollection, inline = false) {
         // TODO - we may want to have a shared component collection?
         const instance = collection.createCollectionItem();
-        const loadable = instance.IFluidLoadable;
+        const loadable = queryObject(instance).IFluidLoadable;
 
         const props = {
             crefTest: {
@@ -4628,17 +4629,16 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
     private async openCollections() {
         const root = this.collabDocument.getRoot();
 
-        const [progressBars, math, videoPlayers, images] = await Promise.all([
+        const [progressBars, videoPlayers, images] = await Promise.all([
             root.get<IFluidHandle>("progressBars").get(),
-            root.get<IFluidHandle<IMathCollection>>("math").get(),
             root.get<IFluidHandle>("videoPlayers").get(),
             root.get<IFluidHandle>("images").get(),
         ]);
 
-        this.math = math;
-        this.progressBars = progressBars.IFluidObjectCollection;
-        this.videoPlayers = videoPlayers.IFluidObjectCollection;
-        this.images = images.IFluidObjectCollection;
+        this.math = await root.get<IFluidHandle<IMathCollection>>("math").get();
+        this.progressBars = queryObject(progressBars).IFluidObjectCollection;
+        this.videoPlayers = queryObject(videoPlayers).IFluidObjectCollection;
+        this.images = queryObject(images).IFluidObjectCollection;
     }
 
     private insertBlobInternal(blob: IGenericBlob) {

--- a/examples/data-objects/external-component-loader/src/externalComponentLoader.tsx
+++ b/examples/data-objects/external-component-loader/src/externalComponentLoader.tsx
@@ -68,7 +68,7 @@ export class ExternalComponentLoader extends DataObject {
         if (loadable === undefined) {
             throw new Error(`${componentUrl} must implement the IFluidLoadable interface to be loaded here`);
         }
-        const collection = (queryObject(obj) as IFluidObject).IFluidObjectCollection;
+        const collection = queryObject(obj).IFluidObjectCollection;
         if (collection !== undefined) {
             obj = collection.createCollectionItem();
             loadable = queryObject(obj).IFluidLoadable;

--- a/examples/data-objects/external-component-loader/src/externalComponentLoader.tsx
+++ b/examples/data-objects/external-component-loader/src/externalComponentLoader.tsx
@@ -5,6 +5,7 @@
 
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import {
+    queryObject,
     IFluidObject,
     IFluidLoadable,
     IFluidRouter,
@@ -63,16 +64,19 @@ export class ExternalComponentLoader extends DataObject {
         }
 
         let obj = await requestFluidObject(router, "/");
-        if (obj.IFluidLoadable === undefined) {
+        let loadable = queryObject(obj).IFluidLoadable;
+        if (loadable === undefined) {
             throw new Error(`${componentUrl} must implement the IFluidLoadable interface to be loaded here`);
         }
-        if (obj.IFluidObjectCollection !== undefined) {
-            obj = obj.IFluidObjectCollection.createCollectionItem();
-            if (obj.IFluidLoadable === undefined) {
+        const collection = (queryObject(obj) as IFluidObject).IFluidObjectCollection;
+        if (collection !== undefined) {
+            obj = collection.createCollectionItem();
+            loadable = queryObject(obj).IFluidLoadable;
+            if (loadable === undefined) {
                 throw new Error(`${componentUrl} must implement the IFluidLoadable interface to be loaded here`);
             }
         }
 
-        return obj.IFluidLoadable;
+        return loadable;
     }
 }

--- a/examples/data-objects/shared-text/src/component.ts
+++ b/examples/data-objects/shared-text/src/component.ts
@@ -13,6 +13,7 @@ import * as API from "@fluid-internal/client-api";
 import { SharedCell } from "@fluidframework/cell";
 import { performanceNow } from "@fluidframework/common-utils";
 import {
+    queryObject,
     IFluidObject,
     IFluidHandle,
     IFluidLoadable,
@@ -50,7 +51,7 @@ const debug = registerDebug("fluid:shared-text");
  */
 async function getHandle(runtimeP: Promise<IFluidRouter>): Promise<IFluidHandle> {
     const component = await requestFluidObject(await runtimeP, "");
-    return component.IFluidLoadable.handle;
+    return queryObject(component).IFluidLoadable.handle;
 }
 
 export class SharedTextRunner

--- a/examples/data-objects/vltava/src/components/anchor/anchor.ts
+++ b/examples/data-objects/vltava/src/components/anchor/anchor.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { IFluidHandle, queryObject } from "@fluidframework/core-interfaces";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import {
     IFluidLastEditedTracker,
@@ -56,11 +56,11 @@ export class Anchor extends DataObject implements IProvideFluidHTMLView, IProvid
 
     protected async hasInitialized() {
         this.defaultComponentInternal =
-            (await this.root.get<IFluidHandle>(this.defaultComponentId).get())
+            queryObject(await this.root.get<IFluidHandle>(this.defaultComponentId).get())
                 .IFluidHTMLView;
 
         this.lastEditedComponent =
-            (await this.root.get<IFluidHandle>(this.lastEditedComponentId).get())
+            queryObject(await this.root.get<IFluidHandle>(this.lastEditedComponentId).get())
                 .IFluidLastEditedTracker;
     }
 }

--- a/examples/hosts/hosts-sample/src/utils.ts
+++ b/examples/hosts/hosts-sample/src/utils.ts
@@ -4,7 +4,7 @@
  */
 
 import { parse } from "querystring";
-import { IFluidObject } from "@fluidframework/core-interfaces";
+import { queryObject } from "@fluidframework/core-interfaces";
 import { IFluidCodeDetails } from "@fluidframework/container-definitions";
 import { Container, Loader } from "@fluidframework/container-loader";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
@@ -44,9 +44,8 @@ async function attachCore(loader: Loader, url: string, div: HTMLDivElement) {
         return;
     }
 
-    const component = response.value as IFluidObject;
     // Try to render the component if it is a view
-    const view: IFluidHTMLView | undefined = component.IFluidHTMLView;
+    const view: IFluidHTMLView | undefined = queryObject(response.value).IFluidHTMLView;
     if (view !== undefined) {
         view.render(div, { display: "block" });
     }

--- a/packages/framework/framework-interfaces/src/collection.ts
+++ b/packages/framework/framework-interfaces/src/collection.ts
@@ -8,6 +8,8 @@ import { IFluidObject } from "@fluidframework/core-interfaces";
 declare module "@fluidframework/core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
     export interface IFluidObject extends Readonly<Partial<IProvideFluidObjectCollection>> { }
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    export interface FluidDataInterfaceCatalog extends Readonly<IProvideFluidObjectCollection> { }
 }
 
 export const IFluidObjectCollection: keyof IProvideFluidObjectCollection = "IFluidObjectCollection";
@@ -21,7 +23,7 @@ export interface IProvideFluidObjectCollection {
  * components in the collection would be like-typed.
  */
 export interface IFluidObjectCollection extends IProvideFluidObjectCollection {
-    createCollectionItem<TOpt = object>(options?: TOpt): IFluidObject;
-    removeCollectionItem(instance: IFluidObject): void;
+    createCollectionItem<TOpt = object>(options?: TOpt): unknown;
+    removeCollectionItem(instance: unknown): void;
     // Need iteration
 }

--- a/packages/framework/framework-interfaces/src/collection.ts
+++ b/packages/framework/framework-interfaces/src/collection.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidObject } from "@fluidframework/core-interfaces";
+// import { IFluidObject } from "@fluidframework/core-interfaces";
 
 declare module "@fluidframework/core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/packages/framework/last-edited-experimental/src/interfaces.ts
+++ b/packages/framework/last-edited-experimental/src/interfaces.ts
@@ -8,6 +8,8 @@ import { IUser } from "@fluidframework/protocol-definitions";
 declare module "@fluidframework/core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
     export interface IFluidObject extends Readonly<Partial<IProvideFluidLastEditedTracker>> { }
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    export interface FluidDataInterfaceCatalog extends Readonly<IProvideFluidLastEditedTracker> { }
 }
 
 export const IFluidLastEditedTracker: keyof IProvideFluidLastEditedTracker = "IFluidLastEditedTracker";

--- a/packages/framework/react/src/helpers/getFluidState.ts
+++ b/packages/framework/react/src/helpers/getFluidState.ts
@@ -4,7 +4,7 @@
  */
 
 import {
-    IFluidObject,
+    queryObject,
     IFluidHandle,
 } from "@fluidframework/core-interfaces";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
@@ -51,8 +51,7 @@ export function getFluidState<
             ?.sharedObjectCreate;
         let value = fluidObjectState.get(fluidKey);
         if (value !== undefined && createCallback !== undefined) {
-            const possibleFluidObjectId = (value as IFluidObject)
-                ?.IFluidHandle?.absolutePath;
+            const possibleFluidObjectId = queryObject(value).IFluidHandle?.absolutePath;
             if (possibleFluidObjectId !== undefined) {
                 value = (fluidObjectMap.get(possibleFluidObjectId)) as IFluidObjectMapItem;
                 fluidState[fluidKey] = value?.fluidObject;

--- a/packages/framework/view-adapters/src/htmlview/htmlViewAdapter.tsx
+++ b/packages/framework/view-adapters/src/htmlview/htmlViewAdapter.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidObject } from "@fluidframework/core-interfaces";
+import { queryObject } from "@fluidframework/core-interfaces";
 import {
     IFluidHTMLView,
     IFluidHTMLOptions,
@@ -22,10 +22,11 @@ export class HTMLViewAdapter implements IFluidHTMLView {
      * Test whether the given view can be successfully adapted by an HTMLViewAdapter.
      * @param view - the view to test if it is adaptable.
      */
-    public static canAdapt(view: IFluidObject) {
+    public static canAdapt(view: unknown) {
+        const viewObj = view as object;
         return (
-            React.isValidElement(view)
-            || view.IFluidHTMLView !== undefined
+            React.isValidElement(viewObj)
+            || queryObject(viewObj).IFluidHTMLView !== undefined
         );
     }
 
@@ -35,17 +36,19 @@ export class HTMLViewAdapter implements IFluidHTMLView {
      */
     private containerNode: HTMLElement | undefined;
 
+    private readonly view: object;
+
     /**
      * @param view - The view to adapt into an IFluidHTMLView
      */
-    constructor(private readonly view: IFluidObject) { }
+    constructor(view: unknown) { this.view = view as object; }
 
     public render(elm: HTMLElement, options?: IFluidHTMLOptions) {
         // Note that if we're already mounted, this can cause multiple rendering with possibly unintended effects.
         // Probably try to avoid doing this.
         this.containerNode = elm;
 
-        const htmlView = this.view.IFluidHTMLView;
+        const htmlView = queryObject(this.view).IFluidHTMLView;
         if (htmlView !== undefined) {
             htmlView.render(elm, options);
             return;
@@ -80,7 +83,7 @@ export class HTMLViewAdapter implements IFluidHTMLView {
             return;
         }
 
-        const htmlView = this.view.IFluidHTMLView;
+        const htmlView = queryObject(this.view).IFluidHTMLView;
         if (htmlView !== undefined && htmlView.remove !== undefined) {
             htmlView.remove();
             this.containerNode = undefined;

--- a/packages/framework/view-interfaces/src/htmlView.ts
+++ b/packages/framework/view-interfaces/src/htmlView.ts
@@ -40,5 +40,7 @@ declare module "@fluidframework/core-interfaces" {
     /* eslint-disable @typescript-eslint/no-empty-interface */
     export interface IFluidObject extends
         Readonly<Partial<IProvideFluidHTMLView>> { }
+    export interface FluidDataInterfaceCatalog extends
+        Readonly<IProvideFluidHTMLView> { }
     /* eslint-enable @typescript-eslint/no-empty-interface */
 }

--- a/packages/framework/view-interfaces/src/mountableView.ts
+++ b/packages/framework/view-interfaces/src/mountableView.ts
@@ -53,4 +53,6 @@ export interface IFluidMountableView extends IProvideFluidMountableView {
 declare module "@fluidframework/core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
     export interface IFluidObject extends Readonly<Partial<IProvideFluidMountableView>> { }
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    export interface FluidDataInterfaceCatalog extends Readonly<IProvideFluidMountableView> { }
 }

--- a/packages/hosts/base-host/src/host.ts
+++ b/packages/hosts/base-host/src/host.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidObject } from "@fluidframework/core-interfaces";
 import {
     IFluidCodeDetails,
     IProxyLoaderFactory,
@@ -99,6 +98,6 @@ export class BaseHost {
             return undefined;
         }
 
-        return response.value as IFluidObject;
+        return response.value as unknown;
     }
 }

--- a/packages/loader/core-interfaces/src/fluidObject.ts
+++ b/packages/loader/core-interfaces/src/fluidObject.ts
@@ -13,6 +13,7 @@ import { IProvideFluidHandle, IProvideFluidHandleContext } from "./handles";
 import { IProvideFluidSerializer } from "./serializer";
 
 /* eslint-disable @typescript-eslint/no-empty-interface */
+// TODO: Remove once all usages are moved over to FluidDataInterfaceCatalog
 export interface IFluidObject extends
     Readonly<Partial<
         IProvideFluidLoadable
@@ -23,4 +24,18 @@ export interface IFluidObject extends
         & IProvideFluidHandle
         & IProvideFluidSerializer>> {
 }
+
+export interface FluidDataInterfaceCatalog extends
+    Readonly<
+        IProvideFluidLoadable
+        & IProvideFluidRunnable
+        & IProvideFluidRouter
+        & IProvideFluidHandleContext
+        & IProvideFluidConfiguration
+        & IProvideFluidHandle
+        & IProvideFluidSerializer> {
+}
 /* eslint-enable @typescript-eslint/no-empty-interface */
+
+/** Prepare the given object to be queried for the interfaces in the Fluid Data Interface Catalog */
+export const queryObject = (obj: unknown) => obj as Partial<FluidDataInterfaceCatalog>;

--- a/packages/loader/core-interfaces/src/handles.ts
+++ b/packages/loader/core-interfaces/src/handles.ts
@@ -51,8 +51,8 @@ export interface IProvideFluidHandle {
  * Handle to a shared FluidObject
  */
 export interface IFluidHandle<
-    // REVIEW: Constrain `T` to `IFluidObject & IFluidLoadable`?
-    T = IFluidObject & IFluidLoadable
+    // REVIEW: Constrain `T` to `T extends IFluidLoadable`?
+    T = unknown & IFluidLoadable
     > extends IProvideFluidHandle {
 
     /**

--- a/packages/loader/core-interfaces/src/handles.ts
+++ b/packages/loader/core-interfaces/src/handles.ts
@@ -4,7 +4,7 @@
  */
 
 import { IRequest, IResponse } from "./fluidRouter";
-import { IFluidObject } from "./fluidObject";
+// import { IFluidObject } from "./fluidObject";
 import { IFluidLoadable } from "./fluidLoadable";
 
 export const IFluidHandleContext: keyof IProvideFluidHandleContext = "IFluidHandleContext";

--- a/packages/loader/core-interfaces/src/index.ts
+++ b/packages/loader/core-interfaces/src/index.ts
@@ -5,7 +5,7 @@
 
 // when merging declarations the module path must match exactly. Because of this we need to explicitly export
 // IFluidObject as opposed to an export *
-export { IFluidObject } from "./fluidObject";
+export { IFluidObject, FluidDataInterfaceCatalog, queryObject } from "./fluidObject";
 
 export * from "./fluidLoadable";
 export * from "./fluidRouter";

--- a/packages/runtime/agent-scheduler/src/scheduler.ts
+++ b/packages/runtime/agent-scheduler/src/scheduler.ts
@@ -6,7 +6,7 @@
 import assert from "assert";
 import { EventEmitter } from "events";
 import {
-    IFluidObject,
+    queryObject,
     IFluidHandle,
     IFluidRouter,
     IFluidRunnable,
@@ -464,8 +464,7 @@ export class TaskManager implements ITaskManager {
             return Promise.reject(`Invalid agent route: ${url}`);
         }
 
-        const fluidObject = response.value as IFluidObject;
-        const agent = fluidObject.IFluidRunnable;
+        const agent = queryObject(response.value).IFluidRunnable;
         if (agent === undefined) {
             return Promise.reject("Fluid object does not implement IFluidRunnable");
         }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -8,7 +8,6 @@ import { EventEmitter } from "events";
 import { AgentSchedulerFactory } from "@fluidframework/agent-scheduler";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import {
-    queryObject,
     IFluidObject,
     IFluidRouter,
     IFluidHandleContext,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -8,6 +8,7 @@ import { EventEmitter } from "events";
 import { AgentSchedulerFactory } from "@fluidframework/agent-scheduler";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import {
+    queryObject,
     IFluidObject,
     IFluidRouter,
     IFluidHandleContext,

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -44,6 +44,8 @@ const minOpsForLastSummary = 50;
 declare module "@fluidframework/core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
     export interface IFluidObject extends Readonly<Partial<IProvideSummarizer>> { }
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    export interface FluidDataInterfaceCatalog extends Readonly<IProvideSummarizer> { }
 }
 
 export const ISummarizer: keyof IProvideSummarizer = "ISummarizer";

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -13,7 +13,7 @@ import {
     IPromiseTimerResult,
 } from "@fluidframework/common-utils";
 import { ChildLogger, PerformanceEvent } from "@fluidframework/telemetry-utils";
-import { IFluidObject, IRequest, DriverHeader } from "@fluidframework/core-interfaces";
+import { queryObject, IRequest, DriverHeader } from "@fluidframework/core-interfaces";
 import {
     IContainerContext,
     LoaderHeader,
@@ -443,8 +443,7 @@ export class SummaryManager extends EventEmitter implements IDisposable {
             return Promise.reject<ISummarizer>("Invalid summarizer route");
         }
 
-        const rawFluidObject = response.value as IFluidObject;
-        const summarizer = rawFluidObject.ISummarizer;
+        const summarizer = queryObject(response.value).ISummarizer;
 
         if (!summarizer) {
             return Promise.reject<ISummarizer>("Fluid object does not implement ISummarizer");

--- a/packages/runtime/runtime-definitions/src/agent.ts
+++ b/packages/runtime/runtime-definitions/src/agent.ts
@@ -118,4 +118,7 @@ declare module "@fluidframework/core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
     export interface IFluidObject extends
         Readonly<Partial<IProvideTaskManager & IProvideAgentScheduler>> { }
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    export interface FluidDataInterfaceCatalog extends
+        Readonly<IProvideTaskManager & IProvideAgentScheduler> { }
 }

--- a/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
+++ b/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
@@ -18,5 +18,5 @@ export async function requestFluidObject<T = unknown>(
     }
 
     assert(response.value);
-    return response.value as T;
+    return response.value as T;  //* Fishy... non-type safe cast, but to the caller it feels so good!
 }

--- a/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
+++ b/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
@@ -4,12 +4,11 @@
  */
 import assert from "assert";
 import {
-    IFluidObject,
     IFluidRouter,
     IRequest,
 } from "@fluidframework/core-interfaces";
 
-export async function requestFluidObject<T = IFluidObject>(
+export async function requestFluidObject<T = unknown>(
     router: IFluidRouter, url: string | IRequest): Promise<T> {
     const request = typeof url === "string" ? { url } : url;
     const response = await router.request(request);

--- a/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
+++ b/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
@@ -44,12 +44,12 @@ export class RemoteFluidObjectHandle implements IFluidHandle {
         return this.absolutePath;
     }
 
-    public async get(): Promise<any> {
+    public async get(): Promise<unknown> {
         if (this.dataStoreP === undefined) {
             this.dataStoreP = this.routeContext.resolveHandle({ url: this.absolutePath })
-                .then<IFluidObject>((response) =>
+                .then<unknown>((response) =>
                     response.mimeType === "fluid/object"
-                        ? response.value as IFluidObject
+                        ? response.value as unknown
                         : Promise.reject("Not found"));
         }
 

--- a/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
+++ b/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
@@ -9,6 +9,7 @@ import {
     IFluidHandleContext,
     IRequest,
     IResponse,
+    IFluidLoadable,
 } from "@fluidframework/core-interfaces";
 
 /**
@@ -24,7 +25,7 @@ export class RemoteFluidObjectHandle implements IFluidHandle {
     public get IFluidHandle() { return this; }
 
     public readonly isAttached = true;
-    private dataStoreP: Promise<IFluidObject> | undefined;
+    private dataStoreP: Promise<IFluidLoadable> | undefined;
 
     /**
      * Creates a new RemoteFluidObjectHandle when parsing an IFluidHandle.
@@ -44,12 +45,13 @@ export class RemoteFluidObjectHandle implements IFluidHandle {
         return this.absolutePath;
     }
 
-    public async get(): Promise<unknown> {
+    public async get(): Promise<IFluidLoadable> {
         if (this.dataStoreP === undefined) {
-            this.dataStoreP = this.routeContext.resolveHandle({ url: this.absolutePath })
-                .then<unknown>((response) =>
+            this.dataStoreP =
+                this.routeContext.resolveHandle({ url: this.absolutePath })
+                .then<IFluidLoadable>((response) =>
                     response.mimeType === "fluid/object"
-                        ? response.value as unknown
+                        ? response.value as IFluidLoadable  //* Fishy...
                         : Promise.reject("Not found"));
         }
 

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -22,7 +22,7 @@ import { IUser } from "@fluidframework/protocol-definitions";
 import { HTMLViewAdapter } from "@fluidframework/view-adapters";
 import { IFluidMountableView } from "@fluidframework/view-interfaces";
 import { extractPackageIdentifierDetails, WebCodeLoader } from "@fluidframework/web-code-loader";
-import { IFluidObject } from "@fluidframework/core-interfaces";
+import { queryObject } from "@fluidframework/core-interfaces";
 import { RequestParser } from "@fluidframework/runtime-utils";
 import { MultiUrlResolver } from "./multiResolver";
 import { getDocumentServiceFactory } from "./multiDocumentServiceFactory";
@@ -280,14 +280,14 @@ async function getFluidObjectAndRender(container: Container, url: string, div: H
         return false;
     }
 
-    const fluidObject = response.value as IFluidObject;
+    const fluidObject = response.value;
     if (fluidObject === undefined) {
         return;
     }
 
     // We should be retaining a reference to mountableView long-term, so we can call unmount() on it to correctly
     // remove it from the DOM if needed.
-    const mountableView: IFluidMountableView = fluidObject.IFluidMountableView;
+    const mountableView: IFluidMountableView = queryObject(fluidObject).IFluidMountableView;
     if (mountableView !== undefined) {
         mountableView.mount(div);
         return;


### PR DESCRIPTION
This is collateral for a post I made in Teams, about using different syntax for feature detection that is hopefully more self-descriptive and easier to learn/understand.

The gist is to change `(obj as IFluidObject).IFoo` to `queryObject(obj).IFoo`, and replace the type `IFluidObject` with `unknown` throughout. And new interfaces you want to be able to query get registered to a type called `FluidDataInterfaceCatalog`.  See the core changes [here](https://github.com/microsoft/FluidFramework/pull/3238/files#diff-2341867e9c2c07b7cb27354b33af8bb0), the rest is updating usages.

It's an incomplete change, but shows a few different places that IFluidObject appears and how it could be changed.