### PR TITLE
Remove prepend oustanding ops

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -177,7 +177,7 @@ export interface IUploadedSummaryData {
 export interface IUnsubmittedSummaryData extends Partial<IGeneratedSummaryData>, Partial<IUploadedSummaryData> {
     readonly referenceSequenceNumber: number;
     readonly submitted: false;
-    readonly message: "disconnected" | "incorrect lastSequenceNumber";
+    readonly reason: "disconnected";
 }
 
 export interface ISubmittedSummaryData extends IGeneratedSummaryData, IUploadedSummaryData {
@@ -1673,14 +1673,14 @@ export class ContainerRuntime extends EventEmitter
         try {
             await this.scheduleManager.pause();
 
-            const attemptData: Omit<IUnsubmittedSummaryData, "message"> = {
+            const attemptData: Omit<IUnsubmittedSummaryData, "reason"> = {
                 referenceSequenceNumber: summaryRefSeqNum,
                 submitted: false,
             };
 
             if (!this.connected) {
                 // If summarizer loses connection it will never reconnect
-                return { ...attemptData, message: "disconnected" };
+                return { ...attemptData, reason: "disconnected" };
             }
 
             const trace = Trace.start();
@@ -1692,7 +1692,7 @@ export class ContainerRuntime extends EventEmitter
             };
 
             if (!this.connected) {
-                return { ...attemptData, ...generateData, message: "disconnected" };
+                return { ...attemptData, ...generateData, reason: "disconnected" };
             }
 
             // Ensure that lastSequenceNumber has not changed after pausing
@@ -1731,7 +1731,7 @@ export class ContainerRuntime extends EventEmitter
             };
 
             if (!this.connected) {
-                return { ...attemptData, ...generateData, ...uploadData, message: "disconnected" };
+                return { ...attemptData, ...generateData, ...uploadData, reason: "disconnected" };
             }
 
             const clientSequenceNumber =

--- a/packages/runtime/runtime-utils/src/summarizerNode.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode.ts
@@ -146,6 +146,14 @@ function decodeSummary(snapshot: ISnapshotTree, logger: Pick<ITelemetryLogger, "
                     let outstandingOps: ISequencedDocumentMessage[] = [];
                     for (const opsBlob of opsBlobs) {
                         const newOutstandingOps = await readAndParseBlob<ISequencedDocumentMessage[]>(opsBlob);
+                        if (outstandingOps.length > 0 && newOutstandingOps.length > 0) {
+                            const latestSeq = outstandingOps[outstandingOps.length - 1].sequenceNumber;
+                            const newEarliestSeq = newOutstandingOps[0].sequenceNumber;
+                            assert(
+                                latestSeq < newEarliestSeq,
+                                `latestSeq exceeds newEarliestSeq in decodeSummary: ${latestSeq} >= ${newEarliestSeq}`,
+                            );
+                        }
                         outstandingOps = outstandingOps.concat(newOutstandingOps);
                     }
                     return outstandingOps;


### PR DESCRIPTION
Fixes #3797 

When loading from a failure summary, the previous outstanding ops should not be prepended to the current tracked outstanding ops. This causes them to be recorded again in the outer-nested _outstandingOps blob.

Original intent was to flatten "failure" summaries rather than leave them nested, but since that doesn't occur, they cannot be prepended.

Also adds some defensive asserts to avoid bad scenarios in the future.