### PR TITLE
joinSession: Incorrectly handle of no token, resulting in critical error.

### DIFF
--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -35,13 +35,10 @@ export async function fetchJoinSession(
     path: string,
     method: string,
     logger: ITelemetryLogger,
-    getVroomToken: (options: TokenFetchOptions, name?: string) => Promise<string | null>,
+    getStorageToken: (options: TokenFetchOptions, name?: string) => Promise<string | null>,
 ): Promise<ISocketStorageDiscovery> {
     return getWithRetryForTokenRefresh(async (options) => {
-        const token = await getVroomToken(options, "JoinSession");
-        if (!token) {
-            throwOdspNetworkError("Failed to acquire Vroom token", fetchIncorrectResponse);
-        }
+        const token = await getStorageToken(options, "JoinSession");
 
         const extraProps = options.refresh ? { secondAttempt: 1, hasClaims: !!options.claims } : {};
         return PerformanceEvent.timedExecAsync(logger, { eventName: "JoinSession", ...extraProps }, async (event) => {

--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -12,10 +12,6 @@ import {
     getOrigin,
 } from "./odspUtils";
 import { getApiRoot } from "./odspUrlHelper";
-import {
-    fetchIncorrectResponse,
-    throwOdspNetworkError,
-} from "./odspError";
 import { TokenFetchOptions } from "./tokenFetch";
 
 /**


### PR DESCRIPTION
We should follow same pattern as everywhere else - go with no token if that was returned..
