### PR TITLE
Restructure ODSP connection telemetry

### DIFF
--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -62,6 +62,7 @@
     "@fluidframework/protocol-base": "^0.1014.0-0",
     "@fluidframework/protocol-definitions": "^0.1014.0-0",
     "@fluidframework/telemetry-utils": "^0.28.0",
+    "assert": "^2.0.0",
     "debug": "^4.1.1",
     "lodash": "^4.17.19",
     "node-fetch": "^2.2.1",

--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -53,9 +53,14 @@ export interface ISocketStorageDiscovery {
     snapshotStorageUrl: string;
     deltaStorageUrl: string;
 
+    /**
+     * The non-AFD URL
+     */
     deltaStreamSocketUrl: string;
 
-    // The AFD URL for PushChannel
+    /**
+     * The AFD URL for PushChannel
+     */
     deltaStreamSocketUrl2?: string;
 }
 

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -387,8 +387,6 @@ export class OdspDocumentService implements IDocumentService {
                     },
                     connectionError,
                 );
-
-                // We have no more fallback options, so just throw the error at this point.
                 throw connectionError;
             }
         };
@@ -407,7 +405,7 @@ export class OdspDocumentService implements IDocumentService {
                 const connection = await connectWithAfd();
                 return connection;
             } catch (connectionError) {
-                // If the AFD connection attempt failed, retry with non-AFD if possible
+                // Fall back to non-AFD if possible
                 if (canRetryOnError(connectionError)) {
                     return connectWithNonAfd();
                 }

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -337,7 +337,7 @@ export class OdspDocumentService implements IDocumentService {
                     this.logger,
                 );
                 this.logger.sendTelemetryEvent({
-                    eventName: "ConnectedWithNonAfdUrl",
+                    eventName: "NonAfdConnectionSuccess",
                 });
                 return connection;
             } catch (connectionError) {
@@ -345,7 +345,7 @@ export class OdspDocumentService implements IDocumentService {
                 const canRetry = canRetryOnError(connectionError);
                 this.logger.sendTelemetryEvent(
                     {
-                        eventName: "FailedConnectionWithNonAfdUrl",
+                        eventName: "NonAfdConnectionFail",
                         canRetry,
                     },
                     connectionError,
@@ -376,7 +376,7 @@ export class OdspDocumentService implements IDocumentService {
                 // we try to connect and immediately try AFD instead.
                 writeLocalStorage(lastAfdConnectionTimeMsKey, Date.now().toString());
                 this.logger.sendTelemetryEvent({
-                    eventName: "ConnectedWithAfdUrl",
+                    eventName: "AfdConnectionSuccess",
                 });
                 return connection;
             } catch (connectionError) {
@@ -386,7 +386,7 @@ export class OdspDocumentService implements IDocumentService {
                 const canRetry = canRetryOnError(connectionError);
                 this.logger.sendTelemetryEvent(
                     {
-                        eventName: "FailedConnectionWithAfdUrl",
+                        eventName: "AfdConnectionFail",
                         canRetry,
                     },
                     connectionError,

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -358,10 +358,10 @@ export class OdspDocumentService implements IDocumentService {
                     20000,
                     this.logger,
                 );
+                const endTime = performance.now();
                 // Set the successful connection attempt in the cache so we can skip the non-AFD failure the next time
                 // we try to connect and immediately try AFD instead.
                 writeLocalStorage(lastAfdConnectionTimeMsKey, Date.now().toString());
-                const endTime = performance.now();
                 this.logger.sendPerformanceEvent({
                     eventName: "AfdConnectionSuccess",
                     duration: endTime - startTime,

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -16,6 +16,7 @@ import {
     IResolvedUrl,
     IDocumentStorageService,
 } from "@fluidframework/driver-definitions";
+import { canRetryOnError } from "@fluidframework/driver-utils";
 import {
     IClient,
     IErrorTrackingService,
@@ -62,18 +63,6 @@ function isAfdCacheValid(): boolean {
     }
 
     return false;
-}
-
-/**
- * Test if we deal with NetworkErrorBasic object and if it has enough information to make a call
- * If in doubt, allow retries
- *
- * @param error - error object
- */
-function canRetryOnError(error: any) {
-    // Always retry unless told otherwise.
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return error === null || typeof error !== "object" || error.canRetry === undefined || error.canRetry;
 }
 
 /**

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -357,6 +357,10 @@ export class OdspDocumentService implements IDocumentService {
         const connectWithAfd = async () => {
             assert(afdUrl !== undefined, "Tried to connect with AFD but no AFD url provided");
 
+            this.logger.sendTelemetryEvent({
+                eventName: "AfdConnectionAttempt",
+            });
+
             try {
                 const connection = await OdspDocumentDeltaConnection.create(
                     tenantId,

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -28,7 +28,6 @@ import {
     HostStoragePolicyInternal,
     ISocketStorageDiscovery,
 } from "./contracts";
-import { debug } from "./debug";
 import { IOdspCache, startingUpdateUsageOpFrequency, updateUsageOpMultiplier } from "./odspCache";
 import { OdspDeltaStorageService } from "./odspDeltaStorageService";
 import { OdspDocumentDeltaConnection } from "./odspDocumentDeltaConnection";

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -77,7 +77,6 @@ function writeLocalStorage(key: string, value: string) {
         localStorage.setItem(key, value);
         return true;
     } catch (e) {
-        debug(`Could not write to localStorage due to ${e}`);
         return false;
     }
 }

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -38,6 +38,7 @@ import {
     ScopeType,
 } from "@fluidframework/protocol-definitions";
 import {
+    canRetryOnError,
     createWriteError,
     createGenericNetworkError,
 } from "@fluidframework/driver-utils";
@@ -57,9 +58,6 @@ const DefaultChunkSize = 16 * 1024;
 // This can be anything other than null
 const ImmediateNoOpResponse = "";
 
-// Test if we deal with NetworkError object and if it has enough information to make a call.
-// If in doubt, allow retries.
-const canRetryOnError = (error: any): boolean => error?.canRetry !== false;
 // eslint-disable-next-line @typescript-eslint/no-unsafe-return
 const getRetryDelayFromError = (error: any): number | undefined => error?.retryAfterSeconds;
 

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -103,3 +103,9 @@ export function createGenericNetworkError(
     }
     return new GenericNetworkError(errorMessage, canRetry, statusCode);
 }
+
+/**
+ * Check if a connection error can be retried.  Unless explicitly disallowed, retry is allowed.
+ * @param error - The error to inspect for ability to retry
+ */
+export const canRetryOnError = (error: any): boolean => error?.canRetry !== false;


### PR DESCRIPTION
I was finding the promise chaining and nesting a bit hard to follow, and the telemetry as well.  This change restructures the connection to unify connection logic and telemetry on AFD vs. non-AFD.  The distinction of cache vs. first-attempt vs. fallback should be derivable from telemetry without specially-named events.  This should also make it easier to observe connection timing (some of the flows don't log enough data to determine this currently).

This change does include one functional change beyond telemetry - currently we only write the AFD-valid cache if there wasn't a valid cache.  With this change, we'll write an updated timestamp to the cache on successful AFD connection regardless of the prior state of the cache.