### PR TITLE
Host pluggable token provider for r11s driver.

### DIFF
--- a/packages/drivers/local-driver/src/localDocumentService.ts
+++ b/packages/drivers/local-driver/src/localDocumentService.ts
@@ -17,14 +17,14 @@ import { LocalDeltaStorageService, LocalDocumentDeltaConnection } from ".";
 export class LocalDocumentService implements api.IDocumentService {
     /**
      * @param localDeltaConnectionServer - delta connection server for ops
-     * @param tokenProvider - token provider with a single token
+     * @param tokenProvider - token provider
      * @param tenantId - ID of tenant
      * @param documentId - ID of document
      */
     constructor(
         public readonly resolvedUrl: api.IResolvedUrl,
         private readonly localDeltaConnectionServer: ILocalDeltaConnectionServer,
-        private readonly tokenProvider: socketStorage.TokenProvider,
+        private readonly tokenProvider: socketStorage.ITokenProvider,
         private readonly tenantId: string,
         private readonly documentId: string,
         private readonly documentDeltaConnectionsMap: Map<string, LocalDocumentDeltaConnection>,
@@ -54,10 +54,11 @@ export class LocalDocumentService implements api.IDocumentService {
      */
     public async connectToDeltaStream(
         client: IClient): Promise<api.IDocumentDeltaConnection> {
+        const ordererToken = await this.tokenProvider.fetchOrdererToken();
         const documentDeltaConnection = await LocalDocumentDeltaConnection.create(
             this.tenantId,
             this.documentId,
-            this.tokenProvider.token,
+            ordererToken.jwt,
             client,
             this.localDeltaConnectionServer.webSocketServer);
 
@@ -101,7 +102,7 @@ export class LocalDocumentService implements api.IDocumentService {
 export function createLocalDocumentService(
     resolvedUrl: api.IResolvedUrl,
     localDeltaConnectionServer: ILocalDeltaConnectionServer,
-    tokenProvider: socketStorage.TokenProvider,
+    tokenProvider: socketStorage.ITokenProvider,
     tenantId: string,
     documentId: string,
     documentDeltaConnectionsMap: Map<string, LocalDocumentDeltaConnection>): api.IDocumentService {

--- a/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
+++ b/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
@@ -10,7 +10,7 @@ import {
     IResolvedUrl,
 } from "@fluidframework/driver-definitions";
 import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
-import { TokenProvider } from "@fluidframework/routerlicious-driver";
+import { DefaultTokenProvider } from "@fluidframework/routerlicious-driver";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import {
     ensureFluidResolvedUrl,
@@ -92,7 +92,7 @@ export class LocalDocumentServiceFactory implements IDocumentServiceFactory {
             throw new Error(`Token was not provided.`);
         }
 
-        const tokenProvider = new TokenProvider(jwtToken);
+        const tokenProvider = new DefaultTokenProvider(jwtToken);
 
         return createLocalDocumentService(
             resolvedUrl,

--- a/packages/drivers/routerlicious-driver/src/createDocumentService2.ts
+++ b/packages/drivers/routerlicious-driver/src/createDocumentService2.ts
@@ -8,7 +8,7 @@ import { IErrorTrackingService } from "@fluidframework/protocol-definitions";
 import { ICredentials } from "@fluidframework/server-services-client";
 import { DocumentService2 } from "./documentService2";
 import { DefaultErrorTracking } from "./errorTracking";
-import { TokenProvider } from "./tokens";
+import { ITokenProvider } from "./tokens";
 
 /**
  * Returns the document service associated with the factory.
@@ -21,7 +21,7 @@ export const createDocumentService2 = (
     ordererUrl: string,
     deltaStorageUrl: string,
     gitUrl: string,
-    tokenProvider: TokenProvider,
+    tokenProvider: ITokenProvider,
     tenantId: string,
     documentId: string,
     errorTracking: IErrorTrackingService = new DefaultErrorTracking(),

--- a/packages/drivers/routerlicious-driver/src/defaultTokenProvider.ts
+++ b/packages/drivers/routerlicious-driver/src/defaultTokenProvider.ts
@@ -1,0 +1,30 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ITokenProvider, ITokenResponse } from "./tokens";
+
+/**
+ * Default token provider in case the host does not provide one. It simply caches the provided jwt and returns it back.
+ */
+
+export class DefaultTokenProvider implements ITokenProvider {
+    constructor(private readonly jwt: string) {
+
+    }
+
+    public async fetchOrdererToken(): Promise<ITokenResponse> {
+        return {
+            fromCache: true,
+            jwt: this.jwt,
+        };
+    }
+
+    public async fetchStorageToken(): Promise<ITokenResponse> {
+        return {
+            fromCache: true,
+            jwt: this.jwt,
+        };
+    }
+}

--- a/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
@@ -9,7 +9,7 @@ import { fromUtf8ToBase64 } from "@fluidframework/common-utils";
 import { IDeltaStorageService, IDocumentDeltaStorageService } from "@fluidframework/driver-definitions";
 import * as api from "@fluidframework/protocol-definitions";
 import Axios from "axios";
-import { TokenProvider } from "./tokens";
+import { ITokenProvider } from "./tokens";
 
 /**
  * Storage service limited to only being able to fetch documents for a specific document
@@ -18,12 +18,11 @@ export class DocumentDeltaStorageService implements IDocumentDeltaStorageService
     constructor(
         private readonly tenantId: string,
         private readonly id: string,
-        private readonly tokenProvider: api.ITokenProvider,
         private readonly storageService: IDeltaStorageService) {
     }
 
     public async get(from?: number, to?: number): Promise<api.ISequencedDocumentMessage[]> {
-        return this.storageService.get(this.tenantId, this.id, this.tokenProvider, from, to);
+        return this.storageService.get(this.tenantId, this.id, from, to);
     }
 }
 
@@ -31,24 +30,23 @@ export class DocumentDeltaStorageService implements IDocumentDeltaStorageService
  * Provides access to the underlying delta storage on the server for routerlicious driver.
  */
 export class DeltaStorageService implements IDeltaStorageService {
-    constructor(private readonly url: string) {
+    constructor(private readonly url: string, private readonly tokenProvider: ITokenProvider) {
     }
 
     public async get(
         tenantId: string,
         id: string,
-        tokenProvider: api.ITokenProvider,
         from?: number,
         to?: number): Promise<api.ISequencedDocumentMessage[]> {
         const query = querystring.stringify({ from, to });
 
         let headers: { Authorization: string } | null = null;
 
-        const token = (tokenProvider as TokenProvider).token;
+        const storageToken = await this.tokenProvider.fetchStorageToken();
 
-        if (token) {
+        if (storageToken) {
             headers = {
-                Authorization: `Basic ${fromUtf8ToBase64(`${tenantId}:${token}`)}`,
+                Authorization: `Basic ${fromUtf8ToBase64(`${tenantId}:${storageToken.jwt}`)}`,
             };
         }
 

--- a/packages/drivers/routerlicious-driver/src/documentService2.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService2.ts
@@ -7,7 +7,7 @@ import { IDocumentDeltaConnection, IResolvedUrl } from "@fluidframework/driver-d
 import * as api from "@fluidframework/protocol-definitions";
 import { ICredentials } from "@fluidframework/server-services-client";
 import { DocumentService } from "./documentService";
-import { TokenProvider } from "./tokens";
+import { ITokenProvider } from "./tokens";
 import { WSDeltaConnection } from "./wsDeltaConnection";
 
 /**
@@ -23,7 +23,7 @@ export class DocumentService2 extends DocumentService {
         errorTracking: api.IErrorTrackingService,
         disableCache: boolean, historianApi: boolean,
         directCredentials: ICredentials | undefined,
-        tokenProvider: TokenProvider,
+        tokenProvider: ITokenProvider,
         tenantId: string,
         documentId: string) {
         super(
@@ -49,10 +49,11 @@ export class DocumentService2 extends DocumentService {
      */
     public async connectToDeltaStream(
         client: api.IClient): Promise<IDocumentDeltaConnection> {
+        const ordererToken = await this.tokenProvider.fetchOrdererToken();
         return WSDeltaConnection.create(
             this.tenantId,
             this.documentId,
-            this.tokenProvider.token,
+            ordererToken.jwt,
             client,
             this.ordererUrl);
     }

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -19,10 +19,11 @@ import {
     getQuorumValuesFromProtocolSummary,
 } from "@fluidframework/driver-utils";
 import Axios from "axios";
+import { DefaultTokenProvider } from "./defaultTokenProvider";
 import { DocumentService } from "./documentService";
 import { DocumentService2 } from "./documentService2";
 import { DefaultErrorTracking } from "./errorTracking";
-import { TokenProvider } from "./tokens";
+import { ITokenProvider } from "./tokens";
 
 /**
  * Factory for creating the routerlicious document service. Use this if you want to
@@ -31,6 +32,7 @@ import { TokenProvider } from "./tokens";
 export class RouterliciousDocumentServiceFactory implements IDocumentServiceFactory {
     public readonly protocolName = "fluid:";
     constructor(
+        private readonly tokenProvider: ITokenProvider | undefined = undefined,
         private readonly useDocumentService2: boolean = false,
         private readonly errorTracking: IErrorTrackingService = new DefaultErrorTracking(),
         private readonly disableCache: boolean = false,
@@ -103,7 +105,8 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
             throw new Error(`Token was not provided.`);
         }
 
-        const tokenProvider = new TokenProvider(jwtToken);
+        // Fall back to default provider if token provider is not provided.
+        const tokenProvider = this.tokenProvider ?? new DefaultTokenProvider(jwtToken);
 
         if (this.useDocumentService2) {
             return new DocumentService2(

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -100,13 +100,19 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
                 `Couldn't parse documentId and/or tenantId. [documentId:${documentId}][tenantId:${tenantId}]`);
         }
 
-        const jwtToken = fluidResolvedUrl.tokens.jwt;
-        if (!jwtToken) {
-            throw new Error(`Token was not provided.`);
-        }
+        let tokenProvider: ITokenProvider;
 
         // Fall back to default provider if token provider is not provided.
-        const tokenProvider = this.tokenProvider ?? new DefaultTokenProvider(jwtToken);
+        if (this.tokenProvider === undefined) {
+            const jwtToken = fluidResolvedUrl.tokens.jwt;
+            if (!jwtToken) {
+                throw new Error(`No token or provider is present.`);
+            } else {
+                tokenProvider = new DefaultTokenProvider(jwtToken);
+            }
+        } else {
+            tokenProvider = this.tokenProvider;
+        }
 
         if (this.useDocumentService2) {
             return new DocumentService2(

--- a/packages/drivers/routerlicious-driver/src/index.ts
+++ b/packages/drivers/routerlicious-driver/src/index.ts
@@ -13,3 +13,4 @@ export * from "./documentService2";
 export * from "./createDocumentService2";
 export * from "./nullBlobStorageService";
 export * from "./documentServiceFactory";
+export * from "./defaultTokenProvider";

--- a/packages/drivers/routerlicious-driver/src/registration.ts
+++ b/packages/drivers/routerlicious-driver/src/registration.ts
@@ -8,7 +8,7 @@ import { IErrorTrackingService } from "@fluidframework/protocol-definitions";
 import { IGitCache } from "@fluidframework/server-services-client";
 import { DocumentService } from "./documentService";
 import { DefaultErrorTracking } from "./errorTracking";
-import { TokenProvider } from "./tokens";
+import { ITokenProvider } from "./tokens";
 
 /**
  * Returns the document service associated with the factory.
@@ -21,7 +21,7 @@ export function createDocumentService(
     ordererUrl: string,
     deltaStorageUrl: string,
     gitUrl: string,
-    tokenProvider: TokenProvider,
+    tokenProvider: ITokenProvider,
     tenantId: string,
     documentId: string,
     errorTracking: IErrorTrackingService = new DefaultErrorTracking(),

--- a/packages/drivers/routerlicious-driver/src/tokens.ts
+++ b/packages/drivers/routerlicious-driver/src/tokens.ts
@@ -3,26 +3,41 @@
  * Licensed under the MIT License.
  */
 
-import { ITokenClaims, ITokenProvider, ITokenService } from "@fluidframework/protocol-definitions";
-import jwtDecode from "jwt-decode";
+import { ITokenClaims } from "@fluidframework/protocol-definitions";
 
 /**
- * Extracts the claims contained within a token.
+ * The ITokenService abstracts the discovery of claims contained within a token
  */
-export class TokenService implements ITokenService {
-    public extractClaims(token: string): ITokenClaims {
-        return jwtDecode(token);
-    }
+export interface ITokenService {
+    extractClaims(token: string): ITokenClaims;
+}
+
+export interface ITokenResponse {
+    // JWT value
+    jwt: string;
+
+    // Flag indicating whether token was obtained from local cache
+    fromCache?: boolean;
 }
 
 /**
- * Checks the validation of a token.
+ * The ITokenProvider abstracts the token fetching mechanism for a host. Host will be responsible for
+ * implementing the interfaces.
  */
-export class TokenProvider implements ITokenProvider {
-    constructor(public token: string) {
-    }
+export interface ITokenProvider {
+    /**
+     * Fetches the orderer token from host
+     * @param refresh - Optional flag indicating whether token fetch must bypass local cache
+     * @returns TokenResponse object representing token value along with flag indicating
+     * whether token came from cache.
+     */
+    fetchOrdererToken(refresh?: boolean): Promise<ITokenResponse>;
 
-    public isValid(): boolean {
-        return (this.token !== undefined && this.token !== null);
-    }
+    /**
+     * Fetches the storage token from host
+     * @param refresh - Optional flag indicating whether token fetch must bypass local cache
+     * @returns TokenResponse object representing token value along with flag indicating
+     * whether token came from cache.
+     */
+    fetchStorageToken(refresh?: boolean): Promise<ITokenResponse>;
 }

--- a/packages/loader/driver-definitions/src/storage.ts
+++ b/packages/loader/driver-definitions/src/storage.ts
@@ -19,7 +19,6 @@ import {
     ISummaryHandle,
     ISummaryTree,
     ITokenClaims,
-    ITokenProvider,
     ITree,
     IVersion,
 } from "@fluidframework/protocol-definitions";
@@ -35,7 +34,6 @@ export interface IDeltaStorageService {
     get(
         tenantId: string,
         id: string,
-        tokenProvider: ITokenProvider,
         from?: number,
         to?: number): Promise<ISequencedDocumentMessage[]>;
 }

--- a/packages/test/end-to-end-tests/src/real-service-tests/r11sEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/real-service-tests/r11sEndToEndTests.spec.ts
@@ -41,6 +41,7 @@ describe(`r11s End-To-End tests`, () => {
         ]);
         const codeLoader = new LocalCodeLoader([[codeDetails, factory]]);
         const documentServiceFactory = new RouterliciousDocumentServiceFactory(
+            undefined,
             false,
             new DefaultErrorTracking(),
             false,

--- a/packages/tools/fetch-tool/src/fluidFetchInit.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchInit.ts
@@ -102,7 +102,7 @@ async function initializeR11s(server: string, pathname: string, r11sResolvedUrl:
     }
 
     console.log(`Connecting to r11s: tenantId=${tenantId} id:${documentId}`);
-    const tokenProvider = new r11s.TokenProvider(paramJWT);
+    const tokenProvider = new r11s.DefaultTokenProvider(paramJWT);
     return r11s.createDocumentService(
         r11sResolvedUrl,
         r11sResolvedUrl.endpoints.ordererUrl,

--- a/server/routerlicious/packages/protocol-definitions/src/tokens.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/tokens.ts
@@ -28,3 +28,7 @@ export interface IActorClient {
 export interface ITokenService {
     extractClaims(token: string): ITokenClaims;
 }
+
+export interface ITokenProvider {
+    isValid(): boolean;
+}

--- a/server/routerlicious/packages/protocol-definitions/src/tokens.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/tokens.ts
@@ -28,7 +28,3 @@ export interface IActorClient {
 export interface ITokenService {
     extractClaims(token: string): ITokenClaims;
 }
-
-export interface ITokenProvider {
-    isValid(): boolean;
-}


### PR DESCRIPTION
The PR enables r11s host to inject a token provider to the driver. The driver provides an ITokenProvider interface. Hosts are responsible for implementing the interface. In case the host is unable to provide one, driver will fall back to a default implementation that uses the initially signed token.

From a service standpoint, r11s service can now expire tokens based on "exp" property of jwt. Clients will go through a regular disconnect -> connect flow to fetch a new token provided by the host.