### PR TITLE
[0.27] Handle Duplicate Outstanding Ops in Summary (#4016)

### DIFF
--- a/packages/runtime/runtime-utils/src/summarizerNode.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode.ts
@@ -149,10 +149,18 @@ function decodeSummary(snapshot: ISnapshotTree, logger: Pick<ITelemetryLogger, "
                         if (outstandingOps.length > 0 && newOutstandingOps.length > 0) {
                             const latestSeq = outstandingOps[outstandingOps.length - 1].sequenceNumber;
                             const newEarliestSeq = newOutstandingOps[0].sequenceNumber;
-                            assert(
-                                latestSeq < newEarliestSeq,
-                                `latestSeq exceeds newEarliestSeq in decodeSummary: ${latestSeq} >= ${newEarliestSeq}`,
-                            );
+                            if (newEarliestSeq <= latestSeq) {
+                                logger.sendTelemetryEvent({
+                                    eventName:"DuplicateOutstandingOps",
+                                    category: "generic",
+                                    // eslint-disable-next-line max-len
+                                    message: `newEarliestSeq <= latestSeq in decodeSummary: ${newEarliestSeq} <= ${latestSeq}`,
+                                });
+                                while (newOutstandingOps.length > 0
+                                    && newOutstandingOps[0].sequenceNumber <= latestSeq) {
+                                    newOutstandingOps.shift();
+                                }
+                            }
                         }
                         outstandingOps = outstandingOps.concat(newOutstandingOps);
                     }
@@ -324,6 +332,11 @@ export class SummarizerNode implements ISummarizerNode {
                 // No base summary to reference
                 throw error;
             }
+            this.logger.logException({
+                eventName: "SummarizingWithBasePlusOps",
+                category: "error",
+            },
+            error);
             const summary = encodeSummary(encodeParam, this.outstandingOps);
             this.wipLocalPaths = {
                 localPath,


### PR DESCRIPTION
Rather than asserting when duplicate ops are found in outstanding ops, log a warning, and skip the duplicate ops.

Also add telemetry for when we generate summary as base + ops.

related #4005
related #3842