### PR TITLE
Website: make quicklink images aria hidden because they are being used as icons

### DIFF
--- a/docs/themes/thxvscode/layouts/partials/connect.html
+++ b/docs/themes/thxvscode/layouts/partials/connect.html
@@ -4,25 +4,25 @@
     <ul class="connect-links">
         <li id="connect-twitter-link">
             <a href={{$tweetLink}} target="_blank">
-                <img alt="Twitter" src="/assets/community/sidebar/twitter.svg" />
+                <img aria-hidden="true" alt="Twitter" src="/assets/community/sidebar/twitter.svg" />
                 Tweet this link
             </a>
         </li>
         <li id="connect-rssfeed">
             <a href="/index.xml" target="_blank">
-                <img alt="RSS" src="/assets/community/sidebar/rss.svg" />
+                <img aria-hidden="true" alt="RSS" src="/assets/community/sidebar/rss.svg" />
                 Subscribe
             </a>
         </li>
         <li id="connect-stack-overflow">
             <a href="https://stackoverflow.com/questions/tagged/fluid-framework" target="_blank">
-                <img alt="Stackoverflow" src="/assets/community/sidebar/stackoverflow.svg" />
+                <img aria-hidden="true" alt="Stackoverflow" src="/assets/community/sidebar/stackoverflow.svg" />
                 Ask questions
             </a>
         </li>
         <li id="connect-twitter">
             <a href="https://twitter.com/{{.Site.Params.Twitterhandle}}" target="_blank">
-                <img alt="Twitter" src="/assets/community/sidebar/twitter.svg" />
+                <img aria-hidden="true" alt="Twitter" src="/assets/community/sidebar/twitter.svg" />
                 @{{.Site.Params.Twitterhandle}}
             </a>
         </li>
@@ -31,14 +31,14 @@
         {{- $editUrl = delimit (slice "https://github.com/" $editUrl) "" -}}
         <li id="connect-editpage">
             <a href="{{$editUrl}}" target="_blank">
-                <img alt="Issues" src="/assets/community/sidebar/github.svg" />
+                <img aria-hidden="true" alt="Issues" src="/assets/community/sidebar/github.svg" />
                 Edit this page
             </a>
         </li>
         {{- end -}}
         <li id="connect-github">
             <a href="https://www.github.com/{{.Site.Params.Githubrepo}}/issues/new/choose" target="_blank">
-                <img alt="Issues" src="/assets/community/sidebar/issue.svg" />
+                <img aria-hidden="true" alt="Issues" src="/assets/community/sidebar/issue.svg" />
                 Report issues
             </a>
         </li>


### PR DESCRIPTION
fixes #3811

Image alt text was being read aloud by screen readers making some items difficult to understand or redundant. 

![image](https://user-images.githubusercontent.com/1434956/96941427-3d81f680-1487-11eb-8233-5952c2ce4a3f.png)
