### PR TITLE
Remove view-adapters dependency from aqueduct

### DIFF
--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -68,7 +68,6 @@
     "@fluidframework/runtime-definitions": "^0.25.1",
     "@fluidframework/runtime-utils": "^0.25.1",
     "@fluidframework/synthesize": "^0.25.1",
-    "@fluidframework/view-adapters": "^0.25.1",
     "@fluidframework/view-interfaces": "^0.25.1",
     "uuid": "^3.3.2"
   },

--- a/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
@@ -6,12 +6,11 @@
 import { NamedFluidDataStoreRegistryEntries } from "@fluidframework/runtime-definitions";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { DependencyContainerRegistry } from "@fluidframework/synthesize";
-import { MountableView } from "@fluidframework/view-adapters";
 import {
     RuntimeRequestHandler,
     deprecated_innerRequestHandler,
 } from "@fluidframework/request-handler";
-import { mountableViewRequestHandler, defaultRouteRequestHandler } from "../request-handlers";
+import { defaultRouteRequestHandler } from "../request-handlers";
 import { BaseContainerRuntimeFactory } from "./baseContainerRuntimeFactory";
 
 const defaultDataStoreId = "default";
@@ -35,15 +34,9 @@ export class ContainerRuntimeFactoryWithDefaultDataStore extends BaseContainerRu
             registryEntries,
             providerEntries,
             [
-                // The mountable view request handler must go before any other request handlers that we might
-                // want to return mountable views, so it can correctly handle the header and reissue the request.
-                mountableViewRequestHandler(
-                    MountableView,
-                    [
-                        ...requestHandlers,
-                        defaultRouteRequestHandler(defaultDataStoreId),
-                        deprecated_innerRequestHandler,
-                    ]),
+                ...requestHandlers,
+                defaultRouteRequestHandler(defaultDataStoreId),
+                deprecated_innerRequestHandler,
             ],
         );
     }


### PR DESCRIPTION
The view-adapters dependency in `ContainerRuntimeFactoryWithDefaultDataStore` pulls in React due to the `MountableView` dependency.  Removing this significantly shrinks bundle sizes.

I was originally thinking about making `ContainerRuntimeFactoryWithDefaultDataStore` take in an `IFluidMountableViewClass` of the developer's choice, which works fine but seems unnecessary in practice.  Mountable view support is only really required if a request handler will return a React view directly, which is never the case for the default data store here.  So the scenario would have to be a container that has an `IFluidHTMLView` default component but then separate view/model for some other component to be delivered with a custom request handler, which seems an unlikely usage pattern.

Instead, the mainstream patterns for separate view/model should be either:
1. An external view approach (as in `external-views`)
2. Starting with the `BaseContainerRuntimeFactory` and customizing it, including providing a mountable view if desired (as in `multiview`).

So it seems safe to just remove it from `ContainerRuntimeFactoryWithDefaultDataStore`.