### PR TITLE
Fix incorrect clicker configuration in Vltava

### DIFF
--- a/examples/data-objects/vltava/src/index.ts
+++ b/examples/data-objects/vltava/src/index.ts
@@ -90,7 +90,7 @@ export class VltavaRuntimeFactory extends ContainerRuntimeFactoryWithDefaultData
 const generateFactory = () => {
     const containerFluidObjectsDefinition: IInternalRegistryEntry[] = [
         {
-            type: Anchor.getFactory().type,
+            type: ClickerInstantiationFactory.type,
             factory: Promise.resolve(ClickerInstantiationFactory),
             capabilities: ["IFluidHTMLView", "IFluidLoadable"],
             friendlyName: "Clicker",


### PR DESCRIPTION
The Clicker registry entry in Vltava is incorrectly pointing to Anchor component.