### PR TITLE
[0.27 port] Restructure ODSP connection telemetry (#3965)

### DIFF
--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -62,6 +62,7 @@
     "@fluidframework/protocol-base": "^0.1013.0",
     "@fluidframework/protocol-definitions": "^0.1013.0",
     "@fluidframework/telemetry-utils": "^0.27.2",
+    "assert": "^2.0.0",
     "debug": "^4.1.1",
     "lodash": "^4.17.19",
     "node-fetch": "^2.2.1",

--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -50,9 +50,14 @@ export interface ISocketStorageDiscovery {
     snapshotStorageUrl: string;
     deltaStorageUrl: string;
 
+    /**
+     * The non-AFD URL
+     */
     deltaStreamSocketUrl: string;
 
-    // The AFD URL for PushChannel
+    /**
+     * The AFD URL for PushChannel
+     */
     deltaStreamSocketUrl2?: string;
 }
 

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -3,11 +3,12 @@
  * Licensed under the MIT License.
  */
 
+import assert from "assert";
 // eslint-disable-next-line import/no-internal-modules
 import cloneDeep from "lodash/cloneDeep";
 
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
-import { performance, TelemetryNullLogger } from "@fluidframework/common-utils";
+import { performance } from "@fluidframework/common-utils";
 import { ChildLogger, TelemetryLogger } from "@fluidframework/telemetry-utils";
 import {
     IDocumentDeltaConnection,
@@ -16,6 +17,7 @@ import {
     IResolvedUrl,
     IDocumentStorageService,
 } from "@fluidframework/driver-definitions";
+import { canRetryOnError } from "@fluidframework/driver-utils";
 import {
     IClient,
     IErrorTrackingService,
@@ -27,7 +29,6 @@ import {
     HostStoragePolicyInternal,
     ISocketStorageDiscovery,
 } from "./contracts";
-import { debug } from "./debug";
 import { IOdspCache, startingUpdateUsageOpFrequency, updateUsageOpMultiplier } from "./odspCache";
 import { OdspDeltaStorageService } from "./odspDeltaStorageService";
 import { OdspDocumentDeltaConnection } from "./odspDocumentDeltaConnection";
@@ -39,6 +40,46 @@ import { TokenFetchOptions } from "./tokenFetch";
 
 const afdUrlConnectExpirationMs = 6 * 60 * 60 * 1000; // 6 hours
 const lastAfdConnectionTimeMsKey = "LastAfdConnectionTimeMs";
+
+const localStorageAvailable = isLocalStorageAvailable();
+
+/**
+ * Helper to check the timestamp in localStorage (if available) indicating whether the cache is still valid.
+ */
+function isAfdCacheValid(): boolean {
+    if (localStorageAvailable) {
+        const lastAfdConnection = localStorage.getItem(lastAfdConnectionTimeMsKey);
+        if (lastAfdConnection !== null) {
+            const lastAfdTimeMs = Number(lastAfdConnection);
+            // If we have used the AFD URL within a certain amount of time in the past,
+            // then we should use it again.
+            if (!isNaN(lastAfdTimeMs) && lastAfdTimeMs > 0
+                && Date.now() - lastAfdTimeMs <= afdUrlConnectExpirationMs) {
+                return true;
+            } else {
+                localStorage.removeItem(lastAfdConnectionTimeMsKey);
+            }
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Safely tries to write to local storage
+ * Returns false if writing to localStorage fails. True otherwise
+ *
+ * @param key - localStorage key
+ * @returns whether or not the write succeeded
+ */
+function writeLocalStorage(key: string, value: string) {
+    try {
+        localStorage.setItem(key, value);
+        return true;
+    } catch (e) {
+        return false;
+    }
+}
 
 /**
  * The DocumentService manages the Socket.IO connection and manages routing requests to connected
@@ -79,8 +120,6 @@ export class OdspDocumentService implements IDocumentService {
     private storageManager?: OdspDocumentStorageService;
 
     private readonly logger: TelemetryLogger;
-
-    private readonly localStorageAvailable: boolean;
 
     private readonly joinSessionKey: string;
 
@@ -123,8 +162,6 @@ export class OdspDocumentService implements IDocumentService {
             this.hostPolicy = cloneDeep(this.hostPolicy);
             this.hostPolicy.summarizerClient = true;
         }
-
-        this.localStorageAvailable = isLocalStorageAvailable();
     }
 
     public get resolvedUrl(): IResolvedUrl {
@@ -251,34 +288,6 @@ export class OdspDocumentService implements IDocumentService {
     }
 
     /**
-     * Safely tries to write to local storage
-     * Returns false if writing to localStorage fails. True otherwise
-     *
-     * @param key - localStorage key
-     * @returns whether or not the write succeeded
-     */
-    private writeLocalStorage(key: string, value: string) {
-        try {
-            localStorage.setItem(key, value);
-            return true;
-        } catch (e) {
-            debug(`Could not write to localStorage due to ${e}`);
-            return false;
-        }
-    }
-
-    /**
-     * Test if we deal with NetworkErrorBasic object and if it has enough information to make a call
-     * If in doubt, allow retries
-     *
-     * @param error - error object
-     */
-    private canRetryOnError(error: any) {
-        // Always retry unless told otherwise.
-        return error === null || typeof error !== "object" || error.canRetry === undefined || error.canRetry;
-    }
-
-    /**
      * Connects to a delta stream endpoint
      * If url #1 fails to connect, tries url #2 if applicable
      *
@@ -287,8 +296,8 @@ export class OdspDocumentService implements IDocumentService {
      * @param token - authorization token for storage service
      * @param io - websocket library
      * @param client - information about the client
-     * @param url - websocket URL
-     * @param url2 - alternate websocket URL
+     * @param nonAfdUrl - websocket URL
+     * @param afdUrl - alternate websocket URL
      */
     private async connectToDeltaStreamWithRetry(
         tenantId: string,
@@ -296,148 +305,115 @@ export class OdspDocumentService implements IDocumentService {
         token: string | null,
         io: SocketIOClientStatic,
         client: IClient,
-        url: string,
-        url2?: string): Promise<IDocumentDeltaConnection> {
-        const hasUrl2 = !!url2;
-
-        // Create null logger if telemetry logger is not available from caller
-        const logger = this.logger ? this.logger : new TelemetryNullLogger();
-
-        let afdCacheValid = false;
-
-        if (this.localStorageAvailable) {
-            const lastAfdConnection = localStorage.getItem(lastAfdConnectionTimeMsKey);
-            if (lastAfdConnection !== null) {
-                const lastAfdTimeMs = Number(lastAfdConnection);
-                // If we have used the AFD URL within a certain amount of time in the past,
-                // then we should use it again.
-                if (!isNaN(lastAfdTimeMs) && lastAfdTimeMs > 0
-                    && Date.now() - lastAfdTimeMs <= afdUrlConnectExpirationMs) {
-                    afdCacheValid = true;
-                } else {
-                    localStorage.removeItem(lastAfdConnectionTimeMsKey);
-                }
-            }
-        }
-
-        // Use AFD URL if in cache
-        if (afdCacheValid && hasUrl2) {
-            debug("Connecting to AFD URL directly due to valid cache.");
-            const startAfd = performance.now();
-
-            return OdspDocumentDeltaConnection.create(
-                tenantId,
-                documentId,
-                token,
-                io,
-                client,
-                url2!,
-                20000,
-                this.logger,
-            ).then((connection) => {
-                logger.sendTelemetryEvent({
-                    eventName: "UsedAfdUrl",
-                    fromCache: true,
-                });
-
-                return connection;
-            }).catch(async (connectionError) => {
-                const endAfd = performance.now();
-                localStorage.removeItem(lastAfdConnectionTimeMsKey);
-                // Retry on non-AFD URL
-                if (this.canRetryOnError(connectionError)) {
-                    // eslint-disable-next-line max-len
-                    debug(`Socket connection error on AFD URL (cached). Error was [${connectionError}]. Retry on non-AFD URL: ${url}`);
-
-                    return OdspDocumentDeltaConnection.create(
-                        tenantId,
-                        documentId,
-                        token,
-                        io,
-                        client,
-                        url,
-                        20000,
-                        this.logger,
-                    ).then((connection) => {
-                        logger.sendPerformanceEvent({
-                            eventName: "UsedNonAfdUrlFallback",
-                            duration: endAfd - startAfd,
-                        }, connectionError);
-
-                        return connection;
-                    }).catch((retryError) => {
-                        logger.sendPerformanceEvent({
-                            eventName: "FailedNonAfdUrlFallback",
-                            duration: endAfd - startAfd,
-                        }, retryError);
-                        throw retryError;
-                    });
-                } else {
-                    logger.sendPerformanceEvent({
-                        eventName: "FailedAfdUrl-NoNonAfdFallback",
-                    }, connectionError);
-                }
-                throw connectionError;
-            });
-        }
-
-        const startNonAfd = performance.now();
-        return OdspDocumentDeltaConnection.create(
-            tenantId,
-            documentId,
-            token,
-            io,
-            client,
-            url,
-            hasUrl2 ? 15000 : 20000,
-            this.logger,
-        ).then((connection) => {
-            logger.sendTelemetryEvent({ eventName: "UsedNonAfdUrl" });
-            return connection;
-        }).catch(async (connectionError) => {
-            const endNonAfd = performance.now();
-            if (hasUrl2 && this.canRetryOnError(connectionError)) {
-                // eslint-disable-next-line max-len
-                debug(`Socket connection error on non-AFD URL. Error was [${connectionError}]. Retry on AFD URL: ${url2}`);
-
-                return OdspDocumentDeltaConnection.create(
+        nonAfdUrl: string,
+        afdUrl?: string,
+    ): Promise<IDocumentDeltaConnection> {
+        const connectWithNonAfd = async () => {
+            const startTime = performance.now();
+            try {
+                const connection = await OdspDocumentDeltaConnection.create(
                     tenantId,
                     documentId,
                     token,
                     io,
                     client,
-                    url2!,
+                    nonAfdUrl,
                     20000,
                     this.logger,
-                ).then((connection) => {
-                    // Refresh AFD cache
-                    const cacheResult = this.writeLocalStorage(lastAfdConnectionTimeMsKey, Date.now().toString());
-                    if (cacheResult) {
-                        // eslint-disable-next-line max-len
-                        debug(`Cached AFD connection time. Expiring in ${new Date(Number(localStorage.getItem(lastAfdConnectionTimeMsKey)) + afdUrlConnectExpirationMs)}`);
-                    }
-                    logger.sendPerformanceEvent({
-                        eventName: "UsedAfdUrl",
-                        duration: endNonAfd - startNonAfd,
-                        refreshedCache: cacheResult,
-                        fromCache: false,
-                    }, connectionError);
-
-                    return connection;
-                }).catch((retryError) => {
-                    logger.sendPerformanceEvent({
-                        eventName: "FailedAfdUrlFallback",
-                        duration: endNonAfd - startNonAfd,
-                    }, retryError);
-                    throw retryError;
+                );
+                const endTime = performance.now();
+                this.logger.sendPerformanceEvent({
+                    eventName: "NonAfdConnectionSuccess",
+                    duration: endTime - startTime,
                 });
-            } else {
-                logger.sendPerformanceEvent({
-                    eventName: "FailedNonAfdUrl-NoAfdFallback",
-                }, connectionError);
+                return connection;
+            } catch (connectionError) {
+                const endTime = performance.now();
+                // Log before throwing
+                const canRetry = canRetryOnError(connectionError);
+                this.logger.sendPerformanceEvent(
+                    {
+                        eventName: "NonAfdConnectionFail",
+                        canRetry,
+                        duration: endTime - startTime,
+                    },
+                    connectionError,
+                );
+                throw connectionError;
+            }
+        };
+
+        const connectWithAfd = async () => {
+            assert(afdUrl !== undefined, "Tried to connect with AFD but no AFD url provided");
+
+            const startTime = performance.now();
+            try {
+                const connection = await OdspDocumentDeltaConnection.create(
+                    tenantId,
+                    documentId,
+                    token,
+                    io,
+                    client,
+                    afdUrl,
+                    20000,
+                    this.logger,
+                );
+                const endTime = performance.now();
+                // Set the successful connection attempt in the cache so we can skip the non-AFD failure the next time
+                // we try to connect and immediately try AFD instead.
+                writeLocalStorage(lastAfdConnectionTimeMsKey, Date.now().toString());
+                this.logger.sendPerformanceEvent({
+                    eventName: "AfdConnectionSuccess",
+                    duration: endTime - startTime,
+                });
+                return connection;
+            } catch (connectionError) {
+                const endTime = performance.now();
+                // Clear cache since it failed
+                localStorage.removeItem(lastAfdConnectionTimeMsKey);
+                // Log before throwing
+                const canRetry = canRetryOnError(connectionError);
+                this.logger.sendPerformanceEvent(
+                    {
+                        eventName: "AfdConnectionFail",
+                        canRetry,
+                        duration: endTime - startTime,
+                    },
+                    connectionError,
+                );
+                throw connectionError;
+            }
+        };
+
+        const afdCacheValid = isAfdCacheValid();
+
+        // First use the AFD URL if we've logged a successful AFD connection in the cache - its presence in the cache
+        // means the non-AFD url has failed in the past, in which case we would prefer to skip doing another
+        // attempt->fail on the non-AFD.
+        if (afdCacheValid && afdUrl !== undefined) {
+            try {
+                const connection = await connectWithAfd();
+                return connection;
+            } catch (connectionError) {
+                // Fall back to non-AFD if possible
+                if (canRetryOnError(connectionError)) {
+                    return connectWithNonAfd();
+                }
+                throw connectionError;
+            }
+        }
+
+        // If we don't have a successful AFD connection in the cache, prefer connecting with non-AFD.
+        try {
+            const connection = await connectWithNonAfd();
+            return connection;
+        } catch (connectionError) {
+            // Fall back to AFD if possible
+            if (canRetryOnError(connectionError) && afdUrl !== undefined) {
+                return connectWithAfd();
             }
             throw connectionError;
-        });
+        }
     }
 
     // Called whenever re receive ops through any channel for this document (snapshot, delta connection, delta storage)

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -39,6 +39,7 @@ import {
     ScopeType,
 } from "@fluidframework/protocol-definitions";
 import {
+    canRetryOnError,
     createWriteError,
     createGenericNetworkError,
 } from "@fluidframework/driver-utils";
@@ -61,9 +62,6 @@ const ImmediateNoOpResponse = "";
 
 const DefaultContentBufferSize = 10;
 
-// Test if we deal with NetworkError object and if it has enough information to make a call.
-// If in doubt, allow retries.
-const canRetryOnError = (error: any): boolean => error?.canRetry !== false;
 const getRetryDelayFromError = (error: any): number | undefined => error?.retryAfterSeconds;
 
 function getNackReconnectInfo(nackContent: INackContent) {

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -103,3 +103,9 @@ export function createGenericNetworkError(
     }
     return new GenericNetworkError(errorMessage, canRetry, statusCode);
 }
+
+/**
+ * Check if a connection error can be retried.  Unless explicitly disallowed, retry is allowed.
+ * @param error - The error to inspect for ability to retry
+ */
+export const canRetryOnError = (error: any): boolean => error?.canRetry !== false;


### PR DESCRIPTION
This change restructures the connection to unify connection logic and telemetry on AFD vs. non-AFD. The distinction of cache vs. first-attempt vs. fallback should be derivable from telemetry without specially-named events. This should also make it easier to observe connection timing (some of the flows don't log enough data to determine this currently).

This change does include one functional change beyond telemetry - currently we only write the AFD-valid cache if there wasn't a valid cache. With this change, we'll write an updated timestamp to the cache on successful AFD connection regardless of the prior state of the cache.