### PR TITLE
Search blob hooks

### DIFF
--- a/examples/data-objects/shared-text/src/component.ts
+++ b/examples/data-objects/shared-text/src/component.ts
@@ -75,6 +75,9 @@ export class SharedTextRunner
     public get IFluidHTMLView() { return this; }
     public get ISharedString() { return this.sharedString; }
 
+    // NOTE: Search blob concept
+    public get getSearchBlobContent() { return this.sharedString.getText(); }
+
     public readonly url = "/text";
     private sharedString: SharedString;
     private insightsMap: ISharedMap;

--- a/examples/data-objects/shared-text/src/index.ts
+++ b/examples/data-objects/shared-text/src/index.ts
@@ -86,7 +86,12 @@ class SharedTextFactoryComponent implements IFluidDataStoreFactory, IRuntimeFact
     public get IRuntimeFactory() { return this; }
 
     public instantiateDataStore(context: IFluidDataStoreContext): void {
-        return sharedTextComponent.instantiateDataStore(context);
+        // NOTE: Search blob concept
+        // Add an option to the context that indicates this component will
+        // use search blobs:
+        const testContext = context;
+        testContext.options.search = true;
+        return sharedTextComponent.instantiateDataStore(testContext);
     }
 
     /**

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -38,6 +38,8 @@ import {
     IQuorum,
     ISequencedDocumentMessage,
     ITreeEntry,
+    TreeEntry,
+    FileMode,
 } from "@fluidframework/protocol-definitions";
 import {
     IAttachMessage,
@@ -49,7 +51,7 @@ import {
     ISummaryTreeWithStats,
     CreateSummarizerNodeSource,
 } from "@fluidframework/runtime-definitions";
-import { generateHandleContextPath, SummaryTreeBuilder } from "@fluidframework/runtime-utils";
+import { generateHandleContextPath, SummaryTreeBuilder, requestFluidObject } from "@fluidframework/runtime-utils";
 import { IChannel, IFluidDataStoreRuntime, IChannelFactory } from "@fluidframework/datastore-definitions";
 import { v4 as uuid } from "uuid";
 import { IChannelContext, snapshotChannel } from "./channelContext";
@@ -103,6 +105,7 @@ export class FluidDataStoreRuntime extends EventEmitter implements IFluidDataSto
             logger);
 
         context.bindRuntime(runtime);
+
         return runtime;
     }
 
@@ -541,6 +544,29 @@ export class FluidDataStoreRuntime extends EventEmitter implements IFluidDataSto
                 // And then store the tree
                 return new TreeTreeEntry(key, snapshot);
             }));
+
+        // NOTE: Search blob concept
+        // if (this.dataStoreContext.options.search === true) {
+        //     // Grab search blob content back from component:
+        //     // TODO: Was unclear to me which method is proper, based on debugging:
+        //     // requestFluidObject(this.requestHandler) OR this.sharedObjectRegistry
+
+        //     const searchBlobContent = "";
+        //     // Add as an entry to snapshot:
+        //     const newTreeEntry: ITreeEntry = {
+        //         path: "",
+        //         type: TreeEntry.Blob,
+        //         value: searchBlobContent,
+        //         mode: FileMode.File,
+        //     };
+        //     const newTree: ITree = {
+        //         entries: [newTreeEntry],
+        //         id: searchBlobContent,
+        //     };
+
+        //     const newEntry = new TreeTreeEntry("searchBlobContent", newTree);
+        //     entries.push(newEntry);
+        }
 
         return entries;
     }


### PR DESCRIPTION
I added a few comments to describe what I was going for. Roughly, for where I'm at: on dataStore load, a component inserts an option to indicate it will have a search blob, and then on a snapshot the core snapshot method will call back to the component for its designated search content.