### PR TITLE
End-to-end test: Additional container config and enable more test to run in compat mode

### DIFF
--- a/packages/test/end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/blobs.spec.ts
@@ -9,11 +9,15 @@ import { ContainerMessageType } from "@fluidframework/container-runtime";
 import { ISummaryConfiguration } from "@fluidframework/protocol-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
-import { generateTest, ICompatLocalTestObjectProvider, TestDataObject } from "./compatUtils";
+import { generateTest, ICompatLocalTestObjectProvider, TestDataObject, ITestContainerConfig } from "./compatUtils";
+
+const testContainerConfig: ITestContainerConfig = {
+    runtimeOptions: { initialSummarizerDelayMs: 100 },
+};
 
 const tests = (args: ICompatLocalTestObjectProvider) => {
     it("attach sends an op", async function() {
-        const container = await args.makeTestContainer(undefined, { initialSummarizerDelayMs: 100 });
+        const container = await args.makeTestContainer(testContainerConfig);
 
         const blobOpP = new Promise((res) => container.on("op", (op) => {
             if (op.contents?.type === ContainerMessageType.BlobAttach) {
@@ -32,14 +36,14 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
     it("can get remote attached blob", async function() {
         const testString = "this is a test string";
         const testKey = "a blob";
-        const container1 = await args.makeTestContainer(undefined, { initialSummarizerDelayMs: 100 });
+        const container1 = await args.makeTestContainer(testContainerConfig);
 
         const component1 = await requestFluidObject<TestDataObject>(container1, "default");
 
         const blob = await component1._runtime.uploadBlob(IsoBuffer.from(testString, "utf-8"));
         component1._root.set(testKey, blob);
 
-        const container2 = await args.makeTestContainer(undefined, { initialSummarizerDelayMs: 100 });
+        const container2 = await args.makeTestContainer(testContainerConfig);
         const component2 = await requestFluidObject<TestDataObject>(container2, "default");
 
         const blobHandle = await component2._root.wait<IFluidHandle<ArrayBufferLike>>(testKey);

--- a/packages/test/end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/blobs.spec.ts
@@ -4,61 +4,16 @@
  */
 
 import * as assert from "assert";
-import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { IsoBuffer } from "@fluidframework/common-utils";
-import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions";
 import { ContainerMessageType } from "@fluidframework/container-runtime";
-import { IUrlResolver } from "@fluidframework/driver-definitions";
-import { LocalResolver } from "@fluidframework/local-driver";
 import { ISummaryConfiguration } from "@fluidframework/protocol-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
-import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
-import { createAndAttachContainer, createLocalLoader, TestContainerRuntimeFactory } from "@fluidframework/test-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { generateTest, ICompatLocalTestObjectProvider, TestDataObject } from "./compatUtils";
 
-class TestComponent extends DataObject {
-    public static readonly type = "@fluid-example/test-component";
-    public get _runtime() { return this.runtime; }
-    public get _root() { return this.root; }
-}
-
-describe("blobs", () => {
-    const docId = "localLoaderTest";
-    const codeDetails: IFluidCodeDetails = {
-        package: "localLoaderTestPackage",
-        config: {},
-    };
-
-    let deltaConnectionServer: ILocalDeltaConnectionServer;
-    let urlResolver: IUrlResolver;
-
-    async function createContainer(): Promise<IContainer> {
-        const fluidModule = {
-            fluidExport: new TestContainerRuntimeFactory(
-                TestComponent.type,
-                new DataObjectFactory(TestComponent.type, TestComponent, [], {}),
-                { initialSummarizerDelayMs: 100 },
-            ),
-        };
-        const loader = createLocalLoader([[codeDetails, fluidModule]], deltaConnectionServer, urlResolver);
-        return createAndAttachContainer(docId, codeDetails, loader, urlResolver);
-    }
-
-    beforeEach(async () => {
-        deltaConnectionServer = LocalDeltaConnectionServer.create(
-            undefined,
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            { summary: { maxOps: 1 } as ISummaryConfiguration },
-        );
-        urlResolver = new LocalResolver();
-    });
-
-    afterEach(async () => {
-        await deltaConnectionServer.webSocketServer.close();
-    });
-
+const tests = (args: ICompatLocalTestObjectProvider) => {
     it("attach sends an op", async function() {
-        const container = await createContainer();
+        const container = await args.makeTestContainer(undefined, { initialSummarizerDelayMs: 100 });
 
         const blobOpP = new Promise((res) => container.on("op", (op) => {
             if (op.contents?.type === ContainerMessageType.BlobAttach) {
@@ -66,7 +21,7 @@ describe("blobs", () => {
             }
         }));
 
-        const component = await requestFluidObject<TestComponent>(container, "default");
+        const component = await requestFluidObject<TestDataObject>(container, "default");
         const blob = await component._runtime.uploadBlob(IsoBuffer.from("some random text"));
 
         component._root.set("my blob", blob);
@@ -77,17 +32,25 @@ describe("blobs", () => {
     it("can get remote attached blob", async function() {
         const testString = "this is a test string";
         const testKey = "a blob";
-        const container1 = await createContainer();
+        const container1 = await args.makeTestContainer(undefined, { initialSummarizerDelayMs: 100 });
 
-        const component1 = await requestFluidObject<TestComponent>(container1, "default");
+        const component1 = await requestFluidObject<TestDataObject>(container1, "default");
 
         const blob = await component1._runtime.uploadBlob(IsoBuffer.from(testString, "utf-8"));
         component1._root.set(testKey, blob);
 
-        const container2 = await createContainer();
-        const component2 = await requestFluidObject<TestComponent>(container2, "default");
+        const container2 = await args.makeTestContainer(undefined, { initialSummarizerDelayMs: 100 });
+        const component2 = await requestFluidObject<TestDataObject>(container2, "default");
 
         const blobHandle = await component2._root.wait<IFluidHandle<ArrayBufferLike>>(testKey);
         assert.strictEqual(new TextDecoder().decode(await blobHandle.get()), testString);
+    });
+};
+
+describe("blobs", () => {
+    // TODO: add back compat test once N-2 is 0.28
+    generateTest(tests, {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        serviceConfiguration: { summary: { maxOps: 1 } as ISummaryConfiguration },
     });
 });

--- a/packages/test/end-to-end-tests/src/test/cellEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/cellEndToEndTests.spec.ts
@@ -12,10 +12,14 @@ import {
     ITestFluidObject,
     ChannelFactoryRegistry,
 } from "@fluidframework/test-utils";
-import { generateTestWithCompat, ICompatLocalTestObjectProvider } from "./compatUtils";
+import { generateTestWithCompat, ICompatLocalTestObjectProvider, ITestContainerConfig } from "./compatUtils";
 
 const cellId = "cellKey";
 const registry: ChannelFactoryRegistry = [[cellId, SharedCell.getFactory()]];
+const testContainerConfig: ITestContainerConfig = {
+    testFluidDataObject: true,
+    registry,
+};
 
 const tests = (args: ICompatLocalTestObjectProvider) => {
     const initialCellValue = "Initial cell value";
@@ -29,17 +33,17 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 
     beforeEach(async () => {
         // Create a Container for the first client.
-        const container1 = await args.makeTestContainer(registry);
+        const container1 = await args.makeTestContainer(testContainerConfig);
         dataObject1 = await requestFluidObject<ITestFluidObject>(container1, "default");
         sharedCell1 = await dataObject1.getSharedObject<SharedCell>(cellId);
 
         // Load the Container that was created by the first client.
-        const container2 = await args.loadTestContainer(registry);
+        const container2 = await args.loadTestContainer(testContainerConfig);
         const dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
         sharedCell2 = await dataObject2.getSharedObject<SharedCell>(cellId);
 
         // Load the Container that was created by the first client.
-        const container3 = await args.loadTestContainer(registry);
+        const container3 = await args.loadTestContainer(testContainerConfig);
         const dataObject3 = await requestFluidObject<ITestFluidObject>(container3, "default");
         sharedCell3 = await dataObject3.getSharedObject<SharedCell>(cellId);
 
@@ -214,5 +218,5 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 };
 
 describe("Cell", () => {
-    generateTestWithCompat(tests, { testFluidDataObject: true });
+    generateTestWithCompat(tests);
 });

--- a/packages/test/end-to-end-tests/src/test/compat.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/compat.spec.ts
@@ -6,6 +6,7 @@
 import { strict as assert } from "assert";
 import { IContainer, IFluidModule } from "@fluidframework/container-definitions";
 import { IFluidRouter } from "@fluidframework/core-interfaces";
+import { ISummaryConfiguration } from "@fluidframework/protocol-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { OpProcessingController, LocalTestObjectProvider, ChannelFactoryRegistry } from "@fluidframework/test-utils";
 import { ILocalDeltaConnectionServer } from "@fluidframework/server-local-server";
@@ -130,5 +131,8 @@ describe("loader/runtime compatibility", () => {
         });
     };
 
-    generateCompatTest(tests);
+    generateCompatTest(tests, {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        serviceConfiguration: { summary: { maxOps: 1 } as ISummaryConfiguration },
+    });
 });

--- a/packages/test/end-to-end-tests/src/test/compatUtils.ts
+++ b/packages/test/end-to-end-tests/src/test/compatUtils.ts
@@ -103,12 +103,14 @@ function convertRegistry(registry: ChannelFactoryRegistry = []): old.ChannelFact
 
 export class TestDataObject extends DataObject {
     public static readonly type = "@fluid-example/test-dataStore";
+    public get _context() { return this.context; }
     public get _runtime() { return this.runtime; }
     public get _root() { return this.root; }
 }
 
 export class OldTestDataObject extends old.DataObject {
     public static readonly type = "@fluid-example/test-dataStore";
+    public get _context() { return this.context; }
     public get _runtime() { return this.runtime; }
     public get _root() { return this.root; }
 }
@@ -181,12 +183,14 @@ export const generateCompatTest = (
 ) => {
     describe("compatibility", () => {
         describe("old loader, new runtime", function() {
+            const dataStoreFactory = (containerOptions?: ITestContainerConfig) =>
+                containerOptions?.testFluidDataObject
+                    ? createTestFluidDataStoreFactory(containerOptions?.registry)
+                    : createPrimedDataStoreFactory();
             const runtimeFactory = (containerOptions?: ITestContainerConfig) =>
                 createRuntimeFactory(
                     TestDataObject.type,
-                    containerOptions?.testFluidDataObject
-                        ? createTestFluidDataStoreFactory(containerOptions?.registry)
-                        : createPrimedDataStoreFactory(),
+                    dataStoreFactory(containerOptions),
                     containerOptions?.runtimeOptions,
                 ) as any as old.IRuntimeFactory;
 

--- a/packages/test/end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
@@ -20,21 +20,25 @@ import {
     ITestFluidObject,
     ChannelFactoryRegistry,
 } from "@fluidframework/test-utils";
-import { generateTestWithCompat, ICompatLocalTestObjectProvider } from "./compatUtils";
+import { generateTestWithCompat, ICompatLocalTestObjectProvider, ITestContainerConfig } from "./compatUtils";
 
 interface ISharedObjectConstructor<T> {
     create(runtime: IFluidDataStoreRuntime, id?: string): T;
 }
 
+const mapId = "mapKey";
+const registry: ChannelFactoryRegistry = [
+    [mapId, SharedMap.getFactory()],
+    [undefined, ConsensusQueue.getFactory()],
+];
+const testContainerConfig: ITestContainerConfig = {
+    testFluidDataObject: true,
+    registry,
+};
+
 function generate(
     name: string, ctor: ISharedObjectConstructor<IConsensusOrderedCollection>,
     input: any[], output: any[]) {
-    const mapId = "mapKey";
-    const registry: ChannelFactoryRegistry = [
-        [mapId, SharedMap.getFactory()],
-        [undefined, ConsensusQueue.getFactory()],
-    ];
-
     const tests = (args: ICompatLocalTestObjectProvider) => {
         let opProcessingController: OpProcessingController;
         let dataStore1: ITestFluidObject;
@@ -45,17 +49,17 @@ function generate(
 
         beforeEach(async () => {
             // Create a Container for the first client.
-            const container1 = await args.makeTestContainer(registry);
+            const container1 = await args.makeTestContainer(testContainerConfig);
             dataStore1 = await requestFluidObject<ITestFluidObject>(container1, "default");
             sharedMap1 = await dataStore1.getSharedObject<SharedMap>(mapId);
 
             // Load the Container that was created by the first client.
-            const container2 = await args.loadTestContainer(registry);
+            const container2 = await args.loadTestContainer(testContainerConfig);
             dataStore2 = await requestFluidObject<ITestFluidObject>(container2, "default");
             sharedMap2 = await dataStore2.getSharedObject<SharedMap>(mapId);
 
             // Load the Container that was created by the first client.
-            const container3 = await args.loadTestContainer(registry);
+            const container3 = await args.loadTestContainer(testContainerConfig);
             const dataStore3 = await requestFluidObject<ITestFluidObject>(container3, "default");
             sharedMap3 = await dataStore3.getSharedObject<SharedMap>(mapId);
 
@@ -336,7 +340,7 @@ function generate(
     };
 
     describe(name, () => {
-        generateTestWithCompat(tests, { testFluidDataObject: true });
+        generateTestWithCompat(tests);
     });
 }
 

--- a/packages/test/end-to-end-tests/src/test/counterEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/counterEndToEndTests.spec.ts
@@ -11,10 +11,14 @@ import {
     ITestFluidObject,
     OpProcessingController,
 } from "@fluidframework/test-utils";
-import { generateTestWithCompat, ICompatLocalTestObjectProvider } from "./compatUtils";
+import { generateTestWithCompat, ICompatLocalTestObjectProvider, ITestContainerConfig } from "./compatUtils";
 
 const counterId = "counterKey";
 const registry: ChannelFactoryRegistry = [[counterId, SharedCounter.getFactory()]];
+const testContainerConfig: ITestContainerConfig = {
+    testFluidDataObject: true,
+    registry,
+};
 
 const tests = (args: ICompatLocalTestObjectProvider) => {
     let opProcessingController: OpProcessingController;
@@ -25,17 +29,17 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 
     beforeEach(async () => {
         // Create a Container for the first client.
-        const container1 = await args.makeTestContainer(registry);
+        const container1 = await args.makeTestContainer(testContainerConfig);
         dataStore1 = await requestFluidObject<ITestFluidObject>(container1, "default");
         sharedCounter1 = await dataStore1.getSharedObject<SharedCounter>(counterId);
 
         // Load the Container that was created by the first client.
-        const container2 = await args.loadTestContainer(registry);
+        const container2 = await args.loadTestContainer(testContainerConfig);
         const dataStore2 = await requestFluidObject<ITestFluidObject>(container2, "default");
         sharedCounter2 = await dataStore2.getSharedObject<SharedCounter>(counterId);
 
         // Load the Container that was created by the first client.
-        const container3 = await args.loadTestContainer(registry);
+        const container3 = await args.loadTestContainer(testContainerConfig);
         const dataStore3 = await requestFluidObject<ITestFluidObject>(container3, "default");
         sharedCounter3 = await dataStore3.getSharedObject<SharedCounter>(counterId);
 
@@ -148,5 +152,5 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 };
 
 describe("SharedCounter", () => {
-    generateTestWithCompat(tests, { testFluidDataObject: true });
+    generateTestWithCompat(tests);
 });

--- a/packages/test/end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -11,7 +11,7 @@ import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 import {
     ChannelFactoryRegistry,
     ITestFluidObject,
- } from "@fluidframework/test-utils";
+} from "@fluidframework/test-utils";
 import { SharedMap, SharedDirectory } from "@fluidframework/map";
 import { Deferred } from "@fluidframework/common-utils";
 import { SharedString, SparseMatrix } from "@fluidframework/sequence";
@@ -25,7 +25,12 @@ import { MessageType, ISequencedDocumentMessage } from "@fluidframework/protocol
 import { DataStoreMessageType } from "@fluidframework/datastore";
 import { ContainerMessageType } from "@fluidframework/container-runtime";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
-import { ICompatLocalTestObjectProvider, generateTestWithCompat, generateTest } from "./compatUtils";
+import {
+    ICompatLocalTestObjectProvider,
+    generateTestWithCompat,
+    generateTest,
+    ITestContainerConfig,
+} from "./compatUtils";
 
 const detachedContainerRefSeqNumber = 0;
 
@@ -53,6 +58,11 @@ const registry: ChannelFactoryRegistry = [
     [sparseMatrixId, SparseMatrix.getFactory()],
 ];
 
+const testContainerConfig: ITestContainerConfig = {
+    testFluidDataObject: true,
+    registry,
+};
+
 const tests = (args: ICompatLocalTestObjectProvider) => {
     let request: IRequest;
     let loader: Loader;
@@ -69,7 +79,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 
     beforeEach(async () => {
         request = args.urlResolver.createCreateNewRequest(documentId);
-        loader = args.makeTestLoader(registry) as Loader;
+        loader = args.makeTestLoader(testContainerConfig) as Loader;
     });
 
     it("Create detached container", async () => {
@@ -153,7 +163,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
         await container.attach(request);
 
         // Now load the container from another loader.
-        const loader2 = args.makeTestLoader(registry);
+        const loader2 = args.makeTestLoader(testContainerConfig);
         // Create a new request url from the resolvedUrl of the first container.
         assert(container.resolvedUrl);
         const requestUrl2 = await args.urlResolver.getAbsoluteUrl(container.resolvedUrl, "");
@@ -208,7 +218,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
         await defP.promise;
 
         // Now load the container from another loader.
-        const loader2 = args.makeTestLoader(registry);
+        const loader2 = args.makeTestLoader(testContainerConfig);
         // Create a new request url from the resolvedUrl of the first container.
         assert(container.resolvedUrl);
         const requestUrl2 = await args.urlResolver.getAbsoluteUrl(container.resolvedUrl, "");
@@ -567,7 +577,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 };
 
 describe("Detached Container", () => {
-    generateTestWithCompat(tests, { testFluidDataObject: true });
+    generateTestWithCompat(tests);
 
     describe("Non-Compat Tests", () => {
         generateTest((args: ICompatLocalTestObjectProvider) => {
@@ -577,7 +587,7 @@ describe("Detached Container", () => {
 
             beforeEach(async () => {
                 request = args.urlResolver.createCreateNewRequest(documentId);
-                loader = args.makeTestLoader(registry) as Loader;
+                loader = args.makeTestLoader(testContainerConfig) as Loader;
             });
 
             it("Load attached container from cache and check if they are same", async () => {

--- a/packages/test/end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
@@ -13,10 +13,14 @@ import {
     ITestFluidObject,
     ChannelFactoryRegistry,
 } from "@fluidframework/test-utils";
-import { generateTestWithCompat, ICompatLocalTestObjectProvider } from "./compatUtils";
+import { generateTestWithCompat, ICompatLocalTestObjectProvider, ITestContainerConfig } from "./compatUtils";
 
 const directoryId = "directoryKey";
 const registry: ChannelFactoryRegistry = [[directoryId, SharedDirectory.getFactory()]];
+const testContainerConfig: ITestContainerConfig = {
+    testFluidDataObject: true,
+    registry,
+};
 
 const tests = (args: ICompatLocalTestObjectProvider) => {
     let opProcessingController: OpProcessingController;
@@ -27,17 +31,17 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 
     beforeEach(async () => {
         // Create a Container for the first client.
-        const container1 = await args.makeTestContainer(registry);
+        const container1 = await args.makeTestContainer(testContainerConfig);
         dataObject1 = await requestFluidObject<ITestFluidObject>(container1, "default");
         sharedDirectory1 = await dataObject1.getSharedObject<SharedDirectory>(directoryId);
 
         // Load the Container that was created by the first client.
-        const container2 = await args.loadTestContainer(registry);
+        const container2 = await args.loadTestContainer(testContainerConfig);
         const dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
         sharedDirectory2 = await dataObject2.getSharedObject<SharedDirectory>(directoryId);
 
         // Load the Container that was created by the first client.
-        const container3 = await args.loadTestContainer(registry);
+        const container3 = await args.loadTestContainer(testContainerConfig);
         const dataObject3 = await requestFluidObject<ITestFluidObject>(container3, "default");
         sharedDirectory3 = await dataObject3.getSharedObject<SharedDirectory>(directoryId);
 
@@ -626,5 +630,5 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 };
 
 describe("Directory", () => {
-    generateTestWithCompat(tests, { testFluidDataObject: true });
+    generateTestWithCompat(tests);
 });

--- a/packages/test/end-to-end-tests/src/test/fluidObjectHandle.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/fluidObjectHandle.spec.ts
@@ -4,95 +4,38 @@
  */
 
 import assert from "assert";
-import {
-    ContainerRuntimeFactoryWithDefaultDataStore,
-    DataObject,
-    DataObjectFactory,
-} from "@fluidframework/aqueduct";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
-import { IContainer, IFluidCodeDetails, ILoader } from "@fluidframework/container-definitions";
-import { IUrlResolver } from "@fluidframework/driver-definitions";
-import { LocalResolver } from "@fluidframework/local-driver";
 import { SharedMap } from "@fluidframework/map";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
-import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import {
-    createAndAttachContainer,
-    createLocalLoader,
     OpProcessingController,
     TestFluidObject,
 } from "@fluidframework/test-utils";
+import {
+    generateTestWithCompat,
+    ICompatLocalTestObjectProvider,
+    TestDataObject,
+} from "./compatUtils";
 
-/**
- * Test data object that extends DataObject so that we can test the FluidOjectHandle created by PureDataObject.
- */
-class TestSharedDataObject extends DataObject {
-    public get _root() {
-        return this.root;
-    }
-
-    public get _runtime() {
-        return this.runtime;
-    }
-
-    public get _context() {
-        return this.context;
-    }
-}
-
-const testSharedDataObjectFactory = new DataObjectFactory(
-    "TestSharedDataObject",
-    TestSharedDataObject,
-    [SharedMap.getFactory()],
-    []);
-
-describe("FluidObjectHandle", () => {
-    const documentId = "componentHandleTest";
-    const documentLoadUrl = `fluid-test://localhost/${documentId}`;
-    const codeDetails: IFluidCodeDetails = {
-        package: "fluidObjectHandleTestPackage",
-        config: {},
-    };
-    const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
-        "default",
-        [
-            ["default", Promise.resolve(testSharedDataObjectFactory)],
-            ["TestSharedDataObject", Promise.resolve(testSharedDataObjectFactory)],
-        ],
-    );
-
-    let deltaConnectionServer: ILocalDeltaConnectionServer;
-    let urlResolver: IUrlResolver;
+const tests = (args: ICompatLocalTestObjectProvider) => {
     let opProcessingController: OpProcessingController;
-    let firstContainerObject1: TestSharedDataObject;
-    let firstContainerObject2: TestSharedDataObject;
-    let secondContainerObject1: TestSharedDataObject;
-
-    async function createContainer(): Promise<IContainer> {
-        const loader: ILoader = createLocalLoader([[codeDetails, runtimeFactory]], deltaConnectionServer, urlResolver);
-        return createAndAttachContainer(documentId, codeDetails, loader, urlResolver);
-    }
-
-    async function loadContainer(): Promise<IContainer> {
-        const loader: ILoader = createLocalLoader([[codeDetails, runtimeFactory]], deltaConnectionServer, urlResolver);
-        return loader.resolve({ url: documentLoadUrl });
-    }
+    let firstContainerObject1: TestDataObject;
+    let firstContainerObject2: TestDataObject;
+    let secondContainerObject1: TestDataObject;
 
     beforeEach(async () => {
-        deltaConnectionServer = LocalDeltaConnectionServer.create();
-        urlResolver = new LocalResolver();
-
         // Create a Container for the first client.
-        const firstContainer = await createContainer();
-        firstContainerObject1 = await requestFluidObject<TestSharedDataObject>(firstContainer, "default");
-        firstContainerObject2 = await testSharedDataObjectFactory.createInstance(
-            firstContainerObject1._context.containerRuntime);
+        const firstContainer = await args.makeTestContainer();
+        firstContainerObject1 = await requestFluidObject<TestDataObject>(firstContainer, "default");
+        const containerRuntime1 = firstContainerObject1._context.containerRuntime;
+        const dataStore = await containerRuntime1.createDataStore(TestDataObject.type);
+        firstContainerObject2 = await requestFluidObject<TestDataObject>(dataStore, "");
 
         // Load the Container that was created by the first client.
-        const secondContainer = await loadContainer();
-        secondContainerObject1 = await requestFluidObject<TestSharedDataObject>(secondContainer, "default");
+        const secondContainer = await args.loadTestContainer();
+        secondContainerObject1 = await requestFluidObject<TestDataObject>(secondContainer, "default");
 
-        opProcessingController = new OpProcessingController(deltaConnectionServer);
+        opProcessingController = new OpProcessingController(args.deltaConnectionServer);
         opProcessingController.addDeltaManagers(
             firstContainerObject1._runtime.deltaManager, secondContainerObject1._runtime.deltaManager);
 
@@ -118,14 +61,18 @@ describe("FluidObjectHandle", () => {
 
         // Verify that the local client's FluidDataObjectRuntime has the correct absolute path.
         const fluidHandleContext11 = firstContainerObject1._runtime.rootRoutingContext;
-        assert.equal(fluidHandleContext11.absolutePath, absolutePath, "The FluidDataObjectRuntime's path is incorrect");
+        // back-compat for N-2 <= 0.27, remove when N-2 >= 0.28
+        if (fluidHandleContext11) {
+            assert.equal(fluidHandleContext11.absolutePath, absolutePath,
+                "The FluidDataObjectRuntime's path is incorrect");
 
-        // Verify that the remote client's FluidDataObjectRuntime has the correct absolute path.
-        const fluidHandleContext12 = secondContainerObject1._runtime.rootRoutingContext;
-        assert.equal(
-            fluidHandleContext12.absolutePath,
-            absolutePath,
-            "The remote FluidDataObjectRuntime's path is incorrect");
+            // Verify that the remote client's FluidDataObjectRuntime has the correct absolute path.
+            const fluidHandleContext12 = secondContainerObject1._runtime.rootRoutingContext;
+            assert.equal(
+                fluidHandleContext12.absolutePath,
+                absolutePath,
+                "The remote FluidDataObjectRuntime's path is incorrect");
+        }
     });
 
     it("can store and retrieve a DDS from handle within same data store runtime", async () => {
@@ -218,8 +165,8 @@ describe("FluidObjectHandle", () => {
             firstContainerObject2.handle.absolutePath,
             "The urls do not match");
     });
+};
 
-    afterEach(async () => {
-        await deltaConnectionServer.webSocketServer.close();
-    });
+describe("FluidObjectHandle", () => {
+    generateTestWithCompat(tests);
 });

--- a/packages/test/end-to-end-tests/src/test/fluidObjectHandle.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/fluidObjectHandle.spec.ts
@@ -55,7 +55,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
         assert.equal(containerRuntime2.absolutePath, absolutePath, "The remote ContainerRuntime's path is incorrect");
     });
 
-    it("should generate the absolute path for FluidDataObjectRuntime correctly", () => {
+    it("should generate the absolute path for FluidDataObjectRuntime correctly", function() {
         // The expected absolute path for the FluidDataObjectRuntime.
         const absolutePath = `/${firstContainerObject1._runtime.id}`;
 
@@ -72,6 +72,8 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 fluidHandleContext12.absolutePath,
                 absolutePath,
                 "The remote FluidDataObjectRuntime's path is incorrect");
+        } else {
+            this.skip();
         }
     });
 

--- a/packages/test/end-to-end-tests/src/test/loaderTest.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/loaderTest.spec.ts
@@ -13,7 +13,7 @@ import { IContainer, IFluidCodeDetails, ILoader } from "@fluidframework/containe
 import { IUrlResolver } from "@fluidframework/driver-definitions";
 import { LocalResolver } from "@fluidframework/local-driver";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
-import {  createAndAttachContainer, createLocalLoader } from "@fluidframework/test-utils";
+import { createAndAttachContainer, createLocalLoader } from "@fluidframework/test-utils";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 
 class TestSharedDataObject1 extends DataObject {

--- a/packages/test/end-to-end-tests/src/test/localTestSignals.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/localTestSignals.spec.ts
@@ -11,7 +11,11 @@ import {
     OpProcessingController,
     ITestFluidObject,
 } from "@fluidframework/test-utils";
-import { generateTestWithCompat, ICompatLocalTestObjectProvider } from "./compatUtils";
+import { generateTestWithCompat, ICompatLocalTestObjectProvider, ITestContainerConfig } from "./compatUtils";
+
+const testContainerConfig: ITestContainerConfig = {
+    testFluidDataObject: true,
+};
 
 const tests = (args: ICompatLocalTestObjectProvider) => {
     let dataObject1: ITestFluidObject;
@@ -19,10 +23,10 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
     let opProcessingController: OpProcessingController;
 
     beforeEach(async () => {
-        const container1 = await args.makeTestContainer() as Container;
+        const container1 = await args.makeTestContainer(testContainerConfig) as Container;
         dataObject1 = await requestFluidObject<ITestFluidObject>(container1, "default");
 
-        const container2 = await args.loadTestContainer() as Container;
+        const container2 = await args.loadTestContainer(testContainerConfig) as Container;
         dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
 
         opProcessingController = new OpProcessingController(args.deltaConnectionServer);
@@ -138,5 +142,5 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 };
 
 describe("TestSignals", () => {
-    generateTestWithCompat(tests, { testFluidDataObject: true });
+    generateTestWithCompat(tests);
 });

--- a/packages/test/end-to-end-tests/src/test/mapEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/mapEndToEndTests.spec.ts
@@ -14,10 +14,14 @@ import {
     ITestFluidObject,
     OpProcessingController,
 } from "@fluidframework/test-utils";
-import { generateTestWithCompat, ICompatLocalTestObjectProvider } from "./compatUtils";
+import { generateTestWithCompat, ICompatLocalTestObjectProvider, ITestContainerConfig } from "./compatUtils";
 
 const mapId = "mapKey";
 const registry: ChannelFactoryRegistry = [[mapId, SharedMap.getFactory()]];
+const testContainerConfig: ITestContainerConfig = {
+    testFluidDataObject: true,
+    registry,
+};
 
 const tests = (args: ICompatLocalTestObjectProvider) => {
     let opProcessingController: OpProcessingController;
@@ -27,15 +31,15 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
     let sharedMap3: ISharedMap;
 
     beforeEach(async () => {
-        const container1 = await args.makeTestContainer(registry) as Container;
+        const container1 = await args.makeTestContainer(testContainerConfig) as Container;
         dataObject1 = await requestFluidObject<ITestFluidObject>(container1, "default");
         sharedMap1 = await dataObject1.getSharedObject<SharedMap>(mapId);
 
-        const container2 = await args.loadTestContainer(registry) as Container;
+        const container2 = await args.loadTestContainer(testContainerConfig) as Container;
         const dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
         sharedMap2 = await dataObject2.getSharedObject<SharedMap>(mapId);
 
-        const container3 = await args.loadTestContainer(registry) as Container;
+        const container3 = await args.loadTestContainer(testContainerConfig) as Container;
         const dataObject3 = await requestFluidObject<ITestFluidObject>(container3, "default");
         sharedMap3 = await dataObject3.getSharedObject<SharedMap>(mapId);
 
@@ -300,5 +304,5 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 };
 
 describe("Map", () => {
-    generateTestWithCompat(tests, { testFluidDataObject: true });
+    generateTestWithCompat(tests);
 });

--- a/packages/test/end-to-end-tests/src/test/oldVersion.ts
+++ b/packages/test/end-to-end-tests/src/test/oldVersion.ts
@@ -68,7 +68,7 @@ const defaultCodeDetails: IFluidCodeDetails = {
  *   IServiceConfiguration
  *   ILocalDeltaConnectionServer
  */
-export class LocalTestObjectProvider<ChannelFactoryRegistryType, ContainerRuntimeOptionsType> {
+export class LocalTestObjectProvider<TestContainerConfigType> {
     private _documentServiceFactory: IDocumentServiceFactory | undefined;
     private _defaultUrlResolver: LocalResolver | undefined;
 
@@ -80,9 +80,7 @@ export class LocalTestObjectProvider<ChannelFactoryRegistryType, ContainerRuntim
      * @param _deltaConnectionServer - optional deltaConnectionServer to share documents between different provider
      */
     constructor(
-        private readonly createFluidEntryPoint: (
-            registry?: ChannelFactoryRegistryType,
-            runtimeOptions?: ContainerRuntimeOptionsType) => fluidEntryPoint,
+        private readonly createFluidEntryPoint: (testContainerConfig?: TestContainerConfigType) => fluidEntryPoint,
         private readonly serviceConfiguration?: Partial<IServiceConfiguration>,
         private _deltaConnectionServer?: ILocalDeltaConnectionServer | undefined,
     ) {
@@ -127,39 +125,27 @@ export class LocalTestObjectProvider<ChannelFactoryRegistryType, ContainerRuntim
 
     /**
      * Make a test loader
-     * @param registry - optional channel to factory pair used create the TestfluidObject with
-     * @param runtimeOptions - optional container runtime options
+     * @param testContainerConfig - optional configuring the test Container
      */
-    public makeTestLoader(
-        registry?: ChannelFactoryRegistryType,
-        runtimeOptions?: ContainerRuntimeOptionsType,
-    ) {
-        return this.createLoader([[defaultCodeDetails, this.createFluidEntryPoint(registry, runtimeOptions)]]);
+    public makeTestLoader(testContainerConfig?: TestContainerConfigType) {
+        return this.createLoader([[defaultCodeDetails, this.createFluidEntryPoint(testContainerConfig)]]);
     }
 
     /**
      * Make a container using a default document id and code details
-     * @param registry - optional channel to factory pair used create the TestfluidObject with
-     * @param runtimeOptions - optional container runtime options
+     * @param testContainerConfig - optional configuring the test Container
      */
-    public async makeTestContainer(
-        registry?: ChannelFactoryRegistryType,
-        runtimeOptions?: ContainerRuntimeOptionsType,
-    ) {
-        const loader = this.makeTestLoader(registry, runtimeOptions);
+    public async makeTestContainer(testContainerConfig?: TestContainerConfigType) {
+        const loader = this.makeTestLoader(testContainerConfig);
         return createAndAttachContainer(defaultDocumentId, defaultCodeDetails, loader, this.urlResolver);
     }
 
     /**
      * Load a container using a default document id and code details
-     * @param registry - optional channel to factory pair used create the TestfluidObject with
-     * @param runtimeOptions - optional container runtime options
+     * @param testContainerConfig - optional configuring the test Container
      */
-    public async loadTestContainer(
-        registry?: ChannelFactoryRegistryType,
-        runtimeOptions?: ContainerRuntimeOptionsType,
-    ) {
-        const loader = this.makeTestLoader(registry, runtimeOptions);
+    public async loadTestContainer(testContainerConfig?: TestContainerConfigType) {
+        const loader = this.makeTestLoader(testContainerConfig);
         return loader.resolve({ url: defaultDocumentLoadUrl });
     }
 

--- a/packages/test/end-to-end-tests/src/test/oldVersion.ts
+++ b/packages/test/end-to-end-tests/src/test/oldVersion.ts
@@ -68,7 +68,7 @@ const defaultCodeDetails: IFluidCodeDetails = {
  *   IServiceConfiguration
  *   ILocalDeltaConnectionServer
  */
-export class LocalTestObjectProvider<ChannelFactoryRegistryType> {
+export class LocalTestObjectProvider<ChannelFactoryRegistryType, ContainerRuntimeOptionsType> {
     private _documentServiceFactory: IDocumentServiceFactory | undefined;
     private _defaultUrlResolver: LocalResolver | undefined;
 
@@ -80,7 +80,9 @@ export class LocalTestObjectProvider<ChannelFactoryRegistryType> {
      * @param _deltaConnectionServer - optional deltaConnectionServer to share documents between different provider
      */
     constructor(
-        private readonly createFluidEntryPoint: (registry?: ChannelFactoryRegistryType) => fluidEntryPoint,
+        private readonly createFluidEntryPoint: (
+            registry?: ChannelFactoryRegistryType,
+            runtimeOptions?: ContainerRuntimeOptionsType) => fluidEntryPoint,
         private readonly serviceConfiguration?: Partial<IServiceConfiguration>,
         private _deltaConnectionServer?: ILocalDeltaConnectionServer | undefined,
     ) {
@@ -126,26 +128,38 @@ export class LocalTestObjectProvider<ChannelFactoryRegistryType> {
     /**
      * Make a test loader
      * @param registry - optional channel to factory pair used create the TestfluidObject with
+     * @param runtimeOptions - optional container runtime options
      */
-    public makeTestLoader(registry?: ChannelFactoryRegistryType) {
-        return this.createLoader([[defaultCodeDetails, this.createFluidEntryPoint(registry) ]]);
+    public makeTestLoader(
+        registry?: ChannelFactoryRegistryType,
+        runtimeOptions?: ContainerRuntimeOptionsType,
+    ) {
+        return this.createLoader([[defaultCodeDetails, this.createFluidEntryPoint(registry, runtimeOptions)]]);
     }
 
     /**
      * Make a container using a default document id and code details
      * @param registry - optional channel to factory pair used create the TestfluidObject with
+     * @param runtimeOptions - optional container runtime options
      */
-    public async makeTestContainer(registry?: ChannelFactoryRegistryType) {
-        const loader = this.makeTestLoader(registry);
+    public async makeTestContainer(
+        registry?: ChannelFactoryRegistryType,
+        runtimeOptions?: ContainerRuntimeOptionsType,
+    ) {
+        const loader = this.makeTestLoader(registry, runtimeOptions);
         return createAndAttachContainer(defaultDocumentId, defaultCodeDetails, loader, this.urlResolver);
     }
 
     /**
      * Load a container using a default document id and code details
      * @param registry - optional channel to factory pair used create the TestfluidObject with
+     * @param runtimeOptions - optional container runtime options
      */
-    public async loadTestContainer(registry?: ChannelFactoryRegistryType) {
-        const loader = this.makeTestLoader(registry);
+    public async loadTestContainer(
+        registry?: ChannelFactoryRegistryType,
+        runtimeOptions?: ContainerRuntimeOptionsType,
+    ) {
+        const loader = this.makeTestLoader(registry, runtimeOptions);
         return loader.resolve({ url: defaultDocumentLoadUrl });
     }
 

--- a/packages/test/end-to-end-tests/src/test/sharedInterval.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/sharedInterval.spec.ts
@@ -4,11 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { IContainer, IFluidCodeDetails, ILoader } from "@fluidframework/container-definitions";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
-import { IChannelFactory } from "@fluidframework/datastore-definitions";
-import { IUrlResolver } from "@fluidframework/driver-definitions";
-import { LocalResolver } from "@fluidframework/local-driver";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
 import { IntervalType, LocalReference } from "@fluidframework/merge-tree";
 import { IBlob } from "@fluidframework/protocol-definitions";
@@ -19,14 +15,12 @@ import {
     SequenceInterval,
     SharedString,
 } from "@fluidframework/sequence";
-import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import {
-    createAndAttachContainer,
-    createLocalLoader,
     OpProcessingController,
     ITestFluidObject,
-    TestFluidObjectFactory,
+    ChannelFactoryRegistry,
 } from "@fluidframework/test-utils";
+import { ICompatLocalTestObjectProvider, generateTestWithCompat } from "./compatUtils";
 
 const assertIntervalsHelper = (
     sharedString: SharedString,
@@ -55,29 +49,8 @@ const assertIntervalsHelper = (
     }
 };
 
-describe("SharedInterval", () => {
-    const documentId = "sharedIntervalTest";
-    const documentLoadUrl = `fluid-test://localhost/${documentId}`;
-    const codeDetails: IFluidCodeDetails = {
-        package: "sharedIntervalTestPackage",
-        config: {},
-    };
-
-    let deltaConnectionServer: ILocalDeltaConnectionServer;
-    let urlResolver: IUrlResolver;
+const tests = (args: ICompatLocalTestObjectProvider) => {
     let opProcessingController: OpProcessingController;
-
-    async function createContainer(factoryEntries: Iterable<[string, IChannelFactory]>): Promise<IContainer> {
-        const factory = new TestFluidObjectFactory(factoryEntries);
-        const loader: ILoader = createLocalLoader([[codeDetails, factory]], deltaConnectionServer, urlResolver);
-        return createAndAttachContainer(documentId, codeDetails, loader, urlResolver);
-    }
-
-    async function loadContainer(factoryEntries: Iterable<[string, IChannelFactory]>): Promise<IContainer> {
-        const factory = new TestFluidObjectFactory(factoryEntries);
-        const loader: ILoader = createLocalLoader([[codeDetails, factory]], deltaConnectionServer, urlResolver);
-        return loader.resolve({ url: documentLoadUrl });
-    }
 
     describe("one client", () => {
         const stringId = "stringKey";
@@ -90,16 +63,13 @@ describe("SharedInterval", () => {
         };
 
         beforeEach(async () => {
-            urlResolver = new LocalResolver();
-            deltaConnectionServer = LocalDeltaConnectionServer.create();
-
-            const container = await createContainer([[stringId, SharedString.getFactory()]]);
+            const container = await args.makeTestContainer([[stringId, SharedString.getFactory()]]);
             const dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
             sharedString = await dataObject.getSharedObject<SharedString>(stringId);
             sharedString.insertText(0, "012");
             intervals = await sharedString.getIntervalCollection("intervals").getView();
 
-            opProcessingController = new OpProcessingController(deltaConnectionServer);
+            opProcessingController = new OpProcessingController(args.deltaConnectionServer);
             opProcessingController.addDeltaManagers(dataObject.runtime.deltaManager);
         });
 
@@ -199,22 +169,16 @@ describe("SharedInterval", () => {
                 await opProcessingController.process();
             }
         });
-
-        afterEach(async () => {
-            await deltaConnectionServer.webSocketServer.close();
-        });
     });
 
     describe("multiple clients", () => {
         it("propagates", async () => {
             const stringId = "stringKey";
-
-            urlResolver = new LocalResolver();
-            deltaConnectionServer = LocalDeltaConnectionServer.create();
-            opProcessingController = new OpProcessingController(deltaConnectionServer);
+            const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
+            opProcessingController = new OpProcessingController(args.deltaConnectionServer);
 
             // Create a Container for the first client.
-            const container1 = await createContainer([[stringId, SharedString.getFactory()]]);
+            const container1 = await args.makeTestContainer(registry);
             const dataObject1 = await requestFluidObject<ITestFluidObject>(container1, "default");
             const sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
 
@@ -224,7 +188,7 @@ describe("SharedInterval", () => {
             assertIntervalsHelper(sharedString1, intervals1, [{ start: 1, end: 7 }]);
 
             // Load the Container that was created by the first client.
-            const container2 = await loadContainer([[stringId, SharedString.getFactory()]]);
+            const container2 = await args.loadTestContainer(registry);
             const dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
 
             opProcessingController.addDeltaManagers(
@@ -245,8 +209,6 @@ describe("SharedInterval", () => {
 
             await opProcessingController.process();
             assertIntervalsHelper(sharedString1, intervals1, [{ start: 1, end: 7 }]);
-
-            await deltaConnectionServer.webSocketServer.close();
         });
     });
 
@@ -254,39 +216,32 @@ describe("SharedInterval", () => {
         const mapId = "mapKey";
         const stringId = "stringKey";
 
+        const registry: ChannelFactoryRegistry = [
+            [mapId, SharedMap.getFactory()],
+            [stringId, SharedString.getFactory()],
+        ];
         let dataObject1: ITestFluidObject;
         let sharedMap1: ISharedMap;
         let sharedMap2: ISharedMap;
         let sharedMap3: ISharedMap;
 
         beforeEach(async () => {
-            deltaConnectionServer = LocalDeltaConnectionServer.create();
-
             // Create a Container for the first client.
-            const container1 = await createContainer([
-                [mapId, SharedMap.getFactory()],
-                [stringId, SharedString.getFactory()],
-            ]);
+            const container1 = await args.makeTestContainer(registry);
             dataObject1 = await requestFluidObject<ITestFluidObject>(container1, "default");
             sharedMap1 = await dataObject1.getSharedObject<SharedMap>(mapId);
 
             // Load the Container that was created by the first client.
-            const container2 = await loadContainer([
-                [mapId, SharedMap.getFactory()],
-                [stringId, SharedString.getFactory()],
-            ]);
+            const container2 = await args.loadTestContainer(registry);
             const dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
             sharedMap2 = await dataObject2.getSharedObject<SharedMap>(mapId);
 
             // Load the Container that was created by the first client.
-            const container3 = await loadContainer([
-                [mapId, SharedMap.getFactory()],
-                [stringId, SharedString.getFactory()],
-            ]);
+            const container3 = await args.loadTestContainer(registry);
             const dataObject3 = await requestFluidObject<ITestFluidObject>(container3, "default");
             sharedMap3 = await dataObject3.getSharedObject<SharedMap>(mapId);
 
-            opProcessingController = new OpProcessingController(deltaConnectionServer);
+            opProcessingController = new OpProcessingController(args.deltaConnectionServer);
             opProcessingController.addDeltaManagers(
                 dataObject1.runtime.deltaManager,
                 dataObject2.runtime.deltaManager,
@@ -361,9 +316,9 @@ describe("SharedInterval", () => {
                 "__fluid_handle__",
                 "Incorrect handle type in shared interval's snapshot");
         });
-
-        afterEach(async () => {
-            await deltaConnectionServer.webSocketServer.close();
-        });
     });
+};
+
+describe("SharedInterval", () => {
+    generateTestWithCompat(tests, { testFluidDataObject: true });
 });

--- a/packages/test/end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
@@ -12,10 +12,14 @@ import {
     ITestFluidObject,
     OpProcessingController,
 } from "@fluidframework/test-utils";
-import { generateTestWithCompat, ICompatLocalTestObjectProvider } from "./compatUtils";
+import { generateTestWithCompat, ICompatLocalTestObjectProvider, ITestContainerConfig } from "./compatUtils";
 
 const stringId = "sharedStringKey";
 const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
+const testContainerConfig: ITestContainerConfig = {
+    testFluidDataObject: true,
+    registry,
+};
 
 const tests = (args: ICompatLocalTestObjectProvider) => {
     let sharedString1: SharedString;
@@ -23,11 +27,11 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
     let opProcessingController: OpProcessingController;
 
     beforeEach(async () => {
-        const container1 = await args.makeTestContainer(registry) as Container;
+        const container1 = await args.makeTestContainer(testContainerConfig) as Container;
         const dataObject1 = await requestFluidObject<ITestFluidObject>(container1, "default");
         sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
 
-        const container2 = await args.loadTestContainer(registry) as Container;
+        const container2 = await args.loadTestContainer(testContainerConfig) as Container;
         const dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
         sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
 
@@ -55,7 +59,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
         await opProcessingController.process();
 
         // Create a initialize a new container with the same id.
-        const newContainer = await args.loadTestContainer(registry) as Container;
+        const newContainer = await args.loadTestContainer(testContainerConfig) as Container;
         const newComponent = await requestFluidObject<ITestFluidObject>(newContainer, "default");
         const newSharedString = await newComponent.getSharedObject<SharedString>(stringId);
         assert.equal(newSharedString.getText(), text, "The new container should receive the inserted text on creation");
@@ -63,5 +67,5 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 };
 
 describe("SharedString", () => {
-    generateTestWithCompat(tests, { testFluidDataObject: true });
+    generateTestWithCompat(tests);
 });

--- a/packages/test/test-utils/src/localLoader.ts
+++ b/packages/test/test-utils/src/localLoader.ts
@@ -80,7 +80,7 @@ const defaultCodeDetails: IFluidCodeDetails = {
  *   IServiceConfiguration
  *   ILocalDeltaConnectionServer
  */
-export class LocalTestObjectProvider<ChannelFactoryRegistryType> {
+export class LocalTestObjectProvider<ChannelFactoryRegistryType, ContainerRuntimeOptionsType> {
     private _documentServiceFactory: IDocumentServiceFactory | undefined;
     private _defaultUrlResolver: LocalResolver | undefined;
 
@@ -92,7 +92,9 @@ export class LocalTestObjectProvider<ChannelFactoryRegistryType> {
      * @param _deltaConnectionServer - optional deltaConnectionServer to share documents between different provider
      */
     constructor(
-        private readonly createFluidEntryPoint: (registry?: ChannelFactoryRegistryType) => fluidEntryPoint,
+        private readonly createFluidEntryPoint: (
+            registry?: ChannelFactoryRegistryType,
+            runtimeOptions?: ContainerRuntimeOptionsType) => fluidEntryPoint,
         private readonly serviceConfiguration?: Partial<IServiceConfiguration>,
         private _deltaConnectionServer?: ILocalDeltaConnectionServer | undefined,
     ) {
@@ -139,16 +141,22 @@ export class LocalTestObjectProvider<ChannelFactoryRegistryType> {
      * Make a test loader
      * @param registry - optional channel to factory pair used create the TestfluidObject with
      */
-    public makeTestLoader(registry?: ChannelFactoryRegistryType) {
-        return this.createLoader([[defaultCodeDetails, this.createFluidEntryPoint(registry) ]]);
+    public makeTestLoader(
+        registry?: ChannelFactoryRegistryType,
+        runtimeOptions?: ContainerRuntimeOptionsType,
+    ) {
+        return this.createLoader([[defaultCodeDetails, this.createFluidEntryPoint(registry, runtimeOptions)]]);
     }
 
     /**
      * Make a container using a default document id and code details
      * @param registry - optional channel to factory pair used create the TestfluidObject with
      */
-    public async makeTestContainer(registry?: ChannelFactoryRegistryType) {
-        const loader = this.makeTestLoader(registry);
+    public async makeTestContainer(
+        registry?: ChannelFactoryRegistryType,
+        runtimeOptions?: ContainerRuntimeOptionsType,
+    ) {
+        const loader = this.makeTestLoader(registry, runtimeOptions);
         return createAndAttachContainer(defaultDocumentId, defaultCodeDetails, loader, this.urlResolver);
     }
 
@@ -156,8 +164,11 @@ export class LocalTestObjectProvider<ChannelFactoryRegistryType> {
      * Load a container using a default document id and code details
      * @param registry - optional channel to factory pair used create the TestfluidObject with
      */
-    public async loadTestContainer(registry?: ChannelFactoryRegistryType) {
-        const loader = this.makeTestLoader(registry);
+    public async loadTestContainer(
+        registry?: ChannelFactoryRegistryType,
+        runtimeOptions?: ContainerRuntimeOptionsType,
+    ) {
+        const loader = this.makeTestLoader(registry, runtimeOptions);
         return loader.resolve({ url: defaultDocumentLoadUrl });
     }
 

--- a/packages/test/test-utils/src/localLoader.ts
+++ b/packages/test/test-utils/src/localLoader.ts
@@ -80,7 +80,7 @@ const defaultCodeDetails: IFluidCodeDetails = {
  *   IServiceConfiguration
  *   ILocalDeltaConnectionServer
  */
-export class LocalTestObjectProvider<ChannelFactoryRegistryType, ContainerRuntimeOptionsType> {
+export class LocalTestObjectProvider<TestContainerConfigType> {
     private _documentServiceFactory: IDocumentServiceFactory | undefined;
     private _defaultUrlResolver: LocalResolver | undefined;
 
@@ -92,9 +92,7 @@ export class LocalTestObjectProvider<ChannelFactoryRegistryType, ContainerRuntim
      * @param _deltaConnectionServer - optional deltaConnectionServer to share documents between different provider
      */
     constructor(
-        private readonly createFluidEntryPoint: (
-            registry?: ChannelFactoryRegistryType,
-            runtimeOptions?: ContainerRuntimeOptionsType) => fluidEntryPoint,
+        private readonly createFluidEntryPoint: (testContainerConfig?: TestContainerConfigType) => fluidEntryPoint,
         private readonly serviceConfiguration?: Partial<IServiceConfiguration>,
         private _deltaConnectionServer?: ILocalDeltaConnectionServer | undefined,
     ) {
@@ -139,36 +137,27 @@ export class LocalTestObjectProvider<ChannelFactoryRegistryType, ContainerRuntim
 
     /**
      * Make a test loader
-     * @param registry - optional channel to factory pair used create the TestfluidObject with
+     * @param testContainerConfig - optional configuring the test Container
      */
-    public makeTestLoader(
-        registry?: ChannelFactoryRegistryType,
-        runtimeOptions?: ContainerRuntimeOptionsType,
-    ) {
-        return this.createLoader([[defaultCodeDetails, this.createFluidEntryPoint(registry, runtimeOptions)]]);
+    public makeTestLoader(testContainerConfig?: TestContainerConfigType) {
+        return this.createLoader([[defaultCodeDetails, this.createFluidEntryPoint(testContainerConfig)]]);
     }
 
     /**
      * Make a container using a default document id and code details
-     * @param registry - optional channel to factory pair used create the TestfluidObject with
+     * @param testContainerConfig - optional configuring the test Container
      */
-    public async makeTestContainer(
-        registry?: ChannelFactoryRegistryType,
-        runtimeOptions?: ContainerRuntimeOptionsType,
-    ) {
-        const loader = this.makeTestLoader(registry, runtimeOptions);
+    public async makeTestContainer(testContainerConfig?: TestContainerConfigType) {
+        const loader = this.makeTestLoader(testContainerConfig);
         return createAndAttachContainer(defaultDocumentId, defaultCodeDetails, loader, this.urlResolver);
     }
 
     /**
      * Load a container using a default document id and code details
-     * @param registry - optional channel to factory pair used create the TestfluidObject with
+     * @param testContainerConfig - optional configuring the test Container
      */
-    public async loadTestContainer(
-        registry?: ChannelFactoryRegistryType,
-        runtimeOptions?: ContainerRuntimeOptionsType,
-    ) {
-        const loader = this.makeTestLoader(registry, runtimeOptions);
+    public async loadTestContainer(testContainerConfig?: TestContainerConfigType) {
+        const loader = this.makeTestLoader(testContainerConfig);
         return loader.resolve({ url: defaultDocumentLoadUrl });
     }
 


### PR DESCRIPTION
Change the API to make/load container from passing in the registry to a config object that contains the registry.
Add runtimeOptions to configure the containe runtime to the config object.
Move testFluidDataObject configuration to the container config instead of the local test object provider config.

Enable compat test for sharedInterval and fluidObjecthandle.
blobs test is a new feature, so compat mode is not enabled, but converted to be easily enabled when N-2 is 0.28.