### PR TITLE
Add the Historian Https Ping Endpoint for Availability Monitoring System

### DIFF
--- a/server/historian/src/routes/git/blobs.ts
+++ b/server/historian/src/routes/git/blobs.ts
@@ -29,6 +29,13 @@ export function create(store: nconf.Provider, tenantService: ITenantService, cac
         return service.getBlob(sha, useCache);
     }
 
+    /**
+     * Historian Https Ping Endpoint for Availability Monitoring System
+     */
+    router.get("/repos/ping", async (request, response) => {
+        response.sendStatus(200);
+    });
+
     router.post("/repos/:ignored?/:tenantId/git/blobs", (request, response, next) => {
         const blobP = createBlob(request.params.tenantId, request.get("Authorization"), request.body);
         utils.handleResponse(

--- a/server/historian/src/routes/git/blobs.ts
+++ b/server/historian/src/routes/git/blobs.ts
@@ -30,7 +30,7 @@ export function create(store: nconf.Provider, tenantService: ITenantService, cac
     }
 
     /**
-     * Historian Https Ping Endpoint for Availability Monitoring System
+     * Historian https ping endpoint for availability monitoring system
      */
     router.get("/repos/ping", async (request, response) => {
         response.sendStatus(200);


### PR DESCRIPTION
We propose to add a new path (/ping) for Historian https, and it will return immediately an OK (200) response whenever a request is received.
The health check system sends an empty GET request to call the ping endpoint. Then, the health check system gets the response from the ping endpoint. The response shows the availability based on the connectivity and the HTTP status code.
The URL address would be: URL/repos/ping