### PR TITLE
Better telemetry & handling of disconnect flows

### DIFF
--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -338,8 +338,7 @@ export class DocumentDeltaConnection
     }
 
     /**
-     * Disconnect from the websocket, and permanently disable this DocumentDeltaConnection.  Subclasses which
-     * override this method must set the "closed" flag after disconnecting.
+     * Disconnect from the websocket.
      * @param socketProtocolError - true if error happened on socket / socket.io protocol level
      *  (not on Fluid protocol level)
      * @param reason - reason for disconnect

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -308,8 +308,8 @@ export class DocumentDeltaConnection
     /**
      * Disconnect from the websocket, and permanently disable this DocumentDeltaConnection.
      */
-    public disconnect() {
-        this.disconnectCore(false, "client closing connection");
+    public close() {
+        this.disconnect(false, "client closing connection");
     }
 
     /**
@@ -319,7 +319,7 @@ export class DocumentDeltaConnection
      *  (not on Fluid protocol level)
      * @param reason - reason for disconnect
      */
-    public disconnectCore(socketProtocolError: boolean, reason: string) {
+    public disconnect(socketProtocolError: boolean, reason: string) {
         this.closed = true;
         this.removeTrackedListeners(false);
         this.socket.disconnect();
@@ -335,20 +335,20 @@ export class DocumentDeltaConnection
         this._details = await new Promise<IConnected>((resolve, reject) => {
             // Listen for connection issues
             this.addConnectionListener("connect_error", (error) => {
-                this.disconnectCore(true, `Socket connection error: ${error}`);
+                this.disconnect(true, `Socket connection error: ${error}`);
                 reject(createErrorObject("connect_error", error));
             });
 
             // Listen for timeouts
             this.addConnectionListener("connect_timeout", () => {
-                this.disconnectCore(true, "connect_timeout");
+                this.disconnect(true, "connect_timeout");
                 reject(createErrorObject("connect_timeout", "Socket connection timed out"));
             });
 
             // Socket can be disconnected while waiting for Fluid protocol messages
             // (connect_document_error / connect_document_success)
             this.addConnectionListener("disconnect", (reason) => {
-                this.disconnectCore(true, `disconnect : ${reason}`);
+                this.disconnect(true, `disconnect : ${reason}`);
                 reject(createErrorObject("disconnect", reason));
             });
 
@@ -377,7 +377,7 @@ export class DocumentDeltaConnection
                 this.emit("error", errorObj);
 
                 // Safety net - disconnect socket if client did not do so as result of processing "error" event.
-                this.disconnectCore(true, `error: ${error}`);
+                this.disconnect(true, `error: ${error}`);
             }));
 
             this.addConnectionListener("connect_document_error", ((error) => {
@@ -391,7 +391,7 @@ export class DocumentDeltaConnection
                 // This is not an error for the socket - it's a protocol error.
                 // In this case we disconnect the socket and indicate that we were unable to create the
                 // DocumentDeltaConnection.
-                this.disconnectCore(false, `connect_document_error: ${error}`);
+                this.disconnect(false, `connect_document_error: ${error}`);
                 reject(createErrorObject("connect_document_error", error));
             }));
 

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -164,11 +164,9 @@ export class DocumentDeltaConnection
             });
 
         this.on("newListener", (event, listener) => {
-            assert(!this.closed, "can't add listeners after close");
-
             // Register for the event on socket.io
             // "error" is special - we already subscribed to it to modify error object on the fly.
-            if (event !== "error" && this.listeners(event).length === 0) {
+            if (!this.closed && event !== "error" && this.listeners(event).length === 0) {
                 this.addTrackedListener(
                     event,
                     (...args: any[]) => {
@@ -357,6 +355,7 @@ export class DocumentDeltaConnection
 
         this._details = await new Promise<IConnected>((resolve, reject) => {
             const fail = (socketProtocolError: boolean, err: DriverError) => {
+                this.closed = true;
                 this.removeTrackedListeners(false);
                 this.disconnect(socketProtocolError, err);
                 reject(err);

--- a/packages/drivers/file-driver/src/fileDocumentDeltaConnection.ts
+++ b/packages/drivers/file-driver/src/fileDocumentDeltaConnection.ts
@@ -16,7 +16,6 @@ import {
     ScopeType,
 } from "@fluidframework/protocol-definitions";
 import { TypedEventEmitter } from "@fluidframework/common-utils";
-import { debug } from "./debug";
 import { FileDeltaStorageService } from "./fileDeltaStorageService";
 
 const MaxBatchDeltas = 2000;
@@ -197,14 +196,14 @@ export class ReplayFileDeltaConnection
     }
 
     public submit(documentMessages: IDocumentMessage[]): void {
-        debug("dropping the outbound message");
+        // ReplayFileDeltaConnection.submit() can't be called - client never sees its own join on,
+        // and thus can never move to sending ops.
+        throw new Error("ReplayFileDeltaConnection.submit() can't be called");
     }
 
     public async submitSignal(message: any) {
-        debug("dropping the outbound signal and wait for response");
     }
 
     public close() {
-        debug("no implementation for disconnect...");
     }
 }

--- a/packages/drivers/file-driver/src/fileDocumentDeltaConnection.ts
+++ b/packages/drivers/file-driver/src/fileDocumentDeltaConnection.ts
@@ -204,7 +204,7 @@ export class ReplayFileDeltaConnection
         debug("dropping the outbound signal and wait for response");
     }
 
-    public disconnect() {
+    public close() {
         debug("no implementation for disconnect...");
     }
 }

--- a/packages/drivers/iframe-driver/src/innerDocumentDeltaConnection.ts
+++ b/packages/drivers/iframe-driver/src/innerDocumentDeltaConnection.ts
@@ -202,7 +202,7 @@ export class InnerDocumentDeltaConnection
     /**
      * Disconnect from the websocket
      */
-    public disconnect() {
+    public close() {
         throw new Error("InnerDocumentDeltaConnection: Disconnect not implemented Yet");
     }
 }

--- a/packages/drivers/iframe-driver/src/innerDocumentDeltaConnection.ts
+++ b/packages/drivers/iframe-driver/src/innerDocumentDeltaConnection.ts
@@ -203,6 +203,6 @@ export class InnerDocumentDeltaConnection
      * Disconnect from the websocket
      */
     public close() {
-        throw new Error("InnerDocumentDeltaConnection: Disconnect not implemented Yet");
+        throw new Error("InnerDocumentDeltaConnection: close() not implemented Yet");
     }
 }

--- a/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
+++ b/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
@@ -191,7 +191,7 @@ export class LocalDocumentDeltaConnection
         this.submitManager.drain();
     }
 
-    public disconnect() {
+    public close() {
         // Do nothing
     }
 

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "assert";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import { DocumentDeltaConnection } from "@fluidframework/driver-base";
-import { IDocumentDeltaConnection } from "@fluidframework/driver-definitions";
+import { IDocumentDeltaConnection, DriverError } from "@fluidframework/driver-definitions";
 import {
     IClient,
     IConnect,
@@ -340,7 +340,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
     /**
      * Disconnect from the websocket
      */
-    protected disconnectCore(socketProtocolError: boolean, reason: string) {
+    protected disconnectCore(socketProtocolError: boolean, reason: DriverError) {
         const key = this.socketReferenceKey;
         assert(key !== undefined, "reetrancy not supported!");
         this.socketReferenceKey = undefined;

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -340,7 +340,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
     /**
      * Disconnect from the websocket
      */
-    public disconnectCore(socketProtocolError: boolean, reason: string) {
+    public disconnect(socketProtocolError: boolean, reason: string) {
         // We set the closed flag as a part of the contract for overriding the disconnect method.  This is used by
         // DocumentDeltaConnection to determine if emitting on the socket is allowed, which is important since
         // OdspDocumentDeltaConnection reuses the socket rather than truly disconnecting it.  Note that below we may

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -340,7 +340,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
     /**
      * Disconnect from the websocket
      */
-    public disconnect(socketProtocolError: boolean = false) {
+    public disconnectCore(socketProtocolError: boolean, reason: string) {
         // We set the closed flag as a part of the contract for overriding the disconnect method.  This is used by
         // DocumentDeltaConnection to determine if emitting on the socket is allowed, which is important since
         // OdspDocumentDeltaConnection reuses the socket rather than truly disconnecting it.  Note that below we may
@@ -352,9 +352,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
             const key = this.socketReferenceKey;
             this.socketReferenceKey = undefined;
 
-            const reason = "client closing connection";
-
-            if (this.enableMultiplexing && !socketProtocolError && this.hasDetails) {
+            if (!socketProtocolError && this.hasDetails) {
                 // tell the server we are disconnecting this client from the document
                 this.socket.emit("disconnect_document", this.clientId, this.documentId);
             }
@@ -365,5 +363,8 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
             // If it's not critical error, we want to raise event on this object only.
             this.emit("disconnect", reason);
         }
+
+        // Remove all listeners after "disconnect" event was raised.
+        this.removeTrackedListeners(false);
     }
 }

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -340,7 +340,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
     /**
      * Disconnect from the websocket
      */
-    protected disconnectCore(socketProtocolError: boolean, reason: DriverError) {
+    protected disconnect(socketProtocolError: boolean, reason: DriverError) {
         const key = this.socketReferenceKey;
         assert(key !== undefined, "reetrancy not supported!");
         this.socketReferenceKey = undefined;

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -340,31 +340,20 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
     /**
      * Disconnect from the websocket
      */
-    public disconnect(socketProtocolError: boolean, reason: string) {
-        // We set the closed flag as a part of the contract for overriding the disconnect method.  This is used by
-        // DocumentDeltaConnection to determine if emitting on the socket is allowed, which is important since
-        // OdspDocumentDeltaConnection reuses the socket rather than truly disconnecting it.  Note that below we may
-        // still send disconnect_document which is allowed; this is only intended to prevent normal messages from
-        // being emitted.
-        this.closed = true;
+    protected disconnectCore(socketProtocolError: boolean, reason: string) {
+        const key = this.socketReferenceKey;
+        assert(key !== undefined, "reetrancy not supported!");
+        this.socketReferenceKey = undefined;
 
-        if (this.socketReferenceKey !== undefined) {
-            const key = this.socketReferenceKey;
-            this.socketReferenceKey = undefined;
-
-            if (!socketProtocolError && this.hasDetails) {
-                // tell the server we are disconnecting this client from the document
-                this.socket.emit("disconnect_document", this.clientId, this.documentId);
-            }
-
-            OdspDocumentDeltaConnection.removeSocketIoReference(key, socketProtocolError, reason);
-
-            // RemoveSocketIoReference() above raises "disconnect" event on socket for socketProtocolError === true
-            // If it's not critical error, we want to raise event on this object only.
-            this.emit("disconnect", reason);
+        if (!socketProtocolError && this.hasDetails) {
+            // tell the server we are disconnecting this client from the document
+            this.socket.emit("disconnect_document", this.clientId, this.documentId);
         }
 
-        // Remove all listeners after "disconnect" event was raised.
-        this.removeTrackedListeners(false);
+        OdspDocumentDeltaConnection.removeSocketIoReference(key, socketProtocolError, reason);
+
+        // RemoveSocketIoReference() above raises "disconnect" event on socket for socketProtocolError === true
+        // If it's not critical error, we want to raise event on this object only.
+        this.emit("disconnect", reason);
     }
 }

--- a/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
@@ -287,15 +287,15 @@ export class ReplayDocumentDeltaConnection
     }
 
     public submit(documentMessage: IDocumentMessage[]): void {
-        debug("dropping the outbound message");
+        // ReplayDocumentDeltaConnection.submit() can't be called - client never sees its own join on,
+        // and thus can never move to sending ops.
+        throw new Error("ReplayDocumentDeltaConnection.submit() can't be called");
     }
 
     public async submitSignal(message: any) {
-        debug("dropping the outbound signal and wait for response");
     }
 
     public close() {
-        debug("no implementation for disconnect...");
     }
 
     /**

--- a/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
@@ -294,7 +294,7 @@ export class ReplayDocumentDeltaConnection
         debug("dropping the outbound signal and wait for response");
     }
 
-    public disconnect() {
+    public close() {
         debug("no implementation for disconnect...");
     }
 

--- a/packages/drivers/routerlicious-driver/src/wsDeltaConnection.ts
+++ b/packages/drivers/routerlicious-driver/src/wsDeltaConnection.ts
@@ -177,7 +177,7 @@ export class WSDeltaConnection
         this.submitManager.add("submitSignal", message);
     }
 
-    public disconnect() {
+    public close() {
         this.socket.close();
     }
 

--- a/packages/loader/container-loader/src/deltaConnection.ts
+++ b/packages/loader/container-loader/src/deltaConnection.ts
@@ -115,7 +115,7 @@ export class DeltaConnection
         if (this._connection !== undefined) {
             const connection = this._connection;
             this._connection = undefined;
-            connection.disconnect();
+            connection.close();
         }
     }
 

--- a/packages/loader/container-loader/src/deltaConnection.ts
+++ b/packages/loader/container-loader/src/deltaConnection.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
 import {
     IConnectionDetails,
 } from "@fluidframework/container-definitions";
@@ -15,7 +14,6 @@ import {
 import {
     IClient,
     IDocumentMessage,
-    INack,
 } from "@fluidframework/protocol-definitions";
 import { TypedEventEmitter } from "@fluidframework/common-utils";
 
@@ -32,19 +30,7 @@ export class DeltaConnection
         return this._details;
     }
 
-    public get nacked(): boolean {
-        return this._nacked;
-    }
-
-    public get connected(): boolean {
-        return this._connection !== undefined;
-    }
-
     private readonly _details: IConnectionDetails;
-    private _nacked = false;
-
-    private readonly forwardEvents = ["op", "signal", "error", "pong"];
-    private readonly nonForwardEvents = ["nack", "disconnect"];
 
     private _connection?: IDocumentDeltaConnection;
 
@@ -74,17 +60,6 @@ export class DeltaConnection
             version: connection.version,
         };
 
-        connection.on("nack", (documentId: string, message: INack[]) => {
-            // Mark nacked and also pause any outbound communication
-            this._nacked = true;
-            this.emit("nack", documentId, message);
-        });
-
-        connection.on("disconnect", (reason) => {
-            this.emit("disconnect", reason);
-            this.close();
-        });
-
         this.on("newListener", (event: string, listener: (...args: any[]) => void) => {
             // Register for the event on connection
             // A number of events that are pass-through.
@@ -92,17 +67,12 @@ export class DeltaConnection
             // that is used as a signal in DocumentDeltaConnection to know if anyone has subscribed
             // to these events, and thus stop accumulating ops / signals in early handlers.
             // See DocumentDeltaConnection.initialMessages() implementation for details.
-            if (this.forwardEvents.includes(event)) {
-                if (this.listeners(event).length === 0) {
-                    this.connection.on(
-                        event as any,
-                        (...args: any[]) => {
-                            this.emit(event, ...args);
-                        });
-                }
-            } else {
-                // These are events that we already subscribed to and already emit on object.
-                assert(this.nonForwardEvents.includes(event));
+            if (this.listeners(event).length === 0) {
+                this.connection.on(
+                    event as any,
+                    (...args: any[]) => {
+                        this.emit(event, ...args);
+                    });
             }
         });
     }
@@ -111,11 +81,11 @@ export class DeltaConnection
      * Closes the delta connection. This disconnects the socket and clears any listeners
      */
     public close() {
-        // closes() assumes silent close - no events fired to avoid reentrancy
-        this.removeAllListeners();
         if (this._connection !== undefined) {
             const connection = this._connection;
             this._connection = undefined;
+            // Avoid re-entrncy - remove all listeners before closing!
+            this.removeAllListeners();
             connection.close();
         }
     }

--- a/packages/loader/container-loader/src/deltaConnection.ts
+++ b/packages/loader/container-loader/src/deltaConnection.ts
@@ -111,12 +111,12 @@ export class DeltaConnection
      * Closes the delta connection. This disconnects the socket and clears any listeners
      */
     public close() {
+        this.removeAllListeners();
         if (this._connection !== undefined) {
             const connection = this._connection;
             this._connection = undefined;
             connection.disconnect();
         }
-        this.removeAllListeners();
     }
 
     public submit(messages: IDocumentMessage[]): void {

--- a/packages/loader/container-loader/src/deltaConnection.ts
+++ b/packages/loader/container-loader/src/deltaConnection.ts
@@ -111,6 +111,7 @@ export class DeltaConnection
      * Closes the delta connection. This disconnects the socket and clears any listeners
      */
     public close() {
+        // closes() assumes silent close - no events fired to avoid reentrancy
         this.removeAllListeners();
         if (this._connection !== undefined) {
             const connection = this._connection;

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -812,7 +812,9 @@ export class DeltaManager
         this.stopSequenceNumberUpdate();
 
         // This raises "disconnect" event
-        this.disconnectFromDeltaStream(error !== undefined ? `${error.message}` : "Container closed");
+        if (this.connection !== undefined) {
+            this.disconnectFromDeltaStream(error !== undefined ? `${error.message}` : "Container closed");
+        }
 
         this._inbound.clear();
         this._outbound.clear();
@@ -1039,9 +1041,7 @@ export class DeltaManager
      */
     private disconnectFromDeltaStream(reason: string) {
         const connection = this.connection;
-        if (connection === undefined) {
-            return;
-        }
+        assert(connection !== undefined);
 
         // We cancel all ops on lost of connectivity, and rely on DDSes to resubmit them.
         // Semantics are not well defined for batches (and they are broken right now on disconnects anyway),
@@ -1075,9 +1075,8 @@ export class DeltaManager
     ) {
         // We quite often get protocol errors before / after observing nack/disconnect
         // we do not want to run through same sequence twice.
-        if (connection !== this.connection) {
-            return;
-        }
+        // We should correctly unregister all event listeners not to re-enter here again!
+        assert(connection === this.connection);
 
         this.disconnectFromDeltaStream(error.message);
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -1057,7 +1057,7 @@ export class DeltaManager
         this._outbound.clear();
         this.emit("disconnect", reason);
 
-        // Avoid re-entrncy - remove all listeners before closing!
+        // Avoid re-entrancy - remove all listeners before closing!
         connection.removeAllListeners();
         connection.close();
     }

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -811,10 +811,8 @@ export class DeltaManager
 
         this.stopSequenceNumberUpdate();
 
-        // This raises "disconnect" event
-        if (this.connection !== undefined) {
-            this.disconnectFromDeltaStream(error !== undefined ? `${error.message}` : "Container closed");
-        }
+        // This raises "disconnect" event if we have active connection.
+        this.disconnectFromDeltaStream(error !== undefined ? `${error.message}` : "Container closed");
 
         this._inbound.clear();
         this._outbound.clear();
@@ -1040,7 +1038,9 @@ export class DeltaManager
      */
     private disconnectFromDeltaStream(reason: string) {
         const connection = this.connection;
-        assert(connection !== undefined);
+        if (connection === undefined) {
+            return;
+        }
 
         // We cancel all ops on lost of connectivity, and rely on DDSes to resubmit them.
         // Semantics are not well defined for batches (and they are broken right now on disconnects anyway),

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -909,7 +909,6 @@ export class DeltaManager
         if (this.closed) {
             // Raise proper events, Log telemetry event and close connection.
             this.disconnectFromDeltaStream(`Disconnect on close`);
-            assert(!connection.connected); // Check we indeed closed it!
             return;
         }
 
@@ -1058,6 +1057,8 @@ export class DeltaManager
         this._outbound.clear();
         this.emit("disconnect", reason);
 
+        // Avoid re-entrncy - remove all listeners before closing!
+        connection.removeAllListeners();
         connection.close();
     }
 

--- a/packages/loader/driver-definitions/src/storage.ts
+++ b/packages/loader/driver-definitions/src/storage.ts
@@ -189,7 +189,7 @@ export interface IDocumentDeltaConnection extends IEventProvider<IDocumentDeltaC
     /**
      * Disconnects the given delta connection
      */
-    disconnect();
+    close();
 
     /**
      * Emits an event from this document delta connection

--- a/packages/loader/driver-definitions/src/storage.ts
+++ b/packages/loader/driver-definitions/src/storage.ts
@@ -109,6 +109,7 @@ export interface IDocumentDeltaConnectionEvents extends IErrorEvent {
     (event: "op", listener: (documentId: string, messages: ISequencedDocumentMessage[]) => void);
     (event: "signal", listener: (message: ISignalMessage) => void);
     (event: "pong", listener: (latency: number) => void);
+    (event: "error", listener: (error: any) => void);
 }
 
 export interface IDocumentDeltaConnection extends IEventProvider<IDocumentDeltaConnectionEvents> {

--- a/packages/loader/test-loader-utils/src/mockDocumentDeltaConnection.ts
+++ b/packages/loader/test-loader-utils/src/mockDocumentDeltaConnection.ts
@@ -73,7 +73,7 @@ export class MockDocumentDeltaConnection
             this.submitSignalHandler(message);
         }
     }
-    public disconnect(reason?: string) {
+    public close(reason?: string) {
         this.emit("disconnect", reason ?? "mock disconnect called");
     }
 

--- a/packages/loader/test-loader-utils/src/mockDocumentDeltaConnection.ts
+++ b/packages/loader/test-loader-utils/src/mockDocumentDeltaConnection.ts
@@ -74,7 +74,7 @@ export class MockDocumentDeltaConnection
         }
     }
     public close(reason?: string) {
-        this.emit("disconnect", reason ?? "mock disconnect called");
+        this.emit("disconnect", reason ?? "mock close() called");
     }
 
     // Mock methods for raising events

--- a/packages/test/end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/container.spec.ts
@@ -155,7 +155,7 @@ describe("Container", () => {
             localResolver);
         assert.strictEqual(container.connectionState, ConnectionState.Connecting,
             "Container should be in Connecting state");
-        deltaConnection.disconnect();
+        deltaConnection.close();
         assert.strictEqual(container.connectionState, ConnectionState.Disconnected,
             "Container should be in Disconnected state");
         deltaConnection.removeAllListeners();

--- a/packages/tools/fetch-tool/src/fluidFetchMessages.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchMessages.ts
@@ -120,7 +120,7 @@ async function* loadAllSequencedMessages(
         timeStart = Date.now();
         const deltaStream = await documentService.connectToDeltaStream(client);
         const initialMessages = deltaStream.initialMessages;
-        deltaStream.disconnect();
+        deltaStream.close();
         console.log(`${Math.floor((Date.now() - timeStart) / 1000)} seconds to connect to web socket`);
 
         if (initialMessages) {


### PR DESCRIPTION
This change covers one of the problems identified in Issue #3896 - some disconnect events do not carry proper reason, pointing out to some logical errors. While I can't pinpoint to particular flaw in current code, this change adds additional telemetry to understand better the problem, but also gets rid of reentrancy by making sure that all event handlers properly removed on various disconnect / error flows.