### PR TITLE
[->main] Use IContainerRuntimeBase for deprecated_innterRequestHandler

### DIFF
--- a/packages/framework/request-handler/src/requestHandlers.ts
+++ b/packages/framework/request-handler/src/requestHandlers.ts
@@ -34,7 +34,7 @@ export type RuntimeRequestHandler = (request: RequestParser, runtime: IContainer
  * handling of external URI to internal handle is required (in future, we will support weak handle references,
  * that will allow any GC policy to be implemented by container authors.)
  */
-export const deprecated_innerRequestHandler = async (request: IRequest, runtime: IContainerRuntime) =>
+export const deprecated_innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
     runtime.IFluidHandleContext.resolveHandle(request);
 
 export const createFluidObjectResponse = (fluidObject: IFluidObject) => {


### PR DESCRIPTION
Bringing the change to main.  It's already been made in 0.25 and 0.26 (though not yet released in patches)