### PR TITLE
Deprecate R11s from Webpack Fluid Loader

### DIFF
--- a/packages/tools/webpack-fluid-loader/README.md
+++ b/packages/tools/webpack-fluid-loader/README.md
@@ -19,7 +19,6 @@ The following environment variables can be defined when running webpack-dev-serv
 | modes | description |
 | ---------| ----------- |
 | `docker` | Use docker running routerlicious server for ordering, etc. You'll need to start this service locally |
-| `r11s`   | Use remote routerlicious server for ordering, etc. |
 | `local`  | Load Fluid object in two side-by-side divs using test-driver (default option) |
 | `tinylicious` | Run against a local instance of tinylicious. You'll need to start this service locally |
 | `spo-df` | Use SharePoint DogFood server with your personal OneDrive for storage |

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -48,14 +48,6 @@ export interface IDockerRouteOptions extends IBaseRouteOptions {
     bearerSecret?: string;
 }
 
-export interface IRouterliciousRouteOptions extends IBaseRouteOptions {
-    mode: "r11s";
-    fluidHost?: string;
-    tenantId?: string;
-    tenantSecret?: string;
-    bearerSecret?: string;
-}
-
 export interface ITinyliciousRouteOptions extends IBaseRouteOptions {
     mode: "tinylicious";
     bearerSecret?: string;

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -48,6 +48,11 @@ export interface IDockerRouteOptions extends IBaseRouteOptions {
     bearerSecret?: string;
 }
 
+/** @deprecated */
+export interface IRouterliciousRouteOptions extends IBaseRouteOptions {
+    mode: "r11s";
+}
+
 export interface ITinyliciousRouteOptions extends IBaseRouteOptions {
     mode: "tinylicious";
     bearerSecret?: string;

--- a/packages/tools/webpack-fluid-loader/src/multiResolver.ts
+++ b/packages/tools/webpack-fluid-loader/src/multiResolver.ts
@@ -37,15 +37,6 @@ function getUrlResolver(options: RouteOptions): IUrlResolver {
                 getUser(),
                 options.bearerSecret);
 
-        case "r11s":
-            return new InsecureUrlResolver(
-                options.fluidHost,
-                options.fluidHost.replace("www", "alfred"),
-                options.fluidHost.replace("www", "historian"),
-                options.tenantId,
-                options.tenantSecret,
-                getUser(),
-                options.bearerSecret);
         case "tinylicious":
             return new InsecureUrlResolver(
                 tinyliciousUrls.hostUrl,
@@ -97,7 +88,6 @@ export class MultiUrlResolver implements IUrlResolver {
         fileName: string,
     ): Promise<IRequest> {
         switch (this.options.mode) {
-            case "r11s":
             case "docker":
             case "tinylicious":
                 return (this.urlResolver as InsecureUrlResolver).createCreateNewRequest(fileName);

--- a/packages/tools/webpack-fluid-loader/src/routes.ts
+++ b/packages/tools/webpack-fluid-loader/src/routes.ts
@@ -58,7 +58,7 @@ export const after = (app: express.Application, server: WebpackDevServer, baseDi
             break;
         }
         case "r11s": {
-            return new Error(`
+            throw new Error(`
             Deprecated. Please use another server.
             `);
         }

--- a/packages/tools/webpack-fluid-loader/src/routes.ts
+++ b/packages/tools/webpack-fluid-loader/src/routes.ts
@@ -69,15 +69,12 @@ export const after = (app: express.Application, server: WebpackDevServer, baseDi
 
     if (options.mode === "docker" || options.mode === "tinylicious") {
         options.bearerSecret = options.bearerSecret || config.get("fluid:webpack:bearerSecret");
-        if (options.mode !== "tinylicious") {
+        if (options.mode === "docker") {
             options.tenantId = options.tenantId || config.get("fluid:webpack:tenantId") || "fluid";
-            if (options.mode === "docker") {
-                options.tenantSecret = options.tenantSecret
-                    || config.get("fluid:webpack:docker:tenantSecret")
-                    || "create-new-tenants-if-going-to-production";
-            } else {
-                options.tenantSecret = options.tenantSecret || config.get("fluid:webpack:tenantSecret");
-            }
+
+            options.tenantSecret = options.tenantSecret
+                || config.get("fluid:webpack:docker:tenantSecret")
+                || "create-new-tenants-if-going-to-production";
         }
     }
 

--- a/packages/tools/webpack-fluid-loader/src/routes.ts
+++ b/packages/tools/webpack-fluid-loader/src/routes.ts
@@ -57,12 +57,17 @@ export const after = (app: express.Application, server: WebpackDevServer, baseDi
             });
             break;
         }
+        case "r11s": {
+            return new Error(`
+            Deprecated. Please use another server.
+            `);
+        }
         default: {
             break;
         }
     }
 
-    if (options.mode === "docker" || options.mode === "r11s" || options.mode === "tinylicious") {
+    if (options.mode === "docker" || options.mode === "tinylicious") {
         options.bearerSecret = options.bearerSecret || config.get("fluid:webpack:bearerSecret");
         if (options.mode !== "tinylicious") {
             options.tenantId = options.tenantId || config.get("fluid:webpack:tenantId") || "fluid";
@@ -73,19 +78,12 @@ export const after = (app: express.Application, server: WebpackDevServer, baseDi
             } else {
                 options.tenantSecret = options.tenantSecret || config.get("fluid:webpack:tenantSecret");
             }
-            if (options.mode === "r11s") {
-                options.fluidHost = options.fluidHost || config.get("fluid:webpack:fluidHost");
-            }
         }
     }
 
     options.npm = options.npm || config.get("fluid:webpack:npm");
 
     console.log(options);
-
-    if (options.mode === "r11s" && !(options.tenantId && options.tenantSecret)) {
-        throw new Error("You must provide a tenantId and tenantSecret to connect to a live routerlicious server");
-    }
 
     let readyP: ((req: express.Request, res: express.Response) => Promise<boolean>) | undefined;
     if (options.mode === "spo-df" || options.mode === "spo") {


### PR DESCRIPTION
No need to have R11s in the webpack fluid loader if we're not supporting it's uptime actively