### PR TITLE
Speculative mitigation for inconsistent summary sequenceNumber

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1734,6 +1734,14 @@ export class ContainerRuntime extends EventEmitter
                 return { ...attemptData, ...generateData, ...uploadData, reason: "disconnected" };
             }
 
+            // We need the summary op's reference sequence number to match our summary sequence number
+            // Otherwise we'll get the wrong sequence number stamped on the summary's .protocol attributes
+            assert(
+                this.deltaManager.lastSequenceNumber === summaryRefSeqNum,
+                `lastSequenceNumber changed before the summary op could be submitted. `
+                    + `${lastSequenceNumber} !== ${summaryRefSeqNum}`,
+            );
+
             const clientSequenceNumber =
                 this.submitSystemMessage(MessageType.Summarize, summaryMessage);
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1739,7 +1739,7 @@ export class ContainerRuntime extends EventEmitter
             assert(
                 this.deltaManager.lastSequenceNumber === summaryRefSeqNum,
                 `lastSequenceNumber changed before the summary op could be submitted. `
-                    + `${lastSequenceNumber} !== ${summaryRefSeqNum}`,
+                    + `${this.deltaManager.lastSequenceNumber} !== ${summaryRefSeqNum}`,
             );
 
             const clientSequenceNumber =


### PR DESCRIPTION
We're seeing instances where the summary claims a .protocol attributes sequenceNumber (e.g. 325) but actually only includes ops up through a prior number (e.g. 322).  As a result, new clients loading the document will start reading ops at 326 based on the attributes and hit errors and/or corrupt the document due to the missing data from 323-325.

When this happens, we see the summary op has the data up to 322, a "message" field up to 322 (e.g. `"Summary @322:318"`), but a referenceSequenceNumber of 325.  We protect against the sequence number moving during summarization with an assert already (as of 0.26), but it seems possible the sequence number could move during summary upload without detection.  This change adds another assert that the sequence number also does not change during summary upload but before the summary op gets created.