### PR TITLE
Use undefined uniformly for gitCache arg in RouterliciousDriver

### DIFF
--- a/examples/hosts/iframe-host/src/outer.ts
+++ b/examples/hosts/iframe-host/src/outer.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 import {
-    DefaultErrorTracking,
     RouterliciousDocumentServiceFactory,
 } from "@fluidframework/routerlicious-driver";
 import { IFluidCodeDetails } from "@fluidframework/container-definitions";
@@ -29,12 +28,7 @@ const getTinyliciousResolver =
         "bearer");
 
 const getTinyliciousDocumentServiceFactory =
-    () => new RouterliciousDocumentServiceFactory(
-        false,
-        new DefaultErrorTracking(),
-        false,
-        true,
-        undefined);
+    () => new RouterliciousDocumentServiceFactory();
 
 export async function loadFrame(iframeId: string, logId: string) {
     const iframe = document.getElementById(iframeId) as HTMLIFrameElement;

--- a/examples/hosts/iframe-host/src/outer.ts
+++ b/examples/hosts/iframe-host/src/outer.ts
@@ -27,15 +27,12 @@ const getTinyliciousResolver =
         { id: "userid0" },
         "bearer");
 
-const getTinyliciousDocumentServiceFactory =
-    () => new RouterliciousDocumentServiceFactory();
-
 export async function loadFrame(iframeId: string, logId: string) {
     const iframe = document.getElementById(iframeId) as HTMLIFrameElement;
 
     const urlResolver = getTinyliciousResolver();
 
-    const documentServiceFactory = getTinyliciousDocumentServiceFactory();
+    const documentServiceFactory = new RouterliciousDocumentServiceFactory();
 
     const host = new IFrameOuterHost({
         urlResolver,
@@ -75,7 +72,7 @@ export async function loadDiv(divId: string) {
 
     const urlResolver = getTinyliciousResolver();
 
-    const documentServiceFactory = getTinyliciousDocumentServiceFactory();
+    const documentServiceFactory = new RouterliciousDocumentServiceFactory();
 
     const pkg: IFluidCodeDetails = {
         package: "@fluid-example/todo@^0.15.0",

--- a/examples/utils/get-tinylicious-container/src/getTinyliciousContainer.ts
+++ b/examples/utils/get-tinylicious-container/src/getTinyliciousContainer.ts
@@ -14,7 +14,7 @@ import {
     IUrlResolver,
 } from "@fluidframework/driver-definitions";
 import { ITokenClaims } from "@fluidframework/protocol-definitions";
-import { RouterliciousDocumentServiceFactory, DefaultErrorTracking } from "@fluidframework/routerlicious-driver";
+import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 import jwt from "jsonwebtoken";
 import { v4 as uuid } from "uuid";
 
@@ -79,13 +79,7 @@ export async function getTinyliciousContainer(
     containerRuntimeFactory: IRuntimeFactory,
     createNew: boolean,
 ): Promise<Container> {
-    const documentServiceFactory = new RouterliciousDocumentServiceFactory(
-        false,
-        new DefaultErrorTracking(),
-        false,
-        true,
-        undefined,
-    );
+    const documentServiceFactory = new RouterliciousDocumentServiceFactory();
 
     const urlResolver = new InsecureTinyliciousUrlResolver();
 

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -29,7 +29,7 @@ export class DocumentService implements api.IDocumentService {
         private readonly disableCache: boolean,
         private readonly historianApi: boolean,
         private readonly directCredentials: ICredentials | undefined,
-        private readonly gitCache: IGitCache | null | undefined,
+        private readonly gitCache: IGitCache | undefined,
         protected tokenProvider: TokenProvider,
         protected tenantId: string,
         protected documentId: string,
@@ -66,7 +66,7 @@ export class DocumentService implements api.IDocumentService {
         const gitManager = new GitManager(historian);
 
         // Insert cached seed data
-        if (this.gitCache) {
+        if (this.gitCache !== undefined) {
             for (const ref of Object.keys(this.gitCache.refs)) {
                 gitManager.addRef(ref, this.gitCache.refs[ref]);
             }

--- a/packages/drivers/routerlicious-driver/src/documentService2.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService2.ts
@@ -35,7 +35,7 @@ export class DocumentService2 extends DocumentService {
             disableCache,
             historianApi,
             directCredentials,
-            null,
+            undefined,
             tokenProvider,
             tenantId,
             documentId);

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -35,7 +35,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
         private readonly errorTracking: IErrorTrackingService = new DefaultErrorTracking(),
         private readonly disableCache: boolean = false,
         private readonly historianApi: boolean = true,
-        private readonly gitCache: IGitCache | null = null,
+        private readonly gitCache: IGitCache | undefined = undefined,
         private readonly credentials?: ICredentials,
     ) {
     }

--- a/packages/tools/webpack-fluid-loader/src/multiDocumentServiceFactory.ts
+++ b/packages/tools/webpack-fluid-loader/src/multiDocumentServiceFactory.ts
@@ -7,7 +7,7 @@ import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidf
 import { MultiDocumentServiceFactory } from "@fluidframework/driver-utils";
 import { LocalDocumentServiceFactory, LocalSessionStorageDbFactory } from "@fluidframework/local-driver";
 import { OdspDocumentServiceFactory } from "@fluidframework/odsp-driver";
-import { RouterliciousDocumentServiceFactory, DefaultErrorTracking } from "@fluidframework/routerlicious-driver";
+import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 import { RouteOptions } from "./loader";
 
 const deltaConns = new Map<string, ILocalDeltaConnectionServer>();
@@ -24,12 +24,6 @@ export function getDocumentServiceFactory(documentId: string, options: RouteOpti
             async () => options.mode === "spo" || options.mode === "spo-df" ? options.odspAccessToken : undefined,
             async () => options.mode === "spo" || options.mode === "spo-df" ? options.pushAccessToken : undefined,
         ),
-        new RouterliciousDocumentServiceFactory(
-            false,
-            new DefaultErrorTracking(),
-            false,
-            true,
-            undefined,
-        ),
+        new RouterliciousDocumentServiceFactory(),
     ]);
 }

--- a/server/admin/src/childLoader.ts
+++ b/server/admin/src/childLoader.ts
@@ -13,7 +13,7 @@ import {
     IResolvedUrl,
 } from "@fluidframework/driver-definitions";
 import { ScopeType } from "@fluidframework/protocol-definitions";
-import { DefaultErrorTracking, RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
+import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 import { ContainerUrlResolver } from "@fluidframework/routerlicious-host";
 import { NodeCodeLoader, NodeAllowList } from "@fluidframework/server-services";
 import { promiseTimeout } from "@fluidframework/server-services-client";

--- a/server/admin/src/childLoader.ts
+++ b/server/admin/src/childLoader.ts
@@ -75,12 +75,7 @@ class KeyValueLoader {
             });
 
         const documentServiceFactories: IDocumentServiceFactory[] = [];
-        documentServiceFactories.push(new RouterliciousDocumentServiceFactory(
-            false,
-            new DefaultErrorTracking(),
-            false,
-            true,
-            undefined));
+        documentServiceFactories.push(new RouterliciousDocumentServiceFactory());
 
         const resolver = new ContainerUrlResolver(
             config.gatewayUrl,

--- a/server/gateway/src/childLoader.ts
+++ b/server/gateway/src/childLoader.ts
@@ -14,7 +14,7 @@ import {
 } from "@fluidframework/driver-definitions";
 import { OdspDocumentServiceFactory } from "@fluidframework/odsp-driver";
 import { ScopeType } from "@fluidframework/protocol-definitions";
-import { DefaultErrorTracking, RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
+import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 import { ContainerUrlResolver } from "@fluidframework/routerlicious-host";
 import { NodeCodeLoader, NodeAllowList } from "@fluidframework/server-services";
 import { promiseTimeout } from "@fluidframework/server-services-client";
@@ -80,12 +80,7 @@ class KeyValueLoader {
             async (siteUrl: string) => Promise.resolve("fake token"),
             async () => Promise.resolve("fake token")));
 
-        documentServiceFactories.push(new RouterliciousDocumentServiceFactory(
-            false,
-            new DefaultErrorTracking(),
-            false,
-            true,
-            undefined));
+        documentServiceFactories.push(new RouterliciousDocumentServiceFactory());
 
         const resolver = new ContainerUrlResolver(
             config.gatewayUrl,

--- a/server/gateway/src/controllers/workerLoader.ts
+++ b/server/gateway/src/controllers/workerLoader.ts
@@ -20,7 +20,7 @@ import {
 } from "@fluidframework/driver-definitions";
 import { OdspDocumentServiceFactory } from "@fluidframework/odsp-driver";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
-import { DefaultErrorTracking, RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
+import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 import { WebCodeLoader, SemVerCdnCodeResolver } from "@fluidframework/web-code-loader";
 import Comlink from "comlink";
 
@@ -58,13 +58,7 @@ class WorkerLoader implements ILoader, IFluidRunnable {
         const urlObj = parse(this.resolved.url);
         let factory: IDocumentServiceFactory;
         if (urlObj.protocol === "fluid:") {
-            factory = new RouterliciousDocumentServiceFactory(
-                false,
-                new DefaultErrorTracking(),
-                false,
-                true,
-                // eslint-disable-next-line no-null/no-null
-                null);
+            factory = new RouterliciousDocumentServiceFactory();
         } else {
             factory = new OdspDocumentServiceFactory(
                 async (siteUrl: string) => Promise.resolve(this.resolved.tokens.storageToken),

--- a/server/headless-agent/client-src/fluid-loader/index.ts
+++ b/server/headless-agent/client-src/fluid-loader/index.ts
@@ -6,7 +6,7 @@
 import { BaseHost, IBaseHostConfig } from "@fluidframework/base-host";
 import { Container } from "@fluidframework/container-loader";
 import { IFluidResolvedUrl, IResolvedUrl } from "@fluidframework/driver-definitions";
-import { DefaultErrorTracking, RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
+import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 import { SemVerCdnCodeResolver } from "@fluidframework/web-code-loader";
 import { HTMLViewAdapter } from "@fluidframework/view-adapters";
 
@@ -16,11 +16,7 @@ interface IWindow extends Window {
 }
 
 export async function startLoading(resolvedUrl: IResolvedUrl) {
-    const serviceFactory = new RouterliciousDocumentServiceFactory(
-        false,
-        new DefaultErrorTracking(),
-        false,
-        true);
+    const serviceFactory = new RouterliciousDocumentServiceFactory();
     const baseHostConfig: IBaseHostConfig = {
         documentServiceFactory: serviceFactory,
         urlResolver: {


### PR DESCRIPTION
In some places we're passing in `null`, in others `undefined`, but both end up having the same effect.  Converting to using `undefined` in all cases for consistency.