### PR TITLE
Add script in build-tools for bundle analysis + danger fixes

### DIFF
--- a/tools/build-tools/bin/fluid-run-bundle-analyses
+++ b/tools/build-tools/bin/fluid-run-bundle-analyses
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require("../dist/bundleSizeAnalysis/runBundleAnalyses.js");

--- a/tools/build-tools/package.json
+++ b/tools/build-tools/package.json
@@ -14,7 +14,8 @@
     "fluid-collect-bundle-analyses": "bin/fluid-collect-bundle-analyses",
     "fluid-doc-stats": "bin/fluid-doc-stats",
     "fluid-layer-check": "bin/fluid-layer-check",
-    "fluid-repo-policy-check": "bin/fluid-repo-policy-check"
+    "fluid-repo-policy-check": "bin/fluid-repo-policy-check",
+    "fluid-run-bundle-analyses": "bin/fluid-run-bundle-analyses"
   },
   "scripts": {
     "build": "tsc -b",
@@ -30,7 +31,7 @@
     "async": "^2.6.2",
     "chalk": "^2.4.2",
     "commander": "^2.20.0",
-    "danger": "10.4.1",
+    "danger": "^10.4.1",
     "fs-extra": "^9.0.1",
     "glob": "^7.1.3",
     "lodash.isequal": "^4.5.0",

--- a/tools/build-tools/src/bundleSizeAnalysis/dangerfile.ts
+++ b/tools/build-tools/src/bundleSizeAnalysis/dangerfile.ts
@@ -3,8 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import { markdown } from "danger";
 import { ADOSizeComparator, getAzureDevopsApi } from "@fluidframework/bundle-size-tools";
+
+// Handle weirdness with Danger import.  The current module setup prevents us
+// from using this file directly, and the js transpilation renames the danger
+// import which prevents danger from removing it before evaluation (because it
+// actually puts its exports in the global namespace at that time)
+declare function markdown(message: string, file?: string, line?: number): void;
 
 const adoConstants = {
     orgUrl: 'https://dev.azure.com/fluidframework',

--- a/tools/build-tools/src/bundleSizeAnalysis/runBundleAnalyses.ts
+++ b/tools/build-tools/src/bundleSizeAnalysis/runBundleAnalyses.ts
@@ -1,0 +1,20 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as child_process from "child_process";
+// Run Danger to report the bundle analysis
+// Do it this way through a script in build-tools instead of running Danger
+// directly at the root of the repo because this better isolates its usage
+// and dependencies
+function main() {
+    try {
+        console.log(child_process.execSync(`npx danger ci -d ${__dirname}/dangerfile.js`).toString());
+    } catch (e) {
+        console.error(e.toString());
+        process.exit(-1);
+    }
+}
+
+main();


### PR DESCRIPTION
Add a script to run bundle analysis so it doesn't need to be handled in the yaml build step.  This is preferable because it better encapsulates its usage and dependencies (using the build step required adding danger and bundle-size-tools dependencies in the root package.json, but also hid how they were being used). 
Also some fixes to the danger file and dependency.