### PR TITLE
fix: correctly update customData in Riddler

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
@@ -170,7 +170,7 @@ export class TenantManager {
         const db = await this.mongoManager.getDatabase();
         const collection = db.collection<ITenantDocument>(this.collectionName);
 
-        await collection.update({ _id: tenantId }, customData, null);
+        await collection.update({ _id: tenantId }, { customData }, null);
 
         return (await this.getTenantDocument(tenantId)).customData;
     }


### PR DESCRIPTION
`updateCustomData` was missing `{}` around `customData` in collection update doc.