### PR TITLE
Make optionalProviders optional

### DIFF
--- a/examples/hosts/app-integration/external-views/src/dataObject.ts
+++ b/examples/hosts/app-integration/external-views/src/dataObject.ts
@@ -71,6 +71,4 @@ export class DiceRoller extends DataObject implements IDiceRoller {
 export const DiceRollerInstantiationFactory = new DataObjectFactory(
     "dice-roller",
     DiceRoller,
-    [],
-    {},
 );

--- a/packages/framework/aqueduct/src/data-object-factories/dataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/dataObjectFactory.ts
@@ -33,7 +33,8 @@ export class DataObjectFactory<TObj extends DataObject<P, S>, P, S> extends Pure
         type: string,
         ctor: new (props: IDataObjectProps<P>) => TObj,
         sharedObjects: readonly IChannelFactory[] = [],
-        optionalProviders: FluidObjectSymbolProvider<P>,
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        optionalProviders: FluidObjectSymbolProvider<P> = {} as FluidObjectSymbolProvider<P>,
         registryEntries?: NamedFluidDataStoreRegistryEntries,
         onDemandInstantiation = true,
     ) {


### PR DESCRIPTION
There might be a nicer way to do this, but since most of our samples just pass an empty object anyway it would be nice to simplify the calling (which will also simplify the explanation in the tutorial).