### PR TITLE
Fix dds link

### DIFF
--- a/docs/content/docs/concepts/dataobject-aqueduct.md
+++ b/docs/content/docs/concepts/dataobject-aqueduct.md
@@ -100,7 +100,7 @@ SharedDirectory.
 
 {{% callout important "See also" %}}
 
-- [Creating and storing distributed data structures](./dds.md#creating-and-storing-distributed-data-structures)
+- [Creating and storing distributed data structures](../dds/#creating-and-storing-distributed-data-structures)
 
 {{% /callout %}}
 


### PR DESCRIPTION
Fixes link to DDS from data objects

.md doesn't seem to work here because hugo doesn't add a trailing slash e.g. http://localhost:1313/docs/concepts/dds.md#creating-and-storing-distributed-data-structures