### PR TITLE
exporting createCreateNewRequest

### DIFF
--- a/packages/drivers/odsp-driver/src/createCreateNewRequest.ts
+++ b/packages/drivers/odsp-driver/src/createCreateNewRequest.ts
@@ -1,3 +1,7 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
 import { IRequest } from "@fluidframework/core-interfaces";
 import { CreateNewHeader } from "@fluidframework/driver-definitions";
 

--- a/packages/drivers/odsp-driver/src/createCreateNewRequest.ts
+++ b/packages/drivers/odsp-driver/src/createCreateNewRequest.ts
@@ -1,0 +1,21 @@
+import { IRequest } from "@fluidframework/core-interfaces";
+import { CreateNewHeader } from "@fluidframework/driver-definitions";
+
+export function createCreateNewRequest(
+    siteUrl: string,
+    driveId: string,
+    filePath: string,
+    fileName: string
+): IRequest {
+    const createNewRequest: IRequest = {
+        url: `${siteUrl}?driveId=${encodeURIComponent(
+            driveId
+        )}&path=${encodeURIComponent(filePath)}`,
+        headers: {
+            [CreateNewHeader.createNew]: {
+                fileName,
+            },
+        },
+    };
+    return createNewRequest;
+}

--- a/packages/drivers/odsp-driver/src/createOdspCreateContainerRequest.ts
+++ b/packages/drivers/odsp-driver/src/createOdspCreateContainerRequest.ts
@@ -5,15 +5,15 @@
 import { IRequest } from "@fluidframework/core-interfaces";
 import { CreateNewHeader } from "@fluidframework/driver-definitions";
 
-export function createCreateNewRequest(
+export function createOdspCreateContainerRequest(
     siteUrl: string,
     driveId: string,
     filePath: string,
-    fileName: string
+    fileName: string,
 ): IRequest {
     const createNewRequest: IRequest = {
         url: `${siteUrl}?driveId=${encodeURIComponent(
-            driveId
+            driveId,
         )}&path=${encodeURIComponent(filePath)}`,
         headers: {
             [CreateNewHeader.createNew]: {

--- a/packages/drivers/odsp-driver/src/index.ts
+++ b/packages/drivers/odsp-driver/src/index.ts
@@ -20,3 +20,4 @@ export * from "./odspCache";
 export * from "./createFile";
 export * from "./odspUrlHelper";
 export * from "./odspError";
+export * from "./createCreateNewRequest";

--- a/packages/drivers/odsp-driver/src/index.ts
+++ b/packages/drivers/odsp-driver/src/index.ts
@@ -20,4 +20,4 @@ export * from "./odspCache";
 export * from "./createFile";
 export * from "./odspUrlHelper";
 export * from "./odspError";
-export * from "./createCreateNewRequest";
+export * from "./createOdspCreateContainerRequest";

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -16,6 +16,7 @@ import {
 import { IOdspResolvedUrl } from "./contracts";
 import { getHashedDocumentId } from "./odspUtils";
 import { getApiRoot } from "./odspUrlHelper";
+import { createCreateNewRequest } from "./createCreateNewRequest";
 
 function getSnapshotUrl(siteUrl: string, driveId: string, itemId: string) {
     const siteOrigin = new URL(siteUrl).origin;
@@ -109,15 +110,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
     }
 
     public createCreateNewRequest(siteUrl: string, driveId: string, filePath: string, fileName: string): IRequest {
-        const createNewRequest: IRequest = {
-            url: `${siteUrl}?driveId=${encodeURIComponent(driveId)}&path=${encodeURIComponent(filePath)}`,
-            headers: {
-                [CreateNewHeader.createNew]: {
-                    fileName,
-                },
-            },
-        };
-        return createNewRequest;
+        return createCreateNewRequest(siteUrl, driveId, filePath, fileName);
     }
 
     private decodeOdspUrl(url: string): { siteUrl: string; driveId: string; itemId: string; path: string } {

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -16,7 +16,7 @@ import {
 import { IOdspResolvedUrl } from "./contracts";
 import { getHashedDocumentId } from "./odspUtils";
 import { getApiRoot } from "./odspUrlHelper";
-import { createCreateNewRequest } from "./createCreateNewRequest";
+import { createOdspCreateContainerRequest } from "./createOdspCreateContainerRequest";
 
 function getSnapshotUrl(siteUrl: string, driveId: string, itemId: string) {
     const siteOrigin = new URL(siteUrl).origin;
@@ -110,7 +110,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
     }
 
     public createCreateNewRequest(siteUrl: string, driveId: string, filePath: string, fileName: string): IRequest {
-        return createCreateNewRequest(siteUrl, driveId, filePath, fileName);
+        return createOdspCreateContainerRequest(siteUrl, driveId, filePath, fileName);
     }
 
     private decodeOdspUrl(url: string): { siteUrl: string; driveId: string; itemId: string; path: string } {


### PR DESCRIPTION
exporting createCreateNewRequest as a standalone function to allow hosts to call it without having to import the rest of the resolver