### PR TITLE
Fix bootstrap wrapping issue with homepage/community

### DIFF
--- a/docs/assets/css/fluid.css
+++ b/docs/assets/css/fluid.css
@@ -19,6 +19,10 @@ footer {
     flex-wrap: wrap;
 }
 
+.row:after, .row:before{
+    display: none;
+}
+
 .cta {
     padding: 2rem 0;
     width: 100%;


### PR DESCRIPTION
Attempt to fix wrapping issue with

```
.row:after, .row:before{
    display: none;
}
```