### PR TITLE
Improvements in RequestParser

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -2,6 +2,7 @@
 
 - [IFluidPackage Changes](#IFluidPackage-Changes)
 - [DataObject changes](#DataObject-changes)
+- [RequestParser](#RequestParser)
 
 ### IFluidPackage Changes
 - Remove npm specific IPackage interface
@@ -17,6 +18,17 @@ This change
 2. Allows DataObjects to modify FluidDataStoreRuntime behavior before it gets registered and used by the rest of the system, including setting various hooks.
 
 But it also puts more constraints on DataObject - its constructor should be light and not do any expensive work (all such work should be done in corresponding initialize methods), or access any data store runtime functionality that requires fully initialized runtime (like loading DDSs will not work in this state)
+
+### RequestParser
+RequestParser's ctor is made protected. Please replace this code
+```
+    const a = new RequestParser(request);
+```
+with this one:
+```
+    const a = RequestParser.create(request);
+```
+
 
 ## 0.27 Breaking Changes
 - [Local Web Host Removed](#Local-Web-Host-Removed)

--- a/examples/apps/spaces/src/fluid-object/index.tsx
+++ b/examples/apps/spaces/src/fluid-object/index.tsx
@@ -78,7 +78,7 @@ export class Spaces extends DataObject implements IFluidHTMLView {
     // specific item we want.  We route through Spaces because it's the one with the registry, and so it's the one
     // that knows how to getViewForItem().
     public async request(req: IRequest): Promise<IResponse> {
-        const requestParser = new RequestParser({ url: req.url });
+        const requestParser = RequestParser.create({ url: req.url });
         // The only time we have a path will be direct links to items.
         if (requestParser.pathParts.length > 0) {
             const itemId = requestParser.pathParts[0];

--- a/examples/data-objects/multiview/container/src/container.tsx
+++ b/examples/data-objects/multiview/container/src/container.tsx
@@ -39,7 +39,7 @@ const createAndAttachCoordinate = async (runtime: IContainerRuntime, id: string)
 
 // Just a little helper, since we're going to request multiple coordinates.
 async function requestObjectStoreFromId<T>(request: RequestParser, runtime: IContainerRuntime, id: string) {
-    const coordinateRequest = new RequestParser({
+    const coordinateRequest = RequestParser.create({
         url: ``,
         headers: request.headers,
     });

--- a/packages/framework/aqueduct/src/container-services/containerServices.ts
+++ b/packages/framework/aqueduct/src/container-services/containerServices.ts
@@ -92,20 +92,20 @@ export const generateContainerServicesRequestHandler =
                 return router.request(subRequest);
             }
 
-            if (request.isLeaf(2)) {
-                // Otherwise we will just return the service
+            if (!request.isLeaf(2)) {
+                // If there is not terminating route but a sub-route was requested then we will fail.
                 return {
-                    status: 200,
-                    mimeType: "fluid/object",
-                    value: service,
+                    status: 400,
+                    mimeType: "text/plain",
+                    value: `request sub-url: [${subRequest}] for service that doesn't support routing`,
                 };
             }
 
-            // If there is not service to route but a sub-route was requested then we will fail.
+            // Otherwise we will just return the service
             return {
-                status: 400,
-                mimeType: "text/plain",
-                value: `request sub-url: [${subRequest}] for service that doesn't support routing`,
+                status: 200,
+                mimeType: "fluid/object",
+                value: service,
             };
         };
     };

--- a/packages/framework/aqueduct/src/container-services/containerServices.ts
+++ b/packages/framework/aqueduct/src/container-services/containerServices.ts
@@ -87,29 +87,25 @@ export const generateContainerServicesRequestHandler =
 
             const service = await factory.getService(runtime);
             const router = service.IFluidRouter;
-            let subRequest = request.createSubRequest(2);
+            const subRequest = request.createSubRequest(2);
             if (router) {
-                // If the service is also a router then we will route to it
-                if (!subRequest) {
-                    // If there is nothing left of the url we will request with empty path.
-                    subRequest = { url: "" };
-                }
-
                 return router.request(subRequest);
-            } else if (!router && subRequest) {
-                // If there is not service to route but a sub-route was requested then we will fail.
+            }
+
+            if (request.isLeaf(2)) {
+                // Otherwise we will just return the service
                 return {
-                    status: 400,
-                    mimeType: "text/plain",
-                    value: `request sub-url: [${subRequest}] for service that doesn't support routing`,
+                    status: 200,
+                    mimeType: "fluid/object",
+                    value: service,
                 };
             }
 
-            // Otherwise we will just return the service
+            // If there is not service to route but a sub-route was requested then we will fail.
             return {
-                status: 200,
-                mimeType: "fluid/object",
-                value: service,
+                status: 400,
+                mimeType: "text/plain",
+                value: `request sub-url: [${subRequest}] for service that doesn't support routing`,
             };
         };
     };

--- a/packages/framework/aqueduct/src/request-handlers/requestHandlers.ts
+++ b/packages/framework/aqueduct/src/request-handlers/requestHandlers.ts
@@ -56,7 +56,7 @@ export const mountableViewRequestHandler =
  */
 export const defaultRouteRequestHandler = (defaultRootId: string) => {
     return async (request: IRequest, runtime: IContainerRuntime) => {
-        const parser = new RequestParser(request);
+        const parser = RequestParser.create(request);
         if (parser.pathParts.length === 0) {
             return runtime.IFluidHandleContext.resolveHandle({
                 url: `/${defaultRootId}${parser.query}`,

--- a/packages/framework/aqueduct/src/test/containerServices.spec.ts
+++ b/packages/framework/aqueduct/src/test/containerServices.spec.ts
@@ -32,7 +32,7 @@ describe("Routerlicious", () => {
         describe("generateContainerServicesRequestHandler", () => {
             it(`Request to ${serviceRoutePathRoot} and no id should fail`, async () => {
                 const requestHandler = generateContainerServicesRequestHandler([]);
-                const requestParser = new RequestParser({ url: `/${serviceRoutePathRoot}` });
+                const requestParser = RequestParser.create({ url: `/${serviceRoutePathRoot}` });
 
                 const response = await requestHandler(requestParser, {} as IContainerRuntime);
 
@@ -42,7 +42,7 @@ describe("Routerlicious", () => {
 
             it("Unknown service should return 404 with no services", async () => {
                 const requestHandler = generateContainerServicesRequestHandler([]);
-                const requestParser = new RequestParser({ url: `/${serviceRoutePathRoot}/id1` });
+                const requestParser = RequestParser.create({ url: `/${serviceRoutePathRoot}/id1` });
 
                 const response = await requestHandler(requestParser, {} as IContainerRuntime);
 
@@ -54,7 +54,7 @@ describe("Routerlicious", () => {
                 const requestHandler = generateContainerServicesRequestHandler([
                     ["id1", async (r) => new ContainerServiceMock(r)],
                 ]);
-                const requestParser = new RequestParser({ url: `/${serviceRoutePathRoot}/id2` });
+                const requestParser = RequestParser.create({ url: `/${serviceRoutePathRoot}/id2` });
 
                 const response = await requestHandler(requestParser, {} as IContainerRuntime);
 
@@ -66,7 +66,7 @@ describe("Routerlicious", () => {
                 const requestHandler = generateContainerServicesRequestHandler([
                     ["id1", async (r) => { return {}; }],
                 ]);
-                const requestParser = new RequestParser({ url: `/${serviceRoutePathRoot}/id1/subroute` });
+                const requestParser = RequestParser.create({ url: `/${serviceRoutePathRoot}/id1/subroute` });
 
                 const response = await requestHandler(requestParser, {} as IContainerRuntime);
 
@@ -79,7 +79,7 @@ describe("Routerlicious", () => {
                 const serviceMap = new Map();
                 serviceMap.set("id1", async (r) => service1);
                 const requestHandler = generateContainerServicesRequestHandler(serviceMap);
-                const requestParser = new RequestParser({ url: `/${serviceRoutePathRoot}/id1` });
+                const requestParser = RequestParser.create({ url: `/${serviceRoutePathRoot}/id1` });
 
                 const response = await requestHandler(requestParser, {} as IContainerRuntime);
 
@@ -92,7 +92,7 @@ describe("Routerlicious", () => {
                 const requestHandler = generateContainerServicesRequestHandler([
                     ["id1", async (r) => new ContainerServiceMock(r)],
                 ]);
-                const requestParser = new RequestParser({ url: `/${serviceRoutePathRoot}/id1` });
+                const requestParser = RequestParser.create({ url: `/${serviceRoutePathRoot}/id1` });
 
                 const response1 = await requestHandler(requestParser, {} as IContainerRuntime);
                 const response2 = await requestHandler(requestParser, {} as IContainerRuntime);
@@ -106,7 +106,7 @@ describe("Routerlicious", () => {
                     ["id1", async (r) => new ContainerServiceMock(r)],
                     ["id2", async (r) => service2],
                 ]);
-                const requestParser = new RequestParser({ url: `/${serviceRoutePathRoot}/id2` });
+                const requestParser = RequestParser.create({ url: `/${serviceRoutePathRoot}/id2` });
 
                 const response = await requestHandler(requestParser, {} as IContainerRuntime);
 
@@ -125,7 +125,7 @@ describe("Routerlicious", () => {
                     ["id1", async (r) => new ContainerServiceMock(r)],
                     ["id1", async (r) => service1],
                 ]);
-                const requestParser = new RequestParser({ url: `/${serviceRoutePathRoot}/id1` });
+                const requestParser = RequestParser.create({ url: `/${serviceRoutePathRoot}/id1` });
 
                 const response = await requestHandler(requestParser, {} as IContainerRuntime);
 
@@ -137,7 +137,7 @@ describe("Routerlicious", () => {
             it("Sub-route should be persisted through", async () => {
                 const service1 = new ContainerServiceMock({} as IContainerRuntime);
                 const requestHandler = generateContainerServicesRequestHandler([["id1", async (r) => service1]]);
-                const requestParser = new RequestParser({ url: `/${serviceRoutePathRoot}/id1/sub1` });
+                const requestParser = RequestParser.create({ url: `/${serviceRoutePathRoot}/id1/sub1` });
 
                 const response = await requestHandler(requestParser, {} as IContainerRuntime);
 

--- a/packages/framework/aqueduct/src/test/defaultRoute.spec.ts
+++ b/packages/framework/aqueduct/src/test/defaultRoute.spec.ts
@@ -37,7 +37,7 @@ class MockRuntime {
     }
 
     protected async resolveHandle(request: IRequest) {
-        const requestParser = new RequestParser(request);
+        const requestParser = RequestParser.create(request);
 
         if (requestParser.pathParts.length > 0) {
             const wait =
@@ -64,13 +64,13 @@ describe("defaultRouteRequestHandler", () => {
     it("Data store request with default ID", async () => {
         const handler = defaultRouteRequestHandler("objectId");
 
-        const requestParser = new RequestParser({ url: "", headers: {} });
+        const requestParser = RequestParser.create({ url: "", headers: {} });
         const response = await handler(requestParser, runtime);
         assert(response);
         assert.equal(response.status, 200);
         assert.equal(response.value.route, "");
 
-        const requestParser2 = new RequestParser({ url: "/", headers: {} });
+        const requestParser2 = RequestParser.create({ url: "/", headers: {} });
         const response2 = await handler(requestParser2, runtime);
         assert(response2);
         assert.equal(response2.status, 200);
@@ -80,11 +80,11 @@ describe("defaultRouteRequestHandler", () => {
     it("Data store request with non-existing default ID", async () => {
         const handler = defaultRouteRequestHandler("foobar");
 
-        const requestParser = new RequestParser({ url: "", headers: { wait: true } });
+        const requestParser = RequestParser.create({ url: "", headers: { wait: true } });
         const responseP = handler(requestParser, runtime);
         await assertRejected(responseP);
 
-        const requestParser2 = new RequestParser({ url: "/", headers: { wait: true } });
+        const requestParser2 = RequestParser.create({ url: "/", headers: { wait: true } });
         const responseP2 = handler(requestParser2, runtime);
         await assertRejected(responseP2);
     });

--- a/packages/framework/aqueduct/src/test/defaultRoute.spec.ts
+++ b/packages/framework/aqueduct/src/test/defaultRoute.spec.ts
@@ -45,15 +45,7 @@ class MockRuntime {
 
             const dataStore = await this.getRootDataStore(requestParser.pathParts[0], wait);
             const subRequest = requestParser.createSubRequest(1);
-            if (subRequest !== undefined) {
-                return dataStore.request(subRequest);
-            } else {
-                return {
-                    status: 200,
-                    mimeType: "fluid/object",
-                    value: dataStore,
-                };
-            }
+            return dataStore.request(subRequest);
         }
         return { status: 404, mimeType: "text/plain", value: "not found" };
     }

--- a/packages/framework/request-handler/src/runtimeRequestHandlerBuilder.ts
+++ b/packages/framework/request-handler/src/runtimeRequestHandlerBuilder.ts
@@ -22,7 +22,7 @@ export class RuntimeRequestHandlerBuilder {
     }
 
     public async handleRequest(request: IRequest, runtime: IContainerRuntime): Promise<IResponse> {
-        const parser = new RequestParser(request);
+        const parser = RequestParser.create(request);
         for (const handler of this.handlers) {
             const response = await handler(parser, runtime);
             if (response !== undefined) {

--- a/packages/framework/request-handler/src/test/requestHandlers.spec.ts
+++ b/packages/framework/request-handler/src/test/requestHandlers.spec.ts
@@ -39,7 +39,7 @@ class MockRuntime {
     }
 
     public async resolveHandle(request: IRequest) {
-        const requestParser = new RequestParser(request);
+        const requestParser = RequestParser.create(request);
 
         if (requestParser.pathParts.length > 0) {
             const wait =
@@ -65,7 +65,7 @@ describe("RequestParser", () => {
         const runtime = new MockRuntime() as any as IContainerRuntime;
 
         it("Empty request", async () => {
-            const requestParser = new RequestParser({ url: "/" });
+            const requestParser = RequestParser.create({ url: "/" });
             const response = await deprecated_innerRequestHandler(
                 requestParser,
                 runtime);
@@ -73,7 +73,7 @@ describe("RequestParser", () => {
         });
 
         it("Data store request without wait", async () => {
-            const requestParser = new RequestParser({ url: "/nonExistingUri" });
+            const requestParser = RequestParser.create({ url: "/nonExistingUri" });
             const responseP = deprecated_innerRequestHandler(
                 requestParser,
                 runtime);
@@ -81,7 +81,7 @@ describe("RequestParser", () => {
         });
 
         it("Data store  request with wait", async () => {
-            const requestParser = new RequestParser({ url: "/nonExistingUri", headers: { wait: true } });
+            const requestParser = RequestParser.create({ url: "/nonExistingUri", headers: { wait: true } });
             const responseP = deprecated_innerRequestHandler(
                 requestParser,
                 runtime);
@@ -89,14 +89,14 @@ describe("RequestParser", () => {
         });
 
         it("Data store  request with sub route", async () => {
-            const requestParser = new RequestParser({ url: "/objectId/route", headers: { wait: true } });
+            const requestParser = RequestParser.create({ url: "/objectId/route", headers: { wait: true } });
             const response = await deprecated_innerRequestHandler(requestParser, runtime);
             assert.equal(response.status, 200);
             assert.equal(response.value.route, "route");
         });
 
         it("Data store  request with non-existing sub route", async () => {
-            const requestParser = new RequestParser({ url: "/objectId/doesNotExist", headers: { wait: true } });
+            const requestParser = RequestParser.create({ url: "/objectId/doesNotExist", headers: { wait: true } });
             const responseP = deprecated_innerRequestHandler(requestParser, runtime);
             await assertRejected(responseP);
         });

--- a/packages/framework/request-handler/src/test/requestHandlers.spec.ts
+++ b/packages/framework/request-handler/src/test/requestHandlers.spec.ts
@@ -47,15 +47,7 @@ class MockRuntime {
 
             const fluidObject = await this.getRootDataStore(requestParser.pathParts[0], wait);
             const subRequest = requestParser.createSubRequest(1);
-            if (subRequest !== undefined) {
-                return fluidObject.request(subRequest);
-            } else {
-                return {
-                    status: 200,
-                    mimeType: "fluid/object",
-                    value: fluidObject,
-                };
-            }
+            return fluidObject.request(subRequest);
         }
         return { status: 404, mimeType: "text/plain", value: "not found" };
     }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -959,9 +959,9 @@ export class ContainerRuntime extends EventEmitter
      */
     public async resolveHandle(request: IRequest): Promise<IResponse> {
         const requestParser = new RequestParser(request);
+        const id = requestParser.pathParts[0];
 
-        if (requestParser.pathParts.length > 0 && requestParser.pathParts[0] === this.blobManager.basePath) {
-            assert(requestParser.pathParts.length === 2 && !requestParser.query);
+        if (id === this.blobManager.basePath && requestParser.isLeaf(2)) {
             const handle = await this.blobManager.getBlob(requestParser.pathParts[1]);
             if (handle) {
                 return {
@@ -980,17 +980,9 @@ export class ContainerRuntime extends EventEmitter
             const wait =
                 typeof request.headers?.wait === "boolean" ? request.headers.wait : undefined;
 
-            const dataStore = await this.getDataStore(requestParser.pathParts[0], wait);
+            const dataStore = await this.getDataStore(id, wait);
             const subRequest = requestParser.createSubRequest(1);
-            if (subRequest !== undefined) {
-                return dataStore.IFluidRouter.request(subRequest);
-            } else {
-                return {
-                    status: 200,
-                    mimeType: "fluid/object",
-                    value: dataStore,
-                };
-            }
+            return dataStore.IFluidRouter.request(subRequest);
         }
 
         return {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -958,7 +958,7 @@ export class ContainerRuntime extends EventEmitter
      * @param request - Request made to the handler.
      */
     public async resolveHandle(request: IRequest): Promise<IResponse> {
-        const requestParser = new RequestParser(request);
+        const requestParser = RequestParser.create(request);
         const id = requestParser.pathParts[0];
 
         if (id === this.blobManager.basePath && requestParser.isLeaf(2)) {

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -47,7 +47,7 @@ import {
     ISummaryTreeWithStats,
     CreateSummarizerNodeSource,
 } from "@fluidframework/runtime-definitions";
-import { generateHandleContextPath, SummaryTreeBuilder } from "@fluidframework/runtime-utils";
+import { generateHandleContextPath, SummaryTreeBuilder, RequestParser } from "@fluidframework/runtime-utils";
 import {
     IChannel,
     IFluidDataStoreRuntime,
@@ -269,11 +269,11 @@ export class FluidDataStoreRuntime extends EventEmitter implements IFluidDataSto
     }
 
     public async request(request: IRequest): Promise<IResponse> {
-        // Parse out the leading slash
-        const id = request.url.startsWith("/") ? request.url.substr(1) : request.url;
+        const parser = new RequestParser(request);
+        const id = parser.pathParts[0];
 
         // Check for a data type reference first
-        if (this.contextsDeferred.has(id)) {
+        if (this.contextsDeferred.has(id) && parser.isLeaf(1)) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const value = await this.contextsDeferred.get(id)!.promise;
             const channel = await value.getChannel();

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -47,7 +47,7 @@ import {
     ISummaryTreeWithStats,
     CreateSummarizerNodeSource,
 } from "@fluidframework/runtime-definitions";
-import { generateHandleContextPath, SummaryTreeBuilder, RequestParser } from "@fluidframework/runtime-utils";
+import { generateHandleContextPath, RequestParser, SummaryTreeBuilder } from "@fluidframework/runtime-utils";
 import {
     IChannel,
     IFluidDataStoreRuntime,
@@ -269,7 +269,7 @@ export class FluidDataStoreRuntime extends EventEmitter implements IFluidDataSto
     }
 
     public async request(request: IRequest): Promise<IResponse> {
-        const parser = new RequestParser(request);
+        const parser = RequestParser.create(request);
         const id = parser.pathParts[0];
 
         // Check for a data type reference first

--- a/packages/runtime/runtime-utils/src/requestParser.ts
+++ b/packages/runtime/runtime-utils/src/requestParser.ts
@@ -29,14 +29,16 @@ export class RequestParser implements IRequest {
 
     private requestPathParts: readonly string[] | undefined;
     public readonly query: string;
-    constructor(private readonly request: Readonly<IRequest>) {
-        // Perf optimizations. Even better would be not to create this object
-        if (request instanceof RequestParser) {
-            this.query = request.query;
-            this.requestPathParts = request.pathParts;
-            return;
-        }
 
+    public static create(request: Readonly<IRequest>) {
+        // Perf optimizations.
+        if (request instanceof RequestParser) {
+            return request;
+        }
+        return new RequestParser(request);
+    }
+
+    protected constructor(private readonly request: Readonly<IRequest>) {
         const queryStartIndex = this.request.url.indexOf("?");
         if (queryStartIndex >= 0) {
             this.query = this.request.url.substring(queryStartIndex);

--- a/packages/runtime/runtime-utils/src/test/requestParser.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/requestParser.spec.ts
@@ -59,8 +59,8 @@ describe("RequestParser", () => {
             assert.equal(requestParser.createSubRequest(3)?.url, "");
         });
         it("Create request from invalid part ", () => {
-            assert.equal(requestParser.createSubRequest(4), undefined);
-            assert.equal(requestParser.createSubRequest(-1), undefined);
+            assert.throws(() => requestParser.createSubRequest(4));
+            assert.throws(() => requestParser.createSubRequest(-1));
         });
     });
 });

--- a/packages/runtime/runtime-utils/src/test/requestParser.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/requestParser.spec.ts
@@ -44,7 +44,7 @@ describe("RequestParser", () => {
     describe(".createSubRequest", () => {
         let requestParser: RequestParser;
         beforeEach(() => {
-            requestParser = new RequestParser({ url: "/dataStoreId//some/route/" });
+            requestParser = RequestParser.create({ url: "/dataStoreId//some/route/" });
         });
         it("Create request from part 0", () => {
             assert.equal(requestParser.createSubRequest(0)?.url, "dataStoreId/some/route");

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -239,7 +239,7 @@ export async function start(
         div.append(leftDiv, rightDiv);
     }
 
-    const reqParser = new RequestParser({ url });
+    const reqParser = RequestParser.create({ url });
     const fluidObjectUrl = `/${reqParser.createSubRequest(4).url}`;
 
     // Load and render the Fluid object.


### PR DESCRIPTION
1. Perf - we keep recreating same object for same request
2. We incorrectly handle terminating requests in couple places, mostly due to not having easier to use tools (isLeaf)
3. sub-request code has extra dead code that can be eliminating by changing signature of the function.