### PR TITLE
Pipeline release work flow (part I)

### DIFF
--- a/tools/build-server-resources/build-version.js
+++ b/tools/build-server-resources/build-version.js
@@ -11,7 +11,7 @@
  * Input:
  *      ./lerna.json or ./package.json - base version number to use
  *      env:VERSION_BUILDNUMBER        - monotonically increasing build number from the CI
- *      env:VERSION_BUILDBRANCH        - the build branch/tags that triggered the build
+ *      env:VERSION_RELEASE            - whether this is a release build or not
  *      env:VERSION_PATCH              - Put the build number in the patch
  * Output:
  *      The computed version output to the console.
@@ -52,80 +52,9 @@ function parseFileVersion(file_version, build_id) {
 
 /**
  * Compute the build suffix
- *
- * The suffix follows the CSemVer-CI format, see https://csemver.org/
- *
- * If the build is trigger by tags, no suffix is needed (those are released bits).
- * Otherwise it is a CI only build, and we add the following suffix depending on the branch
- *     PRs:               refs/pull/*                             | ci.<build_number>.dev
- *     Official branches: refs/heads/main, refs/heads/release/*   | ci.<build_number>.official
- *     Manual builds:     <all others>                            | ci.<build_number>.manual
  */
-function getBuildSuffix(env_build_branch, build_num, isFull) {
-    // Split the branch
-    const build_branch = env_build_branch.split('/');
-    if (build_branch[0] !== 'refs') {
-        console.error(`ERROR: Invalid branch specification ${env_build_branch}`);
-        process.exit(6);
-    }
-
-    // Suffix based on branch.
-
-    // Tag releases
-    if (build_branch[1] === 'tags') {
-        return "";
-    }
-
-    if (!isFull) {
-        return `${build_num}`;
-    }
-
-    // PRs
-    if (build_branch[1] === 'pull') {
-        return `ci.${build_num}.dev`;
-    }
-
-    // main or release branches
-    if (build_branch[1] === 'heads' && (build_branch[2] === 'main' || build_branch[2] === "release")) {
-        return `ci.${build_num}.official`;
-    }
-
-    // Otherwise, it is manual builds
-    return `ci.${build_num}.manual`;
-}
-
-function generateFullVersion(release_version, prerelease_version, build_suffix) {
-    // Generate the full version string
-    if (prerelease_version) {
-        if (build_suffix) {
-            const p = prerelease_version.split('.');
-            while (p.length < 3) {
-                // pad it to at least 3 entries.
-                p.push("0");
-            }
-            return `${release_version}-${p.join(".")}.${build_suffix}`;
-        }
-        return `${release_version}-${prerelease_version}`;
-    }
-
-    if (build_suffix) {
-        // Add "--" between the release and the suffix
-        // one "-" to start he prerelease version
-        // another "-" so that CI build will precede other manually named prerelease build.
-        return `${release_version}--${build_suffix}`;
-    }
-
-    return release_version;
-}
-
-function getFullVersion(file_version, arg_build_num, arg_build_branch, patch) {
-    // Azure DevOp pass in the build number as $(buildNum).$(buildAttempt).
-    // Get the Build number and ignore the attempt number.
-    const build_id = patch ? parseInt(arg_build_num.split('.')[0]) : undefined;
-    const { release_version, prerelease_version } = parseFileVersion(file_version, build_id);
-    const build_suffix = build_id ? "" : getBuildSuffix(arg_build_branch, arg_build_num, true);
-    const fullVersion = generateFullVersion(release_version, prerelease_version, build_suffix);
-    return fullVersion;
+function getBuildSuffix(arg_release, build_num) {
+    return arg_release ? "" : build_num;
 }
 
 /* A simpler CI version that append the build number at the end in the prerelease */
@@ -145,33 +74,28 @@ function generateSimpleVersion(release_version, prerelease_version, build_suffix
     return release_version;
 }
 
-function getSimpleVersion(file_version, arg_build_num, arg_build_branch, patch) {
+function getSimpleVersion(file_version, arg_build_num, arg_release, patch) {
     // Azure DevOp pass in the build number as $(buildNum).$(buildAttempt).
     // Get the Build number and ignore the attempt number.
     const build_id = patch ? parseInt(arg_build_num.split('.')[0]) : undefined;
     const { release_version, prerelease_version } = parseFileVersion(file_version, build_id);
-    const build_suffix = build_id ? "" : getBuildSuffix(arg_build_branch, arg_build_num, false);
+    const build_suffix = build_id ? "" : getBuildSuffix(arg_release, arg_build_num);
     const fullVersion = generateSimpleVersion(release_version, prerelease_version, build_suffix);
     return fullVersion;
 }
 
 function main() {
-    let isFull = false;
     let arg_build_num;
     let arg_patch = false;
-    let arg_build_branch;
+    let arg_release = false;
     let file_version;
     for (let i = 2; i < process.argv.length; i++) {
-        if (process.argv[i] === "--full") {
-            isFull = true;
-            continue;
-        }
         if (process.argv[i] === "--build") {
             arg_build_num = process.argv[++i];
             continue;
         }
-        if (process.argv[i] === "--branch") {
-            arg_build_branch = process.argv[++i];
+        if (process.argv[i] === "--release") {
+            arg_release = true;
             continue;
         }
         if (process.argv[i] === "--patch") {
@@ -194,17 +118,12 @@ function main() {
             process.exit(3);
         }
     }
-
     if (!arg_patch) {
         arg_patch = !!process.env["VERSION_PATCH"];
     }
 
-    if (!arg_build_branch) {
-        arg_build_branch = process.env["VERSION_BUILDBRANCH"];
-        if (!arg_build_branch) {
-            console.error("ERROR: Missing VERSION_BUILDBRANCH environment variable");
-            process.exit(5);
-        }
+    if (!arg_release) {
+        arg_release = !!process.env["VERSION_RELEASE"];
     }
 
     if (!file_version) {
@@ -215,11 +134,8 @@ function main() {
         }
     }
 
-    if (isFull) {
-        console.log(getFullVersion(file_version, arg_build_num, arg_build_branch, arg_patch));
-    } else {
-        console.log(getSimpleVersion(file_version, arg_build_num, arg_build_branch, arg_patch));
-    }
+    // Generate and print the version to console
+    console.log(getSimpleVersion(file_version, arg_build_num, arg_release, arg_patch));
 }
 
 main();

--- a/tools/build-server-resources/build-version.js
+++ b/tools/build-server-resources/build-version.js
@@ -119,11 +119,11 @@ function main() {
         }
     }
     if (!arg_patch) {
-        arg_patch = !!process.env["VERSION_PATCH"];
+        arg_patch = (process.env["VERSION_PATCH"] === "true");
     }
 
     if (!arg_release) {
-        arg_release = !!process.env["VERSION_RELEASE"];
+        arg_release = (process.env["VERSION_RELEASE"] === "true");
     }
 
     if (!file_version) {

--- a/tools/build-tools/src/buildVersion/buildVersion.ts
+++ b/tools/build-tools/src/buildVersion/buildVersion.ts
@@ -139,11 +139,11 @@ function main() {
     }
 
     if (!arg_patch) {
-        arg_patch = !!process.env["VERSION_PATCH"];
+        arg_patch = (process.env["VERSION_PATCH"] === "true");
     }
 
     if (!arg_release) {
-        arg_release = !!process.env["VERSION_RELEASE"];
+        arg_release = (process.env["VERSION_RELEASE"] === "true");
     }
 
     if (!file_version) {

--- a/tools/build-tools/src/buildVersion/buildVersion.ts
+++ b/tools/build-tools/src/buildVersion/buildVersion.ts
@@ -11,7 +11,7 @@
  * Input:
  *      ./lerna.json or ./package.json - base version number to use
  *      env:VERSION_BUILDNUMBER        - monotonically increasing build number from the CI
- *      env:VERSION_BUILDBRANCH        - the build branch/tags that triggered the build
+ *      env:VERSION_RELEASE            - whether this is a release build or not
  *      env:VERSION_PATCH              - Put the build number in the patch
  * Output:
  *      The computed version output to the console.
@@ -56,81 +56,9 @@ function parseFileVersion(file_version: string, build_id?: number) {
 
 /**
  * Compute the build suffix
- *
- * The suffix follows the CSemVer-CI format, see https://csemver.org/ 
- *
- * If the build is trigger by tags, no suffix is needed (those are released bits).
- * Otherwise it is a CI only build, and we add the following suffix depending on the branch
- *     PRs:               refs/pull/*                             | ci.<build_number>.dev
- *     Official branches: refs/heads/main, refs/heads/release/* | ci.<build_number>.official
- *     Manual builds:     <all others>                            | ci.<build_number>.manual
  */
-function getBuildSuffix(env_build_branch: string, build_num: string, isFull: boolean) {
-    // Split the branch
-    const build_branch = env_build_branch.split('/');
-    if (build_branch[0] !== 'refs') {
-        console.error(`ERROR: Invalid branch specification ${env_build_branch}`);
-        process.exit(6);
-    }
-
-    // Suffix based on branch.
-
-    // Tag releases
-    if (build_branch[1] === 'tags') {
-        return "";
-    }
-
-    if (!isFull) {
-        return `${build_num}`;
-    }
-
-    // PRs
-    if (build_branch[1] === 'pull') {
-        return `ci.${build_num}.dev`;
-    }
-
-    // main or release branches
-    if (build_branch[1] === 'heads' && (build_branch[2] === 'main' || build_branch[2] === "release")) {
-        return `ci.${build_num}.official`;
-    }
-
-    // Otherwise, it is manual builds
-    return `ci.${build_num}.manual`;
-}
-
-function generateFullVersion(release_version: string, prerelease_version: string, build_suffix: string) {
-    // Generate the full version string
-    if (prerelease_version) {
-        if (build_suffix) {
-            const p = prerelease_version.split('.');
-            while (p.length < 3) {
-                // pad it to at least 3 entries.
-                p.push("0");
-            }
-            return `${release_version}-${p.join(".")}.${build_suffix}`;
-        }
-        return `${release_version}-${prerelease_version}`;
-    }
-
-    if (build_suffix) {
-        // Add "--" between the release and the suffix
-        // one "-" to start he prerelease version
-        // another "-" so that CI build will precede other manually named prerelease build.
-        return `${release_version}--${build_suffix}`;
-    }
-
-    return release_version;
-}
-
-export function getFullVersion(file_version: string, arg_build_num: string, arg_build_branch: string, patch: boolean) {
-    // Azure DevOp pass in the build number as $(buildNum).$(buildAttempt).
-    // Get the Build number and ignore the attempt number.
-    const build_id = patch? parseInt(arg_build_num.split('.')[0]) : undefined;
-
-    const { release_version, prerelease_version } = parseFileVersion(file_version, build_id);
-    const build_suffix = build_id ? "" : getBuildSuffix(arg_build_branch, arg_build_num, true);
-    const fullVersion = generateFullVersion(release_version, prerelease_version, build_suffix);
-    return fullVersion;
+function getBuildSuffix(arg_release: boolean, build_num: string) {
+    return arg_release? "" : build_num;
 }
 
 /* A simpler CI version that append the build number at the end in the prerelease */
@@ -150,37 +78,31 @@ function generateSimpleVersion(release_version: string, prerelease_version: stri
     return release_version;
 }
 
-export function getSimpleVersion(file_version: string, arg_build_num: string, arg_build_branch: string, patch: boolean) {
+export function getSimpleVersion(file_version: string, arg_build_num: string, arg_release: boolean, patch: boolean) {
     // Azure DevOp pass in the build number as $(buildNum).$(buildAttempt).
     // Get the Build number and ignore the attempt number.
     const build_id = patch? parseInt(arg_build_num.split('.')[0]) : undefined;
 
     const { release_version, prerelease_version } = parseFileVersion(file_version, build_id);
-    const build_suffix = build_id ? "" : getBuildSuffix(arg_build_branch, arg_build_num, false);
+    const build_suffix = build_id ? "" : getBuildSuffix(arg_release, arg_build_num);
     const fullVersion = generateSimpleVersion(release_version, prerelease_version, build_suffix);
     return fullVersion;
 }
 
 function main() {
-    let isFull = false;
     let arg_build_num: string | undefined;
     let arg_patch = false;
-    let arg_build_branch : string | undefined;
+    let arg_release = false;
     let file_version : string | undefined;
     let arg_test = false;
     for (let i = 2; i < process.argv.length; i++) {
-        if (process.argv[i] === "--full") {
-            isFull = true;
-            continue;
-        }
-
         if (process.argv[i] === "--build") {
             arg_build_num = process.argv[++i];
             continue;
         }
 
-        if (process.argv[i] === "--branch") {
-            arg_build_branch = process.argv[++i];
+        if (process.argv[i] === "--release") {
+            arg_release = true;
             continue;
         }
 
@@ -220,12 +142,8 @@ function main() {
         arg_patch = !!process.env["VERSION_PATCH"];
     }
 
-    if (!arg_build_branch) {
-        arg_build_branch = process.env["VERSION_BUILDBRANCH"];
-        if (!arg_build_branch) {
-            console.error("ERROR: Missing VERSION_BUILDBRANCH environment variable");
-            process.exit(5);
-        }
+    if (!arg_release) {
+        arg_release = !!process.env["VERSION_RELEASE"];
     }
 
     if (!file_version) {
@@ -236,11 +154,8 @@ function main() {
         }
     }
 
-    if (isFull) {
-        console.log(getFullVersion(file_version, arg_build_num, arg_build_branch, arg_patch));
-    } else {
-        console.log(getSimpleVersion(file_version, arg_build_num, arg_build_branch, arg_patch));
-    }
+    // Generate and print the version to console
+    console.log(getSimpleVersion(file_version, arg_build_num, arg_release, arg_patch));
 }
 
 main();

--- a/tools/build-tools/src/buildVersion/buildVersionTests.ts
+++ b/tools/build-tools/src/buildVersion/buildVersionTests.ts
@@ -4,63 +4,27 @@
  */
 
 import { strict as assert } from "assert";
-import { getFullVersion, getSimpleVersion } from "./buildVersion";
+import { getSimpleVersion } from "./buildVersion";
 
 export function test() {
     // Test version with id, no prerelease
-    assert.equal(getFullVersion("0.15.0", "12345", "refs/pull/blah", true), "0.15.12345");
-    assert.equal(getFullVersion("0.15.0", "12345", "refs/heads/main", true), "0.15.12345");
-    assert.equal(getFullVersion("0.15.0", "12345.0", "refs/heads/release/0.15", true), "0.15.12345");
-    assert.equal(getFullVersion("0.15.0", "12345.0", "refs/heads/blah", true), "0.15.12345");
-    assert.equal(getFullVersion("0.15.0", "12345.0", "refs/tags/v0.15.x", true), "0.15.12345");
+    assert.equal(getSimpleVersion("0.15.0", "12345.0", false, true), "0.15.12345");
+    assert.equal(getSimpleVersion("0.15.0", "12345.0", true, true), "0.15.12345");
 
     // Test version with id, with prerelease
-    assert.equal(getFullVersion("0.15.0-rc", "12345.0", "refs/pull/blah", true), "0.15.12345-rc");
-    assert.equal(getFullVersion("0.15.0-alpha.1", "12345.0", "refs/heads/main", true), "0.15.12345-alpha.1");
-    assert.equal(getFullVersion("0.15.0-beta.2.1", "12345.0", "refs/heads/release/0.15", true), "0.15.12345-beta.2.1");
-    assert.equal(getFullVersion("0.15.0-beta.2.1", "12345.0", "refs/heads/blah", true), "0.15.12345-beta.2.1");
-    assert.equal(getFullVersion("0.15.0-beta", "12345.0", "refs/tags/v0.15.x", true), "0.15.12345-beta");
+    assert.equal(getSimpleVersion("0.15.0-rc", "12345.0", false, true), "0.15.12345-rc");
+    assert.equal(getSimpleVersion("0.15.0-alpha.1", "12345.0", false, true), "0.15.12345-alpha.1");
+    assert.equal(getSimpleVersion("0.15.0-beta.2.1", "12345.0", false, true), "0.15.12345-beta.2.1");
+    assert.equal(getSimpleVersion("0.15.0-beta", "12345.0", true, true), "0.15.12345-beta");
 
     // Test version no id, no prerelease
-    assert.equal(getFullVersion("0.16.0", "12345.0", "refs/pull/blah", false), "0.16.0--ci.12345.0.dev");
-    assert.equal(getFullVersion("0.16.0", "12345.0", "refs/heads/main", false), "0.16.0--ci.12345.0.official");
-    assert.equal(getFullVersion("0.16.0", "12345.0", "refs/heads/release/0.16.0", false), "0.16.0--ci.12345.0.official");
-    assert.equal(getFullVersion("0.16.0", "12345.0", "refs/heads/blah", false), "0.16.0--ci.12345.0.manual");
-    assert.equal(getFullVersion("0.16.0", "12345.0", "refs/tags/v0.16.0", false), "0.16.0");
+    assert.equal(getSimpleVersion("0.16.0", "12345.0", false, false), "0.16.0-12345.0");
+    assert.equal(getSimpleVersion("0.16.0", "12345.0", true, false), "0.16.0");
 
     // Test version no id, with prerelease
-    assert.equal(getFullVersion("0.16.0-rc", "12345.0", "refs/pull/blah", false), "0.16.0-rc.0.0.ci.12345.0.dev");
-    assert.equal(getFullVersion("0.16.0-alpha.1", "12345.0", "refs/heads/main", false), "0.16.0-alpha.1.0.ci.12345.0.official");
-    assert.equal(getFullVersion("0.16.0-beta.2.1", "12345.0", "refs/heads/release/0.16.1", false), "0.16.0-beta.2.1.ci.12345.0.official");
-    assert.equal(getFullVersion("0.16.0-beta.2.1", "12345.0", "refs/heads/blah", false), "0.16.0-beta.2.1.ci.12345.0.manual");
-    assert.equal(getFullVersion("0.16.0-beta", "12345.0", "refs/tags/v0.16.0", false), "0.16.0-beta");
-
-    // Test version with id, no prerelease
-    assert.equal(getSimpleVersion("0.15.0", "12345.0", "refs/pull/blah", true), "0.15.12345");
-    assert.equal(getSimpleVersion("0.15.0", "12345.0", "refs/heads/main", true), "0.15.12345");
-    assert.equal(getSimpleVersion("0.15.0", "12345.0", "refs/heads/release/0.15", true), "0.15.12345");
-    assert.equal(getSimpleVersion("0.15.0", "12345.0", "refs/heads/blah", true), "0.15.12345");
-    assert.equal(getSimpleVersion("0.15.0", "12345.0", "refs/tags/v0.15.x", true), "0.15.12345");
-
-    // Test version with id, with prerelease
-    assert.equal(getSimpleVersion("0.15.0-rc", "12345.0", "refs/pull/blah", true), "0.15.12345-rc");
-    assert.equal(getSimpleVersion("0.15.0-alpha.1", "12345.0", "refs/heads/main", true), "0.15.12345-alpha.1");
-    assert.equal(getSimpleVersion("0.15.0-beta.2.1", "12345.0", "refs/heads/release/0.15", true), "0.15.12345-beta.2.1");
-    assert.equal(getSimpleVersion("0.15.0-beta.2.1", "12345.0", "refs/heads/blah", true), "0.15.12345-beta.2.1");
-    assert.equal(getSimpleVersion("0.15.0-beta", "12345.0", "refs/tags/v0.15.x", true), "0.15.12345-beta");
-
-    // Test version no id, no prerelease
-    assert.equal(getSimpleVersion("0.16.0", "12345.0", "refs/pull/blah", false), "0.16.0-12345.0");
-    assert.equal(getSimpleVersion("0.16.0", "12345.0", "refs/heads/main", false), "0.16.0-12345.0");
-    assert.equal(getSimpleVersion("0.16.0", "12345.0", "refs/heads/release/0.16.0", false), "0.16.0-12345.0");
-    assert.equal(getSimpleVersion("0.16.0", "12345.0", "refs/heads/blah", false), "0.16.0-12345.0");
-    assert.equal(getSimpleVersion("0.16.0", "12345.0", "refs/tags/v0.16.0", false), "0.16.0");
-
-    // Test version no id, with prerelease
-    assert.equal(getSimpleVersion("0.16.0-rc", "12345.0", "refs/pull/blah", false), "0.16.0-rc.12345.0");
-    assert.equal(getSimpleVersion("0.16.0-alpha.1", "12345.0", "refs/heads/main", false), "0.16.0-alpha.1.12345.0");
-    assert.equal(getSimpleVersion("0.16.0-beta.2.1", "12345.0", "refs/heads/release/0.16.1", false), "0.16.0-beta.2.1.12345.0");
-    assert.equal(getSimpleVersion("0.16.0-beta.2.1", "12345.0", "refs/heads/blah", false), "0.16.0-beta.2.1.12345.0");
-    assert.equal(getSimpleVersion("0.16.0-beta", "12345.0", "refs/tags/v0.16.0", false), "0.16.0-beta");
+    assert.equal(getSimpleVersion("0.16.0-rc", "12345.0", false, false), "0.16.0-rc.12345.0");
+    assert.equal(getSimpleVersion("0.16.0-alpha.1", "12345.0", false, false), "0.16.0-alpha.1.12345.0");
+    assert.equal(getSimpleVersion("0.16.0-beta.2.1", "12345.0", false, false), "0.16.0-beta.2.1.12345.0");
+    assert.equal(getSimpleVersion("0.16.0-beta", "12345.0", true, false), "0.16.0-beta");
     console.log("Test passed!");
 }

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -12,7 +12,6 @@ parameters:
   default: default
   values:
     - default
-    - force
     - skip
 - name: releaseBuildOverride
   displayName: Release Build Override
@@ -35,6 +34,7 @@ trigger:
     - tools/pipelines/build-build-common.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/publish-npm-package.yml
 
 pr:
@@ -48,6 +48,7 @@ pr:
     - tools/pipelines/build-build-common.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -40,3 +40,5 @@ extends:
     taskLint: false
     taskTest: false
     taskAuth: false
+    noPublish: ${{ variables['noPublish'] }}
+    releaseBuild: ${{ variables['releaseBuild'] }}

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -5,6 +5,22 @@
 
 name: $(Build.BuildId)
 
+parameters:
+- name: publishOverride
+  displayName: Publish Override
+  type: string
+  default: default
+  values:
+    - default
+    - force
+    - skip
+- name: releaseBuild
+  type: string
+  default:
+  values:
+    - false
+    - true
+
 trigger:
   branches:
     include:
@@ -40,5 +56,3 @@ extends:
     taskLint: false
     taskTest: false
     taskAuth: false
-    noPublish: ${{ variables['noPublish'] }}
-    releaseBuild: ${{ variables['releaseBuild'] }}

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -14,10 +14,12 @@ parameters:
     - default
     - force
     - skip
-- name: releaseBuild
+- name: releaseBuildOverride
+  displayName: Release Build Override
   type: string
-  default:
+  default: default
   values:
+    - default
     - false
     - true
 
@@ -56,3 +58,5 @@ extends:
     taskLint: false
     taskTest: false
     taskAuth: false
+    publishOverride: ${{ parameters.publishOverride }}
+    releaseBuildOverride: ${{ parameters.releaseBuildOverride }}

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -52,11 +52,11 @@ pr:
 extends:
   template: templates/build-npm-package.yml
   parameters:
+    publishOverride: ${{ parameters.publishOverride }}
+    releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildDirectory: common/build/build-common
     taskBuild: false
     taskBuildDocs: false
     taskLint: false
     taskTest: false
     taskAuth: false
-    publishOverride: ${{ parameters.publishOverride }}
-    releaseBuildOverride: ${{ parameters.releaseBuildOverride }}

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -5,6 +5,24 @@
 
 name: $(Build.BuildId)
 
+parameters:
+- name: publishOverride
+  displayName: Publish Override
+  type: string
+  default: default
+  values:
+    - default
+    - force
+    - skip
+- name: releaseBuildOverride
+  displayName: Release Build Override
+  type: string
+  default: default
+  values:
+    - default
+    - false
+    - true
+
 trigger:
   branches:
     include:
@@ -32,6 +50,8 @@ pr:
 extends:
   template: templates/build-npm-package.yml
   parameters:
+    publishOverride: ${{ parameters.publishOverride }}
+    releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildDirectory: tools/build-tools
     taskBuild: build
     taskBuildDocs: false

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -12,7 +12,6 @@ parameters:
   default: default
   values:
     - default
-    - force
     - skip
 - name: releaseBuildOverride
   displayName: Release Build Override
@@ -33,6 +32,7 @@ trigger:
     - tools/pipelines/build-build-tools.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/publish-npm-package.yml
 
 pr:
@@ -46,6 +46,7 @@ pr:
     - tools/pipelines/build-build-tools.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -6,22 +6,21 @@
 name: $(Build.BuildId)
 
 parameters:
-  - name: publishOverride
-    displayName: Publish Override
-    type: string
-    default: default
-    values:
-      - default
-      - force
-      - skip
-  - name: releaseBuildOverride
-    displayName: Release Build Override
-    type: string
-    default: default
-    values:
-      - default
-      - false
-      - true
+- name: publishOverride
+  displayName: Publish Override
+  type: string
+  default: default
+  values:
+    - default
+    - skip
+- name: releaseBuildOverride
+  displayName: Release Build Override
+  type: string
+  default: default
+  values:
+    - default
+    - false
+    - true
 
 trigger:
   branches:
@@ -42,6 +41,7 @@ trigger:
     - tools/pipelines/build-client.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/publish-npm-package.yml
 
 pr:
@@ -62,6 +62,7 @@ pr:
     - tools/pipelines/build-client.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -5,6 +5,24 @@
 
 name: $(Build.BuildId)
 
+parameters:
+  - name: publishOverride
+    displayName: Publish Override
+    type: string
+    default: default
+    values:
+      - default
+      - force
+      - skip
+  - name: releaseBuildOverride
+    displayName: Release Build Override
+    type: string
+    default: default
+    values:
+      - default
+      - false
+      - true
+
 trigger:
   branches:
     include:
@@ -48,6 +66,8 @@ pr:
 extends:
   template: templates/build-npm-package.yml
   parameters:
+    publishOverride: ${{ parameters.publishOverride }}
+    releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildDirectory: .
     poolBuild: Main
     cgSubDirectory: packages

--- a/tools/pipelines/build-common-definitions.yml
+++ b/tools/pipelines/build-common-definitions.yml
@@ -5,6 +5,24 @@
 
 name: $(Build.BuildId)
 
+parameters:
+  - name: publishOverride
+    displayName: Publish Override
+    type: string
+    default: default
+    values:
+      - default
+      - force
+      - skip
+  - name: releaseBuildOverride
+    displayName: Release Build Override
+    type: string
+    default: default
+    values:
+      - default
+      - false
+      - true
+
 trigger:
   branches:
     include:
@@ -34,5 +52,7 @@ pr:
 extends:
   template: templates/build-npm-package.yml
   parameters:
+    publishOverride: ${{ parameters.publishOverride }}
+    releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildDirectory: common/lib/common-definitions
     taskTest: false

--- a/tools/pipelines/build-common-definitions.yml
+++ b/tools/pipelines/build-common-definitions.yml
@@ -6,22 +6,21 @@
 name: $(Build.BuildId)
 
 parameters:
-  - name: publishOverride
-    displayName: Publish Override
-    type: string
-    default: default
-    values:
-      - default
-      - force
-      - skip
-  - name: releaseBuildOverride
-    displayName: Release Build Override
-    type: string
-    default: default
-    values:
-      - default
-      - false
-      - true
+- name: publishOverride
+  displayName: Publish Override
+  type: string
+  default: default
+  values:
+    - default
+    - skip
+- name: releaseBuildOverride
+  displayName: Release Build Override
+  type: string
+  default: default
+  values:
+    - default
+    - false
+    - true
 
 trigger:
   branches:
@@ -35,6 +34,7 @@ trigger:
     - tools/pipelines/build-common-definitions.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/publish-npm-package.yml
 
 pr:
@@ -48,6 +48,7 @@ pr:
     - tools/pipelines/build-common-definitions.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -6,22 +6,21 @@
 name: $(Build.BuildId)
 
 parameters:
-  - name: publishOverride
-    displayName: Publish Override
-    type: string
-    default: default
-    values:
-      - default
-      - force
-      - skip
-  - name: releaseBuildOverride
-    displayName: Release Build Override
-    type: string
-    default: default
-    values:
-      - default
-      - false
-      - true
+- name: publishOverride
+  displayName: Publish Override
+  type: string
+  default: default
+  values:
+    - default
+    - skip
+- name: releaseBuildOverride
+  displayName: Release Build Override
+  type: string
+  default: default
+  values:
+    - default
+    - false
+    - true
 
 trigger:
   branches:
@@ -35,6 +34,7 @@ trigger:
     - tools/pipelines/build-common-utils.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/publish-npm-package.yml
 
 pr:
@@ -48,6 +48,7 @@ pr:
     - tools/pipelines/build-common-utils.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -5,6 +5,24 @@
 
 name: $(Build.BuildId)
 
+parameters:
+  - name: publishOverride
+    displayName: Publish Override
+    type: string
+    default: default
+    values:
+      - default
+      - force
+      - skip
+  - name: releaseBuildOverride
+    displayName: Release Build Override
+    type: string
+    default: default
+    values:
+      - default
+      - false
+      - true
+
 trigger:
   branches:
     include:
@@ -34,4 +52,6 @@ pr:
 extends:
   template: templates/build-npm-package.yml
   parameters:
+    publishOverride: ${{ parameters.publishOverride }}
+    releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildDirectory: common/lib/common-utils

--- a/tools/pipelines/build-eslint-config-fluid.yml
+++ b/tools/pipelines/build-eslint-config-fluid.yml
@@ -6,22 +6,21 @@
 name: $(Build.BuildId)
 
 parameters:
-  - name: publishOverride
-    displayName: Publish Override
-    type: string
-    default: default
-    values:
-      - default
-      - force
-      - skip
-  - name: releaseBuildOverride
-    displayName: Release Build Override
-    type: string
-    default: default
-    values:
-      - default
-      - false
-      - true
+- name: publishOverride
+  displayName: Publish Override
+  type: string
+  default: default
+  values:
+    - default
+    - skip
+- name: releaseBuildOverride
+  displayName: Release Build Override
+  type: string
+  default: default
+  values:
+    - default
+    - false
+    - true
 
 trigger:
   branches:
@@ -35,6 +34,7 @@ trigger:
     - tools/pipelines/build-eslint-config-fluid.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/publish-npm-package.yml
 
 pr:
@@ -48,6 +48,7 @@ pr:
     - tools/pipelines/build-eslint-config-fluid.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-eslint-config-fluid.yml
+++ b/tools/pipelines/build-eslint-config-fluid.yml
@@ -5,6 +5,24 @@
 
 name: $(Build.BuildId)
 
+parameters:
+  - name: publishOverride
+    displayName: Publish Override
+    type: string
+    default: default
+    values:
+      - default
+      - force
+      - skip
+  - name: releaseBuildOverride
+    displayName: Release Build Override
+    type: string
+    default: default
+    values:
+      - default
+      - false
+      - true
+
 trigger:
   branches:
     include:
@@ -34,6 +52,8 @@ pr:
 extends:
   template: templates/build-npm-package.yml
   parameters:
+    publishOverride: ${{ parameters.publishOverride }}
+    releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildDirectory: common/build/eslint-config-fluid
     taskBuild: false
     taskBuildDocs: false

--- a/tools/pipelines/build-generator-fluid.yml
+++ b/tools/pipelines/build-generator-fluid.yml
@@ -5,6 +5,24 @@
 
 name: $(Build.BuildId)
 
+parameters:
+  - name: publishOverride
+    displayName: Publish Override
+    type: string
+    default: default
+    values:
+      - default
+      - force
+      - skip
+  - name: releaseBuildOverride
+    displayName: Release Build Override
+    type: string
+    default: default
+    values:
+      - default
+      - false
+      - true
+
 trigger:
   branches:
     include:
@@ -34,6 +52,8 @@ pr:
 extends:
   template: templates/build-npm-package.yml
   parameters:
+    publishOverride: ${{ parameters.publishOverride }}
+    releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildDirectory: tools/generator-fluid
     taskBuild: false
     taskBuildDocs: false

--- a/tools/pipelines/build-generator-fluid.yml
+++ b/tools/pipelines/build-generator-fluid.yml
@@ -6,22 +6,21 @@
 name: $(Build.BuildId)
 
 parameters:
-  - name: publishOverride
-    displayName: Publish Override
-    type: string
-    default: default
-    values:
-      - default
-      - force
-      - skip
-  - name: releaseBuildOverride
-    displayName: Release Build Override
-    type: string
-    default: default
-    values:
-      - default
-      - false
-      - true
+- name: publishOverride
+  displayName: Publish Override
+  type: string
+  default: default
+  values:
+    - default
+    - skip
+- name: releaseBuildOverride
+  displayName: Release Build Override
+  type: string
+  default: default
+  values:
+    - default
+    - false
+    - true
 
 trigger:
   branches:
@@ -35,6 +34,7 @@ trigger:
     - tools/pipelines/build-generator-fluid.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/publish-npm-package.yml
 
 pr:
@@ -48,6 +48,7 @@ pr:
     - tools/pipelines/build-generator-fluid.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -5,6 +5,24 @@
 
 name: $(Build.BuildId)
 
+parameters:
+  - name: publishOverride
+    displayName: Publish Override
+    type: string
+    default: default
+    values:
+      - default
+      - force
+      - skip
+  - name: releaseBuildOverride
+    displayName: Release Build Override
+    type: string
+    default: default
+    values:
+      - default
+      - false
+      - true
+
 trigger:
   branches:
     include:
@@ -31,6 +49,8 @@ pr:
 extends:
   template: templates/build-npm-package.yml
   parameters:
+    publishOverride: ${{ parameters.publishOverride }}
+    releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildDirectory: tools/test-tools
     taskBuild: build
     taskBuildDocs: false

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -6,22 +6,21 @@
 name: $(Build.BuildId)
 
 parameters:
-  - name: publishOverride
-    displayName: Publish Override
-    type: string
-    default: default
-    values:
-      - default
-      - force
-      - skip
-  - name: releaseBuildOverride
-    displayName: Release Build Override
-    type: string
-    default: default
-    values:
-      - default
-      - false
-      - true
+- name: publishOverride
+  displayName: Publish Override
+  type: string
+  default: default
+  values:
+    - default
+    - skip
+- name: releaseBuildOverride
+  displayName: Release Build Override
+  type: string
+  default: default
+  values:
+    - default
+    - false
+    - true
 
 trigger:
   branches:
@@ -33,6 +32,7 @@ trigger:
     - tools/pipelines/build-test-tools.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/publish-npm-package.yml
 
 pr:
@@ -45,6 +45,7 @@ pr:
     - tools/pipelines/build-test-tools.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-tinylicious.yml
+++ b/tools/pipelines/build-tinylicious.yml
@@ -5,6 +5,24 @@
 
 name: $(Build.BuildId)
 
+parameters:
+  - name: publishOverride
+    displayName: Publish Override
+    type: string
+    default: default
+    values:
+      - default
+      - force
+      - skip
+  - name: releaseBuildOverride
+    displayName: Release Build Override
+    type: string
+    default: default
+    values:
+      - default
+      - false
+      - true
+
 trigger:
   branches:
     include:
@@ -34,6 +52,8 @@ pr:
 extends:
   template: templates/build-npm-package.yml
   parameters:
+    publishOverride: ${{ parameters.publishOverride }}
+    releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildDirectory: server/tinylicious
     taskBuild: build
     taskBuildDocs: false

--- a/tools/pipelines/build-tinylicious.yml
+++ b/tools/pipelines/build-tinylicious.yml
@@ -6,22 +6,21 @@
 name: $(Build.BuildId)
 
 parameters:
-  - name: publishOverride
-    displayName: Publish Override
-    type: string
-    default: default
-    values:
-      - default
-      - force
-      - skip
-  - name: releaseBuildOverride
-    displayName: Release Build Override
-    type: string
-    default: default
-    values:
-      - default
-      - false
-      - true
+- name: publishOverride
+  displayName: Publish Override
+  type: string
+  default: default
+  values:
+    - default
+    - skip
+- name: releaseBuildOverride
+  displayName: Release Build Override
+  type: string
+  default: default
+  values:
+    - default
+    - false
+    - true
 
 trigger:
   branches:
@@ -35,6 +34,7 @@ trigger:
     - tools/pipelines/build-tinylicious.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/publish-npm-package.yml
 
 pr:
@@ -48,6 +48,7 @@ pr:
     - tools/pipelines/build-tinylicious.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/server-admin.yml
+++ b/tools/pipelines/server-admin.yml
@@ -15,6 +15,7 @@ trigger:
     - tools/pipelines/server-admin.yml
     - tools/pipelines/templates/build-docker-service.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-generate-notice-steps.yml
   
 pr:
@@ -27,6 +28,7 @@ pr:
     - tools/pipelines/server-admin.yml
     - tools/pipelines/templates/build-docker-service.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
   
 extends:
   template: templates/build-docker-service.yml

--- a/tools/pipelines/server-auspkn.yml
+++ b/tools/pipelines/server-auspkn.yml
@@ -15,6 +15,7 @@ trigger:
     - tools/pipelines/server-admin.yml
     - tools/pipelines/templates/build-docker-service.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-generate-notice-steps.yml
   
 pr:
@@ -27,6 +28,7 @@ pr:
     - tools/pipelines/server-admin.yml
     - tools/pipelines/templates/build-docker-service.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
 
 extends:
   template: templates/build-docker-service.yml

--- a/tools/pipelines/server-gateway.yml
+++ b/tools/pipelines/server-gateway.yml
@@ -15,6 +15,7 @@ trigger:
     - tools/pipelines/server-gateway.yml
     - tools/pipelines/templates/build-docker-service.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-generate-notice-steps.yml
 
 pr:
@@ -27,6 +28,7 @@ pr:
     - tools/pipelines/server-gateway.yml
     - tools/pipelines/templates/build-docker-service.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
   
 extends:
   template: templates/build-docker-service.yml

--- a/tools/pipelines/server-gitrest.yml
+++ b/tools/pipelines/server-gitrest.yml
@@ -15,6 +15,7 @@ trigger:
     - tools/pipelines/server-gitrest.yml
     - tools/pipelines/templates/build-docker-service.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-generate-notice-steps.yml
   
 pr:
@@ -27,6 +28,7 @@ pr:
     - tools/pipelines/server-gitrest.yml
     - tools/pipelines/templates/build-docker-service.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
 
 extends:
   template: templates/build-docker-service.yml

--- a/tools/pipelines/server-gitssh.yml
+++ b/tools/pipelines/server-gitssh.yml
@@ -13,8 +13,8 @@ trigger:
     include:
     - server/gitssh
     - tools/pipelines/server-gitssh.yml
-    - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/build-docker-service.yml
+    - tools/pipelines/templates/include-vars.yml
 
 pr:
   branches:
@@ -24,8 +24,8 @@ pr:
     include:
     - server/gitssh
     - tools/pipelines/server-gitssh.yml
-    - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/build-docker-service.yml
+    - tools/pipelines/templates/include-vars.yml
 
 extends:
   template: templates/build-docker-service.yml

--- a/tools/pipelines/server-headless-agent.yml
+++ b/tools/pipelines/server-headless-agent.yml
@@ -14,6 +14,8 @@ trigger:
     - server/headless-agent
     - tools/pipelines/server-headless-agent.yml
     - tools/pipelines/templates/build-docker-service.yml
+    - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-generate-notice-steps.yml
   
 pr:
@@ -25,6 +27,8 @@ pr:
     - server/headless-agent
     - tools/pipelines/server-headless-agent.yml
     - tools/pipelines/templates/build-docker-service.yml
+    - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
   
 extends:
   template: templates/build-docker-service.yml

--- a/tools/pipelines/server-historian.yml
+++ b/tools/pipelines/server-historian.yml
@@ -15,6 +15,7 @@ trigger:
     - tools/pipelines/server-historian.yml
     - tools/pipelines/templates/build-docker-service.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-generate-notice-steps.yml
 
 pr:
@@ -25,8 +26,9 @@ pr:
     include:
     - server/historian
     - tools/pipelines/server-historian.yml
-    - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/build-docker-service.yml
+    - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
 
 extends:
   template: templates/build-docker-service.yml

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -5,6 +5,24 @@
 
 name: $(Build.BuildId)
 
+parameters:
+  - name: publishOverride
+    displayName: Publish Override
+    type: string
+    default: default
+    values:
+      - default
+      - force
+      - skip
+  - name: releaseBuildOverride
+    displayName: Release Build Override
+    type: string
+    default: default
+    values:
+      - default
+      - false
+      - true
+
 trigger:
   branches:
     include:
@@ -38,6 +56,9 @@ pr:
 
 variables:
 - template: templates/include-vars.yml
+  parameters:
+    publishOverride: ${{ parameters.publishOverride }}
+    releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
 - group: container-registry-info
 - name: containerName
   value: fluid-server
@@ -129,6 +150,8 @@ stages:
         - template: templates/include-set-package-version.yml
           parameters:
             buildDirectory: server/routerlicious
+            release: $(release)
+
         # Build
         - task: Docker@2
           displayName: Docker Build - Base

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -6,22 +6,21 @@
 name: $(Build.BuildId)
 
 parameters:
-  - name: publishOverride
-    displayName: Publish Override
-    type: string
-    default: default
-    values:
-      - default
-      - force
-      - skip
-  - name: releaseBuildOverride
-    displayName: Release Build Override
-    type: string
-    default: default
-    values:
-      - default
-      - false
-      - true
+- name: publishOverride
+  displayName: Publish Override
+  type: string
+  default: default
+  values:
+    - default
+    - skip
+- name: releaseBuildOverride
+  displayName: Release Build Override
+  type: string
+  default: default
+  values:
+    - default
+    - false
+    - true
 
 trigger:
   branches:
@@ -35,6 +34,7 @@ trigger:
     - tools/build-server-resources
     - tools/pipelines/server-routerlicious.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-generate-notice-steps.yml
     - tools/pipelines/templates/publish-npm-package.yml
     exclude:
@@ -51,6 +51,7 @@ pr:
     - tools/build-server-resources
     - tools/pipelines/server-routerlicious.yml
     - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
     exclude:
     - server/routerlicious/kubernetes/routerlicious
 

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -63,6 +63,14 @@ parameters:
   type: string
   default:
 
+- name: noPublish
+  type: string
+  default:
+
+- name: releaseBuild
+  type: string
+  default:
+  
 trigger: none
 
 variables:
@@ -92,11 +100,23 @@ stages:
             script: |
               # Show all task group conditions
 
-              echo Build=${{ parameters.taskBuild }}
-              echo Lint=${{ parameters.taskLint }}
-              echo Test=${{ parameters.taskTest }}
-              echo BuildDoc=${{ parameters.taskBuildDocs }}
-              echo TestCoverage=$(testCoverage)
+              echo Tasks Variables;
+              echo "  Build=${{ parameters.taskBuild }}"
+              echo "  Lint=${{ parameters.taskLint }}"
+              echo "  Test=${{ parameters.taskTest }}"
+              echo "  BuildDoc=${{ parameters.taskBuildDocs }}"
+              echo "  TestCoverage=$(testCoverage)"
+              echo
+              echo Override Variables:
+              echo "  noPublish=${{ parameters.noPublish }}"
+              echo "  releaseBuild=${{ parameters.releaseBuild }}"
+              echo
+              echo Computed variables:
+              echo "  componentDetection=$componentDetection"
+              echo "  pushImage=$pushImage"
+              echo "  publish=$publish"
+              echo "  release=$release"
+
         - task: Bash@3
           displayName: Strip MIT License
           inputs:
@@ -137,6 +157,7 @@ stages:
           parameters:
             buildDirectory: ${{ parameters.buildDirectory }}
             buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
+            release: ${{ variables.release }}
 
         # Build
         - ${{ if ne(parameters.taskBuild, 'false') }}:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -63,13 +63,6 @@ parameters:
   type: string
   default:
 
-- name: noPublish
-  type: string
-  default:
-
-- name: releaseBuild
-  type: string
-  default:
   
 trigger: none
 
@@ -108,14 +101,14 @@ stages:
               echo "  TestCoverage=$(testCoverage)"
               echo
               echo Override Variables:
-              echo "  noPublish=${{ parameters.noPublish }}"
+              echo "  publishOverride=${{ parameters.publishOverride }}"
               echo "  releaseBuild=${{ parameters.releaseBuild }}"
               echo
               echo Computed variables:
-              echo "  componentDetection=$componentDetection"
-              echo "  pushImage=$pushImage"
-              echo "  publish=$publish"
-              echo "  release=$release"
+              echo "  componentDetection=${{ variables.componentDetection }}"
+              echo "  pushImage=${{ variables.pushImage }}"
+              echo "  publish=${{ variables.publish }}"
+              echo "  release=${{ variables.release }}"
 
         - task: Bash@3
           displayName: Strip MIT License

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -63,11 +63,21 @@ parameters:
   type: string
   default:
 
-  
+- name: publishOverride
+  type: string
+  default: default
+
+- name: releaseBuildOverride
+  type: string
+  default: default
+
 trigger: none
 
 variables:
   - template: include-vars.yml
+    parameters:
+      publishOverride: ${{ parameters.publishOverride }}
+      releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
 
 stages:
   - stage: build
@@ -77,8 +87,8 @@ stages:
       - job: Build
         pool: ${{ parameters.poolBuild }}
         variables:
-        - name: testCoverage
-          value: ${{ and(eq(parameters.taskTest, 'ci:test'), ne(variables['Build.Reason'], 'PullRequest')) }}
+          testCoverage: ${{ and(eq(parameters.taskTest, 'ci:test'), ne(variables['Build.Reason'], 'PullRequest')) }}
+          releaseBuildVar: $[variables.releaseBuild]
         steps:
         # Setup
         - checkout: self
@@ -93,22 +103,26 @@ stages:
             script: |
               # Show all task group conditions
 
-              echo Tasks Variables;
-              echo "  Build=${{ parameters.taskBuild }}"
-              echo "  Lint=${{ parameters.taskLint }}"
-              echo "  Test=${{ parameters.taskTest }}"
-              echo "  BuildDoc=${{ parameters.taskBuildDocs }}"
-              echo "  TestCoverage=$(testCoverage)"
-              echo
-              echo Override Variables:
-              echo "  publishOverride=${{ parameters.publishOverride }}"
-              echo "  releaseBuild=${{ parameters.releaseBuild }}"
-              echo
-              echo Computed variables:
-              echo "  componentDetection=${{ variables.componentDetection }}"
-              echo "  pushImage=${{ variables.pushImage }}"
-              echo "  publish=${{ variables.publish }}"
-              echo "  release=${{ variables.release }}"
+              echo "
+              Pipeline Variables:
+                releaseBuild=$(releaseBuildVar)
+
+              Override Parameters:
+                publishOverride=${{ parameters.publishOverride }}
+                releaseBuildOverride=${{ parameters.releaseBuildOverride }}
+
+              Tasks Parameters:
+                Build=${{ parameters.taskBuild }}
+                Lint=${{ parameters.taskLint }}
+                Test=${{ parameters.taskTest }}
+                BuildDoc=${{ parameters.taskBuildDocs }}
+                TestCoverage=$(testCoverage)
+
+              Computed variables:
+                componentDetection=${{ variables.componentDetection }}
+                pushImage=${{ variables.pushImage }}
+                publish=${{ variables.publish }}
+                release=$(release)"
 
         - task: Bash@3
           displayName: Strip MIT License
@@ -150,7 +164,7 @@ stages:
           parameters:
             buildDirectory: ${{ parameters.buildDirectory }}
             buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
-            release: ${{ variables.release }}
+            release: $(release)
 
         # Build
         - ${{ if ne(parameters.taskBuild, 'false') }}:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -65,11 +65,9 @@ parameters:
 
 - name: publishOverride
   type: string
-  default: default
 
 - name: releaseBuildOverride
   type: string
-  default: default
 
 trigger: none
 
@@ -119,6 +117,7 @@ stages:
                 TestCoverage=$(testCoverage)
 
               Computed variables:
+                shouldPublish=${{ variables.shouldPublish }}
                 componentDetection=${{ variables.componentDetection }}
                 pushImage=${{ variables.pushImage }}
                 publish=${{ variables.publish }}

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -7,13 +7,16 @@ parameters:
 - name: buildNumberInPatch
   type: string
   default:
+- name: release
+  type: string
+  default:
 
 # Set version
 steps:
 - task: Bash@3
   displayName: Set Package Version
   env:
-    VERSION_BUILDBRANCH: $(Build.SourceBranch)
+    VERSION_RELEASE: ${{ parameters.release }}
     VERSION_BUILDNUMBER: $(Build.BuildNumber)
     VERSION_PATCH: ${{ parameters.buildNumberInPatch }}
   inputs:
@@ -22,8 +25,8 @@ steps:
     script: |
       # expect lerna.json and package.json be in the current working directory
 
-      echo VERSION_BUILDBRANCH=$VERSION_BUILDBRANCH
       echo VERSION_BUILDNUMBER=$VERSION_BUILDNUMBER
+      echo VERSION_RELEASE=$VERSION_RELEASE
       echo VERSION_PATCH=$VERSION_PATCH
 
       version=`node $(Build.SourcesDirectory)/tools/build-server-resources/build-version.js`

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -6,9 +6,11 @@
 parameters:
 - name: publishOverride
   type: string
+  default: default
 
 - name: releaseBuildOverride
   type: string
+  default: default
 
 variables:
 - name: skipComponentGovernanceDetection
@@ -25,7 +27,7 @@ variables:
       eq(parameters.publishOverride, 'force'),
       and(
         ne(parameters.publishOverride, 'skip'),
-        variables.shouldPublish
+        eq(variables.shouldPublish, true)
       )
     )}}
 - name: componentDetection

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -23,12 +23,9 @@ variables:
     )}}
 - name: publish
   value: ${{
-    or(
-      eq(parameters.publishOverride, 'force'),
-      and(
-        ne(parameters.publishOverride, 'skip'),
-        eq(variables.shouldPublish, true)
-      )
+    and(
+      ne(parameters.publishOverride, 'skip'),
+      eq(variables.shouldPublish, true)
     )}}
 - name: componentDetection
   value: ${{ variables.publish }}
@@ -40,7 +37,7 @@ variables:
     )}}
 # compute the release variable
 - ${{ if eq(parameters.releaseBuildOverride, 'default') }}:
-  - ${{ if variables.shouldPublish }}:
+  - ${{ if eq(variables.shouldPublish, true) }}:
     - name: release
       value: $[variables.releaseBuild]
   - ${{ if not(variables.shouldPublish) }}:

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -6,11 +6,17 @@
 variables:
 - name: skipComponentGovernanceDetection
   value: true
-- name: publish
+- name: shouldPublish
   value: ${{
     and(
       ne(variables['Build.Reason'], 'PullRequest'),
       ne(variables['System.TeamProject'], 'public')
+    )}}
+- name: publish
+  value: ${{ 
+    and(
+      variables.shouldPublish,
+      ne(variables.noPublish, true)
     )}}
 - name: componentDetection
   value: ${{ variables.publish }}
@@ -20,3 +26,6 @@ variables:
       variables.publish,
       eq(variables['Build.SourceBranch'], 'refs/heads/main')
     )}}
+- ${{ if and(variables.shouldPublish, eq(variables.releaseBuild, true)) }}:
+  - name: release
+    value: true

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -3,6 +3,10 @@
 
 # common variables
 
+parameters:
+- name: publishOverride
+  type: string
+
 variables:
 - name: skipComponentGovernanceDetection
   value: true
@@ -13,10 +17,10 @@ variables:
       ne(variables['System.TeamProject'], 'public')
     )}}
 - name: publish
-  value: ${{ 
+  value: ${{
     and(
       variables.shouldPublish,
-      ne(variables.noPublish, true)
+      ne(parameters.publishOverride, "skip)
     )}}
 - name: componentDetection
   value: ${{ variables.publish }}

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -7,6 +7,9 @@ parameters:
 - name: publishOverride
   type: string
 
+- name: releaseBuildOverride
+  type: string
+
 variables:
 - name: skipComponentGovernanceDetection
   value: true
@@ -18,9 +21,12 @@ variables:
     )}}
 - name: publish
   value: ${{
-    and(
-      variables.shouldPublish,
-      ne(parameters.publishOverride, "skip)
+    or(
+      eq(parameters.publishOverride, 'force'),
+      and(
+        ne(parameters.publishOverride, 'skip'),
+        variables.shouldPublish
+      )
     )}}
 - name: componentDetection
   value: ${{ variables.publish }}
@@ -30,6 +36,14 @@ variables:
       variables.publish,
       eq(variables['Build.SourceBranch'], 'refs/heads/main')
     )}}
-- ${{ if and(variables.shouldPublish, eq(variables.releaseBuild, true)) }}:
+# compute the release variable
+- ${{ if eq(parameters.releaseBuildOverride, 'default') }}:
+  - ${{ if variables.shouldPublish }}:
+    - name: release
+      value: $[variables.releaseBuild]
+  - ${{ if not(variables.shouldPublish) }}:
+    - name: release
+      value: false
+- ${{ if ne(parameters.releaseBuildOverride, 'default') }}:
   - name: release
-    value: true
+    value: ${{ parameters.releaseBuildOverride }}


### PR DESCRIPTION
Previous, to build and release a package, the workflow is to push a tag and the CI will build it.
That has the drawback where if the build fail, we are left with a tag is public and we shouldn't delete and retag on a different comment.

This change is part 1 of changing to work flow to trigger build for release before tagging it.

The pipeline is changed to accept the "releaseBuild" variable to tell if it is a release build. 
It also added two parameters that can override the behavior for release/pre-release/default, or publish (skip/default).   These parameters can be given when queueing a manual build.

NEXT:  part 2 will contain changes to bump-version tool to trigger the build via azure cli and then tag afterwards.