### PR TITLE
Add createTenant to TenantManager service

### DIFF
--- a/server/routerlicious/packages/services-core/src/tenant.ts
+++ b/server/routerlicious/packages/services-core/src/tenant.ts
@@ -57,6 +57,11 @@ export interface ITenant {
 
 export interface ITenantManager {
     /**
+     * Creates a new tenant with the given id, or a randomly generated id when none is provided.
+     */
+    createTenant(tenantId?: string): Promise<ITenantConfig & { key: string }>;
+
+    /**
      * Retrieves details for the given tenant
      */
     getTenant(tenantId: string): Promise<ITenant>;

--- a/server/routerlicious/packages/services/src/tenant.ts
+++ b/server/routerlicious/packages/services/src/tenant.ts
@@ -37,7 +37,7 @@ export class TenantManager implements core.ITenantManager {
 
     public async createTenant(tenantId?: string): Promise<core.ITenantConfig & { key: string }> {
         const result = await Axios.post<core.ITenantConfig & { key: string }>(
-            `${this.endpoint}/api/tenants/${tenantId || ""}`);
+            `${this.endpoint}/api/tenants/${encodeURIComponent(tenantId || "")}`);
         return result.data;
     }
 

--- a/server/routerlicious/packages/services/src/tenant.ts
+++ b/server/routerlicious/packages/services/src/tenant.ts
@@ -35,6 +35,12 @@ export class TenantManager implements core.ITenantManager {
     constructor(private readonly endpoint: string) {
     }
 
+    public async createTenant(tenantId?: string): Promise<core.ITenantConfig & { key: string }> {
+        const result = await Axios.post<core.ITenantConfig & { key: string }>(
+            `${this.endpoint}/api/tenants/${tenantId || ""}`);
+        return result.data;
+    }
+
     public async getTenant(tenantId: string): Promise<core.ITenant> {
         const [details, key] = await Promise.all([
             Axios.get<core.ITenantConfig>(`${this.endpoint}/api/tenants/${tenantId}`),

--- a/server/routerlicious/packages/test-utils/src/testTenantManager.ts
+++ b/server/routerlicious/packages/test-utils/src/testTenantManager.ts
@@ -4,7 +4,14 @@
  */
 
 import { GitManager } from "@fluidframework/server-services-client";
-import { ITenant, ITenantManager, ITenantOrderer, ITenantStorage, IDb } from "@fluidframework/server-services-core";
+import {
+    ITenant,
+    ITenantManager,
+    ITenantOrderer,
+    ITenantStorage,
+    IDb,
+    ITenantConfig,
+} from "@fluidframework/server-services-core";
 import { TestHistorian } from "./testHistorian";
 import { TestDb } from "./testCollection";
 
@@ -46,6 +53,16 @@ export class TestTenantManager implements ITenantManager {
 
     constructor(url = "http://test", historian = "http://historian", testDb: IDb = new TestDb({})) {
         this.tenant = new TestTenant(url, historian, testDb);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/promise-function-async
+    public createTenant(id?: string): Promise<ITenantConfig & { key: string }> {
+        return Promise.resolve({
+            id: "test-tenant",
+            storage: this.tenant.storage,
+            orderer: this.tenant.orderer,
+            key: "test-tenant-key",
+        });
     }
 
     // eslint-disable-next-line @typescript-eslint/promise-function-async


### PR DESCRIPTION
This code extends the functionality of `ITenantManager` and `TenantManager` within `services-core` and `services` respectively. Similar to the other methods within `services.TenantManager`, this method makes an HTTP Post request to the provided endpoint (typically `auth:endpoint` from `nconf`, which is typically `http://riddler:5000`).

Riddler's `createTenant` endpoint defines `tenantId` as optional, so it is optional here, as well.