### PR TITLE
add package level description

### DIFF
--- a/packages/framework/aqueduct/src/index.ts
+++ b/packages/framework/aqueduct/src/index.ts
@@ -4,11 +4,16 @@
  */
 
 /**
- * The `aqueduct` package contains implementations of the Fluid Framework interfaces that help developers to quickly
- * get started.
+ * The `aqueduct` package is a library for building Fluid objects and Fluid
+ * containers within the Fluid Framework. Its goal is to provide a thin base
+ * layer over the existing Fluid Framework interfaces that allows developers to
+ * get started quickly.
  *
  * @remarks
- * About the package name: An Aqueduct is a way to transport water from a source to another location.
+ * About the package name: An Aqueduct is a way to transport water from a source
+ * to another location. The package name was chosen because its purpose is to
+ * facilitate using lower level constructs and therefore handle 'fluid' items
+ * same as an aqueduct.
  *
  * @packageDocumentation
  */

--- a/packages/framework/data-object-base/src/index.ts
+++ b/packages/framework/data-object-base/src/index.ts
@@ -3,6 +3,13 @@
  * Licensed under the MIT License.
  */
 
+/**
+* The view interfaces provide a generic way for objects to expose their
+* rendering capabilities to consumers.
+*
+* @packageDocumentation
+*/
+
 export * from "./lazyLoadedDataObject";
 export * from "./lazyLoadedDataObjectFactory";
 export * from "./runtimeFactory";

--- a/packages/framework/undo-redo/src/index.ts
+++ b/packages/framework/undo-redo/src/index.ts
@@ -4,7 +4,7 @@
  */
 
 /**
-* This package provides and implementation of an in-memory undo redo stack, as
+* This package provides an implementation of an in-memory undo redo stack, as
 * well as handlers for the SharedMap, and SharedSegmentSequence distributed
 * datastructures.
 *

--- a/packages/framework/undo-redo/src/index.ts
+++ b/packages/framework/undo-redo/src/index.ts
@@ -3,6 +3,93 @@
  * Licensed under the MIT License.
  */
 
+/**
+* This package provides and implementation of an in-memory undo redo stack, as
+* well as handlers for the SharedMap, and SharedSegmentSequence distributed
+* datastructures.
+*
+* <h3>Undo Redo Stack Manager</h3>
+*
+* The undo redo stack manager is where undo and redo commands are issued, and it
+* holds the stack of all undoable and redoable operations. The undo redo stack
+* manager is a stack of stacks.
+*
+* The outer stack contains operations, and the inner stack contains all the
+* IRevertible objects that make up that operation. This allows the consumer of
+* the undo redo stack manager to determine the granularity of what is undone or
+* redone.
+*
+* For instance, you could defined a text operation at the word level, so as a
+* user types you could close the current operation whenever the user types a
+* space. By doing this when the user issues an undo mid-word the characters
+* typed since the last space would be undone, if they issue another undo the
+* previous word would them be undone.
+*
+* As mentioned above operations are a stack of IRevertible objects. As suggested
+* by the name, these objects have the ability to revert some change which
+* usually means two things. They must be able to track what was changed, and
+* store enough metadata to revert that change.
+*
+* In order to create IRevertible object there are provided undo redo handlers
+* for commonly used data structures.
+*
+* <h3>Shared Map Undo Redo Handler</h3>
+*
+* The SharedMapUndoRedoHandler generates IRevertible objects,
+* SharedMapRevertible for all local changes made to a SharedMap and pushes them
+* to the current operation on the undo redo stack. These objects are created via
+* the valueChanged event of the SharedMap. This handler will never close the
+* current operation on the stack. This is a fairly simple handler, and a good
+* example to look at for understanding how IRevertible objects should work.
+*
+* <h3>Shared Segment Sequence Undo Redo Handler</h3>
+*
+* The SharedSegmentSequenceUndoRedoHandler generates IRevertible objects,
+* SharedSegmentSequenceRevertible for any SharedSegmentSequence based
+* distributed datastructures like SharedString, SharedObjectSequence, and
+* SharedNumberSequence.
+*
+* This handler pushes an SharedSegmentSequenceRevertible for every local Insert,
+* Remove, and Annotate operations made to the sequence. The objects are created
+* via the sequenceDelta event of the sequence. Like the SharedMapUndoRedoHandler
+* this handler will never close the current operation on the stack.
+*
+* This handler is more complex than the SharedMapUndoRedoHandler. The handler
+* itself batches the SharedSegmentSequence changes into the smallest number of
+* IRevertible objects it can to minimize the memory and performance overhead on
+* the SharedSegmentSequence of tracking changes for revert.
+*
+* <h3>Shared Segment Sequence Revertible</h3>
+*
+* The SharedSegmentSequenceRevertible does the heavy lifting of tracking and
+* reverting changes on the underlying SharedSegmentSequence. This is
+* accomplished via TrackingGroup objects. A TrackingGroup creates a bi-direction
+* link between itself and the segment. This link is maintained across segment
+* movement, splits, merges, and removal. When a sequence delta event is fired
+* the segments contained in that event are added to a TrackingGroup. The
+* TrackingGroup is then tracked along with additional metadata, like the delta
+* type and the annotate property changes. From the TrackingGroup's segments we
+* can find the ranges in the current document that were affected by the original
+* change even in the presence of other changes. The segments also contain the
+* content which can be used. With the ranges, content, and metadata we can
+* revert the original change on the sequence.
+*
+* As called out above, there is some memory and performance overhead associated
+* with undo redo. This overhead is from the TrackingGroup. This overhead
+* manifests in a few ways:
+*
+* - Removed segments in a TrackingGroup will not be garbage collected from the
+*   backing tree structure.
+* - Segments can only be merged if they have all the same TrackingGroups.
+*
+* This object minimizes the number of TrackingGroups created, so this overhead
+* is very low. This undo redo infrastructure is entirely in-memory so it does
+* not affect other users or sessions. If custom IRevertible objects use
+* TrackingGroups this overhead should be kept in mind to avoid possible
+* performance issues.
+* @packageDocumentation
+*/
+
 export * from "./undoRedoStackManager";
 export * from "./mapHandler";
 export * from "./sequenceHandler";

--- a/packages/framework/undo-redo/src/index.ts
+++ b/packages/framework/undo-redo/src/index.ts
@@ -87,6 +87,7 @@
 * not affect other users or sessions. If custom IRevertible objects use
 * TrackingGroups this overhead should be kept in mind to avoid possible
 * performance issues.
+*
 * @packageDocumentation
 */
 

--- a/packages/framework/view-adapters/src/index.ts
+++ b/packages/framework/view-adapters/src/index.ts
@@ -3,6 +3,21 @@
  * Licensed under the MIT License.
  */
 
+/**
+* Views may be written using a variety of UI frameworks. The view adapters
+* module provides helpful tools for composing these views, intended for use when
+* either:
+*
+* 1. The view being composed is from a different framework than its visual host.
+*
+* 2. It is not known which framework was used in the view being composed.
+*
+* The adapters translate between different view frameworks to satisfy #1, and are
+* able to inspect a view to deduce its framework to satisfy #2.
+*
+* @packageDocumentation
+*/
+
 export * from "./htmlview";
 export * from "./mountableview";
 export * from "./react";

--- a/packages/framework/view-interfaces/README.md
+++ b/packages/framework/view-interfaces/README.md
@@ -1,3 +1,3 @@
 # @fluidframework/view-interfaces
 
-The view interfaces provide a way for view objects to expose their rendering capabilities to consumers.
+The view interfaces provide a generic way for objects to expose their rendering capabilities to consumers.

--- a/packages/runtime/datastore-definitions/src/index.ts
+++ b/packages/runtime/datastore-definitions/src/index.ts
@@ -3,6 +3,13 @@
  * Licensed under the MIT License.
  */
 
+/**
+* This package defines the interfaces required to implement and/or communicate
+* with a data store.
+*
+* @packageDocumentation
+*/
+
 export * from "./channel";
 export * from "./dataStoreRuntime";
 export * from "./jsonable";


### PR DESCRIPTION
As shown here: https://ashy-mud-0acebac10.azurestaticapps.net/apis/ many packages don't have high level descriptions making the API doc less useful. I picked some packages and added a package level description usually lifted from the README.

There is a lot of work to do to get the API docs in a good place but this is a first step.