### PR TITLE
include redis options with historian connection string

### DIFF
--- a/server/historian/src/www.ts
+++ b/server/historian/src/www.ts
@@ -69,7 +69,10 @@ if (redisConfig.tls) {
     };
 }
 
-const redisClient = redis.createClient(redisConfig.port, redisConfig.host);
+const redisClient = redis.createClient(
+    redisConfig.port,
+    redisConfig.host,
+    redisOptions);
 const gitCache = new services.RedisCache(redisClient);
 const tenantCache = new services.RedisTenantCache(redisClient);
 


### PR DESCRIPTION
Congrats on open sourcing!

Looks like the redisOptions didn't get included with the historian connection string.