### PR TITLE
Restore request() on IContainerRuntime

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -295,7 +295,7 @@ example:
     const builder = new RuntimeRequestHandlerBuilder();
     builder.pushHandler(...this.requestHandlers);
     builder.pushHandler(defaultRouteRequestHandler("defaultComponent"));
-    builder.pushHandler(deprecated_innerRequestHandler());
+    builder.pushHandler(innerRequestHandler());
 
     const runtime = await ContainerRuntime.load(
         context,

--- a/docs/content/api_nav.yaml
+++ b/docs/content/api_nav.yaml
@@ -6835,8 +6835,8 @@ api_nav:
         url: /api/request-handler.buildruntimerequesthandler
       - title: createComponentResponse
         url: /api/request-handler.createcomponentresponse
-      - title: deprecated_innerRequestHandler
-        url: /api/request-handler.deprecated_innerrequesthandler
+      - title: innerRequestHandler
+        url: /api/request-handler.innerRequestHandler
       - title: RuntimeRequestHandler
         url: /api/request-handler.runtimerequesthandler
       - title: RuntimeRequestHandlerBuilder

--- a/examples/data-objects/codemirror/src/index.ts
+++ b/examples/data-objects/codemirror/src/index.ts
@@ -11,7 +11,7 @@
 import { ContainerRuntime } from "@fluidframework/container-runtime";
 import { IFluidDataStoreFactory, FlushMode } from "@fluidframework/runtime-definitions";
 import {
-    deprecated_innerRequestHandler,
+    innerRequestHandler,
     buildRuntimeRequestHandler,
 } from "@fluidframework/request-handler";
 import { defaultRouteRequestHandler } from "@fluidframework/aqueduct";
@@ -34,7 +34,7 @@ class CodeMirrorFactory implements IRuntimeFactory {
             registry,
             buildRuntimeRequestHandler(
                 defaultRouteRequestHandler(defaultComponentId),
-                deprecated_innerRequestHandler),
+                innerRequestHandler),
             { generateSummaries: true });
 
         // Flush mode to manual to batch operations within a turn

--- a/examples/data-objects/key-value-cache/src/index.ts
+++ b/examples/data-objects/key-value-cache/src/index.ts
@@ -27,7 +27,7 @@ import {
     IChannelFactory,
 } from "@fluidframework/datastore-definitions";
 import {
-    deprecated_innerRequestHandler,
+    innerRequestHandler,
     buildRuntimeRequestHandler,
 } from "@fluidframework/request-handler";
 import { defaultRouteRequestHandler } from "@fluidframework/aqueduct";
@@ -139,7 +139,7 @@ export class KeyValueFactoryComponent implements IRuntimeFactory, IFluidDataStor
             new Map([[ComponentName, Promise.resolve(this)]]),
             buildRuntimeRequestHandler(
                 defaultRouteRequestHandler(ComponentName),
-                deprecated_innerRequestHandler,
+                innerRequestHandler,
             ),
         );
 

--- a/examples/data-objects/prosemirror/src/index.ts
+++ b/examples/data-objects/prosemirror/src/index.ts
@@ -11,7 +11,7 @@ import {
 import { ContainerRuntime } from "@fluidframework/container-runtime";
 import { IFluidDataStoreFactory, FlushMode } from "@fluidframework/runtime-definitions";
 import {
-    deprecated_innerRequestHandler,
+    innerRequestHandler,
     buildRuntimeRequestHandler,
 } from "@fluidframework/request-handler";
 import { defaultRouteRequestHandler } from "@fluidframework/aqueduct";
@@ -34,7 +34,7 @@ class ProseMirrorFactory implements IRuntimeFactory {
             registry,
             buildRuntimeRequestHandler(
                 defaultRouteRequestHandler(defaultComponentId),
-                deprecated_innerRequestHandler,
+                innerRequestHandler,
             ),
             { generateSummaries: true });
 

--- a/examples/data-objects/scribe/src/scribe.ts
+++ b/examples/data-objects/scribe/src/scribe.ts
@@ -32,7 +32,7 @@ import {
 } from "@fluidframework/runtime-definitions";
 import { IFluidHTMLOptions, IFluidHTMLView } from "@fluidframework/view-interfaces";
 import {
-    deprecated_innerRequestHandler,
+    innerRequestHandler,
     buildRuntimeRequestHandler,
 } from "@fluidframework/request-handler";
 import { defaultRouteRequestHandler } from "@fluidframework/aqueduct";
@@ -470,7 +470,7 @@ class ScribeFactory implements IFluidDataStoreFactory, IRuntimeFactory {
             registry,
             buildRuntimeRequestHandler(
                 defaultRouteRequestHandler(defaultComponentId),
-                deprecated_innerRequestHandler,
+                innerRequestHandler,
             ),
             { generateSummaries: true });
 

--- a/examples/data-objects/shared-text/src/index.ts
+++ b/examples/data-objects/shared-text/src/index.ts
@@ -16,7 +16,7 @@ import {
     NamedFluidDataStoreRegistryEntries,
 } from "@fluidframework/runtime-definitions";
 import {
-    deprecated_innerRequestHandler,
+    innerRequestHandler,
     buildRuntimeRequestHandler,
 } from "@fluidframework/request-handler";
 import { defaultRouteRequestHandler } from "@fluidframework/aqueduct";
@@ -105,7 +105,7 @@ class SharedTextFactoryComponent implements IFluidDataStoreFactory, IRuntimeFact
             ],
             buildRuntimeRequestHandler(
                 defaultRouteRequestHandler(DefaultComponentName),
-                deprecated_innerRequestHandler,
+                innerRequestHandler,
             ),
         );
 

--- a/examples/data-objects/smde/src/index.ts
+++ b/examples/data-objects/smde/src/index.ts
@@ -11,7 +11,7 @@ import {
 import { ContainerRuntime } from "@fluidframework/container-runtime";
 import { IFluidDataStoreFactory, FlushMode } from "@fluidframework/runtime-definitions";
 import {
-    deprecated_innerRequestHandler,
+    innerRequestHandler,
     buildRuntimeRequestHandler,
 } from "@fluidframework/request-handler";
 import { defaultRouteRequestHandler } from "@fluidframework/aqueduct";
@@ -33,7 +33,7 @@ class SmdeContainerFactory implements IRuntimeFactory {
             registry,
             buildRuntimeRequestHandler(
                 defaultRouteRequestHandler(defaultComponentId),
-                deprecated_innerRequestHandler,
+                innerRequestHandler,
             ),
             { generateSummaries: true });
 

--- a/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
@@ -14,7 +14,7 @@ import {
 import {
     RuntimeRequestHandler,
     buildRuntimeRequestHandler,
-    deprecated_innerRequestHandler,
+    innerRequestHandler,
 } from "@fluidframework/request-handler";
 import {
     IFluidDataStoreRegistry,
@@ -70,7 +70,7 @@ export class BaseContainerRuntimeFactory implements
             this.registryEntries,
             buildRuntimeRequestHandler(
                 ...this.requestHandlers,
-                deprecated_innerRequestHandler),
+                innerRequestHandler),
             undefined,
             scope);
 

--- a/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
@@ -8,7 +8,7 @@ import { IContainerRuntime } from "@fluidframework/container-runtime-definitions
 import { DependencyContainerRegistry } from "@fluidframework/synthesize";
 import {
     RuntimeRequestHandler,
-    deprecated_innerRequestHandler,
+    innerRequestHandler,
 } from "@fluidframework/request-handler";
 import { defaultRouteRequestHandler } from "../request-handlers";
 import { BaseContainerRuntimeFactory } from "./baseContainerRuntimeFactory";
@@ -36,7 +36,7 @@ export class ContainerRuntimeFactoryWithDefaultDataStore extends BaseContainerRu
             [
                 ...requestHandlers,
                 defaultRouteRequestHandler(defaultDataStoreId),
-                deprecated_innerRequestHandler,
+                innerRequestHandler,
             ],
         );
     }

--- a/packages/framework/data-object-base/src/runtimeFactory.ts
+++ b/packages/framework/data-object-base/src/runtimeFactory.ts
@@ -10,7 +10,7 @@ import {
 import {
     buildRuntimeRequestHandler,
     RuntimeRequestHandler,
-    deprecated_innerRequestHandler,
+    innerRequestHandler,
 } from "@fluidframework/request-handler";
 import {
     NamedFluidDataStoreRegistryEntries,
@@ -45,7 +45,7 @@ export class RuntimeFactory implements IRuntimeFactory {
             this.registry,
             buildRuntimeRequestHandler(
                 ...this.requestHandlers,
-                deprecated_innerRequestHandler),
+                innerRequestHandler),
         );
 
         // Flush mode to manual to batch operations within a turn

--- a/packages/framework/request-handler/src/requestHandlers.ts
+++ b/packages/framework/request-handler/src/requestHandlers.ts
@@ -34,7 +34,7 @@ export type RuntimeRequestHandler = (request: RequestParser, runtime: IContainer
  * handling of external URI to internal handle is required (in future, we will support weak handle references,
  * that will allow any GC policy to be implemented by container authors.)
  */
-export const deprecated_innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
+export const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
     runtime.IFluidHandleContext.resolveHandle(request);
 
 export const createFluidObjectResponse = (fluidObject: IFluidObject) => {

--- a/packages/framework/request-handler/src/test/requestHandlers.spec.ts
+++ b/packages/framework/request-handler/src/test/requestHandlers.spec.ts
@@ -15,7 +15,7 @@ import { IContainerRuntime } from "@fluidframework/container-runtime-definitions
 import { IFluidDataStoreChannel } from "@fluidframework/runtime-definitions";
 import { RequestParser } from "@fluidframework/runtime-utils";
 import {
-    deprecated_innerRequestHandler,
+    innerRequestHandler,
     createFluidObjectResponse,
 } from "../requestHandlers";
 
@@ -69,12 +69,12 @@ async function assertRejected(p: Promise<IResponse | undefined>) {
 }
 
 describe("RequestParser", () => {
-    describe("deprecated_innerRequestHandler", () => {
+    describe("innerRequestHandler", () => {
         const runtime = new MockRuntime() as any as IContainerRuntime;
 
         it("Empty request", async () => {
             const requestParser = new RequestParser({ url: "/" });
-            const response = await deprecated_innerRequestHandler(
+            const response = await innerRequestHandler(
                 requestParser,
                 runtime);
             assert.equal(response.status, 404);
@@ -82,7 +82,7 @@ describe("RequestParser", () => {
 
         it("Data store request without wait", async () => {
             const requestParser = new RequestParser({ url: "/nonExistingUri" });
-            const responseP = deprecated_innerRequestHandler(
+            const responseP = innerRequestHandler(
                 requestParser,
                 runtime);
             await assertRejected(responseP);
@@ -90,7 +90,7 @@ describe("RequestParser", () => {
 
         it("Data store  request with wait", async () => {
             const requestParser = new RequestParser({ url: "/nonExistingUri", headers: { wait: true } });
-            const responseP = deprecated_innerRequestHandler(
+            const responseP = innerRequestHandler(
                 requestParser,
                 runtime);
             await assertRejected(responseP);
@@ -98,14 +98,14 @@ describe("RequestParser", () => {
 
         it("Data store  request with sub route", async () => {
             const requestParser = new RequestParser({ url: "/objectId/route", headers: { wait: true } });
-            const response = await deprecated_innerRequestHandler(requestParser, runtime);
+            const response = await innerRequestHandler(requestParser, runtime);
             assert.equal(response.status, 200);
             assert.equal(response.value.route, "route");
         });
 
         it("Data store  request with non-existing sub route", async () => {
             const requestParser = new RequestParser({ url: "/objectId/doesNotExist", headers: { wait: true } });
-            const responseP = deprecated_innerRequestHandler(requestParser, runtime);
+            const responseP = innerRequestHandler(requestParser, runtime);
             await assertRejected(responseP);
         });
     });

--- a/packages/runtime/client-api/src/api/codeLoader.ts
+++ b/packages/runtime/client-api/src/api/codeLoader.ts
@@ -24,7 +24,7 @@ import {
 } from "@fluidframework/runtime-definitions";
 import * as sequence from "@fluidframework/sequence";
 import {
-    deprecated_innerRequestHandler,
+    innerRequestHandler,
     buildRuntimeRequestHandler,
 } from "@fluidframework/request-handler";
 import { defaultRouteRequestHandler } from "@fluidframework/aqueduct";
@@ -117,7 +117,7 @@ export class ChaincodeFactory implements IRuntimeFactory {
             ],
             buildRuntimeRequestHandler(
                 defaultRouteRequestHandler(rootStoreId),
-                deprecated_innerRequestHandler,
+                innerRequestHandler,
             ),
             this.runtimeOptions);
 

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -6,6 +6,8 @@
 import {
     IFluidObject,
     IFluidRouter,
+    IRequest,
+    IResponse,
 } from "@fluidframework/core-interfaces";
 import {
     IAudience,
@@ -133,4 +135,10 @@ export interface IContainerRuntime extends
      * @param relativeUrl - A relative request within the container
      */
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
+
+    /**
+     * Resolves handle URI
+     * @param request - request to resolve
+     */
+    resolveHandle(request: IRequest): Promise<IResponse>;
 }

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -10,6 +10,8 @@ import {
     IFluidRouter,
     IProvideFluidHandleContext,
     IProvideFluidSerializer,
+    IRequest,
+    IResponse,
 } from "@fluidframework/core-interfaces";
 import {
     IAudience,
@@ -74,6 +76,11 @@ export interface IContainerRuntimeBase extends
      * Sets the flush mode for operations on the document.
      */
     setFlushMode(mode: FlushMode): void;
+
+    /**
+     * Executes a request against the container runtime
+     */
+    request(request: IRequest): Promise<IResponse>;
 
     /**
      * Submits a container runtime level signal to be sent to other clients.

--- a/packages/test/test-utils/src/testContainerRuntimeFactory.ts
+++ b/packages/test/test-utils/src/testContainerRuntimeFactory.ts
@@ -6,7 +6,7 @@
 import { defaultRouteRequestHandler } from "@fluidframework/aqueduct";
 import { IContainerContext, IRuntime, IRuntimeFactory } from "@fluidframework/container-definitions";
 import { ContainerRuntime, IContainerRuntimeOptions } from "@fluidframework/container-runtime";
-import { deprecated_innerRequestHandler, RuntimeRequestHandlerBuilder } from "@fluidframework/request-handler";
+import { innerRequestHandler, RuntimeRequestHandlerBuilder } from "@fluidframework/request-handler";
 import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 
 /**
@@ -25,7 +25,7 @@ export class TestContainerRuntimeFactory implements IRuntimeFactory {
         const builder = new RuntimeRequestHandlerBuilder();
         builder.pushHandler(
             defaultRouteRequestHandler("default"),
-            deprecated_innerRequestHandler);
+            innerRequestHandler);
 
         const runtime = await ContainerRuntime.load(
             context,


### PR DESCRIPTION
1. Restore request() on IContainerRuntime
2. deprecated_innerRequestHandler -> innerRequestHandler

These changes is the reversal of prior direction, they are required to unblock consumption of 0.25