### PR TITLE
Added state in DataStoreContext to indicate if this is a root data store

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -12,12 +12,6 @@
 Added api `removeAllEntriesForDocId` which allows removal of all entries for a given document id. Also the schema for entries stored inside odsp `IPersistedCache` has changed.
 It now stores/expect values as `IPersistedCacheValueWithEpoch`. So host needs to clear its cached entries in this version.
 
-### Moving DriverHeader and merge with CreateNewHeader
-Compile time only API breaking change between runtime and driver.  Only impacts driver implementer.
-No back-compat or mix version impact.
-
-DriverHeader is a driver concept, so move from core-interface to driver-definitions. CreateNewHeader is also a kind of driver header, merged it into DriverHeader.
-
 ### IFluidPackage Changes
 - Moving IFluidPackage and IFluidCodeDetails from "@fluidframework/container-definitions" to '@fluidframework/core-interfaces'
 - Remove npm specific IPackage interface

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -73,6 +73,18 @@ After:
 
 if for some reason this change causes you problems, we've added a deprecated `Loader._create` method that has the same parameters as the previous constructor which can be used in the interim.
 
+### Moving DriverHeader and merge with CreateNewHeader
+Compile time only API breaking change between runtime and driver.  Only impacts driver implementer.
+No back-compat or mix version impact.
+
+DriverHeader is a driver concept, so move from core-interface to driver-definitions. CreateNewHeader is also a kind of driver header, merged it into DriverHeader.
+
+### Added isRootDataStore property to IFluidDataStoreContext
+"isRootDataStore" tells whether a data store is a root data store or not. A root data store is created via the "createRootDataStore" API on IContainerRuntime.
+
+Root data stores are never garbage collected. They can be found and loaded by name.
+
+Non-root data stores are garbage collected if they are not referenced. They can be referenced by setting their handle in a DDS.
 
 ## 0.27 Breaking Changes
 - [Local Web Host Removed](#Local-Web-Host-Removed)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -79,13 +79,6 @@ No back-compat or mix version impact.
 
 DriverHeader is a driver concept, so move from core-interface to driver-definitions. CreateNewHeader is also a kind of driver header, merged it into DriverHeader.
 
-### Added isRootDataStore property to IFluidDataStoreContext
-"isRootDataStore" tells whether a data store is a root data store or not. A root data store is created via the "createRootDataStore" API on IContainerRuntime.
-
-Root data stores are never garbage collected. They can be found and loaded by name.
-
-Non-root data stores are garbage collected if they are not referenced. They can be referenced by setting their handle in a DDS.
-
 ## 0.27 Breaking Changes
 - [Local Web Host Removed](#Local-Web-Host-Removed)
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -810,9 +810,11 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                     throw new Error(`Invalid snapshot format version ${snapshotFormatVersion}`);
                 }
 
-                // If there is no isRootDataStore in the attributes blob, set it to true. This will ensure that
-                // data stores in older documents are not garbage collected incorrectly. This may lead to additional
-                // roots in the document but they won't break.
+                /**
+                 * If there is no isRootDataStore in the attributes blob, set it to true. This will ensure that data
+                 * stores in older documents are not garbage collected incorrectly. This may lead to additional roots
+                 * in the document but they won't break.
+                 */
                 dataStoreContext = new LocalFluidDataStoreContext(
                     key,
                     pkgFromSnapshot,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1550,7 +1550,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                     sequenceNumber: message.sequenceNumber,
                     snapshot: attachMessage.snapshot ?? {
                         id: null,
-                        entries: [createAttributesBlob(pkg, false /* isRootDataStore */)],
+                        entries: [createAttributesBlob(pkg, true /* isRootDataStore */)],
                     },
                 }),
             pkg);

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1329,12 +1329,12 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
 
     public async createDataStore(pkg: string | string[]): Promise<IFluidRouter>
     {
-        return this._createDataStore(pkg, undefined, false /* isRoot */);
+        return this._createDataStore(pkg, false /* isRoot */);
     }
 
     public async createRootDataStore(pkg: string | string[], rootDataStoreId: string): Promise<IFluidRouter>
     {
-        const fluidDataStore = await this._createDataStore(pkg, rootDataStoreId, true /* isRoot */);
+        const fluidDataStore = await this._createDataStore(pkg, true /* isRoot */, rootDataStoreId);
         fluidDataStore.bindToContext();
         return fluidDataStore;
     }
@@ -1364,8 +1364,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
 
     private async _createDataStore(
         pkg: string | string[],
-        id = uuid(),
         isRoot: boolean,
+        id = uuid(),
         ): Promise<IFluidDataStoreChannel>
     {
         return this._createFluidDataStoreContext(Array.isArray(pkg) ? pkg : [pkg], id, isRoot).realize();

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1386,8 +1386,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             this.summarizerNode.getCreateChildFn(id, { type: CreateSummarizerNodeSource.Local }),
             (cr: IFluidDataStoreChannel) => this.bindFluidDataStore(cr),
             undefined,
-            props,
             isRoot,
+            props,
         );
         this.setupNewContext(context);
         return context;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1350,7 +1350,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             this.summarizerNode.getCreateChildFn(id, { type: CreateSummarizerNodeSource.Local }),
             (cr: IFluidDataStoreChannel) => this.bindFluidDataStore(cr),
             undefined,
-            false /* isRootDataStore */
+            false /* isRootDataStore */,
         );
         this.setupNewContext(context);
         return context;

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -170,10 +170,6 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
         return this._attachState;
     }
 
-    public get isRootDataStore(): boolean {
-        return this._isRootDataStore;
-    }
-
     public get IFluidDataStoreRegistry(): IFluidDataStoreRegistry | undefined {
         return this.registry;
     }
@@ -201,8 +197,8 @@ export abstract class FluidDataStoreContext extends EventEmitter implements
         private bindState: BindState,
         public readonly isLocalDataStore: boolean,
         bindChannel: (channel: IFluidDataStoreChannel) => void,
+        protected isRootDataStore: boolean,
         protected pkg?: readonly string[],
-        protected _isRootDataStore: boolean = false,
     ) {
         super();
 
@@ -601,8 +597,9 @@ export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
             () => {
                 throw new Error("Already attached");
             },
+            true /* isRootDataStore */,
             pkg,
-            true /* isRootDataStore */);
+        );
     }
 
     public generateAttachMessage(): IAttachMessage {
@@ -656,7 +653,7 @@ export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
                 // If there is no isRootDataStore in the attributes blob, set it to true. This will ensure that
                 // data stores in older documents are not garbage collected incorrectly. This may lead to additional
                 // roots in the document but they won't break.
-                this._isRootDataStore = isRootDataStore ?? true;
+                this.isRootDataStore = isRootDataStore ?? true;
             }
 
             this.details = {
@@ -684,11 +681,11 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
         createSummarizerNode: CreateChildSummarizerNodeFn,
         bindChannel: (channel: IFluidDataStoreChannel) => void,
         private readonly snapshotTree: ISnapshotTree | undefined,
+        isRootDataStore: boolean,
         /**
          * @deprecated 0.16 Issue #1635, #3631
          */
         public readonly createProps?: any,
-        isRootDataStore: boolean = false,
     ) {
         super(
             runtime,
@@ -701,8 +698,8 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
             snapshotTree ? BindState.Bound : BindState.NotBound,
             true,
             bindChannel,
-            pkg,
-            isRootDataStore);
+            isRootDataStore,
+            pkg);
         this.attachListeners();
     }
 
@@ -762,11 +759,11 @@ export class LocalFluidDataStoreContext extends LocalFluidDataStoreContextBase {
         createSummarizerNode: CreateChildSummarizerNodeFn,
         bindChannel: (channel: IFluidDataStoreChannel) => void,
         snapshotTree: ISnapshotTree | undefined,
+        isRootDataStore: boolean,
         /**
          * @deprecated 0.16 Issue #1635, #3631
          */
         createProps?: any,
-        isRootDataStore: boolean = false,
     ) {
         super(
             id,
@@ -778,8 +775,8 @@ export class LocalFluidDataStoreContext extends LocalFluidDataStoreContextBase {
             createSummarizerNode,
             bindChannel,
             snapshotTree,
-            createProps,
-            isRootDataStore);
+            isRootDataStore,
+            createProps);
     }
 }
 
@@ -802,7 +799,7 @@ export class LocalDetachedFluidDataStoreContext
         createSummarizerNode: CreateChildSummarizerNodeFn,
         bindChannel: (channel: IFluidDataStoreChannel) => void,
         snapshotTree: ISnapshotTree | undefined,
-        isRootDataStore: boolean = false,
+        isRootDataStore: boolean,
     ) {
         super(
             id,
@@ -814,8 +811,8 @@ export class LocalDetachedFluidDataStoreContext
             createSummarizerNode,
             bindChannel,
             snapshotTree,
-            undefined,
-            isRootDataStore);
+            isRootDataStore,
+        );
         assert(this.pkg === undefined);
         this.detachedRuntimeCreation = true;
     }

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -71,18 +71,27 @@ export function createAttributesBlob(pkg: readonly string[], isRootDataStore: bo
 }
 
 /**
- * Added IFluidDataStoreAttributes similar to IChannelAttributes which will tell
- * the attributes of a store like the package, snapshotFormatVersion to
- * take different decisions based on a particular snapshotFormatVersion.
+ * Added IFluidDataStoreAttributes similar to IChannelAttributes which will tell the attributes of a
+ * store like the package, snapshotFormatVersion to take different decisions based on a particular
+ * snapshotFormatVersion.
  */
 export interface IFluidDataStoreAttributes {
     pkg: string;
     readonly snapshotFormatVersion?: string;
+    /**
+     * This tells whether a data store is root. Root data stores are never collected.
+     * Non-root data stores may be collected if they are not used. If this is not present, default it to
+     * true. This will ensure that older data stores are incorrectly collected.
+     */
     readonly isRootDataStore?: boolean;
 }
 
 interface ISnapshotDetails {
     pkg: readonly string[];
+    /**
+     * This tells whether a data store is root. Root data stores are never collected.
+     * Non-root data stores may be collected if they are not used.
+     */
     isRootDataStore: boolean;
     snapshot?: ISnapshotTree;
 }
@@ -643,21 +652,18 @@ export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
                     throw new Error(`Invalid snapshot format version ${snapshotFormatVersion}`);
                 }
                 this.pkg = pkgFromSnapshot;
-
-                // If there is no isRootDataStore in the attributes blob, set it to true. This will ensure that
-                // data stores in older documents are not garbage collected incorrectly. This may lead to additional
-                // roots in the document but they won't break.
-                isRootStore = isRootDataStore ?? true;
+                isRootStore = isRootDataStore;
             }
 
-            assert(
-                isRootStore !== undefined,
-                "isRootDataStore should be available after reading attributes blob");
-
+            /**
+             * If there is no isRootDataStore in the attributes blob, set it to true. This will ensure that
+             * data stores in older documents are not garbage collected incorrectly. This may lead to additional
+             * roots in the document but they won't break.
+             */
             this.details = {
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 pkg: this.pkg!,
-                isRootDataStore: isRootStore,
+                isRootDataStore: isRootStore ?? true,
                 snapshot: tree ?? undefined,
             };
         }

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -274,6 +274,8 @@ describe("Data Store Context Tests", () => {
                 contents.snapshotFormatVersion,
                 "0.1",
                 "Remote DataStore snapshot version does not match.");
+            // Remote context without the isRootDataStore flag in the snapshot should default it to true.
+            assert.strictEqual(contents.isRootDataStore, true, "Remote DataStore isRootDataStore flag does not match.");
         });
 
         it("Check RemotedDataStore Attributes without isRootDataStore flag", async () => {

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -80,7 +80,8 @@ describe("Data Store Context Tests", () => {
                 summaryTracker,
                 createSummarizerNodeFn,
                 attachCb,
-                undefined);
+                undefined,
+                true /* isRootDataStore */);
 
             await localDataStoreContext.realize();
             const attachMessage = localDataStoreContext.generateAttachMessage();
@@ -91,14 +92,19 @@ describe("Data Store Context Tests", () => {
             const dataStoreAttributes: IFluidDataStoreAttributes = {
                 pkg: JSON.stringify(["TestDataStore1"]),
                 snapshotFormatVersion: "0.1",
+                isRootDataStore: true,
             };
 
-            assert.equal(contents.pkg, dataStoreAttributes.pkg, "Local DataStore package does not match.");
-            assert.equal(
+            assert.strictEqual(contents.pkg, dataStoreAttributes.pkg, "Local DataStore package does not match.");
+            assert.strictEqual(
                 contents.snapshotFormatVersion,
                 dataStoreAttributes.snapshotFormatVersion,
                 "Local DataStore snapshot version does not match.");
-            assert.equal(attachMessage.type, "TestDataStore1", "Attach message type does not match.");
+            assert.strictEqual(
+                contents.isRootDataStore,
+                dataStoreAttributes.isRootDataStore,
+                "Local DataStore isRootDataStore flag does not match");
+            assert.strictEqual(attachMessage.type, "TestDataStore1", "Attach message type does not match.");
         });
 
         it("Supplying array of packages in LocalFluidDataStoreContext should create exception", async () => {
@@ -112,13 +118,14 @@ describe("Data Store Context Tests", () => {
                 summaryTracker,
                 createSummarizerNodeFn,
                 attachCb,
-                undefined);
+                undefined,
+                false /* isRootDataStore */);
 
             await localDataStoreContext.realize()
                 .catch((error) => {
                     exception = true;
                 });
-            assert.equal(exception, true, "Exception did not occur.");
+            assert.strictEqual(exception, true, "Exception did not occur.");
         });
 
         it("Supplying array of packages in LocalFluidDataStoreContext should not create exception", async () => {
@@ -144,7 +151,8 @@ describe("Data Store Context Tests", () => {
                 summaryTracker,
                 createSummarizerNodeFn,
                 attachCb,
-                undefined);
+                undefined,
+                false /* isRootDataStore */);
 
             await localDataStoreContext.realize();
 
@@ -154,14 +162,19 @@ describe("Data Store Context Tests", () => {
             const dataStoreAttributes: IFluidDataStoreAttributes = {
                 pkg: JSON.stringify(["TestComp", "SubComp"]),
                 snapshotFormatVersion: "0.1",
+                isRootDataStore: false,
             };
 
-            assert.equal(contents.pkg, dataStoreAttributes.pkg, "Local DataStore package does not match.");
-            assert.equal(
+            assert.strictEqual(contents.pkg, dataStoreAttributes.pkg, "Local DataStore package does not match.");
+            assert.strictEqual(
                 contents.snapshotFormatVersion,
                 dataStoreAttributes.snapshotFormatVersion,
                 "Local DataStore snapshot version does not match.");
-            assert.equal(attachMessage.type, "SubComp", "Attach message type does not match.");
+            assert.strictEqual(
+                contents.isRootDataStore,
+                dataStoreAttributes.isRootDataStore,
+                "Local DataStore isRootDataStore flag does not match");
+            assert.strictEqual(attachMessage.type, "SubComp", "Attach message type does not match.");
         });
     });
 
@@ -192,6 +205,7 @@ describe("Data Store Context Tests", () => {
             dataStoreAttributes = {
                 pkg: JSON.stringify(["TestDataStore1"]),
                 snapshotFormatVersion: "0.1",
+                isRootDataStore: true,
             };
             const buffer = IsoBuffer.from(JSON.stringify(dataStoreAttributes), "utf-8");
             const blobCache = new Map<string, string>([["fluidDataStoreAttributes", buffer.toString("base64")]]);
@@ -215,11 +229,15 @@ describe("Data Store Context Tests", () => {
             const blob = snapshot.entries[0].value as IBlob;
 
             const contents = JSON.parse(blob.contents) as IFluidDataStoreAttributes;
-            assert.equal(contents.pkg, dataStoreAttributes.pkg, "Remote DataStore package does not match.");
-            assert.equal(
+            assert.strictEqual(contents.pkg, dataStoreAttributes.pkg, "Remote DataStore package does not match.");
+            assert.strictEqual(
                 contents.snapshotFormatVersion,
                 dataStoreAttributes.snapshotFormatVersion,
                 "Remote DataStore snapshot version does not match.");
+            assert.strictEqual(
+                contents.isRootDataStore,
+                dataStoreAttributes.isRootDataStore,
+                "Remote DataStore isRootDataStore flag does not match");
         });
 
         it("Check RemotedDataStore Attributes without version", async () => {
@@ -248,11 +266,50 @@ describe("Data Store Context Tests", () => {
             const blob = snapshot.entries[0].value as IBlob;
 
             const contents = JSON.parse(blob.contents) as IFluidDataStoreAttributes;
-            assert.equal(
+            assert.strictEqual(
                 contents.pkg,
                 JSON.stringify([dataStoreAttributes.pkg]),
                 "Remote DataStore package does not match.");
-            assert.equal(contents.snapshotFormatVersion, "0.1", "Remote DataStore snapshot version does not match.");
+            assert.strictEqual(
+                contents.snapshotFormatVersion,
+                "0.1",
+                "Remote DataStore snapshot version does not match.");
+        });
+
+        it("Check RemotedDataStore Attributes without isRootDataStore flag", async () => {
+            dataStoreAttributes = {
+                pkg: JSON.stringify(["TestDataStore1"]),
+                snapshotFormatVersion: "0.1",
+            };
+            const buffer = IsoBuffer.from(JSON.stringify(dataStoreAttributes), "utf-8");
+            const blobCache = new Map<string, string>([["fluidDataStoreAttributes", buffer.toString("base64")]]);
+            const snapshotTree: ISnapshotTree = {
+                id: "dummy",
+                blobs: { [".component"]: "fluidDataStoreAttributes" },
+                commits: {},
+                trees: {},
+            };
+
+            remotedDataStoreContext = new RemotedFluidDataStoreContext(
+                dataStoreId,
+                Promise.resolve(snapshotTree),
+                containerRuntime,
+                new BlobCacheStorageService(storage as IDocumentStorageService, Promise.resolve(blobCache)),
+                scope,
+                summaryTracker,
+                createSummarizerNodeFn,
+            );
+            const snapshot = await remotedDataStoreContext.snapshot(true);
+            const blob = snapshot.entries[0].value as IBlob;
+
+            const contents = JSON.parse(blob.contents) as IFluidDataStoreAttributes;
+            assert.strictEqual(contents.pkg, dataStoreAttributes.pkg, "Remote DataStore package does not match.");
+            assert.strictEqual(
+                contents.snapshotFormatVersion,
+                dataStoreAttributes.snapshotFormatVersion,
+                "Remote DataStore snapshot version does not match.");
+            // Remote context without the isRootDataStore flag in the snapshot should default it to true.
+            assert.strictEqual(contents.isRootDataStore, true, "Remote DataStore isRootDataStore flag does not match.");
         });
     });
 });

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -278,7 +278,7 @@ describe("Data Store Context Tests", () => {
             assert.strictEqual(contents.isRootDataStore, true, "Remote DataStore isRootDataStore flag does not match.");
         });
 
-        it("Check RemotedDataStore Attributes without isRootDataStore flag", async () => {
+        it("can process RemotedDataStore Attributes without isRootDataStore flag", async () => {
             dataStoreAttributes = {
                 pkg: JSON.stringify(["TestDataStore1"]),
                 snapshotFormatVersion: "0.1",

--- a/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
@@ -124,7 +124,8 @@ describe("Data Store Creation Tests", () => {
                 summaryTracker,
                 getCreateSummarizerNodeFn(dataStoreId),
                 attachCb,
-                undefined);
+                undefined,
+                false /* isRootDataStore */);
 
             try {
                 await context.realize();
@@ -148,7 +149,8 @@ describe("Data Store Creation Tests", () => {
                 summaryTracker,
                 getCreateSummarizerNodeFn(dataStoreId),
                 attachCb,
-                undefined);
+                undefined,
+                false /* isRootDataStore */);
 
             try {
                 await context.realize();
@@ -172,7 +174,8 @@ describe("Data Store Creation Tests", () => {
                 summaryTracker,
                 getCreateSummarizerNodeFn(dataStoreId),
                 attachCb,
-                undefined);
+                undefined,
+                false /* isRootDataStore */);
 
             try {
                 await contextA.realize();
@@ -196,7 +199,8 @@ describe("Data Store Creation Tests", () => {
                 summaryTracker,
                 getCreateSummarizerNodeFn(dataStoreId),
                 attachCb,
-                undefined);
+                undefined,
+                false /* isRootDataStore */);
 
             try {
                 await contextB.realize();
@@ -220,7 +224,8 @@ describe("Data Store Creation Tests", () => {
                 summaryTracker,
                 getCreateSummarizerNodeFn(dataStoreBId),
                 attachCb,
-                undefined);
+                undefined,
+                false /* isRootDataStore */);
 
             try {
                 await contextB.realize();
@@ -241,7 +246,8 @@ describe("Data Store Creation Tests", () => {
                 summaryTracker,
                 getCreateSummarizerNodeFn(dataStoreCId),
                 attachCb,
-                undefined);
+                undefined,
+                false /* isRootDataStore */);
 
             try {
                 await contextC.realize();
@@ -265,7 +271,8 @@ describe("Data Store Creation Tests", () => {
                 summaryTracker,
                 getCreateSummarizerNodeFn(dataStoreId),
                 attachCb,
-                undefined);
+                undefined,
+                false /* isRootDataStore */);
 
             try {
                 await contextFake.realize();
@@ -289,7 +296,8 @@ describe("Data Store Creation Tests", () => {
                 summaryTracker,
                 getCreateSummarizerNodeFn(dataStoreId),
                 attachCb,
-                undefined);
+                undefined,
+                false /* isRootDataStore */);
 
             try {
                 await contextFake.realize();
@@ -313,7 +321,8 @@ describe("Data Store Creation Tests", () => {
                 summaryTracker,
                 getCreateSummarizerNodeFn(dataStoreId),
                 attachCb,
-                undefined);
+                undefined,
+                false /* isRootDataStore */);
 
             try {
                 await contextC.realize();

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -241,13 +241,20 @@ export type CreateChildSummarizerNodeFn = (summarizeInternal: SummarizeInternalF
 export interface IFluidDataStoreContext extends EventEmitter, Partial<IProvideFluidDataStoreRegistry> {
     readonly documentId: string;
     readonly id: string;
-    // A data store created by a client, is a local data store for that client. Also, when a detached container loads
-    // from a snapshot, all the data stores are treated as local data stores because at that stage the container
-    // still doesn't exists in storage and so the data store couldn't have been created by any other client.
-    // Value of this never changes even after the data store is attached.
-    // As implementer of data store runtime, you can use this property to check that this data store belongs to this
-    // client and hence implement any scenario based on that.
+    /**
+     * A data store created by a client, is a local data store for that client. Also, when a detached container loads
+     * from a snapshot, all the data stores are treated as local data stores because at that stage the container
+     * still doesn't exists in storage and so the data store couldn't have been created by any other client.
+     * Value of this never changes even after the data store is attached.
+     * As implementer of data store runtime, you can use this property to check that this data store belongs to this
+     * client and hence implement any scenario based on that.
+     */
     readonly isLocalDataStore: boolean;
+    /**
+     * A data store that is created via the "createRootDataStore" API. Root data stores are never garbage collected and
+     * can be found / loaded by name.
+     */
+    readonly isRootDataStore: boolean;
     /**
      * The package path of the data store as per the package factory.
      */

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -251,11 +251,6 @@ export interface IFluidDataStoreContext extends EventEmitter, Partial<IProvideFl
      */
     readonly isLocalDataStore: boolean;
     /**
-     * A data store that is created via the "createRootDataStore" API. Root data stores are never garbage collected and
-     * can be found / loaded by name.
-     */
-    readonly isRootDataStore: boolean;
-    /**
      * The package path of the data store as per the package factory.
      */
     readonly packagePath: readonly string[];

--- a/packages/test/snapshots/README.md
+++ b/packages/test/snapshots/README.md
@@ -1,6 +1,9 @@
 # @fluid-internal/test-snapshots
 
-If it is the first time you are syncing the content for the snapshot tests you should run the following command:
-`git submodule update --init --recursive`
+If it is the first time you are syncing the content for the snapshot tests, you need to do the following:
+- Make sure you have "git lfs" installed.
+- Run the following command:
+
+    `git submodule update --init --recursive`
 
 This will pull all the content down to enable running the snapshot tests.


### PR DESCRIPTION
Fixes #3968 

This is a pre-cursor to Garbage Collection. We need to identify root data stores as they are always considered referenced and so are not collected.

Added an "isRootDataStore" flag to "IFluidDataStoreAttributes" which is added to the data store's ".component" blob in the summary.