### PR TITLE
Add pipeline work flow to publishing docker images 

### DIFF
--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -6,21 +6,22 @@
 name: $(Build.BuildId)
 
 parameters:
-- name: publishOverride
-  displayName: Publish Override
-  type: string
-  default: default
-  values:
-    - default
-    - skip
 - name: releaseBuildOverride
-  displayName: Release Build Override
+  displayName: Release Build (default = not released)
   type: string
   default: none
   values:
     - none
     - prerelease
     - release
+- name: publishOverride
+  displayName: Publish Override (default = based on branch)
+  type: string
+  default: default
+  values:
+    - default
+    - skip
+    - force
 
 trigger:
   branches:

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -6,21 +6,22 @@
 name: $(Build.BuildId)
 
 parameters:
-- name: publishOverride
-  displayName: Publish Override
-  type: string
-  default: default
-  values:
-    - default
-    - skip
 - name: releaseBuildOverride
-  displayName: Release Build Override
+  displayName: Release Build (default = not released)
   type: string
   default: none
   values:
     - none
     - prerelease
     - release
+- name: publishOverride
+  displayName: Publish Override (default = based on branch)
+  type: string
+  default: default
+  values:
+    - default
+    - skip
+    - force
 
 trigger:
   branches:

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -6,21 +6,22 @@
 name: $(Build.BuildId)
 
 parameters:
-- name: publishOverride
-  displayName: Publish Override
-  type: string
-  default: default
-  values:
-    - default
-    - skip
 - name: releaseBuildOverride
-  displayName: Release Build Override
+  displayName: Release Build (default = not released)
   type: string
   default: none
   values:
     - none
     - prerelease
     - release
+- name: publishOverride
+  displayName: Publish Override (default = based on branch)
+  type: string
+  default: default
+  values:
+    - default
+    - skip
+    - force
 
 trigger:
   branches:

--- a/tools/pipelines/build-common-definitions.yml
+++ b/tools/pipelines/build-common-definitions.yml
@@ -6,21 +6,22 @@
 name: $(Build.BuildId)
 
 parameters:
-- name: publishOverride
-  displayName: Publish Override
-  type: string
-  default: default
-  values:
-    - default
-    - skip
 - name: releaseBuildOverride
-  displayName: Release Build Override
+  displayName: Release Build (default = not released)
   type: string
   default: none
   values:
     - none
     - prerelease
     - release
+- name: publishOverride
+  displayName: Publish Override (default = based on branch)
+  type: string
+  default: default
+  values:
+    - default
+    - skip
+    - force
 
 trigger:
   branches:

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -6,21 +6,22 @@
 name: $(Build.BuildId)
 
 parameters:
-- name: publishOverride
-  displayName: Publish Override
-  type: string
-  default: default
-  values:
-    - default
-    - skip
 - name: releaseBuildOverride
-  displayName: Release Build Override
+  displayName: Release Build (default = not released)
   type: string
   default: none
   values:
     - none
     - prerelease
     - release
+- name: publishOverride
+  displayName: Publish Override (default = based on branch)
+  type: string
+  default: default
+  values:
+    - default
+    - skip
+    - force
 
 trigger:
   branches:

--- a/tools/pipelines/build-eslint-config-fluid.yml
+++ b/tools/pipelines/build-eslint-config-fluid.yml
@@ -6,21 +6,22 @@
 name: $(Build.BuildId)
 
 parameters:
-- name: publishOverride
-  displayName: Publish Override
-  type: string
-  default: default
-  values:
-    - default
-    - skip
 - name: releaseBuildOverride
-  displayName: Release Build Override
+  displayName: Release Build (default = not released)
   type: string
   default: none
   values:
     - none
     - prerelease
     - release
+- name: publishOverride
+  displayName: Publish Override (default = based on branch)
+  type: string
+  default: default
+  values:
+    - default
+    - skip
+    - force
 
 trigger:
   branches:

--- a/tools/pipelines/build-generator-fluid.yml
+++ b/tools/pipelines/build-generator-fluid.yml
@@ -6,21 +6,22 @@
 name: $(Build.BuildId)
 
 parameters:
-- name: publishOverride
-  displayName: Publish Override
-  type: string
-  default: default
-  values:
-    - default
-    - skip
 - name: releaseBuildOverride
-  displayName: Release Build Override
+  displayName: Release Build (default = not released)
   type: string
   default: none
   values:
     - none
     - prerelease
     - release
+- name: publishOverride
+  displayName: Publish Override (default = based on branch)
+  type: string
+  default: default
+  values:
+    - default
+    - skip
+    - force
 
 trigger:
   branches:

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -6,21 +6,22 @@
 name: $(Build.BuildId)
 
 parameters:
-- name: publishOverride
-  displayName: Publish Override
-  type: string
-  default: default
-  values:
-    - default
-    - skip
 - name: releaseBuildOverride
-  displayName: Release Build Override
+  displayName: Release Build (default = not released)
   type: string
   default: none
   values:
     - none
     - prerelease
     - release
+- name: publishOverride
+  displayName: Publish Override (default = based on branch)
+  type: string
+  default: default
+  values:
+    - default
+    - skip
+    - force
 
 trigger:
   branches:

--- a/tools/pipelines/build-tinylicious.yml
+++ b/tools/pipelines/build-tinylicious.yml
@@ -6,21 +6,22 @@
 name: $(Build.BuildId)
 
 parameters:
-- name: publishOverride
-  displayName: Publish Override
-  type: string
-  default: default
-  values:
-    - default
-    - skip
 - name: releaseBuildOverride
-  displayName: Release Build Override
+  displayName: Release Build (default = not released)
   type: string
   default: none
   values:
     - none
     - prerelease
     - release
+- name: publishOverride
+  displayName: Publish Override (default = based on branch)
+  type: string
+  default: default
+  values:
+    - default
+    - skip
+    - force
 
 trigger:
   branches:

--- a/tools/pipelines/server-admin.yml
+++ b/tools/pipelines/server-admin.yml
@@ -23,6 +23,7 @@ pr:
   branches:
     include:
     - main
+    - release/*
   paths:
     include:
     - server/admin

--- a/tools/pipelines/server-auspkn.yml
+++ b/tools/pipelines/server-auspkn.yml
@@ -23,6 +23,7 @@ pr:
   branches:
     include:
     - main
+    - release/*
   paths:
     include:
     - server/auspkn

--- a/tools/pipelines/server-gateway.yml
+++ b/tools/pipelines/server-gateway.yml
@@ -23,6 +23,7 @@ pr:
   branches:
     include:
     - main
+    - release/*
   paths:
     include:
     - server/gateway

--- a/tools/pipelines/server-gitrest.yml
+++ b/tools/pipelines/server-gitrest.yml
@@ -5,6 +5,24 @@
 
 name: $(Build.BuildId)
 
+parameters:
+- name: releaseBuildOverride
+  displayName: Release Build (default = not released)
+  type: string
+  default: none
+  values:
+    - none
+    - prerelease
+    - release
+- name: publishOverride
+  displayName: Publish Override (default = based on branch)
+  type: string
+  default: default
+  values:
+    - default
+    - skip
+    - force
+
 trigger:
   branches:
     include:
@@ -17,12 +35,15 @@ trigger:
     - tools/pipelines/templates/build-docker-service.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-publish-docker-service.yml
+    - tools/pipelines/templates/include-publish-docker-service-steps.yml
     - tools/pipelines/templates/include-generate-notice-steps.yml
   
 pr:
   branches:
     include:
     - main
+    - release/*
   paths:
     include:
     - server/gitrest
@@ -35,6 +56,9 @@ pr:
 extends:
   template: templates/build-docker-service.yml
   parameters:
+    releaseImage: true
+    publishOverride: ${{ parameters.publishOverride }}
+    releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildDirectory: server/gitrest
-    containerName: gitrest
+    containerName: fluidframework/routerlicious/gitrest
     test: true

--- a/tools/pipelines/server-gitssh.yml
+++ b/tools/pipelines/server-gitssh.yml
@@ -5,6 +5,24 @@
 
 name: $(Build.BuildId)
 
+parameters:
+- name: releaseBuildOverride
+  displayName: Release Build (default = not released)
+  type: string
+  default: none
+  values:
+    - none
+    - prerelease
+    - release
+- name: publishOverride
+  displayName: Publish Override (default = based on branch)
+  type: string
+  default: default
+  values:
+    - default
+    - skip
+    - force
+
 trigger:
   branches:
     include:
@@ -15,11 +33,14 @@ trigger:
     - tools/pipelines/server-gitssh.yml
     - tools/pipelines/templates/build-docker-service.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-publish-docker-service.yml
+    - tools/pipelines/templates/include-publish-docker-service-steps.yml
 
 pr:
   branches:
     include:
     - main
+    - release/*
   paths:
     include:
     - server/gitssh
@@ -30,7 +51,10 @@ pr:
 extends:
   template: templates/build-docker-service.yml
   parameters:
+    releaseImage: true
+    publishOverride: ${{ parameters.publishOverride }}
+    releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildDirectory: server/gitssh
-    containerName: gitssh
+    containerName: fluidframework/routerlicious/gitssh
     test: false
     setVersion: false

--- a/tools/pipelines/server-headless-agent.yml
+++ b/tools/pipelines/server-headless-agent.yml
@@ -23,6 +23,7 @@ pr:
   branches:
     include:
     - main
+    - release/*
   paths:
     include:
     - server/headless-agent

--- a/tools/pipelines/server-historian.yml
+++ b/tools/pipelines/server-historian.yml
@@ -5,6 +5,24 @@
 
 name: $(Build.BuildId)
 
+parameters:
+- name: releaseBuildOverride
+  displayName: Release Build (default = not released)
+  type: string
+  default: none
+  values:
+    - none
+    - prerelease
+    - release
+- name: publishOverride
+  displayName: Publish Override (default = based on branch)
+  type: string
+  default: default
+  values:
+    - default
+    - skip
+    - force
+
 trigger:
   branches:
     include:
@@ -17,12 +35,15 @@ trigger:
     - tools/pipelines/templates/build-docker-service.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-publish-docker-service.yml
+    - tools/pipelines/templates/include-publish-docker-service-steps.yml
     - tools/pipelines/templates/include-generate-notice-steps.yml
 
 pr:
   branches:
     include:
     - main
+    - release/*
   paths:
     include:
     - server/historian
@@ -35,6 +56,9 @@ pr:
 extends:
   template: templates/build-docker-service.yml
   parameters:
+    releaseImage: true
+    publishOverride: ${{ parameters.publishOverride }}
+    releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildDirectory: server/historian
-    containerName: historian
+    containerName: fluidframework/routerlicious/historian
     test: true

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -6,21 +6,22 @@
 name: $(Build.BuildId)
 
 parameters:
-- name: publishOverride
-  displayName: Publish Override
-  type: string
-  default: default
-  values:
-    - default
-    - skip
 - name: releaseBuildOverride
-  displayName: Release Build Override
+  displayName: Release Build (default = not released)
   type: string
   default: none
   values:
     - none
     - prerelease
     - release
+- name: publishOverride
+  displayName: Publish Override (default = based on branch)
+  type: string
+  default: default
+  values:
+    - default
+    - skip
+    - force
 
 trigger:
   branches:
@@ -37,6 +38,8 @@ trigger:
     - tools/pipelines/templates/include-generate-notice-steps.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
+    - tools/pipelines/templates/include-publish-docker-service.yml
+    - tools/pipelines/templates/include-publish-docker-service-steps.yml
     exclude:
     - server/routerlicious/kubernetes/routerlicious
   
@@ -56,13 +59,17 @@ pr:
     - server/routerlicious/kubernetes/routerlicious
 
 variables:
+- name: buildNumberInPatch
+  value: false
 - template: templates/include-vars.yml
   parameters:
+    releaseImage: true
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+    buildNumberInPatch: ${{ variables.buildNumberInPatch }}
 - group: container-registry-info
 - name: containerName
-  value: fluid-server
+  value: fluidframework/routerlicious/server
 - name: baseContainerName
   value: $(containerName)-base
 - name: baseContainerTag
@@ -83,7 +90,52 @@ stages:
     - job: build
       displayName: Build - Server
       pool: Main
+      variables:
+        releaseBuildVar: $[variables.releaseBuild]
       steps:
+        - task: Bash@3
+          displayName: Parameters
+          inputs:
+            targetType: 'inline'
+            script: |
+              # Show all task group conditions
+
+              echo "
+              Pipeline Variables:
+                releaseBuild=$(releaseBuildVar)
+
+              Override Parameters:
+                publishOverride=${{ parameters.publishOverride }}
+                releaseBuildOverride=${{ parameters.releaseBuildOverride }}
+
+              Computed variables:
+                shouldPublish=${{ variables.shouldPublish }}                
+                componentDetection=${{ variables.componentDetection }}
+                publish=${{ variables.publish }}
+                canRelease=${{ variables.canRelease }}
+
+                pushImage=${{ variables.pushImage }}
+                releaseImage=${{ variables.releaseImage }}
+                release=$(release)"
+
+              if [[ "$(release)" == "release" ]]; then
+                if [[ "${{ variables.canRelease }}" == "False" ]]; then
+                  echo "##vso[task.logissue type=error]Invalid branch ${{ variables['Build.SourceBranch'] }} for release"
+                  exit -1;
+                fi
+              fi
+
+              if [[ "$(release)" != "none" ]]; then
+                if [[ "${{ variables.publish }}" != "True" ]]; then
+                  echo "##vso[task.logissue type=error]'$(release)' is set but package is not published. Either the branch doesn't default to publish or it is skipped."
+                  exit -1;
+                fi
+                if [[ "${{ variables.pushImage }}" != "True" ]]; then
+                  echo "##vso[task.logissue type=error]'$(release)' is set but image is not pushed. Either the branch doesn't default to push image or it is skipped."
+                  exit -1;
+                fi
+              fi
+
         # Checkout
         - checkout: self
           clean: true
@@ -242,11 +294,19 @@ stages:
           continueOnError: true
           condition: succeededOrFailed()
 
-# Publish stage
+# Publish stages
 - ${{ if eq(variables.publish, true) }}:
   - template: templates/include-publish-npm-package.yml
     parameters:
       buildDirectory: server/routerlicious
       namespace: true
       tagName: server
-      buildNumberInPatch: false
+      buildNumberInPatch: ${{ variables.buildNumberInPatch }}
+
+- ${{ if eq(variables.releaseImage, true) }}:
+  - template: include-publish-docker-service.yml
+    parameters:
+      containerRegistry: $(containerRegistryConnection)
+      containerTag: $(fullRunnerContainerTag)
+      containerRegistryUrl: $(containerRegistryUrl)
+      containerName: ${{ parameters.containerName }}

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -29,10 +29,27 @@ parameters:
   type: boolean
   default: true
 
+- name: releaseImage
+  type: boolean
+  default: false
+
+- name: publishOverride
+  type: string
+  default: default
+
+- name: releaseBuildOverride
+  type: string
+  default: none
+
 trigger: none
 
 variables:
 - template: include-vars.yml
+  parameters:
+    releaseImage: ${{ parameters.releaseImage }}
+    publishOverride: ${{ parameters.publishOverride }}
+    releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+    buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
 - group: container-registry-info
 - name: baseContainerTag
   value: ${{ parameters.containerName }}:$(Build.BuildNumber)
@@ -43,15 +60,68 @@ variables:
     value: $(baseContainerTag)
 - ${{ if eq(variables.pushImage, true) }}:
   - name: containerRegistry
-    value: $(containerRegistryConnection)
+    value: $[variables.containerRegistryConnection]
   - name: containerTag
     value: $(containerRegistryUrl)/$(baseContainerTag)
 
-jobs:
+stages:
+- stage: build
+  displayName: Build Stage
+  jobs:
   - job: build
     displayName: Build Container - ${{ parameters.containerName }}
     pool: Lite
+    variables:
+      releaseBuildVar: $[variables.releaseBuild]
     steps:
+    - task: Bash@3
+      displayName: Parameters
+      inputs:
+        targetType: 'inline'
+        script: |
+          # Show all task group conditions
+
+          echo "
+          Pipeline Variables:
+            releaseBuild=$(releaseBuildVar)
+
+          Override Parameters:
+            publishOverride=${{ parameters.publishOverride }}
+            releaseBuildOverride=${{ parameters.releaseBuildOverride }}
+
+          Tasks Parameters:
+            Lint=${{ parameters.lint }}
+            Test=${{ parameters.test }}
+
+          Computed variables:
+            shouldPublish=${{ variables.shouldPublish }}
+            componentDetection=${{ variables.componentDetection }}
+            publish=${{ variables.publish }}
+            canRelease=${{ variables.canRelease }}
+
+            pushImage=${{ variables.pushImage }}
+            releaseImage=${{ variables.releaseImage }}
+            release=$(release)"
+
+          if [[ "$(release)" == "release" ]]; then
+            if [[ "${{ variables.canRelease }}" == "False" ]]; then
+              echo "##vso[task.logissue type=error]Invalid branch ${{ variables['Build.SourceBranch'] }} for release"
+              exit -1;
+            fi
+          fi
+
+          if [[ "$(release)" != "none" ]]; then
+            if [[ "${{ variables.pushImage }}" != "True" ]]; then
+              echo "##vso[task.logissue type=error]'$(release)' is set but image is not pushed. Either the branch doesn't default to push image or it is skipped."
+              exit -1;
+            fi
+            
+            if [[ "${{ variables.releaseImage }}" != "True" ]]; then
+              echo "##vso[task.logissue type=error]'$(release)' is set but pipeline isn't declared to allow release image."
+              exit -1;
+            fi
+          fi
+
     # Setup
     - checkout: self
       clean: true
@@ -140,9 +210,18 @@ jobs:
       condition: succeededOrFailed()
 
     - task: Docker@0
-      displayName: Docker Cleanup - $(containerTag)
+      displayName: Docker Cleanup - $(baseContainerTag)
       inputs:
         action: Run a Docker command
         customCommand: rmi $(containerTag)
       continueOnError: true
       condition: succeededOrFailed()
+
+# Publish stage
+- ${{ if eq(variables.releaseImage, true) }}:
+  - template: include-publish-docker-service.yml
+    parameters:
+      containerRegistry: $(containerRegistry)
+      containerTag: $(containerTag)
+      containerRegistryUrl: $(containerRegistryUrl)
+      containerName: ${{ parameters.containerName }}

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -75,6 +75,7 @@ variables:
     parameters:
       publishOverride: ${{ parameters.publishOverride }}
       releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+      buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
 
 stages:
   - stage: build
@@ -87,12 +88,6 @@ stages:
           testCoverage: ${{ and(eq(parameters.taskTest, 'ci:test'), ne(variables['Build.Reason'], 'PullRequest')) }}
           releaseBuildVar: $[variables.releaseBuild]
         steps:
-        # Setup
-        - checkout: self
-          clean: true
-          lfs: ${{ parameters.checkoutSubmodules }}
-          submodules: ${{ parameters.checkoutSubmodules }}
-
         - task: Bash@3
           displayName: Parameters
           inputs:
@@ -118,9 +113,30 @@ stages:
               Computed variables:
                 shouldPublish=${{ variables.shouldPublish }}
                 componentDetection=${{ variables.componentDetection }}
-                pushImage=${{ variables.pushImage }}
                 publish=${{ variables.publish }}
+                canRelease=${{ variables.canRelease }}
+
                 release=$(release)"
+
+              if [[ "$(release)" == "release" ]]; then
+                if [[ "${{ variables.canRelease }}" == "False" ]]; then
+                  echo "##vso[task.logissue type=error]Invalid branch ${{ variables['Build.SourceBranch'] }} for release"
+                  exit -1;
+                fi
+              fi
+
+              if [[ "$(release)" != "none" ]]; then
+                if [[ "${{ variables.publish }}" != "True" ]]; then
+                  echo "##vso[task.logissue type=error]'$(release)'' is set but package is not published. Either the branch doesn't default to publish or it is skipped."
+                  exit -1;
+                fi
+              fi
+
+        # Setup
+        - checkout: self
+          clean: true
+          lfs: ${{ parameters.checkoutSubmodules }}
+          submodules: ${{ parameters.checkoutSubmodules }}
 
         # Install
         - task: UseNode@1
@@ -281,4 +297,3 @@ stages:
         namespace: ${{ parameters.namespace }}
         tagName: ${{ parameters.tagName }}
         buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
-        

--- a/tools/pipelines/templates/include-publish-docker-service-steps.yml
+++ b/tools/pipelines/templates/include-publish-docker-service-steps.yml
@@ -1,0 +1,70 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# include-publish-docker-service-steps
+
+parameters:
+- name: environment
+  type: string
+
+- name: pool
+  type: object
+  default: Lite
+
+- name: containerRegistry
+  type: string
+
+- name: containerTag
+  type: string
+
+- name: containerRegistryUrl
+  type: string
+
+- name: containerName
+  type: string
+
+jobs:
+- deployment: publish_${{ replace(parameters.environment, '-', '_') }}
+  displayName: Publish ${{ parameters.environment }}
+  environment: ${{ parameters.environment }}
+  pool: ${{ parameters.pool }}
+  workspace:
+    clean: all
+  strategy:
+    runOnce:
+        deploy:
+            steps:
+            - download: none
+            - task: Docker@2
+              displayName: Login to ACR
+              inputs:
+                command: login
+                containerRegistry: ${{ parameters.containerRegistry }}
+
+            - task: Docker@0
+              displayName: Pull image
+              inputs:
+                action: 'Run a Docker command'
+                customCommand: 'pull ${{ parameters.containerTag }}'
+
+            - task: Docker@0
+              displayName: Tag image
+              inputs:
+                action: 'Run a Docker command'
+                customCommand: 'tag ${{ parameters.containerTag }} ${{ parameters.containerRegistryUrl }}/${{ parameters.containerName }}:$(Build.BuildNumber)'
+
+            - task: Docker@0
+              displayName: Tag image
+              inputs:
+                action: 'Run a Docker command'
+                customCommand: 'tag ${{ parameters.containerTag }} ${{ parameters.containerRegistryUrl }}/${{ parameters.containerName }}:latest'
+
+            - task: Docker@2
+              displayName: Docker Push
+              inputs:
+                containerRegistry: ${{ parameters.containerRegistry }}
+                repository: ${{ parameters.containerName }}
+                command: push
+                tags: |
+                  $(Build.BuildNumber)
+                  latest

--- a/tools/pipelines/templates/include-publish-docker-service.yml
+++ b/tools/pipelines/templates/include-publish-docker-service.yml
@@ -1,0 +1,41 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# include-publish-docker-service
+
+parameters:
+- name: containerRegistry
+  type: string
+- name: containerTag
+  type: string
+- name: containerRegistryUrl
+  type: string
+- name: containerName
+  type: string
+
+stages:
+- stage: publish_internal
+  dependsOn: build
+  displayName: Internal Publish Stage
+  condition: and(succeeded(), or(eq(variables['release'], 'release'), eq(variables['release'], 'prerelease')))
+  jobs:
+  - template: include-publish-docker-service-steps.yml
+    parameters:
+      environment: internal-container-registry
+      containerRegistry: ${{ parameters.containerRegistry }}
+      containerTag: ${{ parameters.containerTag }}
+      containerRegistryUrl: ${{ parameters.containerRegistryUrl }}
+      containerName: internal/${{ parameters.containerName }}
+
+- stage: publish_official
+  dependsOn: build
+  displayName: Official Publish Stage
+  condition: and(succeeded(), eq(variables['release'], 'release'))
+  jobs:
+  - template: include-publish-docker-service-steps.yml
+    parameters:
+      environment: public-container-registry
+      containerRegistry: ${{ parameters.containerRegistry }}
+      containerTag: ${{ parameters.containerTag }}
+      containerRegistryUrl: ${{ parameters.containerRegistryUrl }}
+      containerName: pubic/${{ parameters.containerName }}

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -12,29 +12,66 @@ parameters:
   type: string
   default: none
 
+- name: releaseImage
+  type: boolean
+  default: false
+
+- name: buildNumberInPatch
+  type: string
+
 variables:
 - name: skipComponentGovernanceDetection
   value: true
 - name: shouldPublish
   value: ${{
     and(
-      ne(variables['Build.Reason'], 'PullRequest'),
-      ne(variables['System.TeamProject'], 'public')
+      and(
+        ne(variables['Build.Reason'], 'PullRequest'),
+        ne(variables['System.TeamProject'], 'public')
+      ),
+      or(
+        and(
+          eq(parameters.buildNumberInPatch, false),
+          startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')
+        ),
+        eq(variables['Build.SourceBranch'], 'refs/heads/main')
+      )
+    )}}
+- name: canRelease
+  value: ${{
+    or(
+      eq(parameters.publishOverride, 'force'),
+      or(
+        and(
+          eq(parameters.buildNumberInPatch, true),
+          eq(variables['Build.SourceBranch'], 'refs/heads/main')
+        ),
+        and(
+          eq(parameters.buildNumberInPatch, false),
+          startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')
+        )
+      )
     )}}
 - name: publish
   value: ${{
-    and(
-      ne(parameters.publishOverride, 'skip'),
-      eq(variables.shouldPublish, true)
+    or(
+      eq(parameters.publishOverride, 'force'),
+      and(
+        ne(parameters.publishOverride, 'skip'),
+        eq(variables.shouldPublish, true)
+      )
     )}}
 - name: componentDetection
   value: ${{ variables.publish }}
 - name: pushImage
-  value: ${{
+  value: ${{ variables.publish }}
+- name: releaseImage
+  value: ${{ 
     and(
-      variables.publish,
-      eq(variables['Build.SourceBranch'], 'refs/heads/main')
+      eq(variables.pushImage, true),
+      eq(parameters.releaseImage, true)
     )}}
+
 # compute the release variable
 - ${{ if eq(parameters.releaseBuildOverride, 'none') }}:
   - ${{ if eq(variables.shouldPublish, true) }}:


### PR DESCRIPTION
Align docker image repository name with MCR requirements.
Stricter condition for release builds 
- only main branch can release if the build number is in patch
- only release/* branch can release if build number is in use in prerelease portion of the version
- add force published to override to able to publish and release any where (shouldn't normally used)

Add error checking for release/publish mode.
