### PR TITLE
Update license to point to main branch

### DIFF
--- a/docs/themes/thxvscode/layouts/partials/footer.html
+++ b/docs/themes/thxvscode/layouts/partials/footer.html
@@ -28,7 +28,7 @@
                             href="https://www.microsoft.com/en-us/legal/intellectualproperty/copyright/default.aspx"
                             target="_blank">Terms of Use</a></li>
                     <li><a id="footer-license-link"
-                            href="https://github.com/{{.Site.Params.githubRepo}}/blob/master/LICENSE">License</a>
+                            href="https://github.com/{{.Site.Params.githubRepo}}/blob/main/LICENSE">License</a>
                     </li>
                 </ul>
                 <div class="copyright">


### PR DESCRIPTION
The license file link points to `/blob/master` but this repo used `main` as the default branch.

While GitHub does figure it out and redirect the user to the default branch instead, you get the warning message below. This PR fixes that.

<img width="551" alt="image" src="https://user-images.githubusercontent.com/6044920/92626205-9b6fcb80-f297-11ea-9de5-4b4d3a5e1088.png">
