### PR TITLE
Throw on errors in replay tool instead of logging to console

### DIFF
--- a/packages/tools/replay-tool/src/replayMessages.ts
+++ b/packages/tools/replay-tool/src/replayMessages.ts
@@ -125,10 +125,11 @@ class Logger implements ITelemetryBaseLogger {
             // Stack is not output properly (with newlines), if done as part of event
             const stack: string | undefined = event.stack as string | undefined;
             delete event.stack;
-            const err = `An error has been logged from ${this.containerDescription}!\n
-                        ${JSON.stringify(event)}\nStack:\n${stack}`;
+            const error = new Error(`An error has been logged from ${this.containerDescription}!\n
+                        ${JSON.stringify(event)}`);
+            error.stack = stack;
             // throw instead of printing an error to fail tests
-            throw new Error(err);
+            throw error;
         }
     }
 }

--- a/packages/tools/replay-tool/src/replayMessages.ts
+++ b/packages/tools/replay-tool/src/replayMessages.ts
@@ -125,11 +125,10 @@ class Logger implements ITelemetryBaseLogger {
             // Stack is not output properly (with newlines), if done as part of event
             const stack: string | undefined = event.stack as string | undefined;
             delete event.stack;
-            console.error(`An error has been logged from ${this.containerDescription}!`);
-            console.error(event);
-            if (stack) {
-                console.error(stack);
-            }
+            const err = `An error has been logged from ${this.containerDescription}!\n
+                        ${JSON.stringify(event)}\nStack:\n${stack}`;
+            // throw instead of printing an error to fail tests
+            throw new Error(err);
         }
     }
 }


### PR DESCRIPTION
Fixes #3107

Currently the telemetry logger used in the replay tool will print error details (such as from a container error) as console errors.  The snapshot tests do not have any specific assertions and instead rely on promise resolution to pass/fail, so this functionally hides swallows failures and causes failing tests to report succeeded.  Change the logger to re-throw the error in these cases, causing tests to fail as expected.

Potentially all console errors should be made to fail tests, but that's a different discussion.