### PR TITLE
add playground links to our examples

### DIFF
--- a/docs/content/docs/get-started/examples.md
+++ b/docs/content/docs/get-started/examples.md
@@ -14,6 +14,8 @@ The [Fluid Draft.js](https://github.com/microsoft/FluidExamples/tree/main/draft-
 Fluid Framework to take an existing project and make it collaborative. This example also demonstrates
 how to build an app that supports real-time updates in a rich text editor.
 
+Try out Draft.js in our [Playground](/playground/?path=/docs/react-demos-draft-js--demo).
+
 ## Brainstorming
 
 ![A screenshot of brainstorming app](/images/brainstorm-example.png)
@@ -23,6 +25,8 @@ shows how simple experiences become compelling when you make them collaborative.
 maps (Shared Maps) to update the state of sticky notes as well as keep track of who added which ideas and who
 voted for those ideas.
 
+Try out Brainstorm in our [Playground](/playground/?path=/docs/react-demos-brainstorm--demo).
+
 ## Sudoku
 
 <img src="/images/sudoku-example.png" alt="A screenshot of Sudoku" style="max-height: 400px; margin-left: auto;
@@ -30,3 +34,5 @@ margin-right: auto;">
 
 The [Sudoku](https://github.com/microsoft/FluidExamples/tree/main/sudoku) example demonstrates how to build
 a collaborative game. This example includes key features like presence.
+
+Try out Sudoku in our [Playground](/playground/?path=/docs/react-demos-sudoku--demo).

--- a/docs/content/docs/get-started/examples.md
+++ b/docs/content/docs/get-started/examples.md
@@ -25,7 +25,7 @@ shows how simple experiences become compelling when you make them collaborative.
 maps (Shared Maps) to update the state of sticky notes as well as keep track of who added which ideas and who
 voted for those ideas.
 
-Try out Brainstorm in our [Playground](/playground/?path=/docs/react-demos-brainstorm--demo).
+Try out Brainstorm in the [Playground](/playground/?path=/docs/react-demos-brainstorm--demo).
 
 ## Sudoku
 

--- a/docs/content/docs/get-started/examples.md
+++ b/docs/content/docs/get-started/examples.md
@@ -14,7 +14,7 @@ The [Fluid Draft.js](https://github.com/microsoft/FluidExamples/tree/main/draft-
 Fluid Framework to take an existing project and make it collaborative. This example also demonstrates
 how to build an app that supports real-time updates in a rich text editor.
 
-Try out Draft.js in our [Playground](/playground/?path=/docs/react-demos-draft-js--demo).
+Try out Draft.js in the [Playground](/playground/?path=/docs/react-demos-draft-js--demo).
 
 ## Brainstorming
 

--- a/docs/content/docs/get-started/examples.md
+++ b/docs/content/docs/get-started/examples.md
@@ -35,4 +35,4 @@ margin-right: auto;">
 The [Sudoku](https://github.com/microsoft/FluidExamples/tree/main/sudoku) example demonstrates how to build
 a collaborative game. This example includes key features like presence.
 
-Try out Sudoku in our [Playground](/playground/?path=/docs/react-demos-sudoku--demo).
+Try out Sudoku in the [Playground](/playground/?path=/docs/react-demos-sudoku--demo).


### PR DESCRIPTION
Makes it easier for developers to discover the Playground and see the Examples in action.
