### PR TITLE
Fix summarizer creation error

### DIFF
--- a/examples/utils/get-tinylicious-container/src/getTinyliciousContainer.ts
+++ b/examples/utils/get-tinylicious-container/src/getTinyliciousContainer.ts
@@ -18,10 +18,12 @@ import { RouterliciousDocumentServiceFactory, DefaultErrorTracking } from "@flui
 import jwt from "jsonwebtoken";
 import { v4 as uuid } from "uuid";
 
-// URLResolver knows how to get the URLs to the service to use for a given request, in this case Tinylicious.
-// In order to avoid imposing requirements on the app's URL shapes, we'll expect our request url to have this
-// format (as opposed to a more traditional URL):
-// documentId/containerRelativePathing
+/**
+ * InsecureTinyliciousUrlResolver knows how to get the URLs to the service (in this case Tinylicious) to use
+ * for a given request.  This particular implementation has a goal to avoid imposing requirements on the app's
+ * URL shape, so it expects the request url to have this format (as opposed to a more traditional URL):
+ * documentId/containerRelativePathing
+ */
 class InsecureTinyliciousUrlResolver implements IUrlResolver {
     public async resolve(request: IRequest): Promise<IResolvedUrl> {
         const documentId = request.url.split("/")[0];
@@ -44,12 +46,14 @@ class InsecureTinyliciousUrlResolver implements IUrlResolver {
         return response;
     }
 
-    // Detached flow calls getAbsoluteUrl with the resolved.url produced above (the documentUrl).  It expects
-    // getAbsoluteUrl's return value to be a URL that can then be roundtripped back through resolve again,
-    // and get the same result again.  So we'll return a URL with the same format described above.
-    public async getAbsoluteUrl(resolvedUrl: IResolvedUrl, relativeUrl: string): Promise<string> {
-        const url = (resolvedUrl as IFluidResolvedUrl).url;
-        const documentId = decodeURIComponent(url.replace("fluid://localhost:3000/tinylicious/", ""));
+    public async getAbsoluteUrl(resolvedUrl: IFluidResolvedUrl, relativeUrl: string): Promise<string> {
+        const documentId = decodeURIComponent(resolvedUrl.url.replace("fluid://localhost:3000/tinylicious/", ""));
+        /*
+         * The detached container flow will ultimately call getAbsoluteUrl() with the resolved.url produced by
+         * resolve().  The container expects getAbsoluteUrl's return value to be a URL that can then be roundtripped
+         * back through resolve() again, and get the same result again.  So we'll return a "URL" with the same format
+         * described above.
+         */
         return `${documentId}/${relativeUrl}`;
     }
 


### PR DESCRIPTION
Closes #3335

The detached flow expects to be able to use the resolver's `getAbsoluteUrl()` to reverse-engineer a url that will resolve back to the correct container.  This doesn't matter for the interactive client because it will use the cached container and never actually use that url, but since the summarizer disables caching it requires the url to resolve correctly.

More generally stated, the expected invariant is that the outputted url of `urlResolver.resolve()` can be passed through `urlResolver.getAbsoluteUrl()`, and the outputted url of `urlResolver.getAbsoluteUrl()` can be passed through `urlResolver.resolve()` for a full round-trip.  `getTinyliciousContainer()` was violating that by fudging `getAbsoluteUrl()`, so this provides a correct implementation.