### PR TITLE
Separate the publishing of npmjs to a different stage

### DIFF
--- a/tools/build-tools/src/repoPolicyCheck/handlers/fluidCase.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/fluidCase.ts
@@ -16,11 +16,11 @@ export const handler: Handler = {
         const content = readFile(file);
         // search for Fluid Framework
         if (content.search(/[Ff]luid framework/) !== -1) {
-            return `'framework' need to be capitalized`;
+            return `'framework' need to be capitalized in prose`;
         }
         // search for the work 'fluid' surround by other words
         if (content.search(/[a-z] fluid [a-z]/) !== -1) {
-            return `'fluid' needs to be capitalized`;
+            return `'fluid' needs to be capitalized in prose`;
         }
     },
     resolver: file => {

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -19,7 +19,7 @@ jobs:
     - deployment: publish_${{ replace(feed.environment, '-', '_') }}
       displayName: Publish ${{ feed.environment }}
       pool: ${{ parameters.pool }}
-      environment: test # ${{ feed.environment }}
+      environment: ${{ feed.environment }}
       workspace:
         clean: all
       strategy:
@@ -83,13 +83,13 @@ jobs:
                       echo Tag: $tag
                       cp .npmrc ~/.npmrc
                       t1=0
-                      # for f in *.tgz
-                      # do 
-                      #     if ! npm publish $f $tag ${{ feed.publishFlags }}
-                      #     then
-                      #         let t1+=1
-                      #     fi
-                      # done
+                      for f in *.tgz
+                      do 
+                          if ! npm publish $f $tag ${{ feed.publishFlags }}
+                          then
+                              let t1+=1
+                          fi
+                      done
                       rm ~/.npmrc
                       exit $t1
 

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -19,7 +19,7 @@ jobs:
     - deployment: publish_${{ replace(feed.environment, '-', '_') }}
       displayName: Publish ${{ feed.environment }}
       pool: ${{ parameters.pool }}
-      environment: ${{ feed.environment }}
+      environment: test # ${{ feed.environment }}
       workspace:
         clean: all
       strategy:
@@ -83,13 +83,13 @@ jobs:
                       echo Tag: $tag
                       cp .npmrc ~/.npmrc
                       t1=0
-                      for f in *.tgz
-                      do 
-                          if ! npm publish $f $tag ${{ feed.publishFlags }}
-                          then
-                              let t1+=1
-                          fi
-                      done
+                      # for f in *.tgz
+                      # do 
+                      #     if ! npm publish $f $tag ${{ feed.publishFlags }}
+                      #     then
+                      #         let t1+=1
+                      #     fi
+                      # done
                       rm ~/.npmrc
                       exit $t1
 

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -17,12 +17,9 @@ parameters:
 jobs:
   - ${{ each feed in parameters.feeds }}:
     - deployment: publish_${{ replace(feed.environment, '-', '_') }}
-      variables:
-        enabled: ${{ feed.enabled }} 
       displayName: Publish ${{ feed.environment }}
       pool: ${{ parameters.pool }}
       environment: ${{ feed.environment }}
-      condition: and(succeeded(), or(eq(variables['enabled'], 'release'), eq(variables['enabled'], 'prerelease')))
       workspace:
         clean: all
       strategy:

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -78,4 +78,4 @@ stages:
 
                 echo Tag=$tag
                 git tag $tag
-                git push origin $tag
+                # git push origin $tag

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -17,9 +17,9 @@ parameters:
   type: string
 
 stages:
-- stage: publish
+- stage: publish_internal
   dependsOn: build
-  displayName: Publish Stage
+  displayName: Internal Publish Stage
   jobs:
   - template: include-publish-npm-package-steps.yml
     parameters:
@@ -28,24 +28,32 @@ stages:
       - name: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/ 
         environment: build-feed
         official: false
-        enabled: 'release'
         tagSteps: []
+
+- stage: publish_official
+  dependsOn: build
+  displayName: Official Publish Stage
+  condition: and(succeeded(), or(eq(variables['enabled'], 'release'), eq(variables['enabled'], 'prerelease')))
+  jobs:
+  - template: include-publish-npm-package-steps.yml
+    parameters:
+      namespace: ${{ parameters.namespace }}
+      feeds:
       - name: https://registry.npmjs.org
         environment: npmjs-feed
         customEndPoint: npmjs
         official: true
         publishFlags: --access public
-        enabled: $[variables.release]
         tagSteps:
         - ${{ if ne(parameters.tagName, '') }}:
           - checkout: self
             clean: true
             persistCredentials: true
-            condition: and(succeeded(), eq(variables['enabled'], 'release'))
+            condition: and(succeeded(), eq(variables['release'], 'release'))
 
           - task: Bash@3
             displayName: Tag Release
-            condition: and(succeeded(), eq(variables['enabled'], 'release'))
+            condition: and(succeeded(), eq(variables['release'], 'release'))
             env:
               VERSION_RELEASE: $(release)
               VERSION_BUILDNUMBER: $(Build.BuildNumber)

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -33,7 +33,7 @@ stages:
 - stage: publish_official
   dependsOn: build
   displayName: Official Publish Stage
-  condition: and(succeeded(), or(eq(variables['enabled'], 'release'), eq(variables['enabled'], 'prerelease')))
+  condition: and(succeeded(), or(eq(variables['release'], 'release'), eq(variables['release'], 'prerelease')))
   jobs:
   - template: include-publish-npm-package-steps.yml
     parameters:

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -78,4 +78,4 @@ stages:
 
                 echo Tag=$tag
                 git tag $tag
-                # git push origin $tag
+                git push origin $tag

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -40,7 +40,7 @@ variables:
   - ${{ if eq(variables.shouldPublish, true) }}:
     - name: release
       value: $[variables.releaseBuild]
-  - ${{ if not(variables.shouldPublish) }}:
+  - ${{ if ne(variables.shouldPublish, true) }}:
     - name: release
       value: none
 - ${{ if ne(parameters.releaseBuildOverride, 'none') }}:


### PR DESCRIPTION
So it can be easier to identify which build is published to NPM or not.