### PR TITLE
Start the ordering service state from a summary

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -103,7 +103,7 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
                     lastCheckpoint = getDefaultCheckpooint(leaderEpoch);
                 } else {
                     // Since the document was originated elsewhere or cache was cleared, logOffset info is irrelavant.
-                    // Currently the lambda checkpoits only after updating the logOffset so setting this to lower
+                    // Currently the lambda checkpoints only after updating the logOffset so setting this to lower
                     // is okay. Conceptually this is similar to default checkpoint where logOffset is -1. In this case,
                     // the sequence number is 'n' rather than '0'.
                     lastCheckpoint.logOffset = -1;

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -4,7 +4,7 @@
  */
 
 import { EventEmitter } from "events";
-import { ICreateCommitParams, ICreateTreeEntry, IRef } from "@fluidframework/gitresources";
+import { ICreateCommitParams, ICreateTreeEntry } from "@fluidframework/gitresources";
 import {
     ICollection,
     IContext,
@@ -60,10 +60,6 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
         super();
     }
 
-    // Cache for ref and last summary checkpoint.
-    private existingRef: IRef;
-    private summaryCheckpoint: IDeliCheckpoint;
-
     public async create(config: Provider, context: IContext): Promise<IPartitionLambda> {
         const documentId = config.get("documentId");
         const tenantId = config.get("tenantId");
@@ -85,21 +81,34 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
 
         let lastCheckpoint: IDeliCheckpoint;
 
+        const messageMetaData = {
+            documentId,
+            tenantId,
+        };
+
         // Restore deli state if not present in the cache. Mongodb casts undefined as null so we are checking
-        // both to be safe. Empty sring denotes a cache that was cleared due to a service summary
+        // both to be safe. Empty sring denotes a cache that was cleared due to a service summary or the document
+        // was created within a different tenant.
         // eslint-disable-next-line no-null/no-null
         if (dbObject.deli === undefined || dbObject.deli === null) {
-            const messageMetaData = {
-                documentId,
-                tenantId,
-            };
             context.log.info(`New document. Setting empty deli checkpoint`, { messageMetaData });
             lastCheckpoint = getDefaultCheckpooint(leaderEpoch);
         } else {
             if (dbObject.deli === "") {
+                context.log.info(`Existing document. Fetching checkpoint from summary`, { messageMetaData });
+
                 lastCheckpoint = await this.loadStateFromSummary(tenantId, documentId, gitManager, context.log);
                 if (lastCheckpoint === undefined) {
-                    throw Error("Summary cannot be fetched");
+                    context.log.error(`Summary cannot be fetched`, { messageMetaData });
+                    lastCheckpoint = getDefaultCheckpooint(leaderEpoch);
+                } else {
+                    // Since the document was originated elsewhere or cache was cleared, logOffset info is irrelavant.
+                    // Currently the lambda checkpoits only after updating the logOffset so setting this to lower
+                    // is okay. Conceptually this is similar to default checkpoint where logOffset is -1. In this case,
+                    // the sequence number is 'n' rather than '0'.
+                    lastCheckpoint.logOffset = -1;
+                    lastCheckpoint.epoch = leaderEpoch;
+                    context.log.info(JSON.stringify(lastCheckpoint));
                 }
             } else {
                 lastCheckpoint = JSON.parse(dbObject.deli);
@@ -154,25 +163,23 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
         documentId: string,
         gitManager: IGitManager,
         logger: ILogger): Promise<IDeliCheckpoint> {
-        if (this.summaryCheckpoint === undefined) {
-            this.existingRef = await gitManager.getRef(encodeURIComponent(documentId));
-            if (this.existingRef) {
-                try {
-                    const content = await gitManager.getContent(this.existingRef.object.sha, ".serviceProtocol/deli");
-                    this.summaryCheckpoint = JSON.parse(
-                        Buffer.from(content.content, content.encoding).toString()) as IDeliCheckpoint;
-                } catch (exception) {
-                    const messageMetaData = {
-                        documentId,
-                        tenantId,
-                    };
-                    logger.error(`Error fetching deli state from summary`, { messageMetaData });
-                    logger.error(JSON.stringify(exception), { messageMetaData });
-                    return undefined;
-                }
+        const existingRef = await gitManager.getRef(encodeURIComponent(documentId));
+        if (existingRef) {
+            try {
+                const content = await gitManager.getContent(existingRef.object.sha, ".serviceProtocol/deli");
+                const summaryCheckpoint = JSON.parse(
+                    Buffer.from(content.content, content.encoding).toString()) as IDeliCheckpoint;
+                return summaryCheckpoint;
+            } catch (exception) {
+                const messageMetaData = {
+                    documentId,
+                    tenantId,
+                };
+                logger.error(`Error fetching deli state from summary`, { messageMetaData });
+                logger.error(JSON.stringify(exception), { messageMetaData });
+                return undefined;
             }
         }
-        return this.summaryCheckpoint;
     }
 
     // Check the current epoch with last epoch. If not matched, we need to flip the term.
@@ -219,9 +226,10 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
         gitManager: IGitManager,
         checkpoint: IDeliCheckpoint,
         documentId: string) {
+        const existingRef = await gitManager.getRef(encodeURIComponent(documentId));
         const [lastCommit, scribeContent] = await Promise.all([
-            gitManager.getCommit(this.existingRef.object.sha),
-            gitManager.getContent(this.existingRef.object.sha, ".serviceProtocol/scribe")]);
+            gitManager.getCommit(existingRef.object.sha),
+            gitManager.getContent(existingRef.object.sha, ".serviceProtocol/scribe")]);
 
         const scribe = Buffer.from(scribeContent.content, scribeContent.encoding).toString();
         const serviceProtocolEntries = generateServiceProtocolEntries(JSON.stringify(checkpoint), scribe);

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -407,7 +407,7 @@ export class ScribeLambda extends SequencedLambda {
         await this.messageCollection
             .deleteMany({
                 "documentId": this.documentId,
-                "operation.sequenceNumber": { $lte: checkpoint.protocolState.sequenceNumber },
+                "operation.sequenceNumber": { $lte: this.protocolHead },
                 "tenantId": this.tenantId,
             });
     }

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -92,7 +92,7 @@ export class ScribeLambdaFactory extends EventEmitter implements IPartitionLambd
                 lastCheckpoint = JSON.parse(latestSummary.scribe);
                 opMessages = latestSummary.messages;
                 // Since the document was originated elsewhere or cache was cleared, logOffset info is irrelavant.
-                // Currently the lambda checkpoits only after updating the logOffset so setting this to lower
+                // Currently the lambda checkpoints only after updating the logOffset so setting this to lower
                 // is okay. Conceptually this is similar to default checkpoint where logOffset is -1. In this case,
                 // the sequence number is 'n' rather than '0'.
                 lastCheckpoint.logOffset = -1;

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -74,29 +74,36 @@ export class ScribeLambdaFactory extends EventEmitter implements IPartitionLambd
             await this.messageCollection.find({ documentId, tenantId }, { "operation.sequenceNumber": 1 });
         let opMessages = dbMessages.map((message) => message.operation);
 
+        let lastCheckpoint: IScribe;
+
         // Restore scribe state if not present in the cache. Mongodb casts undefined as null so we are checking
         // both to be safe. Empty sring denotes a cache that was cleared due to a service summary
         if (document.scribe === undefined || document.scribe === null) {
             context.log.info(`New document. Setting empty scribe checkpoint`, { messageMetaData });
-            document.scribe = JSON.stringify(DefaultScribe);
+            lastCheckpoint = DefaultScribe;
             opMessages = [];
         } else if (document.scribe === "") {
+            context.log.info(`Existing document. Fetching checkpoint from summary`, { messageMetaData });
             if (!latestSummary.fromSummary) {
-                context.log.error(`Required summary can't be fetched for`, { messageMetaData });
-                document.scribe = JSON.stringify(DefaultScribe);
+                context.log.error(`Summary can't be fetched`, { messageMetaData });
+                lastCheckpoint = DefaultScribe;
                 opMessages = [];
             } else {
-                context.log.info(`Loading scribe state from service summary`, { messageMetaData });
-                document.scribe = latestSummary.scribe;
+                lastCheckpoint = JSON.parse(latestSummary.scribe);
                 opMessages = latestSummary.messages;
+                // Since the document was originated elsewhere or cache was cleared, logOffset info is irrelavant.
+                // Currently the lambda checkpoits only after updating the logOffset so setting this to lower
+                // is okay. Conceptually this is similar to default checkpoint where logOffset is -1. In this case,
+                // the sequence number is 'n' rather than '0'.
+                lastCheckpoint.logOffset = -1;
+                context.log.info(JSON.stringify(lastCheckpoint));
             }
         } else {
-            context.log.info(`Loading scribe state from cache`, { messageMetaData });
+            lastCheckpoint = JSON.parse(document.scribe);
         }
 
         const term = latestSummary.fromSummary ? latestSummary.term : 1;
-        const scribe: IScribe = JSON.parse(document.scribe);
-        const protocolHandler = initializeProtocol(document.documentId, scribe.protocolState, term);
+        const protocolHandler = initializeProtocol(document.documentId, lastCheckpoint.protocolState, term);
 
         return new ScribeLambda(
             context,
@@ -104,7 +111,7 @@ export class ScribeLambdaFactory extends EventEmitter implements IPartitionLambd
             this.messageCollection,
             document.tenantId,
             document.documentId,
-            scribe,
+            lastCheckpoint,
             gitManager,
             this.producer,
             protocolHandler,

--- a/server/routerlicious/packages/services-shared/src/storage.ts
+++ b/server/routerlicious/packages/services-shared/src/storage.ts
@@ -11,6 +11,7 @@ import {
     MessageType,
     ITreeEntry,
     ICommittedProposal,
+    ISequencedDocumentMessage,
     ISummaryTree,
     SummaryType,
     SummaryObject,
@@ -28,6 +29,9 @@ import {
     IScribe,
     ITenantManager,
     RawOperationType,
+    SequencedOperationType,
+    ISequencedOperationMessage,
+    IDocument,
 } from "@fluidframework/server-services-core";
 import {
     getQuorumTreeEntries,
@@ -308,29 +312,97 @@ export class DocumentStorage implements IDocumentStorage {
         return name;
     }
 
+    private async createObject(
+        collection: ICollection<IDocument>,
+        tenantId: string,
+        documentId: string,
+        deli?: string,
+        scribe?: string): Promise<IDocument> {
+        const value: IDocument = {
+            branchMap: undefined,
+            clients: undefined,
+            createTime: Date.now(),
+            deli,
+            documentId,
+            forks: [],
+            logOffset: 0,
+            parent: null,
+            scribe,
+            sequenceNumber: StartingSequenceNumber,
+            tenantId,
+            version: "0.1",
+        };
+        await collection.insertOne(value);
+        return value;
+    }
+
+    // Looks up the DB and summary for the document.
     private async getOrCreateObject(tenantId: string, documentId: string): Promise<IDocumentDetails> {
         const collection = await this.databaseManager.getDocumentCollection();
-        const result = await collection.findOrCreate(
-            {
-                documentId,
-                tenantId,
-            },
-            {
-                branchMap: undefined,
-                clients: undefined,
-                createTime: Date.now(),
-                deli: undefined,
-                documentId,
-                forks: [],
-                logOffset: 0,
-                parent: null,
-                scribe: undefined,
-                sequenceNumber: StartingSequenceNumber,
-                tenantId,
-                version: "0.1",
+        const document = await collection.findOne({ documentId, tenantId });
+        if (document === null) {
+            // Guard against storage failure. Returns false if storage is unresponsive.
+            const foundInSummaryP = this.readFromSummary(tenantId, documentId).then((result) => {
+                return result;
+            }, (err) => {
+                winston.error(`Error while fetching summary for ${tenantId}/${documentId}`);
+                winston.error(err);
+                return false;
             });
 
-        return result;
+            const inSummary = await foundInSummaryP;
+
+            // Setting an empty string to deli and scribe denotes that the checkpoints should be loaded from summary.
+            const value = inSummary ?
+                await this.createObject(collection, tenantId, documentId, "", "") :
+                await this.createObject(collection, tenantId, documentId);
+
+            return {
+                value,
+                existing: inSummary,
+            };
+        } else {
+            return {
+                value: document,
+                existing: true,
+            };
+        }
+    }
+
+    private async readFromSummary(tenantId: string, documentId: string): Promise<boolean> {
+        const tenant = await this.tenantManager.getTenant(tenantId);
+        const gitManager = tenant.gitManager;
+        const existingRef = await gitManager.getRef(encodeURIComponent(documentId));
+        if (existingRef) {
+            // Fetch ops from logTail and insert into deltas collection.
+            // TODO: Make the rest endpoint handle this case.
+            const opsContent = await gitManager.getContent(existingRef.object.sha, ".logTail/logTail");
+            const ops = JSON.parse(
+                Buffer.from(opsContent.content, opsContent.encoding).toString()) as ISequencedDocumentMessage[];
+            const dbOps: ISequencedOperationMessage[] = ops.map((op: ISequencedDocumentMessage) => {
+                return {
+                    documentId,
+                    operation: op,
+                    tenantId,
+                    type: SequencedOperationType,
+                };
+            });
+            const opsCollection = await this.databaseManager.getDeltaCollection(tenantId, documentId);
+            await opsCollection
+                .insertMany(dbOps, false)
+                // eslint-disable-next-line @typescript-eslint/promise-function-async
+                .catch((error) => {
+                    // Duplicate key errors are ignored
+                    if (error.code !== 11000) {
+                        // Needs to be a full rejection here
+                        return Promise.reject(error);
+                    }
+                });
+            winston.info(`Inserted ${dbOps.length} ops into deltas DB`);
+            return true;
+        } else {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
The PR enables hydrating the ordering service state (deli and scribe) from a summary. Unlike previous iterations, the summary can be generated outside the scope of current tenant. This enables the ordering service to perform the following:

1. Copy over any summary and start the ordering service from that summary.
2. Delete the previous summary from "local/operational storage" and rehydrate the session back from remote storage.
3. DR scenarios when we need to switch ordering service and hydrate the state from a summary.

Conceptually this is very similar to detached flow. In that case, the summary was generated inside a client and service did not know about it prior.

Improvements needed: Currently the client always ask for ops starting from its protocol state sequence number. Since the document was generated elsewhere, the delta caches will not be available. To work around this, we write back the deltas from .logTail. In future, we should make the client aware of this ops.