### PR TITLE
Use public docker endpoints in r11s

### DIFF
--- a/server/gateway/charts/templates/configmap.yaml
+++ b/server/gateway/charts/templates/configmap.yaml
@@ -90,7 +90,6 @@ data:
             "frsBlobStorageUrl": "{{ .Values.historian.frsExternalUrl }}",
             "internalBlobStorageUrl": "{{ .Values.historian.internalUrl }}",
             "repository": "FluidFramework",
-            "clusterNpm": "{{ .Values.worker.clusterNpm }}",
             "npm": "{{ .Values.worker.npm }}",
             "packageManager": {
                 "endpoint": "{{ .Values.packageManager.endpoint }}",

--- a/server/gateway/charts/values.yaml
+++ b/server/gateway/charts/values.yaml
@@ -69,7 +69,6 @@ worker:
       key: ""
     translation:
       key: ""
-  clusterNpm: ""
   npm: ""
 
 

--- a/server/gateway/config.json
+++ b/server/gateway/config.json
@@ -82,10 +82,8 @@
         "blobStorageUrl": "http://historian:3000",
         "internalBlobStorageUrl": "http://historian:3000",
         "repository": "prague",
-        "npm": "https://pragueauspkn.azureedge.net",
-        "clusterNpm": "https://pragueauspkn.azureedge.net",
-        "localNpm": "http://localhost:3002",
-        "localClusterNpm": "http://auspkn:3000",
+        "npm": "https://unpkg.com",
+        "clusterNpm": "https://unpkg.com",
         "packageManager": {
             "endpoint": "https://packages.wu2.prague.office-int.com",
             "username": "prague",

--- a/server/gateway/docker-compose.yml
+++ b/server/gateway/docker-compose.yml
@@ -13,17 +13,14 @@ services:
             - login__accounts
         restart: always
     gitrest:
-        image: prague.azurecr.io/gitrest:1038
-        restart: always
-    cobalt:
-        image: prague.azurecr.io/cobalt:1544
+        image: mcr.microsoft.com/fluidframework/routerlicious/gitrest:latest
         restart: always
     redis:
         image: redis:alpine
     mongodb:
         image: mongo:3.4.3
     riddler:
-        image: prague.azurecr.io/prague:2302
+        image: mcr.microsoft.com/fluidframework/routerlicious/server:latest
         command: node dist/riddler/www.js
         environment:
             - DEBUG=routerlicious:*

--- a/server/gateway/package.json
+++ b/server/gateway/package.json
@@ -17,7 +17,7 @@
     "build": "npm run build:genver && concurrently npm:build:compile npm:lint",
     "build:compile": "concurrently npm:tsc npm:less npm:build:webpack",
     "build:compile:min": "concurrently npm:build:compile npm:build:webpack:min",
-    "build:docker": "docker build . --tag prague.azurecr.io/gateway:test",
+    "build:docker": "docker build . --tag fluidcr.azurecr.io/build/gateway:test",
     "build:full": "npm run build",
     "build:full:compile": "npm run build:compile",
     "build:genver": "gen-version",

--- a/server/routerlicious/docker-compose.yml
+++ b/server/routerlicious/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
     gateway:
-        image: prague.azurecr.io/gateway:latest
+        image: prague.azurecr.io/gateway:test
         ports:
             - "3000:3000"
         command: node dist/www.js
@@ -87,7 +87,7 @@ services:
             - NODE_ENV=development
         restart: always
     historian:
-        image: prague.azurecr.io/historian:30824
+        image: mcr.microsoft.com/fluidframework/routerlicious/historian:latest
         ports:
             - "3001:3000"
         environment:
@@ -95,7 +95,7 @@ services:
             - NODE_ENV=development
         restart: always
     gitrest:
-        image: prague.azurecr.io/gitrest:30825
+        image: mcr.microsoft.com/fluidframework/routerlicious/gitrest:latest
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
@@ -103,7 +103,7 @@ services:
             - git:/home/node/documents
         restart: always
     git:
-        image: prague.azurecr.io/gitssh:654
+        image: mcr.microsoft.com/fluidframework/routerlicious/gitssh:latest
         ports:
             - "3022:22"
         volumes:
@@ -131,19 +131,6 @@ services:
         image: "mongo:3.4.3"
     rabbitmq:
         image: "rabbitmq:alpine"
-    auspkn:
-        image: prague.azurecr.io/auspkn:4149
-        command: node dist/www.js
-        ports:
-            - "3002:3000"
-        environment:
-            - npm__url=http://verdaccio:4873
-    verdaccio:
-        image: verdaccio/verdaccio:3.8.1
-        ports:
-            - "4873:4873"
-        volumes:
-            - ./verdaccio/conf:/verdaccio/conf
 volumes:
   git:
     driver: local

--- a/server/routerlicious/docker-compose.yml
+++ b/server/routerlicious/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
     gateway:
-        image: prague.azurecr.io/gateway:test
+        image: fluidcr.azurecr.io/build/gateway:latest
         ports:
             - "3000:3000"
         command: node dist/www.js


### PR DESCRIPTION
Use public docker endpoints, even for the r11s docker-compose file.
Switch to unpkg for gateway endpoint