### PR TITLE
Add & validate nbf and exp token claims in r11s

### DIFF
--- a/server/routerlicious/packages/protocol-definitions/src/tokens.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/tokens.ts
@@ -10,6 +10,12 @@ export interface ITokenClaims {
     scopes: string[];
     tenantId: string;
     user: IUser;
+    aud: string;
+    iss: string;
+    nbf: number;
+    iat: number;
+    exp: number;
+    ver: string;
 }
 
 export interface ISummaryTokenClaims {

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -145,8 +145,14 @@ async function verifyToken(request: Request, tenantManager: core.ITenantManager)
     }
     const tenantId = getParam(request.params, "tenantId");
     const documentId = getParam(request.params, "id");
+    const now = Math.round((new Date()).getTime() / 1000);
     const claims = jwt.decode(token) as ITokenClaims;
-    if (!claims || claims.documentId !== documentId || claims.tenantId !== tenantId) {
+    if (!claims
+        || claims.documentId !== documentId
+        || claims.tenantId !== tenantId
+        || now < claims.nbf
+        || now >= claims.exp
+    ) {
         return Promise.reject("Invalid access token");
     }
     return tenantManager.verifyToken(tenantId, token);

--- a/server/routerlicious/packages/services-client/src/auth.ts
+++ b/server/routerlicious/packages/services-client/src/auth.ts
@@ -26,11 +26,20 @@ export function generateToken(
         user = generateUser();
     }
 
+    // Current time in seconds
+    const now = Math.round((new Date()).getTime() / 1000);
+
     const claims: ITokenClaims = {
         documentId,
         scopes,
         tenantId,
         user,
+        aud: "",
+        iss: "",
+        iat: now,
+        nbf: now,
+        exp: now + 5 * 60, // 5 minute expiration window
+        ver: "1.0",
     };
 
     return jwt.sign(claims, key);


### PR DESCRIPTION
Improve r11s authentication by adding `nbf` (not before) and `exp` (expiration) claims to JWT tokens.