### PR TITLE
Reorganize HTML structure of site template

### DIFF
--- a/docs/layouts/page/playground.html
+++ b/docs/layouts/page/playground.html
@@ -9,7 +9,6 @@
 <p>To learn more about the Fluid & Storybook, you can go to <a href="https://github.com/microsoft/FluidStorybook">https://github.com/microsoft/FluidStorybook</a></p>
 
 {{ block "footer" . -}}{{ end }}
-{{- partial "analytics.html" . }}
 {{- if templates.Exists "partials/extra-foot.html" -}}
 {{ partial "extra-foot.html" . }}
 {{- end }}

--- a/docs/themes/thxvscode/layouts/_default/baseof.html
+++ b/docs/themes/thxvscode/layouts/_default/baseof.html
@@ -3,8 +3,10 @@
 {{- partial "head.html" . -}}
 
 <body>
-    {{- partial "header.html" . -}}
+    <!-- EU Cookie Compliance JS -->
+    <script src="//uhf.microsoft.com/mscc/statics/mscc-0.3.6.min.js"></script>
     <div id="main">
+        {{- partial "header.html" . -}}
         <div role="main" id="main-content" {{ if .IsHome}}class="home" {{ end}}>
             {{- block "main" . }}{{- end }}
         </div>

--- a/docs/themes/thxvscode/layouts/_default/baseof.html
+++ b/docs/themes/thxvscode/layouts/_default/baseof.html
@@ -7,7 +7,7 @@
     <script src="//uhf.microsoft.com/mscc/statics/mscc-0.3.6.min.js"></script>
     <div id="main">
         {{- partial "header.html" . -}}
-        <div role="main" id="main-content" {{ if .IsHome}}class="home" {{ end}}>
+        <div {{ if .IsHome}}class="home" {{ end}}>
             {{- block "main" . }}{{- end }}
         </div>
     </div>

--- a/docs/themes/thxvscode/layouts/_default/list.html
+++ b/docs/themes/thxvscode/layouts/_default/list.html
@@ -3,7 +3,7 @@
 {{ end }}
 
 {{ define "main" }}
-<main class="site-main section-inner thin animated fadeIn faster">
+<main role="main" id="main-content" class="site-main section-inner thin animated fadeIn faster">
     <h1>{{ title .Title }}</h1>
     {{- if .Content }}
     <div class="content">

--- a/docs/themes/thxvscode/layouts/_default/single.html
+++ b/docs/themes/thxvscode/layouts/_default/single.html
@@ -10,28 +10,29 @@
 <script src="//uhf.microsoft.com/mscc/statics/mscc-0.3.6.min.js"></script>
 
 <!-- > cookie-header  -->
+<main role="main" id="main-content">
+    {{- if (or .Site.Params.images .Site.Params.bgImg) }}
+    <div class="bg-img"></div>
+    {{- end }}
 
-{{- if (or .Site.Params.images .Site.Params.bgImg) }}
-<div class="bg-img"></div>
-{{- end }}
-
-<div class="container body-content docs">
-    <div class="row">
-        <div class="col-md-2 docs-navbar-container"> {{ partial "docNav.html" .}} </div>
-        <div class="col-sm-9 col-md-8 body">
-            <div>
-                <h1>{{.Title}}</h1>
+    <div class="container body-content docs">
+        <div class="row">
+            <div class="col-md-2 docs-navbar-container">{{ partial "docNav.html" .}}</div>
+            <div class="col-sm-9 col-md-8 body">
+                <div>
+                    <h1>{{.Title}}</h1>
+                </div>
+                <div>
+                    {{ .Content }}
+                </div>
             </div>
-            <div>
-                {{ .Content }}
-            </div>
-        </div>
 
-        <div class="hidden-xs col-sm-3 col-md-2 docs-subnavbar-container">
-            {{ partial "toc.html"  .}}
+            <div class="hidden-xs col-sm-3 col-md-2 docs-subnavbar-container">
+                {{ partial "toc.html"  .}}
+            </div>
         </div>
     </div>
-</div>
+</main>
 
 {{ block "footer" . -}}{{ end }}
 {{/* $script := resources.Get "js/main.js" | minify | fingerprint - */}}

--- a/docs/themes/thxvscode/layouts/_default/single.html
+++ b/docs/themes/thxvscode/layouts/_default/single.html
@@ -15,8 +15,6 @@
 <div class="bg-img"></div>
 {{- end }}
 
-{{ partial "navbarSticky.html" . }}
-
 <div class="container body-content docs">
     <div class="row">
         <div class="col-md-2 docs-navbar-container"> {{ partial "docNav.html" .}} </div>
@@ -39,7 +37,6 @@
 {{/* $script := resources.Get "js/main.js" | minify | fingerprint - */}}
 <!-- <script src="{{/* $script.Permalink | relURL */}}" -->
 <!-- {{/* printf "integrity=%q" $script.Data.Integrity | safeHTMLAttr */}}></script> -->
-{{- partial "analytics.html" . }}
 {{- if templates.Exists "partials/extra-foot.html" -}}
 {{ partial "extra-foot.html" . }}
 {{- end }}

--- a/docs/themes/thxvscode/layouts/apis/list.html
+++ b/docs/themes/thxvscode/layouts/apis/list.html
@@ -5,9 +5,6 @@
 
 {{ define "main" }}
 
-{{ partial "navbarSticky.html" . }}
-
-
 <div class="container body-content docs">
     <div class="row">
         <div class="col-md-2 docs-navbar-container"> {{ partial "apiNav.html" .}} </div>
@@ -59,7 +56,6 @@
 {{/* $script := resources.Get "js/main.js" | minify | fingerprint - */}}
 <!-- <script src="{{/* $script.Permalink | relURL */}}" -->
 <!-- {{/* printf "integrity=%q" $script.Data.Integrity | safeHTMLAttr */}}></script> -->
-{{- partial "analytics.html" . }}
 {{- if templates.Exists "partials/extra-foot.html" -}}
 {{ partial "extra-foot.html" . }}
 {{- end }}

--- a/docs/themes/thxvscode/layouts/apis/list.html
+++ b/docs/themes/thxvscode/layouts/apis/list.html
@@ -8,14 +8,12 @@
 <div class="container body-content docs">
     <div class="row">
         <div class="col-md-2 docs-navbar-container"> {{ partial "apiNav.html" .}} </div>
-        <div class="col-sm-9 col-md-8 body">
-
+        <div role="main" id="main-content" class="col-sm-9 col-md-8 body">
             <div>
                 <h1>{{ .Title  }}</h1>
                 {{ $section := .CurrentSection }}
                 {{ $packagePages := where $section.RegularPages "Params.kind" "Package" }}
                 {{ range $grouping, $names :=  $.Site.Data.packages }}
-
 
                 <h2>{{ $grouping | humanize | title }} packages</h2>
 
@@ -30,7 +28,7 @@
                     <tbody>
                         {{ range $names }}
 
-                        {{ range where $packagePages "Params.package" .  }}
+                        {{ range where $packagePages "Params.package" . }}
                         <tr>
                             <td><a href="{{ .Permalink | safeURL }}" title="{{ .Title }}">{{ .Title }}</a></td>
                             <td>{{ truncate 170 (.Params.Summary | markdownify) }}</td>
@@ -42,13 +40,12 @@
                 {{ end }}
 
             </div>
-
         </div>
+
         <div class="hidden-xs col-sm-3 col-md-2 docs-subnavbar-container">
             {{ partial "toc.html" .}}
             <!-- TODO: OR subnav -->
         </div>
-
     </div>
 </div>
 

--- a/docs/themes/thxvscode/layouts/apis/single.html
+++ b/docs/themes/thxvscode/layouts/apis/single.html
@@ -4,9 +4,6 @@
 
 
 {{ define "main" }}
-{{ partial "navbarSticky.html" . }}
-
-
 <div class="container body-content docs">
     <div class="row">
         <div class="col-md-2 docs-navbar-container"> {{ partial "apiNav.html" .}} </div>
@@ -30,7 +27,6 @@
 {{/* $script := resources.Get "js/main.js" | minify | fingerprint - */}}
 <!-- <script src="{{/* $script.Permalink | relURL */}}" -->
 <!-- {{/* printf "integrity=%q" $script.Data.Integrity | safeHTMLAttr */}}></script> -->
-{{- partial "analytics.html" . }}
 {{- if templates.Exists "partials/extra-foot.html" -}}
 {{ partial "extra-foot.html" . }}
 {{- end }}

--- a/docs/themes/thxvscode/layouts/apis/single.html
+++ b/docs/themes/thxvscode/layouts/apis/single.html
@@ -4,20 +4,23 @@
 
 
 {{ define "main" }}
-<div role="main" id="main-content" class="container body-content docs">
+<div class="container body-content docs">
     <div class="row">
         <div class="col-md-2 docs-navbar-container"> {{ partial "apiNav.html" .}} </div>
-        <div class="col-sm-12 col-md-8 body">
-            <div>
-                <h1>{{.Title}}</h1>
+        <div role="main" id="main-content" class="col-sm-12 col-md-10 body">
+            <div class="row">
+                <div class="col-xs-12 col-sm-9 col-md-10">
+                    <div>
+                        <h1>{{.Title}}</h1>
+                    </div>
+                    <div>
+                        {{ .Content }}
+                    </div>
+                </div>
+                <div class="hidden-xs col-sm-3 col-md-2 docs-subnavbar-container">
+                    {{ partial "toc.html" . }}
+                </div>
             </div>
-            <div>
-                {{ .Content }}
-            </div>
-        </div>
-
-        <div class="hidden-xs col-sm-3 col-md-2 docs-subnavbar-container">
-            {{ partial "toc.html" . }}
         </div>
     </div>
 </div>

--- a/docs/themes/thxvscode/layouts/apis/single.html
+++ b/docs/themes/thxvscode/layouts/apis/single.html
@@ -4,7 +4,7 @@
 
 
 {{ define "main" }}
-<div class="container body-content docs">
+<div role="main" id="main-content" class="container body-content docs">
     <div class="row">
         <div class="col-md-2 docs-navbar-container"> {{ partial "apiNav.html" .}} </div>
         <div class="col-sm-12 col-md-8 body">

--- a/docs/themes/thxvscode/layouts/community/list.html
+++ b/docs/themes/thxvscode/layouts/community/list.html
@@ -5,13 +5,10 @@
 
 {{ define "main" }}
 
-{{ partial "navbarSticky.html" . }}
-
 {{ .Content }}
 
 {{ block "footer" . -}}{{ end }}
 
-{{- partial "analytics.html" . }}
 {{- if templates.Exists "partials/extra-foot.html" -}}
 {{ partial "extra-foot.html" . }}
 {{- end }}

--- a/docs/themes/thxvscode/layouts/community/list.html
+++ b/docs/themes/thxvscode/layouts/community/list.html
@@ -5,7 +5,9 @@
 
 {{ define "main" }}
 
+<main role="main" id="main-content">
 {{ .Content }}
+</main>
 
 {{ block "footer" . -}}{{ end }}
 

--- a/docs/themes/thxvscode/layouts/docs/list.html
+++ b/docs/themes/thxvscode/layouts/docs/list.html
@@ -3,8 +3,6 @@
 {{ end }}
 
 {{ define "main" }}
-{{ partial "navbarSticky.html" . }}
-
 <div class="container body-content docs">
     <div class="row">
         <div class="col-md-2 docs-navbar-container"> {{ partial "docNav.html" .}} </div>
@@ -28,7 +26,6 @@
 {{/* $script := resources.Get "js/main.js" | minify | fingerprint - */}}
 <!-- <script src="{{/* $script.Permalink | relURL */}}" -->
 <!-- {{/* printf "integrity=%q" $script.Data.Integrity | safeHTMLAttr */}}></script> -->
-{{- partial "analytics.html" . }}
 {{- if templates.Exists "partials/extra-foot.html" -}}
 {{ partial "extra-foot.html" . }}
 {{- end }}

--- a/docs/themes/thxvscode/layouts/docs/list.html
+++ b/docs/themes/thxvscode/layouts/docs/list.html
@@ -5,14 +5,12 @@
 {{ define "main" }}
 <div class="container body-content docs">
     <div class="row">
-        <div class="col-md-2 docs-navbar-container"> {{ partial "docNav.html" .}} </div>
-        <div class="col-sm-9 col-md-8 body">
-
+        <div class="col-md-2 docs-navbar-container">{{ partial "docNav.html" .}}</div>
+        <div role="main" id="main-content" class="col-sm-9 col-md-8 body">
             <div>
                 <h1>{{ title .Title }}</h1>
-                <div> {{ .Content }}</div>
+                <div>{{ .Content }}</div>
             </div>
-
         </div>
         <div class="hidden-xs col-sm-3 col-md-2 docs-subnavbar-container">
             {{ partial "toc.html" .}}

--- a/docs/themes/thxvscode/layouts/docs/single.html
+++ b/docs/themes/thxvscode/layouts/docs/single.html
@@ -4,9 +4,6 @@
 
 
 {{ define "main" }}
-{{ partial "navbarSticky.html" . }}
-
-
 <div class="container body-content docs">
     <div class="row">
         <div class="col-md-2 docs-navbar-container"> {{ partial "docNav.html" .}} </div>
@@ -30,7 +27,6 @@
 {{/* $script := resources.Get "js/main.js" | minify | fingerprint - */}}
 <!-- <script src="{{/* $script.Permalink | relURL */}}" -->
 <!-- {{/* printf "integrity=%q" $script.Data.Integrity | safeHTMLAttr */}}></script> -->
-{{- partial "analytics.html" . }}
 {{- if templates.Exists "partials/extra-foot.html" -}}
 {{ partial "extra-foot.html" . }}
 {{- end }}

--- a/docs/themes/thxvscode/layouts/docs/single.html
+++ b/docs/themes/thxvscode/layouts/docs/single.html
@@ -2,12 +2,11 @@
 {{ partial "header.html" . }}
 {{ end }}
 
-
 {{ define "main" }}
 <div class="container body-content docs">
     <div class="row">
-        <div class="col-md-2 docs-navbar-container"> {{ partial "docNav.html" .}} </div>
-        <div class="col-sm-9 col-md-8 body">
+        <div class="col-md-2 docs-navbar-container">{{ partial "docNav.html" .}}</div>
+        <div role="main" id="main-content" class="col-sm-9 col-md-8 body">
             <div>
                 <h1>{{.Title}}</h1>
             </div>
@@ -21,7 +20,6 @@
         </div>
     </div>
 </div>
-
 
 {{ block "footer" . -}}{{ end }}
 {{/* $script := resources.Get "js/main.js" | minify | fingerprint - */}}

--- a/docs/themes/thxvscode/layouts/index.html
+++ b/docs/themes/thxvscode/layouts/index.html
@@ -2,26 +2,14 @@
 {{ partial "header.html" . }}
 {{ end }}
 
-
 {{ define "main" }}
-
-<!-- sections.bodyTag-->
-<!-- EU Cookie Compliance JS -->
-<script src="//uhf.microsoft.com/mscc/statics/mscc-0.3.6.min.js"></script>
-
-<!-- > cookie-header  -->
 
 {{- if (or .Site.Params.images .Site.Params.bgImg) }}
 <div class="bg-img"></div>
 {{- end }}
 
-{{ partial "navbarSticky.html" . }}
-
 {{ .Content }}
 
-{{ block "footer" . -}}{{ end }}
-
-{{- partial "analytics.html" . }}
 {{- if templates.Exists "partials/extra-foot.html" -}}
 {{ partial "extra-foot.html" . }}
 {{- end }}

--- a/docs/themes/thxvscode/layouts/index.html
+++ b/docs/themes/thxvscode/layouts/index.html
@@ -4,11 +4,13 @@
 
 {{ define "main" }}
 
-{{- if (or .Site.Params.images .Site.Params.bgImg) }}
-<div class="bg-img"></div>
-{{- end }}
+<div role="main" id="main-content">
+    {{- if (or .Site.Params.images .Site.Params.bgImg) }}
+    <div class="bg-img"></div>
+    {{- end }}
 
-{{ .Content }}
+    {{ .Content }}
+</div>
 
 {{- if templates.Exists "partials/extra-foot.html" -}}
 {{ partial "extra-foot.html" . }}

--- a/docs/themes/thxvscode/layouts/partials/analytics.html
+++ b/docs/themes/thxvscode/layouts/partials/analytics.html
@@ -1,1 +1,0 @@
-{{ template "_internal/google_analytics_async.html" . }}

--- a/docs/themes/thxvscode/layouts/partials/header.html
+++ b/docs/themes/thxvscode/layouts/partials/header.html
@@ -1,2 +1,4 @@
 <!-- EU Cookie Compliance JS -->
 <script src="//uhf.microsoft.com/mscc/statics/mscc-0.3.6.min.js"></script>
+
+{{ partial "navbarSticky.html" . }}

--- a/docs/themes/thxvscode/layouts/partials/header.html
+++ b/docs/themes/thxvscode/layouts/partials/header.html
@@ -1,4 +1,4 @@
-<!-- EU Cookie Compliance JS -->
-<script src="//uhf.microsoft.com/mscc/statics/mscc-0.3.6.min.js"></script>
+<a role="button" id="skip-to-content" class="link-button" href="#main-content">Skip to content<i>&nbsp;</i><span
+    class="glyphicon glyphicon-menu-down"></span></a>
 
 {{ partial "navbarSticky.html" . }}

--- a/docs/themes/thxvscode/layouts/partials/navbarSticky.html
+++ b/docs/themes/thxvscode/layouts/partials/navbarSticky.html
@@ -1,7 +1,5 @@
 {{ $current := .}}
 {{ $topSection := .CurrentSection.FirstSection }}
-<a role="button" id="skip-to-content" class="link-button" href="#main-content">Skip to content<i>&nbsp;</i><span
-        class="glyphicon glyphicon-menu-down"></span></a>
 <div class="navbar-fixed-container">
     <div class="navbar navbar-inverse navbar-fixed-top {{ if .IsHome}}home{{ end }}" data-spy="affix"
         data-offset-top="1">

--- a/docs/themes/thxvscode/layouts/posts/list.html
+++ b/docs/themes/thxvscode/layouts/posts/list.html
@@ -3,8 +3,6 @@
 {{ end }}
 
 {{ define "main" }}
-{{ partial "navbarSticky.html" . }}
-
 <div class="container body-content blog">
     <div class="row">
         <div class="col-md-2 docs-navbar-container">{{ partial "blogNav.html" .}} </div>
@@ -34,7 +32,6 @@
 {{/* $script := resources.Get "js/main.js" | minify | fingerprint - */}}
 <!-- <script src="{{/* $script.Permalink | relURL */}}" -->
 <!-- {{/* printf "integrity=%q" $script.Data.Integrity | safeHTMLAttr */}}></script> -->
-{{- partial "analytics.html" . }}
 {{- if templates.Exists "partials/extra-foot.html" -}}
 {{ partial "extra-foot.html" . }}
 {{- end }}

--- a/docs/themes/thxvscode/layouts/posts/single.html
+++ b/docs/themes/thxvscode/layouts/posts/single.html
@@ -4,15 +4,6 @@
 
 
 {{ define "main" }}
-
-<!-- sections.bodyTag-->
-<!-- EU Cookie Compliance JS -->
-<script src="//uhf.microsoft.com/mscc/statics/mscc-0.3.6.min.js"></script>
-
-<!-- > cookie-header  -->
-
-{{ partial "navbarSticky.html" . }}
-
 <div class="container body-content docs">
     <div class="row">
         <div class="col-md-2 docs-navbar-container"> {{ partial "blogNav.html" .}} </div>
@@ -53,7 +44,6 @@
 {{/* $script := resources.Get "js/main.js" | minify | fingerprint - */}}
 <!-- <script src="{{/* $script.Permalink | relURL */}}" -->
 <!-- {{/* printf "integrity=%q" $script.Data.Integrity | safeHTMLAttr */}}></script> -->
-{{- partial "analytics.html" . }}
 {{- if templates.Exists "partials/extra-foot.html" -}}
 {{ partial "extra-foot.html" . }}
 {{- end }}


### PR DESCRIPTION
- Remove unused analytics partial.
- Remove duplicate cookie script.
- Move nav bar and Skip to Content button outside the #main-content div (fixes #3624).