### PR TITLE
Disable component detection/notice generation, docker image publishing and npm package publishing in any public CI run.

### DIFF
--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -37,14 +37,7 @@ pr:
     - server/routerlicious/kubernetes/routerlicious
 
 variables:
-- name: skipComponentGovernanceDetection
-  value: true
-- name: pushImage
-  value: ${{
-    and(
-      ne(variables['Build.Reason'], 'PullRequest'),
-      eq(variables['Build.SourceBranch'], 'refs/heads/master')
-    )}}
+- template: templates/include-vars.yml
 - group: container-registry-info
 - name: containerName
   value: fluid-server
@@ -92,7 +85,7 @@ stages:
             version: 12.x
 
         # Component detection (not pull request)
-        - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+        - ${{ if eq(variables.componentDetection, true) }}:
           - task: npmAuthenticate@0
             displayName: 'npm Authenticate root .npmrc'
             inputs:

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -249,7 +249,7 @@ stages:
           condition: succeededOrFailed()
 
 # Publish stage
-- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+- ${{ if eq(variables.publish, true) }}:
   - stage: publish
     dependsOn: build
     displayName: Publish Stage

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -36,19 +36,18 @@ parameters:
 trigger: none
 
 variables:
-- name: skipComponentGovernanceDetection
-  value: true
-- name: pushImage
-  value: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
-- name: generateNotice
-  value: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
+- template: include-vars.yml
 - group: container-registry-info
 - name: baseContainerTag
   value: ${{ parameters.containerName }}:$(Build.BuildNumber)
 - ${{ if eq(variables.pushImage, false) }}:
+  - name: containerRegistry
+    value:
   - name: containerTag
     value: $(baseContainerTag)
 - ${{ if eq(variables.pushImage, true) }}:
+  - name: containerRegistry
+    value: $(containerRegistryConnection)
   - name: containerTag
     value: $(containerRegistryUrl)/$(baseContainerTag)
 
@@ -63,8 +62,8 @@ jobs:
       lfs: false
       submodules: false
 
-    # Component detection (not pull request)
-    - ${{ if eq(variables.generateNotice, true) }}:
+    # Component detection
+    - ${{ if eq(variables.componentDetection, true) }}:
       - template: include-generate-notice-steps.yml
         parameters:
           buildDirectory: ${{ parameters.buildDirectory }}
@@ -100,7 +99,7 @@ jobs:
     - task: Docker@2
       displayName: Docker Build
       inputs:
-        containerRegistry: $(containerRegistryConnection)
+        containerRegistry: $(containerRegistry)
         repository: ${{ parameters.containerName }}
         command: build
         dockerFile: ${{ parameters.buildDirectory }}/Dockerfile

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -66,7 +66,7 @@ parameters:
 trigger: none
 
 variables:
-  skipComponentGovernanceDetection: true
+  - template: include-vars.yml
 
 stages:
   - stage: build
@@ -250,7 +250,7 @@ stages:
               publishLocation: 'Container'
 
       # Job - Component detection
-      - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+      - ${{ if eq(variables.componentDetection, true) }}:
         - job: CG
           displayName: Component Detection
           pool: ${{ parameters.poolCG }}
@@ -271,7 +271,7 @@ stages:
               alertWarningLevel: High
 
   # Publish stage
-  - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+  - ${{ if eq(variables.publish, true) }}:
     - stage: publish
       dependsOn: build
       displayName: Publish Stage

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -1,0 +1,22 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# common variables
+
+variables:
+- name: skipComponentGovernanceDetection
+  value: true
+- name: publish
+  value: ${{
+    and(
+      ne(variables['Build.Reason'], 'PullRequest'),
+      ne(variables['System.TeamProject'], 'public')
+    )}}
+- name: componentDetection
+  value: ${{ variables.publish }}
+- name: pushImage
+  value: ${{
+    and(
+      variables.publish,
+      eq(variables['Build.SourceBranch'], 'refs/heads/master')
+    )}}


### PR DESCRIPTION
Disable component detection/notice generation, docker image publishing and npm package publishing in any public CI run.

Also refactor these variables to be shared.