### PR TITLE
Add copy button to QuickStart code blocks

### DIFF
--- a/docs/assets/css/fluid.css
+++ b/docs/assets/css/fluid.css
@@ -131,6 +131,7 @@
     min-width: 55px;
     text-align: center;
 }
+
 .highlight-copy-btn:hover {
     background-color: #666;
 }

--- a/docs/assets/css/fluid.css
+++ b/docs/assets/css/fluid.css
@@ -109,3 +109,28 @@
 .callout.danger .callout-title {
     color: #900;
 }
+
+.highlight {
+    position: relative;
+}
+
+.highlight-copy-btn {
+    position: absolute;
+    right: 7px;
+    border: 0;
+    border-radius: 4px;
+    margin: 0;
+    top: 50%;
+    -ms-transform: translateY(-50%);
+    transform: translateY(-50%);
+    padding: 1px;
+    font-size: 0.7em;
+    line-height: 1.8;
+    color: #fff;
+    background-color: #777;
+    min-width: 55px;
+    text-align: center;
+}
+.highlight-copy-btn:hover {
+    background-color: #666;
+}

--- a/docs/content/docs/get-started/quick-start.md
+++ b/docs/content/docs/get-started/quick-start.md
@@ -1,6 +1,7 @@
 ---
 title: Quick Start
 menuPosition: 2
+codeCopyButton: true
 ---
 
 In this Quick Start we will be getting the [Hello World](https://github.com/microsoft/FluidHelloWorld) Fluid application
@@ -43,6 +44,9 @@ Navigate to the newly created folder and install required dependencies.
 
 ```bash
 cd FluidHelloWorld
+```
+
+```bash
 npm i
 ```
 

--- a/docs/static/js/add-code-copy-button.js
+++ b/docs/static/js/add-code-copy-button.js
@@ -1,6 +1,12 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
 
 // Including this script on a page will add a Copy button to all code blocks.
 // It determines a code block by looking for the "highlight" element.
+// to include this script in your md file add `codeCopyButton: true` in the
+// metadata at the top of the file
 
 const copyMessage = "Copy";
 const addCopyButtonsToCodeBlocks = () => {
@@ -54,8 +60,12 @@ const addCopyButtonsToCodeBlocks = () => {
     Array.prototype.forEach.call(highlightBlocks, addCopyButton);
 };
 
-// Run the script after the page has been loaded
-function r(f) {
-    /in/.test(document.readyState) ? setTimeout("r(" + f + ")", 0) : f();
+// Recursive function that checks to see if the page has loaded.
+// Checks every 9ms and calls addCopyButtonsToCodeBlocks when loading is complete.
+// Ensures we only attempt to add the Copy buttons after the elements exist
+function checkPageLoaded() {
+    document.readyState !== "complete"
+        ? setTimeout(checkPageLoaded, 9)
+        : addCopyButtonsToCodeBlocks();
 }
-r(addCopyButtonsToCodeBlocks);
+checkPageLoaded();

--- a/docs/static/js/add-code-copy-button.js
+++ b/docs/static/js/add-code-copy-button.js
@@ -1,0 +1,61 @@
+
+// Including this script on a page will add a Copy button to all code blocks.
+// It determines a code block by looking for the "highlight" element.
+
+const copyMessage = "Copy";
+const addCopyButtonsToCodeBlocks = () => {
+    // Ensure the browser supports copy
+    if (!document.queryCommandSupported("copy")) {
+        return;
+    }
+
+    const selectText = (node) => {
+        const selection = window.getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(node);
+        selection.removeAllRanges();
+        selection.addRange(range);
+        return selection;
+    };
+
+    const addCopyButton = (element) => {
+        const copyBtn = document.createElement("button");
+        copyBtn.className = "highlight-copy-btn";
+        copyBtn.textContent = copyMessage;
+
+        // Set a message on the button then return to the initial
+        // value after 1 second
+        const flashCopyMessage = (el, msg) => {
+            el.textContent = msg;
+            setTimeout(() => {
+                el.textContent = copyMessage;
+            }, 1000);
+        };
+
+        const codeEl = element.firstElementChild;
+        copyBtn.addEventListener("click", () => {
+            try {
+                const selection = selectText(codeEl);
+                document.execCommand("copy");
+                selection.removeAllRanges();
+
+                flashCopyMessage(copyBtn, "Copied!");
+            } catch (e) {
+                console && console.log(e);
+                flashCopyMessage(copyBtn, "Failed");
+            }
+        });
+
+        element.appendChild(copyBtn);
+    };
+
+    // Add copy button to code blocks
+    const highlightBlocks = document.getElementsByClassName("highlight");
+    Array.prototype.forEach.call(highlightBlocks, addCopyButton);
+};
+
+// Run the script after the page has been loaded
+function r(f) {
+    /in/.test(document.readyState) ? setTimeout("r(" + f + ")", 0) : f();
+}
+r(addCopyButtonsToCodeBlocks);

--- a/docs/themes/thxvscode/layouts/partials/head.html
+++ b/docs/themes/thxvscode/layouts/partials/head.html
@@ -49,7 +49,7 @@
     {{- end }}
 
     {{- if .Params.codeCopyButton -}}
-        <script src="/js/add-code-copy-button.js"></script>
+        <script async src="/js/add-code-copy-button.js"></script>
     {{- end }}
 
     <meta name=" description" content="{{ $summary }}" />

--- a/docs/themes/thxvscode/layouts/partials/head.html
+++ b/docs/themes/thxvscode/layouts/partials/head.html
@@ -48,6 +48,10 @@
     {{ partial "extra-head.html" . }}
     {{- end }}
 
+    {{- if .Params.codeCopyButton -}}
+        <script src="/js/add-code-copy-button.js"></script>
+    {{- end }}
+
     <meta name=" description" content="{{ $summary }}" />
     <meta property="og:title" content="{{.Title}}" />
     <meta property="og:description" content="{{ $summary }}" />


### PR DESCRIPTION
Adds a script that will go through a hugo markdown page and add a copy button next to a code block. I'm using this for the Quick Start page only to make it easier for people getting started.

Thanks to @tylerbutler for helping me make this a js file that is re-useable and not just some in-lined script