### PR TITLE
updated community banner to have contrasting links

### DIFF
--- a/docs/assets/css/fluid.css
+++ b/docs/assets/css/fluid.css
@@ -105,7 +105,7 @@ footer {
 .omt {
     font-size: 16px;
     padding: 8em 4em;
-    background-color: ##f5f5f5;
+    background-color: #f5f5f5;
     color: #444;
 }
 

--- a/docs/assets/css/fluid.css
+++ b/docs/assets/css/fluid.css
@@ -105,8 +105,8 @@ footer {
 .omt {
     font-size: 16px;
     padding: 8em 4em;
-    background-color: #2c2c32;
-    color: rgba(255, 255, 255, 0.6);
+    background-color: ##f5f5f5;
+    color: #444;
 }
 
 .omt .container {


### PR DESCRIPTION
Fixes #3816

I'm sure design could come through and do a MUCH more thorough pass on this page, but this change sticks with the theme and gets us into an accessible state. 

Before

![image](https://user-images.githubusercontent.com/1434956/95786718-fe84c180-0c8c-11eb-9850-b3354e92c5cd.png)



After 

![image](https://user-images.githubusercontent.com/1434956/95786698-f3ca2c80-0c8c-11eb-973b-8ade9c376946.png)
