### PR TITLE
Change deprecated_innerRequestHandler to use runtimebase

### DIFF
--- a/packages/dds/cell/src/packageVersion.ts
+++ b/packages/dds/cell/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/cell";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/dds/counter/src/packageVersion.ts
+++ b/packages/dds/counter/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/counter";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/dds/ink/src/packageVersion.ts
+++ b/packages/dds/ink/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/ink";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/dds/map/src/packageVersion.ts
+++ b/packages/dds/map/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/map";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/dds/matrix/src/packageVersion.ts
+++ b/packages/dds/matrix/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/matrix";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/dds/ordered-collection/src/packageVersion.ts
+++ b/packages/dds/ordered-collection/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/ordered-collection";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/dds/register-collection/src/packageVersion.ts
+++ b/packages/dds/register-collection/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/register-collection";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/dds/sequence/src/packageVersion.ts
+++ b/packages/dds/sequence/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/sequence";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/dds/shared-object-base/src/packageVersion.ts
+++ b/packages/dds/shared-object-base/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/shared-object-base";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/dds/shared-summary-block/src/packageVersion.ts
+++ b/packages/dds/shared-summary-block/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/shared-summary-block";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/drivers/driver-base/src/packageVersion.ts
+++ b/packages/drivers/driver-base/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/driver-base";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/drivers/file-driver/src/packageVersion.ts
+++ b/packages/drivers/file-driver/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/file-driver";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/drivers/fluidapp-odsp-urlResolver/src/packageVersion.ts
+++ b/packages/drivers/fluidapp-odsp-urlResolver/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/fluidapp-odsp-urlresolver";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/drivers/iframe-driver/src/packageVersion.ts
+++ b/packages/drivers/iframe-driver/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/iframe-driver";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/drivers/local-driver/src/packageVersion.ts
+++ b/packages/drivers/local-driver/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/local-driver";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/drivers/odsp-driver/src/packageVersion.ts
+++ b/packages/drivers/odsp-driver/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/odsp-driver";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/drivers/odsp-urlResolver/src/packageVersion.ts
+++ b/packages/drivers/odsp-urlResolver/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/odsp-urlresolver";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/drivers/replay-driver/src/packageVersion.ts
+++ b/packages/drivers/replay-driver/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/replay-driver";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/drivers/routerlicious-driver/src/packageVersion.ts
+++ b/packages/drivers/routerlicious-driver/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/routerlicious-driver";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/drivers/routerlicious-host/src/packageVersion.ts
+++ b/packages/drivers/routerlicious-host/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/routerlicious-host";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/drivers/routerlicious-urlResolver/src/packageVersion.ts
+++ b/packages/drivers/routerlicious-urlResolver/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/routerlicious-urlresolver";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/framework/dds-interceptions/src/packageVersion.ts
+++ b/packages/framework/dds-interceptions/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/dds-interceptions";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/framework/last-edited-experimental/src/packageVersion.ts
+++ b/packages/framework/last-edited-experimental/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/last-edited-experimental";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/framework/request-handler/src/packageVersion.ts
+++ b/packages/framework/request-handler/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/request-handler";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/framework/request-handler/src/requestHandlers.ts
+++ b/packages/framework/request-handler/src/requestHandlers.ts
@@ -34,7 +34,7 @@ export type RuntimeRequestHandler = (request: RequestParser, runtime: IContainer
  * handling of external URI to internal handle is required (in future, we will support weak handle references,
  * that will allow any GC policy to be implemented by container authors.)
  */
-export const deprecated_innerRequestHandler = async (request: IRequest, runtime: IContainerRuntime) =>
+export const deprecated_innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
     runtime.IFluidHandleContext.resolveHandle(request);
 
 export const createFluidObjectResponse = (fluidObject: IFluidObject) => {

--- a/packages/framework/undo-redo/src/packageVersion.ts
+++ b/packages/framework/undo-redo/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/undo-redo";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/loader/container-loader/src/packageVersion.ts
+++ b/packages/loader/container-loader/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/container-loader";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/loader/container-utils/src/packageVersion.ts
+++ b/packages/loader/container-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/container-utils";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/loader/driver-utils/src/packageVersion.ts
+++ b/packages/loader/driver-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/driver-utils";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/loader/execution-context-loader/src/packageVersion.ts
+++ b/packages/loader/execution-context-loader/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/execution-context-loader";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/runtime/container-runtime/src/packageVersion.ts
+++ b/packages/runtime/container-runtime/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/container-runtime";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/runtime/datastore/src/packageVersion.ts
+++ b/packages/runtime/datastore/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/datastore";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/runtime/runtime-utils/src/packageVersion.ts
+++ b/packages/runtime/runtime-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/runtime-utils";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/test/end-to-end-tests/src/packageVersion.ts
+++ b/packages/test/end-to-end-tests/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-internal/end-to-end-tests";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/test/functional-tests/src/packageVersion.ts
+++ b/packages/test/functional-tests/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-internal/functional-tests";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/test/mocha-test-setup/src/packageVersion.ts
+++ b/packages/test/mocha-test-setup/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/mocha-test-setup";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/test/service-load-test/src/packageVersion.ts
+++ b/packages/test/service-load-test/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-internal/service-load-test";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/test/test-utils/src/packageVersion.ts
+++ b/packages/test/test-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/test-utils";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";

--- a/packages/utils/telemetry-utils/src/packageVersion.ts
+++ b/packages/utils/telemetry-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/telemetry-utils";
-export const pkgVersion = "0.25.1";
+export const pkgVersion = "0.25.2";


### PR DESCRIPTION
Bohemia has a dependency on requests on IContainerRuntimeBase, but the current workaround uses the IContainerRuntime interface.  Change this to _Base to ease that transition into the new request model.