### PR TITLE
Rev 'hotloop' to v1.2

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -5348,7 +5348,8 @@
 		"@types/minimist": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY="
+			"integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
+			"dev": true
 		},
 		"@types/mocha": {
 			"version": "5.2.7",
@@ -12774,12 +12775,10 @@
 			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
 		},
 		"hotloop": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/hotloop/-/hotloop-1.1.0.tgz",
-			"integrity": "sha512-vJ8qU6KJyE6hDCodoQerFIMfSDYGDbVw2NN82gf6cGvr53SN6kAsdYSFZm4q/5wd0lRy9pBN24Cbep00AY5v0A==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/hotloop/-/hotloop-1.2.0.tgz",
+			"integrity": "sha512-8lH8RzRJA+hkF6/wBR6pqMbUCN/xxnrYvOlPl1fIzgbwm6z+/m1iFmHeOjHUY8vB9DMj2iXitC6YXH1+c3XlJA==",
 			"requires": {
-				"@types/benchmark": "^1.0.31",
-				"@types/minimist": "^1.2.0",
 				"benchmark": "^2.1.4",
 				"minimist": "^1.2.5"
 			}

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -86,7 +86,7 @@
     "eslint-plugin-prefer-arrow": "~1.1.7",
     "eslint-plugin-react": "~7.18.0",
     "eslint-plugin-unicorn": "~15.0.1",
-    "hotloop": "~1.1.0",
+    "hotloop": "^1.2.0",
     "mocha": "^8.1.1",
     "mocha-junit-reporter": "^1.18.0",
     "nyc": "^15.0.0",


### PR DESCRIPTION
Update the 'hotloop' harness to v1.2 to pick up support for benchmarking async functions:
https://www.npmjs.com/package/hotloop
