### PR TITLE
Add separate yaml for bundle size artifacts

### DIFF
--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -1,0 +1,15 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# bundle size stats pipeline
+
+name: $(Build.BuildId)
+
+extends:
+  template: templates/build-client.yml
+  parameters:
+    taskLint: false
+    taskTest: false
+    taskPack: false
+    taskBundleAnalysis: true
+    taskBuildDocs: false

--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 extends:
-  template: templates/build-client.yml
+  template: ./build-client.yml
   parameters:
     taskLint: false
     taskTest: false

--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -37,10 +37,9 @@ extends:
     taskTest: false
     taskPack: false
     taskBundleAnalysis: true
+    taskPublishBundleSizeArtifacts: true
     taskBuildDocs: false
     buildDirectory: .
     tagName: bundle-artifacts
     poolBuild: Main
     checkoutSubmodules: true
-    taskBundleAnalysis: true
-    taskPublishBundleSizeArtifacts: true

--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -43,3 +43,5 @@ extends:
     tagName: bundle-artifacts
     poolBuild: Main
     checkoutSubmodules: true
+    releaseBuildOverride: none
+    publishOverride: default

--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -2,14 +2,45 @@
 # Licensed under the MIT License.
 
 # bundle size stats pipeline
+# Should be run only as a CI to produce baseline bundle size stats
 
 name: $(Build.BuildId)
 
+trigger:
+  branches:
+    include:
+    - main
+    - release/*
+  paths:
+    include:
+    - packages
+    - components
+    - examples
+    - package.json
+    - package-lock.json
+    - lerna.json
+    - lerna-package-lock.json
+    - tools/pipelines/build-bundle-size-artifacts.yml
+    - tools/pipelines/build-client.yml
+    - tools/pipelines/scripts/build-version.js
+    - tools/pipelines/templates/build-npm-package.yml
+    - tools/pipelines/templates/include-set-package-version.yml
+    - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-publish-npm-package.yml
+    - tools/pipelines/templates/include-publish-npm-package-steps.yml
+    - tools/pipelines/templates/include-git-tag-steps.yml
+
 extends:
-  template: ./build-client.yml
+  template: templates/build-npm-package.yml
   parameters:
     taskLint: false
     taskTest: false
     taskPack: false
     taskBundleAnalysis: true
     taskBuildDocs: false
+    buildDirectory: .
+    tagName: bundle-artifacts
+    poolBuild: Main
+    checkoutSubmodules: true
+    taskBundleAnalysis: true
+    taskPublishBundleSizeArtifacts: true

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -76,7 +76,7 @@ extends:
     poolBuild: Main
     cgSubDirectory: packages
     checkoutSubmodules: true
-    runBundleAnalysis: true
+    taskBundleAnalysis: true
 
     preCG:
     - task: UseNode@1

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -23,6 +23,14 @@ parameters:
   type: string
   default: ci:test
 
+- name: taskBundleAnalysis
+  type: boolean
+  default: false
+
+- name: taskPack
+  type: boolean
+  default: true
+
 - name: poolCG
   type: object
   default: Lite
@@ -51,10 +59,6 @@ parameters:
 - name: namespace
   type: boolean
   default: true
-
-- name: runBundleAnalysis
-  type: boolean
-  default: false
 
 - name: buildNumberInPatch
   type: string
@@ -241,30 +245,31 @@ stages:
             condition: succeededOrFailed()
 
         # Pack
-        - task: Bash@3
-          displayName: npm pack
-          inputs:
-            targetType: 'inline'
-            workingDirectory: ${{ parameters.buildDirectory }}
-            script: |
-              mkdir $(Build.ArtifactStagingDirectory)/pack/
-              if [ -f "lerna.json" ]; then
-                npx lerna exec --no-private --no-sort -- npm pack --unsafe-perm
-                npx lerna exec --no-private --no-sort --parallel -- mv -t $(Build.ArtifactStagingDirectory)/pack/ ./*.tgz
-              else
-                npm pack --unsafe-perm
-                mv -t $(Build.ArtifactStagingDirectory)/pack/ ./*.tgz
-              fi
+        - ${{ if ne(parameters.taskPack, 'false') }}:
+          - task: Bash@3
+            displayName: npm pack
+            inputs:
+              targetType: 'inline'
+              workingDirectory: ${{ parameters.buildDirectory }}
+              script: |
+                mkdir $(Build.ArtifactStagingDirectory)/pack/
+                if [ -f "lerna.json" ]; then
+                  npx lerna exec --no-private --no-sort -- npm pack --unsafe-perm
+                  npx lerna exec --no-private --no-sort --parallel -- mv -t $(Build.ArtifactStagingDirectory)/pack/ ./*.tgz
+                else
+                  npm pack --unsafe-perm
+                  mv -t $(Build.ArtifactStagingDirectory)/pack/ ./*.tgz
+                fi
 
-        - task: PublishBuildArtifacts@1
-          displayName: Publish Artifact - pack
-          inputs:
-            PathtoPublish: '$(Build.ArtifactStagingDirectory)/pack'
-            ArtifactName: 'pack'
-            publishLocation: 'Container'
+          - task: PublishBuildArtifacts@1
+            displayName: Publish Artifact - pack
+            inputs:
+              PathtoPublish: '$(Build.ArtifactStagingDirectory)/pack'
+              ArtifactName: 'pack'
+              publishLocation: 'Container'
 
         # Collect bundle analysis
-        - ${{ if eq(parameters.runBundleAnalysis, true) }}:
+        - ${{ if eq(parameters.taskBundleAnalysis, true) }}:
           - task: Npm@1
             displayName: npm run bundle-analysis
             inputs:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -27,6 +27,10 @@ parameters:
   type: boolean
   default: false
 
+- name: taskPublishBundleSizeArtifacts
+  type: boolean
+  default: false
+
 - name: taskPack
   type: boolean
   default: true
@@ -279,7 +283,12 @@ stages:
 
           - task: PublishBuildArtifacts@1
             displayName: Publish Artifacts - bundle-analysis
-            condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+            condition:
+              and(
+                succeeded(),
+                ne(variables['Build.Reason'], 'PullRequest'),
+                eq(parameters.taskPublishBundleSizeArtifacts, true)
+              )
             inputs:
               PathtoPublish: '${{ parameters.buildDirectory }}/artifacts/bundleAnalysis'
               Artifactname: 'bundleAnalysis'

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -287,7 +287,7 @@ stages:
               and(
                 succeeded(),
                 ne(variables['Build.Reason'], 'PullRequest'),
-                eq(parameters.taskPublishBundleSizeArtifacts, true)
+                eq(${{ parameters.taskPublishBundleSizeArtifacts }}, true)
               )
             inputs:
               PathtoPublish: '${{ parameters.buildDirectory }}/artifacts/bundleAnalysis'

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -249,7 +249,7 @@ stages:
             condition: succeededOrFailed()
 
         # Pack
-        - ${{ if ne(parameters.taskPack, 'false') }}:
+        - ${{ if ne(parameters.taskPack, false) }}:
           - task: Bash@3
             displayName: npm pack
             inputs:


### PR DESCRIPTION
Currently the artifacts are produced as part the regular client CI, but that CI is run in the private ADO project and need to be consumed from the public ADO project.  Instead of providing access to the private project (which would overscope the actual permissions we want to provide), move the artifact generation part into the public project.