### PR TITLE
Remove usages of process.hrtime

### DIFF
--- a/common/lib/common-utils/src/trace.ts
+++ b/common/lib/common-utils/src/trace.ts
@@ -7,6 +7,7 @@ import { performanceNow } from "./performanceNowNode";
 
 /**
  * Helper class for tracing performance of events
+ * Time measurements are in milliseconds as a floating point with a decimal
  */
 export class Trace {
     public static start(): Trace {
@@ -37,10 +38,12 @@ export class Trace {
 export interface ITraceEvent {
     /**
      * Total time elapsed since the start of the Trace.
+     * Measured in milliseconds as a floating point with a decimal
      */
     readonly totalTimeElapsed: number;
     /**
      * Time elapsed since the last trace event.
+     * Measured in milliseconds as a floating point with a decimal
      */
     readonly duration: number;
     /**

--- a/packages/dds/merge-tree/src/collections.ts
+++ b/packages/dds/merge-tree/src/collections.ts
@@ -1028,7 +1028,7 @@ export class IntervalTree<T extends IInterval> implements IRBAugmentation<T, Aug
     intervals = new RedBlackTree<T, AugmentedIntervalNode>(intervalComparer, this);
     diag = false;
     timePut = false;
-    putTime = 0; // ms
+    putTime = 0;
     putCount = 0;
 
     printTiming() {
@@ -1052,7 +1052,7 @@ export class IntervalTree<T extends IInterval> implements IRBAugmentation<T, Aug
         if (this.timePut) {
             const trace = Trace.start();
             this.intervals.put(x, { minmax: x.clone() }, rbConflict);
-            this.putTime += trace.trace().duration;
+            this.putTime += trace.trace().duration * 1000;
             this.putCount++;
         } else {
             this.intervals.put(x, { minmax: x.clone() }, rbConflict);

--- a/packages/dds/merge-tree/src/collections.ts
+++ b/packages/dds/merge-tree/src/collections.ts
@@ -6,6 +6,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions, eqeqeq, object-shorthand */
 /* eslint-disable no-bitwise, no-param-reassign */
 
+import { Trace } from "@fluidframework/common-utils";
 import * as Base from "./base";
 import * as MergeTree from "./mergeTree";
 
@@ -1027,7 +1028,7 @@ export class IntervalTree<T extends IInterval> implements IRBAugmentation<T, Aug
     intervals = new RedBlackTree<T, AugmentedIntervalNode>(intervalComparer, this);
     diag = false;
     timePut = false;
-    putTime = 0;
+    putTime = 0; // ms
     putCount = 0;
 
     printTiming() {
@@ -1049,9 +1050,9 @@ export class IntervalTree<T extends IInterval> implements IRBAugmentation<T, Aug
             };
         }
         if (this.timePut) {
-            const clockStart = MergeTree.clock();
+            const trace = Trace.start();
             this.intervals.put(x, { minmax: x.clone() }, rbConflict);
-            this.putTime += MergeTree.elapsedMicroseconds(clockStart);
+            this.putTime += trace.trace().duration;
             this.putCount++;
         } else {
             this.intervals.put(x, { minmax: x.clone() }, rbConflict);

--- a/packages/dds/merge-tree/src/test/beastTest.ts
+++ b/packages/dds/merge-tree/src/test/beastTest.ts
@@ -8,6 +8,7 @@
 import assert from "assert";
 import fs from "fs";
 import path from "path";
+import { Trace } from "@fluidframework/common-utils";
 import { DebugLogger } from "@fluidframework/telemetry-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -63,24 +64,9 @@ export function simpleTest() {
     printStringProperty(beast.get("Chameleon"));
 }
 
-const clock = () => process.hrtime();
-
-function took(desc: string, start: [number, number]) {
-    // let end: number[] = process.hrtime(start);
-    const duration = elapsedMilliseconds(start);
+function took(desc: string, start: Trace) {
+    const duration = start.trace().duration;
     log(`${desc} took ${duration} ms`);
-    return duration;
-}
-
-function elapsedMilliseconds(start: [number, number]) {
-    const end: number[] = process.hrtime(start);
-    const duration = Math.round((end[0] * 1000) + (end[1] / 1000000));
-    return duration;
-}
-
-function elapsedMicroseconds(start: [number, number]) {
-    const end: number[] = process.hrtime(start);
-    const duration = Math.round((end[0] * 1000000) + (end[1] / 1000));
     return duration;
 }
 
@@ -102,7 +88,7 @@ export function integerTest1() {
         return { data: currentKey };
     }
     let conflictCount = 0;
-    let start = clock();
+    let start = Trace.start();
     while (i < intCount) {
         pos[i] = randInt();
         beast.put(pos[i], i, onConflict);
@@ -116,7 +102,7 @@ export function integerTest1() {
     }
     took("test gen", start);
     const errorCount = 0;
-    start = clock();
+    start = Trace.start();
     for (let j = 0, len = pos.length; j < len; j++) {
         const cp = pos[j];
         /* let prop = */ beast.get(cp);
@@ -196,7 +182,7 @@ function editFlat(source: string, s: number, dl: number, nt = "") {
     return source.substring(0, s) + nt + source.substring(s + dl, source.length);
 }
 
-let accumTime = 0;
+let accumTime = 0; // ms
 
 function checkInsertMergeTree(
     mergeTree: MergeTree.MergeTree,
@@ -204,10 +190,10 @@ function checkInsertMergeTree(
     verbose = false) {
     let checkText = new MergeTree.MergeTreeTextHelper(mergeTree).getText(UniversalSequenceNumber, LocalClientId);
     checkText = editFlat(checkText, pos, 0, textSegment.text);
-    const clockStart = clock();
+    const traceStart = Trace.start();
     insertText(mergeTree, pos, UniversalSequenceNumber, LocalClientId, UniversalSequenceNumber,
         textSegment.text, undefined, undefined);
-    accumTime += elapsedMicroseconds(clockStart);
+    accumTime += traceStart.trace().duration;
     const updatedText = new MergeTree.MergeTreeTextHelper(mergeTree).getText(UniversalSequenceNumber, LocalClientId);
     const result = (checkText == updatedText);
     if ((!result) && verbose) {
@@ -221,9 +207,9 @@ function checkMarkRemoveMergeTree(mergeTree: MergeTree.MergeTree, start: number,
     const helper = new MergeTree.MergeTreeTextHelper(mergeTree);
     const origText = helper.getText(UniversalSequenceNumber, LocalClientId);
     const checkText = editFlat(origText, start, end - start);
-    const clockStart = clock();
+    const traceStart = Trace.start();
     mergeTree.markRangeRemoved(start, end, UniversalSequenceNumber, LocalClientId, UniversalSequenceNumber, false, undefined);
-    accumTime += elapsedMicroseconds(clockStart);
+    accumTime += traceStart.trace().duration;
     const updatedText = helper.getText(UniversalSequenceNumber, LocalClientId);
     const result = (checkText == updatedText);
     if ((!result) && verbose) {
@@ -279,16 +265,16 @@ export function mergeTreeLargeTest() {
         const s = randomString(slen, String.fromCharCode(48 + slen));
         const preLen = mergeTree.getLength(UniversalSequenceNumber, LocalClientId);
         const pos = random.integer(0, preLen)(mt);
-        const clockStart = clock();
+        const traceStart = Trace.start();
         insertText(mergeTree, pos, UniversalSequenceNumber, LocalClientId, UniversalSequenceNumber,
             s, undefined, undefined);
-        accumTime += elapsedMicroseconds(clockStart);
+        accumTime += traceStart.trace().duration;
         if ((i > 0) && (0 == (i % 50000))) {
             const perIter = (accumTime / (i + 1)).toFixed(3);
             treeCount++;
             accumTreeSize += mergeTree.getLength(UniversalSequenceNumber, LocalClientId);
             const averageTreeSize = (accumTreeSize / treeCount).toFixed(3);
-            log(`i: ${i} time: ${accumTime}us which is average ${perIter} per insert with average tree size ${averageTreeSize}`);
+            log(`i: ${i} time: ${accumTime}ms which is average ${perIter} per insert with average tree size ${averageTreeSize}`);
         }
     }
     log(process.memoryUsage().heapUsed);
@@ -300,16 +286,16 @@ export function mergeTreeLargeTest() {
         const preLen = mergeTree.getLength(UniversalSequenceNumber, LocalClientId);
         const pos = random.integer(0, preLen)(mt);
         // Log(itree.toString());
-        const clockStart = clock();
+        const traceStart = Trace.start();
         mergeTree.markRangeRemoved(pos, pos + dlen, UniversalSequenceNumber, LocalClientId, UniversalSequenceNumber, false, undefined);
-        accumTime += elapsedMicroseconds(clockStart);
+        accumTime += traceStart.trace().duration;
 
         if ((i > 0) && (0 == (i % 50000))) {
             const perIter = (accumTime / (i + 1)).toFixed(3);
             treeCount++;
             accumTreeSize += mergeTree.getLength(UniversalSequenceNumber, LocalClientId);
             const averageTreeSize = (accumTreeSize / treeCount).toFixed(3);
-            log(`i: ${i} time: ${accumTime}us which is average ${perIter} per del with average tree size ${averageTreeSize}`);
+            log(`i: ${i} time: ${accumTime}ms which is average ${perIter} per del with average tree size ${averageTreeSize}`);
         }
     }
 }
@@ -355,7 +341,7 @@ export function mergeTreeCheckedTest() {
             treeCount++;
             accumTreeSize += mergeTree.getLength(UniversalSequenceNumber, LocalClientId);
             const averageTreeSize = (accumTreeSize / treeCount).toFixed(3);
-            log(`i: ${i} time: ${accumTime}us which is average ${perIter} per insert with average tree size ${averageTreeSize}`);
+            log(`i: ${i} time: ${accumTime}ms which is average ${perIter} per insert with average tree size ${averageTreeSize}`);
         }
     }
     accumTime = 0;
@@ -376,7 +362,7 @@ export function mergeTreeCheckedTest() {
             treeCount++;
             accumTreeSize += mergeTree.getLength(UniversalSequenceNumber, LocalClientId);
             const averageTreeSize = (accumTreeSize / treeCount).toFixed(3);
-            log(`i: ${i} time: ${accumTime}us which is average ${perIter} per large del with average tree size ${averageTreeSize}`);
+            log(`i: ${i} time: ${accumTime}ms which is average ${perIter} per large del with average tree size ${averageTreeSize}`);
         }
     }
     accumTime = 0;
@@ -408,7 +394,7 @@ export function mergeTreeCheckedTest() {
             treeCount++;
             accumTreeSize += mergeTree.getLength(UniversalSequenceNumber, LocalClientId);
             const averageTreeSize = (accumTreeSize / treeCount).toFixed(3);
-            log(`i: ${i} time: ${accumTime}us which is average ${perIter} per del with average tree size ${averageTreeSize}`);
+            log(`i: ${i} time: ${accumTime}ms which is average ${perIter} per del with average tree size ${averageTreeSize}`);
         }
     }
     accumTime = 0;
@@ -430,7 +416,7 @@ export function mergeTreeCheckedTest() {
             treeCount++;
             accumTreeSize += mergeTree.getLength(UniversalSequenceNumber, LocalClientId);
             const averageTreeSize = (accumTreeSize / treeCount).toFixed(3);
-            log(`i: ${i} time: ${accumTime}us which is average ${perIter} per insert with average tree size ${averageTreeSize}`);
+            log(`i: ${i} time: ${accumTime}ms which is average ${perIter} per insert with average tree size ${averageTreeSize}`);
         }
     }
     accumTime = 0;
@@ -462,7 +448,7 @@ export function mergeTreeCheckedTest() {
             treeCount++;
             accumTreeSize += mergeTree.getLength(UniversalSequenceNumber, LocalClientId);
             const averageTreeSize = (accumTreeSize / treeCount).toFixed(3);
-            log(`i: ${i} time: ${accumTime}us which is average ${perIter} per del with average tree size ${averageTreeSize}`);
+            log(`i: ${i} time: ${accumTime}ms which is average ${perIter} per del with average tree size ${averageTreeSize}`);
         }
     }
     return errorCount;
@@ -506,9 +492,9 @@ export function TestPack(verbose = true) {
 
     const checkIncr = false;
 
-    let getTextTime = 0;
+    let getTextTime = 0; // ms
     let getTextCalls = 0;
-    let incrGetTextTime = 0;
+    let incrGetTextTime = 0; // ms
     let incrGetTextCalls = 0;
     const catchUpTime = 0;
     const catchUps = 0;
@@ -537,11 +523,11 @@ export function TestPack(verbose = true) {
             aveIncrGetTextTime = (incrGetTextTime / incrGetTextCalls).toFixed(1);
         }
         if (client.localOps > 0) {
-            log(`local time ${client.localTime} us ops: ${client.localOps} ave time ${aveLocalTime}`);
+            log(`local time ${client.localTime} ms ops: ${client.localOps} ave time ${aveLocalTime}`);
         }
         log(`get text time: ${aveGetTextTime} incr: ${aveIncrGetTextTime} catch up ${aveCatchUpTime}`);
-        log(`accum time ${client.accumTime} us ops: ${client.accumOps} ave time ${aveTime} - wtime ${adjTime} pack ${avePackTime} ave window ${aveWindow}`);
-        log(`accum window time ${client.accumWindowTime} us ave window time total ${aveWindowTime} not in ops ${aveExtraWindowTime}; max ${client.maxWindowTime}`);
+        log(`accum time ${client.accumTime} ms ops: ${client.accumOps} ave time ${aveTime} - wtime ${adjTime} pack ${avePackTime} ave window ${aveWindow}`);
+        log(`accum window time ${client.accumWindowTime} ms ave window time total ${aveWindowTime} not in ops ${aveExtraWindowTime}; max ${client.maxWindowTime}`);
     }
 
     function manyMergeTrees() {
@@ -585,14 +571,14 @@ export function TestPack(verbose = true) {
 
         function checkTextMatch() {
             // log(`checking text match @${server.getCurrentSeq()}`);
-            let clockStart = clock();
+            let traceStart = Trace.start();
             const serverText = server.getText();
-            getTextTime += elapsedMicroseconds(clockStart);
+            getTextTime += traceStart.trace().duration;
             getTextCalls++;
             if (checkIncr) {
-                clockStart = clock();
+                traceStart = Trace.start();
                 const serverIncrText = server.incrementalGetText();
-                incrGetTextTime += elapsedMicroseconds(clockStart);
+                incrGetTextTime += traceStart.trace().duration;
                 incrGetTextCalls++;
                 if (serverIncrText != serverText) {
                     log("incr get text mismatch");
@@ -796,15 +782,15 @@ export function TestPack(verbose = true) {
             // log(server.mergeTree.toString());
             // log(server.mergeTree.getStats());
             if (0 == (roundCount % 100)) {
-                const clockStart = clock();
+                const traceStart = Trace.start();
                 if (checkTextMatch()) {
                     log(`round: ${roundCount} BREAK`);
                     errorCount++;
                     return errorCount;
                 }
-                checkTime += elapsedMicroseconds(clockStart);
+                checkTime += traceStart.trace().duration;
                 if (verbose) {
-                    log(`wall clock is ${((Date.now() - startTime) / 1000.0).toFixed(1)}`);
+                    log(`wall clock is ${(startTime.trace().duration / 1000.0).toFixed(1)}`);
                 }
                 const stats = server.mergeTree.getStats();
                 const liveAve = (stats.liveCount / stats.nodeCount).toFixed(1);
@@ -874,8 +860,8 @@ export function TestPack(verbose = true) {
             finishRound(roundCount);
         }
 
-        const startTime = Date.now();
-        let checkTime = 0;
+        const startTime = Trace.start();
+        let checkTime = 0; // ms
         let asyncRoundCount = 0;
 
         function asyncStep() {
@@ -1073,8 +1059,8 @@ export function TestPack(verbose = true) {
         const aveTime = (cliA.accumTime / cliA.accumOps).toFixed(3);
         const aveWindowTime = (cliA.accumWindowTime / cliA.accumOps).toFixed(3);
         if (verbose) {
-            log(`accum time ${cliA.accumTime} us ops: ${cliA.accumOps} ave window ${aveWindow} ave time ${aveTime}`);
-            log(`accum window time ${cliA.accumWindowTime} us ave window time ${aveWindowTime}; max ${cliA.maxWindowTime}`);
+            log(`accum time ${cliA.accumTime} ms ops: ${cliA.accumOps} ave window ${aveWindow} ave time ${aveTime}`);
+            log(`accum window time ${cliA.accumWindowTime} ms ave window time ${aveWindowTime}; max ${cliA.maxWindowTime}`);
         }
         // log(cliB.getText());
         return errorCount;
@@ -1338,7 +1324,7 @@ function tst() {
         } while (result);
         return count;
     }
-    const clockStart = clock();
+    const traceStart = Trace.start();
     addCorpus(corpusContent, corpusTree);
     corpusFilename = path.join(__dirname, "../../public/literature/shakespeare.txt");
     corpusContent = fs.readFileSync(corpusFilename, "utf8");
@@ -1353,7 +1339,7 @@ function tst() {
             ntree.put(entry, 1);
         }
     }
-    log(`size: ${ntree.size()}; random insert takes ${elapsedMilliseconds(clockStart)}ms`);
+    log(`size: ${ntree.size()}; random insert takes ${traceStart.trace().duration}ms`);
     for (const entry of a) {
         if (!ntree.get(entry)) {
             log(`biff ${entry}`);
@@ -1653,7 +1639,7 @@ function findReplacePerf(filename: string) {
     const client = new TestClient({ blockUpdateMarkers: true });
     loadTextFromFile(filename, client.mergeTree);
 
-    const clockStart = clock();
+    const traceStart = Trace.start();
 
     let cFetches = 0;
     let cReplaces = 0;
@@ -1692,8 +1678,8 @@ function findReplacePerf(filename: string) {
         }
     }
 
-    const elapsed = elapsedMicroseconds(clockStart);
-    log(`${cFetches} fetches and ${cReplaces} replaces took ${elapsed} microseconds`);
+    const elapsed = traceStart.trace().duration;
+    log(`${cFetches} fetches and ${cReplaces} replaces took ${elapsed} milliseconds`);
 }
 
 const testTST = false;

--- a/packages/dds/merge-tree/src/test/wordUnitTests.ts
+++ b/packages/dds/merge-tree/src/test/wordUnitTests.ts
@@ -8,19 +8,12 @@
 import path from "path";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import random from "random-js";
+import { Trace } from "@fluidframework/common-utils";
 import { LocalReference } from "../localReference";
 import * as ops from "../ops";
 import * as Properties from "../properties";
 import { TestClient } from "./testClient";
 import { loadTextFromFileWithMarkers } from "./testUtils";
-
-const clock = () => process.hrtime();
-
-function elapsedMicroseconds(start: [number, number]) {
-    const end: number[] = process.hrtime(start);
-    const duration = Math.round((end[0] * 1000000) + (end[1] / 1000));
-    return duration;
-}
 
 export function propertyCopy() {
     const propCount = 2000;
@@ -33,7 +26,7 @@ export function propertyCopy() {
         v[i] = i;
         map.set(a[i], v[i]);
     }
-    let clockStart = clock();
+    let traceStart = Trace.start();
     let obj: Properties.MapLike<number>;
     for (let j = 0; j < iterCount; j++) {
         obj = Properties.createMap<number>();
@@ -41,11 +34,11 @@ export function propertyCopy() {
             obj[a[i]] = v[i];
         }
     }
-    let et = elapsedMicroseconds(clockStart);
+    let et = traceStart.trace().duration;
     let perIter = (et / iterCount).toFixed(3);
     let perProp = (et / (iterCount * propCount)).toFixed(3);
-    console.log(`arr prop init time ${perIter} us per ${propCount} properties; ${perProp} us per property`);
-    clockStart = clock();
+    console.log(`arr prop init time ${perIter} ms per ${propCount} properties; ${perProp} ms per property`);
+    traceStart = Trace.start();
     for (let j = 0; j < iterCount; j++) {
         const bObj = Properties.createMap<number>();
         // eslint-disable-next-line guard-for-in, no-restricted-syntax
@@ -53,40 +46,40 @@ export function propertyCopy() {
             bObj[key] = obj[key];
         }
     }
-    et = elapsedMicroseconds(clockStart);
+    et = traceStart.trace().duration;
     perIter = (et / iterCount).toFixed(3);
     perProp = (et / (iterCount * propCount)).toFixed(3);
-    console.log(`obj prop init time ${perIter} us per ${propCount} properties; ${perProp} us per property`);
-    clockStart = clock();
+    console.log(`obj prop init time ${perIter} ms per ${propCount} properties; ${perProp} ms per property`);
+    traceStart = Trace.start();
     for (let j = 0; j < iterCount; j++) {
         const bObj = Properties.createMap<number>();
         for (const [key, value] of map) {
             bObj[key] = value;
         }
     }
-    et = elapsedMicroseconds(clockStart);
+    et = traceStart.trace().duration;
     perIter = (et / iterCount).toFixed(3);
     perProp = (et / (iterCount * propCount)).toFixed(2);
-    console.log(`map prop init time ${perIter} us per ${propCount} properties; ${perProp} us per property`);
-    clockStart = clock();
+    console.log(`map prop init time ${perIter} ms per ${propCount} properties; ${perProp} ms per property`);
+    traceStart = Trace.start();
     for (let j = 0; j < iterCount; j++) {
         const bObj = Properties.createMap<number>();
         map.forEach((value, key) => { bObj[key] = value; });
     }
-    et = elapsedMicroseconds(clockStart);
+    et = traceStart.trace().duration;
     perIter = (et / iterCount).toFixed(3);
     perProp = (et / (iterCount * propCount)).toFixed(2);
-    console.log(`map foreach prop init time ${perIter} us per ${propCount} properties; ${perProp} us per property`);
-    clockStart = clock();
+    console.log(`map foreach prop init time ${perIter} ms per ${propCount} properties; ${perProp} ms per property`);
+    traceStart = Trace.start();
     for (let j = 0; j < iterCount; j++) {
         const bmap = new Map<string, number>();
         map.forEach((value, key) => { bmap.set(key, value); });
     }
-    et = elapsedMicroseconds(clockStart);
+    et = traceStart.trace().duration;
     perIter = (et / iterCount).toFixed(3);
     perProp = (et / (iterCount * propCount)).toFixed(2);
     console.log(
-        `map to map foreach prop init time ${perIter} us per ${propCount} properties; ${perProp} us per property`);
+        `map to map foreach prop init time ${perIter} ms per ${propCount} properties; ${perProp} ms per property`);
     const diffMap = new Map<string, number>();
     map.forEach((value, key) => {
         if (Math.random() < 0.5) {
@@ -95,7 +88,7 @@ export function propertyCopy() {
             diffMap.set(key, value * 3);
         }
     });
-    clockStart = clock();
+    traceStart = Trace.start();
     const grayMap = new Map<string, number>();
     for (let j = 0; j < iterCount; j++) {
         map.forEach((value, key) => {
@@ -105,9 +98,10 @@ export function propertyCopy() {
             }
         });
     }
+    et = traceStart.trace().duration;
     perIter = (et / iterCount).toFixed(3);
     perProp = (et / (iterCount * propCount)).toFixed(2);
-    console.log(`diff time ${perIter} us per ${propCount} properties; ${perProp} us per property`);
+    console.log(`diff time ${perIter} ms per ${propCount} properties; ${perProp} ms per property`);
 }
 
 function makeBookmarks(client: TestClient, bookmarkCount: number) {
@@ -138,7 +132,7 @@ function measureFetch(startFile: string, withBookmarks = false) {
         console.log(`inserting ${bookmarkCount} refs into text`);
     }
     const reps = 20;
-    let clockStart = clock();
+    let traceStart = Trace.start();
     let count = 0;
     for (let i = 0; i < reps; i++) {
         for (let pos = 0; pos < client.getLength();) {
@@ -160,16 +154,16 @@ function measureFetch(startFile: string, withBookmarks = false) {
             count++;
         }
     }
-    let et = elapsedMicroseconds(clockStart);
+    let et = traceStart.trace().duration;
     // eslint-disable-next-line max-len
-    console.log(`fetch of ${count / reps} runs over ${client.getLength()} total chars took ${(et / count).toFixed(1)} microseconds per run`);
+    console.log(`fetch of ${count / reps} runs over ${client.getLength()} total chars took ${(et / count).toFixed(1)} milliseconds per run`);
     // Bonus: measure clone
-    clockStart = clock();
+    traceStart = Trace.start();
     for (let i = 0; i < reps; i++) {
         client.mergeTree.clone();
     }
-    et = elapsedMicroseconds(clockStart);
-    console.log(`naive clone took ${(et / (1000 * reps)).toFixed(1)} milliseconds`);
+    et = traceStart.trace().duration;
+    console.log(`naive clone took ${(et / reps).toFixed(1)} milliseconds`);
 }
 
 const baseDir = "../../src/test/literature";

--- a/packages/dds/merge-tree/src/test/wordUnitTests.ts
+++ b/packages/dds/merge-tree/src/test/wordUnitTests.ts
@@ -15,6 +15,12 @@ import * as Properties from "../properties";
 import { TestClient } from "./testClient";
 import { loadTextFromFileWithMarkers } from "./testUtils";
 
+const clock = () => Trace.start();
+
+function elapsedMicroseconds(trace: Trace) {
+    return trace.trace().duration * 1000;
+}
+
 export function propertyCopy() {
     const propCount = 2000;
     const iterCount = 1000;
@@ -26,7 +32,7 @@ export function propertyCopy() {
         v[i] = i;
         map.set(a[i], v[i]);
     }
-    let traceStart = Trace.start();
+    let clockStart = clock();
     let obj: Properties.MapLike<number>;
     for (let j = 0; j < iterCount; j++) {
         obj = Properties.createMap<number>();
@@ -34,11 +40,11 @@ export function propertyCopy() {
             obj[a[i]] = v[i];
         }
     }
-    let et = traceStart.trace().duration;
+    let et = elapsedMicroseconds(clockStart);
     let perIter = (et / iterCount).toFixed(3);
     let perProp = (et / (iterCount * propCount)).toFixed(3);
-    console.log(`arr prop init time ${perIter} ms per ${propCount} properties; ${perProp} ms per property`);
-    traceStart = Trace.start();
+    console.log(`arr prop init time ${perIter} us per ${propCount} properties; ${perProp} us per property`);
+    clockStart = clock();
     for (let j = 0; j < iterCount; j++) {
         const bObj = Properties.createMap<number>();
         // eslint-disable-next-line guard-for-in, no-restricted-syntax
@@ -46,40 +52,40 @@ export function propertyCopy() {
             bObj[key] = obj[key];
         }
     }
-    et = traceStart.trace().duration;
+    et = elapsedMicroseconds(clockStart);
     perIter = (et / iterCount).toFixed(3);
     perProp = (et / (iterCount * propCount)).toFixed(3);
-    console.log(`obj prop init time ${perIter} ms per ${propCount} properties; ${perProp} ms per property`);
-    traceStart = Trace.start();
+    console.log(`obj prop init time ${perIter} us per ${propCount} properties; ${perProp} us per property`);
+    clockStart = clock();
     for (let j = 0; j < iterCount; j++) {
         const bObj = Properties.createMap<number>();
         for (const [key, value] of map) {
             bObj[key] = value;
         }
     }
-    et = traceStart.trace().duration;
+    et = elapsedMicroseconds(clockStart);
     perIter = (et / iterCount).toFixed(3);
     perProp = (et / (iterCount * propCount)).toFixed(2);
-    console.log(`map prop init time ${perIter} ms per ${propCount} properties; ${perProp} ms per property`);
-    traceStart = Trace.start();
+    console.log(`map prop init time ${perIter} us per ${propCount} properties; ${perProp} us per property`);
+    clockStart = clock();
     for (let j = 0; j < iterCount; j++) {
         const bObj = Properties.createMap<number>();
         map.forEach((value, key) => { bObj[key] = value; });
     }
-    et = traceStart.trace().duration;
+    et = elapsedMicroseconds(clockStart);
     perIter = (et / iterCount).toFixed(3);
     perProp = (et / (iterCount * propCount)).toFixed(2);
-    console.log(`map foreach prop init time ${perIter} ms per ${propCount} properties; ${perProp} ms per property`);
-    traceStart = Trace.start();
+    console.log(`map foreach prop init time ${perIter} us per ${propCount} properties; ${perProp} us per property`);
+    clockStart = clock();
     for (let j = 0; j < iterCount; j++) {
         const bmap = new Map<string, number>();
         map.forEach((value, key) => { bmap.set(key, value); });
     }
-    et = traceStart.trace().duration;
+    et = elapsedMicroseconds(clockStart);
     perIter = (et / iterCount).toFixed(3);
     perProp = (et / (iterCount * propCount)).toFixed(2);
     console.log(
-        `map to map foreach prop init time ${perIter} ms per ${propCount} properties; ${perProp} ms per property`);
+        `map to map foreach prop init time ${perIter} us per ${propCount} properties; ${perProp} us per property`);
     const diffMap = new Map<string, number>();
     map.forEach((value, key) => {
         if (Math.random() < 0.5) {
@@ -88,7 +94,7 @@ export function propertyCopy() {
             diffMap.set(key, value * 3);
         }
     });
-    traceStart = Trace.start();
+    clockStart = clock();
     const grayMap = new Map<string, number>();
     for (let j = 0; j < iterCount; j++) {
         map.forEach((value, key) => {
@@ -98,10 +104,9 @@ export function propertyCopy() {
             }
         });
     }
-    et = traceStart.trace().duration;
     perIter = (et / iterCount).toFixed(3);
     perProp = (et / (iterCount * propCount)).toFixed(2);
-    console.log(`diff time ${perIter} ms per ${propCount} properties; ${perProp} ms per property`);
+    console.log(`diff time ${perIter} us per ${propCount} properties; ${perProp} us per property`);
 }
 
 function makeBookmarks(client: TestClient, bookmarkCount: number) {
@@ -132,7 +137,7 @@ function measureFetch(startFile: string, withBookmarks = false) {
         console.log(`inserting ${bookmarkCount} refs into text`);
     }
     const reps = 20;
-    let traceStart = Trace.start();
+    let clockStart = clock();
     let count = 0;
     for (let i = 0; i < reps; i++) {
         for (let pos = 0; pos < client.getLength();) {
@@ -154,16 +159,16 @@ function measureFetch(startFile: string, withBookmarks = false) {
             count++;
         }
     }
-    let et = traceStart.trace().duration;
+    let et = elapsedMicroseconds(clockStart);
     // eslint-disable-next-line max-len
-    console.log(`fetch of ${count / reps} runs over ${client.getLength()} total chars took ${(et / count).toFixed(1)} milliseconds per run`);
+    console.log(`fetch of ${count / reps} runs over ${client.getLength()} total chars took ${(et / count).toFixed(1)} microseconds per run`);
     // Bonus: measure clone
-    traceStart = Trace.start();
+    clockStart = clock();
     for (let i = 0; i < reps; i++) {
         client.mergeTree.clone();
     }
-    et = traceStart.trace().duration;
-    console.log(`naive clone took ${(et / reps).toFixed(1)} milliseconds`);
+    et = elapsedMicroseconds(clockStart);
+    console.log(`naive clone took ${(et / (1000 * reps)).toFixed(1)} milliseconds`);
 }
 
 const baseDir = "../../src/test/literature";

--- a/packages/dds/sequence/src/test/testFarm.ts
+++ b/packages/dds/sequence/src/test/testFarm.ts
@@ -45,9 +45,9 @@ import * as SharedString from "../intervalCollection";
 
 const clock = () => Trace.start();
 
-function elapsedMicroseconds(trace: Trace) {
+const elapsedMicroseconds = (trace: Trace) => {
     return trace.trace().duration * 1000;
-}
+};
 
 // Enum AsyncRoundState {
 //     Insert,


### PR DESCRIPTION
Fixes #816 

Replace usages of process.hrtime with Timer so we don't accidentally pull in the polyfill, which wraps around the isomorphic performanceNow.  Add some documentation on the units of measurement used