### PR TITLE
fix the nav bar when looking at the docs menu on mobile

### DIFF
--- a/docs/themes/thxvscode/layouts/partials/docNav.html
+++ b/docs/themes/thxvscode/layouts/partials/docNav.html
@@ -45,13 +45,19 @@
         <option value="/docs" {{if .IsHome}}selected{{end}}>Overview</option>
         {{- range .Site.Menus.docs }}
         {{ $menuArea := .Identifier}}
+        {{ $isCurrentPage := eq .URL $current.RelPermalink }}
 
-        <optgroup label="{{ $menuArea }}">
-            {{- range ((where $current.Site.RegularPages "Params.area" "==" $menuArea).ByParam "menuPosition") }}
-            {{ $isCurrentPage := eq .RelPermalink $current.RelPermalink }}
-            <option value="{{.RelPermalink}}" {{ if $isCurrentPage }}selected{{end}}>{{ .Title }}</option>
-            {{ end }}
+        {{- if ne .URL "" -}}
+        {{ $isCurrentPage := eq .URL $current.RelPermalink }}
+        <option value="{{.URL}}" {{ if $isCurrentPage }}selected{{end}}>{{ .Name }}</option>
+        {{- else -}}
+        <optgroup label="{{ $menuArea }}"></optgroup>
+        {{- range ((where $current.Site.RegularPages "Params.area" "==" $menuArea).ByParam "menuPosition") }}
+        {{ $isCurrentPage := eq .RelPermalink $current.RelPermalink }}
+        <option value="{{.RelPermalink}}" {{ if $isCurrentPage }}selected{{end}}>{{ .Title }}</option>
         </optgroup>
+        {{- end -}}
+        {{ end }}
         {{- end }}
     </select>
 </nav>


### PR DESCRIPTION
some entries aren't nested and therefore the mobile dropdown wasn't making them clickable