### PR TITLE
[0.25->0.26] Minimally restore _createDataStoreWithProps for bohemia

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -7,7 +7,7 @@
 - [Container runtime event changes](#Container-runtime-event-changes)
 - [Component is removed from telemetry event names](#Component-is-removed-from-telemetry-event-names)
 - [IComponentContextLegacy is removed](#IComponentContextLegacy-is-removed)
-- [IContainerRuntimeBase._createDataStoreWithProps() is removed](#IContainerRuntimeBase._createDataStoreWithProps-is-removed)
+- [~~IContainerRuntimeBase._createDataStoreWithProps() is removed~~](#IContainerRuntimeBase._createDataStoreWithProps-is-removed)
 - [_createDataStore() APIs are removed](#_createDataStore-APIs-are-removed)
 - [createDataStoreWithRealizationFn() APIs are removed](#createDataStoreWithRealizationFn()-APIs-are-removed)
 - [getDataStore() APIs is removed](#getDataStore()-APIs-is-removed)
@@ -41,6 +41,8 @@ SignalComponentNotFound -> SignalFluidDataStoreNotFound
 Deprecated in 0.18, removed.
 
 ### IContainerRuntimeBase._createDataStoreWithProps is removed
+**Note: This change has been reverted for 0.25 and will be pushed to a later release.**
+
 `IContainerRuntimeBase._createDataStoreWithProps()` has been removed. Please use `IContainerRuntimeBase.createDataStore()` (returns IFluidRouter).
 If you need to pass props to data store, either use request() route to pass initial props directly, or to query Fluid object to interact with it (pass props / call methods to configure object).
 

--- a/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
@@ -140,7 +140,7 @@ export abstract class PureDataObject<P extends IFluidObject = object, S = undefi
             assert(props === undefined);
             await this.initializingFromExisting();
         } else {
-            await this.initializingFirstTime(props);
+            await this.initializingFirstTime(this.context.createProps as S ?? props);
         }
         await this.hasInitialized();
     }

--- a/packages/framework/request-handler/src/requestHandlers.ts
+++ b/packages/framework/request-handler/src/requestHandlers.ts
@@ -34,7 +34,7 @@ export type RuntimeRequestHandler = (request: RequestParser, runtime: IContainer
  * handling of external URI to internal handle is required (in future, we will support weak handle references,
  * that will allow any GC policy to be implemented by container authors.)
  */
-export const deprecated_innerRequestHandler = async (request: IRequest, runtime: IContainerRuntime) =>
+export const deprecated_innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
     runtime.IFluidHandleContext.resolveHandle(request);
 
 export const createFluidObjectResponse = (fluidObject: IFluidObject) => {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1259,6 +1259,11 @@ export class ContainerRuntime extends EventEmitter
         return context;
     }
 
+    public async _createDataStoreWithProps(pkg: string | string[], props?: any, id = uuid()):
+        Promise<IFluidDataStoreChannel> {
+        return this._createFluidDataStoreContext(Array.isArray(pkg) ? pkg : [pkg], id, props).realize();
+    }
+
     private async _createDataStore(pkg: string | string[], id = uuid()): Promise<IFluidDataStoreChannel>
     {
         return this._createFluidDataStoreContext(Array.isArray(pkg) ? pkg : [pkg], id).realize();
@@ -1268,7 +1273,7 @@ export class ContainerRuntime extends EventEmitter
         return this.connected && !this.deltaManager.readonly;
     }
 
-    private _createFluidDataStoreContext(pkg: string[], id) {
+    private _createFluidDataStoreContext(pkg: string[], id: string, props?: any) {
         const context = new LocalFluidDataStoreContext(
             id,
             pkg,
@@ -1278,6 +1283,7 @@ export class ContainerRuntime extends EventEmitter
             this.summaryTracker.createOrGetChild(id, this.deltaManager.lastSequenceNumber),
             this.summarizerNode.getCreateChildFn(id, { type: CreateSummarizerNodeSource.Local }),
             (cr: IFluidDataStoreChannel) => this.bindFluidDataStore(cr),
+            props,
         );
         this.setupNewContext(context);
         return context;

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -679,6 +679,10 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
         summaryTracker: SummaryTracker,
         createSummarizerNode: CreateChildSummarizerNodeFn,
         bindChannel: (channel: IFluidDataStoreChannel) => void,
+        /**
+         * @deprecated 0.16 Issue #1635, #3631
+         */
+        public readonly createProps?: any,
     ) {
         super(
             runtime,
@@ -749,6 +753,10 @@ export class LocalFluidDataStoreContext extends LocalFluidDataStoreContextBase {
         summaryTracker: SummaryTracker,
         createSummarizerNode: CreateChildSummarizerNodeFn,
         bindChannel: (channel: IFluidDataStoreChannel) => void,
+        /**
+         * @deprecated 0.16 Issue #1635, #3631
+         */
+        createProps?: any,
     ) {
         super(
             id,
@@ -758,7 +766,8 @@ export class LocalFluidDataStoreContext extends LocalFluidDataStoreContextBase {
             scope,
             summaryTracker,
             createSummarizerNode,
-            bindChannel);
+            bindChannel,
+            createProps);
     }
 }
 

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -90,6 +90,12 @@ export interface IContainerRuntimeBase extends
     on(event: "leader" | "notleader", listener: () => void): this;
 
     /**
+     * @deprecated 0.16 Issue #1537, #3631
+     * @internal
+     */
+    _createDataStoreWithProps(pkg: string | string[], props?: any, id?: string): Promise<IFluidDataStoreChannel>;
+
+    /**
      * Creates data store. Returns router of data store. Data store is not bound to container,
      * store in such state is not persisted to storage (file). Storing a handle to this store
      * (or any of its parts, like DDS) into already attached DDS (or non-attached DDS that will eventually
@@ -261,6 +267,11 @@ export interface IFluidDataStoreContext extends EventEmitter, Partial<IProvideFl
      */
     readonly hostRuntime: IContainerRuntimeBase;
     readonly snapshotFn: (message: string) => Promise<void>;
+
+    /**
+     * @deprecated 0.16 Issue #1635, #3631
+     */
+    readonly createProps?: any;
 
     /**
      * Ambient services provided with the context


### PR DESCRIPTION
#3631
Port earlier change to minimally restore _createDataStoreWithProps to 0.26. Additional work in the port to 0.26 included adapting the change to the other component creation changes that happened between 0.25 and 0.26.

Future: bring this to main