### PR TITLE
Dev Container: Access docker as non-root user

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,6 @@
 #-------------------------------------------------------------------------------------------------------------
 
 ARG NODE_VERSION=12
-ARG USERNAME=node
 
 # 'node:${VARIANT}' base image includes the following:
 #
@@ -17,33 +16,22 @@ ARG USERNAME=node
 # (See https://github.com/microsoft/vscode-dev-containers/tree/master/containers/javascript-node/.devcontainer)
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${NODE_VERSION}
 
-# Avoid warnings by switching to noninteractive
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Configure apt and install packages
-RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
-
-    # Install additional desired packages here
-    && apt-get install -y \
-        vim \
-
-    # Install Docker CLI / Docker-Compose and create 'docker-init.sh' to proxy docker socket.
-    # (We retrieve the install script from the 'docker-from-docker' dev container template)
-    && mkdir /tmp/library-scripts \
+# Install Docker CLI / Docker-Compose and create '/usr/local/share/docker-init.sh' to proxy the
+# docker socket.  (We retrieve the script from the 'docker-from-docker' dev container template)
+RUN mkdir /tmp/library-scripts \
     && curl -o /tmp/library-scripts/docker-debian.sh -sS https://raw.githubusercontent.com/microsoft/vscode-dev-containers/c3214ad7fcf5086e898e3941a36e0171959a48ca/containers/azure-ansible/.devcontainer/library-scripts/docker-debian.sh \
-    && /bin/bash /tmp/library-scripts/docker-debian.sh "${ENABLE_NONROOT_DOCKER}" "${SOURCE_SOCKET}" "${TARGET_SOCKET}" "${USERNAME}" \
+    && /bin/bash /tmp/library-scripts/docker-debian.sh "${ENABLE_NONROOT_DOCKER}" "${SOURCE_SOCKET}" "${TARGET_SOCKET}" "node" \
+    && rm -rf /tmp/library-scripts/
 
-    # Clean up
-    && apt-get autoremove -y \
+# Install additional desired packages here
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+        vim
+
+# Clean up
+RUN apt-get autoremove -y \
     && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/* /tmp/library-scripts/
-
-# terminal colors with xterm
-ENV TERM xterm
-
-# Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+    && rm -rf /var/lib/apt/lists/*
 
 USER node
 
@@ -53,9 +41,3 @@ RUN git clone https://github.com/zsh-users/zsh-syntax-highlighting ${ZSH_CUSTOM:
 
 # Copy our custom .zshrc to user's home directory
 COPY .zshrc /home/node/.zshrc
-
-# Setting the ENTRYPOINT to docker-init.sh will configure non-root access to
-# the Docker socket if "overrideCommand": false is set in devcontainer.json.
-# The script will also execute CMD if you need to alter startup behaviors.
-ENTRYPOINT [ "/usr/local/share/docker-init.sh" ]
-CMD [ "sleep", "infinity" ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,13 @@
 		"args": { "NODE_VERSION": "12" }
 	},
 
+    // Invoke 'nvm' to install our preferred version of node, per the '.nvmrc' file
+    // at the root of the ${workspaceFolder}.
+    "postCreateCommand": ". /usr/local/share/nvm/nvm.sh; nvm install",
+
+    // Expose 'docker.sock' to the dev container and proxy access for the 'node' user.
 	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind" ],
+	"postStartCommand": "/usr/local/share/docker-init.sh",
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { "terminal.integrated.shell.linux": "/usr/bin/zsh" },
@@ -16,12 +22,10 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
         "dbaeumer.vscode-eslint",
+        "ms-azuretools.vscode-docker",
         "editorconfig.editorconfig"
-    ],
+	],
 
     // Forward port for Tinylicious
     "forwardPorts": [ 3000 ]
-
-    // Required to provide non-root user w/access to docker (see Dockerfile)
-    // "overrideCommand": false,
 }


### PR DESCRIPTION
A few minor improvements:
* Proxies 'docker.sock' so that the default 'node' user can run docker commands w/o sudo
* Invokes 'nvm install' after the container is created to install our preferred node version (specified in .nvmrc)
* Some minor tidying of the Dockerfile