### PR TITLE
Clean up IContentMessage

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -691,41 +691,41 @@
 			}
 		},
 		"@fluidframework/agent-scheduler": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.26.2.tgz",
-			"integrity": "sha512-GslccxEXxhYEZOrrGaJJimA5xSODJM+5UfTHM8y4RUSdH9nGl62/dO4xAdZmwOTodaUQQttGi8Xr5FieUerb2Q==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.26.3.tgz",
+			"integrity": "sha512-akXxw7XRU8sxELaTh78/hJaze3dm8wbSdLRKehHpLfdlzEMZ7BWR9XAMsPLRyMFKOpln1+0ZQJt95SNYGnl2dA==",
 			"requires": {
-				"@fluidframework/container-definitions": "^0.26.2",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/datastore": "^0.26.2",
-				"@fluidframework/datastore-definitions": "^0.26.2",
-				"@fluidframework/map": "^0.26.2",
-				"@fluidframework/register-collection": "^0.26.2",
-				"@fluidframework/runtime-definitions": "^0.26.2",
+				"@fluidframework/container-definitions": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/datastore": "^0.26.3",
+				"@fluidframework/datastore-definitions": "^0.26.3",
+				"@fluidframework/map": "^0.26.3",
+				"@fluidframework/register-collection": "^0.26.3",
+				"@fluidframework/runtime-definitions": "^0.26.3",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.26.2.tgz",
-			"integrity": "sha512-95xWgxdImJua25sT9muAr3KnfcCWJ6E6fMEvO+I1nfKYI2LfOnmGoss88DRys5KFE5RlOmoNS2ocFbHOLLD7mw==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.26.3.tgz",
+			"integrity": "sha512-/HOHn4GdOnjJnCOQgHR+dJx3QC7pgrx4xndnNaLa5bD5npFqtxj2ixOrq17uwDNh74+vjlq1oHaC3+dWtdnWgA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.2",
-				"@fluidframework/container-loader": "^0.26.2",
-				"@fluidframework/container-runtime": "^0.26.2",
-				"@fluidframework/container-runtime-definitions": "^0.26.2",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/datastore": "^0.26.2",
-				"@fluidframework/datastore-definitions": "^0.26.2",
-				"@fluidframework/map": "^0.26.2",
-				"@fluidframework/request-handler": "^0.26.2",
-				"@fluidframework/runtime-definitions": "^0.26.2",
-				"@fluidframework/runtime-utils": "^0.26.2",
-				"@fluidframework/synthesize": "^0.26.2",
-				"@fluidframework/view-interfaces": "^0.26.2",
+				"@fluidframework/container-definitions": "^0.26.3",
+				"@fluidframework/container-loader": "^0.26.3",
+				"@fluidframework/container-runtime": "^0.26.3",
+				"@fluidframework/container-runtime-definitions": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/datastore": "^0.26.3",
+				"@fluidframework/datastore-definitions": "^0.26.3",
+				"@fluidframework/map": "^0.26.3",
+				"@fluidframework/request-handler": "^0.26.3",
+				"@fluidframework/runtime-definitions": "^0.26.3",
+				"@fluidframework/runtime-utils": "^0.26.3",
+				"@fluidframework/synthesize": "^0.26.3",
+				"@fluidframework/view-interfaces": "^0.26.3",
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
@@ -806,13 +806,13 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.26.2.tgz",
-			"integrity": "sha512-Kf6G50wGbW0pdqXT9CggWR0akdQlq3U2nM/WF7M0iUKDOCwQq84enmVHt++x2prG+5R6oUVOogoLootwHUY/Xw==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.26.3.tgz",
+			"integrity": "sha512-UYm67C/32F3mRwC5kiKkkPx9I8OoBAs6c8HdGJRUS1zmeIJCbC06Zjc8ipVjY3vEl0QyCVhNIlEme10ZBFN1Eg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/driver-definitions": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/driver-definitions": "^0.26.3",
 				"@fluidframework/protocol-definitions": "^0.1012.0"
 			},
 			"dependencies": {
@@ -827,20 +827,20 @@
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.26.2.tgz",
-			"integrity": "sha512-/zqT6XzYPgjB+bugnnNYlUr+zxRqQjT/ZloYZ1Bcl+iOti9gbAC/vFy2+VPNznrph5ZASkeE5rSp7rE1cETIUg==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.26.3.tgz",
+			"integrity": "sha512-XWV+WsqKhXkrEqgWe77C76cSZHYMGw1PFR5E7qKs0qLoUvXYXWxYYRklCrY0H9SbpsyIVXD2c2YVaPiHLEsv7Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.2",
-				"@fluidframework/container-utils": "^0.26.2",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/driver-definitions": "^0.26.2",
-				"@fluidframework/driver-utils": "^0.26.2",
+				"@fluidframework/container-definitions": "^0.26.3",
+				"@fluidframework/container-utils": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/driver-definitions": "^0.26.3",
+				"@fluidframework/driver-utils": "^0.26.3",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/telemetry-utils": "^0.26.2",
+				"@fluidframework/telemetry-utils": "^0.26.3",
 				"@types/double-ended-queue": "^2.1.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -891,25 +891,25 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.26.2.tgz",
-			"integrity": "sha512-pBDgv5dcQJATKSLk4J3SbQLedyCunXT3qVJzNW8KHffLpJU1xEM/ZvaJuL7Emku66FBFthq2K3LM8MWu00ywNQ==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.26.3.tgz",
+			"integrity": "sha512-v70FiyLtSTBrsJ1OHdh26Wt3tpVCz6J4xwbPNtTPcajdJcJIJmojEtK0HGVH6jXhCOiSXpJEpAbSEdVa6zDo5w==",
 			"requires": {
-				"@fluidframework/agent-scheduler": "^0.26.2",
+				"@fluidframework/agent-scheduler": "^0.26.3",
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.2",
-				"@fluidframework/container-runtime-definitions": "^0.26.2",
-				"@fluidframework/container-utils": "^0.26.2",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/datastore": "^0.26.2",
-				"@fluidframework/driver-definitions": "^0.26.2",
-				"@fluidframework/driver-utils": "^0.26.2",
+				"@fluidframework/container-definitions": "^0.26.3",
+				"@fluidframework/container-runtime-definitions": "^0.26.3",
+				"@fluidframework/container-utils": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/datastore": "^0.26.3",
+				"@fluidframework/driver-definitions": "^0.26.3",
+				"@fluidframework/driver-utils": "^0.26.3",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.2",
-				"@fluidframework/runtime-utils": "^0.26.2",
-				"@fluidframework/telemetry-utils": "^0.26.2",
+				"@fluidframework/runtime-definitions": "^0.26.3",
+				"@fluidframework/runtime-utils": "^0.26.3",
+				"@fluidframework/telemetry-utils": "^0.26.3",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/node": "^10.17.24",
@@ -962,15 +962,15 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.26.2.tgz",
-			"integrity": "sha512-0LMke6BZ5yeBB4GazdxVYKN5lVpO4YoFNX59wviLLJv8dqlWx1Tq8mO0Gf8vYEkAbo3fhsEPYUuf5kUIw/xang==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.26.3.tgz",
+			"integrity": "sha512-uzIvb+X15YXd04/CkMjCMMkhjquZrkW2Cerl2oOW2VbGGB/N8uhyvjGdH41hjkeooEeHS8+kDFWO0mkNXclbZw==",
 			"requires": {
-				"@fluidframework/container-definitions": "^0.26.2",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/driver-definitions": "^0.26.2",
+				"@fluidframework/container-definitions": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/driver-definitions": "^0.26.3",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.2",
+				"@fluidframework/runtime-definitions": "^0.26.3",
 				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
@@ -985,37 +985,37 @@
 			}
 		},
 		"@fluidframework/container-utils": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.26.2.tgz",
-			"integrity": "sha512-DQPcgYNfXg5bS4axnS2OcmatiTSIVO8GAIvtoeyVhRysYoXkWYQolaujfAzgIK2GrI3JilM0X40H6vPnG2WifQ==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.26.3.tgz",
+			"integrity": "sha512-wUYGQqPCrgIqRsCbo1BV6yPlQaHGColLdPcxq5RfGUeCyULW/+J8JQcPhsexn8iMFAvZJI69H6vtV39pmfskGw==",
 			"requires": {
-				"@fluidframework/container-definitions": "^0.26.2",
-				"@fluidframework/telemetry-utils": "^0.26.2"
+				"@fluidframework/container-definitions": "^0.26.3",
+				"@fluidframework/telemetry-utils": "^0.26.3"
 			}
 		},
 		"@fluidframework/core-interfaces": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.26.2.tgz",
-			"integrity": "sha512-OoqL6nqgLL1rEiajutc29MK8Rr5ww4g8DFq8A0HIEz0Jy0FktaRxwol5e6l71+6YvjaBzOu+mpmMjwB6r/KAXw=="
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.26.3.tgz",
+			"integrity": "sha512-AeHoNrLi+Xiuaa+h7TvQ5Shn0qoKhfsnLUF9U4Y/2w/vMIEaU2TbVet4msAXVnfyMq+EkW7tU1k2c2GKVHDl1A=="
 		},
 		"@fluidframework/datastore": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.26.2.tgz",
-			"integrity": "sha512-QDazgxHKfBMD8URyH7EgiglB+Bk1SAk/zJj60JKkh23hbt/CJJdR4n+D38+8n+BIqW/dTmCx85sPg3HD7Ob/TA==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.26.3.tgz",
+			"integrity": "sha512-w3r/kVZbAIcFr5L6PLfPAYwgLkbRo63RYhCw/GHsgtsm7cwplPgP1K8yJzNyr8D3Fem+Gs9h8QuRGedwZdmkfQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.2",
-				"@fluidframework/container-utils": "^0.26.2",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/datastore-definitions": "^0.26.2",
-				"@fluidframework/driver-definitions": "^0.26.2",
-				"@fluidframework/driver-utils": "^0.26.2",
+				"@fluidframework/container-definitions": "^0.26.3",
+				"@fluidframework/container-utils": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/datastore-definitions": "^0.26.3",
+				"@fluidframework/driver-definitions": "^0.26.3",
+				"@fluidframework/driver-utils": "^0.26.3",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.2",
-				"@fluidframework/runtime-utils": "^0.26.2",
-				"@fluidframework/telemetry-utils": "^0.26.2",
+				"@fluidframework/runtime-definitions": "^0.26.3",
+				"@fluidframework/runtime-utils": "^0.26.3",
+				"@fluidframework/telemetry-utils": "^0.26.3",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
@@ -1064,15 +1064,15 @@
 			}
 		},
 		"@fluidframework/datastore-definitions": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.26.2.tgz",
-			"integrity": "sha512-fDYc8fdhmRvYAuPFq7udy4DKEQYnimWQAqSMsTKWgs5KMCHOcCZcmFh0Hd10lORzQ8m5G7FLPzvmkCRyEzAaLg==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.26.3.tgz",
+			"integrity": "sha512-KsQBJZc+/uJFNJ6dgpNJbfLzcF9aL/VgD7DLVSLQ0AUsdkSyZ0hIYTHlGzjX7hN+7zyNI5GEpoZPkUj49uFtPA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.26.2",
-				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/container-definitions": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.3",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.2",
+				"@fluidframework/runtime-definitions": "^0.26.3",
 				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
@@ -1087,13 +1087,13 @@
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.26.2.tgz",
-			"integrity": "sha512-tMacmATI94jQ1Ako47+/L9P3SGiFwi7fL8eWkzm6oTjanD0zGNNVU2fgatY8E4W4m4rY/ClC7/xCP/mPSY7s/w==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.26.3.tgz",
+			"integrity": "sha512-2NONWqkxFrrAjYmtPn+rQKdFh5uCuN55wdc4qhEMznuJE1Ykf69ydJzapMMd4PfYTl0RscqV99SpfiP5rzI9UQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/driver-definitions": "^0.26.2",
-				"@fluidframework/driver-utils": "^0.26.2",
+				"@fluidframework/driver-definitions": "^0.26.3",
+				"@fluidframework/driver-utils": "^0.26.3",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
 				"@types/debug": "^4.1.5",
 				"@types/node": "^10.17.24",
@@ -1127,12 +1127,12 @@
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.26.2.tgz",
-			"integrity": "sha512-oTppj1WMwQZoyNQmuYxYAnUWEFOSRWzXvDOZLc+Ble4shjZftEpbz7a78P8cXC9yYN3sP9kDkLiL38/YYTWQeg==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.26.3.tgz",
+			"integrity": "sha512-dHlg1U9V+79KLtLAllB5wUrZ3GEaK+qXFxXXYoEKWlQZvTOhSBHuN/DUDVM/bsBq4NBCU2MKpnk4RirE/LO3bQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.3",
 				"@fluidframework/protocol-definitions": "^0.1012.0"
 			},
 			"dependencies": {
@@ -1147,18 +1147,18 @@
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.26.2.tgz",
-			"integrity": "sha512-lQ4Z1/DN7HT04ezOoo2tWhAvgdcNQRKxU6dEzbXVUbgmqZDSHVGkC2fBmgU1I5vez5Ye5NKqZt80LkUkmzTmig==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.26.3.tgz",
+			"integrity": "sha512-mFTnVsGMvUFAW9mRKWlhy6ZZ7TT6lcm25IcjFnyHbUCazuXyexW5cYWwNSHUL8eVfXPFLyGXYyLyBOCT4Py47g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/driver-definitions": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/driver-definitions": "^0.26.3",
 				"@fluidframework/gitresources": "^0.1012.0",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/telemetry-utils": "^0.26.2"
+				"@fluidframework/telemetry-utils": "^0.26.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -1221,22 +1221,22 @@
 			}
 		},
 		"@fluidframework/gitresources": {
-			"version": "0.1014.0-5564",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1014.0-5564.tgz",
-			"integrity": "sha512-PqXhUPI8FiGlw2dB/VCb3ciHzm5a98DKkm+XvbcdTwtDT5AQyjfTpl7ivAqD75Xn40lAX/yZa6oJyl1K11LSBg=="
+			"version": "0.1014.0-6368",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1014.0-6368.tgz",
+			"integrity": "sha512-StiRoivc79/obv8LA1LPcdzYWevzL3xbBftEjWV50w9hA86K1Mr6WSrBc0Hf7x+F6UuUer75O73Kpyo5MK9wwQ=="
 		},
 		"@fluidframework/local-driver": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.26.2.tgz",
-			"integrity": "sha512-aodH+ak2hjQwDOZOO6Ice4i0Htd/EN5H2cJj2n42frOWXjPKHqgcaEoZPTNVo3X7rI6FuCaCN4NCa8+CbXHIOg==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.26.3.tgz",
+			"integrity": "sha512-og6oLWYTH/RHyY11myzgqMZYbUzb/L8A0M1gvrlyFwkUnWHU5J+4tWPZ7F1hXGid7K+Y9E9KPE8F7Q0IG6nW2w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/driver-definitions": "^0.26.2",
-				"@fluidframework/driver-utils": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/driver-definitions": "^0.26.3",
+				"@fluidframework/driver-utils": "^0.26.3",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/routerlicious-driver": "^0.26.2",
+				"@fluidframework/routerlicious-driver": "^0.26.3",
 				"@fluidframework/server-local-server": "^0.1012.0",
 				"@fluidframework/server-services-client": "^0.1012.0",
 				"@fluidframework/server-services-core": "^0.1012.0",
@@ -1403,17 +1403,17 @@
 			}
 		},
 		"@fluidframework/map": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.26.2.tgz",
-			"integrity": "sha512-DFkIBTKYILOmC71OrpiXcGFCU7L9oNSwskD62hsfZMjAm3Ol5Uv7S8SkQ9KrdCsNzmi6Z09pOvE6X2dZakmbLQ==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.26.3.tgz",
+			"integrity": "sha512-7oUlh7edCzcN5WS8lkg3J/RoPY/drf4mtLmTU6xM7cG8Ij8uN3ORjJtLn0wXtMS6EqKydiMBV4hGCab5Z0YNLg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/datastore-definitions": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/datastore-definitions": "^0.26.3",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.2",
+				"@fluidframework/shared-object-base": "^0.26.3",
 				"debug": "^4.1.1",
 				"path-browserify": "^1.0.1"
 			},
@@ -1461,16 +1461,16 @@
 			}
 		},
 		"@fluidframework/merge-tree": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.26.2.tgz",
-			"integrity": "sha512-ICAi/KYEtjb1jIYyIAC2+TFVwsbBCzhW227KknnXEyAnhUx9j+lKXFXZY36gBzJ2vWnWGDOqh+f/01tSVYLAhw==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.26.3.tgz",
+			"integrity": "sha512-dShxdwaDEUFsPBj1iWyOhR23oEd6TT3uDCb3ZGvobdXoSKRijos4JZG4qKHnoV/D73AOxQwQpUvR3ONF4r8+ig==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/datastore-definitions": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/datastore-definitions": "^0.26.3",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/telemetry-utils": "^0.26.2"
+				"@fluidframework/telemetry-utils": "^0.26.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -1499,34 +1499,34 @@
 			}
 		},
 		"@fluidframework/protocol-base": {
-			"version": "0.1014.0-5564",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1014.0-5564.tgz",
-			"integrity": "sha512-QfQuERiahWAv9Rgm/R1zTZWLhX5DB3ikGmYpUGqRHTWvwLQ0jkkhITUfeoE0vVhf2CbAlmSBFQF0J2Sh1VkUow==",
+			"version": "0.1014.0-6368",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1014.0-6368.tgz",
+			"integrity": "sha512-FLse61s5FWGhM6KwOoRZli02+8AT7h6I+7dEF78TMh4RaklNbqSxvvBa7YjPGhPanw7ZMVQaSzaUVy7S5cch0g==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0-0",
-				"@fluidframework/gitresources": "^0.1014.0-5564",
-				"@fluidframework/protocol-definitions": "^0.1014.0-5564",
+				"@fluidframework/gitresources": "^0.1014.0-6368",
+				"@fluidframework/protocol-definitions": "^0.1014.0-6368",
 				"assert": "^2.0.0",
 				"lodash": "^4.17.19"
 			}
 		},
 		"@fluidframework/protocol-definitions": {
-			"version": "0.1014.0-5564",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1014.0-5564.tgz",
-			"integrity": "sha512-cHFjOd0dNvwcS4Cg80f77RD/ADEYlY+9POCa83ko/k10q7HMKOp96cZJs8QxNoZuE517mAfJppEMlF3drbsi8w==",
+			"version": "0.1014.0-6368",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1014.0-6368.tgz",
+			"integrity": "sha512-tPqj48lAribjI89YDLHPDd5auRU2qUFbSPjX65lK649bvISzJl7pgXYZsSd9Y5lYsT0LJDaXbJApAYCSnJjQfQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1"
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.26.2.tgz",
-			"integrity": "sha512-TjZlz2GVBTRIE8sIqkg0Ic9iNAtXXRVNWj8HuyOMK9IrzdNC8mt+7RpNlCIhY63ZO18nNRfZ6OLip9y2vRvZWw==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.26.3.tgz",
+			"integrity": "sha512-6TeAiy0uR9F6LqxLznIHcQuV5R7j0ORk5dljGzpD9dbIlGVEugCYa2Ds5bLhF8NLtcL7cWffEHmx/8fJ1oIacw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/datastore-definitions": "^0.26.2",
+				"@fluidframework/datastore-definitions": "^0.26.3",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.2",
+				"@fluidframework/shared-object-base": "^0.26.3",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
@@ -1556,26 +1556,26 @@
 			}
 		},
 		"@fluidframework/request-handler": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.26.2.tgz",
-			"integrity": "sha512-uEP8fhXI5B4gpURwGjpqkTUc3RkqMiOWEnlMxPecsAZRB63s436ru5wR/hrCyyr82uyf7z7PeNR7WfP6K3YRVQ==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.26.3.tgz",
+			"integrity": "sha512-2aSE4aHqkrSKcli/gHfBCed8bsQbfDGBTYfc73R4451OOjdig4+b09E5DYu6kDFlvZNRPWm0wQblR+dwpsJcTA==",
 			"requires": {
-				"@fluidframework/container-runtime-definitions": "^0.26.2",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/runtime-definitions": "^0.26.2",
-				"@fluidframework/runtime-utils": "^0.26.2"
+				"@fluidframework/container-runtime-definitions": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/runtime-definitions": "^0.26.3",
+				"@fluidframework/runtime-utils": "^0.26.3"
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.26.2.tgz",
-			"integrity": "sha512-ZgTjfsUmLag6z6AnHInMEKGUSr295GbAOPhgkrTWu9eO06mCL0Q4+Dp9zEtKStwoAv5bk32vj/I4DXJRB7XbqQ==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.26.3.tgz",
+			"integrity": "sha512-5G9ZRPAzQVnQAYNadJmXmCD8BK58hijAEqRNRN0JP4HI5O0bfoCEiUa1x399kFbMf8jbWo14LfYdQZEV8NqSNw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/driver-base": "^0.26.2",
-				"@fluidframework/driver-definitions": "^0.26.2",
-				"@fluidframework/driver-utils": "^0.26.2",
+				"@fluidframework/driver-base": "^0.26.3",
+				"@fluidframework/driver-definitions": "^0.26.3",
+				"@fluidframework/driver-utils": "^0.26.3",
 				"@fluidframework/gitresources": "^0.1012.0",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
@@ -1648,14 +1648,14 @@
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.26.2.tgz",
-			"integrity": "sha512-j7IwsiLX/EeF/PiMfS/TrFf8vNrT+feCwD2ldAVGIyxdsJZivbPj3m1dqvYsHNBEZBftjhNe+IQnpuDJ6JGrfQ==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.26.3.tgz",
+			"integrity": "sha512-V6LmLaePMhcM6wfSDe99/t2ACViVSYec8X4o9VTVYbJjyEgDnISAxAIYzvzz3kkhTLB5mMeQ2vMjNFc8TPed8w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.26.2",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/driver-definitions": "^0.26.2",
+				"@fluidframework/container-definitions": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/driver-definitions": "^0.26.3",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
 				"@types/node": "^10.17.24"
 			},
@@ -1671,17 +1671,17 @@
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.26.2.tgz",
-			"integrity": "sha512-nEueuPfeXCqJQEjSdxkS30mlFq0skxneqF+08HlcKJ30LEZIjdAH45aG6RfuXpbKdKcTG9BaTf49KZOwvVhXnQ==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.26.3.tgz",
+			"integrity": "sha512-lXEW1A88WVF3ZGkxQKXHdtcrNVxgRl0cJAILLoVSQFWBlZkStwp1HLywXyBrCbqZwHg4UsMLRNjvDuBmVBSVUg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/datastore-definitions": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/datastore-definitions": "^0.26.3",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.2"
+				"@fluidframework/runtime-definitions": "^0.26.3"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -1727,16 +1727,16 @@
 			}
 		},
 		"@fluidframework/server-lambdas": {
-			"version": "0.1014.0-5564",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1014.0-5564.tgz",
-			"integrity": "sha512-iLz5A6FPeJluroZ/InAlLPTDiq/+r1wL60atnwbH/Bt0OlHDeDtMfPATU5vZxRYIlLcpXNehI+CxAhkkgUsmHQ==",
+			"version": "0.1014.0-6368",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1014.0-6368.tgz",
+			"integrity": "sha512-iD0wEhZonTcWAByA2TkGXtWU3I6hyiFNXn8x/T2Ht6u+mMNex2SdLkJNYALcEamib4622f0jv35nyS0SL0ZwIw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0-0",
-				"@fluidframework/gitresources": "^0.1014.0-5564",
-				"@fluidframework/protocol-base": "^0.1014.0-5564",
-				"@fluidframework/protocol-definitions": "^0.1014.0-5564",
-				"@fluidframework/server-services-client": "^0.1014.0-5564",
-				"@fluidframework/server-services-core": "^0.1014.0-5564",
+				"@fluidframework/gitresources": "^0.1014.0-6368",
+				"@fluidframework/protocol-base": "^0.1014.0-6368",
+				"@fluidframework/protocol-definitions": "^0.1014.0-6368",
+				"@fluidframework/server-services-client": "^0.1014.0-6368",
+				"@fluidframework/server-services-core": "^0.1014.0-6368",
 				"@types/semver": "^6.0.1",
 				"async": "^2.6.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -1756,31 +1756,31 @@
 			}
 		},
 		"@fluidframework/server-local-server": {
-			"version": "0.1014.0-5564",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1014.0-5564.tgz",
-			"integrity": "sha512-Wk+mRum9pacNSS7R7iICYbHGk0ffpQs/N/WXpQiRUw2Gp8UIFuFL4T6VQdTT0qj2J3ntKzeHDgAve8dveApySA==",
+			"version": "0.1014.0-6368",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1014.0-6368.tgz",
+			"integrity": "sha512-qmLFTM0g0LPk34ThmbU+KC5PK6CyazDWN9Nwg4+FLjzDUu1pVaCFuqb9bciY/mL4YJzua+pH6p1ZROvkNJRUDQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0-0",
-				"@fluidframework/protocol-definitions": "^0.1014.0-5564",
-				"@fluidframework/server-lambdas": "^0.1014.0-5564",
-				"@fluidframework/server-memory-orderer": "^0.1014.0-5564",
-				"@fluidframework/server-services-client": "^0.1014.0-5564",
-				"@fluidframework/server-services-core": "^0.1014.0-5564",
-				"@fluidframework/server-test-utils": "^0.1014.0-5564",
+				"@fluidframework/protocol-definitions": "^0.1014.0-6368",
+				"@fluidframework/server-lambdas": "^0.1014.0-6368",
+				"@fluidframework/server-memory-orderer": "^0.1014.0-6368",
+				"@fluidframework/server-services-client": "^0.1014.0-6368",
+				"@fluidframework/server-services-core": "^0.1014.0-6368",
+				"@fluidframework/server-test-utils": "^0.1014.0-6368",
 				"uuid": "^3.3.2"
 			}
 		},
 		"@fluidframework/server-memory-orderer": {
-			"version": "0.1014.0-5564",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1014.0-5564.tgz",
-			"integrity": "sha512-OA8o0C9Sr4Lb3svljitk314DbaE94rmJrrzLDdguV4YprkgO1JMpHJBuKkPFiiLvZ1jqE7GK2aNEIs7DA8GTSA==",
+			"version": "0.1014.0-6368",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1014.0-6368.tgz",
+			"integrity": "sha512-7JIXLRC2hhASZLepfeW4je3G89wvizMlXBl8rQiiBs+I0MOGJiV9lLCUv+gzwz8mkNVR6x84tYuVpfU2/zaTsQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0-0",
-				"@fluidframework/protocol-base": "^0.1014.0-5564",
-				"@fluidframework/protocol-definitions": "^0.1014.0-5564",
-				"@fluidframework/server-lambdas": "^0.1014.0-5564",
-				"@fluidframework/server-services-client": "^0.1014.0-5564",
-				"@fluidframework/server-services-core": "^0.1014.0-5564",
+				"@fluidframework/protocol-base": "^0.1014.0-6368",
+				"@fluidframework/protocol-definitions": "^0.1014.0-6368",
+				"@fluidframework/server-lambdas": "^0.1014.0-6368",
+				"@fluidframework/server-services-client": "^0.1014.0-6368",
+				"@fluidframework/server-services-core": "^0.1014.0-6368",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/lodash": "^4.14.118",
@@ -1795,14 +1795,14 @@
 			}
 		},
 		"@fluidframework/server-services-client": {
-			"version": "0.1014.0-5564",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1014.0-5564.tgz",
-			"integrity": "sha512-YKYBmiwP8bsaegCH9DV6z3Vk8jPBoJXbGuXJlKw/1scjv3A18uR1DmliqSOjZuYBVVCVgS32G9j4hULg8HaZXw==",
+			"version": "0.1014.0-6368",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1014.0-6368.tgz",
+			"integrity": "sha512-Pt1izj56bkx+Gh4Gh7ugCpdWWH+1zTndHzjd+vXCdmWj0MGwClAnMn4X0KFXc2ZnP2RhaZObPnDni4tiU4f8Ig==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0-0",
-				"@fluidframework/gitresources": "^0.1014.0-5564",
-				"@fluidframework/protocol-base": "^0.1014.0-5564",
-				"@fluidframework/protocol-definitions": "^0.1014.0-5564",
+				"@fluidframework/gitresources": "^0.1014.0-6368",
+				"@fluidframework/protocol-base": "^0.1014.0-6368",
+				"@fluidframework/protocol-definitions": "^0.1014.0-6368",
 				"@types/node": "^10.17.24",
 				"axios": "^0.18.0",
 				"debug": "^4.1.1",
@@ -1812,14 +1812,14 @@
 			}
 		},
 		"@fluidframework/server-services-core": {
-			"version": "0.1014.0-5564",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1014.0-5564.tgz",
-			"integrity": "sha512-xk90P7woO3t8WM3hwYUwfMl9bXrlSyinluwmq2pKhPrErdk0CX/E62+ofWY7Jz+5F/pUrDoC088/RufPEZ0xOA==",
+			"version": "0.1014.0-6368",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1014.0-6368.tgz",
+			"integrity": "sha512-AMzdqwNqTHQWF0Z8RBM8DiUcSofBmzdO4AGfnOeAp510D4g4NuCxRx9LtHWvrqzm9wtyjXtPfrlV3XvTPu/WBg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0-0",
-				"@fluidframework/gitresources": "^0.1014.0-5564",
-				"@fluidframework/protocol-definitions": "^0.1014.0-5564",
-				"@fluidframework/server-services-client": "^0.1014.0-5564",
+				"@fluidframework/gitresources": "^0.1014.0-6368",
+				"@fluidframework/protocol-definitions": "^0.1014.0-6368",
+				"@fluidframework/server-services-client": "^0.1014.0-6368",
 				"@types/nconf": "^0.0.37",
 				"@types/node": "^10.17.24",
 				"debug": "^4.1.1",
@@ -1827,16 +1827,16 @@
 			}
 		},
 		"@fluidframework/server-test-utils": {
-			"version": "0.1014.0-5564",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1014.0-5564.tgz",
-			"integrity": "sha512-BWoKA9sa5gzB3CeD14rIsXeBemfaa79WskMpDv/jgpMPNQNG8e7VUlTLTJUo7WiRO6p5519MxN4PEkUERIJQ2w==",
+			"version": "0.1014.0-6368",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1014.0-6368.tgz",
+			"integrity": "sha512-uzEBZBYFZp37MO8LMfC7qh8gQ5wDirA7zyk5MpQpSTiNSmlng9pZHiKZuAYsDFFgRxRx59agrHteKUTrZp+btg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0-0",
-				"@fluidframework/gitresources": "^0.1014.0-5564",
-				"@fluidframework/protocol-base": "^0.1014.0-5564",
-				"@fluidframework/protocol-definitions": "^0.1014.0-5564",
-				"@fluidframework/server-services-client": "^0.1014.0-5564",
-				"@fluidframework/server-services-core": "^0.1014.0-5564",
+				"@fluidframework/gitresources": "^0.1014.0-6368",
+				"@fluidframework/protocol-base": "^0.1014.0-6368",
+				"@fluidframework/protocol-definitions": "^0.1014.0-6368",
+				"@fluidframework/server-services-client": "^0.1014.0-6368",
+				"@fluidframework/server-services-core": "^0.1014.0-6368",
 				"debug": "^4.1.1",
 				"lodash": "^4.17.19",
 				"string-hash": "^1.1.3",
@@ -1844,17 +1844,17 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.26.2.tgz",
-			"integrity": "sha512-FlzPqARyGtdmq5Hz9z5a1fmyJXjGcHN4ls7ibOcAKipnFSBAdpXx6uvfDhFHSo6pcTLDraz0zMt0GJyNrVBkag==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.26.3.tgz",
+			"integrity": "sha512-Md2SzJabzero0p5FTBsnNag89XzD7ARJgHZhRY9FQ+Yw0CyDUaK3oemwpqHcUcl8fxqEz4c5GdabRufvuNrn6g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.26.2",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/datastore": "^0.26.2",
-				"@fluidframework/datastore-definitions": "^0.26.2",
+				"@fluidframework/container-definitions": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/datastore": "^0.26.3",
+				"@fluidframework/datastore-definitions": "^0.26.3",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/telemetry-utils": "^0.26.2",
+				"@fluidframework/telemetry-utils": "^0.26.3",
 				"@types/debug": "^4.1.5",
 				"@types/node": "^10.17.24",
 				"debug": "^4.1.1",
@@ -1872,17 +1872,17 @@
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.26.2.tgz",
-			"integrity": "sha512-lmW1w4w9dooH4PCRWrQnW958tH3kgnB6dGMi1dHx0vd1zaf3WU/BQkn4+wfrn8Dr+l3UiFQ4EfCTl3Ic4Khr5w==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.26.3.tgz",
+			"integrity": "sha512-8HjlLWm/SF5T7zQmwQvvMRBllbDyGrBhae5v8uPjkxjm+hIB7/SdFIFJ4/e4UcXypZjQi4/8kECfHTWrp8ofug==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^0.26.2"
+				"@fluidframework/core-interfaces": "^0.26.3"
 			}
 		},
 		"@fluidframework/telemetry-utils": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.26.2.tgz",
-			"integrity": "sha512-CNJ8HWiJkscElxEINq9VaEqM4b8mCAFi3rd+8aVv3Omhs31FxLOS7eRFZVSxSQZWNjkAGNqVP2KfAvogMxIZUA==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.26.3.tgz",
+			"integrity": "sha512-8T3jspdMuUPTH81UvdavReue4C54Z31XdNd1kbRPM6or5lbXzzzopZReH/dNwPfwYUv7NOd32dm+8HsVKJZ+xw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
@@ -1914,11 +1914,11 @@
 			"dev": true
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.26.2.tgz",
-			"integrity": "sha512-bz96lUptVDP39qRmr98KtitijoAR1oUwhuxQo5RV9uJGxH3iymE97n7Ccww4jMOo8fafDBnkGbob9K77Eej1ug==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.26.3.tgz",
+			"integrity": "sha512-INQr+Px9JTHafLinlyyhLKvDLdpFj01uP186/r30d4A2YPSmtjhtCPj/ZOsoz8kGBfaLfo9xoSj5zyKniMTPaw==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^0.26.2"
+				"@fluidframework/core-interfaces": "^0.26.3"
 			}
 		},
 		"@hapi/address": {
@@ -19782,25 +19782,25 @@
 			}
 		},
 		"old-aqueduct": {
-			"version": "npm:@fluidframework/aqueduct@0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.26.2.tgz",
-			"integrity": "sha512-95xWgxdImJua25sT9muAr3KnfcCWJ6E6fMEvO+I1nfKYI2LfOnmGoss88DRys5KFE5RlOmoNS2ocFbHOLLD7mw==",
+			"version": "npm:@fluidframework/aqueduct@0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.26.3.tgz",
+			"integrity": "sha512-/HOHn4GdOnjJnCOQgHR+dJx3QC7pgrx4xndnNaLa5bD5npFqtxj2ixOrq17uwDNh74+vjlq1oHaC3+dWtdnWgA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.2",
-				"@fluidframework/container-loader": "^0.26.2",
-				"@fluidframework/container-runtime": "^0.26.2",
-				"@fluidframework/container-runtime-definitions": "^0.26.2",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/datastore": "^0.26.2",
-				"@fluidframework/datastore-definitions": "^0.26.2",
-				"@fluidframework/map": "^0.26.2",
-				"@fluidframework/request-handler": "^0.26.2",
-				"@fluidframework/runtime-definitions": "^0.26.2",
-				"@fluidframework/runtime-utils": "^0.26.2",
-				"@fluidframework/synthesize": "^0.26.2",
-				"@fluidframework/view-interfaces": "^0.26.2",
+				"@fluidframework/container-definitions": "^0.26.3",
+				"@fluidframework/container-loader": "^0.26.3",
+				"@fluidframework/container-runtime": "^0.26.3",
+				"@fluidframework/container-runtime-definitions": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/datastore": "^0.26.3",
+				"@fluidframework/datastore-definitions": "^0.26.3",
+				"@fluidframework/map": "^0.26.3",
+				"@fluidframework/request-handler": "^0.26.3",
+				"@fluidframework/runtime-definitions": "^0.26.3",
+				"@fluidframework/runtime-utils": "^0.26.3",
+				"@fluidframework/synthesize": "^0.26.3",
+				"@fluidframework/view-interfaces": "^0.26.3",
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
@@ -19822,15 +19822,15 @@
 			}
 		},
 		"old-cell": {
-			"version": "npm:@fluidframework/cell@0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.26.2.tgz",
-			"integrity": "sha512-3vVB1Ejd/76oGSpKFLuOg5Ez+7eeoErvxWw3e8lKLqVEknSDA/n8rFuL+sj7jD06SqSaA5Q5tJiitNMEXr7rng==",
+			"version": "npm:@fluidframework/cell@0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.26.3.tgz",
+			"integrity": "sha512-oP5jyhP8iMiR9WFY1px4fK92u5RxNj4xOMiYzBGY7Qjl2JBt5FCse9/pXA+yfTMdUPrIXiInSNR0wSvh7wn5Dg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/datastore-definitions": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/datastore-definitions": "^0.26.3",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.2",
+				"@fluidframework/shared-object-base": "^0.26.3",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
@@ -19860,13 +19860,13 @@
 			}
 		},
 		"old-container-definitions": {
-			"version": "npm:@fluidframework/container-definitions@0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.26.2.tgz",
-			"integrity": "sha512-Kf6G50wGbW0pdqXT9CggWR0akdQlq3U2nM/WF7M0iUKDOCwQq84enmVHt++x2prG+5R6oUVOogoLootwHUY/Xw==",
+			"version": "npm:@fluidframework/container-definitions@0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.26.3.tgz",
+			"integrity": "sha512-UYm67C/32F3mRwC5kiKkkPx9I8OoBAs6c8HdGJRUS1zmeIJCbC06Zjc8ipVjY3vEl0QyCVhNIlEme10ZBFN1Eg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/driver-definitions": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/driver-definitions": "^0.26.3",
 				"@fluidframework/protocol-definitions": "^0.1012.0"
 			},
 			"dependencies": {
@@ -19881,20 +19881,20 @@
 			}
 		},
 		"old-container-loader": {
-			"version": "npm:@fluidframework/container-loader@0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.26.2.tgz",
-			"integrity": "sha512-/zqT6XzYPgjB+bugnnNYlUr+zxRqQjT/ZloYZ1Bcl+iOti9gbAC/vFy2+VPNznrph5ZASkeE5rSp7rE1cETIUg==",
+			"version": "npm:@fluidframework/container-loader@0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.26.3.tgz",
+			"integrity": "sha512-XWV+WsqKhXkrEqgWe77C76cSZHYMGw1PFR5E7qKs0qLoUvXYXWxYYRklCrY0H9SbpsyIVXD2c2YVaPiHLEsv7Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.2",
-				"@fluidframework/container-utils": "^0.26.2",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/driver-definitions": "^0.26.2",
-				"@fluidframework/driver-utils": "^0.26.2",
+				"@fluidframework/container-definitions": "^0.26.3",
+				"@fluidframework/container-utils": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/driver-definitions": "^0.26.3",
+				"@fluidframework/driver-utils": "^0.26.3",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/telemetry-utils": "^0.26.2",
+				"@fluidframework/telemetry-utils": "^0.26.3",
 				"@types/double-ended-queue": "^2.1.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -19945,25 +19945,25 @@
 			}
 		},
 		"old-container-runtime": {
-			"version": "npm:@fluidframework/container-runtime@0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.26.2.tgz",
-			"integrity": "sha512-pBDgv5dcQJATKSLk4J3SbQLedyCunXT3qVJzNW8KHffLpJU1xEM/ZvaJuL7Emku66FBFthq2K3LM8MWu00ywNQ==",
+			"version": "npm:@fluidframework/container-runtime@0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.26.3.tgz",
+			"integrity": "sha512-v70FiyLtSTBrsJ1OHdh26Wt3tpVCz6J4xwbPNtTPcajdJcJIJmojEtK0HGVH6jXhCOiSXpJEpAbSEdVa6zDo5w==",
 			"requires": {
-				"@fluidframework/agent-scheduler": "^0.26.2",
+				"@fluidframework/agent-scheduler": "^0.26.3",
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.2",
-				"@fluidframework/container-runtime-definitions": "^0.26.2",
-				"@fluidframework/container-utils": "^0.26.2",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/datastore": "^0.26.2",
-				"@fluidframework/driver-definitions": "^0.26.2",
-				"@fluidframework/driver-utils": "^0.26.2",
+				"@fluidframework/container-definitions": "^0.26.3",
+				"@fluidframework/container-runtime-definitions": "^0.26.3",
+				"@fluidframework/container-utils": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/datastore": "^0.26.3",
+				"@fluidframework/driver-definitions": "^0.26.3",
+				"@fluidframework/driver-utils": "^0.26.3",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.2",
-				"@fluidframework/runtime-utils": "^0.26.2",
-				"@fluidframework/telemetry-utils": "^0.26.2",
+				"@fluidframework/runtime-definitions": "^0.26.3",
+				"@fluidframework/runtime-utils": "^0.26.3",
+				"@fluidframework/telemetry-utils": "^0.26.3",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/node": "^10.17.24",
@@ -20016,15 +20016,15 @@
 			}
 		},
 		"old-datastore-definitions": {
-			"version": "npm:@fluidframework/datastore-definitions@0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.26.2.tgz",
-			"integrity": "sha512-fDYc8fdhmRvYAuPFq7udy4DKEQYnimWQAqSMsTKWgs5KMCHOcCZcmFh0Hd10lORzQ8m5G7FLPzvmkCRyEzAaLg==",
+			"version": "npm:@fluidframework/datastore-definitions@0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.26.3.tgz",
+			"integrity": "sha512-KsQBJZc+/uJFNJ6dgpNJbfLzcF9aL/VgD7DLVSLQ0AUsdkSyZ0hIYTHlGzjX7hN+7zyNI5GEpoZPkUj49uFtPA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.26.2",
-				"@fluidframework/core-interfaces": "^0.26.2",
+				"@fluidframework/container-definitions": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.3",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.2",
+				"@fluidframework/runtime-definitions": "^0.26.3",
 				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
@@ -20039,14 +20039,14 @@
 			}
 		},
 		"old-ink": {
-			"version": "npm:@fluidframework/ink@0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.26.2.tgz",
-			"integrity": "sha512-0mCB4zopVrtiL2NZrxkPvAXJF0NVjoA/7Tmyy/20F05wCzbhv4tj8soAjhivtQH5OaEdKniCnitzSDFlkY9H3w==",
+			"version": "npm:@fluidframework/ink@0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.26.3.tgz",
+			"integrity": "sha512-DRMloDUHwgG4t14QtHb6humixzZ0zWyvGhC0h5ODocwmmrStZtKvXz/ghBQYROqdfLjCv4vOU0t/Hu+Ys8y3sw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/datastore-definitions": "^0.26.2",
+				"@fluidframework/datastore-definitions": "^0.26.3",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.2",
+				"@fluidframework/shared-object-base": "^0.26.3",
 				"@types/debug": "^4.1.5",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
@@ -20078,17 +20078,17 @@
 			}
 		},
 		"old-local-driver": {
-			"version": "npm:@fluidframework/local-driver@0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.26.2.tgz",
-			"integrity": "sha512-aodH+ak2hjQwDOZOO6Ice4i0Htd/EN5H2cJj2n42frOWXjPKHqgcaEoZPTNVo3X7rI6FuCaCN4NCa8+CbXHIOg==",
+			"version": "npm:@fluidframework/local-driver@0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.26.3.tgz",
+			"integrity": "sha512-og6oLWYTH/RHyY11myzgqMZYbUzb/L8A0M1gvrlyFwkUnWHU5J+4tWPZ7F1hXGid7K+Y9E9KPE8F7Q0IG6nW2w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/driver-definitions": "^0.26.2",
-				"@fluidframework/driver-utils": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/driver-definitions": "^0.26.3",
+				"@fluidframework/driver-utils": "^0.26.3",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/routerlicious-driver": "^0.26.2",
+				"@fluidframework/routerlicious-driver": "^0.26.3",
 				"@fluidframework/server-local-server": "^0.1012.0",
 				"@fluidframework/server-services-client": "^0.1012.0",
 				"@fluidframework/server-services-core": "^0.1012.0",
@@ -20255,17 +20255,17 @@
 			}
 		},
 		"old-map": {
-			"version": "npm:@fluidframework/map@0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.26.2.tgz",
-			"integrity": "sha512-DFkIBTKYILOmC71OrpiXcGFCU7L9oNSwskD62hsfZMjAm3Ol5Uv7S8SkQ9KrdCsNzmi6Z09pOvE6X2dZakmbLQ==",
+			"version": "npm:@fluidframework/map@0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.26.3.tgz",
+			"integrity": "sha512-7oUlh7edCzcN5WS8lkg3J/RoPY/drf4mtLmTU6xM7cG8Ij8uN3ORjJtLn0wXtMS6EqKydiMBV4hGCab5Z0YNLg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/datastore-definitions": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/datastore-definitions": "^0.26.3",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.2",
+				"@fluidframework/shared-object-base": "^0.26.3",
 				"debug": "^4.1.1",
 				"path-browserify": "^1.0.1"
 			},
@@ -20313,19 +20313,19 @@
 			}
 		},
 		"old-matrix": {
-			"version": "npm:@fluidframework/matrix@0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.26.2.tgz",
-			"integrity": "sha512-XzbKzalk1MbD6fmd8pTEX1Zub1b++BM+O69rCkQezPzsvmJygGt+MC/VgucRT8rLQUH8L7Zx9DZDum4mcjfUgw==",
+			"version": "npm:@fluidframework/matrix@0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.26.3.tgz",
+			"integrity": "sha512-cKEBIVUNxKMI2+6alKXbL3wwaQB++EjcukzOz8fLf0Im7EdvNhWfQxoFBP5S7cNhB8BxoPU0H5iARkZluuiuEQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/datastore-definitions": "^0.26.2",
-				"@fluidframework/merge-tree": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/datastore-definitions": "^0.26.3",
+				"@fluidframework/merge-tree": "^0.26.3",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-utils": "^0.26.2",
-				"@fluidframework/shared-object-base": "^0.26.2",
-				"@fluidframework/telemetry-utils": "^0.26.2",
+				"@fluidframework/runtime-utils": "^0.26.3",
+				"@fluidframework/shared-object-base": "^0.26.3",
+				"@fluidframework/telemetry-utils": "^0.26.3",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"debug": "^4.1.1",
 				"tslib": "^1.10.0"
@@ -20357,14 +20357,14 @@
 			}
 		},
 		"old-ordered-collection": {
-			"version": "npm:@fluidframework/ordered-collection@0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.26.2.tgz",
-			"integrity": "sha512-MfTntHoOPHow3lKKXy3EAr4FwtH/PuxAFnZtC9WhE4k6zRVoyRHsu4I/HawmmnuZc6ZbyZbcZYwUaQIT0WFJ1g==",
+			"version": "npm:@fluidframework/ordered-collection@0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.26.3.tgz",
+			"integrity": "sha512-X/9wnqq0HeE5cVe50P2yv5rc6vQ9nBnpZ9CoireGx3NBngWed0KsQtjzpL08TkuSo5I9nAVWLCSAXfJTi7uJEQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/datastore-definitions": "^0.26.2",
+				"@fluidframework/datastore-definitions": "^0.26.3",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.2",
+				"@fluidframework/shared-object-base": "^0.26.3",
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
@@ -20394,14 +20394,14 @@
 			}
 		},
 		"old-register-collection": {
-			"version": "npm:@fluidframework/register-collection@0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.26.2.tgz",
-			"integrity": "sha512-TjZlz2GVBTRIE8sIqkg0Ic9iNAtXXRVNWj8HuyOMK9IrzdNC8mt+7RpNlCIhY63ZO18nNRfZ6OLip9y2vRvZWw==",
+			"version": "npm:@fluidframework/register-collection@0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.26.3.tgz",
+			"integrity": "sha512-6TeAiy0uR9F6LqxLznIHcQuV5R7j0ORk5dljGzpD9dbIlGVEugCYa2Ds5bLhF8NLtcL7cWffEHmx/8fJ1oIacw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/datastore-definitions": "^0.26.2",
+				"@fluidframework/datastore-definitions": "^0.26.3",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.2",
+				"@fluidframework/shared-object-base": "^0.26.3",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
@@ -20431,25 +20431,25 @@
 			}
 		},
 		"old-request-handler": {
-			"version": "npm:@fluidframework/request-handler@0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.26.2.tgz",
-			"integrity": "sha512-uEP8fhXI5B4gpURwGjpqkTUc3RkqMiOWEnlMxPecsAZRB63s436ru5wR/hrCyyr82uyf7z7PeNR7WfP6K3YRVQ==",
+			"version": "npm:@fluidframework/request-handler@0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.26.3.tgz",
+			"integrity": "sha512-2aSE4aHqkrSKcli/gHfBCed8bsQbfDGBTYfc73R4451OOjdig4+b09E5DYu6kDFlvZNRPWm0wQblR+dwpsJcTA==",
 			"requires": {
-				"@fluidframework/container-runtime-definitions": "^0.26.2",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/runtime-definitions": "^0.26.2",
-				"@fluidframework/runtime-utils": "^0.26.2"
+				"@fluidframework/container-runtime-definitions": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/runtime-definitions": "^0.26.3",
+				"@fluidframework/runtime-utils": "^0.26.3"
 			}
 		},
 		"old-runtime-definitions": {
-			"version": "npm:@fluidframework/runtime-definitions@0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.26.2.tgz",
-			"integrity": "sha512-j7IwsiLX/EeF/PiMfS/TrFf8vNrT+feCwD2ldAVGIyxdsJZivbPj3m1dqvYsHNBEZBftjhNe+IQnpuDJ6JGrfQ==",
+			"version": "npm:@fluidframework/runtime-definitions@0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.26.3.tgz",
+			"integrity": "sha512-V6LmLaePMhcM6wfSDe99/t2ACViVSYec8X4o9VTVYbJjyEgDnISAxAIYzvzz3kkhTLB5mMeQ2vMjNFc8TPed8w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.26.2",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/driver-definitions": "^0.26.2",
+				"@fluidframework/container-definitions": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/driver-definitions": "^0.26.3",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
 				"@types/node": "^10.17.24"
 			},
@@ -20465,20 +20465,20 @@
 			}
 		},
 		"old-sequence": {
-			"version": "npm:@fluidframework/sequence@0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.26.2.tgz",
-			"integrity": "sha512-N5SaK7wrC4/2TUCf12wN4f0ZwggDUt7xglT7DW5FyKsvPZv+YReTE+PRWf8aLk6YFh8b4wz1SbXKaviG3lDHkw==",
+			"version": "npm:@fluidframework/sequence@0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.26.3.tgz",
+			"integrity": "sha512-Vr8jY5Giqzwiu6eij5YwBJpU3dq/8HiiM2V6fFh7IwjEniq1a77ZxV8lLbWzibImdNEe/wvv3EgCsvdx8tRuUA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/datastore-definitions": "^0.26.2",
-				"@fluidframework/map": "^0.26.2",
-				"@fluidframework/merge-tree": "^0.26.2",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/datastore-definitions": "^0.26.3",
+				"@fluidframework/map": "^0.26.3",
+				"@fluidframework/merge-tree": "^0.26.3",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-utils": "^0.26.2",
-				"@fluidframework/shared-object-base": "^0.26.2",
-				"@fluidframework/telemetry-utils": "^0.26.2",
+				"@fluidframework/runtime-utils": "^0.26.3",
+				"@fluidframework/shared-object-base": "^0.26.3",
+				"@fluidframework/telemetry-utils": "^0.26.3",
 				"debug": "^4.1.1",
 				"lodash": "^4.17.19"
 			},
@@ -20509,23 +20509,23 @@
 			}
 		},
 		"old-test-utils": {
-			"version": "npm:@fluidframework/test-utils@0.26.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.26.2.tgz",
-			"integrity": "sha512-R4Orjn24vxEnf4V1jyE6YGSIM9nOCAuwHRcq8w0poc1WAHbns8TEfeAQ+RLR0LdtgrWSu96AcLsP1QnBvuKxkg==",
+			"version": "npm:@fluidframework/test-utils@0.26.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.26.3.tgz",
+			"integrity": "sha512-7eM5pP/6QS8SKJ+7vjG+MGtOVTT3Vqoif9lFpLpVRtVjyiGsk8Y3G0k+GxV8jcer5FWVZKdHI819eqYD1RYCfg==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.26.2",
-				"@fluidframework/container-definitions": "^0.26.2",
-				"@fluidframework/container-loader": "^0.26.2",
-				"@fluidframework/container-runtime": "^0.26.2",
-				"@fluidframework/core-interfaces": "^0.26.2",
-				"@fluidframework/datastore": "^0.26.2",
-				"@fluidframework/datastore-definitions": "^0.26.2",
-				"@fluidframework/driver-definitions": "^0.26.2",
-				"@fluidframework/local-driver": "^0.26.2",
-				"@fluidframework/map": "^0.26.2",
+				"@fluidframework/aqueduct": "^0.26.3",
+				"@fluidframework/container-definitions": "^0.26.3",
+				"@fluidframework/container-loader": "^0.26.3",
+				"@fluidframework/container-runtime": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/datastore": "^0.26.3",
+				"@fluidframework/datastore-definitions": "^0.26.3",
+				"@fluidframework/driver-definitions": "^0.26.3",
+				"@fluidframework/local-driver": "^0.26.3",
+				"@fluidframework/map": "^0.26.3",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/request-handler": "^0.26.2",
-				"@fluidframework/runtime-definitions": "^0.26.2",
+				"@fluidframework/request-handler": "^0.26.3",
+				"@fluidframework/runtime-definitions": "^0.26.3",
 				"@fluidframework/server-local-server": "^0.1012.0"
 			},
 			"dependencies": {

--- a/packages/drivers/iframe-driver/src/outerDocumentServiceFactory.ts
+++ b/packages/drivers/iframe-driver/src/outerDocumentServiceFactory.ts
@@ -17,7 +17,6 @@ import {
 } from "@fluidframework/driver-definitions";
 import {
     IClient,
-    IContentMessage,
     IDocumentMessage,
     IVersion,
     ISummaryTree,
@@ -208,7 +207,6 @@ export class DocumentServiceFactoryProxy implements IDocumentServiceFactoryProxy
             clientId: deltaStream.clientId,
             existing: deltaStream.existing,
             get initialClients() { return deltaStream.initialClients; },
-            get initialContents() { return [] as IContentMessage[]; },
             get initialMessages() { return deltaStream.initialMessages; },
             get initialSignals() { return deltaStream.initialSignals; },
             maxMessageSize: deltaStream.maxMessageSize,

--- a/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
@@ -199,7 +199,6 @@ export class ReplayDocumentDeltaConnection
             claims: ReplayDocumentDeltaConnection.claims,
             clientId: "",
             existing: true,
-            initialContents: [],
             initialMessages: [],
             initialSignals: [],
             initialClients: [],

--- a/packages/test/end-to-end-tests/src/test/compatUtils.ts
+++ b/packages/test/end-to-end-tests/src/test/compatUtils.ts
@@ -145,7 +145,11 @@ export const createOldRuntimeFactory = (
     dataStoreFactory: IFluidDataStoreFactory | old.IFluidDataStoreFactory,
     runtimeOptions: old.IContainerRuntimeOptions = { initialSummarizerDelayMs: 0 },
 ): old.IRuntimeFactory => {
-    return new old.TestContainerRuntimeFactory(type, dataStoreFactory as old.IFluidDataStoreFactory, runtimeOptions);
+    // TODO: when the old version of 0.27 is released this can use the old version of TestContainerRuntimeFactory
+    // with the default data store
+    // return new old.TestContainerRuntimeFactory(type, dataStoreFactory as old.IFluidDataStoreFactory, runtimeOptions);
+    const factory = new TestContainerRuntimeFactory(type, dataStoreFactory as IFluidDataStoreFactory, runtimeOptions);
+    return factory as unknown as old.IRuntimeFactory;
 };
 
 export function createLoader(

--- a/packages/test/end-to-end-tests/src/test/compatUtils.ts
+++ b/packages/test/end-to-end-tests/src/test/compatUtils.ts
@@ -145,10 +145,7 @@ export const createOldRuntimeFactory = (
     dataStoreFactory: IFluidDataStoreFactory | old.IFluidDataStoreFactory,
     runtimeOptions: old.IContainerRuntimeOptions = { initialSummarizerDelayMs: 0 },
 ): old.IRuntimeFactory => {
-    // TODO: once 0.26 is released this can use the old version of TestContainerRuntimeFactory:
-    // return new old.TestContainerRuntimeFactory(type, dataStoreFactory as old.IFluidDataStoreFactory, runtimeOptions);
-    const factory = new TestContainerRuntimeFactory(type, dataStoreFactory as IFluidDataStoreFactory, runtimeOptions);
-    return factory as unknown as old.IRuntimeFactory;
+    return new old.TestContainerRuntimeFactory(type, dataStoreFactory as old.IFluidDataStoreFactory, runtimeOptions);
 };
 
 export function createLoader(
@@ -271,7 +268,7 @@ export const compatTest = (
                 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                 { summary: { maxOps: 1 } as ISummaryConfiguration },
             );
-            documentServiceFactory = new old.LocalDocumentServiceFactory(deltaConnectionServer);
+            documentServiceFactory = new old.LocalDocumentServiceFactory(deltaConnectionServer as any);
             defaultResolver = new LocalResolver();
         });
 

--- a/tools/build-tools/src/bumpVersion/utils.ts
+++ b/tools/build-tools/src/bumpVersion/utils.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { execWithErrorAsync, execAsync } from "../common/utils";
+import { execAsync } from "../common/utils";
 
 export function fatal(error: string): never {
     const e = new Error(error);
@@ -19,9 +19,7 @@ export function fatal(error: string): never {
  * @param error description of command line to print when error happens
  */
 export async function exec(cmd: string, dir: string, error: string, pipeStdIn?: string) {
-    // TODO: Remove env once publish to the public feed.
-    const env = process.env["NPM_TOKEN"]? process.env : { ...process.env, "NPM_TOKEN": "" };
-    const result = await execAsync(cmd, { cwd: dir, env }, pipeStdIn);
+    const result = await execAsync(cmd, { cwd: dir }, pipeStdIn);
     if (result.error) {
         fatal(`ERROR: Unable to ${error}\nERROR: error during command ${cmd}\nERROR: ${result.error.message}`);
     }

--- a/tools/build-tools/src/common/monoRepo.ts
+++ b/tools/build-tools/src/common/monoRepo.ts
@@ -38,11 +38,9 @@ export class MonoRepo {
     }
 
     public async install() {
-        // TODO: Remove env once publish to the public feed.
-        const env = process.env["NPM_TOKEN"]? process.env : { ...process.env, "NPM_TOKEN": "" };
         console.log(`${MonoRepoKind[this.kind]}: Installing - npm i`);
         const installScript = "npm i";
-        return execWithErrorAsync(installScript, { cwd: this.repoPath, env }, this.repoPath);
+        return execWithErrorAsync(installScript, { cwd: this.repoPath }, this.repoPath);
     }
     public async uninstall() {
         return rimrafWithErrorAsync(this.getNodeModulePath(), this.repoPath);


### PR DESCRIPTION
Follow up to PR #3818 to remove the rest of IContentMessage after updating the server dependency

Also remove no longer needed code in fluid-build tools for NPM_TOKEN env
