### PR TITLE
Catch errors while raising "readonly" events

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -16,7 +16,7 @@ import {
     ContainerErrorType,
 } from "@fluidframework/container-definitions";
 import { performanceNow, TypedEventEmitter } from "@fluidframework/common-utils";
-import { PerformanceEvent, TelemetryLogger } from "@fluidframework/telemetry-utils";
+import { PerformanceEvent, TelemetryLogger, safeRaiseEvent } from "@fluidframework/telemetry-utils";
 import {
     IDocumentDeltaStorageService,
     IDocumentService,
@@ -320,7 +320,7 @@ export class DeltaManager
         const oldValue = this.readonly;
         this._forceReadonly = readonly;
         if (oldValue !== this.readonly) {
-            this.emit("readonly", this.readonly);
+            safeRaiseEvent(this, this.logger, "readonly", this.readonly);
         }
     }
 
@@ -328,7 +328,7 @@ export class DeltaManager
         const oldValue = this.readonly;
         this._readonlyPermissions = readonly;
         if (oldValue !== this.readonly) {
-            this.emit("readonly", this.readonly);
+            safeRaiseEvent(this, this.logger, "readonly", this.readonly);
         }
     }
 

--- a/packages/utils/telemetry-utils/src/events.ts
+++ b/packages/utils/telemetry-utils/src/events.ts
@@ -8,6 +8,18 @@ import {
     ITelemetryLogger,
 } from "@fluidframework/common-definitions";
 
+export function safeRaiseEvent(
+    emitter: EventEmitter,
+    logger: ITelemetryLogger,
+    event: string,
+    ...args) {
+    try {
+        emitter.emit(event, ...args);
+    } catch (error) {
+        logger.sendErrorEvent({ eventName: "RaiseEventError", event }, error);
+    }
+}
+
 export function raiseConnectedEvent(
     logger: ITelemetryLogger,
     emitter: EventEmitter,


### PR DESCRIPTION
We probably need more systematic solution here.
We can bake it into TypedEventEmitter for all errors, but that feels wrong - in some cases we do want to propagate exception , or do something else on exception, in others we prefer fire-and-forget approach.
Open to suggestions.

This fix is only addresses this event only.
See issue #3119 for details
