### PR TITLE
Matrix: Fix undo/redo cache invalidation

### DIFF
--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -70,6 +70,7 @@
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@fluidframework/test-runtime-utils": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",
+    "@tiny-calc/micro": "0.0.0-alpha.5",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -357,12 +357,11 @@ export class SharedMatrix<T extends Serializable = Serializable>
     /** @internal */ public _undoRemoveRows(segment: ISegment) {
         const original = segment as PermutationSegment;
 
-        // (Re)insert the removed number of columns at the original position.
+        // (Re)insert the removed number of rows at the original position.
         const rowStart = this.rows.getPosition(original);
         this.insertRows(rowStart, original.cachedLength);
 
-        // Transfer handles from the original segment to the newly inserted segment.
-        // (This allows us to use getCell(..) below to read the previous cell values)
+        // Transfer handles from the original segment to the newly inserted empty segment.
         const inserted = this.rows.getContainingSegment(rowStart).segment as PermutationSegment;
         original.transferHandlesTo(inserted);
 
@@ -373,7 +372,7 @@ export class SharedMatrix<T extends Serializable = Serializable>
             /* removedCount: */ 0,
             /* insertedCount: */ inserted.cachedLength);
 
-        // Generate setCell ops for each populated cell in the reinserted cols.
+        // Generate setCell ops for each populated cell in the reinserted rows.
         let rowHandle = inserted.start;
         const rowCount = inserted.cachedLength;
         for (let row = rowStart; row < rowStart + rowCount; row++, rowHandle++) {
@@ -405,12 +404,11 @@ export class SharedMatrix<T extends Serializable = Serializable>
         const colStart = this.cols.getPosition(original);
         this.insertCols(colStart, original.cachedLength);
 
-        // Transfer handles from the original segment to the newly inserted segment.
-        // (This allows us to use getCell(..) below to read the previous cell values)
+        // Transfer handles from the original segment to the newly inserted empty segment.
         const inserted = this.cols.getContainingSegment(colStart).segment as PermutationSegment;
         original.transferHandlesTo(inserted);
 
-        // Invalidate the handleCache in case it was populated during the 'rowsChanged'
+        // Invalidate the handleCache in case it was populated during the 'colsChanged'
         // callback, which occurs before the handle span is populated.
         this.cols.handleCache.itemsChanged(
             colStart,

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -358,15 +358,15 @@ export class SharedMatrix<T extends Serializable = Serializable>
         const original = segment as PermutationSegment;
 
         // (Re)insert the removed number of rows at the original position.
-        const rowStart = this.rows.getPosition(original);
-        this.insertRows(rowStart, original.cachedLength);
+        const { op, inserted } = this.rows.insertRelative(original, original.cachedLength);
+        this.submitRowMessage(op);
 
         // Transfer handles from the original segment to the newly inserted empty segment.
-        const inserted = this.rows.getContainingSegment(rowStart).segment as PermutationSegment;
         original.transferHandlesTo(inserted);
 
         // Invalidate the handleCache in case it was populated during the 'rowsChanged'
         // callback, which occurs before the handle span is populated.
+        const rowStart = this.rows.getPosition(inserted);
         this.rows.handleCache.itemsChanged(
             rowStart,
             /* removedCount: */ 0,
@@ -401,15 +401,15 @@ export class SharedMatrix<T extends Serializable = Serializable>
         const original = segment as PermutationSegment;
 
         // (Re)insert the removed number of columns at the original position.
-        const colStart = this.cols.getPosition(original);
-        this.insertCols(colStart, original.cachedLength);
+        const { op, inserted } = this.cols.insertRelative(original, original.cachedLength);
+        this.submitColMessage(op);
 
         // Transfer handles from the original segment to the newly inserted empty segment.
-        const inserted = this.cols.getContainingSegment(colStart).segment as PermutationSegment;
         original.transferHandlesTo(inserted);
 
         // Invalidate the handleCache in case it was populated during the 'colsChanged'
         // callback, which occurs before the handle span is populated.
+        const colStart = this.cols.getPosition(inserted);
         this.cols.handleCache.itemsChanged(
             colStart,
             /* removedCount: */ 0,

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -250,6 +250,10 @@ export class SharedMatrix<T extends Serializable = Serializable>
         this.cells.setCell(rowHandle, colHandle, value);
         this.annotations.setCell(rowHandle, colHandle, undefined);
 
+        this.sendSetCellOp(row, col, value, rowHandle, colHandle);
+    }
+
+    private sendSetCellOp(row: number, col: number, value: T, rowHandle: Handle, colHandle: Handle) {
         // If the SharedMatrix is local, it will by synchronized via a Snapshot when initially connected.
         // Do not queue a message or track the pending op, as there will never be an ACK, etc.
         if (this.isAttached()) {
@@ -381,7 +385,7 @@ export class SharedMatrix<T extends Serializable = Serializable>
                 const value = this.cells.getCell(rowHandle, colHandle);
                 // eslint-disable-next-line no-null/no-null
                 if (value !== undefined && value !== null) {
-                    this.setCellCore(
+                    this.sendSetCellOp(
                         row,
                         col,
                         value,
@@ -424,7 +428,7 @@ export class SharedMatrix<T extends Serializable = Serializable>
                 const value = this.cells.getCell(rowHandle, colHandle);
                 // eslint-disable-next-line no-null/no-null
                 if (value !== undefined && value !== null) {
-                    this.setCellCore(
+                    this.sendSetCellOp(
                         row,
                         col,
                         value,

--- a/packages/dds/matrix/src/undoprovider.ts
+++ b/packages/dds/matrix/src/undoprovider.ts
@@ -12,6 +12,12 @@ import { PermutationSegment, PermutationVector } from "./permutationvector";
 import { IUndoConsumer } from "./types";
 
 export class VectorUndoProvider {
+    // 'currentGroup' and 'currentOp' are used while applying an IRevertable.revert() to coalesce
+    // the recorded into a single IRevertable / tracking group as they move between the undo <->
+    // redo stacks.
+    private currentGroup?: TrackingGroup;
+    private currentOp?: MergeTreeDeltaType;
+
     constructor (
         private readonly manager: IUndoConsumer,
         private readonly undoInsert: (segment: PermutationSegment) => void,
@@ -29,34 +35,63 @@ export class VectorUndoProvider {
             //
             // These properties allow us to rely on MergeTree.getPosition() to find the locations/lengths
             // of all content contained within the tracking group in the future.
-            const trackingGroup = new TrackingGroup();
+
+            // If we are in the process of reverting, the `IRevertible.revert()` will provide the tracking
+            // group so that we can preserve the original segment ranges as a single op/group as we move
+            // ops between the undo <-> redo stacks.
+            const trackingGroup = this.currentGroup ?? new TrackingGroup();
             for (const range of ranges) {
                 trackingGroup.link(range.segment);
             }
 
+            // For SharedMatrix, each IRevertibles always holds a single row/col operation.
+            // Therefore, 'currentOp' must either be undefined or equal to the current op.
+            assert(this.currentOp === undefined || this.currentOp === operation);
+
             switch (operation) {
                 case MergeTreeDeltaType.INSERT:
-                    this.pushRevertible(trackingGroup, this.undoInsert);
+                    if (this.currentOp !== MergeTreeDeltaType.INSERT) {
+                        this.pushRevertible(trackingGroup, this.undoInsert);
+                    }
                     break;
 
                 case MergeTreeDeltaType.REMOVE: {
-                    this.pushRevertible(trackingGroup, this.undoRemove);
+                    if (this.currentOp !== MergeTreeDeltaType.REMOVE) {
+                        this.pushRevertible(trackingGroup, this.undoRemove);
+                    }
                     break;
                 }
 
                 default:
                     assert.fail("operation type not revertible");
             }
+
+            // If we are in the process of reverting, set 'currentOp' to remind ourselves not to push
+            // another revertible until `IRevertable.revert()` finishes the current op and clears this
+            // field.
+            if (this.currentGroup !== undefined) {
+                this.currentOp = operation;
+            }
         }
     }
 
     private pushRevertible(trackingGroup: TrackingGroup, callback: (segment: PermutationSegment) => void) {
-        this.manager.pushToCurrentOperation({
+        const revertible = {
             revert: () => {
-                while (trackingGroup.size > 0) {
-                    const sg = trackingGroup.segments[0] as PermutationSegment;
-                    callback(sg);
-                    sg.trackingCollection.unlink(trackingGroup);
+                assert(this.currentGroup === undefined && this.currentOp === undefined,
+                    "Must not nest calls to IRevertible.revert()");
+
+                this.currentGroup = new TrackingGroup();
+
+                try {
+                    while (trackingGroup.size > 0) {
+                        const sg = trackingGroup.segments[0] as PermutationSegment;
+                        callback(sg);
+                        sg.trackingCollection.unlink(trackingGroup);
+                    }
+                } finally {
+                    this.currentOp = undefined;
+                    this.currentGroup = undefined;
                 }
             },
             discard: () => {
@@ -64,7 +99,11 @@ export class VectorUndoProvider {
                     trackingGroup.unlink(trackingGroup.segments[0]);
                 }
             },
-        });
+        };
+
+        this.manager.pushToCurrentOperation(revertible);
+
+        return revertible;
     }
 }
 

--- a/packages/dds/matrix/test/matrix.spec.ts
+++ b/packages/dds/matrix/test/matrix.spec.ts
@@ -52,7 +52,7 @@ describe("Matrix", () => {
         async function expect<T extends Serializable>(expected: ReadonlyArray<ReadonlyArray<T>>) {
             const actual = extract(matrix);
             assert.deepEqual(actual, expected, "Matrix must match expected.");
-            assert.deepEqual(consumer.extract(), actual, "Matrix must notify IMatrixConsumers of all changes.");
+            assert.deepEqual(extract(consumer), actual, "Matrix must notify IMatrixConsumers of all changes.");
 
             // Ensure ops are ACKed prior to snapshot. Otherwise, unACKed segments won't be included.
             return snapshot(matrix);
@@ -72,8 +72,8 @@ describe("Matrix", () => {
             // in the event that the test case forgets to call/await `expect()`.)
             await snapshot(await snapshot(matrix));
 
-            // Ensure that IMatrixConsumer observed all changes to matrix.
-            assert.deepEqual(consumer.extract(), extract(matrix));
+            assert.deepEqual(extract(consumer), extract(matrix),
+                "Matrix must notify IMatrixConsumers of all changes.");
 
             // Sanity check that removing the consumer stops change notifications.
             matrix.closeMatrix(consumer);
@@ -350,7 +350,7 @@ describe("Matrix", () => {
             }
 
             for (const consumer of [consumer1, consumer2]) {
-                assert.deepEqual(consumer.extract(), actual1, "Matrix must notify IMatrixConsumers of all changes.");
+                assert.deepEqual(extract(consumer), actual1, "Matrix must notify IMatrixConsumers of all changes.");
             }
         };
 
@@ -668,39 +668,6 @@ describe("Matrix", () => {
                     ["B", "A", 2, 3]
                 ]);
             });
-
-            // it("fail", async () => {
-            //     matrix1.insertRows(/* rowStart: */ 0, /* rowCount: */ 4);
-            //     matrix1.insertCols(/* colStart: */ 0, /* colCount: */ 1);
-            //     matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, [0,1,2,3]);
-            //     matrix1.removeCols(/* colStart: */ 0, /* colCount: */ 1);
-            //     matrix1.removeRows(/* rowStart: */ 1, /* rowCount: */ 1);
-            //     await expect([
-            //         [],
-            //         [],
-            //         [],
-            //     ]);
-
-            //     matrix1.removeRows(/* rowStart: */ 0, /* rowCount: */ 1);
-            //     matrix2.insertCols(/* colStart: */ 0, /* colCount: */ 1);
-            //     matrix2.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, [74,37,0]);
-            //     matrix2.insertCols(/* colStart: */ 0, /* colCount: */ 1);
-            //     matrix2.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, [34,92,97]);
-            //     matrix1.insertRows(/* rowStart: */ 1, /* rowCount: */ 1);
-            //     await expect([
-            //         [92, 37],
-            //         [undefined, undefined],
-            //         [97, 0]
-            //     ]);
-
-            //     matrix2.insertCols(/* colStart: */ 0, /* colCount: */ 1);
-            //     matrix2.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, [59,89,55]);
-            //     await expect([
-            //         [59, 92, 37],
-            //         [89, undefined, undefined],
-            //         [55, 97, 0]
-            //     ]);
-            // });
         });
     });
 
@@ -726,7 +693,7 @@ describe("Matrix", () => {
             }
 
             for (const consumer of [consumer1, consumer2]) {
-                assert.deepEqual(consumer.extract(), actual1, "Matrix must notify IMatrixConsumers of all changes.");
+                assert.deepEqual(extract(consumer), actual1, "Matrix must notify IMatrixConsumers of all changes.");
             }
         };
 

--- a/packages/dds/matrix/test/matrix.undo.spec.ts
+++ b/packages/dds/matrix/test/matrix.undo.spec.ts
@@ -11,6 +11,7 @@ import {
     MockFluidDataStoreRuntime,
     MockEmptyDeltaConnection,
     MockStorage,
+    MockContainerRuntimeFactory,
 } from "@fluidframework/test-runtime-utils";
 import { SharedMatrix, SharedMatrixFactory } from "../src";
 import { extract, expectSize } from "./utils";
@@ -19,12 +20,372 @@ import { UndoRedoStackManager } from "./undoRedoStackManager";
 
 describe("Matrix", () => {
     describe("undo/redo", () => {
-        describe("local client", () => {
-            let dataStoreRuntime: MockFluidDataStoreRuntime;
-            let matrix: SharedMatrix<number>;
-            let consumer: TestConsumer<undefined | null | number>;     // Test IMatrixConsumer that builds a copy of `matrix` via observed events.
-            let undo: UndoRedoStackManager;
+        let dataStoreRuntime: MockFluidDataStoreRuntime;
+        let matrix1: SharedMatrix<number>;
+        let consumer1: TestConsumer<undefined | null | number>;     // Test IMatrixConsumer that builds a copy of `matrix` via observed events.
+        let undo1: UndoRedoStackManager;
+        let expect: <T extends Serializable>(expected: ReadonlyArray<ReadonlyArray<T>>) => Promise<void>;
 
+        function singleClientTests() {
+            it("undo/redo setCell", async () => {
+                matrix1.insertRows(/* start: */ 0, /* count: */ 1);
+                matrix1.insertCols(/* start: */ 0, /* count: */ 1);
+                await expect([[undefined]]);
+
+                undo1.closeCurrentOperation();
+
+                matrix1.setCell(/* row: */ 0, /* col: */ 0, 1);
+                await expect([[1]]);
+
+                undo1.undoOperation();
+                await expect([[undefined]]);
+
+                undo1.redoOperation();
+                await expect([[1]]);
+            });
+
+            it("undo/redo insertRow", async () => {
+                matrix1.insertRows(/* start: */ 0, /* count: */ 1);
+                undo1.closeCurrentOperation();
+
+                expectSize(matrix1, /* rowCount */ 1, /* colCount: */ 0);
+
+                undo1.undoOperation();
+                expectSize(matrix1, /* rowCount */ 0, /* colCount: */ 0);
+
+                undo1.redoOperation();
+                expectSize(matrix1, /* rowCount */ 1, /* colCount: */ 0);
+            });
+
+            it("undo/redo removeRow", async () => {
+                matrix1.insertRows(/* start: */ 0, /* count: */ 1);
+                matrix1.insertCols(/* start: */ 0, /* count: */ 1);
+                await expect([[undefined]]);
+
+                matrix1.setCell(/* row: */ 0, /* col: */ 0, 1);
+                await expect([[1]]);
+                undo1.closeCurrentOperation();
+
+                matrix1.removeRows(/* rowStart: */ 0, /* rowCount: */ 1);
+                undo1.closeCurrentOperation();
+
+                expectSize(matrix1, /* rowCount */ 0, /* colCount: */ 1);
+
+                undo1.undoOperation();
+                await expect([[1]]);
+
+                undo1.redoOperation();
+                expectSize(matrix1, /* rowCount */ 0, /* colCount: */ 1);
+            });
+
+            it("undo/redo removeRow 0 of 2x2", async () => {
+                matrix1.insertRows(/* start: */ 0, /* count: */ 2);
+                matrix1.insertCols(/* start: */ 0, /* count: */ 2);
+                matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 2, [
+                    0, 1,
+                    2, 3,
+                ]);
+                undo1.closeCurrentOperation();
+                await expect([
+                    [0, 1],
+                    [2, 3],
+                ]);
+
+                matrix1.removeRows(/* rowStart: */ 0, /* rowCount: */ 1);
+                undo1.closeCurrentOperation();
+                await expect([
+                    [2, 3]
+                ]);
+
+                undo1.undoOperation();
+                await expect([
+                    [0, 1],
+                    [2, 3],
+                ]);
+
+                undo1.redoOperation();
+                await expect([
+                    [2, 3]
+                ]);
+            });
+
+            it("undo/redo removeRow 1 of 2x2", async () => {
+                matrix1.insertRows(/* start: */ 0, /* count: */ 2);
+                matrix1.insertCols(/* start: */ 0, /* count: */ 2);
+                matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 2, [
+                    0, 1,
+                    2, 3,
+                ]);
+                undo1.closeCurrentOperation();
+                await expect([
+                    [0, 1],
+                    [2, 3],
+                ]);
+
+                matrix1.removeRows(/* rowStart: */ 1, /* rowCount: */ 1);
+                undo1.closeCurrentOperation();
+                await expect([
+                    [0, 1]
+                ]);
+
+                undo1.undoOperation();
+                await expect([
+                    [0, 1],
+                    [2, 3],
+                ]);
+
+                undo1.redoOperation();
+                await expect([
+                    [0, 1]
+                ]);
+            });
+
+            it("undo/redo removeRow 0..1 of 3x3", async () => {
+                matrix1.insertRows(/* start: */ 0, /* count: */ 3);
+                matrix1.insertCols(/* start: */ 0, /* count: */ 3);
+                matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 3, [
+                    0, 1, 2,
+                    3, 4, 5,
+                    6, 7, 8,
+                ]);
+                undo1.closeCurrentOperation();
+                await expect([
+                    [0, 1, 2],
+                    [3, 4, 5],
+                    [6, 7, 8],
+                ]);
+
+                matrix1.removeRows(/* rowStart: */ 0, /* rowCount: */ 2);
+                undo1.closeCurrentOperation();
+                await expect([
+                    [6, 7, 8],
+                ]);
+
+                undo1.undoOperation();
+                await expect([
+                    [0, 1, 2],
+                    [3, 4, 5],
+                    [6, 7, 8],
+                ]);
+
+                undo1.redoOperation();
+                await expect([
+                    [6, 7, 8],
+                ]);
+            });
+
+            it("undo/redo removeRow 2..3 of 3x3", async () => {
+                matrix1.insertRows(/* start: */ 0, /* count: */ 3);
+                matrix1.insertCols(/* start: */ 0, /* count: */ 3);
+                matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 3, [
+                    0, 1, 2,
+                    3, 4, 5,
+                    6, 7, 8,
+                ]);
+                undo1.closeCurrentOperation();
+                await expect([
+                    [0, 1, 2],
+                    [3, 4, 5],
+                    [6, 7, 8],
+                ]);
+
+                matrix1.removeRows(/* rowStart: */ 1, /* rowCount: */ 2);
+                undo1.closeCurrentOperation();
+                await expect([
+                    [0, 1, 2],
+                ]);
+
+                undo1.undoOperation();
+                await expect([
+                    [0, 1, 2],
+                    [3, 4, 5],
+                    [6, 7, 8],
+                ]);
+
+                undo1.redoOperation();
+                await expect([
+                    [0, 1, 2],
+                ]);
+            });
+
+            it("undo/redo insertCol", async () => {
+                matrix1.insertCols(/* start: */ 0, /* count: */ 1);
+                undo1.closeCurrentOperation();
+
+                expectSize(matrix1, /* rowCount */ 0, /* colCount: */ 1);
+
+                undo1.undoOperation();
+                expectSize(matrix1, /* rowCount */ 0, /* colCount: */ 0);
+
+                undo1.redoOperation();
+                expectSize(matrix1, /* rowCount */ 0, /* colCount: */ 1);
+            });
+
+            it("undo/redo removeCol", async () => {
+                matrix1.insertRows(/* start: */ 0, /* count: */ 1);
+                matrix1.insertCols(/* start: */ 0, /* count: */ 1);
+                await expect([[undefined]]);
+
+                matrix1.setCell(/* row: */ 0, /* col: */ 0, 1);
+                await expect([[1]]);
+                undo1.closeCurrentOperation();
+
+                matrix1.removeCols(/* colStart: */ 0, /* colCount: */ 1);
+                undo1.closeCurrentOperation();
+
+                expectSize(matrix1, /* rowCount */ 1, /* colCount: */ 0);
+
+                undo1.undoOperation();
+                await expect([[1]]);
+
+                undo1.redoOperation();
+                expectSize(matrix1, /* rowCount */ 1, /* colCount: */ 0);
+            });
+
+            it("undo/redo removeCol 0 of 2x2", async () => {
+                matrix1.insertRows(/* start: */ 0, /* count: */ 2);
+                matrix1.insertCols(/* start: */ 0, /* count: */ 2);
+                matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 2, [
+                    0, 1,
+                    2, 3,
+                ]);
+                await expect([
+                    [0, 1],
+                    [2, 3],
+                ]);
+                undo1.closeCurrentOperation();
+
+                matrix1.removeCols(/* colStart: */ 0, /* colCount: */ 1);
+                undo1.closeCurrentOperation();
+                await expect([
+                    [1],
+                    [3],
+                ]);
+
+                undo1.undoOperation();
+                await expect([
+                    [0, 1],
+                    [2, 3],
+                ]);
+
+                undo1.redoOperation();
+                await expect([
+                    [1],
+                    [3],
+                ]);
+            });
+
+            it("undo/redo removeCol 1 of 2x2", async () => {
+                matrix1.insertRows(/* start: */ 0, /* count: */ 2);
+                matrix1.insertCols(/* start: */ 0, /* count: */ 2);
+                matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 2, [
+                    0, 1,
+                    2, 3,
+                ]);
+                await expect([
+                    [0, 1],
+                    [2, 3],
+                ]);
+                undo1.closeCurrentOperation();
+
+                matrix1.removeCols(/* colStart: */ 1, /* colCount: */ 1);
+                undo1.closeCurrentOperation();
+                await expect([
+                    [0],
+                    [2],
+                ]);
+
+                undo1.undoOperation();
+                await expect([
+                    [0, 1],
+                    [2, 3],
+                ]);
+
+                undo1.redoOperation();
+                await expect([
+                    [0],
+                    [2],
+                ]);
+            });
+
+            it("undo/redo removeCol 0..1 of 3x3", async () => {
+                matrix1.insertRows(/* start: */ 0, /* count: */ 3);
+                matrix1.insertCols(/* start: */ 0, /* count: */ 3);
+                matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 3, [
+                    0, 1, 2,
+                    3, 4, 5,
+                    6, 7, 8,
+                ]);
+                undo1.closeCurrentOperation();
+                await expect([
+                    [0, 1, 2],
+                    [3, 4, 5],
+                    [6, 7, 8],
+                ]);
+
+                matrix1.removeCols(/* colStart: */ 0, /* colCount: */ 2);
+                undo1.closeCurrentOperation();
+                await expect([
+                    [2],
+                    [5],
+                    [8],
+                ]);
+
+                undo1.undoOperation();
+                await expect([
+                    [0, 1, 2],
+                    [3, 4, 5],
+                    [6, 7, 8],
+                ]);
+
+                undo1.redoOperation();
+                await expect([
+                    [2],
+                    [5],
+                    [8],
+                ]);
+            });
+
+            it("undo/redo removeCol 1..2 of 3x3", async () => {
+                matrix1.insertRows(/* start: */ 0, /* count: */ 3);
+                matrix1.insertCols(/* start: */ 0, /* count: */ 3);
+                matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 3, [
+                    0, 1, 2,
+                    3, 4, 5,
+                    6, 7, 8,
+                ]);
+                undo1.closeCurrentOperation();
+                await expect([
+                    [0, 1, 2],
+                    [3, 4, 5],
+                    [6, 7, 8],
+                ]);
+
+                matrix1.removeCols(/* colStart: */ 1, /* colCount: */ 2);
+                undo1.closeCurrentOperation();
+                await expect([
+                    [0],
+                    [3],
+                    [6],
+                ]);
+
+                undo1.undoOperation();
+                await expect([
+                    [0, 1, 2],
+                    [3, 4, 5],
+                    [6, 7, 8],
+                ]);
+
+                undo1.redoOperation();
+                await expect([
+                    [0],
+                    [3],
+                    [6],
+                ]);
+            });
+        }
+
+        describe("local client", () => {
             // Snapshots the given `SharedMatrix`, loads the snapshot into a 2nd SharedMatrix, vets that the two are
             // equivalent, and then returns the 2nd matrix.
             async function snapshot<T extends Serializable>(matrix: SharedMatrix<T>) {
@@ -43,401 +404,180 @@ describe("Matrix", () => {
                 });
 
                 // Vet that the 2nd matrix is equivalent to the original.
-                expectSize(matrix2, matrix.rowCount, matrix.colCount);
-                assert.deepEqual(extract(matrix), extract(matrix2), 'Matrix must round-trip through snapshot/load.');
+                //
+                // BUG: In the case of a disconnected client, the MergeTree snapshot is missing segments
+                //      inserted via 'insertAtReferencePositionLocal()'.
+                //
+                //      (See https://github.com/microsoft/FluidFramework/issues/3950)
+                //
+                // expectSize(matrix2, matrix.rowCount, matrix.colCount);
+                // assert.deepEqual(extract(matrix), extract(matrix2), 'Matrix must round-trip through snapshot/load.');
 
                 return matrix2;
             }
 
-            async function expect<T extends Serializable>(expected: ReadonlyArray<ReadonlyArray<T>>) {
-                const actual = extract(matrix);
-                assert.deepEqual(actual, expected, "Matrix must match expected.");
-                assert.deepEqual(extract(consumer), actual, "Matrix must notify IMatrixConsumers of all changes.");
-
-                // Ensure ops are ACKed prior to snapshot. Otherwise, unACKed segments won't be included.
-                return snapshot(matrix);
-            }
+            before(() => {
+                expect = async <T extends Serializable>(expected: ReadonlyArray<ReadonlyArray<T>>) => {
+                    const actual = extract(matrix1);
+                    assert.deepEqual(actual, expected, "Matrix must match expected.");
+                    assert.deepEqual(extract(consumer1), actual, "Matrix must notify IMatrixConsumers of all changes.");
+                }
+            })
 
             beforeEach(async () => {
                 dataStoreRuntime = new MockFluidDataStoreRuntime();
-                matrix = new SharedMatrix(dataStoreRuntime, "matrix1", SharedMatrixFactory.Attributes);
+                matrix1 = new SharedMatrix(dataStoreRuntime, "matrix1", SharedMatrixFactory.Attributes);
 
                 // Attach a new IMatrixConsumer
-                consumer = new TestConsumer(matrix);
+                consumer1 = new TestConsumer(matrix1);
 
-                undo = new UndoRedoStackManager();
-                matrix.openUndo(undo);
+                undo1 = new UndoRedoStackManager();
+                matrix1.openUndo(undo1);
             });
 
             afterEach(async () => {
                 // Paranoid check that ensures that the SharedMatrix loaded from the snapshot also
                 // round-trips through snapshot/load.  (Also, may help detect snapshot/loaded bugs
                 // in the event that the test case forgets to call/await `expect()`.)
-                await snapshot(await snapshot(matrix));
+                await snapshot(await snapshot(matrix1));
 
                 // Ensure that IMatrixConsumer observed all changes to matrix.
-                assert.deepEqual(extract(consumer), extract(matrix), "Matrix must notify IMatrixConsumers of all changes.");
+                assert.deepEqual(extract(consumer1), extract(matrix1), "Matrix must notify IMatrixConsumers of all changes.");
 
                 // Sanity check that removing the consumer stops change notifications.
-                matrix.closeMatrix(consumer);
-                matrix.insertCols(0, 1);
-                assert.equal(consumer.colCount, matrix.colCount - 1);
+                matrix1.closeMatrix(consumer1);
+                matrix1.insertCols(0, 1);
+                assert.equal(consumer1.colCount, matrix1.colCount - 1);
             });
 
-            it("undo/redo setCell", async () => {
-                matrix.insertRows(/* start: */ 0, /* count: */ 1);
-                matrix.insertCols(/* start: */ 0, /* count: */ 1);
-                await expect([[undefined]]);
+            singleClientTests();
+        });
 
-                undo.closeCurrentOperation();
+        describe("Connected with two clients", () => {
+            let matrix2: SharedMatrix;
+            let undo2: UndoRedoStackManager;
+            let consumer2: TestConsumer;     // Test IMatrixConsumer that builds a copy of `matrix` via observed events.
+            let containerRuntimeFactory: MockContainerRuntimeFactory;
 
-                matrix.setCell(/* row: */ 0, /* col: */ 0, 1);
-                await expect([[1]]);
+            before(() => {
+                expect = async (expected?: readonly (readonly any[])[]) => {
+                    containerRuntimeFactory.processAllMessages();
 
-                undo.undoOperation();
-                await expect([[undefined]]);
+                    const actual1 = extract(matrix1);
+                    const actual2 = extract(matrix2);
 
-                undo.redoOperation();
-                await expect([[1]]);
+                    assert.deepEqual(actual1, actual2);
+
+                    if (expected !== undefined) {
+                        assert.deepEqual(actual1, expected);
+                    }
+
+                    for (const consumer of [consumer1, consumer2]) {
+                        assert.deepEqual(extract(consumer), actual1, "Matrix must notify IMatrixConsumers of all changes.");
+                    }
+                };
             });
 
-            it("undo/redo insertRow", async () => {
-                matrix.insertRows(/* start: */ 0, /* count: */ 1);
-                undo.closeCurrentOperation();
+            beforeEach(async () => {
+                containerRuntimeFactory = new MockContainerRuntimeFactory();
 
-                expectSize(matrix, /* rowCount */ 1, /* colCount: */ 0);
+                // Create and connect the first SharedMatrix.
+                const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
+                matrix1 = new SharedMatrix(dataStoreRuntime1, "matrix1", SharedMatrixFactory.Attributes);
+                matrix1.connect({
+                    deltaConnection: containerRuntimeFactory
+                        .createContainerRuntime(dataStoreRuntime1)
+                        .createDeltaConnection(),
+                    objectStorage: new MockStorage(),
+                });
+                consumer1 = new TestConsumer(matrix1);
+                undo1 = new UndoRedoStackManager();
+                matrix1.openUndo(undo1);
 
-                undo.undoOperation();
-                expectSize(matrix, /* rowCount */ 0, /* colCount: */ 0);
-
-                undo.redoOperation();
-                expectSize(matrix, /* rowCount */ 1, /* colCount: */ 0);
+                // Create and connect the second SharedMatrix.
+                const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
+                matrix2 = new SharedMatrix(dataStoreRuntime2, "matrix2", SharedMatrixFactory.Attributes);
+                matrix2.connect({
+                    deltaConnection: containerRuntimeFactory
+                        .createContainerRuntime(dataStoreRuntime2)
+                        .createDeltaConnection(),
+                    objectStorage: new MockStorage(),
+                });
+                consumer2 = new TestConsumer(matrix2);
+                undo2 = new UndoRedoStackManager();
+                matrix2.openUndo(undo2);
             });
 
-            it("undo/redo removeRow", async () => {
-                matrix.insertRows(/* start: */ 0, /* count: */ 1);
-                matrix.insertCols(/* start: */ 0, /* count: */ 1);
-                await expect([[undefined]]);
+            afterEach(async () => {
+                // Paranoid check that the matrices are have converged on the same state.
+                await expect(undefined as any);
 
-                matrix.setCell(/* row: */ 0, /* col: */ 0, 1);
-                await expect([[1]]);
-                undo.closeCurrentOperation();
-
-                matrix.removeRows(/* rowStart: */ 0, /* rowCount: */ 1);
-                undo.closeCurrentOperation();
-
-                expectSize(matrix, /* rowCount */ 0, /* colCount: */ 1);
-
-                undo.undoOperation();
-                await expect([[1]]);
-
-                undo.redoOperation();
-                expectSize(matrix, /* rowCount */ 0, /* colCount: */ 1);
+                matrix1.closeMatrix(consumer1);
+                matrix2.closeMatrix(consumer2);
             });
 
-            it("undo/redo removeRow 0 of 2x2", async () => {
-                matrix.insertRows(/* start: */ 0, /* count: */ 2);
-                matrix.insertCols(/* start: */ 0, /* count: */ 2);
-                matrix.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 2, [
-                    0, 1,
+            singleClientTests();
+
+            it("reorder row insertion via undo/redo", async () => {
+                matrix1.insertCols(/* start: */ 0, /* count: */ 2);
+                undo1.closeCurrentOperation();
+
+                await expect([]);
+
+                matrix2.insertRows(/* start: */ 0, /* count: */ 1);
+                matrix2.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 2, [
                     2, 3,
                 ]);
-                undo.closeCurrentOperation();
+                undo2.closeCurrentOperation();
+
                 await expect([
-                    [0, 1],
                     [2, 3],
                 ]);
 
-                matrix.removeRows(/* rowStart: */ 0, /* rowCount: */ 1);
-                undo.closeCurrentOperation();
-                await expect([
-                    [2, 3]
-                ]);
-
-                undo.undoOperation();
-                await expect([
-                    [0, 1],
-                    [2, 3],
-                ]);
-
-                undo.redoOperation();
-                await expect([
-                    [2, 3]
-                ]);
-            });
-
-            it("undo/redo removeRow 1 of 2x2", async () => {
-                matrix.insertRows(/* start: */ 0, /* count: */ 2);
-                matrix.insertCols(/* start: */ 0, /* count: */ 2);
-                matrix.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 2, [
+                matrix1.insertRows(/* start: */ 0, /* count: */ 1);
+                matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 2, [
                     0, 1,
-                    2, 3,
                 ]);
-                undo.closeCurrentOperation();
+                undo1.closeCurrentOperation();
+
                 await expect([
                     [0, 1],
                     [2, 3],
                 ]);
 
-                matrix.removeRows(/* rowStart: */ 1, /* rowCount: */ 1);
-                undo.closeCurrentOperation();
+                undo2.undoOperation();
                 await expect([
-                    [0, 1]
+                    [0, 1],
                 ]);
 
-                undo.undoOperation();
+                undo1.undoOperation();
+                await expect([
+                ]);
+
+                undo2.redoOperation();
+                await expect([
+                    [2, 3],
+                ]);
+
+                undo1.redoOperation();
                 await expect([
                     [0, 1],
                     [2, 3],
                 ]);
 
-                undo.redoOperation();
+                undo1.undoOperation();
                 await expect([
-                    [0, 1]
-                ]);
-            });
-
-            it("undo/redo removeRow 0..1 of 3x3", async () => {
-                matrix.insertRows(/* start: */ 0, /* count: */ 3);
-                matrix.insertCols(/* start: */ 0, /* count: */ 3);
-                matrix.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 3, [
-                    0, 1, 2,
-                    3, 4, 5,
-                    6, 7, 8,
-                ]);
-                undo.closeCurrentOperation();
-                await expect([
-                    [0, 1, 2],
-                    [3, 4, 5],
-                    [6, 7, 8],
-                ]);
-
-                matrix.removeRows(/* rowStart: */ 0, /* rowCount: */ 2);
-                undo.closeCurrentOperation();
-                await expect([
-                    [6, 7, 8],
-                ]);
-
-                undo.undoOperation();
-                await expect([
-                    [0, 1, 2],
-                    [3, 4, 5],
-                    [6, 7, 8],
-                ]);
-
-                undo.redoOperation();
-                await expect([
-                    [6, 7, 8],
-                ]);
-            });
-
-            it("undo/redo removeRow 2..3 of 3x3", async () => {
-                matrix.insertRows(/* start: */ 0, /* count: */ 3);
-                matrix.insertCols(/* start: */ 0, /* count: */ 3);
-                matrix.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 3, [
-                    0, 1, 2,
-                    3, 4, 5,
-                    6, 7, 8,
-                ]);
-                undo.closeCurrentOperation();
-                await expect([
-                    [0, 1, 2],
-                    [3, 4, 5],
-                    [6, 7, 8],
-                ]);
-
-                matrix.removeRows(/* rowStart: */ 1, /* rowCount: */ 2);
-                undo.closeCurrentOperation();
-                await expect([
-                    [0, 1, 2],
-                ]);
-
-                undo.undoOperation();
-                await expect([
-                    [0, 1, 2],
-                    [3, 4, 5],
-                    [6, 7, 8],
-                ]);
-
-                undo.redoOperation();
-                await expect([
-                    [0, 1, 2],
-                ]);
-            });
-
-            it("undo/redo insertCol", async () => {
-                matrix.insertCols(/* start: */ 0, /* count: */ 1);
-                undo.closeCurrentOperation();
-
-                expectSize(matrix, /* rowCount */ 0, /* colCount: */ 1);
-
-                undo.undoOperation();
-                expectSize(matrix, /* rowCount */ 0, /* colCount: */ 0);
-
-                undo.redoOperation();
-                expectSize(matrix, /* rowCount */ 0, /* colCount: */ 1);
-            });
-
-            it("undo/redo removeCol", async () => {
-                matrix.insertRows(/* start: */ 0, /* count: */ 1);
-                matrix.insertCols(/* start: */ 0, /* count: */ 1);
-                await expect([[undefined]]);
-
-                matrix.setCell(/* row: */ 0, /* col: */ 0, 1);
-                await expect([[1]]);
-                undo.closeCurrentOperation();
-
-                matrix.removeCols(/* colStart: */ 0, /* colCount: */ 1);
-                undo.closeCurrentOperation();
-
-                expectSize(matrix, /* rowCount */ 1, /* colCount: */ 0);
-
-                undo.undoOperation();
-                await expect([[1]]);
-
-                undo.redoOperation();
-                expectSize(matrix, /* rowCount */ 1, /* colCount: */ 0);
-            });
-
-            it("undo/redo removeCol 0 of 2x2", async () => {
-                matrix.insertRows(/* start: */ 0, /* count: */ 2);
-                matrix.insertCols(/* start: */ 0, /* count: */ 2);
-                matrix.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 2, [
-                    0, 1,
-                    2, 3,
-                ]);
-                await expect([
-                    [0, 1],
-                    [2, 3],
-                ]);
-                undo.closeCurrentOperation();
-
-                matrix.removeCols(/* colStart: */ 0, /* colCount: */ 1);
-                undo.closeCurrentOperation();
-                await expect([
-                    [1],
-                    [3],
-                ]);
-
-                undo.undoOperation();
-                await expect([
-                    [0, 1],
                     [2, 3],
                 ]);
 
-                undo.redoOperation();
+                undo1.undoOperation();
                 await expect([
-                    [1],
-                    [3],
+                    []
                 ]);
-            });
 
-            it("undo/redo removeCol 1 of 2x2", async () => {
-                matrix.insertRows(/* start: */ 0, /* count: */ 2);
-                matrix.insertCols(/* start: */ 0, /* count: */ 2);
-                matrix.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 2, [
-                    0, 1,
-                    2, 3,
-                ]);
+                undo1.redoOperation();
                 await expect([
-                    [0, 1],
                     [2, 3],
-                ]);
-                undo.closeCurrentOperation();
-
-                matrix.removeCols(/* colStart: */ 1, /* colCount: */ 1);
-                undo.closeCurrentOperation();
-                await expect([
-                    [0],
-                    [2],
-                ]);
-
-                undo.undoOperation();
-                await expect([
-                    [0, 1],
-                    [2, 3],
-                ]);
-
-                undo.redoOperation();
-                await expect([
-                    [0],
-                    [2],
-                ]);
-            });
-
-            it("undo/redo removeCol 0..1 of 3x3", async () => {
-                matrix.insertRows(/* start: */ 0, /* count: */ 3);
-                matrix.insertCols(/* start: */ 0, /* count: */ 3);
-                matrix.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 3, [
-                    0, 1, 2,
-                    3, 4, 5,
-                    6, 7, 8,
-                ]);
-                undo.closeCurrentOperation();
-                await expect([
-                    [0, 1, 2],
-                    [3, 4, 5],
-                    [6, 7, 8],
-                ]);
-
-                matrix.removeCols(/* colStart: */ 0, /* colCount: */ 2);
-                undo.closeCurrentOperation();
-                await expect([
-                    [2],
-                    [5],
-                    [8],
-                ]);
-
-                undo.undoOperation();
-                await expect([
-                    [0, 1, 2],
-                    [3, 4, 5],
-                    [6, 7, 8],
-                ]);
-
-                undo.redoOperation();
-                await expect([
-                    [2],
-                    [5],
-                    [8],
-                ]);
-            });
-
-            it("undo/redo removeCol 1..2 of 3x3", async () => {
-                matrix.insertRows(/* start: */ 0, /* count: */ 3);
-                matrix.insertCols(/* start: */ 0, /* count: */ 3);
-                matrix.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 3, [
-                    0, 1, 2,
-                    3, 4, 5,
-                    6, 7, 8,
-                ]);
-                undo.closeCurrentOperation();
-                await expect([
-                    [0, 1, 2],
-                    [3, 4, 5],
-                    [6, 7, 8],
-                ]);
-
-                matrix.removeCols(/* colStart: */ 1, /* colCount: */ 2);
-                undo.closeCurrentOperation();
-                await expect([
-                    [0],
-                    [3],
-                    [6],
-                ]);
-
-                undo.undoOperation();
-                await expect([
-                    [0, 1, 2],
-                    [3, 4, 5],
-                    [6, 7, 8],
-                ]);
-
-                undo.redoOperation();
-                await expect([
-                    [0],
-                    [3],
-                    [6],
                 ]);
             });
         });

--- a/packages/dds/matrix/test/matrix.undo.spec.ts
+++ b/packages/dds/matrix/test/matrix.undo.spec.ts
@@ -52,7 +52,7 @@ describe("Matrix", () => {
             async function expect<T extends Serializable>(expected: ReadonlyArray<ReadonlyArray<T>>) {
                 const actual = extract(matrix);
                 assert.deepEqual(actual, expected, "Matrix must match expected.");
-                assert.deepEqual(consumer.extract(), actual, "Matrix must notify IMatrixConsumers of all changes.");
+                assert.deepEqual(extract(consumer), actual, "Matrix must notify IMatrixConsumers of all changes.");
 
                 // Ensure ops are ACKed prior to snapshot. Otherwise, unACKed segments won't be included.
                 return snapshot(matrix);
@@ -76,7 +76,7 @@ describe("Matrix", () => {
                 await snapshot(await snapshot(matrix));
 
                 // Ensure that IMatrixConsumer observed all changes to matrix.
-                assert.deepEqual(consumer.extract(), extract(matrix));
+                assert.deepEqual(extract(consumer), extract(matrix), "Matrix must notify IMatrixConsumers of all changes.");
 
                 // Sanity check that removing the consumer stops change notifications.
                 matrix.closeMatrix(consumer);


### PR DESCRIPTION
This fixes a bug uncovered by a partner where when restoring a row/col as part of undoing a remove operation, we need to manually invalidate the handle cache after transferring handles to the new segment and before invoking the 'cellsChanged' callback.