### PR TITLE
Allow setting autoreconnect before resuming processing of ops because it is just a policy.

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -647,11 +647,9 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             connectionState: ConnectionState[this.connectionState],
         });
 
-        // If container state is not attached, then don't connect to delta stream. Also don't set the
+        // If container state is not attached and resumed, then don't connect to delta stream. Also don't set the
         // manual reconnection flag to true as we haven't made the initial connection yet.
-        if (reconnect && this._attachState === AttachState.Attached) {
-            // Attached container must have been resumed.
-            assert(this.resumedOpProcessingAfterLoad);
+        if (reconnect && this._attachState === AttachState.Attached && this.resumedOpProcessingAfterLoad) {
             if (this._connectionState === ConnectionState.Disconnected) {
                 // Only track this as a manual reconnection if we are truly the ones kicking it off.
                 this.manualReconnectInProgress = true;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -635,8 +635,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     }
 
     public setAutoReconnect(reconnect: boolean) {
-        assert(this.resumedOpProcessingAfterLoad);
-
         if (reconnect && this.closed) {
             throw new Error("Attempting to setAutoReconnect() a closed DeltaManager");
         }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -647,7 +647,9 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             connectionState: ConnectionState[this.connectionState],
         });
 
-        if (reconnect) {
+        // If container state is not attached, then don't connect to delta stream. Also don't set the
+        // manual reconnection flag to true as we haven't made the initial connection yet.
+        if (reconnect && this._attachState === AttachState.Attached) {
             if (this._connectionState === ConnectionState.Disconnected) {
                 // Only track this as a manual reconnection if we are truly the ones kicking it off.
                 this.manualReconnectInProgress = true;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -650,6 +650,8 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         // If container state is not attached, then don't connect to delta stream. Also don't set the
         // manual reconnection flag to true as we haven't made the initial connection yet.
         if (reconnect && this._attachState === AttachState.Attached) {
+            // Attached container must have been resumed.
+            assert(this.resumedOpProcessingAfterLoad);
             if (this._connectionState === ConnectionState.Disconnected) {
                 // Only track this as a manual reconnection if we are truly the ones kicking it off.
                 this.manualReconnectInProgress = true;


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/3666
Currently setAutoReconnect() is in the form of policy not action, so allow setting it at anytime.