### PR TITLE
Exclude additional files from policy-check

### DIFF
--- a/tools/build-tools/data/exclusions.json
+++ b/tools/build-tools/data/exclusions.json
@@ -1,4 +1,8 @@
 [
+    "docs/layouts/",
+    "docs/themes/thxvscode/assets/",
+    "docs/themes/thxvscode/layouts/",
+    "docs/themes/thxvscode/static/assets/",
     "docs/tutorials/.*\\.tsx?",
     "server/routerlicious/packages/services-client/src/dockerNames.ts",
     "tools/generator-fluid/app/templates/"


### PR DESCRIPTION
Adding the copyright headers to the docs layout files breaks the docs build.