### PR TITLE
add fake browser wrapping around live fluid objects for Docs

### DIFF
--- a/docs/themes/thxvscode/layouts/shortcodes/fluid_bundle_loader.html
+++ b/docs/themes/thxvscode/layouts/shortcodes/fluid_bundle_loader.html
@@ -2,10 +2,96 @@
 {{ $bundleName := .Get "bundleName" }}
 
 <div id="content" style="min-height: 200px; display: flex;">
-    <div id="{{ $idPrefix }}-left" style="flex-grow: 1; width: 50%; border: 1px solid lightgray; box-sizing: border-box; position:
-    relative; padding-bottom: 10px"></div>
-    <div id="{{ $idPrefix }}-right" style="flex-grow: 1; width: 50%; border: 1px solid lightgray; box-sizing: border-box; position:
-    relative; padding-bottom: 10px"></div>
+    <div class="browser-window-wrapper">
+        <div class="browser-window">
+            <div class="browser-window-nav">
+                <div class="browser-window-nav-url">
+                    http://localhost:8080
+                </div>
+            </div>
+            <div class="browser-window-icon-wrapper">
+                <div class="browser-window-icon">−</div>
+                <div class="browser-window-icon">□</div>
+                <div class="browser-window-icon">x</div>
+            </div>
+        </div>
+        <div id="{{ $idPrefix }}-left"></div>
+    </div>
+    <div class="browser-window-wrapper">
+        <div class="browser-window">
+            <div class="browser-window-nav">
+                <div class="browser-window-nav-url">
+                    http://localhost:8080
+                </div>
+            </div>
+            <div class="browser-window-icon-wrapper">
+                <div class="browser-window-icon">−</div>
+                <div class="browser-window-icon">□</div>
+                <div class="browser-window-icon">x</div>
+            </div>
+        </div>
+        <div id="{{ $idPrefix }}-right"></div>
+    </div>
 </div>
 
+<style>
+    .browser-window {
+        position:absolute;
+        top:0;
+        height:40px;
+        width:100%;
+        background-color: #e8e8e8;
+        border-bottom: 1px solid lightgray;
+    }
+    .browser-window-wrapper {
+        flex-grow: 1;
+        width: 50%;
+        border: 1px solid lightgray;
+        box-sizing: border-box;
+        position: relative;
+        padding-bottom: 10px;
+        margin: 2px;
+    }
+    .browser-window-icon-wrapper {
+        position: absolute;
+        display: flex;
+        top: 0px;
+        right: 0px;
+    }
+    .browser-window-icon {
+        position: relative;
+        top: 0px;
+        right: 0px;
+        color: #333333;
+        width:25px;
+        text-align: center;
+    }
+    .browser-window-nav {
+        position: absolute;
+        font-size: 10px;
+        bottom: 5px;
+        left: 10px;
+        height: 20px;
+        width: 65%;
+        border-radius: 2px;
+        box-shadow: 0 30px 40px rgba(0,0,0,.1);
+        background-color: white;
+        border: 1px solid lightgray;
+        overflow: hidden;
+    }
+    .browser-window-nav-url {
+        padding-left:2px;
+    }
+</style>
+
 <script async src="https://fluidframework.blob.core.windows.net/static/js/{{ $bundleName }}"></script>
+
+<script>
+    (() => {
+        const hash = Date.now().toString();
+        const elements = document.getElementsByClassName("browser-window-nav-url");
+        for (const e of elements) {
+            e.innerHTML = "http://localhost:8080/#" + hash;
+        }
+    })();
+</script>

--- a/docs/themes/thxvscode/layouts/shortcodes/fluid_bundle_loader.html
+++ b/docs/themes/thxvscode/layouts/shortcodes/fluid_bundle_loader.html
@@ -38,7 +38,7 @@
     .browser-window {
         position:absolute;
         top:0;
-        height:40px;
+        height:45px;
         width:100%;
         background-color: #e8e8e8;
         border-bottom: 1px solid lightgray;


### PR DESCRIPTION
This change adds a light weight mock Edge(ish) browser boarder around the fluid objects to make them look like independent entities. Before and after images below

## Before

![image](https://user-images.githubusercontent.com/6289462/91477829-cc8ddc00-e853-11ea-9447-2ccc9755c554.png)

## After

![image](https://user-images.githubusercontent.com/6289462/91478792-52f6ed80-e855-11ea-8a29-efdfd0ffdd7b.png)
