### PR TITLE
Add the Alfred Https Ping Endpoint for Availability Monitoring System

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -47,6 +47,10 @@ export function create(
         }, (error) => response.status(400).end(error.toString()));
     }
 
+    router.get("/ping", async (request, response) => {
+        response.sendStatus(200);
+    });
+
     router.patch("/:tenantId/:id/root", async (request, response) => {
         const validP = verifyRequest(request, tenantManager, storage);
         returnResponse(validP, request, response, mapSetBuilder);


### PR DESCRIPTION
We propose to add a new path (/ping) for Alfred https, and it will return immediately an OK (200) response whenever a request is received.  
The health check system sends an empty GET request to call the ping endpoint. Then, the health check system gets the response from the ping endpoint. The response shows the availability based on the connectivity and the HTTP status code. 
The URL address would be:        URL/api/v1/ping