### PR TITLE
remove DeltaManager "caughtUp" event

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -691,41 +691,41 @@
 			}
 		},
 		"@fluidframework/agent-scheduler": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.26.1.tgz",
-			"integrity": "sha512-3GSky/0N8bWpxk1RH99v0bENQxE8nu7fyLWCtt0keM/ZR78H5ANcRVy39nFLOZ505cn7cNJWS+twRrx/lo+/3w==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.26.2.tgz",
+			"integrity": "sha512-GslccxEXxhYEZOrrGaJJimA5xSODJM+5UfTHM8y4RUSdH9nGl62/dO4xAdZmwOTodaUQQttGi8Xr5FieUerb2Q==",
 			"requires": {
-				"@fluidframework/container-definitions": "^0.26.1",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/datastore": "^0.26.1",
-				"@fluidframework/datastore-definitions": "^0.26.1",
-				"@fluidframework/map": "^0.26.1",
-				"@fluidframework/register-collection": "^0.26.1",
-				"@fluidframework/runtime-definitions": "^0.26.1",
+				"@fluidframework/container-definitions": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/datastore": "^0.26.2",
+				"@fluidframework/datastore-definitions": "^0.26.2",
+				"@fluidframework/map": "^0.26.2",
+				"@fluidframework/register-collection": "^0.26.2",
+				"@fluidframework/runtime-definitions": "^0.26.2",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.26.1.tgz",
-			"integrity": "sha512-jBhZ79H+XxrKXx/OA7EX6vswCRK4Px+ojso7dPuSYzJKuCBoddmQSdxF9LWmCIevHV+RexLbMRRVdeeA3ownPA==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.26.2.tgz",
+			"integrity": "sha512-95xWgxdImJua25sT9muAr3KnfcCWJ6E6fMEvO+I1nfKYI2LfOnmGoss88DRys5KFE5RlOmoNS2ocFbHOLLD7mw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.1",
-				"@fluidframework/container-loader": "^0.26.1",
-				"@fluidframework/container-runtime": "^0.26.1",
-				"@fluidframework/container-runtime-definitions": "^0.26.1",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/datastore": "^0.26.1",
-				"@fluidframework/datastore-definitions": "^0.26.1",
-				"@fluidframework/map": "^0.26.1",
-				"@fluidframework/request-handler": "^0.26.1",
-				"@fluidframework/runtime-definitions": "^0.26.1",
-				"@fluidframework/runtime-utils": "^0.26.1",
-				"@fluidframework/synthesize": "^0.26.1",
-				"@fluidframework/view-interfaces": "^0.26.1",
+				"@fluidframework/container-definitions": "^0.26.2",
+				"@fluidframework/container-loader": "^0.26.2",
+				"@fluidframework/container-runtime": "^0.26.2",
+				"@fluidframework/container-runtime-definitions": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/datastore": "^0.26.2",
+				"@fluidframework/datastore-definitions": "^0.26.2",
+				"@fluidframework/map": "^0.26.2",
+				"@fluidframework/request-handler": "^0.26.2",
+				"@fluidframework/runtime-definitions": "^0.26.2",
+				"@fluidframework/runtime-utils": "^0.26.2",
+				"@fluidframework/synthesize": "^0.26.2",
+				"@fluidframework/view-interfaces": "^0.26.2",
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
@@ -806,13 +806,13 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.26.1.tgz",
-			"integrity": "sha512-YJjZXDE12W9bQU0NlWz4efXLBS0PWUI+6gbcsqNIJMzHTcN1RLIUpDyJNGCt52lj+6hD5TdvZ0e1coEv3AqAJg==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.26.2.tgz",
+			"integrity": "sha512-Kf6G50wGbW0pdqXT9CggWR0akdQlq3U2nM/WF7M0iUKDOCwQq84enmVHt++x2prG+5R6oUVOogoLootwHUY/Xw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/driver-definitions": "^0.26.1",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/driver-definitions": "^0.26.2",
 				"@fluidframework/protocol-definitions": "^0.1012.0"
 			},
 			"dependencies": {
@@ -827,20 +827,20 @@
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.26.1.tgz",
-			"integrity": "sha512-Iqbk3w0vunsWugpvGc/TAefSHwbjT6+s3CQWCFSsRZJMdJR8ILmBQpXp4T11MsWStfLforjXtoUVBO+/GrC6nw==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.26.2.tgz",
+			"integrity": "sha512-/zqT6XzYPgjB+bugnnNYlUr+zxRqQjT/ZloYZ1Bcl+iOti9gbAC/vFy2+VPNznrph5ZASkeE5rSp7rE1cETIUg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.1",
-				"@fluidframework/container-utils": "^0.26.1",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/driver-definitions": "^0.26.1",
-				"@fluidframework/driver-utils": "^0.26.1",
+				"@fluidframework/container-definitions": "^0.26.2",
+				"@fluidframework/container-utils": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/driver-definitions": "^0.26.2",
+				"@fluidframework/driver-utils": "^0.26.2",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/telemetry-utils": "^0.26.1",
+				"@fluidframework/telemetry-utils": "^0.26.2",
 				"@types/double-ended-queue": "^2.1.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -891,25 +891,25 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.26.1.tgz",
-			"integrity": "sha512-w2U1g+s4nwCo6gFMIId5E2BrriDiX2M27PB/ZzvuPi6oI2ZO9jsmWH68i5fukaA/RqGvjvkzjbWO/2UYTckv1Q==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.26.2.tgz",
+			"integrity": "sha512-pBDgv5dcQJATKSLk4J3SbQLedyCunXT3qVJzNW8KHffLpJU1xEM/ZvaJuL7Emku66FBFthq2K3LM8MWu00ywNQ==",
 			"requires": {
-				"@fluidframework/agent-scheduler": "^0.26.1",
+				"@fluidframework/agent-scheduler": "^0.26.2",
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.1",
-				"@fluidframework/container-runtime-definitions": "^0.26.1",
-				"@fluidframework/container-utils": "^0.26.1",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/datastore": "^0.26.1",
-				"@fluidframework/driver-definitions": "^0.26.1",
-				"@fluidframework/driver-utils": "^0.26.1",
+				"@fluidframework/container-definitions": "^0.26.2",
+				"@fluidframework/container-runtime-definitions": "^0.26.2",
+				"@fluidframework/container-utils": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/datastore": "^0.26.2",
+				"@fluidframework/driver-definitions": "^0.26.2",
+				"@fluidframework/driver-utils": "^0.26.2",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.1",
-				"@fluidframework/runtime-utils": "^0.26.1",
-				"@fluidframework/telemetry-utils": "^0.26.1",
+				"@fluidframework/runtime-definitions": "^0.26.2",
+				"@fluidframework/runtime-utils": "^0.26.2",
+				"@fluidframework/telemetry-utils": "^0.26.2",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/node": "^10.17.24",
@@ -962,15 +962,15 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.26.1.tgz",
-			"integrity": "sha512-eQw8g4nGNJs2t9kB+7IgD7CiyIyI3DZpV8t8f0UFHMNudxOHq6TYvAmiEC/zVdN8OhcxqJuEX7nLAORpTWhBXg==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.26.2.tgz",
+			"integrity": "sha512-0LMke6BZ5yeBB4GazdxVYKN5lVpO4YoFNX59wviLLJv8dqlWx1Tq8mO0Gf8vYEkAbo3fhsEPYUuf5kUIw/xang==",
 			"requires": {
-				"@fluidframework/container-definitions": "^0.26.1",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/driver-definitions": "^0.26.1",
+				"@fluidframework/container-definitions": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/driver-definitions": "^0.26.2",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.1",
+				"@fluidframework/runtime-definitions": "^0.26.2",
 				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
@@ -985,37 +985,37 @@
 			}
 		},
 		"@fluidframework/container-utils": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.26.1.tgz",
-			"integrity": "sha512-Azta/3jJeHrUtZXCOGIft/geJxUGq2Qy5OvLdJGJr4w35JKSelpGuBjLUMIgmBlnEZMWgNVv1ghdbrwZxqCaTg==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.26.2.tgz",
+			"integrity": "sha512-DQPcgYNfXg5bS4axnS2OcmatiTSIVO8GAIvtoeyVhRysYoXkWYQolaujfAzgIK2GrI3JilM0X40H6vPnG2WifQ==",
 			"requires": {
-				"@fluidframework/container-definitions": "^0.26.1",
-				"@fluidframework/telemetry-utils": "^0.26.1"
+				"@fluidframework/container-definitions": "^0.26.2",
+				"@fluidframework/telemetry-utils": "^0.26.2"
 			}
 		},
 		"@fluidframework/core-interfaces": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.26.1.tgz",
-			"integrity": "sha512-2A2xsOL9fQ/k7AiHJSNUGIvQWBKjQiWvhkIREHk2qOSTAvc+hPNWKDtxUNoKTbZTCVPHXqxpGkQwHA6TtjSnHA=="
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.26.2.tgz",
+			"integrity": "sha512-OoqL6nqgLL1rEiajutc29MK8Rr5ww4g8DFq8A0HIEz0Jy0FktaRxwol5e6l71+6YvjaBzOu+mpmMjwB6r/KAXw=="
 		},
 		"@fluidframework/datastore": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.26.1.tgz",
-			"integrity": "sha512-aLvGlSXKCf+Qbm61eGwYAbAISgcu0CVN3DqFA5ixg5l87nb6PabHUIJHsRmtGsGxG5XF3+Y4bWS3+UQmdkKnDg==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.26.2.tgz",
+			"integrity": "sha512-QDazgxHKfBMD8URyH7EgiglB+Bk1SAk/zJj60JKkh23hbt/CJJdR4n+D38+8n+BIqW/dTmCx85sPg3HD7Ob/TA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.1",
-				"@fluidframework/container-utils": "^0.26.1",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/datastore-definitions": "^0.26.1",
-				"@fluidframework/driver-definitions": "^0.26.1",
-				"@fluidframework/driver-utils": "^0.26.1",
+				"@fluidframework/container-definitions": "^0.26.2",
+				"@fluidframework/container-utils": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/datastore-definitions": "^0.26.2",
+				"@fluidframework/driver-definitions": "^0.26.2",
+				"@fluidframework/driver-utils": "^0.26.2",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.1",
-				"@fluidframework/runtime-utils": "^0.26.1",
-				"@fluidframework/telemetry-utils": "^0.26.1",
+				"@fluidframework/runtime-definitions": "^0.26.2",
+				"@fluidframework/runtime-utils": "^0.26.2",
+				"@fluidframework/telemetry-utils": "^0.26.2",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
@@ -1064,15 +1064,15 @@
 			}
 		},
 		"@fluidframework/datastore-definitions": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.26.1.tgz",
-			"integrity": "sha512-UY3UyMEJ8BU6fegC6MwKY3aoq5pVHBlrom95CchDvjk9moDMgmYQNMBZ4tMEXzMTHdxR8QD6bRlx7pcb6Pf2kw==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.26.2.tgz",
+			"integrity": "sha512-fDYc8fdhmRvYAuPFq7udy4DKEQYnimWQAqSMsTKWgs5KMCHOcCZcmFh0Hd10lORzQ8m5G7FLPzvmkCRyEzAaLg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.26.1",
-				"@fluidframework/core-interfaces": "^0.26.1",
+				"@fluidframework/container-definitions": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.2",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.1",
+				"@fluidframework/runtime-definitions": "^0.26.2",
 				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
@@ -1087,13 +1087,13 @@
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.26.1.tgz",
-			"integrity": "sha512-JuIOCuZGRJHxZVKPD4t5yigvSTPBVvqlXq/NhWmo5KhBLci5pwMwf1P9nEYR5kYd5z7GZiH/vnBGSCV5D14XFA==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.26.2.tgz",
+			"integrity": "sha512-tMacmATI94jQ1Ako47+/L9P3SGiFwi7fL8eWkzm6oTjanD0zGNNVU2fgatY8E4W4m4rY/ClC7/xCP/mPSY7s/w==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/driver-definitions": "^0.26.1",
-				"@fluidframework/driver-utils": "^0.26.1",
+				"@fluidframework/driver-definitions": "^0.26.2",
+				"@fluidframework/driver-utils": "^0.26.2",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
 				"@types/debug": "^4.1.5",
 				"@types/node": "^10.17.24",
@@ -1127,12 +1127,12 @@
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.26.1.tgz",
-			"integrity": "sha512-Xd8CDe5LGPEq6xa6DsCswQuMIDriDso1T3WMcvaUnnuquKTdZh7phTzlsDH4O6dQuhprsKxI/Jnohke2AA/UuA==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.26.2.tgz",
+			"integrity": "sha512-oTppj1WMwQZoyNQmuYxYAnUWEFOSRWzXvDOZLc+Ble4shjZftEpbz7a78P8cXC9yYN3sP9kDkLiL38/YYTWQeg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.26.1",
+				"@fluidframework/core-interfaces": "^0.26.2",
 				"@fluidframework/protocol-definitions": "^0.1012.0"
 			},
 			"dependencies": {
@@ -1147,18 +1147,18 @@
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.26.1.tgz",
-			"integrity": "sha512-hJupVQCg55MWD4+W3CVEr6IdLc88KoAvj8BQvDwnvi1+2aziq7DqVBoHu/nl0+8ZVYZ/gK+4JqFR7L6TP0YPAQ==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.26.2.tgz",
+			"integrity": "sha512-lQ4Z1/DN7HT04ezOoo2tWhAvgdcNQRKxU6dEzbXVUbgmqZDSHVGkC2fBmgU1I5vez5Ye5NKqZt80LkUkmzTmig==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/driver-definitions": "^0.26.1",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/driver-definitions": "^0.26.2",
 				"@fluidframework/gitresources": "^0.1012.0",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/telemetry-utils": "^0.26.1"
+				"@fluidframework/telemetry-utils": "^0.26.2"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -1226,17 +1226,17 @@
 			"integrity": "sha512-PqXhUPI8FiGlw2dB/VCb3ciHzm5a98DKkm+XvbcdTwtDT5AQyjfTpl7ivAqD75Xn40lAX/yZa6oJyl1K11LSBg=="
 		},
 		"@fluidframework/local-driver": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.26.1.tgz",
-			"integrity": "sha512-eNCy0GcknhKZWEA3o/nJWgm9ErEoLLlpqMtQNxIV5f+FOQpojBMVslOh8OWWNIN71FlDJKwfn0m03e/MaCj7xg==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.26.2.tgz",
+			"integrity": "sha512-aodH+ak2hjQwDOZOO6Ice4i0Htd/EN5H2cJj2n42frOWXjPKHqgcaEoZPTNVo3X7rI6FuCaCN4NCa8+CbXHIOg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/driver-definitions": "^0.26.1",
-				"@fluidframework/driver-utils": "^0.26.1",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/driver-definitions": "^0.26.2",
+				"@fluidframework/driver-utils": "^0.26.2",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/routerlicious-driver": "^0.26.1",
+				"@fluidframework/routerlicious-driver": "^0.26.2",
 				"@fluidframework/server-local-server": "^0.1012.0",
 				"@fluidframework/server-services-client": "^0.1012.0",
 				"@fluidframework/server-services-core": "^0.1012.0",
@@ -1403,18 +1403,19 @@
 			}
 		},
 		"@fluidframework/map": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.26.1.tgz",
-			"integrity": "sha512-e0NhYibjO/3C6ucP2ykW3/RL1eG5Iz9BHNJrb/OjyE6aBGwM7fDVuF34KU1dJv2UUIzK4ayimhEvz/nl0QIIMQ==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.26.2.tgz",
+			"integrity": "sha512-DFkIBTKYILOmC71OrpiXcGFCU7L9oNSwskD62hsfZMjAm3Ol5Uv7S8SkQ9KrdCsNzmi6Z09pOvE6X2dZakmbLQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/datastore-definitions": "^0.26.1",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/datastore-definitions": "^0.26.2",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.1",
-				"debug": "^4.1.1"
+				"@fluidframework/shared-object-base": "^0.26.2",
+				"debug": "^4.1.1",
+				"path-browserify": "^1.0.1"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -1460,16 +1461,16 @@
 			}
 		},
 		"@fluidframework/merge-tree": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.26.1.tgz",
-			"integrity": "sha512-GaECIFKAgnhyEuIuDhN8qmY/HbKCOvzTNhWXqp9iuqbs1VQxaDT6ELTGYTvoEWztrxlBcRZEYHTmlK6aE5/Znw==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.26.2.tgz",
+			"integrity": "sha512-ICAi/KYEtjb1jIYyIAC2+TFVwsbBCzhW227KknnXEyAnhUx9j+lKXFXZY36gBzJ2vWnWGDOqh+f/01tSVYLAhw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/datastore-definitions": "^0.26.1",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/datastore-definitions": "^0.26.2",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/telemetry-utils": "^0.26.1"
+				"@fluidframework/telemetry-utils": "^0.26.2"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -1518,14 +1519,14 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.26.1.tgz",
-			"integrity": "sha512-Z73hIo4IcO4VLbxl/7b+gmTK0wQa2lDOEwbXxUVxLI5/fucah6Mzcdf68cNvAl8UtOvb/bXAw7x3YRLAfS3BDw==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.26.2.tgz",
+			"integrity": "sha512-TjZlz2GVBTRIE8sIqkg0Ic9iNAtXXRVNWj8HuyOMK9IrzdNC8mt+7RpNlCIhY63ZO18nNRfZ6OLip9y2vRvZWw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/datastore-definitions": "^0.26.1",
+				"@fluidframework/datastore-definitions": "^0.26.2",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.1",
+				"@fluidframework/shared-object-base": "^0.26.2",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
@@ -1555,26 +1556,26 @@
 			}
 		},
 		"@fluidframework/request-handler": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.26.1.tgz",
-			"integrity": "sha512-Zn0uCDv2shHQcLnA/S5iSymb3NhSJ9TC7FEKps9yUxOG136KXbHufp6tcTVxowLoNt+eI7tfD6Nk5NTHMkAS6A==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.26.2.tgz",
+			"integrity": "sha512-uEP8fhXI5B4gpURwGjpqkTUc3RkqMiOWEnlMxPecsAZRB63s436ru5wR/hrCyyr82uyf7z7PeNR7WfP6K3YRVQ==",
 			"requires": {
-				"@fluidframework/container-runtime-definitions": "^0.26.1",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/runtime-definitions": "^0.26.1",
-				"@fluidframework/runtime-utils": "^0.26.1"
+				"@fluidframework/container-runtime-definitions": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/runtime-definitions": "^0.26.2",
+				"@fluidframework/runtime-utils": "^0.26.2"
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.26.1.tgz",
-			"integrity": "sha512-iVo++glVofR8y9Fj/HtP6Qm38L5kggZQKdWi0GRrBUBFiJVat33XoMmJnKoa7ITSTss3bTcBC4B1uEqmwsJ81Q==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.26.2.tgz",
+			"integrity": "sha512-ZgTjfsUmLag6z6AnHInMEKGUSr295GbAOPhgkrTWu9eO06mCL0Q4+Dp9zEtKStwoAv5bk32vj/I4DXJRB7XbqQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/driver-base": "^0.26.1",
-				"@fluidframework/driver-definitions": "^0.26.1",
-				"@fluidframework/driver-utils": "^0.26.1",
+				"@fluidframework/driver-base": "^0.26.2",
+				"@fluidframework/driver-definitions": "^0.26.2",
+				"@fluidframework/driver-utils": "^0.26.2",
 				"@fluidframework/gitresources": "^0.1012.0",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
@@ -1647,14 +1648,14 @@
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.26.1.tgz",
-			"integrity": "sha512-c0YRh1YntPXP1E/lyVOi/UDJ+jPQ9pcyddlU7IVJxNknLMUpM9GzXleIjf65FMV7L/csexSIt4H51IdJZSmxGw==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.26.2.tgz",
+			"integrity": "sha512-j7IwsiLX/EeF/PiMfS/TrFf8vNrT+feCwD2ldAVGIyxdsJZivbPj3m1dqvYsHNBEZBftjhNe+IQnpuDJ6JGrfQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.26.1",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/driver-definitions": "^0.26.1",
+				"@fluidframework/container-definitions": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/driver-definitions": "^0.26.2",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
 				"@types/node": "^10.17.24"
 			},
@@ -1670,17 +1671,17 @@
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.26.1.tgz",
-			"integrity": "sha512-QTw7icvrz2Il7Z18eTlMNyXLqszbaTWmVVPhmX/f8vGiY2G7N4dRY9Vc4DViwu66CPCloc0w1vKtfeH/czc9xw==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.26.2.tgz",
+			"integrity": "sha512-nEueuPfeXCqJQEjSdxkS30mlFq0skxneqF+08HlcKJ30LEZIjdAH45aG6RfuXpbKdKcTG9BaTf49KZOwvVhXnQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/datastore-definitions": "^0.26.1",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/datastore-definitions": "^0.26.2",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.1"
+				"@fluidframework/runtime-definitions": "^0.26.2"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -1843,17 +1844,17 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.26.1.tgz",
-			"integrity": "sha512-qoOp2Ox7Z8PWCv15yOBkqtFFsUjVm2UO5Xa3mdUThvCWlo6AC/i5uI9ejw09B+FRPou3715RmaSnJU7DEYvL5w==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.26.2.tgz",
+			"integrity": "sha512-FlzPqARyGtdmq5Hz9z5a1fmyJXjGcHN4ls7ibOcAKipnFSBAdpXx6uvfDhFHSo6pcTLDraz0zMt0GJyNrVBkag==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.26.1",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/datastore": "^0.26.1",
-				"@fluidframework/datastore-definitions": "^0.26.1",
+				"@fluidframework/container-definitions": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/datastore": "^0.26.2",
+				"@fluidframework/datastore-definitions": "^0.26.2",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/telemetry-utils": "^0.26.1",
+				"@fluidframework/telemetry-utils": "^0.26.2",
 				"@types/debug": "^4.1.5",
 				"@types/node": "^10.17.24",
 				"debug": "^4.1.1",
@@ -1871,17 +1872,17 @@
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.26.1.tgz",
-			"integrity": "sha512-G+2Hox+fafo/v7eUwkIcxiC0FnItFuJuSElVuTq8nPzbkXtnraF3is+ytUC/+JLr788AvTm8V2bRD9IbyQhBpQ==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.26.2.tgz",
+			"integrity": "sha512-lmW1w4w9dooH4PCRWrQnW958tH3kgnB6dGMi1dHx0vd1zaf3WU/BQkn4+wfrn8Dr+l3UiFQ4EfCTl3Ic4Khr5w==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^0.26.1"
+				"@fluidframework/core-interfaces": "^0.26.2"
 			}
 		},
 		"@fluidframework/telemetry-utils": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.26.1.tgz",
-			"integrity": "sha512-eQhj0bRuQ4VA8AAjk1kGW9PHToIqvLnE7aVdXpmoXLrbcdZ80YigVR6ZCdZ53AQmxfd3QMu7/65o3xpQ306kug==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.26.2.tgz",
+			"integrity": "sha512-CNJ8HWiJkscElxEINq9VaEqM4b8mCAFi3rd+8aVv3Omhs31FxLOS7eRFZVSxSQZWNjkAGNqVP2KfAvogMxIZUA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
@@ -1913,11 +1914,11 @@
 			"dev": true
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.26.1.tgz",
-			"integrity": "sha512-hF/do+i25Xy5607UclWISRJI2iojMt/j2cR6Y/SSDQLwi8b/eG1jv6M/mxDtkN+vpa6bL+5+dW5kU9aB0bMJSw==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.26.2.tgz",
+			"integrity": "sha512-bz96lUptVDP39qRmr98KtitijoAR1oUwhuxQo5RV9uJGxH3iymE97n7Ccww4jMOo8fafDBnkGbob9K77Eej1ug==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^0.26.1"
+				"@fluidframework/core-interfaces": "^0.26.2"
 			}
 		},
 		"@hapi/address": {
@@ -19782,25 +19783,25 @@
 			}
 		},
 		"old-aqueduct": {
-			"version": "npm:@fluidframework/aqueduct@0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.26.1.tgz",
-			"integrity": "sha512-jBhZ79H+XxrKXx/OA7EX6vswCRK4Px+ojso7dPuSYzJKuCBoddmQSdxF9LWmCIevHV+RexLbMRRVdeeA3ownPA==",
+			"version": "npm:@fluidframework/aqueduct@0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.26.2.tgz",
+			"integrity": "sha512-95xWgxdImJua25sT9muAr3KnfcCWJ6E6fMEvO+I1nfKYI2LfOnmGoss88DRys5KFE5RlOmoNS2ocFbHOLLD7mw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.1",
-				"@fluidframework/container-loader": "^0.26.1",
-				"@fluidframework/container-runtime": "^0.26.1",
-				"@fluidframework/container-runtime-definitions": "^0.26.1",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/datastore": "^0.26.1",
-				"@fluidframework/datastore-definitions": "^0.26.1",
-				"@fluidframework/map": "^0.26.1",
-				"@fluidframework/request-handler": "^0.26.1",
-				"@fluidframework/runtime-definitions": "^0.26.1",
-				"@fluidframework/runtime-utils": "^0.26.1",
-				"@fluidframework/synthesize": "^0.26.1",
-				"@fluidframework/view-interfaces": "^0.26.1",
+				"@fluidframework/container-definitions": "^0.26.2",
+				"@fluidframework/container-loader": "^0.26.2",
+				"@fluidframework/container-runtime": "^0.26.2",
+				"@fluidframework/container-runtime-definitions": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/datastore": "^0.26.2",
+				"@fluidframework/datastore-definitions": "^0.26.2",
+				"@fluidframework/map": "^0.26.2",
+				"@fluidframework/request-handler": "^0.26.2",
+				"@fluidframework/runtime-definitions": "^0.26.2",
+				"@fluidframework/runtime-utils": "^0.26.2",
+				"@fluidframework/synthesize": "^0.26.2",
+				"@fluidframework/view-interfaces": "^0.26.2",
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
@@ -19822,15 +19823,15 @@
 			}
 		},
 		"old-cell": {
-			"version": "npm:@fluidframework/cell@0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.26.1.tgz",
-			"integrity": "sha512-kCOPHTkVlhuQrNRwAivLNdx9DIW9JG5Lr4tjvS3z+jXi7p095iO6lD/IEinEE9WelOF1nalvUSlmini+CteMyQ==",
+			"version": "npm:@fluidframework/cell@0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.26.2.tgz",
+			"integrity": "sha512-3vVB1Ejd/76oGSpKFLuOg5Ez+7eeoErvxWw3e8lKLqVEknSDA/n8rFuL+sj7jD06SqSaA5Q5tJiitNMEXr7rng==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/datastore-definitions": "^0.26.1",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/datastore-definitions": "^0.26.2",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.1",
+				"@fluidframework/shared-object-base": "^0.26.2",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
@@ -19860,13 +19861,13 @@
 			}
 		},
 		"old-container-definitions": {
-			"version": "npm:@fluidframework/container-definitions@0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.26.1.tgz",
-			"integrity": "sha512-YJjZXDE12W9bQU0NlWz4efXLBS0PWUI+6gbcsqNIJMzHTcN1RLIUpDyJNGCt52lj+6hD5TdvZ0e1coEv3AqAJg==",
+			"version": "npm:@fluidframework/container-definitions@0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.26.2.tgz",
+			"integrity": "sha512-Kf6G50wGbW0pdqXT9CggWR0akdQlq3U2nM/WF7M0iUKDOCwQq84enmVHt++x2prG+5R6oUVOogoLootwHUY/Xw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/driver-definitions": "^0.26.1",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/driver-definitions": "^0.26.2",
 				"@fluidframework/protocol-definitions": "^0.1012.0"
 			},
 			"dependencies": {
@@ -19881,20 +19882,20 @@
 			}
 		},
 		"old-container-loader": {
-			"version": "npm:@fluidframework/container-loader@0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.26.1.tgz",
-			"integrity": "sha512-Iqbk3w0vunsWugpvGc/TAefSHwbjT6+s3CQWCFSsRZJMdJR8ILmBQpXp4T11MsWStfLforjXtoUVBO+/GrC6nw==",
+			"version": "npm:@fluidframework/container-loader@0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.26.2.tgz",
+			"integrity": "sha512-/zqT6XzYPgjB+bugnnNYlUr+zxRqQjT/ZloYZ1Bcl+iOti9gbAC/vFy2+VPNznrph5ZASkeE5rSp7rE1cETIUg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.1",
-				"@fluidframework/container-utils": "^0.26.1",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/driver-definitions": "^0.26.1",
-				"@fluidframework/driver-utils": "^0.26.1",
+				"@fluidframework/container-definitions": "^0.26.2",
+				"@fluidframework/container-utils": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/driver-definitions": "^0.26.2",
+				"@fluidframework/driver-utils": "^0.26.2",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/telemetry-utils": "^0.26.1",
+				"@fluidframework/telemetry-utils": "^0.26.2",
 				"@types/double-ended-queue": "^2.1.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -19945,25 +19946,25 @@
 			}
 		},
 		"old-container-runtime": {
-			"version": "npm:@fluidframework/container-runtime@0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.26.1.tgz",
-			"integrity": "sha512-w2U1g+s4nwCo6gFMIId5E2BrriDiX2M27PB/ZzvuPi6oI2ZO9jsmWH68i5fukaA/RqGvjvkzjbWO/2UYTckv1Q==",
+			"version": "npm:@fluidframework/container-runtime@0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.26.2.tgz",
+			"integrity": "sha512-pBDgv5dcQJATKSLk4J3SbQLedyCunXT3qVJzNW8KHffLpJU1xEM/ZvaJuL7Emku66FBFthq2K3LM8MWu00ywNQ==",
 			"requires": {
-				"@fluidframework/agent-scheduler": "^0.26.1",
+				"@fluidframework/agent-scheduler": "^0.26.2",
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.1",
-				"@fluidframework/container-runtime-definitions": "^0.26.1",
-				"@fluidframework/container-utils": "^0.26.1",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/datastore": "^0.26.1",
-				"@fluidframework/driver-definitions": "^0.26.1",
-				"@fluidframework/driver-utils": "^0.26.1",
+				"@fluidframework/container-definitions": "^0.26.2",
+				"@fluidframework/container-runtime-definitions": "^0.26.2",
+				"@fluidframework/container-utils": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/datastore": "^0.26.2",
+				"@fluidframework/driver-definitions": "^0.26.2",
+				"@fluidframework/driver-utils": "^0.26.2",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.1",
-				"@fluidframework/runtime-utils": "^0.26.1",
-				"@fluidframework/telemetry-utils": "^0.26.1",
+				"@fluidframework/runtime-definitions": "^0.26.2",
+				"@fluidframework/runtime-utils": "^0.26.2",
+				"@fluidframework/telemetry-utils": "^0.26.2",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/node": "^10.17.24",
@@ -20016,15 +20017,15 @@
 			}
 		},
 		"old-datastore-definitions": {
-			"version": "npm:@fluidframework/datastore-definitions@0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.26.1.tgz",
-			"integrity": "sha512-UY3UyMEJ8BU6fegC6MwKY3aoq5pVHBlrom95CchDvjk9moDMgmYQNMBZ4tMEXzMTHdxR8QD6bRlx7pcb6Pf2kw==",
+			"version": "npm:@fluidframework/datastore-definitions@0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.26.2.tgz",
+			"integrity": "sha512-fDYc8fdhmRvYAuPFq7udy4DKEQYnimWQAqSMsTKWgs5KMCHOcCZcmFh0Hd10lORzQ8m5G7FLPzvmkCRyEzAaLg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.26.1",
-				"@fluidframework/core-interfaces": "^0.26.1",
+				"@fluidframework/container-definitions": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.2",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.1",
+				"@fluidframework/runtime-definitions": "^0.26.2",
 				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
@@ -20039,14 +20040,14 @@
 			}
 		},
 		"old-ink": {
-			"version": "npm:@fluidframework/ink@0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.26.1.tgz",
-			"integrity": "sha512-lDUOKRak/Ro3YHtfSrSPRmrMP0RimcWdVhxGEhbwH0vMXqZclj27MqAkG+2NVdFSRsj7dKRe2WKWPrnHjubMXg==",
+			"version": "npm:@fluidframework/ink@0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.26.2.tgz",
+			"integrity": "sha512-0mCB4zopVrtiL2NZrxkPvAXJF0NVjoA/7Tmyy/20F05wCzbhv4tj8soAjhivtQH5OaEdKniCnitzSDFlkY9H3w==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/datastore-definitions": "^0.26.1",
+				"@fluidframework/datastore-definitions": "^0.26.2",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.1",
+				"@fluidframework/shared-object-base": "^0.26.2",
 				"@types/debug": "^4.1.5",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
@@ -20078,17 +20079,17 @@
 			}
 		},
 		"old-local-driver": {
-			"version": "npm:@fluidframework/local-driver@0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.26.1.tgz",
-			"integrity": "sha512-eNCy0GcknhKZWEA3o/nJWgm9ErEoLLlpqMtQNxIV5f+FOQpojBMVslOh8OWWNIN71FlDJKwfn0m03e/MaCj7xg==",
+			"version": "npm:@fluidframework/local-driver@0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.26.2.tgz",
+			"integrity": "sha512-aodH+ak2hjQwDOZOO6Ice4i0Htd/EN5H2cJj2n42frOWXjPKHqgcaEoZPTNVo3X7rI6FuCaCN4NCa8+CbXHIOg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/driver-definitions": "^0.26.1",
-				"@fluidframework/driver-utils": "^0.26.1",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/driver-definitions": "^0.26.2",
+				"@fluidframework/driver-utils": "^0.26.2",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/routerlicious-driver": "^0.26.1",
+				"@fluidframework/routerlicious-driver": "^0.26.2",
 				"@fluidframework/server-local-server": "^0.1012.0",
 				"@fluidframework/server-services-client": "^0.1012.0",
 				"@fluidframework/server-services-core": "^0.1012.0",
@@ -20255,18 +20256,19 @@
 			}
 		},
 		"old-map": {
-			"version": "npm:@fluidframework/map@0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.26.1.tgz",
-			"integrity": "sha512-e0NhYibjO/3C6ucP2ykW3/RL1eG5Iz9BHNJrb/OjyE6aBGwM7fDVuF34KU1dJv2UUIzK4ayimhEvz/nl0QIIMQ==",
+			"version": "npm:@fluidframework/map@0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.26.2.tgz",
+			"integrity": "sha512-DFkIBTKYILOmC71OrpiXcGFCU7L9oNSwskD62hsfZMjAm3Ol5Uv7S8SkQ9KrdCsNzmi6Z09pOvE6X2dZakmbLQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/datastore-definitions": "^0.26.1",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/datastore-definitions": "^0.26.2",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.1",
-				"debug": "^4.1.1"
+				"@fluidframework/shared-object-base": "^0.26.2",
+				"debug": "^4.1.1",
+				"path-browserify": "^1.0.1"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -20312,19 +20314,19 @@
 			}
 		},
 		"old-matrix": {
-			"version": "npm:@fluidframework/matrix@0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.26.1.tgz",
-			"integrity": "sha512-0sIg6bFpw1ut6loZmB6KtmrFenNG9Sx+kq+GgvNy/6WY/1CRRhejSlxUPNfg6s3NF39O++nREa+IYOQ5w/9Mcw==",
+			"version": "npm:@fluidframework/matrix@0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.26.2.tgz",
+			"integrity": "sha512-XzbKzalk1MbD6fmd8pTEX1Zub1b++BM+O69rCkQezPzsvmJygGt+MC/VgucRT8rLQUH8L7Zx9DZDum4mcjfUgw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/datastore-definitions": "^0.26.1",
-				"@fluidframework/merge-tree": "^0.26.1",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/datastore-definitions": "^0.26.2",
+				"@fluidframework/merge-tree": "^0.26.2",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-utils": "^0.26.1",
-				"@fluidframework/shared-object-base": "^0.26.1",
-				"@fluidframework/telemetry-utils": "^0.26.1",
+				"@fluidframework/runtime-utils": "^0.26.2",
+				"@fluidframework/shared-object-base": "^0.26.2",
+				"@fluidframework/telemetry-utils": "^0.26.2",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"debug": "^4.1.1",
 				"tslib": "^1.10.0"
@@ -20356,14 +20358,14 @@
 			}
 		},
 		"old-ordered-collection": {
-			"version": "npm:@fluidframework/ordered-collection@0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.26.1.tgz",
-			"integrity": "sha512-6ySt/KFgdVe0XWo6LJM+bwpv6zA8eRBuBlvk3Gx5iXDqacbrYS8BTDkyUV8Af4dqPJnH+6ppvWqujLQHHIpG/A==",
+			"version": "npm:@fluidframework/ordered-collection@0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.26.2.tgz",
+			"integrity": "sha512-MfTntHoOPHow3lKKXy3EAr4FwtH/PuxAFnZtC9WhE4k6zRVoyRHsu4I/HawmmnuZc6ZbyZbcZYwUaQIT0WFJ1g==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/datastore-definitions": "^0.26.1",
+				"@fluidframework/datastore-definitions": "^0.26.2",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.1",
+				"@fluidframework/shared-object-base": "^0.26.2",
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
@@ -20393,14 +20395,14 @@
 			}
 		},
 		"old-register-collection": {
-			"version": "npm:@fluidframework/register-collection@0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.26.1.tgz",
-			"integrity": "sha512-Z73hIo4IcO4VLbxl/7b+gmTK0wQa2lDOEwbXxUVxLI5/fucah6Mzcdf68cNvAl8UtOvb/bXAw7x3YRLAfS3BDw==",
+			"version": "npm:@fluidframework/register-collection@0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.26.2.tgz",
+			"integrity": "sha512-TjZlz2GVBTRIE8sIqkg0Ic9iNAtXXRVNWj8HuyOMK9IrzdNC8mt+7RpNlCIhY63ZO18nNRfZ6OLip9y2vRvZWw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/datastore-definitions": "^0.26.1",
+				"@fluidframework/datastore-definitions": "^0.26.2",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.1",
+				"@fluidframework/shared-object-base": "^0.26.2",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
@@ -20430,25 +20432,25 @@
 			}
 		},
 		"old-request-handler": {
-			"version": "npm:@fluidframework/request-handler@0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.26.1.tgz",
-			"integrity": "sha512-Zn0uCDv2shHQcLnA/S5iSymb3NhSJ9TC7FEKps9yUxOG136KXbHufp6tcTVxowLoNt+eI7tfD6Nk5NTHMkAS6A==",
+			"version": "npm:@fluidframework/request-handler@0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.26.2.tgz",
+			"integrity": "sha512-uEP8fhXI5B4gpURwGjpqkTUc3RkqMiOWEnlMxPecsAZRB63s436ru5wR/hrCyyr82uyf7z7PeNR7WfP6K3YRVQ==",
 			"requires": {
-				"@fluidframework/container-runtime-definitions": "^0.26.1",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/runtime-definitions": "^0.26.1",
-				"@fluidframework/runtime-utils": "^0.26.1"
+				"@fluidframework/container-runtime-definitions": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/runtime-definitions": "^0.26.2",
+				"@fluidframework/runtime-utils": "^0.26.2"
 			}
 		},
 		"old-runtime-definitions": {
-			"version": "npm:@fluidframework/runtime-definitions@0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.26.1.tgz",
-			"integrity": "sha512-c0YRh1YntPXP1E/lyVOi/UDJ+jPQ9pcyddlU7IVJxNknLMUpM9GzXleIjf65FMV7L/csexSIt4H51IdJZSmxGw==",
+			"version": "npm:@fluidframework/runtime-definitions@0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.26.2.tgz",
+			"integrity": "sha512-j7IwsiLX/EeF/PiMfS/TrFf8vNrT+feCwD2ldAVGIyxdsJZivbPj3m1dqvYsHNBEZBftjhNe+IQnpuDJ6JGrfQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.26.1",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/driver-definitions": "^0.26.1",
+				"@fluidframework/container-definitions": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/driver-definitions": "^0.26.2",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
 				"@types/node": "^10.17.24"
 			},
@@ -20464,20 +20466,20 @@
 			}
 		},
 		"old-sequence": {
-			"version": "npm:@fluidframework/sequence@0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.26.1.tgz",
-			"integrity": "sha512-9HxEQtR5mq0CumNbWdj9vMw9K+1TWS/NnzyqeH9mmerlpp/rS4CNbaeVo1teo/UYfofu2ExwWWdhNFhMNIvEPQ==",
+			"version": "npm:@fluidframework/sequence@0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.26.2.tgz",
+			"integrity": "sha512-N5SaK7wrC4/2TUCf12wN4f0ZwggDUt7xglT7DW5FyKsvPZv+YReTE+PRWf8aLk6YFh8b4wz1SbXKaviG3lDHkw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/datastore-definitions": "^0.26.1",
-				"@fluidframework/map": "^0.26.1",
-				"@fluidframework/merge-tree": "^0.26.1",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/datastore-definitions": "^0.26.2",
+				"@fluidframework/map": "^0.26.2",
+				"@fluidframework/merge-tree": "^0.26.2",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-utils": "^0.26.1",
-				"@fluidframework/shared-object-base": "^0.26.1",
-				"@fluidframework/telemetry-utils": "^0.26.1",
+				"@fluidframework/runtime-utils": "^0.26.2",
+				"@fluidframework/shared-object-base": "^0.26.2",
+				"@fluidframework/telemetry-utils": "^0.26.2",
 				"debug": "^4.1.1",
 				"lodash": "^4.17.19"
 			},
@@ -20508,23 +20510,23 @@
 			}
 		},
 		"old-test-utils": {
-			"version": "npm:@fluidframework/test-utils@0.26.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.26.1.tgz",
-			"integrity": "sha512-m6VJB273M2leOX0HpFR03bt575hbLAJRkbSkq7YbJopHlV7vk2JjQXotvcLQJGqbwp5//jX45Y16zvX0xdRrcQ==",
+			"version": "npm:@fluidframework/test-utils@0.26.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.26.2.tgz",
+			"integrity": "sha512-R4Orjn24vxEnf4V1jyE6YGSIM9nOCAuwHRcq8w0poc1WAHbns8TEfeAQ+RLR0LdtgrWSu96AcLsP1QnBvuKxkg==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.26.1",
-				"@fluidframework/container-definitions": "^0.26.1",
-				"@fluidframework/container-loader": "^0.26.1",
-				"@fluidframework/container-runtime": "^0.26.1",
-				"@fluidframework/core-interfaces": "^0.26.1",
-				"@fluidframework/datastore": "^0.26.1",
-				"@fluidframework/datastore-definitions": "^0.26.1",
-				"@fluidframework/driver-definitions": "^0.26.1",
-				"@fluidframework/local-driver": "^0.26.1",
-				"@fluidframework/map": "^0.26.1",
+				"@fluidframework/aqueduct": "^0.26.2",
+				"@fluidframework/container-definitions": "^0.26.2",
+				"@fluidframework/container-loader": "^0.26.2",
+				"@fluidframework/container-runtime": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/datastore": "^0.26.2",
+				"@fluidframework/datastore-definitions": "^0.26.2",
+				"@fluidframework/driver-definitions": "^0.26.2",
+				"@fluidframework/local-driver": "^0.26.2",
+				"@fluidframework/map": "^0.26.2",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/request-handler": "^0.26.1",
-				"@fluidframework/runtime-definitions": "^0.26.1",
+				"@fluidframework/request-handler": "^0.26.2",
+				"@fluidframework/runtime-definitions": "^0.26.2",
 				"@fluidframework/server-local-server": "^0.1012.0"
 			},
 			"dependencies": {

--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -95,7 +95,7 @@ export interface IDeltaManagerEvents extends IEvent {
     (event: "prepareSend", listener: (messageBuffer: any[]) => void);
     (event: "submitOp", listener: (message: IDocumentMessage) => void);
     (event: "beforeOpProcessing", listener: (message: ISequencedDocumentMessage) => void);
-    (event: "allSentOpsAckd" | "caughtUp", listener: () => void);
+    (event: "allSentOpsAckd", listener: () => void);
     (event: "pong" | "processTime", listener: (latency: number) => void);
     (event: "connect", listener: (details: IConnectionDetails, opsBehind?: number) => void);
     (event: "disconnect", listener: (reason: string) => void);

--- a/packages/test/end-to-end-tests/src/test/compatUtils.ts
+++ b/packages/test/end-to-end-tests/src/test/compatUtils.ts
@@ -186,17 +186,14 @@ export function createOldLoader(
 }
 
 export const createContainer = async (
-    loader: ILoader | old.ILoader,
+    loader: ILoader,
     urlResolver: IUrlResolver,
 ): Promise<IContainer> => {
-    // Causing build break due to addition of api related to rehydrating container in Loader interface.
-    // Right now we are not using the back compat tests for rehydrating container.
-    // So just typecast for now. Will put a better sol after that.
-    return createAndAttachContainer(documentId, defaultCodeDetails, loader as ILoader, urlResolver);
+    return createAndAttachContainer(documentId, defaultCodeDetails, loader, urlResolver);
 };
 
 export const createContainerWithOldLoader = async (
-    loader: ILoader | old.ILoader,
+    loader: old.ILoader,
     urlResolver: IUrlResolver,
 ): Promise<old.IContainer> => {
     return old.createAndAttachContainer(documentId, defaultCodeDetails, loader, urlResolver);


### PR DESCRIPTION
Close #3435
Remove DeltaManager "caughtUp" event and fix compat test typing. As Jatin noticed and pointed out to me previously, there shouldn't ever be a version mismatch between `Loader` and `Container`.