### PR TITLE
Add closed flag to prevent latent socket emission

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -341,6 +341,13 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
      * Disconnect from the websocket
      */
     public disconnect(socketProtocolError: boolean = false) {
+        // We set the closed flag as a part of the contract for overriding the disconnect method.  This is used by
+        // DocumentDeltaConnection to determine if emitting on the socket is allowed, which is important since
+        // OdspDocumentDeltaConnection reuses the socket rather than truly disconnecting it.  Note that below we may
+        // still send disconnect_document which is allowed; this is only intended to prevent normal messages from
+        // being emitted.
+        this.closed = true;
+
         if (this.socketReferenceKey !== undefined) {
             const key = this.socketReferenceKey;
             this.socketReferenceKey = undefined;
@@ -358,10 +365,5 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
             // If it's not critical error, we want to raise event on this object only.
             this.emit("disconnect", reason);
         }
-
-        // We set the closed flag as a part of the contract for overriding the disconnect method.  This is used by
-        // DocumentDeltaConnection to determine if emitting on the socket is allowed, which is important since
-        // OdspDocumentDeltaConnection reuses the socket rather than truly disconnecting it.
-        this.closed = true;
     }
 }

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -358,5 +358,10 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
             // If it's not critical error, we want to raise event on this object only.
             this.emit("disconnect", reason);
         }
+
+        // We set the closed flag as a part of the contract for overriding the disconnect method.  This is used by
+        // DocumentDeltaConnection to determine if emitting on the socket is allowed, which is important since
+        // OdspDocumentDeltaConnection reuses the socket rather than truly disconnecting it.
+        this.closed = true;
     }
 }


### PR DESCRIPTION
In #3627, we observe messages are being sent with old clientId.  The default implementation of `DocumentDeltaManager.disconnect()` generally protects against this by disconnecting the socket on disconnect().  However, there's nothing actually stopping the `BatchManager` from attempting to emit on the old socket if it still has messages in the queue -- it will just fail because the socket is disconnected.

This is a speculative fix -- we suspect that since `OdspDocumentDeltaManager` overrides `disconnect()` to allow for socket reuse, these still-open sockets are emitting leftover messages.  This change introduces a flag to more explicitly indicate/check whether emitting on the socket should be allowed.

With Helio's #3704, we should have the correct telemetry in place to determine whether this is effective in eliminating the issue.