### PR TITLE
Track in telemetry response time for snapshot fetch requests #3072

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -471,10 +471,53 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
         // snapshot code path. We should leverage the fact that these deltas are returned to speed up the deltas fetch.
         const { headers, url } = getUrlAndHeadersWithAuth(`${this.snapshotUrl}/trees/latest${options}`, storageToken);
 
+        let isOptionsCall = false;
+
+        if (Object.keys(headers).length) {
+            isOptionsCall = true;
+        }
+
         // This event measures only successful cases of getLatest call (no tokens, no retries).
         const { snapshot, canCache } = await PerformanceEvent.timedExecAsync(this.logger, { eventName: "TreesLatest" }, async (event) => {
+            const startTime = performance.now();
             const response = await fetchHelper<IOdspSnapshot>(url, { headers });
+            const endTime = performance.now();
+            const overallTime = endTime - startTime;
             const content = response.content;
+            let dnstime: number | undefined; // domainLookupEnd - domainLookupStart
+            let redirectTime: number | undefined; // redirectEnd -redirectStart
+            let tcpHandshakeTime: number | undefined; // connectEnd  - connectStart
+            let secureConntime: number | undefined; // connectEnd  - secureConnectionStart
+            let responseTime: number | undefined; // responsEnd - responseStart
+            let fetchStToRespEndTime: number | undefined; // responseEnd  - fetchStart
+            let reqStToRespEndTime: number | undefined; // responseEnd - requestStart
+            let networkTime: number | undefined; // responseEnd - startTime
+            const spReqDuration = response.headers.get("sprequestduration");
+
+            const resources1 = performance.getEntriesByType("resource");
+            // Usually the latest fetch call is to the end of resources, so we start from the end.
+            for (let i = resources1.length - 1; i > 0; i--) {
+                const indResTime = resources1[i] as PerformanceResourceTiming;
+                const resource_name = indResTime.name;
+                const resource_initiatortype = indResTime.initiatorType;
+                if ((resource_initiatortype.localeCompare("fetch") === 0) && (resource_name.localeCompare(url) === 0)) {
+                        redirectTime = indResTime.redirectEnd - indResTime.redirectStart;
+                        dnstime = indResTime.domainLookupEnd - indResTime.domainLookupStart;
+                        tcpHandshakeTime = indResTime.connectEnd - indResTime.connectStart;
+                        secureConntime = (indResTime.secureConnectionStart > 0) ? (indResTime.connectEnd - indResTime.secureConnectionStart) : 0;
+                        responseTime = indResTime.responseEnd - indResTime.responseStart;
+                        fetchStToRespEndTime = (indResTime.fetchStart > 0) ? (indResTime.responseEnd - indResTime.fetchStart) : 0;
+                        reqStToRespEndTime = (indResTime.requestStart > 0) ? (indResTime.responseEnd - indResTime.requestStart) : 0;
+                        networkTime = (indResTime.startTime > 0) ? (indResTime.responseEnd - indResTime.startTime) : 0;
+                        if (spReqDuration) {
+                            networkTime = networkTime - parseInt(spReqDuration, 10);
+                        }
+                        break;
+                }
+            }
+
+            const clientTime = networkTime ? overallTime - networkTime : undefined;
+
             event.end({
                 trees: content.trees?.length ?? 0,
                 blobs: content.blobs?.length ?? 0,
@@ -482,9 +525,21 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                 headers: Object.keys(headers).length !== 0 ? true : undefined,
                 sprequestguid: response.headers.get("sprequestguid"),
                 sprequestduration: TelemetryLogger.numberFromString(response.headers.get("sprequestduration")),
+                isoptionscall: isOptionsCall,
+                redirecttime: redirectTime,
+                dnsLookuptime: dnstime,
+                responsenetworkTime: responseTime,
+                tcphandshakeTime: tcpHandshakeTime,
+                secureconnectiontime: secureConntime,
+                fetchstarttorespendtime: fetchStToRespEndTime,
+                reqstarttorespendtime: reqStToRespEndTime,
+                overalltime: overallTime,
+                networktime: networkTime,
+                clienttime: clientTime,
                 contentsize: TelemetryLogger.numberFromString(response.headers.get("content-length")),
                 bodysize: TelemetryLogger.numberFromString(response.headers.get("body-size")),
             });
+
             return {
                 snapshot: content,
                 // There are some scenarios in ODSP where we cannot cache, trees/latest will explicitly tell us when we cannot cache using an HTTP response header.


### PR DESCRIPTION
Pulling in 3072(#3600) into release/0.25.x branch. Verified the changes locally and here's the telemetry data:

fluid:telemetry:OdspDriver TreesLatest_end {"loaderId":"9ff9965e-9e17-46d2-995b-03d48bae817e","clientType":"noninteractive/summarizer","loaderVersion":"0.25.3","containerId":"27335b7a-c31d-42f1-9b71-fb65165e490a","odc":false,"trees":1,"blobs":48,"ops":0,"headers":true,"sprequestguid":"199f7c9f-0079-0000-ceba-39a09c53d3cd","sprequestduration":0,"isoptionscall":true,"redirecttime":0,"dnsLookuptime":0,"responsenetworkTime":25588.770000031218,"tcphandshakeTime":0,"secureconnectiontime":0,"fetchstarttorespendtime":361.3850000547245,"reqstarttorespendtime":0,"overalltime":362.3800000641495,"networktime":361.3850000547245,"clienttime":0.9950000094249845,"contentsize":27667,"bodysize":27667,"duration":16488,"category":"performance","docId":"ETC5NQVwQPKUw9SprtuOuxiGIXhv1YAsrTfsLUQq%2FcA%3D","containerAttachState":"Attached"} tick=41690 