### PR TITLE
Add protection against data loss

### DIFF
--- a/packages/loader/container-definitions/src/error.ts
+++ b/packages/loader/container-definitions/src/error.ts
@@ -16,6 +16,11 @@ export enum ContainerErrorType {
      * Throttling error from server. Server is busy and is asking not to reconnect for some time
      */
     throttlingError = "throttlingError",
+
+    /**
+     * Throttling error from server. Server is busy and is asking not to reconnect for some time
+     */
+    dataCorruption = "dataCorruption",
 }
 
 /**

--- a/packages/loader/container-definitions/src/error.ts
+++ b/packages/loader/container-definitions/src/error.ts
@@ -18,7 +18,7 @@ export enum ContainerErrorType {
     throttlingError = "throttlingError",
 
     /**
-     * Throttling error from server. Server is busy and is asking not to reconnect for some time
+     * Data loss error detected by Container / DeltaManager. Likely points to storage issue.
      */
     dataCorruption = "dataCorruption",
 }

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -1173,14 +1173,16 @@ export class DeltaManager
                 // Validate that we do not have data loss, i.e. sequencing is reset and started again
                 // with numbers that this client already observed before.
                 if (this.previouslyProcessedMessage?.sequenceNumber === message.sequenceNumber) {
-                    const m1 = this.comparableMessagePayload(this.previouslyProcessedMessage);
-                    const m2 = this.comparableMessagePayload(message);
-                    if (m1 !== m2) {
+                    const message1 = this.comparableMessagePayload(this.previouslyProcessedMessage);
+                    const message2 = this.comparableMessagePayload(message);
+                    if (message1 !== message2) {
                         const error = {
                             errorType: ContainerErrorType.dataCorruption,
                             message: "Two messages with same seq# and different payload!",
                             clientId: this.connection?.details.clientId,
                             sequenceNumber: message.sequenceNumber,
+                            message1,
+                            message2,
                         };
                         this.close(error);
                     }


### PR DESCRIPTION
Adding defensive detection of data loss scenario, based on https://github.com/microsoft/FluidFramework/issues/3840
Note: I'm not checking against last known sequence to client as I find it risky - that would add potential race where same op can come at the same time from socket & storage.
Instead, I'm validating that sockets ops only move forward (including across multirole connections)

@GaryWilber , @tanviraumi - Is this valid assumption?
I.e. Can client in normal flow reconnect to another connection and receive prior messages? I.e. can there be a case when newly connected server is behind in retransmitting messages and transmits (after new connection) something that client already observed on another socket?

If this is not the right check, how else (safely) we can detect data loss by PUSH and reversal in sequence numbers?