### PR TITLE
Add reference to cache-scripts.js

### DIFF
--- a/docs/themes/thxvscode/layouts/partials/footer.html
+++ b/docs/themes/thxvscode/layouts/partials/footer.html
@@ -47,3 +47,5 @@
         </div>
     </div>
 </footer>
+
+<script src="/playground/cache-scripts.js"></script>


### PR DESCRIPTION
Adds a script reference to the **cache-scripts.js** script in the playground. 

**Do not merge until** https://github.com/microsoft/FluidStorybook/pull/40 has been merged and the build script in it has successfully been run. A quick way to test if the script generated from the build is there is to hit https://agreeable-hill-0eeff5b10.azurestaticapps.net/playground/cache-scripts.js. If a script loads in the browser then we should be good to go.