### PR TITLE
Bring back functionality which allows for websocket token to be returned with ISocketStorageDiscovery payload

### DIFF
--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -62,6 +62,7 @@ export interface ISocketStorageDiscovery {
      * The AFD URL for PushChannel
      */
     deltaStreamSocketUrl2?: string;
+    socketToken: string;
 }
 
 /**

--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -62,7 +62,14 @@ export interface ISocketStorageDiscovery {
      * The AFD URL for PushChannel
      */
     deltaStreamSocketUrl2?: string;
-    socketToken: string;
+
+    /**
+     * The access token for PushChannel. Optionally returned, depending on implementation.
+     * OneDrive for Consumer implementation returns it and OneDrive for Business implementation
+     * does not return it and instead expects token to be returned via `getWebsocketToken` callback
+     * passed as a parameter to `OdspDocumentService.create()` factory.
+     */
+    socketToken?: string;
 }
 
 /**

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -246,7 +246,7 @@ export class OdspDocumentService implements IDocumentService {
                 const connection = await this.connectToDeltaStreamWithRetry(
                     websocketEndpoint.tenantId,
                     websocketEndpoint.id,
-                    webSocketToken,
+                    webSocketToken || websocketEndpoint.socketToken,
                     io,
                     client,
                     websocketEndpoint.deltaStreamSocketUrl,


### PR DESCRIPTION
This is needed when driver works against OneDrive for Consumer. In Consumer scenario there is no support for acquiring websocket token via oAuth v2 protocol and instead we have to rely on token generated as part of /joinSession call.

This partially reverts this change: https://github.com/microsoft/FluidFramework/pull/3353