### PR TITLE
Move Loader Constructor to Props Pattern

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -4,6 +4,7 @@
 - [DataObject changes](#DataObject-changes)
 - [RequestParser](#RequestParser)
 - [IFluidLodable.url is removed](#IFluidLodable.url-is-removed)
+- [Loader Constructor Changes](#Loader-Constructor-Changes)
 
 ### IFluidPackage Changes
 - Remove npm specific IPackage interface
@@ -32,6 +33,33 @@ with this one:
 
 ### IFluidLodable.url is removed
 `url` property is removed. If you need a path to an object (in a container), you can use IFluidLoadable.handle.absolutePath instead.
+
+### Loader Constructor Changes
+The loader constructor has changed to now take a props object, rather than a series of paramaters. This should make it easier to construct loaders as the optional services can be easily excluded.
+
+Before:
+``` typescript
+    const loader = new Loader(
+        urlResolver,
+        documentServiceFactory,
+        codeLoader,
+        { blockUpdateMarkers: true },
+        {},
+        new Map(),
+    );
+```
+
+After:
+``` typescript
+    const loader = new Loader({
+        urlResolver,
+        documentServiceFactory,
+        codeLoader,
+    });
+```
+
+if for some reason this change causes you problems, we've added a deprecated `Loader._create` method that has the same parameters as the previous constructor which can be used in the interim.
+
 
 ## 0.27 Breaking Changes
 - [Local Web Host Removed](#Local-Web-Host-Removed)

--- a/examples/hosts/hosts-sample/README.md
+++ b/examples/hosts/hosts-sample/README.md
@@ -42,11 +42,11 @@ Creating a loader is a simple process
 ```typescript
 import { Loader } from "@fluidframework/container-loader";
 
-const loader = new Loader(
-    insecureResolver,
+const loader = new Loader({
+    urlResolver,
     documentServicesFactory,
     codeLoader,
-    { blockUpdateMarkers: true });
+});
 ```
 
 The loader takes in four parameters. The first is a set of host interfaces. These allow the loader to interact with

--- a/examples/hosts/iframe-host/src/inframehost.ts
+++ b/examples/hosts/iframe-host/src/inframehost.ts
@@ -8,13 +8,13 @@ import {
 } from "@fluidframework/iframe-driver";
 import { Loader, Container } from "@fluidframework/container-loader";
 import {
-    IProxyLoaderFactory,
     ICodeLoader,
     IContainerContext,
     IRuntime,
     IRuntimeFactory,
     IRuntimeState,
     AttachState,
+    IProxyLoaderFactory,
 } from "@fluidframework/container-definitions";
 import { MultiUrlResolver, MultiDocumentServiceFactory } from "@fluidframework/driver-utils";
 import { IRequest, IResponse, IFluidObject } from "@fluidframework/core-interfaces";
@@ -69,11 +69,11 @@ class ProxyCodeLoader implements ICodeLoader {
 }
 
 export interface IFrameOuterHostConfig {
-    documentServiceFactory: IDocumentServiceFactory | IDocumentServiceFactory[];
-    urlResolver: IUrlResolver | IUrlResolver[];
+    documentServiceFactory: IDocumentServiceFactory;
+    urlResolver: IUrlResolver;
 
     // Any config to be provided to loader.
-    config?: any;
+    options?: any;
 
     // A Fluid object that gives host provided capabilities/configurations
     // to the Fluid object in the container(such as auth).
@@ -88,21 +88,17 @@ export class IFrameOuterHost {
         // todo
         // disable summaries
         // set as non-user client
-        this.loader = new Loader(
-            hostConfig.urlResolver,
-            hostConfig.documentServiceFactory,
-            new ProxyCodeLoader(),
-            hostConfig.config ?? {},
-            hostConfig.scope ?? {},
-            hostConfig.proxyLoaderFactories ?? new Map<string, IProxyLoaderFactory>(),
-        );
+        this.loader = new Loader({
+            ...hostConfig,
+            codeLoader: new ProxyCodeLoader(),
+        });
     }
 
     public async load(request: IRequest, iframe: HTMLIFrameElement): Promise<Container> {
         const proxy = await IFrameDocumentServiceProxyFactory.create(
             MultiDocumentServiceFactory.create(this.hostConfig.documentServiceFactory),
             iframe,
-            this.hostConfig.config,
+            this.hostConfig.options,
             MultiUrlResolver.create(this.hostConfig.urlResolver));
 
         await proxy.createDocumentServiceFromRequest(request);

--- a/examples/hosts/iframe-host/src/inner.ts
+++ b/examples/hosts/iframe-host/src/inner.ts
@@ -34,7 +34,7 @@ export async function runInner(divId: string) {
             codeResolver: new SemVerCdnCodeResolver(),
             documentServiceFactory,
             urlResolver: documentServiceFactory.urlResolver,
-            config: {},
+            options: {},
         });
 
     const url = documentServiceFactory.resolvedUrl.url;

--- a/examples/hosts/iframe-host/src/outer.ts
+++ b/examples/hosts/iframe-host/src/outer.ts
@@ -87,7 +87,7 @@ export async function loadDiv(divId: string) {
             codeResolver: new SemVerCdnCodeResolver(),
             documentServiceFactory,
             urlResolver,
-            config: {},
+            options: {},
         });
 
     const url = createRequest().url;

--- a/examples/hosts/node-host/src/index.ts
+++ b/examples/hosts/node-host/src/index.ts
@@ -4,7 +4,7 @@
  */
 
 import * as url from "url";
-import { IFluidCodeDetails, IProxyLoaderFactory } from "@fluidframework/container-definitions";
+import { IFluidCodeDetails } from "@fluidframework/container-definitions";
 import { Loader } from "@fluidframework/container-loader";
 import { IFluidResolvedUrl } from "@fluidframework/driver-definitions";
 import { IUser } from "@fluidframework/protocol-definitions";
@@ -74,24 +74,21 @@ export async function start(): Promise<void> {
         url: documentUrl,
     };
 
-    const resolver = new ContainerUrlResolver(
+    const urlResolver = new ContainerUrlResolver(
         ordererEndpoint,
         hostToken,
         new Map([[documentUrl, resolved]]));
 
     // A code loader that installs the code package in a specified location (installPath).
     // Once installed, the loader returns an entry point to Fluid Container to invoke the code.
-    const nodeCodeLoader = new NodeCodeLoader(installPath, timeoutMS);
+    const codeLoader = new NodeCodeLoader(installPath, timeoutMS);
 
     // Construct the loader
-    const loader = new Loader(
-        resolver,
-        new RouterliciousDocumentServiceFactory(),
-        nodeCodeLoader,
-        {},
-        {},
-        new Map<string, IProxyLoaderFactory>(),
-    );
+    const loader = new Loader({
+        urlResolver,
+        documentServiceFactory: new RouterliciousDocumentServiceFactory(),
+        codeLoader,
+    });
 
     // Resolving the URL to its underlying Fluid document.
     const fluidDocument = await loader.resolve({ url: documentUrl });

--- a/examples/utils/get-session-storage-container/src/getSessionStorageContainer.ts
+++ b/examples/utils/get-session-storage-container/src/getSessionStorageContainer.ts
@@ -39,14 +39,11 @@ export async function getSessionStorageContainer(
     const module = { fluidExport: containerRuntimeFactory };
     const codeLoader = { load: async () => module };
 
-    const loader = new Loader(
+    const loader = new Loader({
         urlResolver,
         documentServiceFactory,
         codeLoader,
-        { blockUpdateMarkers: true },
-        {},
-        new Map(),
-    );
+    });
 
     let container: Container;
 

--- a/examples/utils/get-tinylicious-container/src/getContainer.ts
+++ b/examples/utils/get-tinylicious-container/src/getContainer.ts
@@ -24,14 +24,11 @@ export async function getContainer(
     const module = { fluidExport: containerRuntimeFactory };
     const codeLoader = { load: async () => module };
 
-    const loader = new Loader (
+    const loader = new Loader ({
         urlResolver,
         documentServiceFactory,
         codeLoader,
-        { blockUpdateMarkers: true },
-        {},
-        new Map(),
-    );
+    });
 
     let container: Container;
 

--- a/packages/hosts/base-host/src/host.ts
+++ b/packages/hosts/base-host/src/host.ts
@@ -6,7 +6,6 @@
 import { IFluidObject } from "@fluidframework/core-interfaces";
 import {
     IFluidCodeDetails,
-    IProxyLoaderFactory,
     IFluidModule,
 } from "@fluidframework/container-definitions";
 import { Loader, Container } from "@fluidframework/container-loader";
@@ -32,23 +31,10 @@ async function createWebLoader(
         }
     }
 
-    const config = hostConfig.config ? hostConfig.config : {};
-
-    // We need to extend options, otherwise we nest properties, like client, too deeply
-    //
-    config.blockUpdateMarkers = true;
-
-    const scope = hostConfig.scope ? hostConfig.scope : {};
-    const proxyLoaderFactories = hostConfig.proxyLoaderFactories ?
-        hostConfig.proxyLoaderFactories : new Map<string, IProxyLoaderFactory>();
-
-    return new Loader(
-        hostConfig.urlResolver,
-        hostConfig.documentServiceFactory,
+    return new Loader({
+        ...hostConfig,
         codeLoader,
-        config,
-        scope,
-        proxyLoaderFactories);
+    });
 }
 
 export class BaseHost {

--- a/packages/hosts/base-host/src/hostConfig.ts
+++ b/packages/hosts/base-host/src/hostConfig.ts
@@ -13,11 +13,11 @@ import { IDocumentServiceFactory, IUrlResolver } from "@fluidframework/driver-de
  * of resolved url.
  */
 export interface IBaseHostConfig {
-    documentServiceFactory: IDocumentServiceFactory | IDocumentServiceFactory[];
-    urlResolver: IUrlResolver | IUrlResolver[];
+    documentServiceFactory: IDocumentServiceFactory;
+    urlResolver: IUrlResolver;
 
     // Any config to be provided to loader.
-    config?: any;
+    options?: any;
 
     // A fluid object that gives host provided capabilities/configurations
     // to the Fluid object in the container(such as auth).

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -446,7 +446,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         // Need to use the property getter for docId because for detached flow we don't have the docId initially.
         // We assign the id later so property getter is used.
         this.subLogger = ChildLogger.create(
-            loader.services.logger,
+            loader.services.subLogger,
             undefined,
             {
                 clientType, // Differentiating summarizer container from main container

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -8,14 +8,12 @@ import { strict as assert } from "assert";
 import merge from "lodash/merge";
 import uuid from "uuid";
 import {
-    ITelemetryBaseLogger,
     ITelemetryLogger,
 } from "@fluidframework/common-definitions";
 import { performance } from "@fluidframework/common-utils";
-import { IFluidObject, IRequest, IResponse, IFluidRouter } from "@fluidframework/core-interfaces";
+import {  IRequest, IResponse, IFluidRouter } from "@fluidframework/core-interfaces";
 import {
     IAudience,
-    ICodeLoader,
     IConnectionDetails,
     IContainer,
     IContainerEvents,
@@ -34,8 +32,6 @@ import {
     IDocumentService,
     IDocumentStorageService,
     IFluidResolvedUrl,
-    IUrlResolver,
-    IDocumentServiceFactory,
     IResolvedUrl,
     CreateNewHeader,
 } from "@fluidframework/driver-definitions";
@@ -197,31 +193,19 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
      */
     public static async load(
         id: string,
-        serviceFactory: IDocumentServiceFactory,
-        codeLoader: ICodeLoader,
-        options: any,
-        scope: IFluidObject,
         loader: Loader,
         request: IRequest,
         resolvedUrl: IFluidResolvedUrl,
-        urlResolver: IUrlResolver,
-        logger?: ITelemetryBaseLogger,
     ): Promise<Container> {
         const [, docId] = id.split("/");
         const container = new Container(
-            options,
-            scope,
-            codeLoader,
             loader,
-            serviceFactory,
-            urlResolver,
             {
                 originalRequest: request,
                 id: decodeURI(docId),
                 resolvedUrl,
                 canReconnect: !(request.headers?.[LoaderHeader.reconnect] === false),
-            },
-            logger);
+            });
 
         return PerformanceEvent.timedExecAsync(container.logger, { eventName: "Load" }, async (event) => {
             return new Promise<Container>((res, rej) => {
@@ -255,24 +239,12 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     }
 
     public static async create(
-        codeLoader: ICodeLoader,
-        options: any,
-        scope: IFluidObject,
         loader: Loader,
         source: DetachedContainerSource,
-        serviceFactory: IDocumentServiceFactory,
-        urlResolver: IUrlResolver,
-        logger?: ITelemetryBaseLogger,
     ): Promise<Container> {
         const container = new Container(
-            options,
-            scope,
-            codeLoader,
             loader,
-            serviceFactory,
-            urlResolver,
-            {},
-            logger);
+            {});
 
         if (source.create) {
             await container.createDetached(source.codeDetails);
@@ -445,16 +417,15 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     public get parentBranch(): string | null {
         return this._parentBranch;
     }
-
+    private get serviceFactory() {return this.loader.services.documentServiceFactory;}
+    private get urlResolver() {return this.loader.services.urlResolver;}
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    public get options() { return this.loader.services.options;}
+    private get scope() { return this.loader.services.scope;}
+    private get codeLoader() { return this.loader.services.codeLoader;}
     constructor(
-        public readonly options: any,
-        private readonly scope: IFluidObject,
-        private readonly codeLoader: ICodeLoader,
         private readonly loader: Loader,
-        private readonly serviceFactory: IDocumentServiceFactory,
-        private readonly urlResolver: IUrlResolver,
         config: IContainerConfig,
-        logger: ITelemetryBaseLogger | undefined,
     ) {
         super();
         this._audience = new Audience();
@@ -475,7 +446,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         // Need to use the property getter for docId because for detached flow we don't have the docId initially.
         // We assign the id later so property getter is used.
         this.subLogger = ChildLogger.create(
-            logger,
+            loader.services.logger,
             undefined,
             {
                 clientType, // Differentiating summarizer container from main container

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -141,12 +141,12 @@ function createCachedResolver(resolver: IUrlResolver) {
 export interface ILoaderProps {
     /**
      * The url resolver used by the loader for resolving external urls
-     * into fluid urls such that the container specified by the
+     * into Fluid urls such that the container specified by the
      * external url can be loaded.
      */
     readonly urlResolver: IUrlResolver;
     /**
-     * The document service factory take the fluid url provided
+     * The document service factory take the Fluid url provided
      * by the resolved url and constucts all the necessary services
      * for communication with the container's server.
      */
@@ -187,12 +187,12 @@ export interface ILoaderProps {
 export interface ILoaderServices {
     /**
      * The url resolver used by the loader for resolving external urls
-     * into fluid urls such that the container specified by the
+     * into Fluid urls such that the container specified by the
      * external url can be loaded.
      */
     readonly urlResolver: IUrlResolver;
     /**
-     * The document service factory take the fluid url provided
+     * The document service factory take the Fluid url provided
      * by the resolved url and constucts all the necessary services
      * for communication with the container's server.
      */

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -236,7 +236,7 @@ export class Loader extends EventEmitter implements ILoader {
     private readonly logger: ITelemetryLogger;
 
     /**
-     * {@deprecated} use constructor with loader props
+     * @deprecated use constructor with loader props
      */
     public static _create(
         resolver: IUrlResolver | IUrlResolver[],

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -135,24 +135,95 @@ function createCachedResolver(resolver: IUrlResolver) {
     return cacheResolver;
 }
 
+/**
+ * Services and properties necessary for creating a loader
+ */
 export interface ILoaderProps {
+    /**
+     * The url resolver used by the loader for resolving external urls
+     * into fluid urls such that the container specified by the
+     * external url can be loaded.
+     */
     readonly urlResolver: IUrlResolver;
+    /**
+     * The document service factory take the fluid url provided
+     * by the resolved url and constucts all the necessary services
+     * for communication with the container's server.
+     */
     readonly documentServiceFactory: IDocumentServiceFactory;
+    /**
+     * The code loader handles loading the necessary code
+     * for running a container once it is loaded.
+     */
     readonly codeLoader: ICodeLoader;
 
+    /**
+     * A property bag of options used by various layers
+     * to control features
+     */
     readonly options?: any;
+
+    /**
+     * Scope is provided to all container and is a set of shared
+     * services for container's to integrate with their host environment.
+     */
     readonly scope?: IFluidObject;
+
+    /**
+     * Proxy loader factories for loading containers via proxy in other contexts,
+     * like web workers, or worker threads.
+     */
     readonly proxyLoaderFactories?: Map<string, IProxyLoaderFactory>;
+
+    /**
+     * The logger that all telemetry should be pushed to.
+     */
     readonly logger?: ITelemetryBaseLogger;
 }
 
+/**
+ * Services and properties used by and exposed by the loader
+ */
 export interface ILoaderServices {
+    /**
+     * The url resolver used by the loader for resolving external urls
+     * into fluid urls such that the container specified by the
+     * external url can be loaded.
+     */
     readonly urlResolver: IUrlResolver;
+    /**
+     * The document service factory take the fluid url provided
+     * by the resolved url and constucts all the necessary services
+     * for communication with the container's server.
+     */
     readonly documentServiceFactory: IDocumentServiceFactory;
+    /**
+     * The code loader handles loading the necessary code
+     * for running a container once it is loaded.
+     */
     readonly codeLoader: ICodeLoader;
+
+    /**
+     * A property bag of options used by various layers
+     * to control features
+     */
     readonly options: any;
+
+    /**
+     * Scope is provided to all container and is a set of shared
+     * services for container's to integrate with their host environment.
+     */
     readonly scope: IFluidObject;
+
+    /**
+     * Proxy loader factories for loading containers via proxy in other contexts,
+     * like web workers, or worker threads.
+     */
     readonly proxyLoaderFactories: Map<string, IProxyLoaderFactory>;
+
+    /**
+     * The logger that all telemetry should be pushed to.
+     */
     readonly logger: ITelemetryLogger;
 }
 

--- a/packages/runtime/client-api/src/api/document.ts
+++ b/packages/runtime/client-api/src/api/document.ts
@@ -9,7 +9,6 @@ import { FluidDataStoreRuntime } from "@fluidframework/datastore";
 import {
     IDeltaManager,
     IFluidCodeDetails,
-    IProxyLoaderFactory,
 } from "@fluidframework/container-definitions";
 import { Container, Loader } from "@fluidframework/container-loader";
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
@@ -257,23 +256,21 @@ async function requestDocument(loader: Loader, container: Container, uri: string
  */
 export async function load(
     url: string,
-    resolver: IUrlResolver,
+    urlResolver: IUrlResolver,
     options: any = {},
-    serviceFactory: IDocumentServiceFactory = defaultDocumentServiceFactory,
+    documentServiceFactory: IDocumentServiceFactory = defaultDocumentServiceFactory,
     runtimeOptions: IContainerRuntimeOptions = { generateSummaries: false },
 ): Promise<Document> {
     const codeLoader = new CodeLoader(runtimeOptions);
 
     // Load the Fluid document
     // For legacy purposes we currently fill in a default domain
-    const loader = new Loader(
-        resolver,
-        serviceFactory,
+    const loader = new Loader({
+        urlResolver,
+        documentServiceFactory,
         codeLoader,
         options,
-        {},
-        new Map<string, IProxyLoaderFactory>(),
-    );
+    });
     const container = await loader.resolve({ url });
 
     // The client-api CodeLoader doesn't actually read the proposed code details, so this doesn't really matter.

--- a/packages/test/end-to-end-tests/src/real-service-tests/r11sEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/real-service-tests/r11sEndToEndTests.spec.ts
@@ -7,7 +7,7 @@ import assert from "assert";
 import * as moniker from "moniker";
 import uuid from "uuid";
 import { IRequest } from "@fluidframework/core-interfaces";
-import { IFluidCodeDetails, IProxyLoaderFactory, AttachState } from "@fluidframework/container-definitions";
+import { IFluidCodeDetails, AttachState } from "@fluidframework/container-definitions";
 import { Loader } from "@fluidframework/container-loader";
 import { IUrlResolver } from "@fluidframework/driver-definitions";
 import {
@@ -47,13 +47,11 @@ describe(`r11s End-To-End tests`, () => {
             true,
             undefined,
         );
-        return new Loader(
+        return new Loader({
             urlResolver,
             documentServiceFactory,
             codeLoader,
-            {},
-            {},
-            new Map<string, IProxyLoaderFactory>());
+        });
     }
 
     const createFluidObject = (async (

--- a/packages/test/end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { IRequest } from "@fluidframework/core-interfaces";
-import { IFluidCodeDetails, IProxyLoaderFactory, AttachState } from "@fluidframework/container-definitions";
+import { IFluidCodeDetails, AttachState } from "@fluidframework/container-definitions";
 import { Loader } from "@fluidframework/container-loader";
 import { IUrlResolver } from "@fluidframework/driver-definitions";
 import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
@@ -66,13 +66,11 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
         ]);
         const codeLoader = new LocalCodeLoader([[codeDetails, factory]]);
         const documentServiceFactory = new LocalDocumentServiceFactory(testDeltaConnectionServer);
-        return new Loader(
+        return new Loader({
             urlResolver,
             documentServiceFactory,
             codeLoader,
-            {},
-            {},
-            new Map<string, IProxyLoaderFactory>());
+        });
     }
 
     beforeEach(async () => {

--- a/packages/test/end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/container.spec.ts
@@ -8,90 +8,65 @@ import { IRequest } from "@fluidframework/core-interfaces";
 import {
     IGenericError,
     ContainerErrorType,
-    IProxyLoaderFactory,
 } from "@fluidframework/container-definitions";
-import { Container, ConnectionState, Loader } from "@fluidframework/container-loader";
+import { Container, ConnectionState, Loader, ILoaderProps } from "@fluidframework/container-loader";
 import {
-    IFluidResolvedUrl,
     IDocumentServiceFactory,
 } from "@fluidframework/driver-definitions";
 import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { MockDocumentDeltaConnection } from "@fluid-internal/test-loader-utils";
 import { LocalCodeLoader } from "@fluidframework/test-utils";
+import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
+
+const id = "fluid-test://localhost/containerTest";
+const testRequest: IRequest = { url: id };
 
 describe("Container", () => {
-    const id = "fluid-test://localhost/containerTest";
-    const testRequest: IRequest = { url: id };
-
     let testDeltaConnectionServer: ILocalDeltaConnectionServer;
-    let localResolver: LocalResolver;
-    let testResolved: IFluidResolvedUrl;
-    let deltaConnection: MockDocumentDeltaConnection;
-    let serviceFactory: Readonly<IDocumentServiceFactory>;
-    let codeLoader: LocalCodeLoader;
-    let loader: Loader;
-
-    beforeEach(async () => {
+    beforeEach(()=>{
         testDeltaConnectionServer = LocalDeltaConnectionServer.create();
-        localResolver = new LocalResolver();
-        testResolved = await localResolver.resolve(testRequest) as IFluidResolvedUrl;
-        serviceFactory = new LocalDocumentServiceFactory(testDeltaConnectionServer);
-        codeLoader = new LocalCodeLoader([]);
-        const options = {};
-
-        loader = new Loader(
-            localResolver,
-            serviceFactory,
-            codeLoader,
-            options,
-            {},
-            new Map<string, IProxyLoaderFactory>(),
-        );
     });
 
+    async function loadContainer(props?: Partial<ILoaderProps>) {
+        const loader =  new Loader({
+            ... props,
+            urlResolver: props?.urlResolver ?? new LocalResolver(),
+            documentServiceFactory :
+                props?.documentServiceFactory ?? new LocalDocumentServiceFactory(testDeltaConnectionServer),
+            codeLoader: props?.codeLoader ?? new LocalCodeLoader([]),
+        });
+
+        const testResolved = await loader.services.urlResolver.resolve(testRequest);
+        ensureFluidResolvedUrl(testResolved);
+        return Container.load(
+            "tenantId/documentId",
+            loader,
+            testRequest,
+            testResolved);
+    }
+
     it("Load container successfully", async () => {
-        let success: boolean;
-        try {
-            await Container.load(
-                "tenantId/documentId",
-                serviceFactory,
-                codeLoader,
-                {},
-                {},
-                loader,
-                testRequest,
-                testResolved,
-                localResolver);
-            success = true;
-        } catch (error) {
-            success = false;
-        }
-        assert.strictEqual(success, true);
+        const container = await loadContainer();
+        assert.strictEqual(container.id, "documentId", "Container's id should be set");
+        assert.strictEqual(container.clientDetails.capabilities.interactive, true,
+            "Client details should be set with interactive as true");
     });
 
     it("Load container unsuccessfully", async () => {
         let success: boolean = true;
         try {
-            const mockFactory = Object.create(serviceFactory) as IDocumentServiceFactory;
+            const documentServiceFactory = new LocalDocumentServiceFactory(testDeltaConnectionServer);
+            const mockFactory = Object.create(documentServiceFactory) as IDocumentServiceFactory;
             // Issue typescript-eslint/typescript-eslint #1256
             mockFactory.createDocumentService = async (resolvedUrl) => {
-                const service = await serviceFactory.createDocumentService(resolvedUrl);
+                const service = await documentServiceFactory.createDocumentService(resolvedUrl);
                 // Issue typescript-eslint/typescript-eslint #1256
                 service.connectToStorage = async () => Promise.reject(false);
                 return service;
             };
 
-            await Container.load(
-                "tenantId/documentId",
-                mockFactory,
-                codeLoader,
-                {},
-                {},
-                loader,
-                testRequest,
-                testResolved,
-                localResolver);
+            await loadContainer({ documentServiceFactory: mockFactory });
             assert.fail("Error expected");
         } catch (error) {
             const err = error as IGenericError;
@@ -103,24 +78,16 @@ describe("Container", () => {
     it("Load container with error", async () => {
         let success: boolean = true;
         try {
-            const mockFactory = Object.create(serviceFactory) as IDocumentServiceFactory;
+            const documentServiceFactory = new LocalDocumentServiceFactory(testDeltaConnectionServer);
+            const mockFactory = Object.create(documentServiceFactory) as IDocumentServiceFactory;
             // Issue typescript-eslint/typescript-eslint #1256
             mockFactory.createDocumentService = async (resolvedUrl) => {
-                const service = await serviceFactory.createDocumentService(resolvedUrl);
+                const service = await documentServiceFactory.createDocumentService(resolvedUrl);
                 // Issue typescript-eslint/typescript-eslint #1256
                 service.connectToDeltaStorage = async () => Promise.reject(false);
                 return service;
             };
-            await Container.load(
-                "tenantId/documentId",
-                mockFactory,
-                codeLoader,
-                {},
-                {},
-                loader,
-                testRequest,
-                testResolved,
-                localResolver);
+            await loadContainer({ documentServiceFactory: mockFactory });
             assert.fail("Error expected");
         } catch (error) {
             assert.strictEqual(error.errorType, ContainerErrorType.genericError, "Error is not a general error");
@@ -131,28 +98,20 @@ describe("Container", () => {
     });
 
     it("Raise disconnected event", async () => {
-        deltaConnection = new MockDocumentDeltaConnection(
+        const deltaConnection = new MockDocumentDeltaConnection(
             "test",
         );
-        const mockFactory = Object.create(serviceFactory) as IDocumentServiceFactory;
+        const documentServiceFactory = new LocalDocumentServiceFactory(testDeltaConnectionServer);
+        const mockFactory = Object.create(documentServiceFactory) as IDocumentServiceFactory;
         // Issue typescript-eslint/typescript-eslint #1256
         mockFactory.createDocumentService = async (resolvedUrl) => {
-            const service = await serviceFactory.createDocumentService(resolvedUrl);
+            const service = await documentServiceFactory.createDocumentService(resolvedUrl);
             // Issue typescript-eslint/typescript-eslint #1256
             service.connectToDeltaStream = async () => deltaConnection;
             return service;
         };
 
-        const container = await Container.load(
-            "tenantId/documentId",
-            mockFactory,
-            codeLoader,
-            {},
-            {},
-            loader,
-            testRequest,
-            testResolved,
-            localResolver);
+        const container = await loadContainer({ documentServiceFactory: mockFactory });
         assert.strictEqual(container.connectionState, ConnectionState.Connecting,
             "Container should be in Connecting state");
         deltaConnection.close();
@@ -162,28 +121,20 @@ describe("Container", () => {
     });
 
     it("Raise connection error event", async () => {
-        deltaConnection = new MockDocumentDeltaConnection(
+        const deltaConnection = new MockDocumentDeltaConnection(
             "test",
         );
-        const mockFactory = Object.create(serviceFactory) as IDocumentServiceFactory;
+        const documentServiceFactory = new LocalDocumentServiceFactory(testDeltaConnectionServer);
+        const mockFactory = Object.create(documentServiceFactory) as IDocumentServiceFactory;
         // Issue typescript-eslint/typescript-eslint #1256
         mockFactory.createDocumentService = async (resolvedUrl) => {
-            const service = await serviceFactory.createDocumentService(resolvedUrl);
+            const service = await documentServiceFactory.createDocumentService(resolvedUrl);
             // Issue typescript-eslint/typescript-eslint #1256
             service.connectToDeltaStream = async () => deltaConnection;
             return service;
         };
         let errorRaised = false;
-        const container = await Container.load(
-            "tenantId/documentId",
-            mockFactory,
-            codeLoader,
-            {},
-            {},
-            loader,
-            testRequest,
-            testResolved,
-            localResolver);
+        const container = await loadContainer({ documentServiceFactory: mockFactory });
         container.on("error", () => {
             errorRaised = true;
         });
@@ -203,27 +154,19 @@ describe("Container", () => {
     });
 
     it("Close called on container", async () => {
-        deltaConnection = new MockDocumentDeltaConnection(
+        const deltaConnection = new MockDocumentDeltaConnection(
             "test",
         );
-        const mockFactory = Object.create(serviceFactory) as IDocumentServiceFactory;
+        const documentServiceFactory = new LocalDocumentServiceFactory(testDeltaConnectionServer);
+        const mockFactory = Object.create(documentServiceFactory) as IDocumentServiceFactory;
         // Issue typescript-eslint/typescript-eslint #1256
         mockFactory.createDocumentService = async (resolvedUrl) => {
-            const service = await serviceFactory.createDocumentService(resolvedUrl);
+            const service = await documentServiceFactory.createDocumentService(resolvedUrl);
             // Issue typescript-eslint/typescript-eslint #1256
             service.connectToDeltaStream = async () => deltaConnection;
             return service;
         };
-        const container = await Container.load(
-            "tenantId/documentId",
-            mockFactory,
-            codeLoader,
-            {},
-            {},
-            loader,
-            testRequest,
-            testResolved,
-            localResolver);
+        const container = await loadContainer({ documentServiceFactory: mockFactory });
         container.on("error", () => {
             assert.ok(false, "Error event should not be raised.");
         });
@@ -234,22 +177,6 @@ describe("Container", () => {
             "Container should be in Disconnected state");
         assert.strictEqual(container.closed, true, "Container should be closed");
         deltaConnection.removeAllListeners();
-    });
-
-    it("Check client details and Id", async () => {
-        const container = await Container.load(
-            "tenantId/documentId",
-            serviceFactory,
-            codeLoader,
-            {},
-            {},
-            loader,
-            testRequest,
-            testResolved,
-            localResolver);
-        assert.strictEqual(container.id, "documentId", "Container's id should be set");
-        assert.strictEqual(container.clientDetails.capabilities.interactive, true,
-            "Client details should be set with interactive as true");
     });
 
     afterEach(async () => {

--- a/packages/test/end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { fromBase64ToUtf8 } from "@fluidframework/common-utils";
-import { IFluidCodeDetails, IProxyLoaderFactory } from "@fluidframework/container-definitions";
+import { IFluidCodeDetails } from "@fluidframework/container-definitions";
 import { Loader } from "@fluidframework/container-loader";
 import { IUrlResolver } from "@fluidframework/driver-definitions";
 import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
@@ -79,13 +79,11 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         ]);
         const codeLoader = new LocalCodeLoader([[codeDetails, factory]]);
         const documentServiceFactory = new LocalDocumentServiceFactory(testDeltaConnectionServer);
-        return new Loader(
+        return new Loader({
             urlResolver,
             documentServiceFactory,
             codeLoader,
-            {},
-            {},
-            new Map<string, IProxyLoaderFactory>());
+        });
     }
 
     const createPeerDataStore = async (

--- a/packages/test/end-to-end-tests/src/test/documentDirty.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/documentDirty.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
-import { IContainer, IFluidCodeDetails, IProxyLoaderFactory } from "@fluidframework/container-definitions";
+import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions";
 import { Container, Loader } from "@fluidframework/container-loader";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
@@ -84,13 +84,11 @@ describe("Document Dirty", () => {
         const urlResolver = new LocalResolver();
         const codeLoader = new LocalCodeLoader([[codeDetails, runtimeFactory]]);
 
-        const loader = new Loader(
+        const loader = new Loader({
             urlResolver,
             documentServiceFactory,
             codeLoader,
-            {},
-            {},
-            new Map<string, IProxyLoaderFactory>());
+        });
 
         return createAndAttachContainer(documentId, codeDetails, loader, urlResolver);
     }

--- a/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
-import { IContainer, IFluidCodeDetails, ILoader, IProxyLoaderFactory } from "@fluidframework/container-definitions";
+import { IContainer, IFluidCodeDetails, ILoader } from "@fluidframework/container-definitions";
 import { ConnectionState, Container, Loader } from "@fluidframework/container-loader";
 import {
     ContainerMessageType,
@@ -83,13 +83,11 @@ describe("Ops on Reconnect", () => {
 
         const codeLoader = new LocalCodeLoader([[codeDetails, runtimeFactory]]);
 
-        return new Loader(
+        return new Loader({
             urlResolver,
             documentServiceFactory,
             codeLoader,
-            {},
-            {},
-            new Map<string, IProxyLoaderFactory>());
+        });
     }
 
     async function createContainer(): Promise<IContainer> {

--- a/packages/test/end-to-end-tests/src/test/upgradeManager.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/upgradeManager.spec.ts
@@ -10,7 +10,6 @@ import {
     ICodeLoader,
     IContainer,
     IFluidCodeDetails,
-    IProxyLoaderFactory,
 } from "@fluidframework/container-definitions";
 import { Container, Loader } from "@fluidframework/container-loader";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
@@ -55,26 +54,22 @@ describe("UpgradeManager", () => {
 
     async function createContainer(factory: IFluidDataStoreFactory): Promise<IContainer> {
         const codeLoader: ICodeLoader = new LocalCodeLoader([[codeDetails, factory]]);
-        const loader = new Loader(
+        const loader = new Loader({
             urlResolver,
             documentServiceFactory,
             codeLoader,
-            {},
-            {},
-            new Map<string, IProxyLoaderFactory>());
+        });
 
         return createAndAttachContainer(documentId, codeDetails, loader, urlResolver);
     }
 
     async function loadContainer(factory: IFluidDataStoreFactory): Promise<IContainer> {
         const codeLoader: ICodeLoader = new LocalCodeLoader([[codeDetails, factory]]);
-        const loader = new Loader(
+        const loader = new Loader({
             urlResolver,
             documentServiceFactory,
             codeLoader,
-            {},
-            {},
-            new Map<string, IProxyLoaderFactory>());
+        });
 
         return loader.resolve({ url: documentLoadUrl });
     }

--- a/packages/test/test-utils/src/localLoader.ts
+++ b/packages/test/test-utils/src/localLoader.ts
@@ -8,7 +8,6 @@ import {
     IContainer,
     ILoader,
     IFluidCodeDetails,
-    IProxyLoaderFactory,
 } from "@fluidframework/container-definitions";
 import { Loader } from "@fluidframework/container-loader";
 import { IUrlResolver, IDocumentServiceFactory } from "@fluidframework/driver-definitions";
@@ -30,13 +29,11 @@ export function createLocalLoader(
     const documentServiceFactory = new LocalDocumentServiceFactory(deltaConnectionServer);
     const codeLoader: ICodeLoader = new LocalCodeLoader(packageEntries);
 
-    return new Loader(
+    return new Loader({
         urlResolver,
         documentServiceFactory,
         codeLoader,
-        {},
-        {},
-        new Map<string, IProxyLoaderFactory>());
+    });
 }
 
 /**
@@ -126,13 +123,11 @@ export class LocalTestObjectProvider<ChannelFactoryRegistryType> {
 
     private createLoader(packageEntries: Iterable<[IFluidCodeDetails, fluidEntryPoint]>) {
         const codeLoader = new LocalCodeLoader(packageEntries);
-        return new Loader(
-            this.urlResolver,
-            this.documentServiceFactory,
+        return new Loader({
+            urlResolver: this.urlResolver,
+            documentServiceFactory: this.documentServiceFactory,
             codeLoader,
-            {},
-            {},
-            new Map<string, IProxyLoaderFactory>());
+        });
     }
 
     /**

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -13,7 +13,6 @@ import {
     IFluidPackage,
     IFluidCodeDetails,
     IFluidCodeResolver,
-    IProxyLoaderFactory,
     IResolvedFluidCodeDetails,
     isFluidBrowserPackage,
 } from "@fluidframework/container-definitions";
@@ -161,13 +160,11 @@ async function createWebLoader(
         wrapWithRuntimeFactoryIfNeeded(codeDetails.package as IFluidPackage, fluidModule),
     );
 
-    return new Loader(
+    return new Loader({
         urlResolver,
         documentServiceFactory,
         codeLoader,
-        { blockUpdateMarkers: true },
-        {},
-        new Map<string, IProxyLoaderFactory>());
+    });
 }
 
 export async function start(


### PR DESCRIPTION
As part of some prototyping related to the version work, I saw the need to add another parameter to the loader constructor. I'm not sure what will come to fruition, as I'm continuing to explore a few designs. However, in looking at adding a new param i saw that the current constructor already takes several optional params, which is cumbersome, as each preceding optional param must be specified to specify the next. Moving the loader to a props pattern will make the loader easier to work with and construct. 

Additionally, many of these same parameters are then passed to the container. I've simplified this to just pull the properties it needs directly from the load itself.