### PR TITLE
[0.25->0.26] Port telemetry changes for tracking clientIds from previous connections

### DIFF
--- a/packages/framework/request-handler/src/requestHandlers.ts
+++ b/packages/framework/request-handler/src/requestHandlers.ts
@@ -34,7 +34,7 @@ export type RuntimeRequestHandler = (request: RequestParser, runtime: IContainer
  * handling of external URI to internal handle is required (in future, we will support weak handle references,
  * that will allow any GC policy to be implemented by container authors.)
  */
-export const deprecated_innerRequestHandler = async (request: IRequest, runtime: IContainerRuntime) =>
+export const deprecated_innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
     runtime.IFluidHandleContext.resolveHandle(request);
 
 export const createFluidObjectResponse = (fluidObject: IFluidObject) => {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1397,9 +1397,8 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         if (value === ConnectionState.Connected) {
             this._clientId = this.pendingClientId;
-            if (this._clientId !== undefined) {
-                this.clientIdHistory.push(this._clientId);
-            }
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            this.clientIdHistory.push(this._clientId!);
             if (this.clientIdHistory.length > this.maxClientIdHistory) {
                 this.clientIdHistory.shift();
             }

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -891,6 +891,8 @@ export class DeltaManager
      * @param connection - The newly established connection
      */
     private setupNewSuccessfulConnection(connection: DeltaConnection, requestedMode: ConnectionMode) {
+        // Old connection should have been cleaned up before establishing a new one
+        assert(this.connection === undefined, "old connection exists on new connection setup");
         this.connection = connection;
 
         // Does information in scopes & mode matches?


### PR DESCRIPTION
Bringing changes originally made in #3613 to 0.26 branch for patch release.
#3605