### PR TITLE
Add drive ID support to odsp-utils

### DIFF
--- a/packages/utils/odsp-utils/src/odspDrives.ts
+++ b/packages/utils/odsp-utils/src/odspDrives.ts
@@ -63,9 +63,16 @@ export async function getDriveItemByRootFileName(
     path: string,
     authRequestInfo: IOdspAuthRequestInfo,
     create: boolean,
+    driveId?: string,
 ): Promise<IOdspDriveItem> {
-    const accountPath = account ? `/${account}` : "";
-    const getDriveItemUrl = `https://${server}${accountPath}/_api/v2.1/drive/root:${path}:`;
+    const accountPath = account !== undefined ? `/${account}` : "";
+    let getDriveItemUrl;
+    if (driveId !== undefined && driveId !== "") {
+        const encodedDrive = encodeURIComponent(driveId);
+        getDriveItemUrl = `https://${server}${accountPath}/_api/v2.1/drives/${encodedDrive}/root:${path}:`;
+    } else {
+        getDriveItemUrl = `https://${server}${accountPath}/_api/v2.1/drive/root:${path}:`;
+    }
     return getDriveItem(getDriveItemUrl, authRequestInfo, create);
 }
 


### PR DESCRIPTION
Allows for a defined driveID that is different from the user's own personal drive.
Required for #3826 