### PR TITLE
Add Live Fluid Dice-Roller in Docs

### DIFF
--- a/docs/content/docs/get-started/quick-start.md
+++ b/docs/content/docs/get-started/quick-start.md
@@ -4,8 +4,11 @@ menuPosition: 2
 codeCopyButton: true
 ---
 
-In this Quick Start we will be getting the [Hello World](https://github.com/microsoft/FluidHelloWorld) Fluid application
+In this Quick Start we will be getting the following [Hello World](https://github.com/microsoft/FluidHelloWorld) Fluid application
 running locally on your machine.
+
+{{< fluid_bundle_loader idPrefix="dice-roller"
+bundleName="dice-roller.9af6bdd702e6cd4ad6cf.js" >}}
 
 ## Set up your development environment
 

--- a/docs/content/docs/get-started/tutorial.md
+++ b/docs/content/docs/get-started/tutorial.md
@@ -30,7 +30,7 @@ There are a handful of key concepts to understand.
 
 ## The DiceRoller app
 
-![](/docs/get-started/images/dice-roller.gif)
+{{< fluid_bundle_loader >}}
 
 To explore these concepts, we'll be looking at a simple app that enables all connected clients to roll a dice and view
 the result. We'll do this by writing a data object to represent the dice, configuring container code to use that Data

--- a/docs/content/docs/get-started/tutorial.md
+++ b/docs/content/docs/get-started/tutorial.md
@@ -30,7 +30,8 @@ There are a handful of key concepts to understand.
 
 ## The DiceRoller app
 
-{{< fluid_bundle_loader >}}
+{{< fluid_bundle_loader idPrefix="dice-roller"
+bundleName="dice-roller.9af6bdd702e6cd4ad6cf.js" >}}
 
 To explore these concepts, we'll be looking at a simple app that enables all connected clients to roll a dice and view
 the result. We'll do this by writing a data object to represent the dice, configuring container code to use that Data

--- a/docs/themes/thxvscode/layouts/shortcodes/fluid_bundle_loader.html
+++ b/docs/themes/thxvscode/layouts/shortcodes/fluid_bundle_loader.html
@@ -1,8 +1,11 @@
+{{ $idPrefix := .Get "idPrefix" }}
+{{ $bundleName := .Get "bundleName" }}
+
 <div id="content" style="min-height: 200px; display: flex;">
-    <div id="dice-roller-left" style="flex-grow: 1; width: 50%; border: 1px solid lightgray; box-sizing: border-box; position:
+    <div id="{{ $idPrefix }}-left" style="flex-grow: 1; width: 50%; border: 1px solid lightgray; box-sizing: border-box; position:
     relative; padding-bottom: 10px"></div>
-    <div id="dice-roller-right" style="flex-grow: 1; width: 50%; border: 1px solid lightgray; box-sizing: border-box; position:
+    <div id="{{ $idPrefix }}-right" style="flex-grow: 1; width: 50%; border: 1px solid lightgray; box-sizing: border-box; position:
     relative; padding-bottom: 10px"></div>
 </div>
 
-<script async src="https://fluidframework.blob.core.windows.net/static/js/dice-roller.376ccc4b8ef6aabc4904.js"></script>
+<script async src="https://fluidframework.blob.core.windows.net/static/js/{{ $bundleName }}"></script>

--- a/docs/themes/thxvscode/layouts/shortcodes/fluid_bundle_loader.html
+++ b/docs/themes/thxvscode/layouts/shortcodes/fluid_bundle_loader.html
@@ -1,0 +1,8 @@
+<div id="content" style="min-height: 200px; display: flex;">
+    <div id="dice-roller-left" style="flex-grow: 1; width: 50%; border: 1px solid lightgray; box-sizing: border-box; position:
+    relative; padding-bottom: 10px"></div>
+    <div id="dice-roller-right" style="flex-grow: 1; width: 50%; border: 1px solid lightgray; box-sizing: border-box; position:
+    relative; padding-bottom: 10px"></div>
+</div>
+
+<script async src="https://fluidframework.blob.core.windows.net/static/js/dice-roller.376ccc4b8ef6aabc4904.js"></script>


### PR DESCRIPTION
This change adds a side-by-side dice-roller example to the docs. It adds it to both the QuickStart and Tutorial page.

It works by using session-storage and always generates a new document on load. The bundle is uploaded to the cdn and it uses the standard side-by-side html template.

I've added a shortcode so that we can re-use this with other examples through the docs. I tried getting the three examples working but because the space is really limited (with side-by-side plus in a tiny width div) the solutions need to be a bit custom and will take a bit more time.