### PR TITLE
Ignore additional lint rules in v7 config

### DIFF
--- a/common/build/eslint-config-fluid/eslint7.js
+++ b/common/build/eslint-config-fluid/eslint7.js
@@ -128,12 +128,7 @@ module.exports = {
         "@typescript-eslint/no-require-imports": "error",
         "@typescript-eslint/no-this-alias": "error",
         "@typescript-eslint/no-unused-expressions": "error",
-        "@typescript-eslint/no-unused-vars": [
-            "error",
-            {
-                "args": "none"
-            }
-        ],
+        "@typescript-eslint/no-unused-vars": "off",
         "@typescript-eslint/no-unnecessary-qualifier": "error",
         "@typescript-eslint/no-unnecessary-type-arguments": "error",
         "@typescript-eslint/no-unnecessary-type-assertion": "error",
@@ -153,6 +148,7 @@ module.exports = {
             }
         ],
         "@typescript-eslint/restrict-plus-operands": "error",
+        "@typescript-eslint/restrict-template-expressions": "off",
         "@typescript-eslint/require-await": "off",
         "@typescript-eslint/semi": [
             "error",


### PR DESCRIPTION
These rules need to be disabled in the v7 config to ease migration of the monorepos. Once we're on v7 we can turn these back on if needed.