### PR TITLE
Publish R11s as consumable package

### DIFF
--- a/server/routerlicious/packages/routerlicious/README.md
+++ b/server/routerlicious/packages/routerlicious/README.md
@@ -1,5 +1,11 @@
-# @fluid-internal/server-routerlicious
+# @fluidframework/server-routerlicious
 
 Fluid server package containing the reference implementation of Fluid ordering service.
 
 See [GitHub](https://github.com/microsoft/FluidFramework) for more details on the Fluid Framework and packages within.
+
+## Exported Modules & Services
+
+All services are included in the package's `dist/` folder. These packaged services can be used in conjunction with customized or additional helper services. Alternatively, pick-and-choose which services to host if some are unnecessary for your use-case.
+
+Riddler and Alfred also have classes and functions exported to make it easier to mix-and-match implementation details within customized versions of each.

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -1,7 +1,6 @@
 {
-  "name": "@fluid-internal/server-routerlicious",
+  "name": "@fluidframework/server-routerlicious",
   "version": "0.1012.1",
-  "private": true,
   "description": "Fluid reference server implementation",
   "homepage": "https://fluidframework.com",
   "repository": "microsoft/FluidFramework",

--- a/server/routerlicious/packages/routerlicious/src/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/index.ts
@@ -1,0 +1,32 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/* eslint-disable import/no-internal-modules */
+
+import * as alfredUtils from "./alfred/utils";
+import * as alfredApp from "./alfred/app";
+import * as alfredRoutes from "./alfred/routes";
+import * as alfredApi from "./alfred/routes/api";
+import * as riddlerApp from "./riddler/app";
+import * as riddlerApi from "./riddler/api";
+
+// Alfred
+export * from "./alfred/runnerFactory";
+export * from "./alfred/runner";
+export const alfred = {
+    app: alfredApp,
+    routes: alfredRoutes,
+    api: alfredApi,
+    utils: alfredUtils,
+};
+
+// Riddler
+export * from "./riddler/runnerFactory";
+export * from "./riddler/runner";
+export * from "./riddler/tenantManager";
+export const riddler = {
+    app: riddlerApp,
+    api: riddlerApi,
+};

--- a/tools/build-tools/data/layerInfo.json
+++ b/tools/build-tools/data/layerInfo.json
@@ -261,7 +261,7 @@
             },
             "Routerlicious-Server": {
                 "packages": [
-                    "@fluid-internal/server-routerlicious"
+                    "@fluidframework/server-routerlicious"
                 ],
                 "deps": [
                     "Server-Libs"


### PR DESCRIPTION
In order to blend development of FRS with the open-sourced Routerlicious components, we need to be able to consume as much as possible from OSS without manually copy-pasting updates between the 2 repos. 

This change exports some modules defined in Routerlicious in a way that makes them consumable as a typed NPM package. It also exposes r11s as a public package.