### PR TITLE
Fix link in node-host example README

### DIFF
--- a/examples/hosts/node-host/README.md
+++ b/examples/hosts/node-host/README.md
@@ -2,7 +2,7 @@
 
 ## Fluid Loader for Node.js evironment
 
-This example demonstrates loading Fluid objects inside Node.js environment. To understand how Fluid loader works, read the [literate](../literate/README.md) loader example first.
+This example demonstrates loading Fluid objects inside Node.js environment. To understand how Fluid loader works, read the [literate](../hosts-sample/README.md) loader example first.
 
 ## Difference with Literate Loader
 


### PR DESCRIPTION
"literate" example was renamed to "hosts-sample" here: https://github.com/microsoft/FluidFramework/commit/e42370eee1a226a00723568288c0e31bd17a0cf7