### PR TITLE
Fluid Garbage Collection - Prototype

### DIFF
--- a/packages/dds/cell/src/cell.ts
+++ b/packages/dds/cell/src/cell.ts
@@ -167,7 +167,7 @@ export class SharedCell<T extends Serializable = any> extends SharedObject<IShar
      *
      * @returns the snapshot of the current state of the cell
      */
-    public snapshot(): ITree {
+    protected snapshotCore(): ITree {
         // Get a serializable form of data
         const content: ICellValue = {
             type: ValueType[ValueType.Plain],

--- a/packages/dds/counter/src/counter.ts
+++ b/packages/dds/counter/src/counter.ts
@@ -101,7 +101,7 @@ export class SharedCounter extends SharedObject<ISharedCounterEvents> implements
      *
      * @returns the snapshot of the current state of the counter
      */
-    public snapshot(): ITree {
+    protected snapshotCore(): ITree {
         // Get a serializable form of data
         const content: ICounterSnapshotFormat = {
             value: this.value,

--- a/packages/dds/ink/src/ink.ts
+++ b/packages/dds/ink/src/ink.ts
@@ -130,7 +130,7 @@ export class Ink extends SharedObject<IInkEvents> implements IInk {
     /**
      * {@inheritDoc @fluidframework/shared-object-base#SharedObject.snapshot}
      */
-    public snapshot(): ITree {
+    protected snapshotCore(): ITree {
         const tree: ITree = {
             entries: [
                 {

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -587,7 +587,7 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
     /**
      * {@inheritDoc @fluidframework/shared-object-base#SharedObject.snapshot}
      */
-    public snapshot(): ITree {
+    protected snapshotCore(): ITree {
         return serializeDirectory(this.root);
     }
 

--- a/packages/dds/map/src/map.ts
+++ b/packages/dds/map/src/map.ts
@@ -252,7 +252,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
     /**
     * {@inheritDoc @fluidframework/shared-object-base#SharedObject.snapshot}
     */
-    public snapshot(): ITree {
+    protected snapshotCore(): ITree {
         let currentSize = 0;
         let counter = 0;
         let headerBlob: IMapDataObjectSerializable = {};

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -428,7 +428,7 @@ export class SharedMatrix<T extends Serializable = Serializable>
         }
     }
 
-    public snapshot(): ITree {
+    protected snapshotCore(): ITree {
         return {
             entries: [
                 {

--- a/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
+++ b/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
@@ -184,7 +184,7 @@ export class ConsensusOrderedCollection<T = any>
         } while (!(await this.acquire(callback)));
     }
 
-    public snapshot(): ITree {
+    protected snapshotCore(): ITree {
         // If we are transitioning from unattached to attached mode,
         // then we are losing all checked out work!
         this.removeClient(idForLocalUnattachedClient);

--- a/packages/dds/register-collection/src/consensusRegisterCollection.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollection.ts
@@ -186,7 +186,7 @@ export class ConsensusRegisterCollection<T>
         return [...this.data.keys()];
     }
 
-    public snapshot(): ITree {
+    protected snapshotCore(): ITree {
         const dataObj: { [key: string]: ILocalData<T> } = {};
         this.data.forEach((v, k) => { dataObj[k] = v; });
 

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -412,7 +412,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
         return sharedCollection;
     }
 
-    public snapshot(): ITree {
+    protected snapshotCore(): ITree {
         const tree: ITree = {
             entries: [
                 {

--- a/packages/dds/sequence/src/sharedIntervalCollection.ts
+++ b/packages/dds/sequence/src/sharedIntervalCollection.ts
@@ -145,7 +145,7 @@ export class SharedIntervalCollection<TInterval extends ISerializableInterval = 
         return sharedCollection;
     }
 
-    public snapshot(): ITree {
+    protected snapshotCore(): ITree {
         const tree: ITree = {
             entries: [
                 {

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -61,6 +61,12 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
      */
     private _isBoundToContext: boolean = false;
 
+    private _referencedRoutes: string[] = [];
+
+    public getReferencedRoutes(): string[] {
+        return this._referencedRoutes;
+    }
+
     /**
      * Gets the connection state
      * @returns The state of the connection
@@ -186,7 +192,17 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
     /**
      * {@inheritDoc (ISharedObject:interface).snapshot}
      */
-    public abstract snapshot(): ITree;
+    public snapshot(): ITree {
+        this.runtime.IFluidSerializer.startRecordingRoutes();
+
+        const snapshot: ITree = this.snapshotCore();
+
+        this._referencedRoutes = this.runtime.IFluidSerializer.serializedRoutes;
+
+        this.runtime.IFluidSerializer.stopRecordingRoutes();
+
+        return snapshot;
+    }
 
     /**
      * Set the owner of the object if it is an OwnedSharedObject
@@ -204,6 +220,8 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
     protected abstract loadCore(
         branchId: string | undefined,
         services: IChannelStorageService): Promise<void>;
+
+    protected abstract snapshotCore(): ITree;
 
     /**
      * Allows the distributed data type to perform custom local loading.

--- a/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
+++ b/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
@@ -97,7 +97,7 @@ export class SharedSummaryBlock extends SharedObject implements ISharedSummaryBl
     /**
      * {@inheritDoc @fluidframework/shared-object-base#SharedObject.snapshot}
      */
-    public snapshot(): ITree {
+    protected snapshotCore(): ITree {
         const contentsBlob: ISharedSummaryBlockDataSerializable = {};
         this.data.forEach((value, key) => {
             contentsBlob[key] = value;

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -1213,7 +1213,7 @@ export class DeltaManager
                         const error = {
                             errorType: ContainerErrorType.dataCorruption,
                             message: "Two messages with same seq# and different payload!",
-                            clientId: this.connection?.details.clientId,
+                            clientId: this.connection?.clientId,
                             sequenceNumber: message.sequenceNumber,
                             message1,
                             message2,

--- a/packages/loader/core-interfaces/src/serializer.ts
+++ b/packages/loader/core-interfaces/src/serializer.ts
@@ -41,4 +41,10 @@ export interface IFluidSerializer extends IProvideFluidSerializer {
      * handles will be realized as part of the parse
      */
     parse(value: string): any;
+
+    serializedRoutes: string[];
+
+    startRecordingRoutes(): void;
+
+    stopRecordingRoutes(): void;
 }

--- a/packages/runtime/datastore-definitions/src/channel.ts
+++ b/packages/runtime/datastore-definitions/src/channel.ts
@@ -32,6 +32,8 @@ export interface IChannel extends IFluidLoadable {
      * Enables the channel to send and receive ops
      */
     connect(services: IChannelServices): void;
+
+    getReferencedRoutes(): string[];
 }
 
 /**

--- a/packages/runtime/datastore/src/channelContext.ts
+++ b/packages/runtime/datastore/src/channelContext.ts
@@ -28,6 +28,8 @@ export interface IChannelContext {
     summarize(fullTree?: boolean): Promise<ISummarizeResult>;
 
     reSubmit(content: any, localOpMetadata: unknown): void;
+
+    getReferencedRoutes(): string[];
 }
 
 export function createServiceEndpoints(

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -567,8 +567,19 @@ export class FluidDataStoreRuntime extends EventEmitter implements IFluidDataSto
                 // And then store the tree
                 return new TreeTreeEntry(key, snapshot);
             }));
-
         return entries;
+    }
+
+    public getReferencedRoutes(): string[] {
+        const referencedRoutes: string[] = [];
+        this.contexts.forEach((value: IChannelContext) => {
+            const routes = value.getReferencedRoutes();
+            referencedRoutes.push(...routes);
+        });
+        return referencedRoutes;
+    }
+
+    public collectUnreferencedFluidObjects(referencedObjectRoutes: string[]) {
     }
 
     public async summarize(fullTree = false): Promise<ISummaryTreeWithStats> {

--- a/packages/runtime/datastore/src/localChannelContext.ts
+++ b/packages/runtime/datastore/src/localChannelContext.ts
@@ -196,4 +196,9 @@ export class LocalChannelContext implements IChannelContext {
             this.collectExtraBlobsAndSanitizeSnapshot(value, blobMap);
         }
     }
+
+    public getReferencedRoutes(): string[] {
+        assert(this.channel, "Channel should be available");
+        return this.channel.getReferencedRoutes();
+    }
 }

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -204,4 +204,9 @@ export class RemoteChannelContext implements IChannelContext {
         this.services.deltaConnection.setConnectionState(this.dataStoreContext.connected);
         return this.channel;
     }
+
+    public getReferencedRoutes(): string[] {
+        assert(this.channel, "Channel should be available");
+        return this.channel.getReferencedRoutes();
+    }
 }

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -193,6 +193,10 @@ export interface IFluidDataStoreChannel extends
      * @param localOpMetadata - The local metadata associated with the original message.
      */
     reSubmit(type: string, content: any, localOpMetadata: unknown);
+
+    getReferencedRoutes(): string[];
+
+    collectUnreferencedFluidObjects(referencedObjects: string[]): void;
 }
 
 /**

--- a/packages/runtime/runtime-utils/src/serializer.ts
+++ b/packages/runtime/runtime-utils/src/serializer.ts
@@ -24,6 +24,9 @@ export class FluidSerializer implements IFluidSerializer {
         }
     }
 
+    private _serializedRoutes: string[] = [];
+    private shouldRecordRoutes: boolean = false;
+
     public get IFluidSerializer() { return this; }
 
     public replaceHandles(
@@ -74,7 +77,7 @@ export class FluidSerializer implements IFluidSerializer {
             });
     }
 
-    // Invoked by `replaceHandles()` for non-null objects to recursively replace IFluidHandle references
+    // Invoked by `replaceRoutes()` for non-null objects to recursively replace IFluidHandle references
     // with serialized handles (cloning as-needed to avoid mutating the original `input` object.)
     private recursivelyReplaceHandles(
         input: any,
@@ -121,9 +124,28 @@ export class FluidSerializer implements IFluidSerializer {
 
     private serializeHandle(handle: IFluidHandle, bind: IFluidHandle) {
         bind.bind(handle);
+
+        if (this.shouldRecordRoutes) {
+            this._serializedRoutes.push(handle.absolutePath);
+        }
+
         return {
             type: "__fluid_handle__",
             url: handle.absolutePath,
         };
+    }
+
+    public get serializedRoutes() {
+        return this._serializedRoutes;
+    }
+
+    public startRecordingRoutes() {
+        this._serializedRoutes = [];
+        this.shouldRecordRoutes = true;
+    }
+
+    public stopRecordingRoutes() {
+        this._serializedRoutes = [];
+        this.shouldRecordRoutes = false;
     }
 }

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -541,6 +541,12 @@ export class MockFluidDataStoreRuntime extends EventEmitter
     public reSubmit(content: any, localOpMetadata: unknown) {
         return;
     }
+
+    public getReferencedRoutes(): string[] {
+        return [];
+    }
+
+    public collectUnreferencedFluidObjects(referencedObject: string[]): void { }
 }
 
 /**

--- a/packages/test/end-to-end-tests/src/test/gcEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/gcEndToEndTests.spec.ts
@@ -1,0 +1,239 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import {
+    ContainerRuntimeFactoryWithDefaultDataStore,
+    DataObject,
+    DataObjectFactory,
+} from "@fluidframework/aqueduct";
+import { IContainer, IFluidCodeDetails, ILoader } from "@fluidframework/container-definitions";
+import { Container } from "@fluidframework/container-loader";
+import { IUrlResolver } from "@fluidframework/driver-definitions";
+import { readAndParse } from "@fluidframework/driver-utils";
+import { LocalResolver } from "@fluidframework/local-driver";
+import { ISharedDirectory, ISharedMap, SharedMap } from "@fluidframework/map";
+import { ISnapshotTree } from "@fluidframework/protocol-definitions";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
+import {
+    createAndAttachContainer,
+    createLocalLoader,
+    OpProcessingController,
+} from "@fluidframework/test-utils";
+
+class TestDataObject extends DataObject {
+    public get _root() {
+        return this.root;
+    }
+
+    public get _runtime() {
+        return this.runtime;
+    }
+
+    public get _context() {
+        return this.context;
+    }
+}
+
+describe("Garbage Collection", () => {
+    const documentId = "cellTest";
+    // const documentLoadUrl = `fluid-test://localhost/${documentId}`;
+    const codeDetails: IFluidCodeDetails = {
+        package: "sharedCellTestPackage",
+        config: {},
+    };
+    const factory = new DataObjectFactory(
+        "TestDataObject",
+        TestDataObject,
+        [],
+        []);
+
+    let deltaConnectionServer: ILocalDeltaConnectionServer;
+    let urlResolver: IUrlResolver;
+    let opProcessingController: OpProcessingController;
+    let container: IContainer;
+
+    let ds1: TestDataObject;
+    let ds1dds1: ISharedDirectory;
+    let ds1dds2: ISharedMap;
+
+    let ds2: TestDataObject;
+    let ds2dds1: ISharedDirectory;
+    let ds2dds2: ISharedMap;
+
+    let ds3: TestDataObject;
+    let ds3dds1: ISharedDirectory;
+    let ds3dds2: ISharedMap;
+
+    let ds4: TestDataObject;
+    let ds4dds1: ISharedDirectory;
+    let ds4dds2: ISharedMap;
+
+    let expectedDeletedStores: string[];
+
+    async function createContainer(): Promise<IContainer> {
+        const runtimeFactory =
+            new ContainerRuntimeFactoryWithDefaultDataStore(
+                "default",
+                [
+                    ["default", Promise.resolve(factory)],
+                    ["TestDataObject", Promise.resolve(factory)],
+                ],
+            );
+        const loader: ILoader = createLocalLoader([[codeDetails, runtimeFactory]], deltaConnectionServer, urlResolver);
+        return createAndAttachContainer(documentId, codeDetails, loader, urlResolver);
+    }
+
+    async function getSnapshot(handle: string) {
+        const storageService = (container as Container).storage;
+        assert(storageService);
+        const versions = await storageService.getVersions(handle, 1);
+        const version = versions[0];
+        assert(version, "No version in snapshot");
+        const snapshotTree = await storageService.getSnapshotTree(version);
+        assert(snapshotTree, "No snapshot tree");
+        return snapshotTree;
+    }
+
+    async function waitForSummary(): Promise<ISnapshotTree> {
+        let handle: string = "";
+        // wait for summary ack/nack
+        await new Promise((resolve, reject) => container.on("op", (op) => {
+            if (op.type === "summaryAck") {
+                handle = op.contents.handle;
+                resolve();
+            } else if (op.type === "summaryNack") {
+                reject("summaryNack");
+            }
+        }));
+
+        return getSnapshot(handle);
+    }
+
+    async function validateReferenceStates(snapshotTree: ISnapshotTree) {
+        const storageService = (container as Container).storage;
+        assert(storageService);
+
+        const deletedDataStores = await readAndParse<any>(storageService, snapshotTree.blobs[".deletedDataStores"]);
+        assert.deepStrictEqual(deletedDataStores, expectedDeletedStores);
+    }
+
+    async function createDataStoreReferencesTree() {
+        // Get DataStore DS1.
+        ds1 = await requestFluidObject<TestDataObject>(container, "default");
+        ds1dds1 = ds1._root;
+        // Create DDS2 in DS1 and store in root DS1DDS1.
+        ds1dds2 = SharedMap.create(ds1._runtime);
+        ds1dds1.set("ds1dds2", ds1dds2.handle);
+
+        // Create DataStore DS2.
+        ds2 = await factory.createInstance(ds1._context.containerRuntime);
+        // Store DS2 in DS1DDS2
+        ds1dds2.set("ds2", ds2.handle);
+
+        // Create DDS2 in DS2 and store in root DS2DDS1.
+        ds2dds1 = ds2._root;
+        ds2dds2 = SharedMap.create(ds2._runtime);
+        ds2dds1.set("ds2dds2", ds2dds2.handle);
+
+        // Create DataStore DS3.
+        ds3 = await factory.createInstance(ds1._context.containerRuntime);
+        // Store DS3 in DS2DDS2
+        ds2dds2.set("ds3", ds3.handle);
+
+        // Create DDS2 in DS3 and store in DS3DDS1.
+        ds3dds1 = ds3._root;
+        ds3dds2 = SharedMap.create(ds3._runtime);
+        ds3dds1.set("ds3dds2", ds3dds2.handle);
+
+        // Create DataStore DS4.
+        ds4 = await factory.createInstance(ds1._context.containerRuntime);
+        // Store DS4 in DS3DDS2
+        ds3dds2.set("ds4", ds4.handle);
+
+        // Create DDS2 in DS4 and store in DS4DDS1.
+        ds4dds1 = ds4._root;
+        ds4dds2 = SharedMap.create(ds4._runtime);
+        ds4dds1.set("ds4dds2", ds4dds2.handle);
+
+        opProcessingController.addDeltaManagers(ds1._runtime.deltaManager);
+        await opProcessingController.process();
+    }
+
+    beforeEach(async () => {
+        deltaConnectionServer = LocalDeltaConnectionServer.create();
+        urlResolver = new LocalResolver();
+
+        // Create a Container for the first client.
+        container = await createContainer();
+
+        opProcessingController = new OpProcessingController(deltaConnectionServer);
+
+        expectedDeletedStores = [];
+
+        await createDataStoreReferencesTree();
+    });
+
+    it("should not collect referenced objects", async () => {
+        // wait for summary ack/nack
+        const snapshotTree = await waitForSummary();
+        await validateReferenceStates(snapshotTree);
+    });
+
+    it("should collect unreferenced objects", async () => {
+        // wait for summary ack/nack
+        let snapshotTree = await waitForSummary();
+        await validateReferenceStates(snapshotTree);
+
+        ds2dds2.delete("ds3");
+        expectedDeletedStores.push(ds3.id);
+        expectedDeletedStores.push(ds4.id);
+
+        // wait for summary ack/nack
+        snapshotTree = await waitForSummary();
+        await validateReferenceStates(snapshotTree);
+    });
+
+    it("should collect unreferenced objects after multiple summaries", async () => {
+        ds2dds2.delete("ds3");
+        expectedDeletedStores.push(ds3.id);
+        expectedDeletedStores.push(ds4.id);
+
+        let snapshotTree = await waitForSummary();
+        await validateReferenceStates(snapshotTree);
+
+        // Do some operation to trigger summary.
+        ds1dds2.set("key", "value");
+
+        snapshotTree = await waitForSummary();
+        await validateReferenceStates(snapshotTree);
+    });
+
+    it("should uncollect objects after they are referenced back", async () => {
+        ds2dds2.delete("ds3");
+        expectedDeletedStores.push(ds3.id);
+        expectedDeletedStores.push(ds4.id);
+
+        let snapshotTree = await waitForSummary();
+        await validateReferenceStates(snapshotTree);
+
+        ds2dds2.set("ds4", ds4.handle);
+        expectedDeletedStores.pop();
+
+        snapshotTree = await waitForSummary();
+        await validateReferenceStates(snapshotTree);
+
+        ds4dds2.set("ds3", ds3.handle);
+        expectedDeletedStores.pop();
+
+        snapshotTree = await waitForSummary();
+        await validateReferenceStates(snapshotTree);
+    });
+
+    afterEach(async () => {
+        await deltaConnectionServer.webSocketServer.close();
+    });
+});


### PR DESCRIPTION
This is a prototype for garbage collection in fluid. It's in a very early stage and lot of things are very draft-y.
An overview of what this change does:
1. Container runtime runs garbage collection in summaryInternal after it has summarized each data store. It then adds the data stores that are to be deleted in a separate blob in the main summary.
**Note:** This will change and mostly be part of each individual data store's tree.
2. Container runtime requests the referenced data stores for a list of routes to referenced fluid objects in it.
3. Data store in turn requests each DDS for a list of routes to referenced fluid objects in it.
4. Each DDS keeps track of the route to any fluid object in it. It does so during snapshot by capturing the absolutePath to each IFluidHandle it serializes. I made a couple of changes for this:
   4.1. Changed `snapshot` method in `SharedObject` to not be abstract. It now calls into the FluidSerializer and asks it to record each serialized handle's absolutePath during the snapshot process.
   4.2. `SharedObject` gets this list from the FluidSerializer and caches it.
   4.3. Each DDS now implements `snapshotCore` which does exactly the same thing as `snapshot` does today. It is called by SharedObject's snapshot method.
   4.4. When asked for the list of routes to referenced fluid objects, the SharedObject returns the list cached above.
   4.5. At any given point in time, this list corresponds to the data in the last snapshot.
**Note:** I am currently using the FluidSerializer of the DataStoreRuntime to record the list of serialized handles and store the information in the SharedObject. Another implementation I was thinking of was to have each SharedObject its own FluidSerializer and store the information there.