### PR TITLE
Don't rely on webpack polyfilling path

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -18777,7 +18777,6 @@
 				"events": "^3.0.0",
 				"https-browserify": "^1.0.0",
 				"os-browserify": "^0.3.0",
-				"path-browserify": "0.0.1",
 				"process": "^0.11.10",
 				"punycode": "^1.2.4",
 				"querystring-es3": "^0.2.0",
@@ -21289,9 +21288,9 @@
 			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
 		},
 		"path-browserify": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
-			"integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+			"integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
 		},
 		"path-dirname": {
 			"version": "1.0.2",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -59,7 +59,8 @@
     "@fluidframework/protocol-base": "^0.1013.0-0",
     "@fluidframework/protocol-definitions": "^0.1013.0-0",
     "@fluidframework/shared-object-base": "^0.28.0",
-    "debug": "^4.1.1"
+    "debug": "^4.1.1",
+    "path-browserify": "^1.0.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -4,7 +4,6 @@
  */
 
 import { strict as assert } from "assert";
-import path from "path";
 import { fromBase64ToUtf8 } from "@fluidframework/common-utils";
 import { addBlobToTree } from "@fluidframework/protocol-base";
 import {
@@ -40,12 +39,11 @@ import {
 } from "./localValues";
 import { pkgVersion } from "./packageVersion";
 
-// path-browserify only supports posix functionality but doesn't have a path.posix to enforce it.  But we need to
-// enforce posix when using the normal node module on Windows (otherwise it will use path.win32).  Also including an
-// assert here to help protect in case path-browserify changes in the future, because we only want posix path
-// functionality.
-const posix = path.posix || path;
-assert(posix.sep === "/");
+// We use path-browserify since this code can run safely on the server or the browser.
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const path: typeof import("path") = require("path-browserify");
+const posix = path.posix;
+
 const snapshotFileName = "header";
 
 /**

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -19,6 +19,7 @@ import {
     IChannelFactory,
 } from "@fluidframework/datastore-definitions";
 import { SharedObject, ValueType } from "@fluidframework/shared-object-base";
+import * as path from "path-browserify";
 import { debug } from "./debug";
 import {
     IDirectory,
@@ -40,9 +41,8 @@ import {
 import { pkgVersion } from "./packageVersion";
 
 // We use path-browserify since this code can run safely on the server or the browser.
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-const path: typeof import("path") = require("path-browserify");
-const posix = path.posix;
+// We standardize on using posix slashes everywhere.
+const posix: typeof import("path").posix = path.posix;
 
 const snapshotFileName = "header";
 


### PR DESCRIPTION
Resolves #3667, where we are seeing issues in Webpack 5 due to the reliance on directory.ts on the bundler polyfilling the node Path usage here. 

Ideally, we'd use a lean utility library to implement this functionality to minimize bundle size, but as a step to unblock webpack we will explicitly require path-browserify 