### PR TITLE
Push socketio dependency down into DocumentDeltaConnections

### DIFF
--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -35,7 +35,8 @@
     "@types/debug": "^4.1.5",
     "@types/node": "^10.17.24",
     "@types/socket.io-client": "^1.4.32",
-    "debug": "^4.1.1"
+    "debug": "^4.1.1",
+    "socket.io-client": "^2.1.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -19,6 +19,7 @@ import {
     ISignalMessage,
     ITokenClaims,
 } from "@fluidframework/protocol-definitions";
+import io from "socket.io-client";
 import { debug } from "./debug";
 
 const protocolVersions = ["^0.4.0", "^0.3.0", "^0.2.0", "^0.1.0"];
@@ -58,9 +59,7 @@ export class DocumentDeltaConnection
      * @param tenantId - the ID of the tenant
      * @param id - document ID
      * @param token - authorization token for storage service
-     * @param io - websocket library
      * @param client - information about the client
-     * @param mode - connection mode
      * @param url - websocket URL
      * @param timeoutMs - timeout for socket connection attempt in milliseconds (default: 20000)
      */
@@ -68,7 +67,6 @@ export class DocumentDeltaConnection
         tenantId: string,
         id: string,
         token: string | null,
-        io: SocketIOClientStatic,
         client: IClient,
         url: string,
         timeoutMs: number = 20000): Promise<IDocumentDeltaConnection> {

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactory.ts
@@ -7,7 +7,6 @@ import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
 import { HostStoragePolicy } from "./contracts";
 import { IPersistedCache } from "./odspCache";
 import { OdspDocumentServiceFactoryCore } from "./odspDocumentServiceFactoryCore";
-import { getSocketIo } from "./getSocketIo";
 import { StorageTokenFetcher, PushTokenFetcher } from "./tokenFetch";
 
 /**
@@ -26,7 +25,6 @@ export class OdspDocumentServiceFactory
         super(
             getStorageToken,
             getWebsocketToken,
-            async () => getSocketIo(),
             persistedCache,
             hostPolicy,
         );

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -100,7 +100,6 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
     constructor(
         private readonly getStorageToken: StorageTokenFetcher,
         private readonly getWebsocketToken: PushTokenFetcher,
-        private readonly getSocketIOClient: () => Promise<SocketIOClientStatic>,
         protected persistedCache: IPersistedCache = new LocalPersistentCache(),
         private readonly hostPolicy: HostStoragePolicy = {},
     ) {
@@ -121,7 +120,6 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
             this.toInstrumentedStorageTokenFetcher(odspLogger, resolvedUrl as IOdspResolvedUrl, this.getStorageToken),
             this.toInstrumentedPushTokenFetcher(odspLogger, this.getWebsocketToken),
             odspLogger,
-            this.getSocketIOClient,
             cache,
             this.hostPolicy,
         );

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryWithCodeSplit.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryWithCodeSplit.ts
@@ -21,7 +21,6 @@ export class OdspDocumentServiceFactoryWithCodeSplit
         super(
             getStorageToken,
             getWebsocketToken,
-            async () => import("./getSocketIo").then((m) => m.getSocketIo()),
             persistedCache,
             hostPolicy,
         );

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -41,7 +41,6 @@
     "debug": "^4.1.1",
     "isomorphic-ws": "^4.0.1",
     "jwt-decode": "^2.2.0",
-    "socket.io-client": "^2.1.1",
     "ws": "^6.1.2"
   },
   "devDependencies": {

--- a/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
+++ b/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
@@ -58,7 +58,6 @@ export class R11sDocumentDeltaConnection extends DocumentDeltaConnection impleme
         tenantId: string,
         id: string,
         token: string | null,
-        io: SocketIOClientStatic,
         client: IClient,
         url: string): Promise<IDocumentDeltaConnection> {
         try {
@@ -66,7 +65,6 @@ export class R11sDocumentDeltaConnection extends DocumentDeltaConnection impleme
                 tenantId,
                 id,
                 token,
-                io,
                 client,
                 url,
             );

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -8,7 +8,6 @@ import * as api from "@fluidframework/driver-definitions";
 import { IClient, IErrorTrackingService } from "@fluidframework/protocol-definitions";
 import { GitManager, Historian, ICredentials, IGitCache } from "@fluidframework/server-services-client";
 import Axios from "axios";
-import io from "socket.io-client";
 import { DeltaStorageService, DocumentDeltaStorageService } from "./deltaStorageService";
 import { DocumentStorageService } from "./documentStorageService";
 import { R11sDocumentDeltaConnection } from "./documentDeltaConnection";
@@ -107,7 +106,6 @@ export class DocumentService implements api.IDocumentService {
             this.tenantId,
             this.documentId,
             this.tokenProvider.token,
-            io,
             client,
             this.ordererUrl);
     }


### PR DESCRIPTION
Currently, the socket.io dependency is passed through several driver classes/packages (`DocumentServiceFactory`, `DocumentService`, `DocumentDeltaConnection`) but is only actually used in the `DocumentDeltaConnection`.  The goal of this change is to consolidate awareness of the dependency to the `DocumentDeltaConnection`.