### PR TITLE
First step on moving away from IFluidDataStoreRuntime.IFluidHandleContext

### DIFF
--- a/examples/data-objects/codemirror/src/codemirror.ts
+++ b/examples/data-objects/codemirror/src/codemirror.ts
@@ -224,7 +224,7 @@ export class CodeMirrorComponent
     ) {
         super();
         this.url = context.id;
-        this.innerHandle = new FluidObjectHandle(this, this.url, runtime.objectsRoutingContext);
+        this.innerHandle = new FluidObjectHandle(this, this.url, runtime.objectRoutingContext);
     }
 
     public async request(request: IRequest): Promise<IResponse> {

--- a/examples/data-objects/codemirror/src/codemirror.ts
+++ b/examples/data-objects/codemirror/src/codemirror.ts
@@ -224,7 +224,7 @@ export class CodeMirrorComponent
     ) {
         super();
         this.url = context.id;
-        this.innerHandle = new FluidObjectHandle(this, this.url, runtime.IFluidHandleContext);
+        this.innerHandle = new FluidObjectHandle(this, this.url, runtime.objectsRoutingContext);
     }
 
     public async request(request: IRequest): Promise<IResponse> {

--- a/examples/data-objects/image-collection/src/images.ts
+++ b/examples/data-objects/image-collection/src/images.ts
@@ -120,7 +120,7 @@ export class ImageCollection extends LazyLoadedDataObject<ISharedDirectory> impl
                     this.root.get(key),
                     `${this.url}/${key}`,
                     key,
-                    this.runtime.objectsRoutingContext));
+                    this.runtime.objectRoutingContext));
         }
 
         this.root.on("valueChanged", (changed) => {
@@ -132,7 +132,7 @@ export class ImageCollection extends LazyLoadedDataObject<ISharedDirectory> impl
                     this.root.get(changed.key),
                     `${this.url}/${changed.key}`,
                     changed.key,
-                    this.runtime.objectsRoutingContext);
+                    this.runtime.objectRoutingContext);
                 this.images.set(changed.key, player);
             }
         });

--- a/examples/data-objects/image-collection/src/images.ts
+++ b/examples/data-objects/image-collection/src/images.ts
@@ -120,7 +120,7 @@ export class ImageCollection extends LazyLoadedDataObject<ISharedDirectory> impl
                     this.root.get(key),
                     `${this.url}/${key}`,
                     key,
-                    this.runtime.IFluidHandleContext));
+                    this.runtime.objectsRoutingContext));
         }
 
         this.root.on("valueChanged", (changed) => {
@@ -132,7 +132,7 @@ export class ImageCollection extends LazyLoadedDataObject<ISharedDirectory> impl
                     this.root.get(changed.key),
                     `${this.url}/${changed.key}`,
                     changed.key,
-                    this.runtime.IFluidHandleContext);
+                    this.runtime.objectsRoutingContext);
                 this.images.set(changed.key, player);
             }
         });

--- a/examples/data-objects/math/src/mathComponent.ts
+++ b/examples/data-objects/math/src/mathComponent.ts
@@ -546,7 +546,7 @@ export class MathCollection extends LazyLoadedDataObject<ISharedDirectory> imple
 
     public createCollectionItem(options?: IMathOptions): MathInstance {
         const leafId = `math-${Date.now()}`;
-        return new MathInstance(`${this.url}/${leafId}`, leafId, this.runtime.IFluidHandleContext, this, options);
+        return new MathInstance(`${this.url}/${leafId}`, leafId, this.runtime.objectsRoutingContext, this, options);
     }
 
     public getText(instance: MathInstance) {
@@ -613,7 +613,7 @@ export class MathCollection extends LazyLoadedDataObject<ISharedDirectory> imple
                     options = mathMarker.properties.componentOptions;
                 }
                 mathMarker.mathInstance = new MathInstance(
-                    `${this.url}/${id}`, id, this.runtime.IFluidHandleContext, this, options, true);
+                    `${this.url}/${id}`, id, this.runtime.objectsRoutingContext, this, options, true);
             }
             return mathMarker.mathInstance as MathInstance;
         }

--- a/examples/data-objects/math/src/mathComponent.ts
+++ b/examples/data-objects/math/src/mathComponent.ts
@@ -546,7 +546,7 @@ export class MathCollection extends LazyLoadedDataObject<ISharedDirectory> imple
 
     public createCollectionItem(options?: IMathOptions): MathInstance {
         const leafId = `math-${Date.now()}`;
-        return new MathInstance(`${this.url}/${leafId}`, leafId, this.runtime.objectsRoutingContext, this, options);
+        return new MathInstance(`${this.url}/${leafId}`, leafId, this.runtime.objectRoutingContext, this, options);
     }
 
     public getText(instance: MathInstance) {
@@ -613,7 +613,7 @@ export class MathCollection extends LazyLoadedDataObject<ISharedDirectory> imple
                     options = mathMarker.properties.componentOptions;
                 }
                 mathMarker.mathInstance = new MathInstance(
-                    `${this.url}/${id}`, id, this.runtime.objectsRoutingContext, this, options, true);
+                    `${this.url}/${id}`, id, this.runtime.objectRoutingContext, this, options, true);
             }
             return mathMarker.mathInstance as MathInstance;
         }

--- a/examples/data-objects/progress-bars/src/progressBars.ts
+++ b/examples/data-objects/progress-bars/src/progressBars.ts
@@ -144,7 +144,7 @@ export class ProgressCollection
         super();
 
         this.url = context.id;
-        this.handle = new FluidObjectHandle(this, "", this.runtime.objectsRoutingContext);
+        this.handle = new FluidObjectHandle(this, "", this.runtime.objectRoutingContext);
     }
 
     public changeValue(key: string, newValue: number) {
@@ -202,7 +202,7 @@ export class ProgressCollection
                     this.root.get(key),
                     `${this.url}/${key}`,
                     key,
-                    this.runtime.objectsRoutingContext,
+                    this.runtime.objectRoutingContext,
                     this));
         }
 
@@ -216,7 +216,7 @@ export class ProgressCollection
                         this.root.get(changed.key),
                         `${this.url}/${changed.key}`,
                         changed.key,
-                        this.runtime.objectsRoutingContext,
+                        this.runtime.objectRoutingContext,
                         this));
                 this.emit("progressAdded", `/${changed.key}`);
             }

--- a/examples/data-objects/progress-bars/src/progressBars.ts
+++ b/examples/data-objects/progress-bars/src/progressBars.ts
@@ -144,7 +144,7 @@ export class ProgressCollection
         super();
 
         this.url = context.id;
-        this.handle = new FluidObjectHandle(this, "", this.runtime.IFluidHandleContext);
+        this.handle = new FluidObjectHandle(this, "", this.runtime.objectsRoutingContext);
     }
 
     public changeValue(key: string, newValue: number) {
@@ -202,7 +202,7 @@ export class ProgressCollection
                     this.root.get(key),
                     `${this.url}/${key}`,
                     key,
-                    this.runtime.IFluidHandleContext,
+                    this.runtime.objectsRoutingContext,
                     this));
         }
 
@@ -216,7 +216,7 @@ export class ProgressCollection
                         this.root.get(changed.key),
                         `${this.url}/${changed.key}`,
                         changed.key,
-                        this.runtime.IFluidHandleContext,
+                        this.runtime.objectsRoutingContext,
                         this));
                 this.emit("progressAdded", `/${changed.key}`);
             }

--- a/examples/data-objects/prosemirror/src/prosemirror.ts
+++ b/examples/data-objects/prosemirror/src/prosemirror.ts
@@ -127,7 +127,7 @@ export class ProseMirror extends EventEmitter
         super();
 
         this.url = context.id;
-        this.innerHandle = new FluidObjectHandle(this, this.url, runtime.objectsRoutingContext);
+        this.innerHandle = new FluidObjectHandle(this, this.url, runtime.objectRoutingContext);
     }
 
     public async request(request: IRequest): Promise<IResponse> {

--- a/examples/data-objects/prosemirror/src/prosemirror.ts
+++ b/examples/data-objects/prosemirror/src/prosemirror.ts
@@ -127,7 +127,7 @@ export class ProseMirror extends EventEmitter
         super();
 
         this.url = context.id;
-        this.innerHandle = new FluidObjectHandle(this, this.url, runtime.IFluidHandleContext);
+        this.innerHandle = new FluidObjectHandle(this, this.url, runtime.objectsRoutingContext);
     }
 
     public async request(request: IRequest): Promise<IResponse> {

--- a/examples/data-objects/scribe/src/scribe.ts
+++ b/examples/data-objects/scribe/src/scribe.ts
@@ -408,7 +408,7 @@ export class Scribe
         super();
 
         this.url = context.id;
-        this.innerHandle = new FluidObjectHandle(this, this.url, this.runtime.IFluidHandleContext);
+        this.innerHandle = new FluidObjectHandle(this, this.url, this.runtime.objectsRoutingContext);
     }
 
     public async request(request: IRequest): Promise<IResponse> {

--- a/examples/data-objects/scribe/src/scribe.ts
+++ b/examples/data-objects/scribe/src/scribe.ts
@@ -408,7 +408,7 @@ export class Scribe
         super();
 
         this.url = context.id;
-        this.innerHandle = new FluidObjectHandle(this, this.url, this.runtime.objectsRoutingContext);
+        this.innerHandle = new FluidObjectHandle(this, this.url, this.runtime.objectRoutingContext);
     }
 
     public async request(request: IRequest): Promise<IResponse> {

--- a/examples/data-objects/shared-text/src/component.ts
+++ b/examples/data-objects/shared-text/src/component.ts
@@ -87,7 +87,7 @@ export class SharedTextRunner
         private readonly context: IFluidDataStoreContext,
     ) {
         super();
-        this.innerHandle = new FluidObjectHandle(this, this.url, this.runtime.objectsRoutingContext);
+        this.innerHandle = new FluidObjectHandle(this, this.url, this.runtime.objectRoutingContext);
     }
 
     public render(element: HTMLElement) {

--- a/examples/data-objects/shared-text/src/component.ts
+++ b/examples/data-objects/shared-text/src/component.ts
@@ -87,7 +87,7 @@ export class SharedTextRunner
         private readonly context: IFluidDataStoreContext,
     ) {
         super();
-        this.innerHandle = new FluidObjectHandle(this, this.url, this.runtime.IFluidHandleContext);
+        this.innerHandle = new FluidObjectHandle(this, this.url, this.runtime.objectsRoutingContext);
     }
 
     public render(element: HTMLElement) {

--- a/examples/data-objects/smde/src/smde.ts
+++ b/examples/data-objects/smde/src/smde.ts
@@ -66,7 +66,7 @@ export class Smde extends EventEmitter implements
         super();
 
         this.url = context.id;
-        this.innerHandle = new FluidObjectHandle(this, this.url, this.runtime.objectsRoutingContext);
+        this.innerHandle = new FluidObjectHandle(this, this.url, this.runtime.objectRoutingContext);
     }
 
     public async request(request: IRequest): Promise<IResponse> {

--- a/examples/data-objects/smde/src/smde.ts
+++ b/examples/data-objects/smde/src/smde.ts
@@ -66,7 +66,7 @@ export class Smde extends EventEmitter implements
         super();
 
         this.url = context.id;
-        this.innerHandle = new FluidObjectHandle(this, this.url, this.runtime.IFluidHandleContext);
+        this.innerHandle = new FluidObjectHandle(this, this.url, this.runtime.objectsRoutingContext);
     }
 
     public async request(request: IRequest): Promise<IResponse> {

--- a/examples/data-objects/video-players/src/videoPlayers.ts
+++ b/examples/data-objects/video-players/src/videoPlayers.ts
@@ -223,7 +223,7 @@ export class VideoPlayerCollection extends LazyLoadedDataObject<ISharedDirectory
                 new VideoPlayer(
                     this.root.get(key),
                     `${this.url}/${key}`,
-                    this.runtime.IFluidHandleContext,
+                    this.runtime.objectsRoutingContext,
                     key,
                     youTubeApi,
                     this));
@@ -237,7 +237,7 @@ export class VideoPlayerCollection extends LazyLoadedDataObject<ISharedDirectory
                 const player = new VideoPlayer(
                     this.root.get(changed.key),
                     `${this.url}/${changed.key}`,
-                    this.runtime.IFluidHandleContext,
+                    this.runtime.objectsRoutingContext,
                     changed.key,
                     youTubeApi,
                     this);

--- a/examples/data-objects/video-players/src/videoPlayers.ts
+++ b/examples/data-objects/video-players/src/videoPlayers.ts
@@ -223,7 +223,7 @@ export class VideoPlayerCollection extends LazyLoadedDataObject<ISharedDirectory
                 new VideoPlayer(
                     this.root.get(key),
                     `${this.url}/${key}`,
-                    this.runtime.objectsRoutingContext,
+                    this.runtime.objectRoutingContext,
                     key,
                     youTubeApi,
                     this));
@@ -237,7 +237,7 @@ export class VideoPlayerCollection extends LazyLoadedDataObject<ISharedDirectory
                 const player = new VideoPlayer(
                     this.root.get(changed.key),
                     `${this.url}/${changed.key}`,
-                    this.runtime.objectsRoutingContext,
+                    this.runtime.objectRoutingContext,
                     changed.key,
                     youTubeApi,
                     this);

--- a/packages/framework/aqueduct/src/data-objects/dataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/dataObject.ts
@@ -87,7 +87,7 @@ export abstract class DataObject<O extends IFluidObject = object, S = undefined,
         });
         const path = `${this.bigBlobs}${uuid()}`;
         this.root.set(path, blob);
-        return new BlobHandle(path, this.root, this.runtime.IFluidHandleContext);
+        return new BlobHandle(path, this.root, this.runtime.objectsRoutingContext);
     }
 
     /**

--- a/packages/framework/aqueduct/src/data-objects/dataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/dataObject.ts
@@ -87,7 +87,7 @@ export abstract class DataObject<O extends IFluidObject = object, S = undefined,
         });
         const path = `${this.bigBlobs}${uuid()}`;
         this.root.set(path, blob);
-        return new BlobHandle(path, this.root, this.runtime.objectsRoutingContext);
+        return new BlobHandle(path, this.root, this.runtime.objectRoutingContext);
     }
 
     /**

--- a/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
@@ -90,7 +90,7 @@ export abstract class PureDataObject<O extends IFluidObject = object, S = undefi
         // Create a FluidObjectHandle with empty string as `path`. This is because reaching this PureDataObject is the
         // same as reaching its routeContext (FluidDataStoreRuntime) so there is so the relative path to it from the
         // routeContext is empty.
-        this.innerHandle = new FluidObjectHandle(this, "", this.runtime.IFluidHandleContext);
+        this.innerHandle = new FluidObjectHandle(this, "", this.runtime.objectsRoutingContext);
 
         // Container event handlers
         this.runtime.once("dispose", () => {

--- a/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
@@ -90,7 +90,7 @@ export abstract class PureDataObject<O extends IFluidObject = object, S = undefi
         // Create a FluidObjectHandle with empty string as `path`. This is because reaching this PureDataObject is the
         // same as reaching its routeContext (FluidDataStoreRuntime) so there is so the relative path to it from the
         // routeContext is empty.
-        this.innerHandle = new FluidObjectHandle(this, "", this.runtime.objectsRoutingContext);
+        this.innerHandle = new FluidObjectHandle(this, "", this.runtime.objectRoutingContext);
 
         // Container event handlers
         this.runtime.once("dispose", () => {

--- a/packages/framework/data-object-base/src/lazyLoadedDataObject.ts
+++ b/packages/framework/data-object-base/src/lazyLoadedDataObject.ts
@@ -63,7 +63,7 @@ export abstract class LazyLoadedDataObject<
             this._handle = new FluidObjectHandle(
                 this,
                 "",
-                this.runtime.IFluidHandleContext);
+                this.runtime.objectsRoutingContext);
         }
 
         return this._handle;
@@ -72,7 +72,7 @@ export abstract class LazyLoadedDataObject<
     /**
      * Absolute URL to the data object within the document
      */
-    public get url() { return this.runtime.IFluidHandleContext.absolutePath; }
+    public get url() { return this.runtime.objectsRoutingContext.absolutePath; }
 
     // #endregion IFluidLoadable
 

--- a/packages/framework/data-object-base/src/lazyLoadedDataObject.ts
+++ b/packages/framework/data-object-base/src/lazyLoadedDataObject.ts
@@ -63,7 +63,7 @@ export abstract class LazyLoadedDataObject<
             this._handle = new FluidObjectHandle(
                 this,
                 "",
-                this.runtime.objectsRoutingContext);
+                this.runtime.objectRoutingContext);
         }
 
         return this._handle;
@@ -72,7 +72,7 @@ export abstract class LazyLoadedDataObject<
     /**
      * Absolute URL to the data object within the document
      */
-    public get url() { return this.runtime.objectsRoutingContext.absolutePath; }
+    public get url() { return this.runtime.objectRoutingContext.absolutePath; }
 
     // #endregion IFluidLoadable
 

--- a/packages/runtime/agent-scheduler/src/scheduler.ts
+++ b/packages/runtime/agent-scheduler/src/scheduler.ts
@@ -55,7 +55,7 @@ class AgentScheduler extends EventEmitter implements IAgentScheduler {
     public get IAgentScheduler() { return this; }
 
     private get clientId(): string {
-        if (!this.runtime.IFluidHandleContext.isAttached) {
+        if (this.runtime.attachState === AttachState.Detached) {
             return UnattachedClientId;
         }
         const clientId = this.runtime.clientId;
@@ -209,7 +209,7 @@ class AgentScheduler extends EventEmitter implements IAgentScheduler {
         // Probably okay for now to have every client try to do this.
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         quorum.on("removeMember", async (clientId: string) => {
-            assert(this.runtime.IFluidHandleContext.isAttached);
+            assert(this.runtime.objectsRoutingContext.isAttached);
             // Cleanup only if connected. If not, cleanup will happen in initializeCore() that runs on connection.
             if (this.isActive()) {
                 const leftTasks: string[] = [];
@@ -244,7 +244,7 @@ class AgentScheduler extends EventEmitter implements IAgentScheduler {
             }
         });
 
-        if (!this.runtime.IFluidHandleContext.isAttached) {
+        if (this.runtime.attachState === AttachState.Detached) {
             this.runtime.waitAttached().then(() => {
                 this.clearRunningTasks();
             }).catch((error) => {
@@ -253,7 +253,7 @@ class AgentScheduler extends EventEmitter implements IAgentScheduler {
         }
 
         this.runtime.on("disconnected", () => {
-            if (this.runtime.IFluidHandleContext.isAttached) {
+            if (this.runtime.attachState !== AttachState.Detached) {
                 this.clearRunningTasks();
             }
         });
@@ -300,7 +300,7 @@ class AgentScheduler extends EventEmitter implements IAgentScheduler {
 
     private isActive() {
         // Scheduler should be active in detached container.
-        if (!this.runtime.IFluidHandleContext.isAttached) {
+        if (this.runtime.attachState === AttachState.Detached) {
             return true;
         }
         if (!this.runtime.connected) {
@@ -389,7 +389,7 @@ export class TaskManager implements ITaskManager {
         private readonly scheduler: IAgentScheduler,
         private readonly runtime: IFluidDataStoreRuntime,
         private readonly context: IFluidDataStoreContext) {
-        this.innerHandle = new FluidObjectHandle(this, "", this.runtime.IFluidHandleContext);
+        this.innerHandle = new FluidObjectHandle(this, "", this.runtime.objectsRoutingContext);
     }
 
     public async request(request: IRequest): Promise<IResponse> {

--- a/packages/runtime/agent-scheduler/src/scheduler.ts
+++ b/packages/runtime/agent-scheduler/src/scheduler.ts
@@ -209,7 +209,7 @@ class AgentScheduler extends EventEmitter implements IAgentScheduler {
         // Probably okay for now to have every client try to do this.
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         quorum.on("removeMember", async (clientId: string) => {
-            assert(this.runtime.objectsRoutingContext.isAttached);
+            assert(this.runtime.objectRoutingContext.isAttached);
             // Cleanup only if connected. If not, cleanup will happen in initializeCore() that runs on connection.
             if (this.isActive()) {
                 const leftTasks: string[] = [];
@@ -389,7 +389,7 @@ export class TaskManager implements ITaskManager {
         private readonly scheduler: IAgentScheduler,
         private readonly runtime: IFluidDataStoreRuntime,
         private readonly context: IFluidDataStoreContext) {
-        this.innerHandle = new FluidObjectHandle(this, "", this.runtime.objectsRoutingContext);
+        this.innerHandle = new FluidObjectHandle(this, "", this.runtime.objectRoutingContext);
     }
 
     public async request(request: IRequest): Promise<IResponse> {

--- a/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
@@ -43,7 +43,7 @@ export interface IFluidDataStoreRuntime extends
 
     readonly rootRoutingContext: IFluidHandleContext;
     readonly ddsRoutingContext: IFluidHandleContext;
-    readonly objectsRoutingContext: IFluidHandleContext;
+    readonly objectRoutingContext: IFluidHandleContext;
 
     readonly options: any;
 

--- a/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
@@ -41,6 +41,10 @@ export interface IFluidDataStoreRuntime extends
 
     readonly IFluidHandleContext: IFluidHandleContext;
 
+    readonly rootRoutingContext: IFluidHandleContext;
+    readonly ddsRoutingContext: IFluidHandleContext;
+    readonly objectsRoutingContext: IFluidHandleContext;
+
     readonly options: any;
 
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -140,6 +140,10 @@ export class FluidDataStoreRuntime extends EventEmitter implements IFluidDataSto
 
     public get IFluidHandleContext() { return this; }
 
+    public get rootRoutingContext() { return this; }
+    public get ddsRoutingContext() { return this; }
+    public get objectsRoutingContext() { return this; }
+
     private _disposed = false;
     public get disposed() { return this._disposed; }
 

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -142,7 +142,7 @@ export class FluidDataStoreRuntime extends EventEmitter implements IFluidDataSto
 
     public get rootRoutingContext() { return this; }
     public get ddsRoutingContext() { return this; }
-    public get objectsRoutingContext() { return this; }
+    public get objectRoutingContext() { return this; }
 
     private _disposed = false;
     public get disposed() { return this._disposed; }

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -366,7 +366,7 @@ export class MockFluidDataStoreRuntime extends EventEmitter
     public get IFluidHandleContext(): IFluidHandleContext { return this; }
     public get rootRoutingContext(): IFluidHandleContext { return this; }
     public get ddsRoutingContext(): IFluidHandleContext { return this; }
-    public get objectsRoutingContext(): IFluidHandleContext { return this; }
+    public get objectRoutingContext(): IFluidHandleContext { return this; }
 
     public get IFluidRouter() { return this; }
 

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -364,6 +364,10 @@ export class MockQuorum implements IQuorum, EventEmitter {
 export class MockFluidDataStoreRuntime extends EventEmitter
     implements IFluidDataStoreRuntime, IFluidDataStoreChannel, IFluidHandleContext {
     public get IFluidHandleContext(): IFluidHandleContext { return this; }
+    public get rootRoutingContext(): IFluidHandleContext { return this; }
+    public get ddsRoutingContext(): IFluidHandleContext { return this; }
+    public get objectsRoutingContext(): IFluidHandleContext { return this; }
+
     public get IFluidRouter() { return this; }
 
     public readonly IFluidSerializer = new FluidSerializer();

--- a/packages/test/end-to-end-tests/src/real-service-tests/r11sEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/real-service-tests/r11sEndToEndTests.spec.ts
@@ -125,7 +125,7 @@ describe(`r11s End-To-End tests`, () => {
         // Get the sub component and assert that it is attached.
         const response2 = await container2.request({ url: `/${subComponent1.context.id}` });
         const subComponent2 = response2.value as ITestFluidObject;
-        assert.strictEqual(subComponent2.runtime.IFluidHandleContext.isAttached, true,
+        assert(subComponent2.runtime.attachState !== AttachState.Detached,
             "Component should be attached!!");
 
         // Verify the attributes of the root channel of both sub components.

--- a/packages/test/end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -92,7 +92,7 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
         const dataStore2 = peerDataStore.peerDataStore;
         const dataStore2RuntimeChannel = peerDataStore.peerDataStoreRuntimeChannel;
 
-        assert.strictEqual(dataStore2.runtime.IFluidHandleContext.isAttached, false,
+        assert(dataStore2.runtime.attachState === AttachState.Detached,
             createTestStatementForAttachedDetached("DataStore2", false));
 
         // Create a channel
@@ -101,7 +101,7 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
 
         dataStore2RuntimeChannel.bindToContext();
 
-        assert.strictEqual(dataStore2.runtime.IFluidHandleContext.isAttached, true,
+        assert(dataStore2.runtime.attachState !== AttachState.Detached,
             createTestStatementForAttachedDetached("DataStore2", true));
 
         assert.strictEqual(channel.handle.isAttached, false,
@@ -117,7 +117,7 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
         const peerDataStore = await createPeerDataStore(defaultDataStore.context.containerRuntime);
         const dataStore2 = peerDataStore.peerDataStore;
         const dataStore2RuntimeChannel = peerDataStore.peerDataStoreRuntimeChannel;
-        assert.strictEqual(dataStore2.runtime.IFluidHandleContext.isAttached, false,
+        assert(dataStore2.runtime.attachState === AttachState.Detached,
             createTestStatementForAttachedDetached("DataStore2", false));
 
         // Create a channel
@@ -128,7 +128,7 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
         (await channel.handle.get() as SharedObject).bindToContext();
         dataStore2RuntimeChannel.bindToContext();
 
-        assert.strictEqual(dataStore2.runtime.IFluidHandleContext.isAttached, true,
+        assert(dataStore2.runtime.attachState !== AttachState.Detached,
             createTestStatementForAttachedDetached("DataStore2", true));
 
         // Channel should get attached as it was registered to its dataStore
@@ -144,7 +144,7 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
         // Create another dataStore which returns the runtime channel.
         const peerDataStore = await createPeerDataStore(defaultDataStore.context.containerRuntime);
         const dataStore2 = peerDataStore.peerDataStore;
-        assert.strictEqual(dataStore2.runtime.IFluidHandleContext.isAttached, false,
+        assert(dataStore2.runtime.attachState === AttachState.Detached,
             createTestStatementForAttachedDetached("DataStore2", false));
 
         // Create a channel
@@ -157,7 +157,7 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
         assert.strictEqual(channel.handle.isAttached, true,
             createTestStatementForAttachedDetached("Channel", true));
 
-        assert.strictEqual(dataStore2.runtime.IFluidHandleContext.isAttached, true,
+        assert(dataStore2.runtime.attachState !== AttachState.Detached,
             createTestStatementForAttachedDetached("DataStore2", true));
     });
 
@@ -170,7 +170,7 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
         const peerDataStore = await createPeerDataStore(defaultDataStore.context.containerRuntime);
         const dataStore2 = peerDataStore.peerDataStore;
         const dataStore2RuntimeChannel = peerDataStore.peerDataStoreRuntimeChannel;
-        assert.strictEqual(dataStore2.runtime.IFluidHandleContext.isAttached, false,
+        assert(dataStore2.runtime.attachState === AttachState.Detached,
             createTestStatementForAttachedDetached("DataStore2", false));
 
         // Create a channel
@@ -202,7 +202,7 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
         const dataStore2 = peerDataStore.peerDataStore;
         const dataStore2RuntimeChannel = peerDataStore.peerDataStoreRuntimeChannel;
 
-        assert.strictEqual(dataStore2.runtime.IFluidHandleContext.isAttached, false,
+        assert(dataStore2.runtime.attachState === AttachState.Detached,
             createTestStatementForAttachedDetached("DataStore2", false));
 
         // Create a channel
@@ -225,10 +225,8 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
         const peerDataStore = await createPeerDataStore(defaultDataStore.context.containerRuntime);
         const dataStore2 = peerDataStore.peerDataStore;
 
-        assert.strictEqual(dataStore2.runtime.IFluidHandleContext.isAttached, false,
+        assert(dataStore2.runtime.attachState === AttachState.Detached,
             createTestStatementForAttachedDetached("DataStore2", false));
-        assert.strictEqual(dataStore2.runtime.IFluidHandleContext.isAttached, false,
-            "DataStore2 should be unattached");
 
         // Create a channel
         const channel = dataStore2.runtime.createChannel("test1", "https://graph.microsoft.com/types/map");
@@ -250,10 +248,8 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
             const dataStore2 = peerDataStore.peerDataStore;
             const dataStore2RuntimeChannel = peerDataStore.peerDataStoreRuntimeChannel;
 
-            assert.strictEqual(dataStore2.runtime.IFluidHandleContext.isAttached, false,
+            assert(dataStore2.runtime.attachState === AttachState.Detached,
                 createTestStatementForAttachedDetached("DataStore2", false));
-            assert.strictEqual(dataStore2.runtime.IFluidHandleContext.isAttached, false,
-                "DataStore2 should be unattached");
 
             // Create first channel
             const channel1 = dataStore2.runtime.createChannel("test1", "https://graph.microsoft.com/types/map");
@@ -291,10 +287,8 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
             const peerDataStore = await createPeerDataStore(defaultDataStore.context.containerRuntime);
             const dataStore2 = peerDataStore.peerDataStore;
 
-            assert.strictEqual(dataStore2.runtime.IFluidHandleContext.isAttached, false,
+            assert(dataStore2.runtime.attachState === AttachState.Detached,
                 createTestStatementForAttachedDetached("DataStore2", false));
-            assert.strictEqual(dataStore2.runtime.IFluidHandleContext.isAttached, false,
-                "DataStore2 should be unattached");
 
             // Create first channel
             const channel1 = dataStore2.runtime.createChannel("test1", "https://graph.microsoft.com/types/map");
@@ -331,15 +325,13 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
             // Create another dataStore which returns the runtime channel.
             const peerDataStore1 = await createPeerDataStore(defaultDataStore.context.containerRuntime);
             const dataStore2 = peerDataStore1.peerDataStore;
-            assert.strictEqual(dataStore2.runtime.IFluidHandleContext.isAttached, false,
+            assert(dataStore2.runtime.attachState === AttachState.Detached,
                 createTestStatementForAttachedDetached("DataStore2", false));
-            assert.strictEqual(dataStore2.runtime.IFluidHandleContext.isAttached, false,
-                "DataStore2 should be unattached");
 
             // Create another dataStore which returns the runtime channel.
             const peerDataStore2 = await createPeerDataStore(defaultDataStore.context.containerRuntime);
             const dataStore3 = peerDataStore2.peerDataStore;
-            assert.strictEqual(dataStore3.runtime.IFluidHandleContext.isAttached, false,
+            assert(dataStore3.runtime.attachState === AttachState.Detached,
                 createTestStatementForAttachedDetached("DataStore2", false));
 
             // Create first channel from dataStore2
@@ -362,9 +354,9 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
                 "Test Channel 1 should be bound now after attaching it");
             assert.strictEqual(testChannelOfDataStore3.isAttached(), true,
                 "Test Channel 2 should be bound now after attaching other DDS");
-            assert.strictEqual(dataStore2.runtime.IFluidHandleContext.isAttached, true,
+            assert(dataStore2.runtime.attachState !== AttachState.Detached,
                 "DataStore 2 should be attached");
-            assert.strictEqual(dataStore3.runtime.IFluidHandleContext.isAttached, true,
+            assert(dataStore3.runtime.attachState !== AttachState.Detached,
                 "DataStore 3 should be attached");
         });
 
@@ -378,13 +370,13 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
             // Create another data store which returns the runtime channel.
             const peerDataStore1 = await createPeerDataStore(defaultDataStore.context.containerRuntime);
             const dataStore2 = peerDataStore1.peerDataStore as TestFluidObject;
-            assert.strictEqual(dataStore2.runtime.IFluidHandleContext.isAttached, false,
+            assert(dataStore2.runtime.attachState === AttachState.Detached,
                 "DataStore2 should be unattached");
 
             // Create another data store which returns the runtime channel.
             const peerDataStore2 = await createPeerDataStore(defaultDataStore.context.containerRuntime);
             const dataStore3 = peerDataStore2.peerDataStore as TestFluidObject;
-            assert.strictEqual(dataStore3.runtime.IFluidHandleContext.isAttached, false,
+            assert(dataStore3.runtime.attachState === AttachState.Detached,
                 "DataStore3 should be unattached");
 
             // Create first channel from dataStore2
@@ -427,20 +419,20 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
             // Create another dataStore which returns the runtime channel.
             const peerDataStore1 = await createPeerDataStore(defaultDataStore.context.containerRuntime);
             const dataStore2 = peerDataStore1.peerDataStore as TestFluidObject;
-            assert.strictEqual(dataStore2.runtime.IFluidHandleContext.isAttached, false,
+            assert(dataStore2.runtime.attachState === AttachState.Detached,
                 "DataStore2 should be unattached");
 
             // Create another dataStore which returns the runtime channel.
             // Create another dataStore which returns the runtime channel.
             const peerDataStore2 = await createPeerDataStore(defaultDataStore.context.containerRuntime);
             const dataStore3 = peerDataStore2.peerDataStore as TestFluidObject;
-            assert.strictEqual(dataStore3.runtime.IFluidHandleContext.isAttached, false,
+            assert(dataStore3.runtime.attachState === AttachState.Detached,
                 "DataStore3 should be unattached");
 
             // Create another dataStore which returns the runtime channel.
             const peerDataStore3 = await createPeerDataStore(defaultDataStore.context.containerRuntime);
             const dataStore4 = peerDataStore3.peerDataStore as TestFluidObject;
-            assert.strictEqual(dataStore4.runtime.IFluidHandleContext.isAttached, false,
+            assert(dataStore4.runtime.attachState === AttachState.Detached,
                 "DataStore4 should be unattached");
 
             // Create two channel from dataStore2
@@ -478,11 +470,11 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
             assert.strictEqual(channel2OfDataStore2.isAttached(), true, "Test Channel 22 should be bound");
             assert.strictEqual(channel1OfDataStore3.isAttached(), true, "Test Channel 13 should be bound");
             assert.strictEqual(channel2OfDataStore3.isAttached(), true, "Test Channel 23 should be bound");
-            assert.strictEqual(dataStore2.runtime.IFluidHandleContext.isAttached, true,
+            assert(dataStore2.runtime.attachState !== AttachState.Detached,
                 "DataStore 2 should have get bound");
-            assert.strictEqual(dataStore3.runtime.IFluidHandleContext.isAttached, true,
+            assert(dataStore3.runtime.attachState !== AttachState.Detached,
                 "DataStore 3 should have get bound");
-            assert.strictEqual(dataStore4.runtime.IFluidHandleContext.isAttached, true,
+            assert(dataStore4.runtime.attachState !== AttachState.Detached,
                 "DataStore 4 should have get bound");
             assert.strictEqual(channel1OfDataStore4.isAttached(), true, "Test Channel 14 should be bound");
         });

--- a/packages/test/end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -136,7 +136,7 @@ const tests = (args: ICompatTestArgs) => {
         // Now attach the container
         await container.attach(request);
 
-        assert.strictEqual(testDataStore.runtime.IFluidHandleContext.isAttached, true,
+        assert(testDataStore.runtime.attachState !== AttachState.Detached,
             "DataStore should be attached!!");
 
         // Get the sub dataStore's "root" channel and verify that it is attached.
@@ -169,7 +169,7 @@ const tests = (args: ICompatTestArgs) => {
         // Get the sub dataStore and assert that it is attached.
         const response2 = await container2.request({ url: `/${subDataStore1.context.id}` });
         const subDataStore2 = response2.value as ITestFluidObject;
-        assert.strictEqual(subDataStore2.runtime.IFluidHandleContext.isAttached, true,
+        assert(subDataStore2.runtime.attachState !== AttachState.Detached,
             "DataStore should be attached!!");
 
         // Verify the attributes of the root channel of both sub dataStores.

--- a/packages/test/end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/error.spec.ts
@@ -60,11 +60,9 @@ describe("Errors Types", () => {
         try {
             const mockFactory = Object.create(serviceFactory) as IDocumentServiceFactory;
             // Issue typescript-eslint/typescript-eslint #1256
-            // eslint-disable-next-line @typescript-eslint/unbound-method
             mockFactory.createDocumentService = async (resolvedUrl) => {
                 const service = await serviceFactory.createDocumentService(resolvedUrl);
                 // Issue typescript-eslint/typescript-eslint #1256
-                // eslint-disable-next-line @typescript-eslint/unbound-method
                 service.connectToDeltaStorage = async () => Promise.reject(false);
                 return service;
             };

--- a/packages/test/end-to-end-tests/src/test/fluidObjectHandle.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/fluidObjectHandle.spec.ts
@@ -117,11 +117,11 @@ describe("FluidObjectHandle", () => {
         const absolutePath = `/${firstContainerObject1._runtime.id}`;
 
         // Verify that the local client's FluidDataObjectRuntime has the correct absolute path.
-        const fluidHandleContext11 = firstContainerObject1._runtime.IFluidHandleContext;
+        const fluidHandleContext11 = firstContainerObject1._runtime.rootRoutingContext;
         assert.equal(fluidHandleContext11.absolutePath, absolutePath, "The FluidDataObjectRuntime's path is incorrect");
 
         // Verify that the remote client's FluidDataObjectRuntime has the correct absolute path.
-        const fluidHandleContext12 = secondContainerObject1._runtime.IFluidHandleContext;
+        const fluidHandleContext12 = secondContainerObject1._runtime.rootRoutingContext;
         assert.equal(
             fluidHandleContext12.absolutePath,
             absolutePath,

--- a/packages/test/test-utils/src/testFluidObject.ts
+++ b/packages/test/test-utils/src/testFluidObject.ts
@@ -59,7 +59,7 @@ export class TestFluidObject implements ITestFluidObject {
         private readonly factoryEntriesMap: Map<string, IChannelFactory>,
     ) {
         this.url = context.id;
-        this.innerHandle = new FluidObjectHandle(this, "", runtime.IFluidHandleContext);
+        this.innerHandle = new FluidObjectHandle(this, "", runtime.objectsRoutingContext);
     }
 
     /**

--- a/packages/test/test-utils/src/testFluidObject.ts
+++ b/packages/test/test-utils/src/testFluidObject.ts
@@ -59,7 +59,7 @@ export class TestFluidObject implements ITestFluidObject {
         private readonly factoryEntriesMap: Map<string, IChannelFactory>,
     ) {
         this.url = context.id;
-        this.innerHandle = new FluidObjectHandle(this, "", runtime.objectsRoutingContext);
+        this.innerHandle = new FluidObjectHandle(this, "", runtime.objectRoutingContext);
     }
 
     /**


### PR DESCRIPTION
Our container / data store routes are ambiguous:
/_blobs/123 may mean blob with ID = 123, or it may mean DDS=123 under data store _blobs.
/store/root may mean DDS=root under data store, or it may mean custom route 'root' into object (like DataObject).

The biggest problem is IFluidDataStoreRuntime.IFluidHandleContext, as everybody grabs it and vases URIs based on it, without any real coordination. This entry point needs to be split into /dds/ & /object/ routes.
This change is the very first change on this path.

Prototyping branch: https://github.com/microsoft/FluidFramework/compare/main...vladsud:Routing?expand=1
First cleanup: PR #3886: Cleanup of serializer interfaces

We also should not use IDataStoreRuntime.IFluidHandleContext.isAttached as a proxy for testing IDataStoreRuntime.attach state.
With this and other PR, we will get to zero usage of IDataStoreRuntime.IFluidHandleContext and it can be deleted.