### PR TITLE
Fix odsp driver to use id of first tree in response as versionId.

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -355,9 +355,14 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
 
                 const odspSnapshot: IOdspSnapshot = cachedSnapshot;
 
-                const { trees, blobs, ops, id } = odspSnapshot;
+                const { trees, blobs, ops } = odspSnapshot;
+                let { id } = odspSnapshot;
                 if (trees) {
                     this.initTreesCache(trees);
+                    // versionId is the id of the first tree
+                    if (trees.length > 0) {
+                        id = trees[0].id;
+                    }
                 }
                 if (blobs) {
                     this.initBlobsCache(blobs);

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -356,7 +356,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                 const odspSnapshot: IOdspSnapshot = cachedSnapshot;
 
                 const { trees, blobs, ops } = odspSnapshot;
-                let { id } = odspSnapshot;
+                // id should be undefined in case of just ops in snapshot.
+                let id: string | undefined;
                 if (trees) {
                     this.initTreesCache(trees);
                     // versionId is the id of the first tree

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -216,8 +216,8 @@ export async function start(
 
             documentId = moniker.choose();
             url = url.replace(id, documentId);
-
-            const newLoader = await createWebLoader(documentId, fluidModule, options, urlResolver, codeDetails);
+            const urlResolver2 = new MultiUrlResolver(documentId, window.location.origin, options);
+            const newLoader = await createWebLoader(documentId, fluidModule, options, urlResolver2, codeDetails);
             container1 = await newLoader.createDetachedContainer(codeDetails);
         }
     }

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -216,9 +216,9 @@ export async function start(
 
             documentId = moniker.choose();
             url = url.replace(id, documentId);
-            const urlResolver2 = new MultiUrlResolver(documentId, window.location.origin, options);
-            const newLoader = await createWebLoader(documentId, fluidModule, options, urlResolver2, codeDetails);
-            container1 = await newLoader.createDetachedContainer(codeDetails);
+            const urlResolver = new MultiUrlResolver(documentId, window.location.origin, options);
+            const loader1 = await createWebLoader(documentId, fluidModule, options, urlResolver, codeDetails);
+            container1 = await loader1.createDetachedContainer(codeDetails);
         }
     }
 

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -191,7 +191,7 @@ export async function start(
         config: {},
     };
 
-    const urlResolver = new MultiUrlResolver(window.location.origin, options);
+    const urlResolver = new MultiUrlResolver(documentId, window.location.origin, options);
 
     // Create the loader that is used to load the Container.
     const loader1 = await createWebLoader(documentId, fluidModule, options, urlResolver, codeDetails);

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -191,10 +191,10 @@ export async function start(
         config: {},
     };
 
-    const urlResolver = new MultiUrlResolver(documentId, window.location.origin, options);
+    let urlResolver = new MultiUrlResolver(documentId, window.location.origin, options);
 
     // Create the loader that is used to load the Container.
-    const loader1 = await createWebLoader(documentId, fluidModule, options, urlResolver, codeDetails);
+    let loader1 = await createWebLoader(documentId, fluidModule, options, urlResolver, codeDetails);
 
     let container1: Container;
     if (autoAttach || manualAttach) {
@@ -216,8 +216,8 @@ export async function start(
 
             documentId = moniker.choose();
             url = url.replace(id, documentId);
-            const urlResolver = new MultiUrlResolver(documentId, window.location.origin, options);
-            const loader1 = await createWebLoader(documentId, fluidModule, options, urlResolver, codeDetails);
+            urlResolver = new MultiUrlResolver(documentId, window.location.origin, options);
+            loader1 = await createWebLoader(documentId, fluidModule, options, urlResolver, codeDetails);
             container1 = await loader1.createDetachedContainer(codeDetails);
         }
     }

--- a/packages/tools/webpack-fluid-loader/src/multiResolver.ts
+++ b/packages/tools/webpack-fluid-loader/src/multiResolver.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { parse } from "url";
-import { IFluidResolvedUrl, IResolvedUrl, IUrlResolver } from "@fluidframework/driver-definitions";
+import { IResolvedUrl, IUrlResolver } from "@fluidframework/driver-definitions";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { LocalResolver } from "@fluidframework/local-driver";
 import { InsecureUrlResolver } from "@fluidframework/test-runtime-utils";
@@ -76,6 +75,7 @@ const getUser = (): IDevServerUser => ({
 export class MultiUrlResolver implements IUrlResolver {
     private readonly urlResolver: IUrlResolver;
     constructor(
+        private readonly documentId: string,
         private readonly rawUrl: string,
         private readonly options: RouteOptions) {
         this.urlResolver = getUrlResolver(options);
@@ -86,14 +86,7 @@ export class MultiUrlResolver implements IUrlResolver {
         if (url.startsWith("/")) {
             url = url.substr(1);
         }
-        const fluidResolvedUrl = resolvedUrl as IFluidResolvedUrl;
-
-        const parsedUrl = parse(fluidResolvedUrl.url);
-        if (parsedUrl.pathname === undefined) {
-            throw new Error("Url should contain tenant and docId!!");
-        }
-        const [, , documentId] = parsedUrl.pathname.split("/");
-        return `${this.rawUrl}/${documentId}/${url}`;
+        return `${this.rawUrl}/${this.documentId}/${url}`;
     }
 
     async resolve(request: IRequest): Promise<IResolvedUrl | undefined> {


### PR DESCRIPTION
1.) This was a regression in odsp driver when we moved from sha to id as version id because id returned in snapshot in not the id of the tree, Version id is the id of the first tree returned in snapshot.
2.) Fix absolute url in webpack fluid loader.