### PR TITLE
Update commit/build search distance for bundle analysis

### DIFF
--- a/tools/bundle-size-tools/src/ADO/Constants.ts
+++ b/tools/bundle-size-tools/src/ADO/Constants.ts
@@ -16,19 +16,19 @@ export interface IADOConstants {
   // The ID for the build that runs to validate PRs
   // Used to update tagged PRs on CI build completion
   // Note: Assumes CI and PR builds both run in the same org/project
-  prBuildDefinitionId: number | undefined,
+  prBuildDefinitionId?: number,
 
   // The name of the build artifact that contains the bundle size artifacts
   bundleAnalysisArtifactName: string,
 
   // The guid of the repo
   // Used to post/update comments in ADO
-  projectRepoGuid: string | undefined,
+  projectRepoGuid?: string,
 
   // The number of most recent ADO builds to pull when searching for one associated
   // with a specific commit, default 20.  Pulling more builds takes longer, but may
   // be useful when there are a high volume of commits/builds.
-  buildsToSearch: number | undefined,
+  buildsToSearch?: number,
 }
 
 // The name of the metric that represents the size of the whole bundle


### PR DESCRIPTION
There are two variables here for bundle analysis: our commit search distance and our build search distance.  The commit search distance is the default number of commits to look back from the common branching commit in main.  We need it because not all commits' associated pipeline builds produce size artifacts, and it needs to be sufficiently larger than the average number of consecutive commits not producing size artifacts.  The build search distance is the default number of most recent builds to pull from the CI pipeline.  We can't pull just a build for a specific commit, so this needs to be sufficiently larger than the average number of commits to main past the branch's common branching commit (i.e. the faster commits go into main the larger this will need to be).

The default number of builds was 20 which was fine, but the default commit distance was 5 which was not large enough.  Just use 20 for both by default (the overlap will be smaller); consumers can still adjust these as needed.