### PR TITLE
Don't use synthetic default import for debug in driver-base

### DIFF
--- a/packages/drivers/driver-base/src/debug.ts
+++ b/packages/drivers/driver-base/src/debug.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import registerDebug from "debug";
+import { debug as registerDebug } from "debug";
 import { pkgName, pkgVersion } from "./packageVersion";
 
 export const debug = registerDebug("fluid:socket-storage-shared");


### PR DESCRIPTION
The `driver-base` package can only be imported (directly or indirectly) in TypeScript projects that have `allowSyntheticDefaultImports` set, because its generated `.d.ts` files use a synthetic default from the `debug` package. Fix by using a non-default import.

(Many Fluid packages have a debug.ts like this, but `driver-base` appears to be the only one that makes it externally visible by exporting it through index.ts, thus causing the hiccup.)