### PR TITLE
Disable Rejection on Quorum Proposals

### DIFF
--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -45,7 +45,7 @@ class PendingProposal implements IPendingProposal, ISequencedProposal {
     }
 
     public get rejectionDisabled() {
-        return this.canReject;
+        return !this.canReject;
     }
 
     public disableRejection() {

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -44,6 +44,10 @@ class PendingProposal implements IPendingProposal, ISequencedProposal {
         this.sendReject(this.sequenceNumber);
     }
 
+    public get rejectionDisabled() {
+        return this.canReject;
+    }
+
     public disableRejection() {
         this.canReject = false;
     }

--- a/server/routerlicious/packages/protocol-definitions/src/consensus.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/consensus.ts
@@ -36,8 +36,24 @@ export type IApprovedProposal = { approvalSequenceNumber: number } & ISequencedP
  */
 export type ICommittedProposal = { commitSequenceNumber: number } & IApprovedProposal;
 
+/**
+ * A proposal that has been propposed, but not yet accepted or committed
+ */
 export interface IPendingProposal extends ISequencedProposal {
+    /**
+     * Sends a rejection for the proposal
+     */
     reject();
+
+    /**
+     * Disables the sending of rejections for this proposal
+     */
+    disableRejection();
+
+    /**
+     * Returns true if rejections has been disable, otherwise false
+     */
+    readonly rejectionDisabled: boolean;
 }
 
 export interface IQuorumEvents extends IErrorEvent {


### PR DESCRIPTION
Allow quorum proposals to have their ability to reject disabled. Specifically, this can be used for code proposals to force a code proposal by disabling its rejection this is useful for hotfixes or security issues where a new code proposal must be accepted.


fixes #3479  