### PR TITLE
Smde and key-value-cache was broken due to wrong order of arguments while creating data stores.

### DIFF
--- a/examples/data-objects/key-value-cache/src/index.ts
+++ b/examples/data-objects/key-value-cache/src/index.ts
@@ -112,7 +112,7 @@ class KeyValue implements IKeyValue, IFluidObject, IFluidRouter {
 export class KeyValueFactoryComponent implements IRuntimeFactory, IFluidDataStoreFactory {
     public static readonly type = "@fluid-example/key-value-cache";
     public readonly type = KeyValueFactoryComponent.type;
-
+    private readonly defaultComponentId = "default";
     public get IRuntimeFactory() { return this; }
     public get IFluidDataStoreFactory() { return this; }
 
@@ -140,13 +140,13 @@ export class KeyValueFactoryComponent implements IRuntimeFactory, IFluidDataStor
             context,
             new Map([[ComponentName, Promise.resolve(this)]]),
             buildRuntimeRequestHandler(
-                defaultRouteRequestHandler(ComponentName),
+                defaultRouteRequestHandler(this.defaultComponentId),
                 deprecated_innerRequestHandler,
             ),
         );
 
         if (!runtime.existing) {
-            await runtime.createRootDataStore(ComponentName, ComponentName);
+            await runtime.createRootDataStore(ComponentName, this.defaultComponentId);
         }
 
         return runtime;

--- a/examples/data-objects/smde/src/index.ts
+++ b/examples/data-objects/smde/src/index.ts
@@ -42,7 +42,7 @@ class SmdeContainerFactory implements IRuntimeFactory {
 
         // On first boot create the base component
         if (!runtime.existing) {
-            await runtime.createRootDataStore(defaultComponentId, defaultComponent);
+            await runtime.createRootDataStore(defaultComponent, defaultComponentId);
         }
 
         return runtime;


### PR DESCRIPTION
We were using dataStore id with a "/" which is not allowed. For ex: a/b cann't be the data store id because then it would treat b as an entity present inside A which is not the case.
So supply a proper data store id.