### PR TITLE
Change fetch tool to handle sharepoint urls with drive id and item id in query params

### DIFF
--- a/packages/tools/fetch-tool/src/fluidFetch.ts
+++ b/packages/tools/fetch-tool/src/fluidFetch.ts
@@ -33,10 +33,8 @@ async function fluidFetchOneFile(urlStr: string, name?: string) {
 
 async function tryFluidFetchOneSharePointFile(server: string, driveItem: IOdspDriveItem) {
     const { path, name, drive, item } = driveItem;
-    if (name.endsWith(".b") || name.endsWith(".fluid")) {
-        console.log(`File: ${path}/${name}`);
-        await fluidFetchOneFile(`https://${server}/_api/v2.1/drives/${drive}/items/${item}`, name);
-    }
+    console.log(`File: ${path}/${name}`);
+    await fluidFetchOneFile(`https://${server}/_api/v2.1/drives/${drive}/items/${item}`, name);
 }
 
 function getSharePointSpecificDriveItem(url: URL): { drive: string; item: string } | undefined {
@@ -89,7 +87,9 @@ async function fluidFetchMain() {
         if (serverRelativePath) {
             const files = await getSharepointFiles(server, serverRelativePath, false);
             for (const file of files) {
-                await tryFluidFetchOneSharePointFile(server, file);
+                if (file.name.endsWith(".b") || file.name.endsWith(".fluid")) {
+                    await tryFluidFetchOneSharePointFile(server, file);
+                }
             }
             return;
         }

--- a/packages/tools/fetch-tool/src/fluidFetch.ts
+++ b/packages/tools/fetch-tool/src/fluidFetch.ts
@@ -5,11 +5,11 @@
 
 import fs from "fs";
 import util from "util";
-import { isSharepointURL } from "@fluidframework/odsp-utils";
+import { isSharepointURL, IOdspDriveItem } from "@fluidframework/odsp-utils";
 import { paramSaveDir, paramURL, parseArguments } from "./fluidFetchArgs";
 import { connectionInfo, fluidFetchInit } from "./fluidFetchInit";
 import { fluidFetchMessages } from "./fluidFetchMessages";
-import { getSharepointFiles } from "./fluidFetchSharePoint";
+import { getSharepointFiles, getSingleSharePointFile } from "./fluidFetchSharePoint";
 import { fluidFetchSnapshot } from "./fluidFetchSnapshot";
 
 async function fluidFetchOneFile(urlStr: string, name?: string) {
@@ -29,6 +29,23 @@ async function fluidFetchOneFile(urlStr: string, name?: string) {
 
     await fluidFetchMessages(documentService, saveDir);
     await fluidFetchSnapshot(documentService, saveDir);
+}
+
+async function tryFluidFetchOneSharePointFile(server: string, driveItem: IOdspDriveItem) {
+    const { path, name, drive, item } = driveItem;
+    if (name.endsWith(".b") || name.endsWith(".fluid")) {
+        console.log(`File: ${path}/${name}`);
+        await fluidFetchOneFile(`https://${server}/_api/v2.1/drives/${drive}/items/${item}`, name);
+    }
+}
+
+function getSharePointSpecificDriveItem(url: URL): { drive: string; item: string } | undefined {
+    if (url.searchParams.has("driveId") && url.searchParams.has("itemId")) {
+        return {
+            drive: url.searchParams.get("driveId") as string,
+            item: url.searchParams.get("itemId") as string,
+        };
+    }
 }
 
 function getSharepointServerRelativePathFromURL(url: URL) {
@@ -59,15 +76,20 @@ async function fluidFetchMain() {
     const url = new URL(paramURL);
     const server = url.hostname;
     if (isSharepointURL(server)) {
+        // See if the url already has the specific item
+        const driveItem = getSharePointSpecificDriveItem(url);
+        if (driveItem) {
+            const file = await getSingleSharePointFile(server, driveItem.drive, driveItem.item);
+            await tryFluidFetchOneSharePointFile(server, file);
+            return;
+        }
+
         // See if the url given represent a sharepoint directory
         const serverRelativePath = getSharepointServerRelativePathFromURL(url);
         if (serverRelativePath) {
             const files = await getSharepointFiles(server, serverRelativePath, false);
-            for (const { path, name, drive, item } of files) {
-                if (name.endsWith(".b") || name.endsWith(".fluid")) {
-                    console.log(`File: ${path}/${name}`);
-                    await fluidFetchOneFile(`https://${server}/_api/v2.1/drives/${drive}/items/${item}`, name);
-                }
+            for (const file of files) {
+                await tryFluidFetchOneSharePointFile(server, file);
             }
             return;
         }

--- a/packages/tools/fetch-tool/src/fluidFetchSharePoint.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchSharePoint.ts
@@ -6,6 +6,7 @@
 import {
     getChildrenByDriveItem,
     getDriveItemByServerRelativePath,
+    getDriveItemFromDriveAndItem,
     IClientConfig,
     IOdspDriveItem,
     getOdspRefreshTokenFn,
@@ -119,4 +120,19 @@ export async function getSharepointFiles(server: string, serverRelativePath: str
         }
     }
     return files;
+}
+
+export async function getSingleSharePointFile(
+    server: string,
+    drive: string,
+    item: string,
+) {
+    const clientConfig = getMicrosoftConfiguration();
+
+    return resolveWrapper<IOdspDriveItem>(
+        // eslint-disable-next-line @typescript-eslint/promise-function-async
+        (authRequestInfo) => getDriveItemFromDriveAndItem(server, drive, item, authRequestInfo),
+        server,
+        clientConfig,
+    );
 }

--- a/packages/utils/odsp-utils/src/odspDrives.ts
+++ b/packages/utils/odsp-utils/src/odspDrives.ts
@@ -99,6 +99,16 @@ export async function getDriveItemByServerRelativePath(
     return getDriveItem(getDriveItemUrl, authRequestInfo, create);
 }
 
+export async function getDriveItemFromDriveAndItem(
+    server: string,
+    drive: string,
+    item: string,
+    authRequestInfo: IOdspAuthRequestInfo,
+): Promise<IOdspDriveItem> {
+    const url = `https://${server}/_api/v2.1/drives/${drive}/items/${item}`;
+    return getDriveItem(url, authRequestInfo, false);
+}
+
 export async function getChildrenByDriveItem(
     driveItem: IOdspDriveItem,
     server: string,


### PR DESCRIPTION
Change fetch tool to handle SharePoint URLs with drive and item IDs as query parameters.

This is the same structure as the URLs that are generated from service-load-test files. After this change, it should be possible to directly paste the URL from the console to fetch tool.