### PR TITLE
Update sanitize.ts to kill 99.9% of germs

### DIFF
--- a/packages/test/snapshots/src/sanitize.ts
+++ b/packages/test/snapshots/src/sanitize.ts
@@ -118,6 +118,9 @@ function fixSnapshotEntries(entries: any) {
     }
 
     entries.forEach((element) => {
+        if (element.value?.entries) {
+            fixSnapshotEntries(element.value.entries);
+        }
         if (element.value?.contents) {
             try {
                 let data = JSON.parse(element.value.contents);
@@ -158,9 +161,6 @@ function fixContents(messageContents: any) {
         } else if (typeof contents.seg === "string") {
             contents.seg = replaceText(contents.seg);
         }
-        if (typeof contents.props === "object") {
-            contents.props = replaceObject(contents.props);
-        }
     }
 
     // Map op-specific fields
@@ -169,11 +169,11 @@ function fixContents(messageContents: any) {
     }
 
     // Everything else under contents.contents.content.contents
-    if (contents.value) {
-        replaceObject(contents.value);
+    if (typeof contents.value === "object") {
+        contents.value = replaceObject(contents.value);
     }
 
-    if (contents.props) {
+    if (typeof contents.props === "object") {
         contents.props = replaceObject(contents.props);
     }
 }


### PR DESCRIPTION
fixes #633
The sanitize tool was a bit incomplete in what it scrubbed out.  Add more scrubbing, particularly for:
- sequence segment properties
- attach messages (component id/type/pkg)
- code proposals (component id)
- map keys/values
- nested content values

I _think_ I included all the parts where the JSON structure might be variable to be scrubbed by default, while the surrounding parts are not.  Since this does attempt to keep some information, it's possible new DDSs might violate this.
- contents.props
- contents.value
- contents.snapshot.entries.value.contents
- contents.snapshot.entries.value.entries.value.contents

There are definitely other ways to do this (especially if we want it to be more restrictive/don't need some of the preserved keys), but tried for a balance here.

I'll add this into fluid-fetch to run by default in a followup.