### PR TITLE
Wrap the logger used by replay-driver to markup log events

### DIFF
--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -33,6 +33,7 @@
     "@fluidframework/driver-definitions": "^0.28.0",
     "@fluidframework/driver-utils": "^0.28.0",
     "@fluidframework/protocol-definitions": "^0.1014.0-0",
+    "@fluidframework/telemetry-utils": "^0.28.0",
     "debug": "^4.1.1"
   },
   "devDependencies": {

--- a/packages/drivers/replay-driver/src/replayDocumentServiceFactory.ts
+++ b/packages/drivers/replay-driver/src/replayDocumentServiceFactory.ts
@@ -5,24 +5,11 @@
 
 import { IDocumentService, IDocumentServiceFactory, IResolvedUrl } from "@fluidframework/driver-definitions";
 import { ISummaryTree } from "@fluidframework/protocol-definitions";
-import { ITelemetryBaseEvent, ITelemetryBaseLogger } from "@fluidframework/common-definitions";
+import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
+import { ChildLogger } from "@fluidframework/telemetry-utils";
 import { ReplayController } from "./replayController";
 import { ReplayControllerStatic } from "./replayDocumentDeltaConnection";
 import { ReplayDocumentService } from "./replayDocumentService";
-
-/**
- * Wrapper logger that adds isReplay: true to each event.
- * ReplayDriver is used in testing/debugging scenarios, so we want to be able to filter these events out sometimes
- */
-class ReplayDriverTelemetryLogger implements ITelemetryBaseLogger {
-    constructor(
-        private readonly logger: ITelemetryBaseLogger,
-    ) { }
-
-    send(event: ITelemetryBaseEvent): void {
-        this.logger.send({ ...event, isReplay: true });
-    }
-}
 
 export class ReplayDocumentServiceFactory implements IDocumentServiceFactory {
     public static create(
@@ -53,10 +40,13 @@ export class ReplayDocumentServiceFactory implements IDocumentServiceFactory {
         resolvedUrl: IResolvedUrl,
         logger?: ITelemetryBaseLogger,
     ): Promise<IDocumentService> {
-        const replayLogger = logger && new ReplayDriverTelemetryLogger(logger);
-        return Promise.resolve(ReplayDocumentService.create(
+        // Always include isReplay: true on events for the Replay Driver.
+        // It's used in testing/debugging scenarios, so we want to be able to filter these events out sometimes.
+        const replayLogger = ChildLogger.create(logger, undefined /* namespace */, { isReplay: true } /* properties */);
+
+        return ReplayDocumentService.create(
             await this.documentServiceFactory.createDocumentService(resolvedUrl, replayLogger),
-            this.controller));
+            this.controller);
     }
 
     // TODO: Issue-2109 Implement detach container api or put appropriate comment.


### PR DESCRIPTION
Fixes #3902 

This allows us to mark up all events with isReplay: true so we can separate these logs from other logs.