### PR TITLE
Cache Container on attach

### DIFF
--- a/packages/loader/container-loader/src/index.ts
+++ b/packages/loader/container-loader/src/index.ts
@@ -8,3 +8,4 @@ export * from "./container";
 export * from "./deltaManager";
 export * from "./loader";
 export * from "./networkUtils";
+export * from "./utils";

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -36,7 +36,7 @@ import {
 } from "@fluidframework/driver-utils";
 import { Container } from "./container";
 import { debug } from "./debug";
-import { IParsedUrl, parseUrl } from "./utils";
+import { IParsedUrl, parseHeader, parseUrl } from "./utils";
 
 function canUseCache(request: IRequest): boolean {
     if (request.headers === undefined) {
@@ -178,6 +178,7 @@ export class Loader extends EventEmitter implements ILoader {
             },
             this.documentServiceFactory,
             this.resolver,
+            this.containers,
             this.subLogger);
     }
 
@@ -195,6 +196,7 @@ export class Loader extends EventEmitter implements ILoader {
             },
             this.documentServiceFactory,
             this.resolver,
+            this.containers,
             this.subLogger);
     }
 
@@ -230,7 +232,7 @@ export class Loader extends EventEmitter implements ILoader {
                 return Promise.reject(`Invalid URL ${resolvedAsFluid.url}`);
             }
             const { fromSequenceNumber } =
-                this.parseHeader(parsed, { url: baseUrl, headers: request.headers });
+                parseHeader(parsed, { url: baseUrl, headers: request.headers });
             const proxyLoader = await proxyLoaderFactory.createProxyLoader(
                 parsed.id,
                 this.options,
@@ -254,7 +256,7 @@ export class Loader extends EventEmitter implements ILoader {
         }
 
         request.headers = request.headers ?? {};
-        const { canCache, fromSequenceNumber } = this.parseHeader(parsed, request);
+        const { canCache, fromSequenceNumber } = parseHeader(parsed, request);
 
         debug(`${canCache} ${request.headers[LoaderHeader.pause]} ${request.headers[LoaderHeader.version]}`);
 
@@ -297,42 +299,6 @@ export class Loader extends EventEmitter implements ILoader {
         }
 
         return { container, parsed };
-    }
-
-    private canUseCache(request: IRequest): boolean {
-        if (request.headers === undefined) {
-            return true;
-        }
-
-        const noCache =
-            request.headers[LoaderHeader.cache] === false ||
-            request.headers[LoaderHeader.reconnect] === false ||
-            request.headers[LoaderHeader.pause] === true;
-
-        return !noCache;
-    }
-
-    private parseHeader(parsed: IParsedUrl, request: IRequest) {
-        let fromSequenceNumber = -1;
-
-        request.headers = request.headers ?? {};
-
-        const headerSeqNum = request.headers[LoaderHeader.sequenceNumber];
-        if (headerSeqNum !== undefined) {
-            fromSequenceNumber = headerSeqNum;
-        }
-
-        // If set in both query string and headers, use query string
-        request.headers[LoaderHeader.version] = parsed.version ?? request.headers[LoaderHeader.version];
-
-        // Version === null means not use any snapshot.
-        if (request.headers[LoaderHeader.version] === "null") {
-            request.headers[LoaderHeader.version] = null;
-        }
-        return {
-            canCache: this.canUseCache(request),
-            fromSequenceNumber,
-        };
     }
 
     private async loadContainer(

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -216,9 +216,7 @@ export class Loader extends EventEmitter implements ILoader {
         const { canCache } = this.parseHeader(parsedUrl, request);
 
         if (canCache) {
-            const versionedId = request.headers?.[LoaderHeader.version] !== undefined
-                ? `${parsedUrl.id}@${request.headers[LoaderHeader.version]}`
-                : parsedUrl.id;
+            const versionedId = this.getKeyForContainerCache(request, parsedUrl);
             this.containers.set(versionedId, Promise.resolve(container));
         }
     }
@@ -252,6 +250,13 @@ export class Loader extends EventEmitter implements ILoader {
         }
     }
 
+    private getKeyForContainerCache(request: IRequest, parsedUrl: IParsedUrl): string {
+        const versionedId = request.headers?.[LoaderHeader.version] !== undefined
+            ? `${parsedUrl.id}@${request.headers[LoaderHeader.version]}`
+            : parsedUrl.id;
+        return versionedId;
+    }
+
     private async resolveCore(
         request: IRequest,
     ): Promise<{ container: Container; parsed: IParsedUrl }> {
@@ -271,9 +276,7 @@ export class Loader extends EventEmitter implements ILoader {
 
         let container: Container;
         if (canCache) {
-            const versionedId = request.headers[LoaderHeader.version] !== undefined
-                ? `${parsed.id}@${request.headers[LoaderHeader.version]}`
-                : parsed.id;
+            const versionedId = this.getKeyForContainerCache(request, parsed);
             const maybeContainer = await this.containers.get(versionedId);
             if (maybeContainer !== undefined) {
                 container = maybeContainer;

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -216,8 +216,8 @@ export class Loader extends EventEmitter implements ILoader {
         const { canCache } = this.parseHeader(parsedUrl, request);
 
         if (canCache) {
-            const versionedId = this.getKeyForContainerCache(request, parsedUrl);
-            this.containers.set(versionedId, Promise.resolve(container));
+            const key = this.getKeyForContainerCache(request, parsedUrl);
+            this.containers.set(key, Promise.resolve(container));
         }
     }
 
@@ -251,10 +251,10 @@ export class Loader extends EventEmitter implements ILoader {
     }
 
     private getKeyForContainerCache(request: IRequest, parsedUrl: IParsedUrl): string {
-        const versionedId = request.headers?.[LoaderHeader.version] !== undefined
+        const key = request.headers?.[LoaderHeader.version] !== undefined
             ? `${parsedUrl.id}@${request.headers[LoaderHeader.version]}`
             : parsedUrl.id;
-        return versionedId;
+        return key;
     }
 
     private async resolveCore(
@@ -276,8 +276,8 @@ export class Loader extends EventEmitter implements ILoader {
 
         let container: Container;
         if (canCache) {
-            const versionedId = this.getKeyForContainerCache(request, parsed);
-            const maybeContainer = await this.containers.get(versionedId);
+            const key = this.getKeyForContainerCache(request, parsed);
+            const maybeContainer = await this.containers.get(key);
             if (maybeContainer !== undefined) {
                 container = maybeContainer;
             } else {
@@ -286,7 +286,7 @@ export class Loader extends EventEmitter implements ILoader {
                         parsed.id,
                         request,
                         resolvedAsFluid);
-                this.containers.set(versionedId, containerP);
+                this.containers.set(key, containerP);
                 container = await containerP;
             }
         } else {

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -352,5 +352,4 @@ export class Loader extends EventEmitter implements ILoader {
             this.resolver,
             this.subLogger);
     }
-
 }

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -352,4 +352,5 @@ export class Loader extends EventEmitter implements ILoader {
             this.resolver,
             this.subLogger);
     }
+
 }

--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -7,8 +7,6 @@ import { parse } from "url";
 import { fromUtf8ToBase64, Uint8ArrayToString } from "@fluidframework/common-utils";
 import { ISummaryTree, ISnapshotTree, SummaryType } from "@fluidframework/protocol-definitions";
 import uuid from "uuid";
-import { IRequest } from "@fluidframework/core-interfaces";
-import { LoaderHeader } from "@fluidframework/container-definitions";
 
 export interface IParsedUrl {
     id: string;
@@ -97,40 +95,4 @@ export function convertProtocolAndAppSummaryToSnapshotTree(
     };
 
     return snapshotTree;
-}
-
-export function canUseCache(request: IRequest): boolean {
-    if (request.headers === undefined) {
-        return true;
-    }
-
-    const noCache =
-        request.headers[LoaderHeader.cache] === false ||
-        request.headers[LoaderHeader.reconnect] === false ||
-        request.headers[LoaderHeader.pause] === true;
-
-    return !noCache;
-}
-
-export function parseHeader(parsed: IParsedUrl, request: IRequest) {
-    let fromSequenceNumber = -1;
-
-    request.headers = request.headers ?? {};
-
-    const headerSeqNum = request.headers[LoaderHeader.sequenceNumber];
-    if (headerSeqNum !== undefined) {
-        fromSequenceNumber = headerSeqNum;
-    }
-
-    // If set in both query string and headers, use query string
-    request.headers[LoaderHeader.version] = parsed.version ?? request.headers[LoaderHeader.version];
-
-    // Version === null means not use any snapshot.
-    if (request.headers[LoaderHeader.version] === "null") {
-        request.headers[LoaderHeader.version] = null;
-    }
-    return {
-        canCache: canUseCache(request),
-        fromSequenceNumber,
-    };
 }

--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -7,6 +7,8 @@ import { parse } from "url";
 import { fromUtf8ToBase64, Uint8ArrayToString } from "@fluidframework/common-utils";
 import { ISummaryTree, ISnapshotTree, SummaryType } from "@fluidframework/protocol-definitions";
 import uuid from "uuid";
+import { IRequest } from "@fluidframework/core-interfaces";
+import { LoaderHeader } from "@fluidframework/container-definitions";
 
 export interface IParsedUrl {
     id: string;
@@ -95,4 +97,40 @@ export function convertProtocolAndAppSummaryToSnapshotTree(
     };
 
     return snapshotTree;
+}
+
+export function canUseCache(request: IRequest): boolean {
+    if (request.headers === undefined) {
+        return true;
+    }
+
+    const noCache =
+        request.headers[LoaderHeader.cache] === false ||
+        request.headers[LoaderHeader.reconnect] === false ||
+        request.headers[LoaderHeader.pause] === true;
+
+    return !noCache;
+}
+
+export function parseHeader(parsed: IParsedUrl, request: IRequest) {
+    let fromSequenceNumber = -1;
+
+    request.headers = request.headers ?? {};
+
+    const headerSeqNum = request.headers[LoaderHeader.sequenceNumber];
+    if (headerSeqNum !== undefined) {
+        fromSequenceNumber = headerSeqNum;
+    }
+
+    // If set in both query string and headers, use query string
+    request.headers[LoaderHeader.version] = parsed.version ?? request.headers[LoaderHeader.version];
+
+    // Version === null means not use any snapshot.
+    if (request.headers[LoaderHeader.version] === "null") {
+        request.headers[LoaderHeader.version] = null;
+    }
+    return {
+        canCache: canUseCache(request),
+        fromSequenceNumber,
+    };
 }


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/3808
Cache the attached container so that the loader can load the cached container if reuired.