### PR TITLE
Remove exposure of event manipulation methods from IDocumentDeltaConnection

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -917,6 +917,74 @@ export class DeltaManager
         }
     }
 
+    private readonly opHandler = (documentId: string, messages: ISequencedDocumentMessage[]) => {
+        if (messages instanceof Array) {
+            this.enqueueMessages(messages);
+        } else {
+            this.enqueueMessages([messages]);
+        }
+    };
+
+    private readonly signalHandler = (message: ISignalMessage) => {
+        this._inboundSignal.push(message);
+    };
+
+    // Always connect in write mode after getting nacked.
+    private readonly nackHandler = (documentId: string, messages: INack[]) => {
+        const message = messages[0];
+        // TODO: we should remove this check when service updates?
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        if (this._readonlyPermissions) {
+            this.close(createWriteError("WriteOnReadOnlyDocument"));
+        }
+
+        // check message.content for Back-compat with old service.
+        const reconnectInfo = message.content !== undefined
+            ? getNackReconnectInfo(message.content) :
+            createGenericNetworkError(`Nack: unknown reason`, true);
+
+        if (this.reconnectMode !== ReconnectMode.Enabled) {
+            this.logger.sendErrorEvent({
+                eventName: "NackWithNoReconnect",
+                reason: reconnectInfo.message,
+                mode: this.connectionMode,
+            });
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        this.reconnectOnError(
+            "write",
+            reconnectInfo,
+        );
+    };
+
+    // Connection mode is always read on disconnect/error unless the system mode was write.
+    private readonly disconnectHandler = (disconnectReason) => {
+        // Note: we might get multiple disconnect calls on same socket, as early disconnect notification
+        // ("server_disconnect", ODSP-specific) is mapped to "disconnect"
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        this.reconnectOnError(
+            this.defaultReconnectionMode,
+            createReconnectError("Disconnect", disconnectReason),
+        );
+    };
+
+    private readonly errorHandler = (error) => {
+        // Observation based on early pre-production telemetry:
+        // We are getting transport errors from WebSocket here, right before or after "disconnect".
+        // This happens only in Firefox.
+        logNetworkFailure(this.logger, { eventName: "DeltaConnectionError" }, error);
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        this.reconnectOnError(
+            this.defaultReconnectionMode,
+            createReconnectError("error", error),
+        );
+    };
+
+    private readonly pongHandler = (latency: number) => {
+        this.emit("pong", latency);
+    };
+
     /**
      * Once we've successfully gotten a connection, we need to set up state, attach event listeners, and process
      * initial messages.
@@ -953,73 +1021,12 @@ export class DeltaManager
 
         this._outbound.systemResume();
 
-        connection.on("op", (documentId: string, messages: ISequencedDocumentMessage[]) => {
-            if (messages instanceof Array) {
-                this.enqueueMessages(messages);
-            } else {
-                this.enqueueMessages([messages]);
-            }
-        });
-
-        connection.on("signal", (message: ISignalMessage) => {
-            this._inboundSignal.push(message);
-        });
-
-        // Always connect in write mode after getting nacked.
-        connection.on("nack", (documentId: string, messages: INack[]) => {
-            const message = messages[0];
-            // TODO: we should remove this check when service updates?
-            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-            if (this._readonlyPermissions) {
-                this.close(createWriteError("WriteOnReadOnlyDocument"));
-            }
-
-            // check message.content for Back-compat with old service.
-            const reconnectInfo = message.content !== undefined
-                ? getNackReconnectInfo(message.content) :
-                createGenericNetworkError(`Nack: unknown reason`, true);
-
-            if (this.reconnectMode !== ReconnectMode.Enabled) {
-                this.logger.sendErrorEvent({
-                    eventName: "NackWithNoReconnect",
-                    reason: reconnectInfo.message,
-                    mode: this.connectionMode,
-                });
-            }
-
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            this.reconnectOnError(
-                "write",
-                reconnectInfo,
-            );
-        });
-
-        // Connection mode is always read on disconnect/error unless the system mode was write.
-        connection.on("disconnect", (disconnectReason) => {
-            // Note: we might get multiple disconnect calls on same socket, as early disconnect notification
-            // ("server_disconnect", ODSP-specific) is mapped to "disconnect"
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            this.reconnectOnError(
-                this.defaultReconnectionMode,
-                createReconnectError("Disconnect", disconnectReason),
-            );
-        });
-
-        connection.on("error", (error) => {
-            // Observation based on early pre-production telemetry:
-            // We are getting transport errors from WebSocket here, right before or after "disconnect".
-            // This happens only in Firefox.
-            logNetworkFailure(this.logger, { eventName: "DeltaConnectionError" }, error);
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            this.reconnectOnError(
-                this.defaultReconnectionMode,
-                createReconnectError("error", error),
-            );
-        });
-
-        connection.on("pong", (latency: number) => {
-            this.emit("pong", latency);
-        });
+        connection.on("op", this.opHandler);
+        connection.on("signal", this.signalHandler);
+        connection.on("nack", this.nackHandler);
+        connection.on("disconnect", this.disconnectHandler);
+        connection.on("error", this.errorHandler);
+        connection.on("pong", this.pongHandler);
 
         const initialMessages = connection.initialMessages;
 
@@ -1077,7 +1084,12 @@ export class DeltaManager
         this.connection = undefined;
 
         // Remove listeners first so we don't try to retrigger this flow accidentally through reconnectOnError
-        connection.removeAllListeners();
+        connection.off("op", this.opHandler);
+        connection.off("signal", this.signalHandler);
+        connection.off("nack", this.nackHandler);
+        connection.off("disconnect", this.disconnectHandler);
+        connection.off("error", this.errorHandler);
+        connection.off("pong", this.pongHandler);
 
         // We cancel all ops on lost of connectivity, and rely on DDSes to resubmit them.
         // Semantics are not well defined for batches (and they are broken right now on disconnects anyway),

--- a/packages/loader/driver-definitions/src/storage.ts
+++ b/packages/loader/driver-definitions/src/storage.ts
@@ -191,20 +191,6 @@ export interface IDocumentDeltaConnection extends IEventProvider<IDocumentDeltaC
     close();
 
     /**
-     * Emits an event from this document delta connection
-     * @param event - The event to emit
-     * @param args - The arguments for the event
-     */
-    emit(event: string, ...args: any[]): boolean;
-
-    /**
-     * Gets the listeners for an event
-     * @param event - The name of the event
-     */
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    listeners(event: string): Function[];
-
-    /**
      * Removes all listeners from all events
      */
     removeAllListeners(): void;

--- a/packages/loader/driver-definitions/src/storage.ts
+++ b/packages/loader/driver-definitions/src/storage.ts
@@ -189,11 +189,6 @@ export interface IDocumentDeltaConnection extends IEventProvider<IDocumentDeltaC
      * Disconnects the given delta connection
      */
     close();
-
-    /**
-     * Removes all listeners from all events
-     */
-    removeAllListeners(): void;
 }
 
 export interface IDocumentService {


### PR DESCRIPTION
Generally speaking, our implementations of `IDocumentDeltaConnection` have complex event registration/unregistration logic that can't be safely reasoned about from outside and is likely to differ from implementation-to-implementation (e.g. consider ODSP's reuse of the socket).  Exposing these methods risks incorrect modification of the events -- e.g. consider that a call to `removeAllListeners()` will additionally remove the `"newListener"` handler which is charged with tracking the events registered.

Additionally, the signatures specified here conflict with the signatures of `EventEmitter`, increasing the likelihood of incorrect usage.

~~The existing calls to `removeAllListeners()` seem unnecessary in their contexts, so just removing them.~~ Converted existing calls to `removeAllListeners()` to specific unregistration.