### PR TITLE
Blob: Consume and return ArrayBufferLike

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -180,7 +180,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
     public async readBlob(blobId: string): Promise<ArrayBufferLike> {
         this.checkAttachmentGETUrl();
 
-        const response = await getWithRetryForTokenRefresh(async (options) => {
+        return getWithRetryForTokenRefresh(async (options) => {
             const storageToken = await this.getStorageToken(options, "ReadDataBlob");
             const unAuthedUrl = `${this.attachmentGETUrl}/${encodeURIComponent(blobId)}/content`;
             const { url, headers } = getUrlAndHeadersWithAuth(unAuthedUrl, storageToken);
@@ -193,13 +193,12 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                 },
                 async (event) => {
                     const res = await fetchHelper(url, { headers });
-                    event.end({ size: res.content.length });
-                    return res;
+                    const content = await res.arrayBuffer();
+                    event.end({ size: content.byteLength });
+                    return content;
                 },
             );
         });
-
-        return response.content;
     }
 
     public async read(blobid: string): Promise<string> {

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -177,12 +177,12 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
         return response.content;
     }
 
-    public async readBlob(blobid: string): Promise<IsoBuffer> {
+    public async readBlob(blobId: string): Promise<ArrayBufferLike> {
         this.checkAttachmentGETUrl();
 
         const response = await getWithRetryForTokenRefresh(async (options) => {
             const storageToken = await this.getStorageToken(options, "ReadDataBlob");
-            const unAuthedUrl = `${this.attachmentGETUrl}/${encodeURIComponent(blobid)}/content`;
+            const unAuthedUrl = `${this.attachmentGETUrl}/${encodeURIComponent(blobId)}/content`;
             const { url, headers } = getUrlAndHeadersWithAuth(unAuthedUrl, storageToken);
 
             return PerformanceEvent.timedExecAsync(

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { IsoBuffer } from "@fluidframework/common-utils";
 import {
     OnlineStatus, isOnline,
 } from "@fluidframework/driver-utils";
@@ -64,7 +63,7 @@ export async function getWithRetryForTokenRefresh<T>(get: (options: TokenFetchOp
     });
 }
 
-async function fetchHelperCore(
+export async function fetchHelper(
     requestInfo: RequestInfo,
     requestInit: RequestInit | undefined,
 ): Promise<Response> {
@@ -98,22 +97,6 @@ async function fetchHelperCore(
 }
 
 /**
- * A utility function to fetch with support for retries
- * @param requestInfo - fetch requestInfo, can be a string
- * @param requestInit - fetch requestInit
- */
-export async function fetchHelper(
-    requestInfo: RequestInfo,
-    requestInit: RequestInit | undefined,
-): Promise<IOdspResponse<IsoBuffer>> {
-    const response = await fetchHelperCore(requestInfo, requestInit);
-    return {
-        headers: new Map(response.headers),
-        content: IsoBuffer.from(await response.arrayBuffer()),
-    };
-}
-
-/**
  * A utility function to fetch and parse as JSON with support for retries
  * @param requestInfo - fetch requestInfo, can be a string
  * @param requestInit - fetch requestInit
@@ -122,7 +105,7 @@ export async function fetchAndParseHelper<T>(
     requestInfo: RequestInfo,
     requestInit: RequestInit | undefined,
 ): Promise<IOdspResponse<T>> {
-    const response = await fetchHelperCore(requestInfo, requestInit);
+    const response = await fetchHelper(requestInfo, requestInit);
     // JSON.parse() can fail and message (that goes into telemetry) would container full request URI, including
     // tokens... It fails for me with "Unexpected end of JSON input" quite often - an attempt to download big file
     // (many ops) almost always ends up with this error - I'd guess 1% of op request end up here... It always

--- a/packages/drivers/replay-driver/src/replayController.ts
+++ b/packages/drivers/replay-driver/src/replayController.ts
@@ -22,7 +22,7 @@ export abstract class ReadDocumentStorageServiceBase implements IDocumentStorage
         return Promise.reject("Invalid operation");
     }
 
-    public async createBlob(file: Uint8Array): Promise<api.ICreateBlobResponse> {
+    public async createBlob(file: ArrayBufferLike): Promise<api.ICreateBlobResponse> {
         return Promise.reject("Invalid operation");
     }
 

--- a/packages/drivers/routerlicious-driver/src/documentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentStorageService.ts
@@ -97,7 +97,14 @@ export class DocumentStorageService implements IDocumentStorageService {
     }
 
     public async readBlob(blobId: string): Promise<ArrayBufferLike> {
-        return IsoBuffer.from(await this.read(blobId), "base64");
+        const iso = IsoBuffer.from(await this.read(blobId), "base64");
+
+        // In a Node environment, IsoBuffer may be a Node.js Buffer.  Node.js will
+        // pool multiple small Buffer instances into a single ArrayBuffer, in which
+        // case we need to slice the appropriate span of bytes.
+        return iso.byteLength === iso.buffer.byteLength
+            ? iso.buffer
+            : iso.buffer.slice(iso.byteOffset, iso.byteOffset + iso.byteLength);
     }
 
     public getRawUrl(blobId: string): string {

--- a/packages/drivers/routerlicious-driver/src/documentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentStorageService.ts
@@ -87,12 +87,16 @@ export class DocumentStorageService implements IDocumentStorageService {
         throw new Error("NOT IMPLEMENTED!");
     }
 
-    public async createBlob(file: Uint8Array): Promise<ICreateBlobResponse> {
-        const response = this.manager.createBlob(Uint8ArrayToString(file, "base64"), "base64");
+    public async createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse> {
+        const response = this.manager.createBlob(
+            Uint8ArrayToString(
+                new Uint8Array(file), "base64"),
+            "base64");
+
         return response.then((r) => ({ id: r.sha, url: r.url }));
     }
 
-    public async readBlob(blobId: string) {
+    public async readBlob(blobId: string): Promise<ArrayBufferLike> {
         return IsoBuffer.from(await this.read(blobId), "base64");
     }
 

--- a/packages/drivers/routerlicious-driver/src/nullBlobStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/nullBlobStorageService.ts
@@ -39,10 +39,10 @@ export class NullBlobStorageService implements IDocumentStorageService {
         return Promise.reject("Invalid operation");
     }
 
-    public async createBlob(file: Uint8Array): Promise<api.ICreateBlobResponse> {
+    public async createBlob(file: ArrayBufferLike): Promise<api.ICreateBlobResponse> {
         return Promise.reject("Null blob storage can not create blob");
     }
-    public async readBlob(blobId: string) {
+    public async readBlob(blobId: string): Promise<ArrayBufferLike> {
         return Promise.reject("Null blob storage can not read blob");
     }
 

--- a/packages/loader/driver-definitions/src/storage.ts
+++ b/packages/loader/driver-definitions/src/storage.ts
@@ -79,9 +79,9 @@ export interface IDocumentStorageService {
     /**
      * Creates a blob out of the given buffer
      */
-    createBlob(file: Uint8Array): Promise<ICreateBlobResponse>;
+    createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
 
-    readBlob(id: string): Promise<Uint8Array>;
+    readBlob(id: string): Promise<ArrayBufferLike>;
 
     /**
      * Fetch blob Data url

--- a/packages/loader/driver-utils/src/documentStorageServiceProxy.ts
+++ b/packages/loader/driver-utils/src/documentStorageServiceProxy.ts
@@ -47,11 +47,11 @@ export class DocumentStorageServiceProxy implements IDocumentStorageService {
         return this.internalStorageService.downloadSummary(handle);
     }
 
-    public async createBlob(file: Uint8Array): Promise<ICreateBlobResponse> {
+    public async createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse> {
         return this.internalStorageService.createBlob(file);
     }
 
-    public async readBlob(blobId: string) {
+    public async readBlob(blobId: string): Promise<ArrayBufferLike> {
         return this.internalStorageService.readBlob(blobId);
     }
 

--- a/packages/runtime/client-api/package.json
+++ b/packages/runtime/client-api/package.json
@@ -52,6 +52,7 @@
     "@fluidframework/container-definitions": "^0.28.0",
     "@fluidframework/container-loader": "^0.28.0",
     "@fluidframework/container-runtime": "^0.28.0",
+    "@fluidframework/core-interfaces": "^0.28.0",
     "@fluidframework/datastore": "^0.28.0",
     "@fluidframework/driver-definitions": "^0.28.0",
     "@fluidframework/ink": "^0.28.0",

--- a/packages/runtime/client-api/src/api/document.ts
+++ b/packages/runtime/client-api/src/api/document.ts
@@ -13,7 +13,7 @@ import {
 } from "@fluidframework/container-definitions";
 import { Container, Loader } from "@fluidframework/container-loader";
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
-import { Deferred, IsoBuffer } from "@fluidframework/common-utils";
+import { Deferred } from "@fluidframework/common-utils";
 import { IDocumentServiceFactory, IUrlResolver } from "@fluidframework/driver-definitions";
 import * as ink from "@fluidframework/ink";
 import { ISharedDirectory, ISharedMap, SharedDirectory, SharedMap } from "@fluidframework/map";
@@ -25,6 +25,7 @@ import {
 import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 import * as sequence from "@fluidframework/sequence";
 import { ISharedObject } from "@fluidframework/shared-object-base";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { CodeLoader } from "./codeLoader";
 import { debug } from "./debug";
 
@@ -191,8 +192,8 @@ export class Document extends EventEmitter {
         return this.closeFn();
     }
 
-    public async uploadBlob(file: IsoBuffer): Promise<any> {
-        return this.runtime.uploadBlob(file);
+    public async uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>> {
+        return this.runtime.uploadBlob(blob);
     }
 }
 

--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { IsoBuffer } from "@fluidframework/common-utils";
 import { IFluidHandle, IFluidHandleContext } from "@fluidframework/core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { generateHandleContextPath } from "@fluidframework/runtime-utils";
@@ -15,7 +14,7 @@ import { generateHandleContextPath } from "@fluidframework/runtime-utils";
  * DataObject.request() recognizes requests in the form of `/blobs/<id>`
  * and loads blob.
  */
-export class BlobHandle implements IFluidHandle {
+export class BlobHandle implements IFluidHandle<ArrayBufferLike> {
     public get IFluidHandle(): IFluidHandle { return this; }
 
     public get isAttached(): boolean {
@@ -47,7 +46,7 @@ export class BlobManager {
         private readonly sendBlobAttachOp: (blobId: string) => void,
     ) { }
 
-    public async getBlob(blobId: string): Promise<BlobHandle> {
+    public async getBlob(blobId: string): Promise<IFluidHandle<ArrayBufferLike>> {
         return new BlobHandle(
             `${this.basePath}/${blobId}`,
             this.routeContext,
@@ -56,7 +55,7 @@ export class BlobManager {
         );
     }
 
-    public async createBlob(blob: IsoBuffer): Promise<BlobHandle> {
+    public async createBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>> {
         const response = await this.getStorage().createBlob(blob);
 
         const handle = new BlobHandle(

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -32,7 +32,6 @@ import {
 import { IContainerRuntime, IContainerRuntimeDirtyable } from "@fluidframework/container-runtime-definitions";
 import {
     Deferred,
-    IsoBuffer,
     Trace,
     unreachableCase,
 } from "@fluidframework/common-utils";
@@ -1807,7 +1806,7 @@ export class ContainerRuntime extends EventEmitter
         this.submit(ContainerMessageType.FluidDataStoreOp, envelope, localOpMetadata);
     }
 
-    public async uploadBlob(blob: IsoBuffer): Promise<IFluidHandle<string>> {
+    public async uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>> {
         return this.blobManager.createBlob(blob);
     }
 

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -20,7 +20,7 @@ import {
     BindState,
     AttachState,
 } from "@fluidframework/container-definitions";
-import { Deferred, IsoBuffer } from "@fluidframework/common-utils";
+import { Deferred } from "@fluidframework/common-utils";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { readAndParse } from "@fluidframework/driver-utils";
 import { BlobTreeEntry } from "@fluidframework/protocol-base";
@@ -559,7 +559,7 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
         );
     }
 
-    public async uploadBlob(blob: IsoBuffer): Promise<IFluidHandle<string>> {
+    public async uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>> {
         return this.containerRuntime.uploadBlob(blob);
     }
 }

--- a/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
@@ -5,7 +5,6 @@
 
 import { EventEmitter } from "events";
 import { IDisposable, ITelemetryLogger } from "@fluidframework/common-definitions";
-import { IsoBuffer } from "@fluidframework/common-utils";
 import {
     IFluidHandleContext,
     IFluidSerializer,
@@ -100,9 +99,9 @@ export interface IFluidDataStoreRuntime extends
     // Blob related calls
     /**
      * Api to upload a blob of data.
-     * @param file - blob to be uploaded.
+     * @param blob - blob to be uploaded.
      */
-    uploadBlob(file: IsoBuffer): Promise<IFluidHandle<string>>;
+    uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
 
     /**
      * Submits the signal to be sent to other clients.

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -23,7 +23,6 @@ import {
 import {
     Deferred,
     unreachableCase,
-    IsoBuffer,
 } from "@fluidframework/common-utils";
 import {
     ChildLogger,
@@ -445,10 +444,10 @@ export class FluidDataStoreRuntime extends EventEmitter implements IFluidDataSto
         return this.snapshotFn(message);
     }
 
-    public async uploadBlob(file: IsoBuffer): Promise<IFluidHandle<string>> {
+    public async uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>> {
         this.verifyNotClosed();
 
-        return this.dataStoreContext.uploadBlob(file);
+        return this.dataStoreContext.uploadBlob(blob);
     }
 
     public process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown) {

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -5,7 +5,6 @@
 
 import { EventEmitter } from "events";
 import { ITelemetryLogger, IDisposable } from "@fluidframework/common-definitions";
-import { IsoBuffer } from "@fluidframework/common-utils";
 import {
     IFluidObject,
     IFluidRouter,
@@ -119,7 +118,7 @@ export interface IContainerRuntimeBase extends
 
     getTaskManager(): Promise<ITaskManager>;
 
-    uploadBlob(blob: IsoBuffer): Promise<IFluidHandle<string>>;
+    uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
 }
 
 /**
@@ -350,7 +349,7 @@ export interface IFluidDataStoreContext extends EventEmitter, Partial<IProvideFl
         createParam: CreateChildSummarizerNodeParam,
     ): CreateChildSummarizerNodeFn;
 
-    uploadBlob(blob: IsoBuffer): Promise<IFluidHandle<string>>;
+    uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
 }
 
 export interface IFluidDataStoreContextDetached extends IFluidDataStoreContext {

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -457,7 +457,7 @@ export class MockFluidDataStoreRuntime extends EventEmitter
         return null;
     }
 
-    public async uploadBlob(file): Promise<any> {
+    public async uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>> {
         return null;
     }
 

--- a/packages/test/end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/blobs.spec.ts
@@ -14,6 +14,7 @@ import { ISummaryConfiguration } from "@fluidframework/protocol-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { createAndAttachContainer, createLocalLoader, TestContainerRuntimeFactory } from "@fluidframework/test-utils";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
 
 class TestComponent extends DataObject {
     public static readonly type = "@fluid-example/test-component";
@@ -86,7 +87,7 @@ describe("blobs", () => {
         const container2 = await createContainer();
         const component2 = await requestFluidObject<TestComponent>(container2, "default");
 
-        const blobHandle = await component2._root.wait(testKey);
-        assert.strictEqual((await blobHandle.get()).toString("utf-8"), testString);
+        const blobHandle = await component2._root.wait<IFluidHandle<ArrayBufferLike>>(testKey);
+        assert.strictEqual(new TextDecoder().decode(await blobHandle.get()), testString);
     });
 });


### PR DESCRIPTION
I like the new blob API and propose we go a step further, passing buffers in both directions.