### PR TITLE
Assign reviewers when PRs change

### DIFF
--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -1,7 +1,7 @@
 name: "Auto Assign Pull Request"
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened, synchronize, reopened]
     branches:
     - main
     - release/*


### PR DESCRIPTION
Additional files can be added or edited after a PR is opened, so reviewers should be reevaluated when the PR is updated.