### PR TITLE
Handle Duplicate Outstanding Ops in Summary

### DIFF
--- a/packages/runtime/runtime-utils/src/summarizerNode.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode.ts
@@ -332,7 +332,7 @@ export class SummarizerNode implements ISummarizerNode {
                 throw error;
             }
             this.logger.logException({
-                eventName: "SummaringWithBaseSummaryPlusOps",
+                eventName: "SummarizingWithBasePlusOps",
                 category: "error",
             },
             error);

--- a/packages/runtime/runtime-utils/src/summarizerNode.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode.ts
@@ -154,9 +154,10 @@ function decodeSummary(snapshot: ISnapshotTree, logger: Pick<ITelemetryLogger, "
                                     eventName:"DuplicateOutstandingOps",
                                     category: "generic",
                                     // eslint-disable-next-line max-len
-                                    message: `latestSeq exceeds newEarliestSeq in decodeSummary: ${latestSeq} >= ${newEarliestSeq}`,
+                                    message: `newEarliestSeq <= latestSeq in decodeSummary: ${newEarliestSeq} <= ${latestSeq}`,
                                 });
-                                while (newOutstandingOps[0].sequenceNumber <= latestSeq) {
+                                while (newOutstandingOps.length > 0
+                                    && newOutstandingOps[0].sequenceNumber <= latestSeq) {
                                     newOutstandingOps.shift();
                                 }
                             }


### PR DESCRIPTION
Rather than asserting when duplicate ops are found in outstanding ops, log a warning, and skip the duplicate ops.

Also add telemetry for when we generate summary as base + ops.

related #4005
related #3842