### PR TITLE
Use tsconfig directory as base for path resolution

### DIFF
--- a/tools/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -128,7 +128,8 @@ export class TscTask extends LeafTask {
                 logVerbose(`${this.node.pkg.nameColored}: ts fail to parse ${configFileFullPath}`);
                 return undefined;
             }
-            const options = ts.parseJsonConfigFileContent(config, ts.sys, this.node.pkg.directory, parsedCommand.options, configFileFullPath);
+            const configDir = path.parse(configFileFullPath).dir;
+            const options = ts.parseJsonConfigFileContent(config, ts.sys, configDir, parsedCommand.options, configFileFullPath);
             if (options.errors.length) {
                 logVerbose(`${this.node.pkg.nameColored}: ts fail to parse file content ${configFileFullPath}`);
                 return undefined;


### PR DESCRIPTION
Relative paths in tsconfig need to be resolved against the location of the tsconfig, but currently we're resolving against the location of the package.json.