### PR TITLE
Isomorphic performance object (server changes)

### DIFF
--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -523,9 +523,9 @@
 			"integrity": "sha512-H+wEaxuIHODVNqyY8XSMY6ww7ndrRfht9CXKUAUzdQjUN1Oi++YonKcD3CXWZod6afxZ6abDmltIO9wLrjOJzg=="
 		},
 		"@fluidframework/common-utils": {
-			"version": "0.24.0-4481",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0-4481.tgz",
-			"integrity": "sha512-wKHWvGb2YpSOl2hR/9ljBu68a6zUXS2SfuLtu5lRDgEKDVnkIWvveAVNFaGMXMrPWfFwHVKvMLyi1bgoKRLomg==",
+			"version": "0.24.0-5441",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0-5441.tgz",
+			"integrity": "sha512-8/Tsgr6ahR1k72Ac6h3aoTzNuXfS4ojbXIuJs7Gfl/uT8zgSzD537xKHgOZ2GtLCJrlVAei2n5Yaf74uOpmJRg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@types/events": "^3.0.0",
@@ -533,7 +533,6 @@
 				"base64-js": "^1.3.1",
 				"events": "^3.1.0",
 				"lodash": "^4.17.19",
-				"performance-now": "^2.1.0",
 				"sha.js": "^2.4.11"
 			}
 		},

--- a/server/routerlicious/packages/memory-orderer/src/localOrdererConnection.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrdererConnection.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { performanceNow } from "@fluidframework/common-utils";
+import { performance } from "@fluidframework/common-utils";
 import {
     IClient,
     IClientJoin,
@@ -120,7 +120,7 @@ export class LocalOrdererConnection implements IOrdererConnection {
                     {
                         action: "start",
                         service: "alfred",
-                        timestamp: performanceNow(),
+                        timestamp: performance.now(),
                     });
             }
         });

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -52,9 +52,9 @@
       "integrity": "sha512-H+wEaxuIHODVNqyY8XSMY6ww7ndrRfht9CXKUAUzdQjUN1Oi++YonKcD3CXWZod6afxZ6abDmltIO9wLrjOJzg=="
     },
     "@fluidframework/common-utils": {
-      "version": "0.24.0-4481",
-      "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0-4481.tgz",
-      "integrity": "sha512-wKHWvGb2YpSOl2hR/9ljBu68a6zUXS2SfuLtu5lRDgEKDVnkIWvveAVNFaGMXMrPWfFwHVKvMLyi1bgoKRLomg==",
+      "version": "0.24.0-5441",
+      "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0-5441.tgz",
+      "integrity": "sha512-8/Tsgr6ahR1k72Ac6h3aoTzNuXfS4ojbXIuJs7Gfl/uT8zgSzD537xKHgOZ2GtLCJrlVAei2n5Yaf74uOpmJRg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.19.1",
         "@types/events": "^3.0.0",
@@ -62,7 +62,6 @@
         "base64-js": "^1.3.1",
         "events": "^3.1.0",
         "lodash": "^4.17.19",
-        "performance-now": "^2.1.0",
         "sha.js": "^2.4.11"
       }
     },


### PR DESCRIPTION
Common project changes for fixing #3654
Depends on PR #3672

Fix non-isomorphic references to performance object in odsp driver.

Replace all `performanceNow()` calls with `performance.now()`.