### PR TITLE
[0.26 port] Add closed flag to prevent latent socket emission (#3787)

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -341,6 +341,13 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
      * Disconnect from the websocket
      */
     public disconnect(socketProtocolError: boolean = false) {
+        // We set the closed flag as a part of the contract for overriding the disconnect method.  This is used by
+        // DocumentDeltaConnection to determine if emitting on the socket is allowed, which is important since
+        // OdspDocumentDeltaConnection reuses the socket rather than truly disconnecting it.  Note that below we may
+        // still send disconnect_document which is allowed; this is only intended to prevent normal messages from
+        // being emitted.
+        this.closed = true;
+
         if (this.socketReferenceKey !== undefined) {
             const key = this.socketReferenceKey;
             this.socketReferenceKey = undefined;


### PR DESCRIPTION
Speculative fix to prevent OdspDocumentDeltaConnection from emitting on reused sockets after disconnect.