### PR TITLE
add styles to playground page

### DIFF
--- a/docs/layouts/page/playground.html
+++ b/docs/layouts/page/playground.html
@@ -25,8 +25,9 @@
 {{ partial "navbarSticky.html" . }}
 
 <h2>This body is replaced when Storybook is injected during the build process.</h2>
-<p>To learn more about the Fluid & Storybook, you can go to <a
-        href="https://github.com/microsoft/FluidStorybook">https://github.com/microsoft/FluidStorybook</a></p>
+<p>To learn more about the Fluid & Storybook, you can go to 
+  <a href="https://github.com/microsoft/FluidStorybook"> https://github.com/microsoft/FluidStorybook </a>
+</p>
 
 {{ block "footer" . -}}{{ end }}
 {{- partial "analytics.html" . }}

--- a/docs/layouts/page/playground.html
+++ b/docs/layouts/page/playground.html
@@ -1,12 +1,32 @@
 {{ define "header" }}
 {{ partial "header.html" . }}
+
 {{ end }}
 
+
 {{ define "main" }}
+<style>
+    /* move scroll into playground area */
+    html {
+        overflow-y: hidden;
+    }
+
+    /* body is overflow hidden, so it needs to fill the entire screen height */
+    body {
+        height: 100vh;
+    }
+
+    /* #root comes from storybook, and the first div child has 100vh height, which does not work in playground
+    due to the 50px header and 90px footer (50 + 90 = 140) */
+    #root>div {
+        height: calc(100vh - 140px);
+    }
+</style>
 {{ partial "navbarSticky.html" . }}
 
 <h2>This body is replaced when Storybook is injected during the build process.</h2>
-<p>To learn more about the Fluid & Storybook, you can go to <a href="https://github.com/microsoft/FluidStorybook">https://github.com/microsoft/FluidStorybook</a></p>
+<p>To learn more about the Fluid & Storybook, you can go to <a
+        href="https://github.com/microsoft/FluidStorybook">https://github.com/microsoft/FluidStorybook</a></p>
 
 {{ block "footer" . -}}{{ end }}
 {{- partial "analytics.html" . }}

--- a/docs/layouts/page/playground.html
+++ b/docs/layouts/page/playground.html
@@ -1,6 +1,5 @@
 {{ define "header" }}
 {{ partial "header.html" . }}
-
 {{ end }}
 
 

--- a/docs/layouts/page/playground.html
+++ b/docs/layouts/page/playground.html
@@ -2,7 +2,6 @@
 {{ partial "header.html" . }}
 {{ end }}
 
-
 {{ define "main" }}
 <style>
     /* move scroll into playground area */


### PR DESCRIPTION
fixes #3589

Page layout for playground needs to be a bit different. All scrolling should be done inside of the storybook embed and the embed needs to be 140px shorter than the window height due to header and footer


![image](https://user-images.githubusercontent.com/1434956/92771075-6e7eef80-f34f-11ea-95c0-20a9a5ec1f09.png)


works full screen too

![image](https://user-images.githubusercontent.com/1434956/92771148-7e96cf00-f34f-11ea-8f6b-a4c3a1fb9b5e.png)

sidebar properly scrolls as well

![image](https://user-images.githubusercontent.com/1434956/92771218-8ce4eb00-f34f-11ea-9009-f7ffc0ad0309.png)

Docs and source tabs look good as well

![image](https://user-images.githubusercontent.com/1434956/92772011-33c98700-f350-11ea-9603-9d0a8e871f6d.png)

![image](https://user-images.githubusercontent.com/1434956/92772070-417f0c80-f350-11ea-87a1-f130ab3a5ce7.png)

