### PR TITLE
Remove Shared Object FluidObject Interfaces

### DIFF
--- a/examples/data-objects/scribe/src/tools-core/author.ts
+++ b/examples/data-objects/scribe/src/tools-core/author.ts
@@ -4,7 +4,6 @@
  */
 
 import * as api from "@fluid-internal/client-api";
-import { IFluidObject } from "@fluidframework/core-interfaces";
 import { ILoader } from "@fluidframework/container-definitions";
 import { ISharedMap } from "@fluidframework/map";
 import * as MergeTree from "@fluidframework/merge-tree";
@@ -94,6 +93,15 @@ export interface IScribeMetrics {
 export declare type ScribeMetricsCallback = (metrics: IScribeMetrics) => void;
 export declare type QueueCallback = (metrics: IScribeMetrics, author: IAuthor) => void;
 
+export async function requestSharedString(loader: ILoader, urlBase: string): Promise<ISharedString> {
+    const response = await loader.request({ url: `${urlBase}/sharedstring` });
+    if (response.status !== 200 || response.mimeType !== "fluid/sharedstring") {
+        return Promise.reject("Invalid document");
+    }
+
+    return response.value as ISharedString;
+}
+
 export async function typeFile(
     loader: ILoader,
     urlBase: string,
@@ -159,22 +167,13 @@ export async function typeFile(
     const authors: IAuthor[] = [author];
 
     for (let i = 1; i < writers; i++) {
-        const response = await loader.request({ url: urlBase });
-        if (response.status !== 200 || response.mimeType !== "fluid/object") {
-            return Promise.reject("Invalid document");
-        }
-
-        const component = response.value as IFluidObject;
-        if (!component.ISharedString) {
-            return Promise.reject("Cannot type into document");
-        }
-
+        const sharedString = await requestSharedString(loader, urlBase);
         author = {
             ackCounter: new Counter(),
             latencyCounter: new Counter(),
             metrics: clone(m),
             pingCounter: new Counter(),
-            ss: component.ISharedString,
+            ss: sharedString,
             typingCounter: new Counter(),
         };
         authors.push(author);

--- a/examples/data-objects/scribe/src/tools-core/scribe.ts
+++ b/examples/data-objects/scribe/src/tools-core/scribe.ts
@@ -5,7 +5,6 @@
 
 import childProcess from "child_process";
 import path from "path";
-import { IFluidObject } from "@fluidframework/core-interfaces";
 import { ILoader } from "@fluidframework/container-definitions";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
 import * as MergeTree from "@fluidframework/merge-tree";
@@ -46,20 +45,12 @@ async function conductor(
     const docId = "";
     const chunks = author.normalizeText(text).split("\n");
 
-    const response = await loader.request({ url });
-    if (response.status !== 200 || response.mimeType !== "fluid/object") {
-        return Promise.reject("Invalid document");
-    }
-
-    const component = response.value as IFluidObject;
-    if (!component.ISharedString) {
-        return Promise.reject("Cannot type into document");
-    }
+    const sharedString = await author.requestSharedString(loader, url);
 
     const chunksMap = SharedMap.create(runtime);
     scribeMap.set("chunks", chunksMap.handle);
 
-    setParagraphs(chunks, component.ISharedString);
+    setParagraphs(chunks, sharedString);
 
     chunks.forEach((chunk, index) => {
         const chunkKey = `p-${index}`;
@@ -72,7 +63,7 @@ async function conductor(
             loader,
             url,
             runtime,
-            component.ISharedString,
+            sharedString,
             chunksMap,
             text,
             intervalTime,

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -10,21 +10,10 @@ import { IFluidDataStoreRuntime, IChannelAttributes } from "@fluidframework/data
 import { SharedSegmentSequence } from "./sequence";
 import { SharedStringFactory } from "./sequenceFactory";
 
-declare module "@fluidframework/core-interfaces" {
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    export interface IFluidObject extends Readonly<Partial<IProvideSharedString>> { }
-}
-
-export const ISharedString: keyof IProvideSharedString = "ISharedString";
-
-export interface IProvideSharedString {
-    readonly ISharedString: ISharedString;
-}
-
 /**
  * Fluid object interface describing access methods on a SharedString
  */
-export interface ISharedString extends SharedSegmentSequence<SharedStringSegment>, IProvideSharedString {
+export interface ISharedString extends SharedSegmentSequence<SharedStringSegment> {
     insertText(pos: number, text: string, props?: MergeTree.PropertySet);
 
     insertMarker(pos: number, refType: MergeTree.ReferenceType, props?: MergeTree.PropertySet);

--- a/packages/dds/shared-object-base/src/types.ts
+++ b/packages/dds/shared-object-base/src/types.ts
@@ -7,17 +7,6 @@ import { ITree, ISequencedDocumentMessage } from "@fluidframework/protocol-defin
 import { IChannel, IChannelServices } from "@fluidframework/datastore-definitions";
 import { IErrorEvent, IEventProvider, IEventThisPlaceHolder } from "@fluidframework/common-definitions";
 
-declare module "@fluidframework/core-interfaces" {
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface IFluidObject extends Readonly<Partial<IProvideSharedObject>> { }
-}
-
-export const ISharedObject: keyof IProvideSharedObject = "ISharedObject";
-
-export interface IProvideSharedObject {
-    readonly ISharedObject: ISharedObject;
-}
-
 export interface ISharedObjectEvents extends IErrorEvent {
     (event: "pre-op" | "op",
         listener: (op: ISequencedDocumentMessage, local: boolean, target: IEventThisPlaceHolder) => void);
@@ -27,7 +16,7 @@ export interface ISharedObjectEvents extends IErrorEvent {
  * Base interface for shared objects from which other interfaces derive. Implemented by SharedObject
  */
 export interface ISharedObject<TEvent extends ISharedObjectEvents = ISharedObjectEvents>
-    extends IProvideSharedObject, IChannel, IEventProvider<TEvent> {
+    extends IChannel, IEventProvider<TEvent> {
     /**
      * Binds the given shared object to its containing data store runtime, causing it to attach once
      * the runtime attaches.

--- a/packages/runtime/datastore-definitions/src/channel.ts
+++ b/packages/runtime/datastore-definitions/src/channel.ts
@@ -8,18 +8,7 @@ import { ISequencedDocumentMessage, ITree } from "@fluidframework/protocol-defin
 import { IChannelAttributes } from "./storage";
 import { IFluidDataStoreRuntime } from "./dataStoreRuntime";
 
-declare module "@fluidframework/core-interfaces" {
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface IFluidObject extends Readonly<Partial<IProvideChannel>> { }
-}
-
-export const IChannel: keyof IProvideChannel = "IChannel";
-
-export interface IProvideChannel {
-    readonly IChannel: IChannel;
-}
-
-export interface IChannel extends IProvideChannel, IFluidLoadable {
+export interface IChannel extends IFluidLoadable {
     /**
      * A readonly identifier for the channel
      */


### PR DESCRIPTION
Remove the unused interfaces on FluidObject
- ISharedString
- ISharedObject
- IChannel

In addition to being unused these interfaces represent bad practices. A DataStore shouldn't externally expose it's dds for others to access directly. It should instead expose and API and control the data model of the dds. 

While gernerally unused there is a coupling between our scribe tool and our shared text examples that leverages the ISharedString interface. To remove this interface from IFluidObject, which broadly exposes this bad practice, I've move it to using the request pattern. While still not ideal, this localizes the contract between the two rather than leaking this across the system.

Related #3264
Related #2566