### PR TITLE
Add Uint8ArrayToString helper

### DIFF
--- a/common/lib/common-utils/src/bufferBrowser.ts
+++ b/common/lib/common-utils/src/bufferBrowser.ts
@@ -6,6 +6,30 @@
 import * as base64js from "base64-js";
 
 /**
+ * Converts a Uint8Array to a string of the provided encoding
+ * Useful when the array might be an IsoBuffer
+ * @param arr - The array to convert
+ * @param encoding - Optional target encoding; only "utf8" and "base64" are
+ * supported, with "utf8" being default
+ * @returns The converted string
+ */
+export function Uint8ArrayToString(arr: Uint8Array, encoding?: string): string {
+    switch (encoding) {
+        case "base64": {
+            return base64js.fromByteArray(arr);
+        }
+        case "utf8":
+        case "utf-8":
+        case undefined: {
+            return new TextDecoder().decode(arr);
+        }
+        default: {
+            throw new Error("invalid/unsupported encoding");
+        }
+    }
+}
+
+/**
  * Minimal implementation of Buffer for our usages in the browser environment.
  */
 export class IsoBuffer extends Uint8Array {
@@ -16,20 +40,7 @@ export class IsoBuffer extends Uint8Array {
      * @param encoding
      */
     public toString(encoding?: string): string {
-        switch (encoding) {
-            case "base64": {
-                // TODO: check any sanitization
-                return base64js.fromByteArray(this);
-            }
-            case "utf8":
-            case "utf-8":
-            case undefined: {
-                return new TextDecoder().decode(this);
-            }
-            default: {
-                throw new Error("invalid/unsupported encoding");
-            }
-        }
+        return Uint8ArrayToString(this, encoding);
     }
 
     /**
@@ -77,6 +88,10 @@ export class IsoBuffer extends Uint8Array {
                 throw new Error("invalid/unsupported encoding");
             }
         }
+    }
+
+    static isBuffer(obj: any): boolean {
+        throw new Error("unimplemented");
     }
 
     /**

--- a/common/lib/common-utils/src/bufferNode.ts
+++ b/common/lib/common-utils/src/bufferNode.ts
@@ -16,8 +16,24 @@ export declare class Buffer extends Uint8Array {
      * @param length - number
      */
     static from(value, encodingOrOffset?, length?): IsoBuffer;
-    static fromArrayBuffer(arrayBuffer: ArrayBuffer, byteOffset?: number, byteLength?: number): IsoBuffer;
-    static fromString(str: string, encoding?: string): IsoBuffer;
+    static isBuffer(obj: any): obj is Buffer;
 }
 export const IsoBuffer = Buffer;
 export type IsoBuffer = Buffer;
+
+/**
+ * Converts a Uint8Array to a string of the provided encoding
+ * Useful when the array might be an IsoBuffer
+ * @param arr - The array to convert
+ * @param encoding - Optional target encoding; only "utf8" and "base64" are
+ * supported, with "utf8" being default
+ * @returns The converted string
+ */
+export function Uint8ArrayToString(arr: Uint8Array, encoding?: string): string {
+    // Make this check because Buffer.from(arr) will always do a buffer copy
+    if (Buffer.isBuffer(arr)) {
+        return arr.toString(encoding);
+    } else {
+        return Buffer.from(arr).toString(encoding);
+    }
+}

--- a/common/lib/common-utils/src/packageVersion.ts
+++ b/common/lib/common-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/common-utils";
-export const pkgVersion = "0.22.0";
+export const pkgVersion = "0.22.1";

--- a/common/lib/common-utils/testJest/buffer.spec.ts
+++ b/common/lib/common-utils/testJest/buffer.spec.ts
@@ -7,7 +7,7 @@ import * as BufferNode from "../src/bufferNode";
 import * as BufferBrowser from "../src/bufferBrowser";
 
 describe("Buffer isomorphism", () => {
-    test("from string utf-8/16 is compatible", async () => {
+    test("from string utf-8/16 is compatible", () => {
         const testArray = [
             "",
             "asdfasdf", // ascii range
@@ -31,7 +31,7 @@ describe("Buffer isomorphism", () => {
         expect(nodeBuffer.toString("utf-8")).toEqual(browserBuffer.toString("utf-8"));
     });
 
-    test("from string base64 is compatible", async () => {
+    test("from string base64 is compatible", () => {
         const testArray = [
             "",
             "aa_/-",
@@ -52,7 +52,7 @@ describe("Buffer isomorphism", () => {
         }
     });
 
-    test("from arraybuffer is compatible", async () => {
+    test("from arraybuffer is compatible", () => {
         const testArray = [
             "",
             "asdfasdf", // ascii range
@@ -69,7 +69,7 @@ describe("Buffer isomorphism", () => {
         }
     });
 
-    test("utf8 base64 conversion is compatible", async () => {
+    test("utf8 base64 conversion is compatible", () => {
         const testArrayUtf8 = [
             "",
             "asdfasdf", // ascii range
@@ -99,7 +99,7 @@ describe("Buffer isomorphism", () => {
         }
     });
 
-    test("bytelength is compatible", async () => {
+    test("bytelength is compatible", () => {
         const testString = "8J+YgvCfkoHwn4+84oCN4pmC77iP8J+SgfCfj7zigI3wn5KB4oCN4pmC";
 
         const nodeBufferUtf8 = BufferNode.IsoBuffer.from(testString);
@@ -109,5 +109,17 @@ describe("Buffer isomorphism", () => {
         const nodeBufferBase64 = BufferNode.IsoBuffer.from(testString, "base64");
         const browserBufferBase64 = BufferBrowser.IsoBuffer.from(testString, "base64");
         expect(nodeBufferBase64.byteLength).toEqual(browserBufferBase64.byteLength);
-    })
+    });
+
+    test("Uint8ArrayToString is compatible", () => {
+        const testArray = new Uint8Array([1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377]);
+
+        const nodeStringUtf8 = BufferNode.Uint8ArrayToString(testArray, "utf8");
+        const browserStringUtf8 = BufferBrowser.Uint8ArrayToString(testArray, "utf8");
+        expect(nodeStringUtf8).toEqual(browserStringUtf8);
+
+        const nodeStringBase64 = BufferNode.Uint8ArrayToString(testArray, "base64");
+        const browserStringBase64 = BufferBrowser.Uint8ArrayToString(testArray, "base64");
+        expect(nodeStringBase64).toEqual(browserStringBase64);
+    });
 });


### PR DESCRIPTION
#2450 

Add a helper to convert uint8arrays to strings to work around a buffer dependency in protocol-definitions.  `ISummaryBlob.content` in protocol-definitions had type `string | Buffer`, but the addition of the isomorphic Buffer  implementation `IsoBuffer` does not allow a direct swap due to layering (the implementation is in common-utils).  To keep the definitions vanilla-ly typed, swap `Buffer` here for `Uint8Array` and add a helper to do the equivalent `Buffer.toString` conversion.