### PR TITLE
Fix name of Webpack fluid loader

### DIFF
--- a/server/admin/README.md
+++ b/server/admin/README.md
@@ -8,7 +8,6 @@ Coming soon...
 
 ## Trademark
 
-This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services. Use of these
-trademarks or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/
-intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this
-project must not cause confusion or imply Microsoft sponsorship.
+This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services. Use of these trademarks
+or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.

--- a/server/auspkn/README.md
+++ b/server/auspkn/README.md
@@ -12,7 +12,6 @@ the original personal access token directly.
 
 ## Trademark
 
-This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services. Use of these
-trademarks or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/
-intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this
-project must not cause confusion or imply Microsoft sponsorship.
+This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services. Use of these trademarks
+or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.

--- a/server/gateway/README.md
+++ b/server/gateway/README.md
@@ -41,7 +41,6 @@ When making additional changes, stop both gateway and the other entry point and 
 
 ## Trademark
 
-This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services. Use of these
-trademarks or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/
-intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this
-project must not cause confusion or imply Microsoft sponsorship.
+This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services. Use of these trademarks
+or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.

--- a/server/gitrest/README.md
+++ b/server/gitrest/README.md
@@ -83,7 +83,6 @@ curl --verbose localhost:3000/repos/prague/test/git/tags/a8588b3913aa692c3642697
 
 ## Trademark
 
-This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services. Use of these
-trademarks or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/
-intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this
-project must not cause confusion or imply Microsoft sponsorship.
+This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services. Use of these trademarks
+or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.

--- a/server/headless-agent/README.md
+++ b/server/headless-agent/README.md
@@ -20,7 +20,6 @@ node dist/puppeteer/cli.js -d <documentId> -t <agentType>
 
 ## Trademark
 
-This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services. Use of these
-trademarks or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/
-intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this
-project must not cause confusion or imply Microsoft sponsorship.
+This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services. Use of these trademarks
+or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.

--- a/server/historian/README.md
+++ b/server/historian/README.md
@@ -32,7 +32,6 @@ your local files into the container so you will need to npm install, npm run bui
 
 ## Trademark
 
-This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services. Use of these
-trademarks or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/
-intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this
-project must not cause confusion or imply Microsoft sponsorship.
+This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services. Use of these trademarks
+or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.

--- a/server/routerlicious/README.md
+++ b/server/routerlicious/README.md
@@ -310,7 +310,6 @@ Coming Soon...
 
 ## Trademark
 
-This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services. Use of these
-trademarks or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/
-intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this
-project must not cause confusion or imply Microsoft sponsorship.
+This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services. Use of these trademarks
+or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.

--- a/server/service-monitor/README.md
+++ b/server/service-monitor/README.md
@@ -74,7 +74,6 @@ kubectl delete cronjob service-monitoring
 
 ## Trademark
 
-This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services. Use of these
-trademarks or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/
-intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this
-project must not cause confusion or imply Microsoft sponsorship.
+This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services. Use of these trademarks
+or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.

--- a/server/tinylicious/README.md
+++ b/server/tinylicious/README.md
@@ -4,7 +4,7 @@ Tinylicious is a minimal, self-contained, test implementation of the Fluid Frame
 
 ## What is this for?
 
-Tinylicious includes most of the basic features needed to **test** data stores and containers. While we use the [Webpack Component Loader](../../packages/tools/webpack-fluid-loader)'s in browser service for our much of our data store and container development, Tinylicious offers some advantages because it's a standalone process. For instance, testing a Fluid Container from 2+ simultaneously connected clients can be easier using Tinylicious.
+Tinylicious includes most of the basic features needed to **test** data stores and containers. While we use the [Webpack Fluid Loader](../../packages/tools/webpack-fluid-loader)'s in browser service for our much of our data store and container development, Tinylicious offers some advantages because it's a standalone process. For instance, testing a Fluid Container from 2+ simultaneously connected clients can be easier using Tinylicious.
 
 If you're looking for a reference implementation of the Fluid service, don't look here! Go check out [Routerlicious](../routerlicious).
 

--- a/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -20,10 +20,9 @@ const repository = 'microsoft/FluidFramework';
 const trademark = `
 ## Trademark
 
-This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services. Use of these
-trademarks or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/
-intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this
-project must not cause confusion or imply Microsoft sponsorship.
+This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services. Use of these trademarks
+or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 `;
 
 function packageShouldBePrivate(name: string): boolean {


### PR DESCRIPTION
It is not webpack component loader any more

Also fix line break in the URL in trademark verbiage.