### PR TITLE
Connect in write mode for detached container flow

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -584,7 +584,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             const connected = this.connectionState === ConnectionState.Connected;
             assert(!connected || this._deltaManager.connectionMode === "read", "Unexpected connection state");
             this.propagateConnectionState();
-            this.resumeInternal({ fetchOpsFromStorage: false, reason: "createDetached" });
+            this.resumeInternal({ fetchOpsFromStorage: false, reason: "createDetached", mode: "write" });
         } finally {
             this.attachInProgress = false;
         }


### PR DESCRIPTION
Since the client starts in read mode for the detached flow, they always get nack'd on their first op and have to run through the disconnect/reconnect flow.  It seems probably correct to connect in write mode, same as what we do for loading an existing document.