### PR TITLE
returning decrypted tenant key

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
@@ -131,7 +131,15 @@ export class TenantManager {
      * Retrieves the secret for the given tenant
      */
     public async getTenantKey(tenantId: string): Promise<string> {
-        return (await this.getTenantDocument(tenantId)).key;
+        const encryptedTenantKey = (await this.getTenantDocument(tenantId)).key;
+        const tenantKey = this.secretManager.decryptSecret(encryptedTenantKey);
+        if (tenantKey == null) {
+            winston.error("Tenant key decryption failed.");
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            Promise.reject("Tenant key decryption failed.");
+        }
+
+        return tenantKey;
     }
 
     /**


### PR DESCRIPTION
Riddler will store the encrypted key in MongoDb.
GetTenantKey will return the decrypted key.