### PR TITLE
Make DocumentDeltaConnection early handles non-nullable and split connection listener tracking

### DIFF
--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -127,6 +127,7 @@ export class DocumentDeltaConnection
 
     // Listeners only needed while the connection is in progress
     private connectionListeners: IEventListener[] = [];
+    // Listeners used throughout the lifetime of the DocumentDeltaConnection
     private trackedListeners: IEventListener[] = [];
 
     protected get hasDetails(): boolean {


### PR DESCRIPTION
Was looking into removing BatchManager but need to think a bit more on how to do so safely.  Splitting out the rest of that change which should be safe.

This change does a few things:
1. Makes the early op/signal handlers non-nullable - we already unregister them when the initial ops/signals are retrieved and wipe the `queuedMessages`/`queuedSignals` so nulling them doesn't provide any real additional benefit.
2. Splits the tracked listeners into two separate collections (rather than using a flag in a single collection), making it simpler to follow the register/unregister logic.
3. Makes removal methods private to scope API surface (they were not being extended anyway).