### PR TITLE
Support for using long lived tokens with ODSP driver

### DIFF
--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -28,9 +28,9 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl {
     // Tokens are not obtained by the ODSP driver using the resolve flow, the app must provide them.
     tokens: {};
 
-    fileName: string,
+    fileName: string;
 
-    summarizer: boolean,
+    summarizer: boolean;
 }
 
 /**

--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -33,7 +33,7 @@ import {
     invalidFileNameStatusCode,
     fetchIncorrectResponse,
 } from "./odspError";
-import { StorageTokenFetcher, tokenFromResponse } from "./tokenFetch";
+import { TokenFetchOptions } from "./tokenFetch";
 
 const isInvalidFileName = (fileName: string): boolean => {
     const invalidCharsRegex = /["*/:<>?\\|]+/g;
@@ -45,7 +45,7 @@ const isInvalidFileName = (fileName: string): boolean => {
  * Returns resolved url
  */
 export async function createNewFluidFile(
-    getStorageToken: StorageTokenFetcher,
+    getStorageToken: (options: TokenFetchOptions, name?: string) => Promise<string | null>,
     newFileInfo: INewFileInfo,
     logger: ITelemetryLogger,
     createNewSummary: ISummaryTree,
@@ -61,8 +61,8 @@ export async function createNewFluidFile(
         `${getApiRoot(getOrigin(newFileInfo.siteUrl))}/drives/${newFileInfo.driveId}/items/root:` +
         `${filePath}/${encodedFilename}`;
 
-    const itemId = await getWithRetryForTokenRefresh(async (refresh: boolean, claims?: string) => {
-        const storageToken = tokenFromResponse(await getStorageToken(newFileInfo.siteUrl, refresh, claims));
+    const itemId = await getWithRetryForTokenRefresh(async (options) => {
+        const storageToken = await getStorageToken(options, "CreateNewFile");
 
         return PerformanceEvent.timedExecAsync(
             logger,

--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -33,6 +33,7 @@ import {
     invalidFileNameStatusCode,
     fetchIncorrectResponse,
 } from "./odspError";
+import { StorageTokenFetcher, tokenFromResponse } from "./tokenFetch";
 
 const isInvalidFileName = (fileName: string): boolean => {
     const invalidCharsRegex = /["*/:<>?\\|]+/g;
@@ -44,7 +45,7 @@ const isInvalidFileName = (fileName: string): boolean => {
  * Returns resolved url
  */
 export async function createNewFluidFile(
-    getStorageToken: (siteUrl: string, refresh: boolean) => Promise<string | null>,
+    getStorageToken: StorageTokenFetcher,
     newFileInfo: INewFileInfo,
     logger: ITelemetryLogger,
     createNewSummary: ISummaryTree,
@@ -60,8 +61,8 @@ export async function createNewFluidFile(
         `${getApiRoot(getOrigin(newFileInfo.siteUrl))}/drives/${newFileInfo.driveId}/items/root:` +
         `${filePath}/${encodedFilename}`;
 
-    const itemId = await getWithRetryForTokenRefresh(async (refresh: boolean) => {
-        const storageToken = await getStorageToken(newFileInfo.siteUrl, refresh);
+    const itemId = await getWithRetryForTokenRefresh(async (refresh: boolean, claims?: string) => {
+        const storageToken = tokenFromResponse(await getStorageToken(newFileInfo.siteUrl, refresh, claims));
 
         return PerformanceEvent.timedExecAsync(
             logger,

--- a/packages/drivers/odsp-driver/src/index.ts
+++ b/packages/drivers/odsp-driver/src/index.ts
@@ -21,3 +21,5 @@ export * from "./createFile";
 export * from "./odspUrlHelper";
 export * from "./odspError";
 export * from "./createOdspCreateContainerRequest";
+export * from "./tokenFetch";
+export * from "./parseAuthErrorClaims";

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -17,7 +17,7 @@ export class OdspDeltaStorageService implements api.IDocumentDeltaStorageService
     constructor(
         private readonly deltaFeedUrlProvider: () => Promise<string>,
         private ops: ISequencedDeltaOpMessage[] | undefined,
-        private readonly getStorageToken: (refresh: boolean, name?: string) => Promise<string | null>,
+        private readonly getStorageToken: (refresh: boolean, name?: string, claims?: string) => Promise<string | null>,
         private readonly logger?: ITelemetryLogger,
     ) {
     }
@@ -33,12 +33,12 @@ export class OdspDeltaStorageService implements api.IDocumentDeltaStorageService
         }
         this.ops = undefined;
 
-        return getWithRetryForTokenRefresh(async (refresh: boolean) => {
+        return getWithRetryForTokenRefresh(async (refresh: boolean, claims?: string) => {
             // Note - this call ends up in getSocketStorageDiscovery() and can refresh token
             // Thus it needs to be done before we call getStorageToken() to reduce extra calls
             const baseUrl = await this.buildUrl(from, to);
 
-            const storageToken = await this.getStorageToken(refresh, "DeltaStorage");
+            const storageToken = await this.getStorageToken(refresh, "DeltaStorage", claims);
 
             const { url, headers } = getUrlAndHeadersWithAuth(baseUrl, storageToken);
 

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -9,6 +9,7 @@ import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions"
 import { IDeltaStorageGetResponse, ISequencedDeltaOpMessage } from "./contracts";
 import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth";
 import { fetchHelper, getWithRetryForTokenRefresh } from "./odspUtils";
+import { TokenFetchOptions } from "./tokenFetch";
 
 /**
  * Provides access to the underlying delta storage on the server for sharepoint driver.
@@ -17,7 +18,7 @@ export class OdspDeltaStorageService implements api.IDocumentDeltaStorageService
     constructor(
         private readonly deltaFeedUrlProvider: () => Promise<string>,
         private ops: ISequencedDeltaOpMessage[] | undefined,
-        private readonly getStorageToken: (refresh: boolean, name?: string, claims?: string) => Promise<string | null>,
+        private readonly getStorageToken: (options: TokenFetchOptions, name?: string) => Promise<string | null>,
         private readonly logger?: ITelemetryLogger,
     ) {
     }
@@ -33,12 +34,12 @@ export class OdspDeltaStorageService implements api.IDocumentDeltaStorageService
         }
         this.ops = undefined;
 
-        return getWithRetryForTokenRefresh(async (refresh: boolean, claims?: string) => {
+        return getWithRetryForTokenRefresh(async (options) => {
             // Note - this call ends up in getSocketStorageDiscovery() and can refresh token
             // Thus it needs to be done before we call getStorageToken() to reduce extra calls
             const baseUrl = await this.buildUrl(from, to);
 
-            const storageToken = await this.getStorageToken(refresh, "DeltaStorage", claims);
+            const storageToken = await this.getStorageToken(options, "DeltaStorage");
 
             const { url, headers } = getUrlAndHeadersWithAuth(baseUrl, storageToken);
 

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -118,7 +118,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
             if (errorObject !== null && typeof errorObject === "object" && errorObject.canRetry) {
                 const socketError: IOdspSocketError = errorObject.socketError;
                 if (typeof socketError === "object" && socketError !== null) {
-                    // We have to special-case error types here in terms of what is retrayable.
+                    // We have to special-case error types here in terms of what is retriable.
                     // These errors have to re retried, we just need new joinSession result to connect to right server:
                     //    400: Invalid tenant or document id. The WebSocket is connected to a different document
                     //         Document is full (with retryAfter)

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactory.ts
@@ -8,6 +8,7 @@ import { HostStoragePolicy } from "./contracts";
 import { IPersistedCache } from "./odspCache";
 import { OdspDocumentServiceFactoryCore } from "./odspDocumentServiceFactoryCore";
 import { getSocketIo } from "./getSocketIo";
+import { StorageTokenFetcher, PushTokenFetcher } from "./tokenFetch";
 
 /**
  * Factory for creating the sharepoint document service. Use this if you want to
@@ -17,8 +18,8 @@ export class OdspDocumentServiceFactory
     extends OdspDocumentServiceFactoryCore
     implements IDocumentServiceFactory {
     constructor(
-        getStorageToken: (siteUrl: string, refresh: boolean) => Promise<string | null>,
-        getWebsocketToken: (refresh: boolean) => Promise<string | null>,
+        getStorageToken: StorageTokenFetcher,
+        getWebsocketToken: PushTokenFetcher,
         persistedCache?: IPersistedCache,
         hostPolicy?: HostStoragePolicy,
     ) {

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
+import { ITelemetryBaseLogger, ITelemetryLogger } from "@fluidframework/common-definitions";
 import {
     IDocumentService,
     IDocumentServiceFactory,
@@ -25,7 +25,13 @@ import {
 import { OdspDocumentService } from "./odspDocumentService";
 import { INewFileInfo } from "./odspUtils";
 import { createNewFluidFile } from "./createFile";
-import { StorageTokenFetcher, PushTokenFetcher } from "./tokenFetch";
+import {
+    StorageTokenFetcher,
+    PushTokenFetcher,
+    TokenFetchOptions,
+    isTokenFromCache,
+    tokenFromResponse,
+} from "./tokenFetch";
 
 /**
  * Factory for creating the sharepoint document service. Use this if you want to
@@ -70,7 +76,7 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
             },
             async (event) => {
                 odspResolvedUrl = await createNewFluidFile(
-                    this.getStorageToken,
+                    this.toInstrumentedStorageTokenFetcher(logger2, odspResolvedUrl, this.getStorageToken),
                     newFileParams,
                     logger2,
                     createNewSummary);
@@ -104,10 +110,7 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
         resolvedUrl: IResolvedUrl,
         logger?: ITelemetryBaseLogger,
     ): Promise<IDocumentService> {
-        const odspLogger = ChildLogger.create(
-            logger,
-            "OdspDriver");
-
+        const odspLogger = ChildLogger.create(logger, "OdspDriver");
         const cache = createOdspCache(
             this.persistedCache,
             this.nonPersistentCache,
@@ -115,12 +118,51 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
 
         return OdspDocumentService.create(
             resolvedUrl,
-            this.getStorageToken,
-            this.getWebsocketToken,
+            this.toInstrumentedStorageTokenFetcher(odspLogger, resolvedUrl as IOdspResolvedUrl, this.getStorageToken),
+            this.toInstrumentedPushTokenFetcher(odspLogger, this.getWebsocketToken),
             odspLogger,
             this.getSocketIOClient,
             cache,
             this.hostPolicy,
         );
+    }
+
+    private toInstrumentedStorageTokenFetcher(
+        logger: ITelemetryLogger,
+        resolvedUrl: IOdspResolvedUrl,
+        tokenFetcher: StorageTokenFetcher,
+    ): (options: TokenFetchOptions, name?: string) => Promise<string | null> {
+        return async (options: TokenFetchOptions, name?: string) => {
+            if (options.refresh) {
+                // Potential perf issue: Host should optimize and provide non-expired tokens on all critical paths.
+                // Exceptions: race conditions around expiration, revoked tokens, host that does not care
+                // (fluid-fetcher)
+                logger.sendTelemetryEvent({ eventName: "StorageTokenRefresh", hasClaims: !!options.claims });
+            }
+
+            return PerformanceEvent.timedExecAsync(
+                logger,
+                { eventName: `${name || "OdspDocumentService"}_GetToken` },
+                async (event) => tokenFetcher(resolvedUrl.siteUrl, options.refresh, options.claims)
+                .then((tokenResponse) => {
+                    event.end({ fromCache: isTokenFromCache(tokenResponse) });
+                    return tokenFromResponse(tokenResponse);
+                }));
+        };
+    }
+
+    private toInstrumentedPushTokenFetcher(
+        logger: ITelemetryLogger,
+        tokenFetcher: PushTokenFetcher,
+    ): (options: TokenFetchOptions) => Promise<string | null> {
+        return async (options: TokenFetchOptions) => {
+            return PerformanceEvent.timedExecAsync(
+                logger,
+                { eventName: "GetWebsocketToken" },
+                async (event) => tokenFetcher(options.refresh, options.claims).then((tokenResponse) => {
+                    event.end({ fromCache: isTokenFromCache(tokenResponse) });
+                    return tokenFromResponse(tokenResponse);
+                }));
+        };
     }
 }

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -25,6 +25,7 @@ import {
 import { OdspDocumentService } from "./odspDocumentService";
 import { INewFileInfo } from "./odspUtils";
 import { createNewFluidFile } from "./createFile";
+import { StorageTokenFetcher, PushTokenFetcher } from "./tokenFetch";
 
 /**
  * Factory for creating the sharepoint document service. Use this if you want to
@@ -91,8 +92,8 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
    * @param persistedCache - PersistedCache provided by host for use in this session.
    */
     constructor(
-        private readonly getStorageToken: (siteUrl: string, refresh: boolean) => Promise<string | null>,
-        private readonly getWebsocketToken: (refresh: boolean) => Promise<string | null>,
+        private readonly getStorageToken: StorageTokenFetcher,
+        private readonly getWebsocketToken: PushTokenFetcher,
         private readonly getSocketIOClient: () => Promise<SocketIOClientStatic>,
         protected persistedCache: IPersistedCache = new LocalPersistentCache(),
         private readonly hostPolicy: HostStoragePolicy = {},

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryWithCodeSplit.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryWithCodeSplit.ts
@@ -7,13 +7,14 @@ import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
 import { IPersistedCache } from "./odspCache";
 import { OdspDocumentServiceFactoryCore } from "./odspDocumentServiceFactoryCore";
 import { HostStoragePolicy } from "./contracts";
+import { StorageTokenFetcher, PushTokenFetcher } from "./tokenFetch";
 
 export class OdspDocumentServiceFactoryWithCodeSplit
     extends OdspDocumentServiceFactoryCore
     implements IDocumentServiceFactory {
     constructor(
-        getStorageToken: (siteUrl: string, refresh: boolean) => Promise<string | null>,
-        getWebsocketToken: (refresh: boolean) => Promise<string | null>,
+        getStorageToken: StorageTokenFetcher,
+        getWebsocketToken: PushTokenFetcher,
         persistedCache?: IPersistedCache,
         hostPolicy?: HostStoragePolicy,
     ) {

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -311,8 +311,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                 let cachedSnapshot: IOdspSnapshot | undefined;
 
                 // No need to ask cache twice - if first request was unsuccessful, cache unlikely to have data on second turn.
-                if (tokenFetchOptions.refresh || tokenFetchOptions.claims) {
-                    cachedSnapshot = await this.fetchSnapshot(snapshotOptions,tokenFetchOptions);
+                if (tokenFetchOptions.refresh) {
+                    cachedSnapshot = await this.fetchSnapshot(snapshotOptions, tokenFetchOptions);
                 } else {
                     cachedSnapshot = await PerformanceEvent.timedExecAsync(
                         this.logger,

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -50,6 +50,7 @@ import {
 } from "./odspCache";
 import { getWithRetryForTokenRefresh, fetchHelper } from "./odspUtils";
 import { throwOdspNetworkError } from "./odspError";
+import { TokenFetchOptions } from "./tokenFetch";
 
 /* eslint-disable max-len */
 
@@ -121,7 +122,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
 
     constructor(
         odspResolvedUrl: IOdspResolvedUrl,
-        private readonly getStorageToken: (refresh: boolean, name?: string, claims?: string) => Promise<string | null>,
+        private readonly getStorageToken: (options: TokenFetchOptions, name?: string) => Promise<string | null>,
         private readonly logger: ITelemetryLogger,
         private readonly fetchFullSnapshot: boolean,
         private readonly cache: IOdspCache,
@@ -161,8 +162,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
         if (!blob) {
             this.checkSnapshotUrl();
 
-            const response = await getWithRetryForTokenRefresh(async (refresh, claims) => {
-                const storageToken = await this.getStorageToken(refresh, "GetBlob", claims);
+            const response = await getWithRetryForTokenRefresh(async (options) => {
+                const storageToken = await this.getStorageToken(options, "GetBlob");
 
                 const { url, headers } = getUrlAndHeadersWithAuth(`${this.snapshotUrl}/blobs/${blobid}`, storageToken);
 
@@ -279,11 +280,11 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
         if (this.firstVersionCall && count === 1 && (blobid === null || blobid === this.documentId)) {
             this.firstVersionCall = false;
 
-            return getWithRetryForTokenRefresh(async (refresh, claims) => {
-                if (refresh) {
+            return getWithRetryForTokenRefresh(async (tokenFetchOptions) => {
+                if (tokenFetchOptions.refresh) {
                     // This is the most critical code path for boot.
                     // If we get incorrect / expired token first time, that adds up to latency of boot
-                    this.logger.sendErrorEvent({ eventName: "TreeLatest_SecondCall" });
+                    this.logger.sendErrorEvent({ eventName: "TreeLatest_SecondCall", hasClaims: !!tokenFetchOptions.claims });
                 }
 
                 const hostPolicy: ISnapshotOptions = {
@@ -299,10 +300,10 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                 }
 
                 let delimiter = "?";
-                let options = "";
+                let snapshotOptions = "";
                 for (const [key, value] of Object.entries(hostPolicy)) {
                     if (value !== undefined) {
-                        options = `${options}${delimiter}${key}=${value}`;
+                        snapshotOptions = `${snapshotOptions}${delimiter}${key}=${value}`;
                         delimiter = "&";
                     }
                 }
@@ -310,8 +311,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                 let cachedSnapshot: IOdspSnapshot | undefined;
 
                 // No need to ask cache twice - if first request was unsuccessful, cache unlikely to have data on second turn.
-                if (refresh || claims) {
-                    cachedSnapshot = await this.fetchSnapshot(options, refresh, claims);
+                if (tokenFetchOptions.refresh || tokenFetchOptions.claims) {
+                    cachedSnapshot = await this.fetchSnapshot(snapshotOptions,tokenFetchOptions);
                 } else {
                     cachedSnapshot = await PerformanceEvent.timedExecAsync(
                         this.logger,
@@ -328,7 +329,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
 
                             let method: string;
                             if (this.hostPolicy.concurrentSnapshotFetch && !this.hostPolicy.summarizerClient) {
-                                const snapshotP = this.fetchSnapshot(options, refresh, claims);
+                                const snapshotP = this.fetchSnapshot(snapshotOptions, tokenFetchOptions);
 
                                 const promiseRaceWinner = await promiseRaceWithWinner([cachedSnapshotP, snapshotP]);
                                 cachedSnapshot = promiseRaceWinner.value;
@@ -347,7 +348,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                                 method = cachedSnapshot !== undefined ? "cache" : "network";
 
                                 if (cachedSnapshot === undefined) {
-                                    cachedSnapshot = await this.fetchSnapshot(options, refresh, claims);
+                                    cachedSnapshot = await this.fetchSnapshot(snapshotOptions, tokenFetchOptions);
                                 }
                             }
                             event.end({ method });
@@ -425,8 +426,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
             });
         }
 
-        return getWithRetryForTokenRefresh(async (refresh, claims) => {
-            const storageToken = await this.getStorageToken(refresh, "GetVersions", claims);
+        return getWithRetryForTokenRefresh(async (options) => {
+            const storageToken = await this.getStorageToken(options, "GetVersions");
             const { url, headers } = getUrlAndHeadersWithAuth(`${this.snapshotUrl}/versions?count=${count}`, storageToken);
 
             // Fetch the latest snapshot versions for the document
@@ -464,12 +465,12 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
         });
     }
 
-    private async fetchSnapshot(options: string, refresh: boolean, claims?: string) {
-        const storageToken = await this.getStorageToken(refresh, "TreesLatest", claims);
+    private async fetchSnapshot(snapshotOptions: string, tokenFetchOptions: TokenFetchOptions) {
+        const storageToken = await this.getStorageToken(tokenFetchOptions, "TreesLatest");
 
         // TODO: This snapshot will return deltas, which we currently aren't using. We need to enable this flag to go down the "optimized"
         // snapshot code path. We should leverage the fact that these deltas are returned to speed up the deltas fetch.
-        const { headers, url } = getUrlAndHeadersWithAuth(`${this.snapshotUrl}/trees/latest${options}`, storageToken);
+        const { headers, url } = getUrlAndHeadersWithAuth(`${this.snapshotUrl}/trees/latest${snapshotOptions}`, storageToken);
 
         // This event measures only successful cases of getLatest call (no tokens, no retries).
         const { snapshot, canCache } = await PerformanceEvent.timedExecAsync(this.logger, { eventName: "TreesLatest" }, async (event) => {
@@ -571,8 +572,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
         }
         let tree = this.treesCache.get(id);
         if (!tree) {
-            tree = await getWithRetryForTokenRefresh(async (refresh, claims) => {
-                const storageToken = await this.getStorageToken(refresh, "ReadTree", claims);
+            tree = await getWithRetryForTokenRefresh(async (options) => {
+                const storageToken = await this.getStorageToken(options, "ReadTree");
 
                 const response = await fetchSnapshot(this.snapshotUrl!, storageToken, id, this.fetchFullSnapshot, this.logger);
                 const odspSnapshot: IOdspSnapshot = response.content;
@@ -683,8 +684,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
             type: SnapshotType.Channel,
         };
 
-        return getWithRetryForTokenRefresh(async (refresh, claims) => {
-            const storageToken = await this.getStorageToken(refresh, "WriteSummaryTree", claims);
+        return getWithRetryForTokenRefresh(async (options) => {
+            const storageToken = await this.getStorageToken(options, "WriteSummaryTree");
 
             const { url, headers } = getUrlAndHeadersWithAuth(`${this.snapshotUrl}/snapshot`, storageToken);
             headers["Content-Type"] = "application/json";
@@ -694,7 +695,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
             return PerformanceEvent.timedExecAsync(this.logger,
                 {
                     eventName: "uploadSummary",
-                    attempt: refresh ? 2 : 1,
+                    attempt: options.refresh ? 2 : 1,
+                    hasClaims: !!options.claims,
                     headers: Object.keys(headers).length !== 0 ? true : undefined,
                 },
                 async () => {

--- a/packages/drivers/odsp-driver/src/odspError.ts
+++ b/packages/drivers/odsp-driver/src/odspError.ts
@@ -7,6 +7,7 @@ import {
     NetworkErrorBasic,
     GenericNetworkError,
     NonRetryableError,
+    AuthorizationError,
     isOnline,
     createGenericNetworkError,
     OnlineStatus,
@@ -16,6 +17,7 @@ import {
     DriverErrorType,
 } from "@fluidframework/driver-definitions";
 import { IOdspSocketError } from "./contracts";
+import { parseAuthErrorClaims } from "./parseAuthErrorClaims";
 
 export const offlineFetchFailureStatusCode: number = 709;
 export const fetchFailureStatusCode: number = 710;
@@ -66,6 +68,7 @@ export function createOdspNetworkError(
     errorMessage: string,
     statusCode?: number,
     retryAfterSeconds?: number,
+    claims?: string,
 ): OdspError {
     let error: OdspError;
 
@@ -75,7 +78,7 @@ export function createOdspNetworkError(
             break;
         case 401:
         case 403:
-            error = new NetworkErrorBasic(errorMessage, DriverErrorType.authorizationError, false);
+            error = new AuthorizationError(errorMessage, statusCode, claims);
             break;
         case 404:
             error = new NetworkErrorBasic(errorMessage, DriverErrorType.fileNotFoundOrAccessDeniedError, false);
@@ -113,6 +116,7 @@ export function createOdspNetworkError(
     }
 
     error.online = OnlineStatus[isOnline()];
+
     return error;
 }
 
@@ -124,18 +128,16 @@ export function throwOdspNetworkError(
     statusCode: number,
     response?: Response,
 ) {
-    let message = errorMessage;
-    let sprequestguid;
-    if (response) {
-        message = `${message}, msg = ${response.statusText}, type = ${response.type}`;
-        sprequestguid = response.headers ? `${response.headers.get("sprequestguid")}` : undefined;
-    }
+    const claims = statusCode === 401 && response?.headers ? parseAuthErrorClaims(response.headers) : undefined;
 
     const networkError = createOdspNetworkError(
-        message,
+        response ? `${errorMessage}, msg = ${response.statusText}, type = ${response.type}` : errorMessage,
         statusCode,
-        undefined /* retryAfterSeconds */);
-    (networkError as any).sprequestguid = sprequestguid;
+        undefined /* retryAfterSeconds */,
+        claims);
+
+    (networkError as any).sprequestguid = response?.headers ? `${response.headers.get("sprequestguid")}` : undefined;
+
     throw networkError;
 }
 
@@ -146,5 +148,8 @@ export function errorObjectFromSocketError(socketError: IOdspSocketError) {
     return createOdspNetworkError(
         socketError.message,
         socketError.code,
-        socketError.retryAfter);
+        socketError.retryAfter,
+        // TODO: When long lived token is supported for websocket then IOdspSocketError need to support
+        // passing "claims" value that is used to fetch new token
+        undefined /* claims */);
 }

--- a/packages/drivers/odsp-driver/src/odspError.ts
+++ b/packages/drivers/odsp-driver/src/odspError.ts
@@ -78,7 +78,7 @@ export function createOdspNetworkError(
             break;
         case 401:
         case 403:
-            error = new AuthorizationError(errorMessage, statusCode, claims);
+            error = new AuthorizationError(errorMessage, claims);
             break;
         case 404:
             error = new NetworkErrorBasic(errorMessage, DriverErrorType.fileNotFoundOrAccessDeniedError, false);

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -23,6 +23,7 @@ import {
     fetchIncorrectResponse,
     throwOdspNetworkError,
 } from "./odspError";
+import { TokenFetchOptions } from "./tokenFetch";
 
 /** Parse the given url and return the origin (host name) */
 export const getOrigin = (url: string) => new URL(url).origin;
@@ -42,15 +43,15 @@ export function getHashedDocumentId(driveId: string, itemId: string): string {
  * token on failure. Only specific cases get retry call with refresh = true, all other / unknonw errors
  * simply propagate to caller
  */
-export async function getWithRetryForTokenRefresh<T>(get: (refresh: boolean, claims?: string) => Promise<T>) {
-    return get(false).catch(async (e) => {
+export async function getWithRetryForTokenRefresh<T>(get: (options: TokenFetchOptions) => Promise<T>) {
+    return get({ refresh: false }).catch(async (e) => {
         switch (e.errorType) {
             // If the error is 401 or 403 refresh the token and try once more.
             case DriverErrorType.authorizationError:
-                return get(true, e.claims);
+                return get({ refresh: true, claims: e.claims });
             // fetchIncorrectResponse indicates some error on the wire, retry once.
             case DriverErrorType.incorrectServerResponse:
-                return get(true);
+                return get({ refresh: true });
             default:
                 // All code paths (deltas, blobs, trees) already throw exceptions.
                 // Throwing is better than returning null as most code paths do not return nullable-objects,

--- a/packages/drivers/odsp-driver/src/parseAuthErrorClaims.ts
+++ b/packages/drivers/odsp-driver/src/parseAuthErrorClaims.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { fromBase64ToUtf8 } from "@fluidframework/common-utils";
+
 /**
  * Checks if response headers contains `www-authenticate` header and extracts claims that should be
  * passed to token authority when requesting new token. More details can be found here:
@@ -31,7 +33,7 @@ export function parseAuthErrorClaims(responseHeader: Headers): string | undefine
         if (!detectedErrorIndicator && nameValuePair[0].trim().toLowerCase() === "error") {
           detectedErrorIndicator = JSON.parse(nameValuePair[1].trim().toLowerCase()) === "insufficient_claims";
         } else if (!claims && nameValuePair[0].trim().toLowerCase() === "claims") {
-          claims = atob(JSON.parse(section.substring(section.indexOf("=") + 1).trim()));
+          claims = fromBase64ToUtf8(JSON.parse(section.substring(section.indexOf("=") + 1).trim()));
         }
       }
     });

--- a/packages/drivers/odsp-driver/src/parseAuthErrorClaims.ts
+++ b/packages/drivers/odsp-driver/src/parseAuthErrorClaims.ts
@@ -7,8 +7,7 @@ import { fromBase64ToUtf8 } from "@fluidframework/common-utils";
 
 /**
  * Checks if response headers contains `www-authenticate` header and extracts claims that should be
- * passed to token authority when requesting new token. More details can be found here:
- * https://microsoft.sharepoint.com/:w:/t/aad/protocols/ERSWYtOQB45GgG4e2q3Cz00B6C36zi4gAs6JhdQG_wvVeQ
+ * passed to token authority when requesting new token.
  *
  * Header sample:
  * www-authenticate=Bearer realm="",

--- a/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
@@ -18,7 +18,7 @@ describe("DeltaStorageService", () => {
 
     it("Should build the correct sharepoint delta url with auth", async () => {
         const deltaStorageService = new OdspDeltaStorageService(async () => testDeltaStorageUrl,
-            undefined, async (refresh) => "?access_token=123");
+            undefined, async (_refresh) => "?access_token=123");
         const actualDeltaUrl = await deltaStorageService.buildUrl(2, 8);
         // eslint-disable-next-line max-len
         const expectedDeltaUrl = `${deltaStorageBasePath}/drives/testdrive/items/testitem/opStream?filter=sequenceNumber%20ge%203%20and%20sequenceNumber%20le%207`;
@@ -64,7 +64,7 @@ describe("DeltaStorageService", () => {
         let deltaStorageService: OdspDeltaStorageService;
         before(() => {
             deltaStorageService = new OdspDeltaStorageService(async () => testDeltaStorageUrl,
-                undefined, async (refresh) => "");
+                undefined, async (_refresh) => "");
         });
 
         it("Should deserialize the delta feed response correctly", async () => {
@@ -114,7 +114,7 @@ describe("DeltaStorageService", () => {
         let deltaStorageService: OdspDeltaStorageService;
         before(() => {
             deltaStorageService = new OdspDeltaStorageService(async () => testDeltaStorageUrl,
-                undefined, async (refresh) => "");
+                undefined, async (_refresh) => "");
         });
 
         it("Should deserialize the delta feed response correctly", async () => {

--- a/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
@@ -33,8 +33,8 @@ describe("Odsp Create Container Test", () => {
     };
 
     const odspDocumentServiceFactory = new OdspDocumentServiceFactory(
-        async (url: string, refresh: boolean) => "token",
-        async (refresh: boolean) => "token");
+        async (_url: string, _refresh: boolean, _claims?: string) => "token",
+        async (_refresh: boolean, _claims?: string) => "token");
 
     const createSummary = (putAppTree: boolean, putProtocolTree: boolean, sequenceNumber: number) => {
         const summary: ISummaryTree = {

--- a/packages/drivers/odsp-driver/src/test/odspError.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspError.spec.ts
@@ -198,7 +198,7 @@ describe("Odsp Error", () => {
     });
 
     it("AuthorizationError errors retries with insufficient claims", async () => {
-        const res = getWithRetryForTokenRefresh(async (refresh, claims) => {
+        const res = await getWithRetryForTokenRefresh(async (refresh, claims) => {
             if (refresh && claims === "{\"access_token\":{\"nbf\":{\"essential\":true, \"value\":\"1597959090\"}}}") {
                 return 1;
             } else {

--- a/packages/drivers/odsp-driver/src/test/odspError.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspError.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 /*!
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
@@ -23,7 +24,12 @@ describe("Odsp Error", () => {
     const testResponse = { // Implements only part of Response.headers
         statusText: "testStatusText",
         type: "default",
-        headers: { get(name: string): string | null { return "xxx-xxx"; } },
+        headers: { get(name: string): string | null {
+            if (name === "sprequestguid") {
+                return "xxx-xxx";
+            }
+            return null;
+        } },
     } as Response;
 
     function createOdspNetworkErrorWithResponse(
@@ -49,8 +55,7 @@ describe("Odsp Error", () => {
         );
         if (networkError.errorType !== DriverErrorType.genericNetworkError) {
             assert.fail("networkError should be a genericNetworkError");
-        }
-        else {
+        } else {
             assert.notEqual(-1, networkError.message.indexOf("TestMessage"),
                 "message should contain original message");
             assert.notEqual(-1, networkError.message.indexOf("testStatusText"),
@@ -61,7 +66,7 @@ describe("Odsp Error", () => {
         }
     });
 
-    it("throwOdspNetworkError sprequestguid exist", async () => {
+    it("throwOdspNetworkError sprequestguid exists", async () => {
         const error1: any = createOdspNetworkErrorWithResponse("Error", 400);
         const errorBag = { ...error1.getCustomProperties() };
         assert.equal("xxx-xxx", errorBag.sprequestguid, "sprequestguid should be 'xxx-xxx'");
@@ -81,8 +86,7 @@ describe("Odsp Error", () => {
         const networkError = errorObjectFromSocketError(socketError);
         if (networkError.errorType !== DriverErrorType.genericNetworkError) {
             assert.fail("networkError should be a genericNetworkError");
-        }
-        else {
+        } else {
             assert.equal(networkError.message, "testMessage");
             assert.equal(networkError.canRetry, false);
             assert.equal(networkError.statusCode, 400);
@@ -97,8 +101,7 @@ describe("Odsp Error", () => {
         const networkError = errorObjectFromSocketError(socketError);
         if (networkError.errorType !== DriverErrorType.genericNetworkError) {
             assert.fail("networkError should be a genericNetworkError");
-        }
-        else {
+        } else {
             assert.equal(networkError.message, "testMessage");
             assert.equal(networkError.canRetry, false);
             assert.equal(networkError.statusCode, 400);
@@ -114,15 +117,14 @@ describe("Odsp Error", () => {
         const networkError = errorObjectFromSocketError(socketError);
         if (networkError.errorType !== DriverErrorType.throttlingError) {
             assert.fail("networkError should be a throttlingError");
-        }
-        else {
+        } else {
             assert.equal(networkError.message, "testMessage");
             assert.equal(networkError.retryAfterSeconds, 10);
         }
     });
 
     it("Access Denied retries", async () => {
-        const res = await getWithRetryForTokenRefresh(async (refresh) => {
+        const res = await getWithRetryForTokenRefresh(async (refresh, _claims) => {
             if (refresh) {
                 return 1;
             } else {
@@ -132,19 +134,8 @@ describe("Odsp Error", () => {
         assert.equal(res, 1, "did not successfully retried with new token");
     });
 
-    it("Access Denied retries", async () => {
-        const res = getWithRetryForTokenRefresh(async (refresh) => {
-            if (refresh) {
-                return 1;
-            } else {
-                throwOdspNetworkError("some error", invalidFileNameStatusCode);
-            }
-        });
-        await assert.rejects(res, "did not successfully retried with new token");
-    });
-
     it("fetch incorrect response retries", async () => {
-        const res = await getWithRetryForTokenRefresh(async (refresh) => {
+        const res = await getWithRetryForTokenRefresh(async (refresh, _claims) => {
             if (refresh) {
                 return 1;
             } else {
@@ -155,7 +146,7 @@ describe("Odsp Error", () => {
     });
 
     it("Other errors - no retries", async () => {
-        const res = getWithRetryForTokenRefresh(async (refresh) => {
+        const res = getWithRetryForTokenRefresh(async (refresh, _claims) => {
             if (refresh) {
                 return 1;
             } else {
@@ -163,5 +154,57 @@ describe("Odsp Error", () => {
             }
         });
         await assert.rejects(res, "Other errors should not result in retries!");
+    });
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const testResponseWithInsufficientClaims = {
+        statusText: "testStatusText",
+        type: "default",
+        headers: { get(name: string): string | null {
+            if (name === "sprequestguid") {
+                return "xxx-xxx";
+            }
+            if (name === "www-authenticate") {
+                // tslint:disable-next-line: max-line-length
+                return "Bearer realm=\"6c482541-f706-4168-9e58-8e35a9992f58\",client_id=\"00000003-0000-0ff1-ce00-000000000000\",trusted_issuers=\"00000001-0000-0000-c000-000000000000@*,D3776938-3DBA-481F-A652-4BEDFCAB7CD8@*,https://sts.windows.net/*/,00000003-0000-0ff1-ce00-000000000000@90140122-8516-11e1-8eff-49304924019b\",authorization_uri=\"https://login.windows.net/common/oauth2/authorize\",error=\"insufficient_claims\",claims=\"eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTU5Nzk1OTA5MCJ9fX0=\"";
+            }
+            return null;
+        } },
+    } as Response;
+
+    function throwAuthorizationError(errorMessage: string) {
+        throwOdspNetworkError(
+            errorMessage,
+            401,
+            testResponseWithInsufficientClaims,
+        );
+    }
+
+    it("Authorization error first-class properties", async () => {
+        try {
+            throwAuthorizationError("TestMessage");
+        } catch (error) {
+            assert.equal(error.errorType, DriverErrorType.authorizationError, "errorType should be authorizationError");
+            assert.notEqual(error.message.indexOf("TestMessage"), -1,
+                "message should contain original message");
+            assert.equal(error.canRetry, false, "canRetry should be false");
+            assert.equal(error.statusCode, 401, "status code should be 401");
+            assert.equal(
+                error.claims,
+                "{\"access_token\":{\"nbf\":{\"essential\":true, \"value\":\"1597959090\"}}}",
+                "claims should be extracted from response",
+            );
+        }
+    });
+
+    it("AuthorizationError errors retries with insufficient claims", async () => {
+        const res = getWithRetryForTokenRefresh(async (refresh, claims) => {
+            if (refresh && claims === "{\"access_token\":{\"nbf\":{\"essential\":true, \"value\":\"1597959090\"}}}") {
+                return 1;
+            } else {
+                throwAuthorizationError("some error");
+            }
+        });
+        assert.equal(res, 1, "did not successfully retried with claims");
     });
 });

--- a/packages/drivers/odsp-driver/src/test/odspError.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspError.spec.ts
@@ -124,8 +124,8 @@ describe("Odsp Error", () => {
     });
 
     it("Access Denied retries", async () => {
-        const res = await getWithRetryForTokenRefresh(async (refresh, _claims) => {
-            if (refresh) {
+        const res = await getWithRetryForTokenRefresh(async (options) => {
+            if (options.refresh) {
                 return 1;
             } else {
                 throwOdspNetworkError("some error", 401);
@@ -135,8 +135,8 @@ describe("Odsp Error", () => {
     });
 
     it("fetch incorrect response retries", async () => {
-        const res = await getWithRetryForTokenRefresh(async (refresh, _claims) => {
-            if (refresh) {
+        const res = await getWithRetryForTokenRefresh(async (options) => {
+            if (options.refresh) {
                 return 1;
             } else {
                 throwOdspNetworkError("some error", fetchIncorrectResponse);
@@ -146,8 +146,8 @@ describe("Odsp Error", () => {
     });
 
     it("Other errors - no retries", async () => {
-        const res = getWithRetryForTokenRefresh(async (refresh, _claims) => {
-            if (refresh) {
+        const res = getWithRetryForTokenRefresh(async (options) => {
+            if (options.refresh) {
                 return 1;
             } else {
                 throwOdspNetworkError("some error", invalidFileNameStatusCode);
@@ -198,8 +198,11 @@ describe("Odsp Error", () => {
     });
 
     it("AuthorizationError errors retries with insufficient claims", async () => {
-        const res = await getWithRetryForTokenRefresh(async (refresh, claims) => {
-            if (refresh && claims === "{\"access_token\":{\"nbf\":{\"essential\":true, \"value\":\"1597959090\"}}}") {
+        const res = await getWithRetryForTokenRefresh(async (options) => {
+            if (
+                options.refresh &&
+                options.claims === "{\"access_token\":{\"nbf\":{\"essential\":true, \"value\":\"1597959090\"}}}"
+            ) {
                 return 1;
             } else {
                 throwAuthorizationError("some error");

--- a/packages/drivers/odsp-driver/src/test/odspError.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspError.spec.ts
@@ -188,7 +188,6 @@ describe("Odsp Error", () => {
             assert.notEqual(error.message.indexOf("TestMessage"), -1,
                 "message should contain original message");
             assert.equal(error.canRetry, false, "canRetry should be false");
-            assert.equal(error.statusCode, 401, "status code should be 401");
             assert.equal(
                 error.claims,
                 "{\"access_token\":{\"nbf\":{\"essential\":true, \"value\":\"1597959090\"}}}",

--- a/packages/drivers/odsp-driver/src/test/odspError.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspError.spec.ts
@@ -134,6 +134,17 @@ describe("Odsp Error", () => {
         assert.equal(res, 1, "did not successfully retried with new token");
     });
 
+    it("invalid file name - no retry", async () => {
+        const res = getWithRetryForTokenRefresh(async (options) => {
+            if (options.refresh) {
+                return 1;
+            } else {
+                throwOdspNetworkError("some error", invalidFileNameStatusCode);
+            }
+        });
+        await assert.rejects(res, "Invalid file name should not result in retry!");
+    });
+
     it("fetch incorrect response retries", async () => {
         const res = await getWithRetryForTokenRefresh(async (options) => {
             if (options.refresh) {

--- a/packages/drivers/odsp-driver/src/test/parseAuthErrorClaims.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/parseAuthErrorClaims.spec.ts
@@ -13,8 +13,6 @@ const invalidWwwAuthenticateHeaderWithUnexpectedErrorValue =
   "Bearer realm=\"6c482541-f706-4168-9e58-8e35a9992f58\",client_id=\"00000003-0000-0ff1-ce00-000000000000\",trusted_issuers=\"00000001-0000-0000-c000-000000000000@*,D3776938-3DBA-481F-A652-4BEDFCAB7CD8@*,https://sts.windows.net/*/,00000003-0000-0ff1-ce00-000000000000@90140122-8516-11e1-8eff-49304924019b\",authorization_uri=\"https://login.windows.net/common/oauth2/authorize\",error=\"not_insufficient_claims\",claims=\"eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTU5Nzk1OTA5MCJ9fX0=\"";
 const invalidWwwAuthenticateHeaderWithoutClaims =
   "Bearer realm=\"6c482541-f706-4168-9e58-8e35a9992f58\",client_id=\"00000003-0000-0ff1-ce00-000000000000\",trusted_issuers=\"00000001-0000-0000-c000-000000000000@*,D3776938-3DBA-481F-A652-4BEDFCAB7CD8@*,https://sts.windows.net/*/,00000003-0000-0ff1-ce00-000000000000@90140122-8516-11e1-8eff-49304924019b\",authorization_uri=\"https://login.windows.net/common/oauth2/authorize\",error=\"insufficient_claims\",not_claims=\"eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTU5Nzk1OTA5MCJ9fX0=\"";
-const invalidWwwAuthenticateHeaderWithMalformedClaimsValue =
-  "Bearer realm=\"6c482541-f706-4168-9e58-8e35a9992f58\",client_id=\"00000003-0000-0ff1-ce00-000000000000\",trusted_issuers=\"00000001-0000-0000-c000-000000000000@*,D3776938-3DBA-481F-A652-4BEDFCAB7CD8@*,https://sts.windows.net/*/,00000003-0000-0ff1-ce00-000000000000@90140122-8516-11e1-8eff-49304924019b\",authorization_uri=\"https://login.windows.net/common/oauth2/authorize\",error=\"insufficient_claims\",claims=\"not_encoded\"";
 const validWwwAuthenticateHeader =
   "Bearer realm=\"6c482541-f706-4168-9e58-8e35a9992f58\",client_id=\"00000003-0000-0ff1-ce00-000000000000\",trusted_issuers=\"00000001-0000-0000-c000-000000000000@*,D3776938-3DBA-481F-A652-4BEDFCAB7CD8@*,https://sts.windows.net/*/,00000003-0000-0ff1-ce00-000000000000@90140122-8516-11e1-8eff-49304924019b\",authorization_uri=\"https://login.windows.net/common/oauth2/authorize\",error=\"insufficient_claims\",claims=\"eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTU5Nzk1OTA5MCJ9fX0=\"";
 
@@ -50,15 +48,6 @@ describe("parseAuthErrorClaims", () => {
     };
     const result = parseAuthErrorClaims(headers as any);
     assert.equal(result, undefined);
-  });
-
-  it("throws if claims value is in unexpected format", async () => {
-    const headers = {
-      get: (name: string) =>
-        name.toLowerCase() === "www-authenticate" ? invalidWwwAuthenticateHeaderWithMalformedClaimsValue : undefined,
-    };
-    const testFunc = () => parseAuthErrorClaims(headers as any);
-    assert.throws(testFunc);
   });
 
   it("returns decoded claims value", async () => {

--- a/packages/drivers/odsp-driver/src/test/parseAuthErrorClaims.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/parseAuthErrorClaims.spec.ts
@@ -1,0 +1,71 @@
+/* eslint-disable max-len */
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import assert from "assert";
+import { parseAuthErrorClaims } from "../parseAuthErrorClaims";
+
+const invalidWwwAuthenticateHeaderWithoutError =
+  "Bearer realm=\"6c482541-f706-4168-9e58-8e35a9992f58\",client_id=\"00000003-0000-0ff1-ce00-000000000000\",trusted_issuers=\"00000001-0000-0000-c000-000000000000@*,D3776938-3DBA-481F-A652-4BEDFCAB7CD8@*,https://sts.windows.net/*/,00000003-0000-0ff1-ce00-000000000000@90140122-8516-11e1-8eff-49304924019b\",authorization_uri=\"https://login.windows.net/common/oauth2/authorize\",not_error=\"insufficient_claims\",claims=\"eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTU5Nzk1OTA5MCJ9fX0=\"";
+const invalidWwwAuthenticateHeaderWithUnexpectedErrorValue =
+  "Bearer realm=\"6c482541-f706-4168-9e58-8e35a9992f58\",client_id=\"00000003-0000-0ff1-ce00-000000000000\",trusted_issuers=\"00000001-0000-0000-c000-000000000000@*,D3776938-3DBA-481F-A652-4BEDFCAB7CD8@*,https://sts.windows.net/*/,00000003-0000-0ff1-ce00-000000000000@90140122-8516-11e1-8eff-49304924019b\",authorization_uri=\"https://login.windows.net/common/oauth2/authorize\",error=\"not_insufficient_claims\",claims=\"eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTU5Nzk1OTA5MCJ9fX0=\"";
+const invalidWwwAuthenticateHeaderWithoutClaims =
+  "Bearer realm=\"6c482541-f706-4168-9e58-8e35a9992f58\",client_id=\"00000003-0000-0ff1-ce00-000000000000\",trusted_issuers=\"00000001-0000-0000-c000-000000000000@*,D3776938-3DBA-481F-A652-4BEDFCAB7CD8@*,https://sts.windows.net/*/,00000003-0000-0ff1-ce00-000000000000@90140122-8516-11e1-8eff-49304924019b\",authorization_uri=\"https://login.windows.net/common/oauth2/authorize\",error=\"insufficient_claims\",not_claims=\"eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTU5Nzk1OTA5MCJ9fX0=\"";
+const invalidWwwAuthenticateHeaderWithMalformedClaimsValue =
+  "Bearer realm=\"6c482541-f706-4168-9e58-8e35a9992f58\",client_id=\"00000003-0000-0ff1-ce00-000000000000\",trusted_issuers=\"00000001-0000-0000-c000-000000000000@*,D3776938-3DBA-481F-A652-4BEDFCAB7CD8@*,https://sts.windows.net/*/,00000003-0000-0ff1-ce00-000000000000@90140122-8516-11e1-8eff-49304924019b\",authorization_uri=\"https://login.windows.net/common/oauth2/authorize\",error=\"insufficient_claims\",claims=\"not_encoded\"";
+const validWwwAuthenticateHeader =
+  "Bearer realm=\"6c482541-f706-4168-9e58-8e35a9992f58\",client_id=\"00000003-0000-0ff1-ce00-000000000000\",trusted_issuers=\"00000001-0000-0000-c000-000000000000@*,D3776938-3DBA-481F-A652-4BEDFCAB7CD8@*,https://sts.windows.net/*/,00000003-0000-0ff1-ce00-000000000000@90140122-8516-11e1-8eff-49304924019b\",authorization_uri=\"https://login.windows.net/common/oauth2/authorize\",error=\"insufficient_claims\",claims=\"eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTU5Nzk1OTA5MCJ9fX0=\"";
+
+describe("parseAuthErrorClaims", () => {
+  it("returns undefined if headers does not have expected entry", async () => {
+    const headers = { get: (_name: string) => undefined };
+    const result = parseAuthErrorClaims(headers as any);
+    assert.equal(result, undefined);
+  });
+
+  it("returns undefined if header does not have expected error indicator", async () => {
+    const headers = {
+      get: (name: string) =>
+        name.toLowerCase() === "www-authenticate" ? invalidWwwAuthenticateHeaderWithoutError : undefined,
+    };
+    const result = parseAuthErrorClaims(headers as any);
+    assert.equal(result, undefined);
+});
+
+  it("returns undefined if error in header does not match expected value", async () => {
+    const headers = {
+      get: (name: string) =>
+        name.toLowerCase() === "www-authenticate" ? invalidWwwAuthenticateHeaderWithUnexpectedErrorValue : undefined,
+    };
+    const result = parseAuthErrorClaims(headers as any);
+    assert.equal(result, undefined);
+  });
+
+  it("returns undefined if header does not have expected claims indicator", async () => {
+    const headers = {
+      get: (name: string) =>
+        name.toLowerCase() === "www-authenticate" ? invalidWwwAuthenticateHeaderWithoutClaims : undefined,
+    };
+    const result = parseAuthErrorClaims(headers as any);
+    assert.equal(result, undefined);
+  });
+
+  it("throws if claims value is in unexpected format", async () => {
+    const headers = {
+      get: (name: string) =>
+        name.toLowerCase() === "www-authenticate" ? invalidWwwAuthenticateHeaderWithMalformedClaimsValue : undefined,
+    };
+    const testFunc = () => parseAuthErrorClaims(headers as any);
+    assert.throws(testFunc);
+  });
+
+  it("returns decoded claims value", async () => {
+    const headers = {
+      get: (name: string) => (name.toLowerCase() === "www-authenticate" ? validWwwAuthenticateHeader : undefined),
+    };
+    const result = parseAuthErrorClaims(headers as any);
+    assert.equal(result, "{\"access_token\":{\"nbf\":{\"essential\":true, \"value\":\"1597959090\"}}}");
+  });
+});

--- a/packages/drivers/odsp-driver/src/test/tokenFetch.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/tokenFetch.spec.ts
@@ -1,0 +1,45 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import assert from "assert";
+import { tokenFromResponse, isTokenFromCache } from "../tokenFetch";
+
+describe("tokenFromResponse", () => {
+  it("returns token verbatim when token value is passed as a string", async () => {
+    const token = "fake token";
+    const result = tokenFromResponse(token);
+    assert.equal(result, token);
+  });
+
+  it("returns token extracted from TokenResponse when token value is passed as object", async () => {
+    const tokenResponse = { token: "fake token", fromCache: false };
+    const result = tokenFromResponse(tokenResponse);
+    assert.equal(result, tokenResponse.token);
+  });
+
+  it("returns null when token value is passed as null", async () => {
+    const result = tokenFromResponse(null);
+    assert.equal(result, null);
+  });
+});
+
+describe("isTokenFromCache", () => {
+    it("returns undefined when token value is passed as a string", async () => {
+      const token = "fake token";
+      const result = isTokenFromCache(token);
+      assert.equal(result, undefined);
+    });
+
+    it("returns fromCache value extracted from TokenResponse when token value is passed as object", async () => {
+      const tokenResponse = { token: "fake token", fromCache: true };
+      const result = isTokenFromCache(tokenResponse);
+      assert.equal(result, tokenResponse.fromCache);
+    });
+
+    it("returns undefined when token value is passed as null", async () => {
+      const result = isTokenFromCache(null);
+      assert.equal(result, undefined);
+    });
+});

--- a/packages/drivers/odsp-driver/src/tokenFetch.ts
+++ b/packages/drivers/odsp-driver/src/tokenFetch.ts
@@ -1,0 +1,59 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Represents token response
+ */
+export interface TokenResponse {
+    /** Token value */
+    token: string;
+    /** Flag indicating whether token was obtained from local cache */
+    fromCache?: boolean;
+}
+
+/**
+ * Method signature for callback method used to fetch Storage token
+ * @param siteUrl Storage site url
+ * @param refresh Flag indicating whether token fetch must bypass local cache
+ * @param claims Optional string indicating claims that will be passed to token authority
+ * @returns If successful, TokenResponse object representing token value along with flag indicating
+ * whether token came from cache. Legacy implementation may return a string for token value;
+ * in this case it should be assumes that fromCache signal is undefined. Null is returned in case of failure.
+ */
+// eslint-disable-next-line max-len
+export type StorageTokenFetcher = (siteUrl: string, refresh: boolean, claims?: string) => Promise<string | TokenResponse | null>;
+
+/**
+ * Method signature for callback method used to fetch Push token
+ * @param refresh Flag indicating whether token fetch must bypass local cache
+ * @param claims Optional string indicating claims that will be passed to token authority
+ * @returns If successful, TokenResponse object representing token value along with flag indicating
+ * whether token came from cache. Legacy implementation may return a string for token value;
+ * in this case it should be assumes that fromCache signal is undefined. Null is returned in case of failure.
+ */
+export type PushTokenFetcher = (refresh: boolean, claims?: string) => Promise<string | TokenResponse | null>;
+
+/**
+ * Helper method which transforms return value for StorageTokenFetcher and PushTokenFetcher to token string
+ * @param tokenResponse return value for StorageTokenFetcher and PushTokenFetcher methods
+ * @returns Token value
+ */
+export function tokenFromResponse(tokenResponse: string | TokenResponse | null): string | null {
+    return tokenResponse === null || typeof tokenResponse === "string"
+        ? tokenResponse
+        : tokenResponse.token;
+}
+
+/**
+ * Helper method which returns flag indicating whether token response comes from local cache
+ * @param tokenResponse return value for StorageTokenFetcher and PushTokenFetcher methods
+ * @returns Value indicating whether response came from cache.
+ * Undefined is returned when we could not determine the source of token.
+ */
+export function isTokenFromCache(tokenResponse: string | TokenResponse | null): boolean | undefined {
+    return tokenResponse === null || typeof tokenResponse === "string"
+        ? undefined
+        : tokenResponse.fromCache;
+}

--- a/packages/drivers/odsp-driver/src/tokenFetch.ts
+++ b/packages/drivers/odsp-driver/src/tokenFetch.ts
@@ -15,9 +15,9 @@ export interface TokenResponse {
 
 /**
  * Method signature for callback method used to fetch Storage token
- * @param siteUrl Storage site url
- * @param refresh Flag indicating whether token fetch must bypass local cache
- * @param claims Optional string indicating claims that will be passed to token authority
+ * @param siteUrl - Storage site url
+ * @param refresh - Flag indicating whether token fetch must bypass local cache
+ * @param claims - Optional string indicating claims that will be passed to token authority
  * @returns If successful, TokenResponse object representing token value along with flag indicating
  * whether token came from cache. Legacy implementation may return a string for token value;
  * in this case it should be assumes that fromCache signal is undefined. Null is returned in case of failure.
@@ -27,8 +27,8 @@ export type StorageTokenFetcher = (siteUrl: string, refresh: boolean, claims?: s
 
 /**
  * Method signature for callback method used to fetch Push token
- * @param refresh Flag indicating whether token fetch must bypass local cache
- * @param claims Optional string indicating claims that will be passed to token authority
+ * @param refresh - Flag indicating whether token fetch must bypass local cache
+ * @param claims - Optional string indicating claims that will be passed to token authority
  * @returns If successful, TokenResponse object representing token value along with flag indicating
  * whether token came from cache. Legacy implementation may return a string for token value;
  * in this case it should be assumes that fromCache signal is undefined. Null is returned in case of failure.
@@ -37,7 +37,7 @@ export type PushTokenFetcher = (refresh: boolean, claims?: string) => Promise<st
 
 /**
  * Helper method which transforms return value for StorageTokenFetcher and PushTokenFetcher to token string
- * @param tokenResponse return value for StorageTokenFetcher and PushTokenFetcher methods
+ * @param tokenResponse - return value for StorageTokenFetcher and PushTokenFetcher methods
  * @returns Token value
  */
 export function tokenFromResponse(tokenResponse: string | TokenResponse | null): string | null {
@@ -48,7 +48,7 @@ export function tokenFromResponse(tokenResponse: string | TokenResponse | null):
 
 /**
  * Helper method which returns flag indicating whether token response comes from local cache
- * @param tokenResponse return value for StorageTokenFetcher and PushTokenFetcher methods
+ * @param tokenResponse - return value for StorageTokenFetcher and PushTokenFetcher methods
  * @returns Value indicating whether response came from cache.
  * Undefined is returned when we could not determine the source of token.
  */

--- a/packages/drivers/odsp-driver/src/tokenFetch.ts
+++ b/packages/drivers/odsp-driver/src/tokenFetch.ts
@@ -9,8 +9,23 @@
 export interface TokenResponse {
     /** Token value */
     token: string;
+
     /** Flag indicating whether token was obtained from local cache */
     fromCache?: boolean;
+}
+
+/**
+ * Represents token fetch options
+ */
+export interface TokenFetchOptions {
+    /**
+     * Value indicating whether fresh token has to be returned.
+     * If false then it is okay to return cached unexpired token if available.
+     */
+    refresh: boolean;
+
+    /** Claims that have to be passed with token fetch request */
+    claims?: string;
 }
 
 /**

--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -34,10 +34,10 @@ export async function fetchJoinSession(
     path: string,
     method: string,
     logger: ITelemetryLogger,
-    getVroomToken: (refresh: boolean, name?: string) => Promise<string | undefined | null>,
+    getVroomToken: (refresh: boolean, name?: string, claims?: string) => Promise<string | null>,
 ): Promise<ISocketStorageDiscovery> {
-    return getWithRetryForTokenRefresh(async (refresh: boolean) => {
-        const token = await getVroomToken(refresh, "JoinSession");
+    return getWithRetryForTokenRefresh(async (refresh: boolean, claims?: string) => {
+        const token = await getVroomToken(refresh, "JoinSession", claims);
         if (!token) {
             throwOdspNetworkError("Failed to acquire Vroom token", fetchIncorrectResponse);
         }

--- a/packages/loader/driver-definitions/src/driverError.ts
+++ b/packages/loader/driver-definitions/src/driverError.ts
@@ -86,7 +86,6 @@ export interface IGenericNetworkError extends IDriverErrorBase {
 
 export interface IAuthorizationError extends IDriverErrorBase {
     readonly errorType: DriverErrorType.authorizationError;
-    readonly statusCode?: number;
     readonly claims?: string;
 }
 

--- a/packages/loader/driver-definitions/src/driverError.ts
+++ b/packages/loader/driver-definitions/src/driverError.ts
@@ -84,6 +84,12 @@ export interface IGenericNetworkError extends IDriverErrorBase {
     readonly statusCode?: number;
 }
 
+export interface IAuthorizationError extends IDriverErrorBase {
+    readonly errorType: DriverErrorType.authorizationError;
+    readonly statusCode?: number;
+    readonly claims?: string;
+}
+
 /**
  * Having this uber interface without types that have their own interfaces
  * allows compiler to differentiate interfaces based on error type
@@ -104,4 +110,5 @@ export interface IDriverBasicError extends IDriverErrorBase {
 export type DriverError =
     | IThrottlingWarning
     | IGenericNetworkError
+    | IAuthorizationError
     | IDriverBasicError;

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -49,7 +49,6 @@ export class AuthorizationError extends CustomErrorWithProps implements IAuthori
 
     constructor(
         errorMessage: string,
-        readonly statusCode?: number,
         readonly claims?: string,
     ) {
         super(errorMessage);

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -6,6 +6,7 @@
 import {
     IThrottlingWarning,
     IDriverErrorBase,
+    IAuthorizationError,
     DriverErrorType,
 } from "@fluidframework/driver-definitions";
 import { CustomErrorWithProps } from "@fluidframework/telemetry-utils";
@@ -37,6 +38,19 @@ export class GenericNetworkError extends CustomErrorWithProps implements IDriver
         errorMessage: string,
         readonly canRetry: boolean,
         readonly statusCode?: number,
+    ) {
+        super(errorMessage);
+    }
+}
+
+export class AuthorizationError extends CustomErrorWithProps implements IAuthorizationError {
+    readonly errorType = DriverErrorType.authorizationError;
+    readonly canRetry = false;
+
+    constructor(
+        errorMessage: string,
+        readonly statusCode?: number,
+        readonly claims?: string,
     ) {
         super(errorMessage);
     }

--- a/packages/test/service-load-test/src/nodeStressTest.ts
+++ b/packages/test/service-load-test/src/nodeStressTest.ts
@@ -22,15 +22,15 @@ import { ITestConfig, IRunConfig, fluidExport, ILoadTest } from "./loadTestDataS
 const packageName = `${pkgName}@${pkgVersion}`;
 
 interface ITestConfigs {
-    full: ITestConfig,
-    mini: ITestConfig,
+    full: ITestConfig;
+    mini: ITestConfig;
 }
 
 interface IConfig {
-    server: string,
-    driveId: string,
-    username: string,
-    profiles: ITestConfigs,
+    server: string;
+    driveId: string;
+    username: string;
+    profiles: ITestConfigs;
 }
 
 const codeDetails: IFluidCodeDetails = {
@@ -53,7 +53,7 @@ function createLoader(config: IConfig, password: string) {
     const loader = new Loader(
         urlResolver,
         new OdspDocumentServiceFactory(
-            async (siteUrl: string, refresh) => {
+            async (_siteUrl: string, refresh: boolean, _claims?: string) => {
                 const tokens = await odspTokenManager.getOdspTokens(
                     config.server,
                     getMicrosoftConfiguration(),
@@ -62,7 +62,7 @@ function createLoader(config: IConfig, password: string) {
                 );
                 return tokens.accessToken;
             },
-            async (refresh: boolean) => {
+            async (refresh: boolean, _claims?: string) => {
                 const tokens = await odspTokenManager.getPushTokens(
                     config.server,
                     getMicrosoftConfiguration(),

--- a/packages/tools/fetch-tool/src/fluidFetchInit.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchInit.ts
@@ -54,7 +54,7 @@ async function initializeODSPCore(
   item:   ${itemId}
   docId:  ${docId}`);
 
-    const getStorageTokenStub = async (siteUrl: string, refresh: boolean) => {
+    const getStorageTokenStub = async (siteUrl: string, refresh: boolean, _claims?: string) => {
         return resolveWrapper(
             async (authRequestInfo: IOdspAuthRequestInfo) => {
                 if ((refresh || !authRequestInfo.accessToken) && authRequestInfo.refreshTokenFn) {
@@ -67,7 +67,7 @@ async function initializeODSPCore(
         );
     };
     // eslint-disable-next-line @typescript-eslint/promise-function-async
-    const getWebsocketTokenStub = () => Promise.resolve("");
+    const getWebsocketTokenStub = (_refresh: boolean, _claims?: string) => Promise.resolve("");
     const odspDocumentServiceFactory = new odsp.OdspDocumentServiceFactory(
         getStorageTokenStub,
         getWebsocketTokenStub);

--- a/server/gateway/src/childLoader.ts
+++ b/server/gateway/src/childLoader.ts
@@ -77,7 +77,7 @@ class KeyValueLoader {
         const documentServiceFactories: IDocumentServiceFactory[] = [];
         // TODO: figure out how to pass clientId and token here
         documentServiceFactories.push(new OdspDocumentServiceFactory(
-            async (siteUrl: string) => Promise.resolve("fake token"),
+            async () => Promise.resolve("fake token"),
             async () => Promise.resolve("fake token")));
 
         documentServiceFactories.push(new RouterliciousDocumentServiceFactory(

--- a/server/gateway/src/controllers/loaderHost.ts
+++ b/server/gateway/src/controllers/loaderHost.ts
@@ -38,7 +38,7 @@ export async function initialize(
     const documentServiceFactories: IDocumentServiceFactory[] = [];
     // TODO: need to be support refresh token
     documentServiceFactories.push(new OdspDocumentServiceFactory(
-        async (siteUrl: string) => Promise.resolve(resolved.tokens.storageToken),
+        async () => Promise.resolve(resolved.tokens.storageToken),
         async () => Promise.resolve(resolved.tokens.socketToken)));
 
     documentServiceFactories.push(new RouterliciousDocumentServiceFactory(

--- a/server/gateway/src/controllers/workerLoader.ts
+++ b/server/gateway/src/controllers/workerLoader.ts
@@ -67,7 +67,7 @@ class WorkerLoader implements ILoader, IFluidRunnable {
                 null);
         } else {
             factory = new OdspDocumentServiceFactory(
-                async (siteUrl: string) => Promise.resolve(this.resolved.tokens.storageToken),
+                async () => Promise.resolve(this.resolved.tokens.storageToken),
                 async () => Promise.resolve(this.resolved.tokens.socketToken));
         }
         const container = await Container.load(


### PR DESCRIPTION
Long lived token (LLT) can be supplied by OdspDocumentService.getStorageToken. To proper use them we need to handle authorization error (401) and check for www-authenticate header indicating whether LLT is no longer valid. Method signatures have been changed to allow for passing "claims" value extracted from www-authenticate header payload when requesting fresh token.

Also added a change which allows for returning token as object which carries token value along with fromCache property indicating whether token was returned from local cache. This property will be logged with events describing result of token fetching.