### PR TITLE
Track in telemetry response time for snapshot fetch requests #3072

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -466,10 +466,53 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
         // snapshot code path. We should leverage the fact that these deltas are returned to speed up the deltas fetch.
         const { headers, url } = getUrlAndHeadersWithAuth(`${this.snapshotUrl}/trees/latest${snapshotOptions}`, storageToken);
 
+        let isOptionsCall = false;
+
+        if (Object.keys(headers).length) {
+            isOptionsCall = true;
+        }
+
         // This event measures only successful cases of getLatest call (no tokens, no retries).
         const { snapshot, canCache } = await PerformanceEvent.timedExecAsync(this.logger, { eventName: "TreesLatest" }, async (event) => {
+            const startTime = performance.now();
             const response = await fetchHelper<IOdspSnapshot>(url, { headers });
+            const endTime = performance.now();
+            const overallTime = endTime - startTime;
             const content = response.content;
+            let dnstime: number | undefined; // domainLookupEnd - domainLookupStart
+            let redirectTime: number | undefined; // redirectEnd -redirectStart
+            let tcpHandshakeTime: number | undefined; // connectEnd  - connectStart
+            let secureConntime: number | undefined; // connectEnd  - secureConnectionStart
+            let responseTime: number | undefined; // responsEnd - responseStart
+            let fetchStToRespEndTime: number | undefined; // responseEnd  - fetchStart
+            let reqStToRespEndTime: number | undefined; // responseEnd - requestStart
+            let networkTime: number | undefined; // responseEnd - startTime
+            const spReqDuration = response.headers.get("sprequestduration");
+
+            const resources1 = performance.getEntriesByType("resource");
+            // Usually the latest fetch call is to the end of resources, so we start from the end.
+            for (let i = resources1.length - 1; i > 0; i--) {
+                const indResTime = resources1[i] as PerformanceResourceTiming;
+                const resource_name = indResTime.name;
+                const resource_initiatortype = indResTime.initiatorType;
+                if ((resource_initiatortype.localeCompare("fetch") === 0) && (resource_name.localeCompare(url) === 0)) {
+                        redirectTime = indResTime.redirectEnd - indResTime.redirectStart;
+                        dnstime = indResTime.domainLookupEnd - indResTime.domainLookupStart;
+                        tcpHandshakeTime = indResTime.connectEnd - indResTime.connectStart;
+                        secureConntime = (indResTime.secureConnectionStart > 0) ? (indResTime.connectEnd - indResTime.secureConnectionStart) : 0;
+                        responseTime = indResTime.responseEnd - indResTime.responseStart;
+                        fetchStToRespEndTime = (indResTime.fetchStart > 0) ? (indResTime.responseEnd - indResTime.fetchStart) : 0;
+                        reqStToRespEndTime = (indResTime.requestStart > 0) ? (indResTime.responseEnd - indResTime.requestStart) : 0;
+                        networkTime = (indResTime.startTime > 0) ? (indResTime.responseEnd - indResTime.startTime) : 0;
+                        if (spReqDuration) {
+                            networkTime = networkTime - parseInt(spReqDuration, 10);
+                        }
+                        break;
+                }
+            }
+
+            const clientTime = networkTime ? overallTime - networkTime : undefined;
+
             event.end({
                 trees: content.trees?.length ?? 0,
                 blobs: content.blobs?.length ?? 0,
@@ -477,9 +520,21 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                 headers: Object.keys(headers).length !== 0 ? true : undefined,
                 sprequestguid: response.headers.get("sprequestguid"),
                 sprequestduration: TelemetryLogger.numberFromString(response.headers.get("sprequestduration")),
+                isoptionscall: isOptionsCall,
+                redirecttime: redirectTime,
+                dnsLookuptime: dnstime,
+                responsenetworkTime: responseTime,
+                tcphandshakeTime: tcpHandshakeTime,
+                secureconnectiontime: secureConntime,
+                fetchstarttorespendtime: fetchStToRespEndTime,
+                reqstarttorespendtime: reqStToRespEndTime,
+                overalltime: overallTime,
+                networktime: networkTime,
+                clienttime: clientTime,
                 contentsize: TelemetryLogger.numberFromString(response.headers.get("content-length")),
                 bodysize: TelemetryLogger.numberFromString(response.headers.get("body-size")),
             });
+
             return {
                 snapshot: content,
                 // There are some scenarios in ODSP where we cannot cache, trees/latest will explicitly tell us when we cannot cache using an HTTP response header.


### PR DESCRIPTION
Pulling in 3072(https://github.com/microsoft/FluidFramework/pull/3600) into release/0.26 branch. Verified the changes locally and here's the telemetry data:

fluid:telemetry:OdspDriver TreesLatest_end {"loaderId":"a326338b-34cf-4eed-824d-3a98bc76252a","clientType":"noninteractive/summarizer","loaderVersion":"0.26.2","containerId":"be690e41-9cc6-4bc5-96b9-428138e743e4","odc":false,"trees":1,"blobs":48,"ops":0,"headers":true,"sprequestguid":"a5997c9f-10ab-0000-ceb9-36a40e5f5d2f","sprequestduration":0,"isoptionscall":true,"redirecttime":0,"dnsLookuptime":0,"responsenetworkTime":13566.339999902993,"tcphandshakeTime":0,"secureconnectiontime":0,"fetchstarttorespendtime":344.5699999574572,"reqstarttorespendtime":0,"overalltime":345.50499997567385,"networktime":344.5699999574572,"clienttime":0.9350000182166696,"contentsize":27723,"bodysize":27723,"duration":5042,"category":"performance","docId":"4ZPGocs2k%2B7WIaob2UmPvux7gLuu2v7e0e%2B0%2F6f%2Fyb8%3D","containerAttachState":"Attached"} tick=18263 