### PR TITLE
Change return type of serialize container api.

### DIFF
--- a/packages/loader/container-definitions/src/loader.ts
+++ b/packages/loader/container-definitions/src/loader.ts
@@ -9,7 +9,6 @@ import {
     IDocumentMessage,
     IQuorum,
     ISequencedDocumentMessage,
-    ISnapshotTree,
 } from "@fluidframework/protocol-definitions";
 import { IResolvedUrl } from "@fluidframework/driver-definitions";
 import { IEvent, IEventProvider } from "@fluidframework/common-definitions";

--- a/packages/loader/container-definitions/src/loader.ts
+++ b/packages/loader/container-definitions/src/loader.ts
@@ -125,7 +125,7 @@ export interface IContainer extends IEventProvider<IContainerEvents>, IFluidRout
     /**
      * Extract the snapshot from the detached container.
      */
-    serialize(): ISnapshotTree;
+    serialize(): string;
 
     /**
      * Get an absolute url for a provided container-relative request url.
@@ -165,7 +165,7 @@ export interface ILoader extends IFluidRouter {
      * Creates a new container using the specified snapshot but in an unattached state. While unattached all
      * updates will only be local until the user explicitly attaches the container to a service provider.
      */
-    rehydrateDetachedContainerFromSnapshot(snapshot: ISnapshotTree): Promise<IContainer>;
+    rehydrateDetachedContainerFromSnapshot(snapshot: string): Promise<IContainer>;
 }
 
 /**

--- a/packages/loader/container-definitions/src/loader.ts
+++ b/packages/loader/container-definitions/src/loader.ts
@@ -125,7 +125,7 @@ export interface IContainer extends IEventProvider<IContainerEvents>, IFluidRout
     /**
      * Extract the snapshot from the detached container.
      */
-    serialize(): string;
+    serialize(): ISnapshotTree;
 
     /**
      * Get an absolute url for a provided container-relative request url.

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -499,12 +499,13 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         return this._attachState;
     }
 
-    public serialize(): ISnapshotTree {
+    public serialize(): string {
         assert.strictEqual(this.attachState, AttachState.Detached, "Should only be called in detached container");
 
         const appSummary: ISummaryTree = this.context.createSummary();
         const protocolSummary = this.protocolHandler.captureSummary();
-        return convertProtocolAndAppSummaryToSnapshotTree(protocolSummary, appSummary);
+        const snapshotTree = convertProtocolAndAppSummaryToSnapshotTree(protocolSummary, appSummary);
+        return JSON.stringify(snapshotTree);
     }
 
     public async attach(request: IRequest): Promise<void> {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -499,13 +499,12 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         return this._attachState;
     }
 
-    public serialize(): string {
+    public serialize(): ISnapshotTree {
         assert.strictEqual(this.attachState, AttachState.Detached, "Should only be called in detached container");
 
         const appSummary: ISummaryTree = this.context.createSummary();
         const protocolSummary = this.protocolHandler.captureSummary();
-        const snapshotTree = convertProtocolAndAppSummaryToSnapshotTree(protocolSummary, appSummary);
-        return JSON.stringify(snapshotTree);
+        return convertProtocolAndAppSummaryToSnapshotTree(protocolSummary, appSummary);
     }
 
     public async attach(request: IRequest): Promise<void> {

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -28,7 +28,7 @@ import {
     IResolvedUrl,
     IUrlResolver,
 } from "@fluidframework/driver-definitions";
-import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
+import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import {
     ensureFluidResolvedUrl,
     MultiUrlResolver,

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -106,7 +106,7 @@ export class RelativeLoader extends EventEmitter implements ILoader {
         throw new Error("Relative loader should not create a detached container");
     }
 
-    public async rehydrateDetachedContainerFromSnapshot(source: ISnapshotTree): Promise<Container> {
+    public async rehydrateDetachedContainerFromSnapshot(source: string): Promise<Container> {
         throw new Error("Relative loader should not create a detached container from snapshot");
     }
 
@@ -181,7 +181,7 @@ export class Loader extends EventEmitter implements ILoader {
             this.subLogger);
     }
 
-    public async rehydrateDetachedContainerFromSnapshot(snapshot: ISnapshotTree): Promise<Container> {
+    public async rehydrateDetachedContainerFromSnapshot(snapshot: string): Promise<Container> {
         debug(`Container creating in detached state: ${performance.now()} `);
 
         return Container.create(
@@ -190,7 +190,7 @@ export class Loader extends EventEmitter implements ILoader {
             this.scope,
             this,
             {
-                snapshot,
+                snapshot: JSON.parse(snapshot),
                 create: false,
             },
             this.documentServiceFactory,

--- a/packages/loader/execution-context-loader/src/webWorkerLoader.ts
+++ b/packages/loader/execution-context-loader/src/webWorkerLoader.ts
@@ -76,7 +76,7 @@ export class WebWorkerLoader implements ILoader, IFluidRunnable, IFluidRouter {
         return this.proxy.createDetachedContainer(source);
     }
 
-    public async rehydrateDetachedContainerFromSnapshot(source: ISnapshotTree): Promise<IContainer> {
+    public async rehydrateDetachedContainerFromSnapshot(source: string): Promise<IContainer> {
         return this.proxy.rehydrateDetachedContainerFromSnapshot(source);
     }
 }

--- a/packages/loader/execution-context-loader/src/webWorkerLoader.ts
+++ b/packages/loader/execution-context-loader/src/webWorkerLoader.ts
@@ -10,7 +10,6 @@ import {
     IResponse,
 } from "@fluidframework/core-interfaces";
 import { IContainer, ILoader, IFluidCodeDetails } from "@fluidframework/container-definitions";
-import { ISnapshotTree } from "@fluidframework/protocol-definitions";
 import { IFluidResolvedUrl } from "@fluidframework/driver-definitions";
 import Comlink from "comlink";
 

--- a/packages/test/end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -108,7 +108,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
     it("Dehydrated container snapshot", async () => {
         const { container } =
             await createDetachedContainerAndGetRootDataStore();
-        const snapshotTree = JSON.parse(container.serialize());
+        const snapshotTree = container.serialize();
 
         assert.strictEqual(Object.keys(snapshotTree.trees).length, 3,
             "3 trees should be there(protocol, default dataStore, scheduler");
@@ -132,12 +132,12 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
     it("Dehydrated container snapshot 2 times with changes in between", async () => {
         const { container, defaultDataStore } =
             await createDetachedContainerAndGetRootDataStore();
-        const snapshotTree1 = JSON.parse(container.serialize());
+        const snapshotTree1 = container.serialize();
         // Create a channel
         const channel = defaultDataStore.runtime.createChannel("test1",
             "https://graph.microsoft.com/types/map") as SharedMap;
         channel.bindToContext();
-        const snapshotTree2 = JSON.parse(container.serialize());
+        const snapshotTree2 = container.serialize();
 
         assert.strictEqual(JSON.stringify(Object.keys(snapshotTree1.trees)),
             JSON.stringify(Object.keys(snapshotTree2.trees)),
@@ -172,7 +172,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         const rootOfDataStore1 = await defaultDataStore.getSharedObject<SharedMap>(sharedMapId);
         rootOfDataStore1.set("dataStore2", dataStore2.handle);
 
-        const snapshotTree = JSON.parse(container.serialize());
+        const snapshotTree = container.serialize();
 
         assert.strictEqual(Object.keys(snapshotTree.trees).length, 4, "4 trees should be there");
         assert(snapshotTree.trees[dataStore2.runtime.id], "Handle Bounded dataStore should be in summary");
@@ -182,7 +182,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         const { container } =
             await createDetachedContainerAndGetRootDataStore();
 
-        const snapshotTree = JSON.parse(container.serialize());
+        const snapshotTree = container.serialize();
 
         const container2 = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree);
 
@@ -225,7 +225,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         const { container } =
             await createDetachedContainerAndGetRootDataStore();
 
-        const snapshotTree = JSON.parse(container.serialize());
+        const snapshotTree = container.serialize();
 
         const container2 = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree);
         await container2.attach(request);
@@ -274,7 +274,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         const sharedStringBefore = await defaultDataStoreBefore.getSharedObject<SharedString>(sharedStringId);
         sharedStringBefore.insertText(0, "Hello");
 
-        const snapshotTree = JSON.parse(container.serialize());
+        const snapshotTree = container.serialize();
 
         const container2 = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree);
 
@@ -293,7 +293,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         const defaultComponent1 = response1.value as TestFluidObject;
         const sharedString1 = await defaultComponent1.getSharedObject<SharedString>(sharedStringId);
         sharedString1.insertText(0, str);
-        const snapshotTree = JSON.parse(container.serialize());
+        const snapshotTree = container.serialize();
 
         const container2 = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree);
         const responseBefore = await container2.request({ url: "/" });
@@ -327,7 +327,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         peerDataStore.peerDataStoreRuntimeChannel.bindToContext();
         const sharedMap1 = await dataStore2.getSharedObject<SharedMap>(sharedMapId);
         sharedMap1.set("0", "A");
-        const snapshotTree = JSON.parse(container.serialize());
+        const snapshotTree = container.serialize();
 
         const rehydratedContainer = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree);
         await rehydratedContainer.attach(request);
@@ -370,7 +370,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         peerDataStore.peerDataStoreRuntimeChannel.bindToContext();
         const sharedMap1 = await dataStore2.getSharedObject<SharedMap>(sharedMapId);
         sharedMap1.set("0", "A");
-        const snapshotTree = JSON.parse(container.serialize());
+        const snapshotTree = container.serialize();
 
         const rehydratedContainer = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree);
         await rehydratedContainer.attach(request);
@@ -413,7 +413,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         const rootOfDataStore1 = await defaultDataStore.getSharedObject<SharedMap>(sharedMapId);
         rootOfDataStore1.set("dataStore2", dataStore2.handle);
 
-        const snapshotTree = JSON.parse(container.serialize());
+        const snapshotTree = container.serialize();
         const rehydratedContainer = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree);
 
         const response = await rehydratedContainer.request({ url: `/${dataStore2.context.id}` });
@@ -433,7 +433,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         const rootOfDataStore1 = await defaultDataStore.getSharedObject<SharedMap>(sharedMapId);
         rootOfDataStore1.set("dd2", dds2.handle);
 
-        const snapshotTree = JSON.parse(container.serialize());
+        const snapshotTree = container.serialize();
         const rehydratedContainer = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree);
 
         const response = await rehydratedContainer.request({ url: `/${defaultDataStore.runtime.id}/${ddsId}` });
@@ -461,7 +461,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         const rootOfDataStore1 = await defaultDataStore.getSharedObject<SharedMap>(sharedMapId);
         rootOfDataStore1.set("dd2", dds2.handle);
 
-        const snapshotTree = JSON.parse(container.serialize());
+        const snapshotTree = container.serialize();
         const rehydratedContainer = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree);
 
         const responseForDDS = await rehydratedContainer.request({ url: `/${defaultDataStore.runtime.id}/${ddsId}` });
@@ -495,7 +495,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         const rootOfDataStore1 = await defaultDataStore.getSharedObject<SharedMap>(sharedMapId);
         rootOfDataStore1.set("dataStore2", dataStore2.handle);
 
-        const snapshotTree = JSON.parse(container.serialize());
+        const snapshotTree = container.serialize();
         const rehydratedContainer = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree);
 
         const responseForDDS = await rehydratedContainer.request({ url: `/${dataStore2.runtime.id}/${ddsId}` });
@@ -517,7 +517,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         // Create another not bounded dataStore
         await createPeerDataStore(defaultDataStore.context.containerRuntime);
 
-        const snapshotTree = JSON.parse(container.serialize());
+        const snapshotTree = container.serialize();
 
         assert.strictEqual(Object.keys(snapshotTree.trees).length, 3,
             "3 trees should be there(protocol, default dataStore, scheduler). Not bounded/Unreferenced " +

--- a/packages/test/end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -36,7 +36,6 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         package: "detachedContainerTestPackage1",
         config: {},
     };
-
     const sharedStringId = "ss1Key";
     const sharedMapId = "sm1Key";
     const crcId = "crc1Key";

--- a/packages/test/end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -108,7 +108,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
     it("Dehydrated container snapshot", async () => {
         const { container } =
             await createDetachedContainerAndGetRootDataStore();
-        const snapshotTree = container.serialize();
+        const snapshotTree = JSON.parse(container.serialize());
 
         assert.strictEqual(Object.keys(snapshotTree.trees).length, 3,
             "3 trees should be there(protocol, default dataStore, scheduler");
@@ -132,12 +132,12 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
     it("Dehydrated container snapshot 2 times with changes in between", async () => {
         const { container, defaultDataStore } =
             await createDetachedContainerAndGetRootDataStore();
-        const snapshotTree1 = container.serialize();
+        const snapshotTree1 = JSON.parse(container.serialize());
         // Create a channel
         const channel = defaultDataStore.runtime.createChannel("test1",
             "https://graph.microsoft.com/types/map") as SharedMap;
         channel.bindToContext();
-        const snapshotTree2 = container.serialize();
+        const snapshotTree2 = JSON.parse(container.serialize());
 
         assert.strictEqual(JSON.stringify(Object.keys(snapshotTree1.trees)),
             JSON.stringify(Object.keys(snapshotTree2.trees)),
@@ -172,7 +172,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         const rootOfDataStore1 = await defaultDataStore.getSharedObject<SharedMap>(sharedMapId);
         rootOfDataStore1.set("dataStore2", dataStore2.handle);
 
-        const snapshotTree = container.serialize();
+        const snapshotTree = JSON.parse(container.serialize());
 
         assert.strictEqual(Object.keys(snapshotTree.trees).length, 4, "4 trees should be there");
         assert(snapshotTree.trees[dataStore2.runtime.id], "Handle Bounded dataStore should be in summary");
@@ -517,7 +517,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         // Create another not bounded dataStore
         await createPeerDataStore(defaultDataStore.context.containerRuntime);
 
-        const snapshotTree = container.serialize();
+        const snapshotTree = JSON.parse(container.serialize());
 
         assert.strictEqual(Object.keys(snapshotTree.trees).length, 3,
             "3 trees should be there(protocol, default dataStore, scheduler). Not bounded/Unreferenced " +

--- a/packages/test/end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -36,6 +36,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         package: "detachedContainerTestPackage1",
         config: {},
     };
+
     const sharedStringId = "ss1Key";
     const sharedMapId = "sm1Key";
     const crcId = "crc1Key";

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -371,7 +371,7 @@ async function attachContainer(
             const listItem = document.createElement("option");
             listItem.innerText = `Summary_${summaryNum}`;
             summaryNum += 1;
-            listItem.value = summary;
+            listItem.value = JSON.stringify(summary);
             summaryList.appendChild(listItem);
             rehydrateButton.onclick = async () => {
                 const snapshot = summaryList.value;

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -371,11 +371,11 @@ async function attachContainer(
             const listItem = document.createElement("option");
             listItem.innerText = `Summary_${summaryNum}`;
             summaryNum += 1;
-            listItem.value = JSON.stringify(summary);
+            listItem.value = summary;
             summaryList.appendChild(listItem);
             rehydrateButton.onclick = async () => {
                 const snapshot = summaryList.value;
-                currentContainer = await loader.rehydrateDetachedContainerFromSnapshot(JSON.parse(snapshot));
+                currentContainer = await loader.rehydrateDetachedContainerFromSnapshot(snapshot);
                 let newLeftDiv: HTMLDivElement;
                 if (rightDiv !== undefined) {
                     newLeftDiv = makeSideBySideDiv(uuid());


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/3832
Change return type of serialize container api so that host can return what it gets from serailize().
Also host don't have to depend on how we serialized it.