### PR TITLE
Remove reference to Msft-internal security groups

### DIFF
--- a/tools/getkeys/README.md
+++ b/tools/getkeys/README.md
@@ -1,7 +1,7 @@
 # @fluid-internal/getkeys
 
-This tool is specifically for Microsoft internal development.
+_This tool is specifically for Microsoft internal development._
 
-This folder contains a script that will get secret values from the prague keyvault and store them as environment variables. In order to have access to the prague keyvault you must be a member of the prague-secrets or WAC Bohemia security group.
+This folder contains a script that will get secret values from the prague keyvault and store them as environment variables. In order to have access to the prague keyvault you must be a member of the proper security group(s).
 
 To run the script, run `npm i`, then `npm start`. The script will then prompt you to use a code to login to your Microsoft account. If you are using bash or zsh, you may have to restart the shell or run `source ~/.bashrc` or `source ~/.zshrc` after running the script.


### PR DESCRIPTION
I'll make sure the right info is in the team OneNote notebook