### PR TITLE
build-common: Remove dev dependency on api-extractor

### DIFF
--- a/common/build/build-common/package.json
+++ b/common/build/build-common/package.json
@@ -12,7 +12,6 @@
   },
   "scripts": {},
   "peerDependencies": {
-    "api-extractor": ">=7.7.2",
     "typescript": ">=3.7.4"
   }
 }


### PR DESCRIPTION
Fixes #3710.