### PR TITLE
Replace private registry URLs in lockfiles

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2716,7 +2716,7 @@
 			"dependencies": {
 				"@microsoft/api-extractor-model": {
 					"version": "7.8.18",
-					"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/api-extractor-model/-/api-extractor-model-7.8.18.tgz",
+					"resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.8.18.tgz",
 					"integrity": "sha1-FaClMha5IaQjiKsp3e4+szwtmZU=",
 					"dev": true,
 					"requires": {
@@ -2817,7 +2817,7 @@
 		},
 		"@microsoft/api-extractor": {
 			"version": "7.8.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/api-extractor/-/api-extractor-7.8.0.tgz",
+			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.8.0.tgz",
 			"integrity": "sha1-/qaOTyHBvxgCBWD9VyixX+RPCXY=",
 			"dev": true,
 			"requires": {
@@ -2834,7 +2834,7 @@
 		},
 		"@microsoft/api-extractor-model": {
 			"version": "7.8.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/api-extractor-model/-/api-extractor-model-7.8.0.tgz",
+			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.8.0.tgz",
 			"integrity": "sha1-X1MpmPARCfI9V7QigDu99a1lXYA=",
 			"dev": true,
 			"requires": {
@@ -2849,7 +2849,7 @@
 		},
 		"@microsoft/tsdoc": {
 			"version": "0.12.19",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/tsdoc/-/tsdoc-0.12.19.tgz",
+			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.19.tgz",
 			"integrity": "sha1-IXPMuSRpqvYgMfqUmdIbFtB/m1c=",
 			"dev": true
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1638,7 +1638,7 @@
       "dependencies": {
         "@microsoft/api-extractor-model": {
           "version": "7.8.18",
-          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/api-extractor-model/-/api-extractor-model-7.8.18.tgz",
+          "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.8.18.tgz",
           "integrity": "sha1-FaClMha5IaQjiKsp3e4+szwtmZU=",
           "dev": true,
           "requires": {
@@ -1739,7 +1739,7 @@
     },
     "@microsoft/api-extractor": {
       "version": "7.8.0",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/api-extractor/-/api-extractor-7.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.8.0.tgz",
       "integrity": "sha1-/qaOTyHBvxgCBWD9VyixX+RPCXY=",
       "dev": true,
       "requires": {
@@ -1756,7 +1756,7 @@
     },
     "@microsoft/api-extractor-model": {
       "version": "7.8.0",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/api-extractor-model/-/api-extractor-model-7.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.8.0.tgz",
       "integrity": "sha1-X1MpmPARCfI9V7QigDu99a1lXYA=",
       "dev": true,
       "requires": {
@@ -1766,7 +1766,7 @@
     },
     "@microsoft/tsdoc": {
       "version": "0.12.19",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/tsdoc/-/tsdoc-0.12.19.tgz",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.19.tgz",
       "integrity": "sha1-IXPMuSRpqvYgMfqUmdIbFtB/m1c=",
       "dev": true
     },

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -1767,7 +1767,7 @@
 		},
 		"@microsoft/api-documenter": {
 			"version": "7.8.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/api-documenter/-/api-documenter-7.8.0.tgz",
+			"resolved": "https://registry.npmjs.org/@microsoft/api-documenter/-/api-documenter-7.8.0.tgz",
 			"integrity": "sha1-koFjKetChr8oS5LjG8vtBbi9UZU=",
 			"dev": true,
 			"requires": {
@@ -1782,7 +1782,7 @@
 		},
 		"@microsoft/api-extractor": {
 			"version": "7.8.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/api-extractor/-/api-extractor-7.8.0.tgz",
+			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.8.0.tgz",
 			"integrity": "sha1-/qaOTyHBvxgCBWD9VyixX+RPCXY=",
 			"dev": true,
 			"requires": {
@@ -1807,7 +1807,7 @@
 		},
 		"@microsoft/api-extractor-model": {
 			"version": "7.8.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/api-extractor-model/-/api-extractor-model-7.8.0.tgz",
+			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.8.0.tgz",
 			"integrity": "sha1-X1MpmPARCfI9V7QigDu99a1lXYA=",
 			"dev": true,
 			"requires": {
@@ -1817,7 +1817,7 @@
 		},
 		"@microsoft/tsdoc": {
 			"version": "0.12.19",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/tsdoc/-/tsdoc-0.12.19.tgz",
+			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.19.tgz",
 			"integrity": "sha1-IXPMuSRpqvYgMfqUmdIbFtB/m1c=",
 			"dev": true
 		},

--- a/server/routerlicious/package-lock.json
+++ b/server/routerlicious/package-lock.json
@@ -1638,7 +1638,7 @@
     },
     "@microsoft/api-documenter": {
       "version": "7.8.0",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/api-documenter/-/api-documenter-7.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-documenter/-/api-documenter-7.8.0.tgz",
       "integrity": "sha1-koFjKetChr8oS5LjG8vtBbi9UZU=",
       "dev": true,
       "requires": {
@@ -1653,7 +1653,7 @@
     },
     "@microsoft/api-extractor": {
       "version": "7.8.0",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/api-extractor/-/api-extractor-7.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.8.0.tgz",
       "integrity": "sha1-/qaOTyHBvxgCBWD9VyixX+RPCXY=",
       "dev": true,
       "requires": {
@@ -1678,7 +1678,7 @@
     },
     "@microsoft/api-extractor-model": {
       "version": "7.8.0",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/api-extractor-model/-/api-extractor-model-7.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.8.0.tgz",
       "integrity": "sha1-X1MpmPARCfI9V7QigDu99a1lXYA=",
       "dev": true,
       "requires": {
@@ -1688,7 +1688,7 @@
     },
     "@microsoft/tsdoc": {
       "version": "0.12.19",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/tsdoc/-/tsdoc-0.12.19.tgz",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.19.tgz",
       "integrity": "sha1-IXPMuSRpqvYgMfqUmdIbFtB/m1c=",
       "dev": true
     },


### PR DESCRIPTION
Lockfiles should not point to private registries, because that prevents people without access from using the packages properly. This PR corrects the lockfiles that are not correct. A separate PR will add policy-check support to prevent these from getting checked in in the future.