### PR TITLE
Track additional clientIds from previous connections

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1423,7 +1423,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 messageClientId: message.clientId,
                 historyIndex: this.clientIdHistory.indexOf(message.clientId),
                 sequenceNumber: message.sequenceNumber,
-                clientSequenceNumber: this._deltaManager.lastSequenceNumber,
+                clientSequenceNumber: message.clientSequenceNumber,
             });
         }
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1451,7 +1451,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         } else {
             const local = this.clientIdHistory.includes(message.clientId);
             if (local && this._clientId !== message.clientId) {
-                this.logger.sendErrorEvent({ eventName: "matchedOldClientIdInSignal"})
+                this.logger.sendErrorEvent({ eventName: "matchedOldClientIdInSignal" });
             }
             this.context!.processSignal(message, local);
         }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -237,7 +237,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
      * this change
      */
     private readonly clientIdHistory: string[] = [];
-    private readonly maxClientIdHistory = 5;
+    private readonly maxClientIdHistory = 100;
     private _id: string | undefined;
     private originalRequest: IRequest | undefined;
     private readonly _deltaManager: DeltaManager;
@@ -1422,6 +1422,8 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 clientId: this._clientId,
                 messageClientId: message.clientId,
                 historyIndex: this.clientIdHistory.indexOf(message.clientId),
+                sequenceNumber: message.sequenceNumber,
+                clientSequenceNumber: this._deltaManager.lastSequenceNumber,
             });
         }
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -172,8 +172,8 @@ export class DeltaManager
     private closed = false;
 
     // track clientId used last time when we sent any ops
-    private readonly lastSubmittedClientIds: string[] = [];
-    private readonly maxSavedClientIds = 5;
+    private lastSubmittedClientIds: string[] = [];
+    private maxSavedClientIds = 5;
 
     private handler: IDeltaHandlerStrategy | undefined;
     private deltaStorageP: Promise<IDocumentDeltaStorageService> | undefined;
@@ -1194,12 +1194,7 @@ export class DeltaManager
         assert(!this.connection || this.connection.details.clientId !== message.clientId ||
             this.lastSubmittedClientIds.includes(message.clientId), "Not accounting local messages correctly");
 
-        const foundIndex = this.lastSubmittedClientIds.indexOf(message.clientId);
-        if (foundIndex >= 0) {
-            // Report if we're getting messages from a clientId older than the most recent
-            if (foundIndex !== this.lastSubmittedClientIds.length - 1) {
-                this.logger.sendTelemetryEvent({ eventName: "matchedNonPreviousClientId" });
-            }
+        if (this.lastSubmittedClientIds.includes(message.clientId)) {
             const clientSequenceNumber = message.clientSequenceNumber;
 
             assert(this.clientSequenceNumberObserved < clientSequenceNumber, "client seq# not growing");

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -172,8 +172,7 @@ export class DeltaManager
     private closed = false;
 
     // track clientId used last time when we sent any ops
-    private lastSubmittedClientIds: string[] = [];
-    private maxSavedClientIds = 5;
+    private lastSubmittedClientId: string | undefined;
 
     private handler: IDeltaHandlerStrategy | undefined;
     private deltaStorageP: Promise<IDocumentDeltaStorageService> | undefined;
@@ -589,11 +588,8 @@ export class DeltaManager
         // we keep info about old connection as long as possible to be able to account for all non-acked ops
         // that we pick up on next connection.
         assert(this.connection);
-        if (!this.lastSubmittedClientIds.includes(this.connection.details.clientId)) {
-            this.lastSubmittedClientIds.push(this.connection.details.clientId);
-            if (this.lastSubmittedClientIds.length > this.maxSavedClientIds) {
-                this.lastSubmittedClientIds.shift();
-            }
+        if (this.lastSubmittedClientId !== this.connection?.details.clientId) {
+            this.lastSubmittedClientId = this.connection?.details.clientId;
             this.clientSequenceNumber = 0;
             this.clientSequenceNumberObserved = 0;
         }
@@ -885,8 +881,6 @@ export class DeltaManager
      * @param connection - The newly established connection
      */
     private setupNewSuccessfulConnection(connection: DeltaConnection, requestedMode: ConnectionMode) {
-        // Old connection should have been cleaned up before establishing a new one
-        assert(this.connection === undefined);
         this.connection = connection;
 
         // Does information in scopes & mode matches?
@@ -1192,9 +1186,9 @@ export class DeltaManager
 
         // if we have connection, and message is local, then we better treat is as local!
         assert(!this.connection || this.connection.details.clientId !== message.clientId ||
-            this.lastSubmittedClientIds.includes(message.clientId), "Not accounting local messages correctly");
+            this.lastSubmittedClientId === message.clientId, "Not accounting local messages correctly");
 
-        if (this.lastSubmittedClientIds.includes(message.clientId)) {
+        if (this.lastSubmittedClientId !== undefined && this.lastSubmittedClientId === message.clientId) {
             const clientSequenceNumber = message.clientSequenceNumber;
 
             assert(this.clientSequenceNumberObserved < clientSequenceNumber, "client seq# not growing");

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -882,7 +882,7 @@ export class DeltaManager
      */
     private setupNewSuccessfulConnection(connection: DeltaConnection, requestedMode: ConnectionMode) {
         // Old connection should have been cleaned up before establishing a new one
-        assert(this.connection === undefined);
+        assert(this.connection === undefined, "old connection exists on new connection setup");
         this.connection = connection;
 
         // Does information in scopes & mode matches?

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -881,6 +881,8 @@ export class DeltaManager
      * @param connection - The newly established connection
      */
     private setupNewSuccessfulConnection(connection: DeltaConnection, requestedMode: ConnectionMode) {
+        // Old connection should have been cleaned up before establishing a new one
+        assert(this.connection === undefined);
         this.connection = connection;
 
         // Does information in scopes & mode matches?


### PR DESCRIPTION
Fixes #3605
The suspicion is there is a timing issue around reconnects where we end up with multiple connections with pending ops that can be linked back to the original connection, but not each other resulting in multiple submissions of the same ops. We haven't identified where exactly that is in the code, so we want to add additional telemetry and additional clientId handling to allow us to tell that both connections in this case are the same client.

Keep track of the previous ~~5~~ 💯 clientIds in the delta manager instead of just the last one.