### PR TITLE
When machine loses connection, we close container with critical error on any fetch request.

### DIFF
--- a/packages/drivers/odsp-driver/src/odspError.ts
+++ b/packages/drivers/odsp-driver/src/odspError.ts
@@ -103,7 +103,7 @@ export function createOdspNetworkError(
             error = new NetworkErrorBasic(errorMessage, DriverErrorType.offlineError, true);
             break;
         case fetchFailureStatusCode:
-            error = new NetworkErrorBasic(errorMessage, DriverErrorType.fetchFailure, false);
+            error = new NetworkErrorBasic(errorMessage, DriverErrorType.fetchFailure, true);
             break;
         case fetchIncorrectResponse:
             error = new NetworkErrorBasic(errorMessage, DriverErrorType.incorrectServerResponse, false);

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -4,7 +4,7 @@
  */
 
 import {
-    OnlineStatus,
+    OnlineStatus, isOnline,
 } from "@fluidframework/driver-utils";
 import {
     DriverErrorType,
@@ -107,8 +107,8 @@ export async function fetchHelper<T>(
         // While we do not know for sure whether computer is offline, this error is not actionable and
         // is pretty good indicator we are offline. Treating it as offline scenario will make it
         // easier to see other errors in telemetry.
-        let online = OnlineStatus.Unknown;
-        if (error && typeof error === "object" && error.message === "TypeError: Failed to fetch") {
+        let online = isOnline();
+        if (`${error}` === "TypeError: Failed to fetch") {
             online = OnlineStatus.Offline;
         }
         throwOdspNetworkError(


### PR DESCRIPTION
This is due to two facts:
1) Detection of specific error message that fetch() throws was wrong.
2) in general any fetch error (i.e. no response) should be considered retryable.
