### PR TITLE
Service load log

### DIFF
--- a/packages/test/service-load-test/README.md
+++ b/packages/test/service-load-test/README.md
@@ -57,3 +57,9 @@ If present, launch in Test Runner mode with the given runId (to distinguish from
 #### --debug, -d
 
 Launches each test runner with `--inspect-brk` and a unique Node debugging port. (Not compatible with `--runId`)
+
+#### --log, -l
+
+Overrides DEBUG environment variable for telemetry logging to console. If DEBUG env variable is unset and this is not provided, only errors will print. The value passed here should be a filter string for the logger namespace.
+
+>To print all messages, provide `--log '*'` or `--log 'fluid:*'`. For example, to filter to only Container logs, provide something like: `-l 'fluid:telemetry:Container:*'`.

--- a/packages/test/service-load-test/package.json
+++ b/packages/test/service-load-test/package.json
@@ -52,7 +52,6 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.27.0",
-    "@fluidframework/common-utils": "^0.24.0-0",
     "@fluidframework/container-definitions": "^0.27.0",
     "@fluidframework/container-loader": "^0.27.0",
     "@fluidframework/odsp-driver": "^0.27.0",

--- a/packages/test/service-load-test/package.json
+++ b/packages/test/service-load-test/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.27.0",
+    "@fluidframework/common-utils": "^0.24.0-0",
     "@fluidframework/container-definitions": "^0.27.0",
     "@fluidframework/container-loader": "^0.27.0",
     "@fluidframework/odsp-driver": "^0.27.0",

--- a/packages/test/service-load-test/src/nodeStressTest.ts
+++ b/packages/test/service-load-test/src/nodeStressTest.ts
@@ -16,7 +16,6 @@ import {
     getMicrosoftConfiguration,
     OdspTokenConfig,
 } from "@fluidframework/tool-utils";
-import { BaseTelemetryNullLogger } from "@fluidframework/common-utils";
 import { pkgName, pkgVersion } from "./packageVersion";
 import { ITestConfig, IRunConfig, fluidExport, ILoadTest } from "./loadTestDataStore";
 
@@ -77,7 +76,6 @@ function createLoader(config: IConfig, password: string) {
         {},
         {},
         new Map<string, IProxyLoaderFactory>(),
-        new BaseTelemetryNullLogger(),
     );
     return loader;
 }

--- a/packages/test/service-load-test/src/nodeStressTest.ts
+++ b/packages/test/service-load-test/src/nodeStressTest.ts
@@ -10,15 +10,16 @@ import { IProxyLoaderFactory, IFluidCodeDetails } from "@fluidframework/containe
 import { Loader } from "@fluidframework/container-loader";
 import { OdspDocumentServiceFactory, OdspDriverUrlResolver } from "@fluidframework/odsp-driver";
 import { LocalCodeLoader } from "@fluidframework/test-utils";
-
 import {
     OdspTokenManager,
     odspTokensCache,
     getMicrosoftConfiguration,
     OdspTokenConfig,
 } from "@fluidframework/tool-utils";
+import { BaseTelemetryNullLogger } from "@fluidframework/common-utils";
 import { pkgName, pkgVersion } from "./packageVersion";
 import { ITestConfig, IRunConfig, fluidExport, ILoadTest } from "./loadTestDataStore";
+
 const packageName = `${pkgName}@${pkgVersion}`;
 
 interface ITestConfigs {
@@ -76,6 +77,7 @@ function createLoader(config: IConfig, password: string) {
         {},
         {},
         new Map<string, IProxyLoaderFactory>(),
+        new BaseTelemetryNullLogger(),
     );
     return loader;
 }
@@ -121,6 +123,7 @@ async function main() {
         .option("-u, --url <url>", "Load an existing data store rather than creating new")
         .option("-r, --runId <runId>", "run a child process with the given id. Requires --url option.")
         .option("-d, --debug", "Debug child processes via --inspect-brk")
+        .option("-l, --log <filter>", "Filter debug logging. If not provided, uses DEBUG env variable.")
         .parse(process.argv);
 
     const password: string = commander.password;
@@ -128,6 +131,11 @@ async function main() {
     let url: string | undefined = commander.url;
     const runId: number | undefined = commander.runId === undefined ? undefined : parseInt(commander.runId, 10);
     const debug: true | undefined = commander.debug;
+    const log: string | undefined = commander.log;
+
+    if (log !== undefined) {
+        process.env.DEBUG = log;
+    }
 
     if (config.profiles[profile] === undefined) {
         console.error("Invalid --profile argument not found in testConfig.json profiles");


### PR DESCRIPTION
Add `--log` option to service-load-test command line utility to override DEBUG env variable. This controls the telemetry logged during execution. If undefined, it will only send errors.