### PR TITLE
Fixed InsecureTinyliciousUrlResolver to include relative path and added tests

### DIFF
--- a/examples/utils/get-session-storage-container/src/getSessionStorageContainer.ts
+++ b/examples/utils/get-session-storage-container/src/getSessionStorageContainer.ts
@@ -54,7 +54,6 @@ export async function getSessionStorageContainer(
         container = await loader.createDetachedContainer({ package: "", config: {} });
         await container.attach({ url });
     } else {
-        // The InsecureTinyliciousUrlResolver expects the url of the request to be the documentId.
         container = await loader.resolve({ url });
         // If we didn't create the container properly, then it won't function correctly.  So we'll throw if we got a
         // new container here, where we expect this to be loading an existing container.

--- a/examples/utils/get-tinylicious-container/package.json
+++ b/examples/utils/get-tinylicious-container/package.json
@@ -29,6 +29,7 @@
     "@fluidframework/container-loader": "^0.28.0",
     "@fluidframework/core-interfaces": "^0.28.0",
     "@fluidframework/driver-definitions": "^0.28.0",
+    "@fluidframework/driver-utils": "^0.28.0",
     "@fluidframework/protocol-definitions": "^0.1014.0-0",
     "@fluidframework/routerlicious-driver": "^0.28.0",
     "jsonwebtoken": "^8.4.0",
@@ -38,6 +39,7 @@
     "@fluidframework/build-common": "^0.19.2",
     "@fluidframework/eslint-config-fluid": "^0.20.0-0",
     "@fluidframework/test-tools": "^0.2.3074",
+    "@types/mocha": "^5.2.5",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
@@ -49,6 +51,7 @@
     "eslint-plugin-prefer-arrow": "~1.2.2",
     "eslint-plugin-react": "~7.21.2",
     "eslint-plugin-unicorn": "~22.0.0",
+    "mocha": "^8.1.1",
     "rimraf": "^2.6.2",
     "typescript": "~3.7.4",
     "typescript-formatter": "7.1.0"

--- a/examples/utils/get-tinylicious-container/src/getTinyliciousContainer.ts
+++ b/examples/utils/get-tinylicious-container/src/getTinyliciousContainer.ts
@@ -27,10 +27,12 @@ import { getContainer } from "./getContainer";
  */
 class InsecureTinyliciousUrlResolver implements IUrlResolver {
     public async resolve(request: IRequest): Promise<IResolvedUrl> {
-        const documentId = request.url.split("/")[0];
+        const parsedUrl = new URL(request.url);
+        const fullPath = parsedUrl.pathname.substr(1);
+        const documentId = fullPath.split("/")[0];
         const encodedDocId = encodeURIComponent(documentId);
 
-        const documentUrl = `fluid://localhost:3000/tinylicious/${encodedDocId}`;
+        const documentUrl = `fluid://localhost:3000/tinylicious/${fullPath}`;
         const deltaStorageUrl = `http://localhost:3000/deltas/tinylicious/${encodedDocId}`;
         const storageUrl = `http://localhost:3000/repos/tinylicious`;
 

--- a/examples/utils/get-tinylicious-container/src/getTinyliciousContainer.ts
+++ b/examples/utils/get-tinylicious-container/src/getTinyliciousContainer.ts
@@ -44,6 +44,8 @@ class InsecureTinyliciousUrlResolver implements IUrlResolver {
             },
             tokens: { jwt: this.auth(documentId) },
             type: "fluid",
+            // This is wrong as it should contain the full path, but it doesn't matter
+            // because we never give out loader in this flow
             url: documentUrl,
         };
         return response;

--- a/examples/utils/get-tinylicious-container/src/getTinyliciousContainer.ts
+++ b/examples/utils/get-tinylicious-container/src/getTinyliciousContainer.ts
@@ -3,76 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import { IRequest } from "@fluidframework/core-interfaces";
 import {
     IRuntimeFactory,
 } from "@fluidframework/container-definitions";
 import { Container } from "@fluidframework/container-loader";
-import {
-    IFluidResolvedUrl,
-    IResolvedUrl,
-    IUrlResolver,
-} from "@fluidframework/driver-definitions";
-import { ITokenClaims } from "@fluidframework/protocol-definitions";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
-import jwt from "jsonwebtoken";
-import { v4 as uuid } from "uuid";
 import { getContainer } from "./getContainer";
-
-/**
- * InsecureTinyliciousUrlResolver knows how to get the URLs to the service (in this case Tinylicious) to use
- * for a given request.  This particular implementation has a goal to avoid imposing requirements on the app's
- * URL shape, so it expects the request url to have this format (as opposed to a more traditional URL):
- * documentId/containerRelativePathing
- */
-export class InsecureTinyliciousUrlResolver implements IUrlResolver {
-    public async resolve(request: IRequest): Promise<IResolvedUrl> {
-        const url = request.url;
-        const documentId = url.split("/")[0];
-        const encodedDocId = encodeURIComponent(documentId);
-        url.replace(documentId,encodedDocId);
-
-        const documentUrl = `fluid://localhost:3000/tinylicious/${url}`;
-        const deltaStorageUrl = `http://localhost:3000/deltas/tinylicious/${encodedDocId}`;
-        const storageUrl = `http://localhost:3000/repos/tinylicious`;
-
-        const response: IFluidResolvedUrl = {
-            endpoints: {
-                deltaStorageUrl,
-                ordererUrl: "http://localhost:3000",
-                storageUrl,
-            },
-            tokens: { jwt: this.auth(documentId) },
-            type: "fluid",
-            url: documentUrl,
-        };
-        return response;
-    }
-
-    public async getAbsoluteUrl(resolvedUrl: IFluidResolvedUrl, relativeUrl: string): Promise<string> {
-        const documentId = decodeURIComponent(resolvedUrl.url.replace("fluid://localhost:3000/tinylicious/", ""));
-        /*
-         * The detached container flow will ultimately call getAbsoluteUrl() with the resolved.url produced by
-         * resolve().  The container expects getAbsoluteUrl's return value to be a URL that can then be roundtripped
-         * back through resolve() again, and get the same result again.  So we'll return a "URL" with the same format
-         * described above.
-         */
-        return `${documentId}/${relativeUrl}`;
-    }
-
-    private auth(documentId: string) {
-        const claims: ITokenClaims = {
-            documentId,
-            scopes: ["doc:read", "doc:write", "summary:write"],
-            tenantId: "tinylicious",
-            user: { id: uuid() },
-        };
-
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        return jwt.sign(claims, "12345");
-    }
-}
-
+import { InsecureTinyliciousUrlResolver } from "./insecureTinyliciousUrlResolver";
 /**
  * Connect to the Tinylicious service and retrieve a Container with the given ID running the given code.
  * @param documentId - The document id to retrieve or create

--- a/examples/utils/get-tinylicious-container/src/getTinyliciousContainer.ts
+++ b/examples/utils/get-tinylicious-container/src/getTinyliciousContainer.ts
@@ -27,12 +27,10 @@ import { getContainer } from "./getContainer";
  */
 class InsecureTinyliciousUrlResolver implements IUrlResolver {
     public async resolve(request: IRequest): Promise<IResolvedUrl> {
-        const parsedUrl = new URL(request.url);
-        const fullPath = parsedUrl.pathname.substr(1);
-        const documentId = fullPath.split("/")[0];
+        const documentId = request.url.split("/")[0];
         const encodedDocId = encodeURIComponent(documentId);
 
-        const documentUrl = `fluid://localhost:3000/tinylicious/${fullPath}`;
+        const documentUrl = `fluid://localhost:3000/tinylicious/${encodedDocId}`;
         const deltaStorageUrl = `http://localhost:3000/deltas/tinylicious/${encodedDocId}`;
         const storageUrl = `http://localhost:3000/repos/tinylicious`;
 

--- a/examples/utils/get-tinylicious-container/src/getTinyliciousContainer.ts
+++ b/examples/utils/get-tinylicious-container/src/getTinyliciousContainer.ts
@@ -25,12 +25,14 @@ import { getContainer } from "./getContainer";
  * URL shape, so it expects the request url to have this format (as opposed to a more traditional URL):
  * documentId/containerRelativePathing
  */
-class InsecureTinyliciousUrlResolver implements IUrlResolver {
+export class InsecureTinyliciousUrlResolver implements IUrlResolver {
     public async resolve(request: IRequest): Promise<IResolvedUrl> {
-        const documentId = request.url.split("/")[0];
+        const url = request.url;
+        const documentId = url.split("/")[0];
         const encodedDocId = encodeURIComponent(documentId);
+        url.replace(documentId,encodedDocId);
 
-        const documentUrl = `fluid://localhost:3000/tinylicious/${encodedDocId}`;
+        const documentUrl = `fluid://localhost:3000/tinylicious/${url}`;
         const deltaStorageUrl = `http://localhost:3000/deltas/tinylicious/${encodedDocId}`;
         const storageUrl = `http://localhost:3000/repos/tinylicious`;
 

--- a/examples/utils/get-tinylicious-container/src/getTinyliciousContainer.ts
+++ b/examples/utils/get-tinylicious-container/src/getTinyliciousContainer.ts
@@ -44,8 +44,6 @@ export class InsecureTinyliciousUrlResolver implements IUrlResolver {
             },
             tokens: { jwt: this.auth(documentId) },
             type: "fluid",
-            // This is wrong as it should contain the full path, but it doesn't matter
-            // because we never give out loader in this flow
             url: documentUrl,
         };
         return response;

--- a/examples/utils/get-tinylicious-container/src/insecureTinyliciousUrlResolver.ts
+++ b/examples/utils/get-tinylicious-container/src/insecureTinyliciousUrlResolver.ts
@@ -1,0 +1,68 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IRequest } from "@fluidframework/core-interfaces";
+import {
+    IFluidResolvedUrl,
+    IResolvedUrl,
+    IUrlResolver,
+} from "@fluidframework/driver-definitions";
+import { ITokenClaims } from "@fluidframework/protocol-definitions";
+import jwt from "jsonwebtoken";
+import { v4 as uuid } from "uuid";
+/**
+ * InsecureTinyliciousUrlResolver knows how to get the URLs to the service (in this case Tinylicious) to use
+ * for a given request.  This particular implementation has a goal to avoid imposing requirements on the app's
+ * URL shape, so it expects the request url to have this format (as opposed to a more traditional URL):
+ * documentId/containerRelativePathing
+ */
+export class InsecureTinyliciousUrlResolver implements IUrlResolver {
+    public async resolve(request: IRequest): Promise<IResolvedUrl> {
+        const url = request.url;
+        const documentId = url.split("/")[0];
+        const encodedDocId = encodeURIComponent(documentId);
+        const documentRelativePath = url.slice(documentId.length);
+        url.replace(documentId,encodedDocId);
+
+        const documentUrl = `fluid://localhost:3000/tinylicious/${encodedDocId}${documentRelativePath}`;
+        const deltaStorageUrl = `http://localhost:3000/deltas/tinylicious/${encodedDocId}`;
+        const storageUrl = `http://localhost:3000/repos/tinylicious`;
+
+        const response: IFluidResolvedUrl = {
+            endpoints: {
+                deltaStorageUrl,
+                ordererUrl: "http://localhost:3000",
+                storageUrl,
+            },
+            tokens: { jwt: this.auth(documentId) },
+            type: "fluid",
+            url: documentUrl,
+        };
+        return response;
+    }
+
+    public async getAbsoluteUrl(resolvedUrl: IFluidResolvedUrl, relativeUrl: string): Promise<string> {
+        const documentId = decodeURIComponent(resolvedUrl.url.replace("fluid://localhost:3000/tinylicious/", ""));
+        /*
+         * The detached container flow will ultimately call getAbsoluteUrl() with the resolved.url produced by
+         * resolve().  The container expects getAbsoluteUrl's return value to be a URL that can then be roundtripped
+         * back through resolve() again, and get the same result again.  So we'll return a "URL" with the same format
+         * described above.
+         */
+        return `${documentId}/${relativeUrl}`;
+    }
+
+    private auth(documentId: string) {
+        const claims: ITokenClaims = {
+            documentId,
+            scopes: ["doc:read", "doc:write", "summary:write"],
+            tenantId: "tinylicious",
+            user: { id: uuid() },
+        };
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return jwt.sign(claims, "12345");
+    }
+}

--- a/examples/utils/get-tinylicious-container/src/insecureTinyliciousUrlResolver.ts
+++ b/examples/utils/get-tinylicious-container/src/insecureTinyliciousUrlResolver.ts
@@ -20,11 +20,9 @@ import { v4 as uuid } from "uuid";
  */
 export class InsecureTinyliciousUrlResolver implements IUrlResolver {
     public async resolve(request: IRequest): Promise<IResolvedUrl> {
-        const url = request.url;
-        const documentId = url.split("/")[0];
+        const documentId = request.url.split("/")[0];
         const encodedDocId = encodeURIComponent(documentId);
-        const documentRelativePath = url.slice(documentId.length);
-        url.replace(documentId,encodedDocId);
+        const documentRelativePath = request.url.slice(documentId.length);
 
         const documentUrl = `fluid://localhost:3000/tinylicious/${encodedDocId}${documentRelativePath}`;
         const deltaStorageUrl = `http://localhost:3000/deltas/tinylicious/${encodedDocId}`;

--- a/examples/utils/get-tinylicious-container/src/test/insecureTinyliciousUrlResolverTest.spec.ts
+++ b/examples/utils/get-tinylicious-container/src/test/insecureTinyliciousUrlResolverTest.spec.ts
@@ -4,11 +4,9 @@
  */
 
 import { strict as assert } from "assert";
-// import { DriverHeader, IFluidResolvedUrl } from "@fluidframework/driver-definitions";
 import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
-// import { IUser } from "@fluidframework/protocol-definitions";
 import { IRequest } from "@fluidframework/core-interfaces";
-import { InsecureTinyliciousUrlResolver } from "../getTinyliciousContainer";
+import { InsecureTinyliciousUrlResolver } from "../insecureTinyliciousUrlResolver";
 
 describe("Insecure Url Resolver Test", () => {
     const documentId = "fileName";
@@ -19,7 +17,7 @@ describe("Insecure Url Resolver Test", () => {
         resolver = new InsecureTinyliciousUrlResolver();
     });
 
-    it("Test RequestUrl for url with only document id", async () => {
+    it("Should resolve url with only document id", async () => {
         const testRequest: IRequest = {
             url: `${documentId}`,
             headers: {},
@@ -32,11 +30,10 @@ describe("Insecure Url Resolver Test", () => {
         assert.strictEqual(resolvedUrl.url, expectedResolvedUrl, "resolved url is wrong");
     });
 
-    it("Test RequestUrl for url with data object ids", async () => {
+    it("Should resolve url with data object ids", async () => {
         const path = "dataObject1/dataObject2";
         const testRequest: IRequest = {
             url: `${documentId}/${path}`,
-            headers: {},
         };
 
         const resolvedUrl = await resolver.resolve(testRequest);
@@ -46,10 +43,9 @@ describe("Insecure Url Resolver Test", () => {
         assert.strictEqual(resolvedUrl.url, expectedResolvedUrl, "resolved url is wrong");
     });
 
-    it("Test RequestUrl for url with a slash at the end", async () => {
+    it("Should resolve url with a slash at the end", async () => {
         const testRequest: IRequest = {
             url: `${documentId}/`,
-            headers: {},
         };
 
         const resolvedUrl = await resolver.resolve(testRequest);
@@ -59,10 +55,9 @@ describe("Insecure Url Resolver Test", () => {
         assert.strictEqual(resolvedUrl.url, expectedResolvedUrl, "resolved url is wrong");
     });
 
-    it("Test RequestUrl for url with 2 slashes at the end", async () => {
+    it("Should resolve url with 2 slashes at the end", async () => {
         const testRequest: IRequest = {
             url: `${documentId}//`,
-            headers: {},
         };
 
         const resolvedUrl = await resolver.resolve(testRequest);
@@ -72,17 +67,17 @@ describe("Insecure Url Resolver Test", () => {
         assert.strictEqual(resolvedUrl.url, expectedResolvedUrl, "resolved url is wrong");
     });
 
-    it("Test RequestUrl for url with special characters", async () => {
-        const path = "dataObject!@";
+    it("Should resolve url with special characters", async () => {
+        const path = "dataObject!@$";
+        const testDocumentId = "fileName!@$";
         const testRequest: IRequest = {
-            url: `${documentId}/${path}`,
-            headers: {},
+            url: `${testDocumentId}/${path}`,
         };
 
         const resolvedUrl = await resolver.resolve(testRequest);
         ensureFluidResolvedUrl(resolvedUrl);
 
-        const expectedResolvedUrl = `${hostUrl}/tinylicious/${documentId}/${path}`;
+        const expectedResolvedUrl = `${hostUrl}/tinylicious/${encodeURIComponent(testDocumentId)}/${path}`;
         assert.strictEqual(resolvedUrl.url, expectedResolvedUrl, "resolved url is wrong");
     });
 });

--- a/examples/utils/get-tinylicious-container/src/test/insecureTinyliciousUrlResolverTest.spec.ts
+++ b/examples/utils/get-tinylicious-container/src/test/insecureTinyliciousUrlResolverTest.spec.ts
@@ -1,0 +1,88 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+// import { DriverHeader, IFluidResolvedUrl } from "@fluidframework/driver-definitions";
+import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
+// import { IUser } from "@fluidframework/protocol-definitions";
+import { IRequest } from "@fluidframework/core-interfaces";
+import { InsecureTinyliciousUrlResolver } from "../getTinyliciousContainer";
+
+describe("Insecure Url Resolver Test", () => {
+    const documentId = "fileName";
+    const hostUrl = "fluid://localhost:3000";
+    let resolver: InsecureTinyliciousUrlResolver;
+
+    beforeEach(() => {
+        resolver = new InsecureTinyliciousUrlResolver();
+    });
+
+    it("Test RequestUrl for url with only document id", async () => {
+        const testRequest: IRequest = {
+            url: `${documentId}`,
+            headers: {},
+        };
+
+        const resolvedUrl = await resolver.resolve(testRequest);
+        ensureFluidResolvedUrl(resolvedUrl);
+
+        const expectedResolvedUrl = `${hostUrl}/tinylicious/${documentId}`;
+        assert.strictEqual(resolvedUrl.url, expectedResolvedUrl, "resolved url is wrong");
+    });
+
+    it("Test RequestUrl for url with data object ids", async () => {
+        const path = "dataObject1/dataObject2";
+        const testRequest: IRequest = {
+            url: `${documentId}/${path}`,
+            headers: {},
+        };
+
+        const resolvedUrl = await resolver.resolve(testRequest);
+        ensureFluidResolvedUrl(resolvedUrl);
+
+        const expectedResolvedUrl = `${hostUrl}/tinylicious/${documentId}/${path}`;
+        assert.strictEqual(resolvedUrl.url, expectedResolvedUrl, "resolved url is wrong");
+    });
+
+    it("Test RequestUrl for url with a slash at the end", async () => {
+        const testRequest: IRequest = {
+            url: `${documentId}/`,
+            headers: {},
+        };
+
+        const resolvedUrl = await resolver.resolve(testRequest);
+        ensureFluidResolvedUrl(resolvedUrl);
+
+        const expectedResolvedUrl = `${hostUrl}/tinylicious/${documentId}/`;
+        assert.strictEqual(resolvedUrl.url, expectedResolvedUrl, "resolved url is wrong");
+    });
+
+    it("Test RequestUrl for url with 2 slashes at the end", async () => {
+        const testRequest: IRequest = {
+            url: `${documentId}//`,
+            headers: {},
+        };
+
+        const resolvedUrl = await resolver.resolve(testRequest);
+        ensureFluidResolvedUrl(resolvedUrl);
+
+        const expectedResolvedUrl = `${hostUrl}/tinylicious/${documentId}//`;
+        assert.strictEqual(resolvedUrl.url, expectedResolvedUrl, "resolved url is wrong");
+    });
+
+    it("Test RequestUrl for url with special characters", async () => {
+        const path = "dataObject!@";
+        const testRequest: IRequest = {
+            url: `${documentId}/${path}`,
+            headers: {},
+        };
+
+        const resolvedUrl = await resolver.resolve(testRequest);
+        ensureFluidResolvedUrl(resolvedUrl);
+
+        const expectedResolvedUrl = `${hostUrl}/tinylicious/${documentId}/${path}`;
+        assert.strictEqual(resolvedUrl.url, expectedResolvedUrl, "resolved url is wrong");
+    });
+});

--- a/examples/utils/get-tinylicious-container/tsconfig.json
+++ b/examples/utils/get-tinylicious-container/tsconfig.json
@@ -5,8 +5,11 @@
         "node_modules"
     ],
     "compilerOptions": {
-        "module": "esnext",
-        "outDir": "dist"
+        "rootDir": "./src",
+        "outDir": "./dist",
+        "types": [
+            "mocha"
+        ]
     },
     "include": [
         "src/**/*"


### PR DESCRIPTION
Fixed InsecureTinyliciousUrlResolver to include relative path instead of just document id. Added several test cases.
Removed a stale comment in getSessionStorageContainer.ts
related to #2079 