### PR TITLE
Bump policy-check version in client and server

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -752,9 +752,9 @@
 			"integrity": "sha512-1pYGzO4NRlaMz+REq+YtzY8gmckZ9aCSzf0FpYsinEfSLOjPYRvgIvN6z4i4WDn5jocD3y8YH4RTSyVBgTtTtQ=="
 		},
 		"@fluidframework/build-tools": {
-			"version": "0.2.3049",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.3049.tgz",
-			"integrity": "sha512-X+m4U9Hb730TxoaaZ9Qqf1z6qo09FlDI69aLNITFJA+E9YWQmx9JhfbwWzkLD86FEhA8g+nYcw6wWCtmz4vPiQ==",
+			"version": "0.2.4847",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.4847.tgz",
+			"integrity": "sha512-5cN1RqjSHG1xSsjRswuVAGKN1d4TzBXDeuQp46RlnZv154GneleLsh0kbdhwsr2AwU/+M2DMs7yEeVCTaUWeAA==",
 			"dev": true,
 			"requires": {
 				"async": "^2.6.2",
@@ -763,9 +763,11 @@
 				"fs-extra": "^9.0.1",
 				"glob": "^7.1.3",
 				"lodash.isequal": "^4.5.0",
+				"package-lock-sanitizer": "^1.0.1",
 				"replace-in-file": "^6.0.0",
 				"rimraf": "^2.6.2",
 				"semver": "^7.1.2",
+				"shelljs": "^0.8.4",
 				"sort-package-json": "1.40.0",
 				"typescript": "^3.7.4"
 			},
@@ -816,9 +818,9 @@
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -863,26 +865,26 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.0.tgz",
-					"integrity": "sha512-Br2EPI/MNK0iabGkId5MLWs4rYkGSny4ltSNetSOt76MULq4U1hiWgq2OWDO/uDecsW3wqTyKvUgnzjX2AR2Ow=="
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.1.tgz",
+					"integrity": "sha512-xMqyqL9OQ3Jjh4vMgUIzl6SOTvbkX7Daw0VIFxbCNs/5E0mLKOWA0NTGUdfdYWfi9vUbOKK9Ri31hu+JQWB0bg=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.0.tgz",
-					"integrity": "sha512-vCA0Whi/lcz2M9LiohouBuBNtMP2L01PoAwbiaOkXJGaEBbMEGlSvcCx/u5iq2juE7OSuR6nj3JKu0pB57Ql1A==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.1.tgz",
+					"integrity": "sha512-k+4vUZJ5uvkwISQLWOcWAJkdIiiCFY2FDYD//RC02kxDqtii8XLh8ww8ZWzJVqeYD6vyfTXa35W7CPZQfMiH3Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -934,26 +936,26 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.0.tgz",
-					"integrity": "sha512-Br2EPI/MNK0iabGkId5MLWs4rYkGSny4ltSNetSOt76MULq4U1hiWgq2OWDO/uDecsW3wqTyKvUgnzjX2AR2Ow=="
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.1.tgz",
+					"integrity": "sha512-xMqyqL9OQ3Jjh4vMgUIzl6SOTvbkX7Daw0VIFxbCNs/5E0mLKOWA0NTGUdfdYWfi9vUbOKK9Ri31hu+JQWB0bg=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.0.tgz",
-					"integrity": "sha512-vCA0Whi/lcz2M9LiohouBuBNtMP2L01PoAwbiaOkXJGaEBbMEGlSvcCx/u5iq2juE7OSuR6nj3JKu0pB57Ql1A==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.1.tgz",
+					"integrity": "sha512-k+4vUZJ5uvkwISQLWOcWAJkdIiiCFY2FDYD//RC02kxDqtii8XLh8ww8ZWzJVqeYD6vyfTXa35W7CPZQfMiH3Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -974,9 +976,9 @@
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -1036,26 +1038,26 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.0.tgz",
-					"integrity": "sha512-Br2EPI/MNK0iabGkId5MLWs4rYkGSny4ltSNetSOt76MULq4U1hiWgq2OWDO/uDecsW3wqTyKvUgnzjX2AR2Ow=="
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.1.tgz",
+					"integrity": "sha512-xMqyqL9OQ3Jjh4vMgUIzl6SOTvbkX7Daw0VIFxbCNs/5E0mLKOWA0NTGUdfdYWfi9vUbOKK9Ri31hu+JQWB0bg=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.0.tgz",
-					"integrity": "sha512-vCA0Whi/lcz2M9LiohouBuBNtMP2L01PoAwbiaOkXJGaEBbMEGlSvcCx/u5iq2juE7OSuR6nj3JKu0pB57Ql1A==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.1.tgz",
+					"integrity": "sha512-k+4vUZJ5uvkwISQLWOcWAJkdIiiCFY2FDYD//RC02kxDqtii8XLh8ww8ZWzJVqeYD6vyfTXa35W7CPZQfMiH3Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -1076,9 +1078,9 @@
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -1116,9 +1118,9 @@
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -1136,9 +1138,9 @@
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -1176,26 +1178,26 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.0.tgz",
-					"integrity": "sha512-Br2EPI/MNK0iabGkId5MLWs4rYkGSny4ltSNetSOt76MULq4U1hiWgq2OWDO/uDecsW3wqTyKvUgnzjX2AR2Ow=="
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.1.tgz",
+					"integrity": "sha512-xMqyqL9OQ3Jjh4vMgUIzl6SOTvbkX7Daw0VIFxbCNs/5E0mLKOWA0NTGUdfdYWfi9vUbOKK9Ri31hu+JQWB0bg=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.0.tgz",
-					"integrity": "sha512-vCA0Whi/lcz2M9LiohouBuBNtMP2L01PoAwbiaOkXJGaEBbMEGlSvcCx/u5iq2juE7OSuR6nj3JKu0pB57Ql1A==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.1.tgz",
+					"integrity": "sha512-k+4vUZJ5uvkwISQLWOcWAJkdIiiCFY2FDYD//RC02kxDqtii8XLh8ww8ZWzJVqeYD6vyfTXa35W7CPZQfMiH3Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -1260,41 +1262,41 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.0.tgz",
-					"integrity": "sha512-Br2EPI/MNK0iabGkId5MLWs4rYkGSny4ltSNetSOt76MULq4U1hiWgq2OWDO/uDecsW3wqTyKvUgnzjX2AR2Ow=="
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.1.tgz",
+					"integrity": "sha512-xMqyqL9OQ3Jjh4vMgUIzl6SOTvbkX7Daw0VIFxbCNs/5E0mLKOWA0NTGUdfdYWfi9vUbOKK9Ri31hu+JQWB0bg=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.0.tgz",
-					"integrity": "sha512-vCA0Whi/lcz2M9LiohouBuBNtMP2L01PoAwbiaOkXJGaEBbMEGlSvcCx/u5iq2juE7OSuR6nj3JKu0pB57Ql1A==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.1.tgz",
+					"integrity": "sha512-k+4vUZJ5uvkwISQLWOcWAJkdIiiCFY2FDYD//RC02kxDqtii8XLh8ww8ZWzJVqeYD6vyfTXa35W7CPZQfMiH3Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
 				},
 				"@fluidframework/server-lambdas": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1012.0.tgz",
-					"integrity": "sha512-4mtvqd/IxBX2LVyjNkZmC75toozqvSBouJ6mMrQcaBETlW6Kr937KcUbO/qqVUUTfHYGhjx+i8pSbdfGB7s/fw==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1012.1.tgz",
+					"integrity": "sha512-fGKYZ8Pd1LoVDEPX4FSaFYql3G7kt7G/oqTt8zF2rwWWxAWRMriatv+9FenT5mCekbVCafsXHD6uOCLxq6wFpQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-base": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
-						"@fluidframework/server-services-client": "^0.1012.0",
-						"@fluidframework/server-services-core": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-base": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
+						"@fluidframework/server-services-client": "^0.1012.1",
+						"@fluidframework/server-services-core": "^0.1012.1",
 						"@types/semver": "^6.0.1",
 						"async": "^2.6.1",
 						"double-ended-queue": "^2.1.0-0",
@@ -1307,31 +1309,31 @@
 					}
 				},
 				"@fluidframework/server-local-server": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1012.0.tgz",
-					"integrity": "sha512-9/68DrvUGbcJ7D3lZ0OVseD0lWXTFHslAZyHtfInRfQ1Gn709PPs1rueA+JRLve0YxthhAwm8dDcAjOAvv72Ag==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1012.1.tgz",
+					"integrity": "sha512-l7Bylcrth/+I3Sk7jz3v3ew8/aT3Oi8BOLqi8yWcGnE7eh6DMFgQDugKibmKYmJ3R15k842JmdCeE2v/cTjOTg==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
-						"@fluidframework/server-lambdas": "^0.1012.0",
-						"@fluidframework/server-memory-orderer": "^0.1012.0",
-						"@fluidframework/server-services-client": "^0.1012.0",
-						"@fluidframework/server-services-core": "^0.1012.0",
-						"@fluidframework/server-test-utils": "^0.1012.0",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
+						"@fluidframework/server-lambdas": "^0.1012.1",
+						"@fluidframework/server-memory-orderer": "^0.1012.1",
+						"@fluidframework/server-services-client": "^0.1012.1",
+						"@fluidframework/server-services-core": "^0.1012.1",
+						"@fluidframework/server-test-utils": "^0.1012.1",
 						"uuid": "^3.3.2"
 					}
 				},
 				"@fluidframework/server-memory-orderer": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1012.0.tgz",
-					"integrity": "sha512-EydzyTt0MUDIDgX2lrOtApGqNi2kHSc20Uz+121rdrzVriUWhwOeBUcaV2SJYk/HL/Sw9IDxoea5sDZu6+dkdw==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1012.1.tgz",
+					"integrity": "sha512-a2lCkVghFEO2oCvgan376wwkpUNLF2YwGOKSHw+ku+r8qeSTq6SMxe11tAOrQPay6YpAYeiXLEBElH0YpN9V5Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/protocol-base": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
-						"@fluidframework/server-lambdas": "^0.1012.0",
-						"@fluidframework/server-services-client": "^0.1012.0",
-						"@fluidframework/server-services-core": "^0.1012.0",
+						"@fluidframework/protocol-base": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
+						"@fluidframework/server-lambdas": "^0.1012.1",
+						"@fluidframework/server-services-client": "^0.1012.1",
+						"@fluidframework/server-services-core": "^0.1012.1",
 						"@types/debug": "^4.1.5",
 						"@types/double-ended-queue": "^2.1.0",
 						"@types/lodash": "^4.14.118",
@@ -1346,14 +1348,14 @@
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1012.0.tgz",
-					"integrity": "sha512-mTAnKBaKam26+sQEM6LDfuejNaEhE6yr+t7gHQGbttF9ZfUZD2RhN1cpCwnVRrJLRm5WJL8EpiiUVGjEPgFhRA==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1012.1.tgz",
+					"integrity": "sha512-jjhI2yP2cVffeiQqQAcko5XlmpMnGAefgvtV23o94Xtga9+HWh8345+FOpqXlPj7033hBp48+lavNYlsVeLarA==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-base": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-base": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
 						"@types/node": "^10.17.24",
 						"axios": "^0.18.0",
 						"debug": "^4.1.1",
@@ -1363,14 +1365,14 @@
 					}
 				},
 				"@fluidframework/server-services-core": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1012.0.tgz",
-					"integrity": "sha512-gFpEQQKcM4hy3zkUt7/msgZLhtoWCKNV+J2nrI5gOk/EkzUdjOcXq2OMa/4YCu9E/KmeoiJEvWSBk5/8o3hOuw==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1012.1.tgz",
+					"integrity": "sha512-lHVp8pR8pdXqHBeIugaZzcZNnAS1YAy8J0iE9Pl9IXTQf5rEBdQMzNh6KwqqI8BlU5Lq2+wg1viXscYkUTfmkQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
-						"@fluidframework/server-services-client": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
+						"@fluidframework/server-services-client": "^0.1012.1",
 						"@types/nconf": "^0.0.37",
 						"@types/node": "^10.17.24",
 						"debug": "^4.1.1",
@@ -1378,16 +1380,16 @@
 					}
 				},
 				"@fluidframework/server-test-utils": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1012.0.tgz",
-					"integrity": "sha512-zUNdwVl1Q6oUrm1ReYbqbjclXV55xmvN0W2W4cSllL63WI24RClCdPnquuZcYEcd5K1ugUOQII/zJelTtHELYQ==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1012.1.tgz",
+					"integrity": "sha512-XvBawWKYxwkdRvBYqZ+xya/zXO9PWzBl1aZw+f2UGRWGJz2NI/R2kkuuw25BM4s2dm53m8nA8lm4229INsJC8Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-base": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
-						"@fluidframework/server-services-client": "^0.1012.0",
-						"@fluidframework/server-services-core": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-base": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
+						"@fluidframework/server-services-client": "^0.1012.1",
+						"@fluidframework/server-services-core": "^0.1012.1",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
 						"string-hash": "^1.1.3",
@@ -1432,26 +1434,26 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.0.tgz",
-					"integrity": "sha512-Br2EPI/MNK0iabGkId5MLWs4rYkGSny4ltSNetSOt76MULq4U1hiWgq2OWDO/uDecsW3wqTyKvUgnzjX2AR2Ow=="
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.1.tgz",
+					"integrity": "sha512-xMqyqL9OQ3Jjh4vMgUIzl6SOTvbkX7Daw0VIFxbCNs/5E0mLKOWA0NTGUdfdYWfi9vUbOKK9Ri31hu+JQWB0bg=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.0.tgz",
-					"integrity": "sha512-vCA0Whi/lcz2M9LiohouBuBNtMP2L01PoAwbiaOkXJGaEBbMEGlSvcCx/u5iq2juE7OSuR6nj3JKu0pB57Ql1A==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.1.tgz",
+					"integrity": "sha512-k+4vUZJ5uvkwISQLWOcWAJkdIiiCFY2FDYD//RC02kxDqtii8XLh8ww8ZWzJVqeYD6vyfTXa35W7CPZQfMiH3Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -1487,9 +1489,9 @@
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -1544,9 +1546,9 @@
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -1602,39 +1604,39 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.0.tgz",
-					"integrity": "sha512-Br2EPI/MNK0iabGkId5MLWs4rYkGSny4ltSNetSOt76MULq4U1hiWgq2OWDO/uDecsW3wqTyKvUgnzjX2AR2Ow=="
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.1.tgz",
+					"integrity": "sha512-xMqyqL9OQ3Jjh4vMgUIzl6SOTvbkX7Daw0VIFxbCNs/5E0mLKOWA0NTGUdfdYWfi9vUbOKK9Ri31hu+JQWB0bg=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.0.tgz",
-					"integrity": "sha512-vCA0Whi/lcz2M9LiohouBuBNtMP2L01PoAwbiaOkXJGaEBbMEGlSvcCx/u5iq2juE7OSuR6nj3JKu0pB57Ql1A==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.1.tgz",
+					"integrity": "sha512-k+4vUZJ5uvkwISQLWOcWAJkdIiiCFY2FDYD//RC02kxDqtii8XLh8ww8ZWzJVqeYD6vyfTXa35W7CPZQfMiH3Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1012.0.tgz",
-					"integrity": "sha512-mTAnKBaKam26+sQEM6LDfuejNaEhE6yr+t7gHQGbttF9ZfUZD2RhN1cpCwnVRrJLRm5WJL8EpiiUVGjEPgFhRA==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1012.1.tgz",
+					"integrity": "sha512-jjhI2yP2cVffeiQqQAcko5XlmpMnGAefgvtV23o94Xtga9+HWh8345+FOpqXlPj7033hBp48+lavNYlsVeLarA==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-base": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-base": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
 						"@types/node": "^10.17.24",
 						"axios": "^0.18.0",
 						"debug": "^4.1.1",
@@ -1659,9 +1661,9 @@
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -1698,26 +1700,26 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.0.tgz",
-					"integrity": "sha512-Br2EPI/MNK0iabGkId5MLWs4rYkGSny4ltSNetSOt76MULq4U1hiWgq2OWDO/uDecsW3wqTyKvUgnzjX2AR2Ow=="
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.1.tgz",
+					"integrity": "sha512-xMqyqL9OQ3Jjh4vMgUIzl6SOTvbkX7Daw0VIFxbCNs/5E0mLKOWA0NTGUdfdYWfi9vUbOKK9Ri31hu+JQWB0bg=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.0.tgz",
-					"integrity": "sha512-vCA0Whi/lcz2M9LiohouBuBNtMP2L01PoAwbiaOkXJGaEBbMEGlSvcCx/u5iq2juE7OSuR6nj3JKu0pB57Ql1A==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.1.tgz",
+					"integrity": "sha512-k+4vUZJ5uvkwISQLWOcWAJkdIiiCFY2FDYD//RC02kxDqtii8XLh8ww8ZWzJVqeYD6vyfTXa35W7CPZQfMiH3Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -1860,9 +1862,9 @@
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -4332,6 +4334,481 @@
 			"requires": {
 				"@nodelib/fs.scandir": "2.1.3",
 				"fastq": "^1.6.0"
+			}
+		},
+		"@oclif/command": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
+			"integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
+			"dev": true,
+			"requires": {
+				"@oclif/config": "^1.15.1",
+				"@oclif/errors": "^1.3.3",
+				"@oclif/parser": "^3.8.3",
+				"@oclif/plugin-help": "^3",
+				"debug": "^4.1.1",
+				"semver": "^7.3.2"
+			},
+			"dependencies": {
+				"@oclif/plugin-help": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.0.tgz",
+					"integrity": "sha512-7jxtpwVWAVbp1r46ZnTK/uF+FeZc6y4p1XcGaIUuPAp7wx6NJhIRN/iMT9UfNFX/Cz7mq+OyJz+E+i0zrik86g==",
+					"dev": true,
+					"requires": {
+						"@oclif/command": "^1.5.20",
+						"@oclif/config": "^1.15.1",
+						"chalk": "^2.4.1",
+						"indent-string": "^4.0.0",
+						"lodash.template": "^4.4.0",
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"widest-line": "^3.1.0",
+						"wrap-ansi": "^4.0.0"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"widest-line": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+					"integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-4.0.0.tgz",
+					"integrity": "sha512-uMTsj9rDb0/7kk1PbcbCcwvHUxp60fGDB/NNXpVa0Q+ic/e7y5+BwTxKfQ33VYgDppSwi/FBzpetYzo8s6tfbg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+							"dev": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+							"dev": true
+						},
+						"string-width": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+							"dev": true,
+							"requires": {
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^4.0.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
+					}
+				}
+			}
+		},
+		"@oclif/config": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.17.0.tgz",
+			"integrity": "sha512-Lmfuf6ubjQ4ifC/9bz1fSCHc6F6E653oyaRXxg+lgT4+bYf9bk+nqrUpAbrXyABkCqgIBiFr3J4zR/kiFdE1PA==",
+			"dev": true,
+			"requires": {
+				"@oclif/errors": "^1.3.3",
+				"@oclif/parser": "^3.8.0",
+				"debug": "^4.1.1",
+				"globby": "^11.0.1",
+				"is-wsl": "^2.1.1",
+				"tslib": "^2.0.0"
+			},
+			"dependencies": {
+				"@nodelib/fs.stat": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+					"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+					"dev": true
+				},
+				"array-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+					"dev": true
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"dir-glob": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+					"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+					"dev": true,
+					"requires": {
+						"path-type": "^4.0.0"
+					}
+				},
+				"fast-glob": {
+					"version": "3.2.4",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+					"integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+					"dev": true,
+					"requires": {
+						"@nodelib/fs.stat": "^2.0.2",
+						"@nodelib/fs.walk": "^1.2.3",
+						"glob-parent": "^5.1.0",
+						"merge2": "^1.3.0",
+						"micromatch": "^4.0.2",
+						"picomatch": "^2.2.1"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"globby": {
+					"version": "11.0.1",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+					"integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+					"dev": true,
+					"requires": {
+						"array-union": "^2.1.0",
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.1.1",
+						"ignore": "^5.1.4",
+						"merge2": "^1.3.0",
+						"slash": "^3.0.0"
+					}
+				},
+				"ignore": {
+					"version": "5.1.8",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+					"dev": true
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"is-wsl": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+					"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+					"dev": true,
+					"requires": {
+						"is-docker": "^2.0.0"
+					}
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+					"dev": true
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+					"dev": true
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				},
+				"tslib": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+					"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
+					"dev": true
+				}
+			}
+		},
+		"@oclif/errors": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.3.tgz",
+			"integrity": "sha512-EJR6AIOEkt/NnARNIVAskPDVtdhtO5TTNXmhDrGqMoWVsr0R6DkkLrMyq95BmHvlVWM1nduoq4fQPuCyuF2jaA==",
+			"dev": true,
+			"requires": {
+				"clean-stack": "^3.0.0",
+				"fs-extra": "^9.0.1",
+				"indent-string": "^4.0.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"clean-stack": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.0.tgz",
+					"integrity": "sha512-RHxtgFvXsRQ+1AM7dlozLDY7ssmvUUh0XEnfnyhYgJTO6beNZHBogiaCwGM9Q3rFrUkYxOtsZRC0zAturg5bjg==",
+					"dev": true,
+					"requires": {
+						"escape-string-regexp": "4.0.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"escape-string-regexp": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+					"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				}
+			}
+		},
+		"@oclif/linewrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
+			"integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==",
+			"dev": true
+		},
+		"@oclif/parser": {
+			"version": "3.8.5",
+			"resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.5.tgz",
+			"integrity": "sha512-yojzeEfmSxjjkAvMRj0KzspXlMjCfBzNRPkWw8ZwOSoNWoJn+OCS/m/S+yfV6BvAM4u2lTzX9Y5rCbrFIgkJLg==",
+			"dev": true,
+			"requires": {
+				"@oclif/errors": "^1.2.2",
+				"@oclif/linewrap": "^1.0.0",
+				"chalk": "^2.4.2",
+				"tslib": "^1.9.3"
+			}
+		},
+		"@oclif/plugin-help": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-2.2.3.tgz",
+			"integrity": "sha512-bGHUdo5e7DjPJ0vTeRBMIrfqTRDBfyR5w0MP41u0n3r7YG5p14lvMmiCXxi6WDaP2Hw5nqx3PnkAIntCKZZN7g==",
+			"dev": true,
+			"requires": {
+				"@oclif/command": "^1.5.13",
+				"chalk": "^2.4.1",
+				"indent-string": "^4.0.0",
+				"lodash.template": "^4.4.0",
+				"string-width": "^3.0.0",
+				"strip-ansi": "^5.0.0",
+				"widest-line": "^2.0.1",
+				"wrap-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-4.0.0.tgz",
+					"integrity": "sha512-uMTsj9rDb0/7kk1PbcbCcwvHUxp60fGDB/NNXpVa0Q+ic/e7y5+BwTxKfQ33VYgDppSwi/FBzpetYzo8s6tfbg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+							"dev": true
+						},
+						"string-width": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+							"dev": true,
+							"requires": {
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^4.0.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
+					}
+				}
 			}
 		},
 		"@octokit/auth-token": {
@@ -11179,6 +11656,12 @@
 			"integrity": "sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ==",
 			"dev": true
 		},
+		"fs": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/fs/-/fs-0.0.2.tgz",
+			"integrity": "sha1-4fJE7zkzwbKmS9R5kTYGDQ9ZFPg=",
+			"dev": true
+		},
 		"fs-exists-sync": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
@@ -12996,8 +13479,7 @@
 		"is-docker": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
-			"integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
-			"optional": true
+			"integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw=="
 		},
 		"is-extendable": {
 			"version": "0.1.1",
@@ -19370,9 +19852,9 @@
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -19391,9 +19873,9 @@
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -19438,26 +19920,26 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.0.tgz",
-					"integrity": "sha512-Br2EPI/MNK0iabGkId5MLWs4rYkGSny4ltSNetSOt76MULq4U1hiWgq2OWDO/uDecsW3wqTyKvUgnzjX2AR2Ow=="
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.1.tgz",
+					"integrity": "sha512-xMqyqL9OQ3Jjh4vMgUIzl6SOTvbkX7Daw0VIFxbCNs/5E0mLKOWA0NTGUdfdYWfi9vUbOKK9Ri31hu+JQWB0bg=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.0.tgz",
-					"integrity": "sha512-vCA0Whi/lcz2M9LiohouBuBNtMP2L01PoAwbiaOkXJGaEBbMEGlSvcCx/u5iq2juE7OSuR6nj3JKu0pB57Ql1A==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.1.tgz",
+					"integrity": "sha512-k+4vUZJ5uvkwISQLWOcWAJkdIiiCFY2FDYD//RC02kxDqtii8XLh8ww8ZWzJVqeYD6vyfTXa35W7CPZQfMiH3Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -19509,26 +19991,26 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.0.tgz",
-					"integrity": "sha512-Br2EPI/MNK0iabGkId5MLWs4rYkGSny4ltSNetSOt76MULq4U1hiWgq2OWDO/uDecsW3wqTyKvUgnzjX2AR2Ow=="
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.1.tgz",
+					"integrity": "sha512-xMqyqL9OQ3Jjh4vMgUIzl6SOTvbkX7Daw0VIFxbCNs/5E0mLKOWA0NTGUdfdYWfi9vUbOKK9Ri31hu+JQWB0bg=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.0.tgz",
-					"integrity": "sha512-vCA0Whi/lcz2M9LiohouBuBNtMP2L01PoAwbiaOkXJGaEBbMEGlSvcCx/u5iq2juE7OSuR6nj3JKu0pB57Ql1A==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.1.tgz",
+					"integrity": "sha512-k+4vUZJ5uvkwISQLWOcWAJkdIiiCFY2FDYD//RC02kxDqtii8XLh8ww8ZWzJVqeYD6vyfTXa35W7CPZQfMiH3Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -19549,9 +20031,9 @@
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -19588,9 +20070,9 @@
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -19633,41 +20115,41 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.0.tgz",
-					"integrity": "sha512-Br2EPI/MNK0iabGkId5MLWs4rYkGSny4ltSNetSOt76MULq4U1hiWgq2OWDO/uDecsW3wqTyKvUgnzjX2AR2Ow=="
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.1.tgz",
+					"integrity": "sha512-xMqyqL9OQ3Jjh4vMgUIzl6SOTvbkX7Daw0VIFxbCNs/5E0mLKOWA0NTGUdfdYWfi9vUbOKK9Ri31hu+JQWB0bg=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.0.tgz",
-					"integrity": "sha512-vCA0Whi/lcz2M9LiohouBuBNtMP2L01PoAwbiaOkXJGaEBbMEGlSvcCx/u5iq2juE7OSuR6nj3JKu0pB57Ql1A==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.1.tgz",
+					"integrity": "sha512-k+4vUZJ5uvkwISQLWOcWAJkdIiiCFY2FDYD//RC02kxDqtii8XLh8ww8ZWzJVqeYD6vyfTXa35W7CPZQfMiH3Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
 				},
 				"@fluidframework/server-lambdas": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1012.0.tgz",
-					"integrity": "sha512-4mtvqd/IxBX2LVyjNkZmC75toozqvSBouJ6mMrQcaBETlW6Kr937KcUbO/qqVUUTfHYGhjx+i8pSbdfGB7s/fw==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1012.1.tgz",
+					"integrity": "sha512-fGKYZ8Pd1LoVDEPX4FSaFYql3G7kt7G/oqTt8zF2rwWWxAWRMriatv+9FenT5mCekbVCafsXHD6uOCLxq6wFpQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-base": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
-						"@fluidframework/server-services-client": "^0.1012.0",
-						"@fluidframework/server-services-core": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-base": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
+						"@fluidframework/server-services-client": "^0.1012.1",
+						"@fluidframework/server-services-core": "^0.1012.1",
 						"@types/semver": "^6.0.1",
 						"async": "^2.6.1",
 						"double-ended-queue": "^2.1.0-0",
@@ -19680,31 +20162,31 @@
 					}
 				},
 				"@fluidframework/server-local-server": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1012.0.tgz",
-					"integrity": "sha512-9/68DrvUGbcJ7D3lZ0OVseD0lWXTFHslAZyHtfInRfQ1Gn709PPs1rueA+JRLve0YxthhAwm8dDcAjOAvv72Ag==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1012.1.tgz",
+					"integrity": "sha512-l7Bylcrth/+I3Sk7jz3v3ew8/aT3Oi8BOLqi8yWcGnE7eh6DMFgQDugKibmKYmJ3R15k842JmdCeE2v/cTjOTg==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
-						"@fluidframework/server-lambdas": "^0.1012.0",
-						"@fluidframework/server-memory-orderer": "^0.1012.0",
-						"@fluidframework/server-services-client": "^0.1012.0",
-						"@fluidframework/server-services-core": "^0.1012.0",
-						"@fluidframework/server-test-utils": "^0.1012.0",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
+						"@fluidframework/server-lambdas": "^0.1012.1",
+						"@fluidframework/server-memory-orderer": "^0.1012.1",
+						"@fluidframework/server-services-client": "^0.1012.1",
+						"@fluidframework/server-services-core": "^0.1012.1",
+						"@fluidframework/server-test-utils": "^0.1012.1",
 						"uuid": "^3.3.2"
 					}
 				},
 				"@fluidframework/server-memory-orderer": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1012.0.tgz",
-					"integrity": "sha512-EydzyTt0MUDIDgX2lrOtApGqNi2kHSc20Uz+121rdrzVriUWhwOeBUcaV2SJYk/HL/Sw9IDxoea5sDZu6+dkdw==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1012.1.tgz",
+					"integrity": "sha512-a2lCkVghFEO2oCvgan376wwkpUNLF2YwGOKSHw+ku+r8qeSTq6SMxe11tAOrQPay6YpAYeiXLEBElH0YpN9V5Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/protocol-base": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
-						"@fluidframework/server-lambdas": "^0.1012.0",
-						"@fluidframework/server-services-client": "^0.1012.0",
-						"@fluidframework/server-services-core": "^0.1012.0",
+						"@fluidframework/protocol-base": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
+						"@fluidframework/server-lambdas": "^0.1012.1",
+						"@fluidframework/server-services-client": "^0.1012.1",
+						"@fluidframework/server-services-core": "^0.1012.1",
 						"@types/debug": "^4.1.5",
 						"@types/double-ended-queue": "^2.1.0",
 						"@types/lodash": "^4.14.118",
@@ -19719,14 +20201,14 @@
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1012.0.tgz",
-					"integrity": "sha512-mTAnKBaKam26+sQEM6LDfuejNaEhE6yr+t7gHQGbttF9ZfUZD2RhN1cpCwnVRrJLRm5WJL8EpiiUVGjEPgFhRA==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1012.1.tgz",
+					"integrity": "sha512-jjhI2yP2cVffeiQqQAcko5XlmpMnGAefgvtV23o94Xtga9+HWh8345+FOpqXlPj7033hBp48+lavNYlsVeLarA==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-base": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-base": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
 						"@types/node": "^10.17.24",
 						"axios": "^0.18.0",
 						"debug": "^4.1.1",
@@ -19736,14 +20218,14 @@
 					}
 				},
 				"@fluidframework/server-services-core": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1012.0.tgz",
-					"integrity": "sha512-gFpEQQKcM4hy3zkUt7/msgZLhtoWCKNV+J2nrI5gOk/EkzUdjOcXq2OMa/4YCu9E/KmeoiJEvWSBk5/8o3hOuw==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1012.1.tgz",
+					"integrity": "sha512-lHVp8pR8pdXqHBeIugaZzcZNnAS1YAy8J0iE9Pl9IXTQf5rEBdQMzNh6KwqqI8BlU5Lq2+wg1viXscYkUTfmkQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
-						"@fluidframework/server-services-client": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
+						"@fluidframework/server-services-client": "^0.1012.1",
 						"@types/nconf": "^0.0.37",
 						"@types/node": "^10.17.24",
 						"debug": "^4.1.1",
@@ -19751,16 +20233,16 @@
 					}
 				},
 				"@fluidframework/server-test-utils": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1012.0.tgz",
-					"integrity": "sha512-zUNdwVl1Q6oUrm1ReYbqbjclXV55xmvN0W2W4cSllL63WI24RClCdPnquuZcYEcd5K1ugUOQII/zJelTtHELYQ==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1012.1.tgz",
+					"integrity": "sha512-XvBawWKYxwkdRvBYqZ+xya/zXO9PWzBl1aZw+f2UGRWGJz2NI/R2kkuuw25BM4s2dm53m8nA8lm4229INsJC8Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-base": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
-						"@fluidframework/server-services-client": "^0.1012.0",
-						"@fluidframework/server-services-core": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-base": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
+						"@fluidframework/server-services-client": "^0.1012.1",
+						"@fluidframework/server-services-core": "^0.1012.1",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
 						"string-hash": "^1.1.3",
@@ -19805,26 +20287,26 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.0.tgz",
-					"integrity": "sha512-Br2EPI/MNK0iabGkId5MLWs4rYkGSny4ltSNetSOt76MULq4U1hiWgq2OWDO/uDecsW3wqTyKvUgnzjX2AR2Ow=="
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.1.tgz",
+					"integrity": "sha512-xMqyqL9OQ3Jjh4vMgUIzl6SOTvbkX7Daw0VIFxbCNs/5E0mLKOWA0NTGUdfdYWfi9vUbOKK9Ri31hu+JQWB0bg=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.0.tgz",
-					"integrity": "sha512-vCA0Whi/lcz2M9LiohouBuBNtMP2L01PoAwbiaOkXJGaEBbMEGlSvcCx/u5iq2juE7OSuR6nj3JKu0pB57Ql1A==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.1.tgz",
+					"integrity": "sha512-k+4vUZJ5uvkwISQLWOcWAJkdIiiCFY2FDYD//RC02kxDqtii8XLh8ww8ZWzJVqeYD6vyfTXa35W7CPZQfMiH3Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -19866,9 +20348,9 @@
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -19903,9 +20385,9 @@
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -19940,9 +20422,9 @@
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -19974,9 +20456,9 @@
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -20018,9 +20500,9 @@
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -20064,41 +20546,41 @@
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.0.tgz",
-					"integrity": "sha512-Br2EPI/MNK0iabGkId5MLWs4rYkGSny4ltSNetSOt76MULq4U1hiWgq2OWDO/uDecsW3wqTyKvUgnzjX2AR2Ow=="
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.1.tgz",
+					"integrity": "sha512-xMqyqL9OQ3Jjh4vMgUIzl6SOTvbkX7Daw0VIFxbCNs/5E0mLKOWA0NTGUdfdYWfi9vUbOKK9Ri31hu+JQWB0bg=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.0.tgz",
-					"integrity": "sha512-vCA0Whi/lcz2M9LiohouBuBNtMP2L01PoAwbiaOkXJGaEBbMEGlSvcCx/u5iq2juE7OSuR6nj3JKu0pB57Ql1A==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.1.tgz",
+					"integrity": "sha512-k+4vUZJ5uvkwISQLWOcWAJkdIiiCFY2FDYD//RC02kxDqtii8XLh8ww8ZWzJVqeYD6vyfTXa35W7CPZQfMiH3Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.0.tgz",
-					"integrity": "sha512-1Z//VfbBRyTEwJBZq0od9+J2TYOxiwvJq+CnewfWzU8hmH/cPGueLVEFVQmPvf3W4wxrLSWEUAC0MSYM2bkLLg==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.1.tgz",
+					"integrity": "sha512-L5BVD9YYvossY0TfSMyT4j7VvbOmD7lvmJVNcqitNTKnPYtfjuK6X7t/o22Yc4llxhlorysqeVUrd23T/Iy4XA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
 				},
 				"@fluidframework/server-lambdas": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1012.0.tgz",
-					"integrity": "sha512-4mtvqd/IxBX2LVyjNkZmC75toozqvSBouJ6mMrQcaBETlW6Kr937KcUbO/qqVUUTfHYGhjx+i8pSbdfGB7s/fw==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1012.1.tgz",
+					"integrity": "sha512-fGKYZ8Pd1LoVDEPX4FSaFYql3G7kt7G/oqTt8zF2rwWWxAWRMriatv+9FenT5mCekbVCafsXHD6uOCLxq6wFpQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-base": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
-						"@fluidframework/server-services-client": "^0.1012.0",
-						"@fluidframework/server-services-core": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-base": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
+						"@fluidframework/server-services-client": "^0.1012.1",
+						"@fluidframework/server-services-core": "^0.1012.1",
 						"@types/semver": "^6.0.1",
 						"async": "^2.6.1",
 						"double-ended-queue": "^2.1.0-0",
@@ -20111,31 +20593,31 @@
 					}
 				},
 				"@fluidframework/server-local-server": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1012.0.tgz",
-					"integrity": "sha512-9/68DrvUGbcJ7D3lZ0OVseD0lWXTFHslAZyHtfInRfQ1Gn709PPs1rueA+JRLve0YxthhAwm8dDcAjOAvv72Ag==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1012.1.tgz",
+					"integrity": "sha512-l7Bylcrth/+I3Sk7jz3v3ew8/aT3Oi8BOLqi8yWcGnE7eh6DMFgQDugKibmKYmJ3R15k842JmdCeE2v/cTjOTg==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
-						"@fluidframework/server-lambdas": "^0.1012.0",
-						"@fluidframework/server-memory-orderer": "^0.1012.0",
-						"@fluidframework/server-services-client": "^0.1012.0",
-						"@fluidframework/server-services-core": "^0.1012.0",
-						"@fluidframework/server-test-utils": "^0.1012.0",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
+						"@fluidframework/server-lambdas": "^0.1012.1",
+						"@fluidframework/server-memory-orderer": "^0.1012.1",
+						"@fluidframework/server-services-client": "^0.1012.1",
+						"@fluidframework/server-services-core": "^0.1012.1",
+						"@fluidframework/server-test-utils": "^0.1012.1",
 						"uuid": "^3.3.2"
 					}
 				},
 				"@fluidframework/server-memory-orderer": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1012.0.tgz",
-					"integrity": "sha512-EydzyTt0MUDIDgX2lrOtApGqNi2kHSc20Uz+121rdrzVriUWhwOeBUcaV2SJYk/HL/Sw9IDxoea5sDZu6+dkdw==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1012.1.tgz",
+					"integrity": "sha512-a2lCkVghFEO2oCvgan376wwkpUNLF2YwGOKSHw+ku+r8qeSTq6SMxe11tAOrQPay6YpAYeiXLEBElH0YpN9V5Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/protocol-base": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
-						"@fluidframework/server-lambdas": "^0.1012.0",
-						"@fluidframework/server-services-client": "^0.1012.0",
-						"@fluidframework/server-services-core": "^0.1012.0",
+						"@fluidframework/protocol-base": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
+						"@fluidframework/server-lambdas": "^0.1012.1",
+						"@fluidframework/server-services-client": "^0.1012.1",
+						"@fluidframework/server-services-core": "^0.1012.1",
 						"@types/debug": "^4.1.5",
 						"@types/double-ended-queue": "^2.1.0",
 						"@types/lodash": "^4.14.118",
@@ -20150,14 +20632,14 @@
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1012.0.tgz",
-					"integrity": "sha512-mTAnKBaKam26+sQEM6LDfuejNaEhE6yr+t7gHQGbttF9ZfUZD2RhN1cpCwnVRrJLRm5WJL8EpiiUVGjEPgFhRA==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1012.1.tgz",
+					"integrity": "sha512-jjhI2yP2cVffeiQqQAcko5XlmpMnGAefgvtV23o94Xtga9+HWh8345+FOpqXlPj7033hBp48+lavNYlsVeLarA==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-base": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-base": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
 						"@types/node": "^10.17.24",
 						"axios": "^0.18.0",
 						"debug": "^4.1.1",
@@ -20167,14 +20649,14 @@
 					}
 				},
 				"@fluidframework/server-services-core": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1012.0.tgz",
-					"integrity": "sha512-gFpEQQKcM4hy3zkUt7/msgZLhtoWCKNV+J2nrI5gOk/EkzUdjOcXq2OMa/4YCu9E/KmeoiJEvWSBk5/8o3hOuw==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1012.1.tgz",
+					"integrity": "sha512-lHVp8pR8pdXqHBeIugaZzcZNnAS1YAy8J0iE9Pl9IXTQf5rEBdQMzNh6KwqqI8BlU5Lq2+wg1viXscYkUTfmkQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
-						"@fluidframework/server-services-client": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
+						"@fluidframework/server-services-client": "^0.1012.1",
 						"@types/nconf": "^0.0.37",
 						"@types/node": "^10.17.24",
 						"debug": "^4.1.1",
@@ -20182,16 +20664,16 @@
 					}
 				},
 				"@fluidframework/server-test-utils": {
-					"version": "0.1012.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1012.0.tgz",
-					"integrity": "sha512-zUNdwVl1Q6oUrm1ReYbqbjclXV55xmvN0W2W4cSllL63WI24RClCdPnquuZcYEcd5K1ugUOQII/zJelTtHELYQ==",
+					"version": "0.1012.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1012.1.tgz",
+					"integrity": "sha512-XvBawWKYxwkdRvBYqZ+xya/zXO9PWzBl1aZw+f2UGRWGJz2NI/R2kkuuw25BM4s2dm53m8nA8lm4229INsJC8Q==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.0",
-						"@fluidframework/protocol-base": "^0.1012.0",
-						"@fluidframework/protocol-definitions": "^0.1012.0",
-						"@fluidframework/server-services-client": "^0.1012.0",
-						"@fluidframework/server-services-core": "^0.1012.0",
+						"@fluidframework/gitresources": "^0.1012.1",
+						"@fluidframework/protocol-base": "^0.1012.1",
+						"@fluidframework/protocol-definitions": "^0.1012.1",
+						"@fluidframework/server-services-client": "^0.1012.1",
+						"@fluidframework/server-services-core": "^0.1012.1",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
 						"string-hash": "^1.1.3",
@@ -20435,6 +20917,195 @@
 				"registry-auth-token": "^3.0.1",
 				"registry-url": "^3.0.3",
 				"semver": "^5.1.0"
+			}
+		},
+		"package-lock-sanitizer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-lock-sanitizer/-/package-lock-sanitizer-1.0.1.tgz",
+			"integrity": "sha512-MDpr4A9wgsY6w1fqOPp0krxiyGHedMq63/fOs5oh1IMVGWNXXqEySaCbZzQgJP9WWI+dzSOyQN4+7PnmsaXqxw==",
+			"dev": true,
+			"requires": {
+				"@oclif/command": "^1.5.11",
+				"@oclif/config": "^1.12.8",
+				"@oclif/errors": "^1.2.2",
+				"@oclif/plugin-help": "^2.1.6",
+				"fs": "0.0.2",
+				"replace-in-file": "^5.0.2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"cliui": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^6.2.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"replace-in-file": {
+					"version": "5.0.2",
+					"resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-5.0.2.tgz",
+					"integrity": "sha512-1Vc7Sbr/rTuHgU1PZuBb7tGsFx3D4NKdhV4BpEF2MuN/6+SoXcFtx+dZ1Zz+5Dq4k5x9js87Y+gXQYPTQ9ppkA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^3.0.0",
+						"glob": "^7.1.6",
+						"yargs": "^15.0.2"
+					}
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"yargs": {
+					"version": "15.4.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+					"dev": true,
+					"requires": {
+						"cliui": "^6.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^4.1.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^4.2.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^18.1.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
 			}
 		},
 		"pako": {
@@ -21760,6 +22431,15 @@
 				}
 			}
 		},
+		"rechoir": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"dev": true,
+			"requires": {
+				"resolve": "^1.1.6"
+			}
+		},
 		"redent": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -22614,6 +23294,17 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+		},
+		"shelljs": {
+			"version": "0.8.4",
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+			"integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.0.0",
+				"interpret": "^1.0.0",
+				"rechoir": "^0.6.2"
+			}
 		},
 		"shellwords": {
 			"version": "0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -376,9 +376,9 @@
       }
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.3049",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.3049.tgz",
-      "integrity": "sha512-X+m4U9Hb730TxoaaZ9Qqf1z6qo09FlDI69aLNITFJA+E9YWQmx9JhfbwWzkLD86FEhA8g+nYcw6wWCtmz4vPiQ==",
+      "version": "0.2.4847",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.4847.tgz",
+      "integrity": "sha512-5cN1RqjSHG1xSsjRswuVAGKN1d4TzBXDeuQp46RlnZv154GneleLsh0kbdhwsr2AwU/+M2DMs7yEeVCTaUWeAA==",
       "dev": true,
       "requires": {
         "async": "^2.6.2",
@@ -387,9 +387,11 @@
         "fs-extra": "^9.0.1",
         "glob": "^7.1.3",
         "lodash.isequal": "^4.5.0",
+        "package-lock-sanitizer": "^1.0.1",
         "replace-in-file": "^6.0.0",
         "rimraf": "^2.6.2",
         "semver": "^7.1.2",
+        "shelljs": "^0.8.4",
         "sort-package-json": "1.40.0",
         "typescript": "^3.7.4"
       },
@@ -1812,6 +1814,499 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
+      }
+    },
+    "@oclif/command": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
+      "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
+      "dev": true,
+      "requires": {
+        "@oclif/config": "^1.15.1",
+        "@oclif/errors": "^1.3.3",
+        "@oclif/parser": "^3.8.3",
+        "@oclif/plugin-help": "^3",
+        "debug": "^4.1.1",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "@oclif/plugin-help": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.0.tgz",
+          "integrity": "sha512-7jxtpwVWAVbp1r46ZnTK/uF+FeZc6y4p1XcGaIUuPAp7wx6NJhIRN/iMT9UfNFX/Cz7mq+OyJz+E+i0zrik86g==",
+          "dev": true,
+          "requires": {
+            "@oclif/command": "^1.5.20",
+            "@oclif/config": "^1.15.1",
+            "chalk": "^2.4.1",
+            "indent-string": "^4.0.0",
+            "lodash.template": "^4.4.0",
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "widest-line": "^3.1.0",
+            "wrap-ansi": "^4.0.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-4.0.0.tgz",
+          "integrity": "sha512-uMTsj9rDb0/7kk1PbcbCcwvHUxp60fGDB/NNXpVa0Q+ic/e7y5+BwTxKfQ33VYgDppSwi/FBzpetYzo8s6tfbg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "@oclif/config": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.17.0.tgz",
+      "integrity": "sha512-Lmfuf6ubjQ4ifC/9bz1fSCHc6F6E653oyaRXxg+lgT4+bYf9bk+nqrUpAbrXyABkCqgIBiFr3J4zR/kiFdE1PA==",
+      "dev": true,
+      "requires": {
+        "@oclif/errors": "^1.3.3",
+        "@oclif/parser": "^3.8.0",
+        "debug": "^4.1.1",
+        "globby": "^11.0.1",
+        "is-wsl": "^2.1.1",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@nodelib/fs.stat": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+          "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+          "dev": true
+        },
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+          "dev": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "dir-glob": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+          "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+          "dev": true,
+          "requires": {
+            "path-type": "^4.0.0"
+          }
+        },
+        "fast-glob": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+          "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.0",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.2",
+            "picomatch": "^2.2.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "globby": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+          "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.1.1",
+            "ignore": "^5.1.4",
+            "merge2": "^1.3.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "dev": true
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+          "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
+          "dev": true
+        }
+      }
+    },
+    "@oclif/errors": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.3.tgz",
+      "integrity": "sha512-EJR6AIOEkt/NnARNIVAskPDVtdhtO5TTNXmhDrGqMoWVsr0R6DkkLrMyq95BmHvlVWM1nduoq4fQPuCyuF2jaA==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^3.0.0",
+        "fs-extra": "^9.0.1",
+        "indent-string": "^4.0.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "clean-stack": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.0.tgz",
+          "integrity": "sha512-RHxtgFvXsRQ+1AM7dlozLDY7ssmvUUh0XEnfnyhYgJTO6beNZHBogiaCwGM9Q3rFrUkYxOtsZRC0zAturg5bjg==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "4.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@oclif/linewrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
+      "integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==",
+      "dev": true
+    },
+    "@oclif/parser": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.5.tgz",
+      "integrity": "sha512-yojzeEfmSxjjkAvMRj0KzspXlMjCfBzNRPkWw8ZwOSoNWoJn+OCS/m/S+yfV6BvAM4u2lTzX9Y5rCbrFIgkJLg==",
+      "dev": true,
+      "requires": {
+        "@oclif/errors": "^1.2.2",
+        "@oclif/linewrap": "^1.0.0",
+        "chalk": "^2.4.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@oclif/plugin-help": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-2.2.3.tgz",
+      "integrity": "sha512-bGHUdo5e7DjPJ0vTeRBMIrfqTRDBfyR5w0MP41u0n3r7YG5p14lvMmiCXxi6WDaP2Hw5nqx3PnkAIntCKZZN7g==",
+      "dev": true,
+      "requires": {
+        "@oclif/command": "^1.5.13",
+        "chalk": "^2.4.1",
+        "indent-string": "^4.0.0",
+        "lodash.template": "^4.4.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0",
+        "widest-line": "^2.0.1",
+        "wrap-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "widest-line": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+          "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "wrap-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-4.0.0.tgz",
+          "integrity": "sha512-uMTsj9rDb0/7kk1PbcbCcwvHUxp60fGDB/NNXpVa0Q+ic/e7y5+BwTxKfQ33VYgDppSwi/FBzpetYzo8s6tfbg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        }
       }
     },
     "@octokit/auth-token": {
@@ -3629,6 +4124,15 @@
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
       "dev": true
     },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
     "debuglog": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
@@ -4508,6 +5012,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz",
       "integrity": "sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ==",
+      "dev": true
+    },
+    "fs": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.2.tgz",
+      "integrity": "sha1-4fJE7zkzwbKmS9R5kTYGDQ9ZFPg=",
       "dev": true
     },
     "fs-extra": {
@@ -5531,6 +6041,12 @@
         }
       }
     },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true
+    },
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -5633,6 +6149,12 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
+    "is-docker": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+      "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
       "dev": true
     },
     "is-extendable": {
@@ -5768,6 +6290,15 @@
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
     },
     "isarray": {
       "version": "0.0.1",
@@ -7368,6 +7899,195 @@
         "release-zalgo": "^1.0.0"
       }
     },
+    "package-lock-sanitizer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-lock-sanitizer/-/package-lock-sanitizer-1.0.1.tgz",
+      "integrity": "sha512-MDpr4A9wgsY6w1fqOPp0krxiyGHedMq63/fOs5oh1IMVGWNXXqEySaCbZzQgJP9WWI+dzSOyQN4+7PnmsaXqxw==",
+      "dev": true,
+      "requires": {
+        "@oclif/command": "^1.5.11",
+        "@oclif/config": "^1.12.8",
+        "@oclif/errors": "^1.2.2",
+        "@oclif/plugin-help": "^2.1.6",
+        "fs": "0.0.2",
+        "replace-in-file": "^5.0.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "replace-in-file": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-5.0.2.tgz",
+          "integrity": "sha512-1Vc7Sbr/rTuHgU1PZuBb7tGsFx3D4NKdhV4BpEF2MuN/6+SoXcFtx+dZ1Zz+5Dq4k5x9js87Y+gXQYPTQ9ppkA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "glob": "^7.1.6",
+            "yargs": "^15.0.2"
+          }
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "parallel-transform": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
@@ -7819,6 +8539,15 @@
         "dezalgo": "^1.0.0",
         "graceful-fs": "^4.1.2",
         "once": "^1.3.0"
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
       }
     },
     "redent": {
@@ -8276,6 +9005,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -9445,6 +10185,55 @@
       "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
+      }
+    },
+    "widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "windows-release": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "devDependencies": {
-    "@fluidframework/build-tools": "^0.2.3049",
+    "@fluidframework/build-tools": "^0.2.4847",
     "@fluidframework/test-tools": "^0.2.3074",
     "@mattetti/custom-api-documenter": "^0.2.1",
     "@microsoft/api-extractor": "^7.7.2",

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -461,9 +461,9 @@
 			"integrity": "sha512-1pYGzO4NRlaMz+REq+YtzY8gmckZ9aCSzf0FpYsinEfSLOjPYRvgIvN6z4i4WDn5jocD3y8YH4RTSyVBgTtTtQ=="
 		},
 		"@fluidframework/build-tools": {
-			"version": "0.2.3049",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.3049.tgz",
-			"integrity": "sha512-X+m4U9Hb730TxoaaZ9Qqf1z6qo09FlDI69aLNITFJA+E9YWQmx9JhfbwWzkLD86FEhA8g+nYcw6wWCtmz4vPiQ==",
+			"version": "0.2.4847",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.4847.tgz",
+			"integrity": "sha512-5cN1RqjSHG1xSsjRswuVAGKN1d4TzBXDeuQp46RlnZv154GneleLsh0kbdhwsr2AwU/+M2DMs7yEeVCTaUWeAA==",
 			"dev": true,
 			"requires": {
 				"async": "^2.6.2",
@@ -472,9 +472,11 @@
 				"fs-extra": "^9.0.1",
 				"glob": "^7.1.3",
 				"lodash.isequal": "^4.5.0",
+				"package-lock-sanitizer": "^1.0.1",
 				"replace-in-file": "^6.0.0",
 				"rimraf": "^2.6.2",
 				"semver": "^7.1.2",
+				"shelljs": "^0.8.4",
 				"sort-package-json": "1.40.0",
 				"typescript": "^3.7.4"
 			},
@@ -1863,6 +1865,536 @@
 			"requires": {
 				"@nodelib/fs.scandir": "2.1.3",
 				"fastq": "^1.6.0"
+			}
+		},
+		"@oclif/command": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
+			"integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
+			"dev": true,
+			"requires": {
+				"@oclif/config": "^1.15.1",
+				"@oclif/errors": "^1.3.3",
+				"@oclif/parser": "^3.8.3",
+				"@oclif/plugin-help": "^3",
+				"debug": "^4.1.1",
+				"semver": "^7.3.2"
+			},
+			"dependencies": {
+				"@oclif/plugin-help": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.0.tgz",
+					"integrity": "sha512-7jxtpwVWAVbp1r46ZnTK/uF+FeZc6y4p1XcGaIUuPAp7wx6NJhIRN/iMT9UfNFX/Cz7mq+OyJz+E+i0zrik86g==",
+					"dev": true,
+					"requires": {
+						"@oclif/command": "^1.5.20",
+						"@oclif/config": "^1.15.1",
+						"chalk": "^2.4.1",
+						"indent-string": "^4.0.0",
+						"lodash.template": "^4.4.0",
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"widest-line": "^3.1.0",
+						"wrap-ansi": "^4.0.0"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-4.0.0.tgz",
+					"integrity": "sha512-uMTsj9rDb0/7kk1PbcbCcwvHUxp60fGDB/NNXpVa0Q+ic/e7y5+BwTxKfQ33VYgDppSwi/FBzpetYzo8s6tfbg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+							"dev": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+							"dev": true
+						},
+						"string-width": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+							"dev": true,
+							"requires": {
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^4.0.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
+					}
+				}
+			}
+		},
+		"@oclif/config": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.17.0.tgz",
+			"integrity": "sha512-Lmfuf6ubjQ4ifC/9bz1fSCHc6F6E653oyaRXxg+lgT4+bYf9bk+nqrUpAbrXyABkCqgIBiFr3J4zR/kiFdE1PA==",
+			"dev": true,
+			"requires": {
+				"@oclif/errors": "^1.3.3",
+				"@oclif/parser": "^3.8.0",
+				"debug": "^4.1.1",
+				"globby": "^11.0.1",
+				"is-wsl": "^2.1.1",
+				"tslib": "^2.0.0"
+			},
+			"dependencies": {
+				"@nodelib/fs.stat": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+					"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+					"dev": true
+				},
+				"array-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+					"dev": true
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"dir-glob": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+					"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+					"dev": true,
+					"requires": {
+						"path-type": "^4.0.0"
+					}
+				},
+				"fast-glob": {
+					"version": "3.2.4",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+					"integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+					"dev": true,
+					"requires": {
+						"@nodelib/fs.stat": "^2.0.2",
+						"@nodelib/fs.walk": "^1.2.3",
+						"glob-parent": "^5.1.0",
+						"merge2": "^1.3.0",
+						"micromatch": "^4.0.2",
+						"picomatch": "^2.2.1"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"globby": {
+					"version": "11.0.1",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+					"integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+					"dev": true,
+					"requires": {
+						"array-union": "^2.1.0",
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.1.1",
+						"ignore": "^5.1.4",
+						"merge2": "^1.3.0",
+						"slash": "^3.0.0"
+					}
+				},
+				"ignore": {
+					"version": "5.1.8",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+					"dev": true
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"is-wsl": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+					"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+					"dev": true,
+					"requires": {
+						"is-docker": "^2.0.0"
+					}
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+					"dev": true
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+					"dev": true
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				},
+				"tslib": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+					"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
+					"dev": true
+				}
+			}
+		},
+		"@oclif/errors": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.3.tgz",
+			"integrity": "sha512-EJR6AIOEkt/NnARNIVAskPDVtdhtO5TTNXmhDrGqMoWVsr0R6DkkLrMyq95BmHvlVWM1nduoq4fQPuCyuF2jaA==",
+			"dev": true,
+			"requires": {
+				"clean-stack": "^3.0.0",
+				"fs-extra": "^9.0.1",
+				"indent-string": "^4.0.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"clean-stack": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.0.tgz",
+					"integrity": "sha512-RHxtgFvXsRQ+1AM7dlozLDY7ssmvUUh0XEnfnyhYgJTO6beNZHBogiaCwGM9Q3rFrUkYxOtsZRC0zAturg5bjg==",
+					"dev": true,
+					"requires": {
+						"escape-string-regexp": "4.0.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"escape-string-regexp": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+					"dev": true
+				},
+				"fs-extra": {
+					"version": "9.0.1",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+					"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+					"dev": true,
+					"requires": {
+						"at-least-node": "^1.0.0",
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^6.0.1",
+						"universalify": "^1.0.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"jsonfile": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+					"integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.6",
+						"universalify": "^1.0.0"
+					}
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"universalify": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+					"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+					"dev": true
+				},
+				"wrap-ansi": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+					"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				}
+			}
+		},
+		"@oclif/linewrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
+			"integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==",
+			"dev": true
+		},
+		"@oclif/parser": {
+			"version": "3.8.5",
+			"resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.5.tgz",
+			"integrity": "sha512-yojzeEfmSxjjkAvMRj0KzspXlMjCfBzNRPkWw8ZwOSoNWoJn+OCS/m/S+yfV6BvAM4u2lTzX9Y5rCbrFIgkJLg==",
+			"dev": true,
+			"requires": {
+				"@oclif/errors": "^1.2.2",
+				"@oclif/linewrap": "^1.0.0",
+				"chalk": "^2.4.2",
+				"tslib": "^1.9.3"
+			}
+		},
+		"@oclif/plugin-help": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-2.2.3.tgz",
+			"integrity": "sha512-bGHUdo5e7DjPJ0vTeRBMIrfqTRDBfyR5w0MP41u0n3r7YG5p14lvMmiCXxi6WDaP2Hw5nqx3PnkAIntCKZZN7g==",
+			"dev": true,
+			"requires": {
+				"@oclif/command": "^1.5.13",
+				"chalk": "^2.4.1",
+				"indent-string": "^4.0.0",
+				"lodash.template": "^4.4.0",
+				"string-width": "^3.0.0",
+				"strip-ansi": "^5.0.0",
+				"widest-line": "^2.0.1",
+				"wrap-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				},
+				"widest-line": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+					"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+					"dev": true,
+					"requires": {
+						"string-width": "^2.1.1"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+							"dev": true
+						},
+						"string-width": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+							"dev": true,
+							"requires": {
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^4.0.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
+					}
+				},
+				"wrap-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-4.0.0.tgz",
+					"integrity": "sha512-uMTsj9rDb0/7kk1PbcbCcwvHUxp60fGDB/NNXpVa0Q+ic/e7y5+BwTxKfQ33VYgDppSwi/FBzpetYzo8s6tfbg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+							"dev": true
+						},
+						"string-width": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+							"dev": true,
+							"requires": {
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^4.0.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
+					}
+				}
 			}
 		},
 		"@octokit/auth-token": {
@@ -7575,6 +8107,12 @@
 			"integrity": "sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ==",
 			"dev": true
 		},
+		"fs": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/fs/-/fs-0.0.2.tgz",
+			"integrity": "sha1-4fJE7zkzwbKmS9R5kTYGDQ9ZFPg=",
+			"dev": true
+		},
 		"fs-constants": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -9013,6 +9551,12 @@
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
 			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+			"dev": true
+		},
+		"is-docker": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+			"integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
 			"dev": true
 		},
 		"is-extendable": {
@@ -12135,6 +12679,206 @@
 				"release-zalgo": "^1.0.0"
 			}
 		},
+		"package-lock-sanitizer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-lock-sanitizer/-/package-lock-sanitizer-1.0.1.tgz",
+			"integrity": "sha512-MDpr4A9wgsY6w1fqOPp0krxiyGHedMq63/fOs5oh1IMVGWNXXqEySaCbZzQgJP9WWI+dzSOyQN4+7PnmsaXqxw==",
+			"dev": true,
+			"requires": {
+				"@oclif/command": "^1.5.11",
+				"@oclif/config": "^1.12.8",
+				"@oclif/errors": "^1.2.2",
+				"@oclif/plugin-help": "^2.1.6",
+				"fs": "0.0.2",
+				"replace-in-file": "^5.0.2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"cliui": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^6.2.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"replace-in-file": {
+					"version": "5.0.2",
+					"resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-5.0.2.tgz",
+					"integrity": "sha512-1Vc7Sbr/rTuHgU1PZuBb7tGsFx3D4NKdhV4BpEF2MuN/6+SoXcFtx+dZ1Zz+5Dq4k5x9js87Y+gXQYPTQ9ppkA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^3.0.0",
+						"glob": "^7.1.6",
+						"yargs": "^15.0.2"
+					}
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"yargs": {
+					"version": "15.4.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+					"dev": true,
+					"requires": {
+						"cliui": "^6.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^4.1.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^4.2.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^18.1.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
+		},
 		"pako": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -12949,6 +13693,15 @@
 				}
 			}
 		},
+		"rechoir": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"dev": true,
+			"requires": {
+				"resolve": "^1.1.6"
+			}
+		},
 		"redent": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -13740,6 +14493,17 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+		},
+		"shelljs": {
+			"version": "0.8.4",
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+			"integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.0.0",
+				"interpret": "^1.0.0",
+				"rechoir": "^0.6.2"
+			}
 		},
 		"side-channel": {
 			"version": "1.0.2",
@@ -16277,6 +17041,55 @@
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 			"requires": {
 				"string-width": "^1.0.2 || 2"
+			}
+		},
+		"widest-line": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+			"integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+			"dev": true,
+			"requires": {
+				"string-width": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				}
 			}
 		},
 		"window-size": {

--- a/server/routerlicious/package-lock.json
+++ b/server/routerlicious/package-lock.json
@@ -375,9 +375,9 @@
       }
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.3049",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.3049.tgz",
-      "integrity": "sha512-X+m4U9Hb730TxoaaZ9Qqf1z6qo09FlDI69aLNITFJA+E9YWQmx9JhfbwWzkLD86FEhA8g+nYcw6wWCtmz4vPiQ==",
+      "version": "0.2.4847",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.4847.tgz",
+      "integrity": "sha512-5cN1RqjSHG1xSsjRswuVAGKN1d4TzBXDeuQp46RlnZv154GneleLsh0kbdhwsr2AwU/+M2DMs7yEeVCTaUWeAA==",
       "dev": true,
       "requires": {
         "async": "^2.6.2",
@@ -386,9 +386,11 @@
         "fs-extra": "^9.0.1",
         "glob": "^7.1.3",
         "lodash.isequal": "^4.5.0",
+        "package-lock-sanitizer": "^1.0.1",
         "replace-in-file": "^6.0.0",
         "rimraf": "^2.6.2",
         "semver": "^7.1.2",
+        "shelljs": "^0.8.4",
         "sort-package-json": "1.40.0",
         "typescript": "^3.7.4"
       },
@@ -1734,6 +1736,521 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
+      }
+    },
+    "@oclif/command": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
+      "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
+      "dev": true,
+      "requires": {
+        "@oclif/config": "^1.15.1",
+        "@oclif/errors": "^1.3.3",
+        "@oclif/parser": "^3.8.3",
+        "@oclif/plugin-help": "^3",
+        "debug": "^4.1.1",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "@oclif/plugin-help": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.0.tgz",
+          "integrity": "sha512-7jxtpwVWAVbp1r46ZnTK/uF+FeZc6y4p1XcGaIUuPAp7wx6NJhIRN/iMT9UfNFX/Cz7mq+OyJz+E+i0zrik86g==",
+          "dev": true,
+          "requires": {
+            "@oclif/command": "^1.5.20",
+            "@oclif/config": "^1.15.1",
+            "chalk": "^2.4.1",
+            "indent-string": "^4.0.0",
+            "lodash.template": "^4.4.0",
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "widest-line": "^3.1.0",
+            "wrap-ansi": "^4.0.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-4.0.0.tgz",
+          "integrity": "sha512-uMTsj9rDb0/7kk1PbcbCcwvHUxp60fGDB/NNXpVa0Q+ic/e7y5+BwTxKfQ33VYgDppSwi/FBzpetYzo8s6tfbg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "@oclif/config": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.17.0.tgz",
+      "integrity": "sha512-Lmfuf6ubjQ4ifC/9bz1fSCHc6F6E653oyaRXxg+lgT4+bYf9bk+nqrUpAbrXyABkCqgIBiFr3J4zR/kiFdE1PA==",
+      "dev": true,
+      "requires": {
+        "@oclif/errors": "^1.3.3",
+        "@oclif/parser": "^3.8.0",
+        "debug": "^4.1.1",
+        "globby": "^11.0.1",
+        "is-wsl": "^2.1.1",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@nodelib/fs.stat": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+          "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+          "dev": true
+        },
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+          "dev": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "dir-glob": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+          "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+          "dev": true,
+          "requires": {
+            "path-type": "^4.0.0"
+          }
+        },
+        "fast-glob": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+          "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.0",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.2",
+            "picomatch": "^2.2.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "globby": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+          "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.1.1",
+            "ignore": "^5.1.4",
+            "merge2": "^1.3.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "dev": true
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+          "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
+          "dev": true
+        }
+      }
+    },
+    "@oclif/errors": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.3.tgz",
+      "integrity": "sha512-EJR6AIOEkt/NnARNIVAskPDVtdhtO5TTNXmhDrGqMoWVsr0R6DkkLrMyq95BmHvlVWM1nduoq4fQPuCyuF2jaA==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^3.0.0",
+        "fs-extra": "^9.0.1",
+        "indent-string": "^4.0.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "clean-stack": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.0.tgz",
+          "integrity": "sha512-RHxtgFvXsRQ+1AM7dlozLDY7ssmvUUh0XEnfnyhYgJTO6beNZHBogiaCwGM9Q3rFrUkYxOtsZRC0zAturg5bjg==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "4.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@oclif/linewrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
+      "integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==",
+      "dev": true
+    },
+    "@oclif/parser": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.5.tgz",
+      "integrity": "sha512-yojzeEfmSxjjkAvMRj0KzspXlMjCfBzNRPkWw8ZwOSoNWoJn+OCS/m/S+yfV6BvAM4u2lTzX9Y5rCbrFIgkJLg==",
+      "dev": true,
+      "requires": {
+        "@oclif/errors": "^1.2.2",
+        "@oclif/linewrap": "^1.0.0",
+        "chalk": "^2.4.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@oclif/plugin-help": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-2.2.3.tgz",
+      "integrity": "sha512-bGHUdo5e7DjPJ0vTeRBMIrfqTRDBfyR5w0MP41u0n3r7YG5p14lvMmiCXxi6WDaP2Hw5nqx3PnkAIntCKZZN7g==",
+      "dev": true,
+      "requires": {
+        "@oclif/command": "^1.5.13",
+        "chalk": "^2.4.1",
+        "indent-string": "^4.0.0",
+        "lodash.template": "^4.4.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0",
+        "widest-line": "^2.0.1",
+        "wrap-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "widest-line": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+          "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "wrap-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-4.0.0.tgz",
+          "integrity": "sha512-uMTsj9rDb0/7kk1PbcbCcwvHUxp60fGDB/NNXpVa0Q+ic/e7y5+BwTxKfQ33VYgDppSwi/FBzpetYzo8s6tfbg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        }
       }
     },
     "@octokit/auth-token": {
@@ -3546,6 +4063,15 @@
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
       "dev": true
     },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
     "debuglog": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
@@ -4425,6 +4951,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz",
       "integrity": "sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ==",
+      "dev": true
+    },
+    "fs": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.2.tgz",
+      "integrity": "sha1-4fJE7zkzwbKmS9R5kTYGDQ9ZFPg=",
       "dev": true
     },
     "fs-extra": {
@@ -5437,6 +5969,12 @@
         }
       }
     },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true
+    },
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -5539,6 +6077,12 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
+    "is-docker": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+      "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
       "dev": true
     },
     "is-extendable": {
@@ -5674,6 +6218,15 @@
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
     },
     "isarray": {
       "version": "0.0.1",
@@ -7280,6 +7833,195 @@
         "release-zalgo": "^1.0.0"
       }
     },
+    "package-lock-sanitizer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-lock-sanitizer/-/package-lock-sanitizer-1.0.1.tgz",
+      "integrity": "sha512-MDpr4A9wgsY6w1fqOPp0krxiyGHedMq63/fOs5oh1IMVGWNXXqEySaCbZzQgJP9WWI+dzSOyQN4+7PnmsaXqxw==",
+      "dev": true,
+      "requires": {
+        "@oclif/command": "^1.5.11",
+        "@oclif/config": "^1.12.8",
+        "@oclif/errors": "^1.2.2",
+        "@oclif/plugin-help": "^2.1.6",
+        "fs": "0.0.2",
+        "replace-in-file": "^5.0.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "replace-in-file": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-5.0.2.tgz",
+          "integrity": "sha512-1Vc7Sbr/rTuHgU1PZuBb7tGsFx3D4NKdhV4BpEF2MuN/6+SoXcFtx+dZ1Zz+5Dq4k5x9js87Y+gXQYPTQ9ppkA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "glob": "^7.1.6",
+            "yargs": "^15.0.2"
+          }
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "parallel-transform": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
@@ -7731,6 +8473,15 @@
         "dezalgo": "^1.0.0",
         "graceful-fs": "^4.1.2",
         "once": "^1.3.0"
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
       }
     },
     "redent": {
@@ -8188,6 +8939,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -9351,6 +10113,55 @@
       "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
+      }
+    },
+    "widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "windows-release": {

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@fluidframework/build-tools": "^0.2.3049",
+    "@fluidframework/build-tools": "^0.2.4847",
     "@microsoft/api-documenter": "^7.4.6",
     "@microsoft/api-extractor": "^7.7.2",
     "concurrently": "^5.2.0",


### PR DESCRIPTION
This change will help ensure private registry URLs don't sneak into our lockfiles. See #3602 and #3603 for more info.