### PR TITLE
Fix for TestCollection returning the same collection for every document

### DIFF
--- a/packages/drivers/local-driver/src/localSessionStorageDb.ts
+++ b/packages/drivers/local-driver/src/localSessionStorageDb.ts
@@ -29,6 +29,9 @@ class LocalSessionStorageCollection<T> implements ICollection<T> {
         const queryKeys = Object.keys(query);
         let filteredCollection = this.getAllInternal();
         queryKeys.forEach((key) => {
+            if (!query[key]) {
+                return;
+            }
             if (query[key].$gt > 0 || query[key].$lt > 0) {
                 if (query[key].$gt > 0) {
                     filteredCollection = filteredCollection.filter(

--- a/server/routerlicious/packages/test-utils/src/testCollection.ts
+++ b/server/routerlicious/packages/test-utils/src/testCollection.ts
@@ -83,13 +83,14 @@ export class TestCollection implements ICollection<any> {
     }
 
     private findOneInternal(query: any): any {
+        let returnValue: any;
         if (query._id) {
-            const returnValue = this.collection.find((value) => value._id === query._id);
-            return returnValue === undefined ? null : returnValue;
+            returnValue = this.collection.find((value) => value._id === query._id);
         } else {
             const found = this.findInternal(query);
-            return found[0];
+            returnValue = found[0];
         }
+        return returnValue === undefined ? null : returnValue;
     }
 
     private findInternal(query: any, sort?: any): any[] {
@@ -105,6 +106,9 @@ export class TestCollection implements ICollection<any> {
         const queryKeys = Object.keys(query);
         let filteredCollection = this.collection;
         queryKeys.forEach((key) => {
+            if (!query[key]) {
+                return;
+            }
             if (query[key].$gt > 0 || query[key].$lt > 0) {
                 if (query[key].$gt > 0) {
                     filteredCollection = filteredCollection.filter(

--- a/server/routerlicious/packages/test-utils/src/testCollection.ts
+++ b/server/routerlicious/packages/test-utils/src/testCollection.ts
@@ -12,49 +12,7 @@ export class TestCollection implements ICollection<any> {
     }
 
     public async find(query: any, sort: any): Promise<any[]> {
-        function getValueByKey(propertyBag, key: string) {
-            const keys = key.split(".");
-            let value = propertyBag;
-            keys.forEach((splitKey) => {
-                value = value[splitKey];
-            });
-            return value;
-        }
-
-        const queryKeys = Object.keys(query);
-        let filteredCollection = this.collection;
-        queryKeys.forEach((key) => {
-            if (query[key].$gt > 0 || query[key].$lt > 0) {
-                if (query[key].$gt > 0) {
-                    filteredCollection = filteredCollection.filter(
-                        (value) => getValueByKey(value, key) > query[key].$gt);
-                }
-                if (query[key].$lt > 0) {
-                    filteredCollection = filteredCollection.filter(
-                        (value) => getValueByKey(value, key) < query[key].$lt);
-                }
-            } else {
-                filteredCollection = filteredCollection.filter(
-                    (value) => getValueByKey(value, key) === query[key]);
-            }
-        });
-
-        if (sort && Object.keys(sort).length === 1) {
-            // eslint-disable-next-line no-inner-declarations
-            function compare(a, b) {
-                const sortKey = Object.keys(sort)[0];
-                if (sort[sortKey] === 1) {
-                    // A goes before b, sorting in ascending order
-                    return getValueByKey(a, sortKey) - getValueByKey(b, sortKey);
-                } else {
-                    // B goes before a, sorting in descending order
-                    return getValueByKey(b, sortKey) - getValueByKey(a, sortKey);
-                }
-            }
-
-            filteredCollection = filteredCollection.sort(compare);
-        }
-        return filteredCollection;
+        return this.findInternal(query, sort);
     }
 
     public async findAll(): Promise<any[]> {
@@ -125,8 +83,59 @@ export class TestCollection implements ICollection<any> {
     }
 
     private findOneInternal(query: any): any {
-        const returnValue = this.collection.find((value) => value._id === query._id);
-        return returnValue === undefined ? null : returnValue;
+        if (query._id) {
+            const returnValue = this.collection.find((value) => value._id === query._id);
+            return returnValue === undefined ? null : returnValue;
+        } else {
+            const found = this.findInternal(query);
+            return found[0];
+        }
+    }
+
+    private findInternal(query: any, sort?: any): any[] {
+        function getValueByKey(propertyBag, key: string) {
+            const keys = key.split(".");
+            let value = propertyBag;
+            keys.forEach((splitKey) => {
+                value = value[splitKey];
+            });
+            return value;
+        }
+
+        const queryKeys = Object.keys(query);
+        let filteredCollection = this.collection;
+        queryKeys.forEach((key) => {
+            if (query[key].$gt > 0 || query[key].$lt > 0) {
+                if (query[key].$gt > 0) {
+                    filteredCollection = filteredCollection.filter(
+                        (value) => getValueByKey(value, key) > query[key].$gt);
+                }
+                if (query[key].$lt > 0) {
+                    filteredCollection = filteredCollection.filter(
+                        (value) => getValueByKey(value, key) < query[key].$lt);
+                }
+            } else {
+                filteredCollection = filteredCollection.filter(
+                    (value) => getValueByKey(value, key) === query[key]);
+            }
+        });
+
+        if (sort && Object.keys(sort).length === 1) {
+            // eslint-disable-next-line no-inner-declarations
+            function compare(a, b) {
+                const sortKey = Object.keys(sort)[0];
+                if (sort[sortKey] === 1) {
+                    // A goes before b, sorting in ascending order
+                    return getValueByKey(a, sortKey) - getValueByKey(b, sortKey);
+                } else {
+                    // B goes before a, sorting in descending order
+                    return getValueByKey(b, sortKey) - getValueByKey(a, sortKey);
+                }
+            }
+
+            filteredCollection = filteredCollection.sort(compare);
+        }
+        return filteredCollection;
     }
 }
 

--- a/server/tinylicious/src/services/inMemorycollection.ts
+++ b/server/tinylicious/src/services/inMemorycollection.ts
@@ -84,13 +84,14 @@ export class Collection<T> implements ICollection<T> {
     }
 
     private findOneInternal(query: any): any {
+        let returnValue: any;
         if (query._id) {
-            const returnValue = this.collection.find((value) => (value as any)._id === query._id);
-            return returnValue === undefined ? null : returnValue;
+            returnValue = this.collection.find((value) => (value as any)._id === query._id);
         } else {
             const found = this.findInternal(query);
-            return found[0];
+            returnValue = found[0];
         }
+        return returnValue === undefined ? null : returnValue;
     }
 
     private findInternal(query: any, sort?: any): T[] {
@@ -106,6 +107,9 @@ export class Collection<T> implements ICollection<T> {
         const queryKeys = Object.keys(query);
         let filteredCollection = this.collection;
         queryKeys.forEach((key) => {
+            if (!query[key]) {
+                return;
+            }
             if (query[key].$gt > 0 || query[key].$lt > 0) {
                 if (query[key].$gt > 0) {
                     filteredCollection = filteredCollection.filter(


### PR DESCRIPTION
Fixes #3465.

TestCollection's "findOneInternal" function always tries to find a collection based on the passed query's '_id'. However, in case of the document storage, the query (and the collection value) does not have '_id' but has a documentId and a tenantId.
So, it always ends up returning the same value for every query since '_id" is undefined.

With the fix here, it creates a separate storage for each tenantId/documentId combination.

There are couple of other fixes:
- Callers expect the return value of the "find" APIs in collection should be "null" and not "undefined" when a collection is not found. Example - "getOrCreateObject" in DocumentStorage expects the "findOne" call to return "null".
- The keys in the "query" passed to "findOneInternal" can have undefined value. In "findInternal", we should check that before dereferencing it.