### PR TITLE
Enable testing orderer services in case blob storage services are down

### DIFF
--- a/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
+++ b/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
@@ -33,7 +33,9 @@ export class LocalDocumentServiceFactory implements IDocumentServiceFactory {
     /**
      * @param localDeltaConnectionServer - delta connection server for ops
      */
-    constructor(private readonly localDeltaConnectionServer: ILocalDeltaConnectionServer) { }
+    constructor(
+        private readonly localDeltaConnectionServer: ILocalDeltaConnectionServer,
+        private readonly innerDocumentService?: IDocumentService) { }
 
     public async createContainer(
         createNewSummary: ISummaryTree,
@@ -100,7 +102,8 @@ export class LocalDocumentServiceFactory implements IDocumentServiceFactory {
             tokenProvider,
             tenantId,
             documentId,
-            this.documentDeltaConnectionsMap);
+            this.documentDeltaConnectionsMap,
+            this.innerDocumentService);
     }
 
     /**

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -17,7 +17,6 @@ import {
     isFluidBrowserPackage,
 } from "@fluidframework/container-definitions";
 import { Container, Loader } from "@fluidframework/container-loader";
-import { IUrlResolver } from "@fluidframework/driver-definitions";
 import { IUser } from "@fluidframework/protocol-definitions";
 import { HTMLViewAdapter } from "@fluidframework/view-adapters";
 import { IFluidMountableView } from "@fluidframework/view-interfaces";
@@ -27,9 +26,11 @@ import {
     WebCodeLoader,
 } from "@fluidframework/web-code-loader";
 import { IFluidObject } from "@fluidframework/core-interfaces";
+import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
+import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
 import { RequestParser } from "@fluidframework/runtime-utils";
 import { MultiUrlResolver } from "./multiResolver";
-import { getDocumentServiceFactory } from "./multiDocumentServiceFactory";
+import { deltaConns, getDocumentServiceFactory } from "./multiDocumentServiceFactory";
 
 export interface IDevServerUser extends IUser {
     name: string;
@@ -149,10 +150,21 @@ async function createWebLoader(
     documentId: string,
     fluidModule: IFluidModule,
     options: RouteOptions,
-    urlResolver: IUrlResolver,
+    urlResolver: MultiUrlResolver,
     codeDetails: IFluidCodeDetails,
+    testAlfred: boolean = false,
 ): Promise<Loader> {
-    const documentServiceFactory = getDocumentServiceFactory(documentId, options);
+    let documentServiceFactory: IDocumentServiceFactory = getDocumentServiceFactory(documentId, options);
+    // Create the inner document service which will be wrapped inside local driver. The inner document service
+    // will be used for ops(like delta connection/delta ops) while for storage, local storage would be used.
+    if (testAlfred) {
+        const resolvedUrl = await urlResolver.resolve(await urlResolver.createRequestForCreateNew(documentId));
+        const innerDocumentService = await documentServiceFactory.createDocumentService(resolvedUrl);
+        documentServiceFactory = new LocalDocumentServiceFactory(
+            deltaConns.get(documentId),
+            innerDocumentService);
+    }
+
     const codeLoader = new WebCodeLoader(new WebpackCodeResolver(options));
 
     await codeLoader.seedModule(
@@ -161,7 +173,8 @@ async function createWebLoader(
     );
 
     return new Loader({
-        urlResolver,
+        urlResolver: testAlfred ?
+            new MultiUrlResolver(documentId, window.location.origin, options, true) : urlResolver,
         documentServiceFactory,
         codeLoader,
     });
@@ -182,8 +195,9 @@ export async function start(
      * So, we create a new `id` and use that as the `documentId`.
      * We will also replace the url in the browser with a new url of format - http://localhost:8080/doc/<documentId>.
      */
-    const autoAttach: boolean = id === "new";
+    const autoAttach: boolean = id === "new" || id === "testalfred";
     const manualAttach: boolean = id === "manualAttach";
+    const testAlfred = id === "testalfred";
     if (autoAttach || manualAttach) {
         documentId = moniker.choose();
         url = url.replace(id, `doc/${documentId}`);
@@ -197,7 +211,7 @@ export async function start(
     let urlResolver = new MultiUrlResolver(documentId, window.location.origin, options);
 
     // Create the loader that is used to load the Container.
-    let loader1 = await createWebLoader(documentId, fluidModule, options, urlResolver, codeDetails);
+    let loader1 = await createWebLoader(documentId, fluidModule, options, urlResolver, codeDetails, testAlfred);
 
     let container1: Container;
     if (autoAttach || manualAttach) {
@@ -220,7 +234,7 @@ export async function start(
             documentId = moniker.choose();
             url = url.replace(id, documentId);
             urlResolver = new MultiUrlResolver(documentId, window.location.origin, options);
-            loader1 = await createWebLoader(documentId, fluidModule, options, urlResolver, codeDetails);
+            loader1 = await createWebLoader(documentId, fluidModule, options, urlResolver, codeDetails, testAlfred);
             container1 = await loader1.createDetachedContainer(codeDetails);
         }
     }
@@ -228,8 +242,8 @@ export async function start(
     let leftDiv: HTMLDivElement = div;
     let rightDiv: HTMLDivElement | undefined;
 
-    // For side by side mode, create two divs.
-    if (options.mode === "local" && !options.single) {
+    // For side by side mode, create two divs. Use side by side mode to test alfred.
+    if ((options.mode === "local" && !options.single) || testAlfred) {
         div.style.display = "flex";
         leftDiv = makeSideBySideDiv("sbs-left");
         rightDiv = makeSideBySideDiv("sbs-right");
@@ -258,13 +272,14 @@ export async function start(
             leftDiv,
             rightDiv,
             manualAttach,
+            testAlfred,
         );
     }
 
     // For side by side mode, we need to create a second container and Fluid object.
     if (rightDiv) {
         // Create a new loader that is used to load the second container.
-        const loader2 = await createWebLoader(documentId, fluidModule, options, urlResolver, codeDetails);
+        const loader2 = await createWebLoader(documentId, fluidModule, options, urlResolver, codeDetails, testAlfred);
 
         // Create a new request url from the resolvedUrl of the first container.
         const requestUrl2 = await urlResolver.getAbsoluteUrl(container1.resolvedUrl, "");
@@ -330,6 +345,7 @@ async function attachContainer(
     leftDiv: HTMLDivElement,
     rightDiv: HTMLDivElement | undefined,
     manualAttach: boolean,
+    testAlfred: boolean,
 ) {
     // This is called once loading is complete to replace the url in the address bar with the new `url`.
     const replaceUrl = () => {
@@ -340,7 +356,10 @@ async function attachContainer(
     let currentContainer = container;
     let currentLeftDiv = leftDiv;
     const attached = new Deferred();
-    const attachUrl = await urlResolver.createRequestForCreateNew(documentId);
+    // To test alfred, we use local driver as wrapper for actual document service. So create request
+    // using local resolver.
+    const attachUrl = testAlfred ? new LocalResolver().createCreateNewRequest(documentId)
+        : await urlResolver.createRequestForCreateNew(documentId);
 
     if (manualAttach) {
         // Create an "Attach Container" button that the user can click when they want to attach the container.

--- a/packages/tools/webpack-fluid-loader/src/multiDocumentServiceFactory.ts
+++ b/packages/tools/webpack-fluid-loader/src/multiDocumentServiceFactory.ts
@@ -10,7 +10,7 @@ import { OdspDocumentServiceFactory } from "@fluidframework/odsp-driver";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 import { RouteOptions } from "./loader";
 
-const deltaConns = new Map<string, ILocalDeltaConnectionServer>();
+export const deltaConns = new Map<string, ILocalDeltaConnectionServer>();
 
 export function getDocumentServiceFactory(documentId: string, options: RouteOptions) {
     const deltaConn = deltaConns.get(documentId) ??

--- a/packages/tools/webpack-fluid-loader/src/multiResolver.ts
+++ b/packages/tools/webpack-fluid-loader/src/multiResolver.ts
@@ -77,8 +77,14 @@ export class MultiUrlResolver implements IUrlResolver {
     constructor(
         private readonly documentId: string,
         private readonly rawUrl: string,
-        private readonly options: RouteOptions) {
-        this.urlResolver = getUrlResolver(options);
+        private readonly options: RouteOptions,
+        private readonly useLocalResolver: boolean = false,
+    ) {
+        if (this.useLocalResolver) {
+            this.urlResolver = new LocalResolver();
+        } else {
+            this.urlResolver = getUrlResolver(options);
+        }
     }
 
     async getAbsoluteUrl(resolvedUrl: IResolvedUrl, relativeUrl: string): Promise<string> {
@@ -96,6 +102,9 @@ export class MultiUrlResolver implements IUrlResolver {
     public async createRequestForCreateNew(
         fileName: string,
     ): Promise<IRequest> {
+        if (this.useLocalResolver) {
+            return (this.urlResolver as LocalResolver).createCreateNewRequest(fileName);
+        }
         switch (this.options.mode) {
             case "r11s":
             case "docker":

--- a/packages/tools/webpack-fluid-loader/src/routes.ts
+++ b/packages/tools/webpack-fluid-loader/src/routes.ts
@@ -238,10 +238,10 @@ export const after = (app: express.Application, server: WebpackDevServer, baseDi
         }
 
         const documentId = req.params.id;
-        // For testing alfred, we use the path: http://localhost:8080/testalfred. This will use the local storage
+        // For testing orderer, we use the path: http://localhost:8080/testorderer. This will use the local storage
         // instead of using actual storage service to which the connection is made. This will enable testing
-        // alfred even if the blob storage services are down.
-        if (documentId !== "new" && documentId !== "manualAttach" && documentId !== "testalfred") {
+        // orderer even if the blob storage services are down.
+        if (documentId !== "new" && documentId !== "manualAttach" && documentId !== "testorderer") {
             // The `id` is not for a new document. We assume the user is trying to load an existing document and
             // redirect them to - http://localhost:8080/doc/<id>.
             const reqUrl = req.url.replace(documentId, `doc/${documentId}`);

--- a/packages/tools/webpack-fluid-loader/src/routes.ts
+++ b/packages/tools/webpack-fluid-loader/src/routes.ts
@@ -238,7 +238,10 @@ export const after = (app: express.Application, server: WebpackDevServer, baseDi
         }
 
         const documentId = req.params.id;
-        if (documentId !== "new" && documentId !== "manualAttach") {
+        // For testing alfred, we use the path: http://localhost:8080/testalfred. This will use the local storage
+        // instead of using actual storage service to which the connection is made. This will enable testing
+        // alfred even if the blob storage services are down.
+        if (documentId !== "new" && documentId !== "manualAttach" && documentId !== "testalfred") {
             // The `id` is not for a new document. We assume the user is trying to load an existing document and
             // redirect them to - http://localhost:8080/doc/<id>.
             const reqUrl = req.url.replace(documentId, `doc/${documentId}`);


### PR DESCRIPTION
This is just for testing purpose as suggested by @tanviraumi 
1.) Wrap the actual driver to be used like r11s inside local driver so that for storage, local storage is used while for delta connection actual driver is used.
2.) Use path localhost/testorderer to use this path.
3.) Side by side mode is used in this testing.
4.) Summaries won't work because ops and storage are of different driver but can be disabled in container runtime. But orderer will be testable even without disabling because we will go through the connection.