### PR TITLE
Fallback to non blob request if size too big or timeout in snapshot fetch call

### DIFF
--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -63,6 +63,7 @@
     "@fluidframework/protocol-base": "^0.1014.0-0",
     "@fluidframework/protocol-definitions": "^0.1014.0-0",
     "@fluidframework/telemetry-utils": "^0.28.0",
+    "abort-controller": "^3.0.0",
     "assert": "^2.0.0",
     "debug": "^4.1.1",
     "lodash": "^4.17.19",

--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -202,6 +202,13 @@ export interface ISnapshotOptions {
      * if snapshot is bigger in size than specified limit.
      */
     mds?: number;
+
+    /*
+     * Maximum time limit to fetch snapshot (in seconds)
+     * If specified, client will timeout the fetch request if it exceeds the time limit and
+     * will try to fetch the snapshot without blobs.
+     */
+    timeout?: number;
 }
 
 export interface HostStoragePolicy {

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -344,7 +344,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                     blobs: 2,
                     ...this.hostPolicy.snapshotOptions,
                     mds: this.hostPolicy.snapshotOptions?.mds ? Math.min(this.hostPolicy.snapshotOptions.mds, maxSnapshotSizeLimit) : maxSnapshotSizeLimit,
-                    timeout: this.hostPolicy.snapshotOptions?.timeout ? Math.min(this.hostPolicy.snapshotOptions.timeout, maxSnapshotFetchTimeout) : maxSnapshotFetchTimeout;
+                    timeout: this.hostPolicy.snapshotOptions?.timeout ? Math.min(this.hostPolicy.snapshotOptions.timeout, maxSnapshotFetchTimeout) : maxSnapshotFetchTimeout,
                 };
 
                 let cachedSnapshot: IOdspSnapshot | undefined;
@@ -589,7 +589,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
         }
 
         // This event measures only successful cases of getLatest call (no tokens, no retries).
-        const { snapshot, canCache } = await PerformanceEvent.timedExecAsync(this.logger, { eventName: "TreesLatest", fetchTimeout: snapshotOptions.timeout }, async (event) => {
+        const { snapshot, canCache } = await PerformanceEvent.timedExecAsync(this.logger, { eventName: "TreesLatest", fetchTimeout: snapshotOptions.timeout, maxSnapshotSize: snapshotOptions.mds }, async (event) => {
             const startTime = performance.now();
             let response: IOdspResponse<IOdspSnapshot>;
             if (usePost) {

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -9,6 +9,7 @@ import {
     fetchIncorrectResponse,
     offlineFetchFailureStatusCode,
     fetchFailureStatusCode,
+    fetchTimeoutStatusCode,
 } from "@fluidframework/odsp-doclib-utils";
 import {
     default as fetch,
@@ -84,6 +85,9 @@ export async function fetchHelper(
         let online = isOnline();
         if (`${error}` === "TypeError: Failed to fetch") {
             online = OnlineStatus.Offline;
+        }
+        if (error.name === "AbortError") {
+            throwOdspNetworkError("Timeout during fetch", fetchTimeoutStatusCode);
         }
         throwOdspNetworkError(
             `Fetch error: ${error}`,

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -20,6 +20,8 @@ export const fetchFailureStatusCode: number = 710;
 export const invalidFileNameStatusCode: number = 711;
 // no response, or can't parse response
 export const fetchIncorrectResponse = 712;
+// Fetch request took more time then limit.
+export const fetchTimeoutStatusCode = 713;
 
 export enum OdspErrorType {
     /**
@@ -38,6 +40,13 @@ export enum OdspErrorType {
      * such case.
      */
     snapshotTooBig = "snapshotTooBig",
+
+    /*
+     * Maximum time limit to fetch reached. Host application specified limit for fetching of snapshot, when
+     * that limit is reached, request fails. Hosting application is expected to have fall-back behavior for
+     * such case.
+     */
+    fetchTimeout = "fetchTimeout",
 
     /*
         * SPO admin toggle: fluid service is not enabled.
@@ -105,6 +114,9 @@ export function createOdspNetworkError(
             break;
         case fetchIncorrectResponse:
             error = new NetworkErrorBasic(errorMessage, DriverErrorType.incorrectServerResponse, false);
+            break;
+        case fetchTimeoutStatusCode:
+            error = new NonRetryableError(errorMessage, OdspErrorType.fetchTimeout);
             break;
         default:
             error = createGenericNetworkError(errorMessage, true, retryAfterSeconds, statusCode);


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/4005
1.) If either the snapshot size is bigger than specified policy or it took more time to fetch snapshot then specified, then fallback to fetch snapshot without blobs.
2.) Take policy of host or driver whichever is min.
The non blob snapshot requests fetches the skeleton of the snapshot(without blobs), which causes the size of snapshot to become small. Later the blobs are fetched as per the requirement.