### PR TITLE
Move event typing to dependencies

### DIFF
--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -67,6 +67,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1-0",
+    "@types/events": "^3.0.0",
     "assert": "^2.0.0",
     "base64-js": "^1.3.1",
     "events": "^3.1.0",
@@ -80,7 +81,6 @@
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/benchmark": "^1.0.31",
-    "@types/events": "^3.0.0",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
     "@types/mocha": "^5.2.5",


### PR DESCRIPTION
EventEmitter is used in an exported type, so it is a required dependencies instead of dev dependencies.