### PR TITLE
[bump] package version for common-utils

### DIFF
--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/common-utils",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/common-utils",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Collection of utility functions for Fluid",
   "homepage": "https://fluidframework.com",
   "repository": "microsoft/FluidFramework",

--- a/common/lib/common-utils/src/packageVersion.ts
+++ b/common/lib/common-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/common-utils";
-export const pkgVersion = "0.24.0";
+export const pkgVersion = "0.24.1";

--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -51,7 +51,7 @@
     "@fluid-example/fluid-object-interfaces": "^0.27.0",
     "@fluid-example/search-menu": "^0.27.0",
     "@fluid-internal/client-api": "^0.27.0",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/container-definitions": "^0.27.0",
     "@fluidframework/core-interfaces": "^0.27.0",
     "@fluidframework/datastore-definitions": "^0.27.0",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -50,7 +50,7 @@
     "@fluid-internal/client-api": "^0.27.0",
     "@fluidframework/aqueduct": "^0.27.0",
     "@fluidframework/cell": "^0.27.0",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/container-definitions": "^0.27.0",
     "@fluidframework/container-runtime": "^0.27.0",
     "@fluidframework/core-interfaces": "^0.27.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -792,9 +792,9 @@
 			"integrity": "sha512-H+wEaxuIHODVNqyY8XSMY6ww7ndrRfht9CXKUAUzdQjUN1Oi++YonKcD3CXWZod6afxZ6abDmltIO9wLrjOJzg=="
 		},
 		"@fluidframework/common-utils": {
-			"version": "0.24.0-5441",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0-5441.tgz",
-			"integrity": "sha512-8/Tsgr6ahR1k72Ac6h3aoTzNuXfS4ojbXIuJs7Gfl/uT8zgSzD537xKHgOZ2GtLCJrlVAei2n5Yaf74uOpmJRg==",
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+			"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@types/events": "^3.0.0",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -52,7 +52,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/core-interfaces": "^0.27.0",
     "@fluidframework/datastore-definitions": "^0.27.0",
     "@fluidframework/protocol-definitions": "^0.1013.0-0",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -50,7 +50,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/datastore-definitions": "^0.27.0",
     "@fluidframework/protocol-definitions": "^0.1013.0-0",
     "@fluidframework/shared-object-base": "^0.27.0",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -52,7 +52,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/datastore-definitions": "^0.27.0",
     "@fluidframework/protocol-definitions": "^0.1013.0-0",
     "@fluidframework/shared-object-base": "^0.27.0",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/core-interfaces": "^0.27.0",
     "@fluidframework/datastore-definitions": "^0.27.0",
     "@fluidframework/protocol-base": "^0.1013.0-0",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/core-interfaces": "^0.27.0",
     "@fluidframework/datastore-definitions": "^0.27.0",
     "@fluidframework/merge-tree": "^0.27.0",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/container-definitions": "^0.27.0",
     "@fluidframework/core-interfaces": "^0.27.0",
     "@fluidframework/datastore-definitions": "^0.27.0",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -52,7 +52,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/datastore-definitions": "^0.27.0",
     "@fluidframework/protocol-definitions": "^0.1013.0-0",
     "@fluidframework/shared-object-base": "^0.27.0",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -52,7 +52,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/datastore-definitions": "^0.27.0",
     "@fluidframework/protocol-definitions": "^0.1013.0-0",
     "@fluidframework/shared-object-base": "^0.27.0",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/core-interfaces": "^0.27.0",
     "@fluidframework/datastore-definitions": "^0.27.0",
     "@fluidframework/map": "^0.27.0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/datastore-definitions": "^0.27.0",
     "@fluidframework/protocol-definitions": "^0.1013.0-0",
     "@fluidframework/shared-object-base": "^0.27.0"

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -27,7 +27,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/driver-definitions": "^0.27.0",
     "@fluidframework/driver-utils": "^0.27.0",
     "@fluidframework/protocol-definitions": "^0.1013.0-0",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -28,7 +28,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/driver-definitions": "^0.27.0",
     "@fluidframework/driver-utils": "^0.27.0",
     "@fluidframework/protocol-definitions": "^0.1013.0-0",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/driver-definitions": "^0.27.0",
     "@fluidframework/driver-utils": "^0.27.0",
     "@fluidframework/protocol-definitions": "^0.1013.0-0",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -31,7 +31,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/core-interfaces": "^0.27.0",
     "@fluidframework/driver-definitions": "^0.27.0",
     "@fluidframework/odsp-driver": "^0.27.0"

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/core-interfaces": "^0.27.0",
     "@fluidframework/driver-definitions": "^0.27.0",
     "@fluidframework/driver-utils": "^0.27.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/core-interfaces": "^0.27.0",
     "@fluidframework/driver-definitions": "^0.27.0",
     "@fluidframework/driver-utils": "^0.27.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/core-interfaces": "^0.27.0",
     "@fluidframework/driver-base": "^0.27.0",
     "@fluidframework/driver-definitions": "^0.27.0",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/driver-definitions": "^0.27.0",
     "@fluidframework/driver-utils": "^0.27.0",
     "@fluidframework/protocol-definitions": "^0.1013.0-0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/driver-base": "^0.27.0",
     "@fluidframework/driver-definitions": "^0.27.0",
     "@fluidframework/driver-utils": "^0.27.0",

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -27,7 +27,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/core-interfaces": "^0.27.0",
     "@fluidframework/driver-definitions": "^0.27.0",
     "@types/debug": "^4.1.5",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/container-definitions": "^0.27.0",
     "@fluidframework/container-loader": "^0.27.0",
     "@fluidframework/container-runtime": "^0.27.0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/container-definitions": "^0.27.0",
     "@fluidframework/container-runtime": "^0.27.0",
     "@fluidframework/core-interfaces": "^0.27.0",

--- a/packages/hosts/base-host/package.json
+++ b/packages/hosts/base-host/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/container-definitions": "^0.27.0",
     "@fluidframework/container-loader": "^0.27.0",
     "@fluidframework/core-interfaces": "^0.27.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/container-definitions": "^0.27.0",
     "@fluidframework/container-utils": "^0.27.0",
     "@fluidframework/core-interfaces": "^0.27.0",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/core-interfaces": "^0.27.0",
     "@fluidframework/driver-definitions": "^0.27.0",
     "@fluidframework/gitresources": "^0.1013.0-0",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -26,7 +26,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/driver-definitions": "^0.27.0",
     "@fluidframework/protocol-definitions": "^0.1013.0-0"
   },

--- a/packages/runtime/client-api/package.json
+++ b/packages/runtime/client-api/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.27.0",
     "@fluidframework/cell": "^0.27.0",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/container-definitions": "^0.27.0",
     "@fluidframework/container-loader": "^0.27.0",
     "@fluidframework/container-runtime": "^0.27.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@fluidframework/agent-scheduler": "^0.27.0",
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/container-definitions": "^0.27.0",
     "@fluidframework/container-runtime-definitions": "^0.27.0",
     "@fluidframework/container-utils": "^0.27.0",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/container-definitions": "^0.27.0",
     "@fluidframework/core-interfaces": "^0.27.0",
     "@fluidframework/protocol-definitions": "^0.1013.0-0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/container-definitions": "^0.27.0",
     "@fluidframework/container-utils": "^0.27.0",
     "@fluidframework/core-interfaces": "^0.27.0",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/container-definitions": "^0.27.0",
     "@fluidframework/core-interfaces": "^0.27.0",
     "@fluidframework/driver-definitions": "^0.27.0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/core-interfaces": "^0.27.0",
     "@fluidframework/datastore-definitions": "^0.27.0",
     "@fluidframework/protocol-base": "^0.1013.0-0",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/container-definitions": "^0.27.0",
     "@fluidframework/core-interfaces": "^0.27.0",
     "@fluidframework/datastore-definitions": "^0.27.0",

--- a/packages/test/end-to-end-tests/package.json
+++ b/packages/test/end-to-end-tests/package.json
@@ -61,7 +61,7 @@
     "@fluidframework/base-host": "^0.27.0",
     "@fluidframework/build-common": "^0.19.2",
     "@fluidframework/cell": "^0.27.0",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/container-definitions": "^0.27.0",
     "@fluidframework/container-loader": "^0.27.0",
     "@fluidframework/container-runtime": "^0.27.0",

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@fluid-internal/test-loader-utils": "^0.27.0",
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/container-loader": "^0.27.0",
     "@fluidframework/container-runtime": "^0.27.0",
     "@fluidframework/eslint-config-fluid": "^0.19.1",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@fluid-internal/replay-tool": "^0.27.0",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/protocol-definitions": "^0.1013.0-0"
   },
   "devDependencies": {

--- a/packages/test/version-test-1/package.json
+++ b/packages/test/version-test-1/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.27.0",
     "@fluidframework/base-host": "^0.27.0",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/view-interfaces": "^0.27.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2"

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@fluid-internal/fluidapp-odsp-urlresolver": "^0.27.0",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/container-runtime": "^0.27.0",
     "@fluidframework/datastore": "^0.27.0",
     "@fluidframework/driver-definitions": "^0.27.0",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.27.0",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/container-definitions": "^0.27.0",
     "@fluidframework/container-loader": "^0.27.0",
     "@fluidframework/core-interfaces": "^0.27.0",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "debug": "^4.1.1",
     "events": "^3.1.0"
   },

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -25,7 +25,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/odsp-utils": "^0.27.0",
     "proper-lockfile": "^4.1.1"
   },

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -523,9 +523,9 @@
 			"integrity": "sha512-H+wEaxuIHODVNqyY8XSMY6ww7ndrRfht9CXKUAUzdQjUN1Oi++YonKcD3CXWZod6afxZ6abDmltIO9wLrjOJzg=="
 		},
 		"@fluidframework/common-utils": {
-			"version": "0.24.0-5441",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0-5441.tgz",
-			"integrity": "sha512-8/Tsgr6ahR1k72Ac6h3aoTzNuXfS4ojbXIuJs7Gfl/uT8zgSzD537xKHgOZ2GtLCJrlVAei2n5Yaf74uOpmJRg==",
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+			"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@types/events": "^3.0.0",

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -46,7 +46,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/server-services": "^0.1013.0",
     "@fluidframework/server-services-core": "^0.1013.0",
     "@fluidframework/server-services-utils": "^0.1013.0",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -49,7 +49,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/gitresources": "^0.1013.0",
     "@fluidframework/protocol-base": "^0.1013.0",
     "@fluidframework/protocol-definitions": "^0.1013.0",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -50,7 +50,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/protocol-definitions": "^0.1013.0",
     "@fluidframework/server-lambdas": "^0.1013.0",
     "@fluidframework/server-memory-orderer": "^0.1013.0",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -27,7 +27,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/protocol-base": "^0.1013.0",
     "@fluidframework/protocol-definitions": "^0.1013.0",
     "@fluidframework/server-lambdas": "^0.1013.0",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -51,7 +51,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/gitresources": "^0.1013.0",
     "@fluidframework/protocol-definitions": "^0.1013.0",
     "assert": "^2.0.0",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -24,7 +24,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/gitresources": "^0.1013.0",
     "@fluidframework/protocol-definitions": "^0.1013.0",
     "@fluidframework/server-kafka-orderer": "^0.1013.0",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -61,7 +61,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/gitresources": "^0.1013.0",
     "@fluidframework/protocol-definitions": "^0.1013.0",
     "@fluidframework/server-kafka-orderer": "^0.1013.0",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -49,7 +49,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/gitresources": "^0.1013.0",
     "@fluidframework/protocol-base": "^0.1013.0",
     "@fluidframework/protocol-definitions": "^0.1013.0",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -24,7 +24,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/gitresources": "^0.1013.0",
     "@fluidframework/protocol-definitions": "^0.1013.0",
     "@fluidframework/server-services-client": "^0.1013.0",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -24,7 +24,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/gitresources": "^0.1013.0",
     "@fluidframework/protocol-base": "^0.1013.0",
     "@fluidframework/protocol-definitions": "^0.1013.0",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@azure/event-hubs": "^1.0.8",
     "@azure/event-processor-host": "^1.0.6",
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/protocol-definitions": "^0.1013.0",
     "@fluidframework/server-services-client": "^0.1013.0",
     "@fluidframework/server-services-core": "^0.1013.0",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -45,7 +45,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/gitresources": "^0.1013.0",
     "@fluidframework/protocol-base": "^0.1013.0",
     "@fluidframework/protocol-definitions": "^0.1013.0",

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -52,9 +52,9 @@
       "integrity": "sha512-H+wEaxuIHODVNqyY8XSMY6ww7ndrRfht9CXKUAUzdQjUN1Oi++YonKcD3CXWZod6afxZ6abDmltIO9wLrjOJzg=="
     },
     "@fluidframework/common-utils": {
-      "version": "0.24.0-5441",
-      "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0-5441.tgz",
-      "integrity": "sha512-8/Tsgr6ahR1k72Ac6h3aoTzNuXfS4ojbXIuJs7Gfl/uT8zgSzD537xKHgOZ2GtLCJrlVAei2n5Yaf74uOpmJRg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+      "integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.19.1",
         "@types/events": "^3.0.0",

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -23,7 +23,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/gitresources": "^0.1012.0",
     "@fluidframework/protocol-base": "^0.1012.0",
     "@fluidframework/protocol-definitions": "^0.1012.0",


### PR DESCRIPTION
            @fluidframework/build-common:     0.20.0 (unchanged)
     @fluidframework/eslint-config-fluid:     0.20.0 (unchanged)
      @fluidframework/common-definitions:     0.20.0 (unchanged)
            @fluidframework/common-utils:     0.24.0 -> 0.24.1
                                  Server:   0.1013.0 (unchanged)
                                  Client:     0.27.0 (unchanged)
                         generator-fluid:      0.3.0 (unchanged)
                             tinylicious:      0.2.0 (unchanged)
                             dice-roller:      0.0.1 (unchanged)

Also remove pre-release dependencies for common-utils
            @fluidframework/common-utils -> ^0.24.0