### PR TITLE
Website CTAs: use hover styles when focusing to avoid inaccessible text 

### DIFF
--- a/docs/assets/css/fluid.css
+++ b/docs/assets/css/fluid.css
@@ -51,7 +51,7 @@ footer {
     padding-left: 0;
 }
 
-.cta:hover {
+.cta:hover, .cta:focus {
     text-decoration: none;
     transition: none;
     background: #5a5a66;


### PR DESCRIPTION
Focus Before:

![image](https://user-images.githubusercontent.com/1434956/95387087-1d5a1100-08a5-11eb-86af-8ffca04ead08.png)

![image](https://user-images.githubusercontent.com/1434956/95387238-48dcfb80-08a5-11eb-91db-b6b2832d00e8.png)


Focus After:

![image](https://user-images.githubusercontent.com/1434956/95387168-3236a480-08a5-11eb-9c8e-9ae293459a9a.png)

![image](https://user-images.githubusercontent.com/1434956/95387247-4e3a4600-08a5-11eb-9d78-f167cef8349b.png)
