### PR TITLE
Improve Container Code Proposal Api

### DIFF
--- a/packages/loader/container-definitions/src/loader.ts
+++ b/packages/loader/container-definitions/src/loader.ts
@@ -7,6 +7,7 @@ import { IRequest, IResponse, IFluidRouter, IFluidCodeDetails, IFluidPackage } f
 import {
     IClientDetails,
     IDocumentMessage,
+    IPendingProposal,
     IQuorum,
     ISequencedDocumentMessage,
 } from "@fluidframework/protocol-definitions";
@@ -78,6 +79,7 @@ export interface IContainerEvents extends IEvent {
      * @param opsBehind - number of ops this client is behind (if present).
      */
     (event: "connect", listener: (opsBehind?: number) => void);
+    (event: "codeDetailsProposed", codeDetails: IFluidCodeDetails, proposal: IPendingProposal);
     (event: "contextDisposed" | "contextChanged",
         listener: (codeDetails: IFluidCodeDetails, previousCodeDetails: IFluidCodeDetails | undefined) => void);
     (event: "disconnected" | "attaching" | "attached", listener: () => void);
@@ -111,6 +113,17 @@ export interface IContainer extends IEventProvider<IContainerEvents>, IFluidRout
      * Indicates the attachment state of the container to a host service.
      */
     readonly attachState: AttachState;
+
+    /**
+     * The current code details for the container's runtime
+     */
+    readonly codeDetails: IFluidCodeDetails | undefined
+
+    /**
+     * Propose new code details that define the code to be loaded
+     * for this container's runtime.
+     */
+    proposeCodeDetails(codeDetails: IFluidCodeDetails): Promise<void>
 
     /**
      * Attaches the Container to the Container specified by the given Request.

--- a/packages/loader/container-definitions/src/loader.ts
+++ b/packages/loader/container-definitions/src/loader.ts
@@ -79,7 +79,7 @@ export interface IContainerEvents extends IEvent {
      * @param opsBehind - number of ops this client is behind (if present).
      */
     (event: "connect", listener: (opsBehind?: number) => void);
-    (event: "codeDetailsProposed", codeDetails: IFluidCodeDetails, proposal: IPendingProposal);
+    (event: "codeDetailsProposed", listener: (codeDetails: IFluidCodeDetails, proposal: IPendingProposal) => void);
     (event: "contextDisposed" | "contextChanged",
         listener: (codeDetails: IFluidCodeDetails, previousCodeDetails: IFluidCodeDetails | undefined) => void);
     (event: "disconnected" | "attaching" | "attached", listener: () => void);
@@ -120,12 +120,22 @@ export interface IContainer extends IEventProvider<IContainerEvents>, IFluidRout
     readonly codeDetails: IFluidCodeDetails | undefined
 
     /**
+     * Returns true if the container has been closed, otherwise false
+     */
+    readonly closed: boolean;
+
+    /**
+     * Closes the container
+     */
+    close(error?: ICriticalContainerError): void;
+
+    /**
      * Propose new code details that define the code to be loaded
      * for this container's runtime. The returned promise will
-     * resolve when the proposal is accepted, and reject if
+     * be true when the proposal is accepted, and false if
      * the proposal is rejected.
      */
-    proposeCodeDetails(codeDetails: IFluidCodeDetails): Promise<void>
+    proposeCodeDetails(codeDetails: IFluidCodeDetails): Promise<boolean>
 
     /**
      * Attaches the Container to the Container specified by the given Request.

--- a/packages/loader/container-definitions/src/loader.ts
+++ b/packages/loader/container-definitions/src/loader.ts
@@ -121,7 +121,9 @@ export interface IContainer extends IEventProvider<IContainerEvents>, IFluidRout
 
     /**
      * Propose new code details that define the code to be loaded
-     * for this container's runtime.
+     * for this container's runtime. The returned promise will
+     * resolve when the proposal is accepted, and reject if
+     * the proposal is rejected.
      */
     proposeCodeDetails(codeDetails: IFluidCodeDetails): Promise<void>
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -808,7 +808,9 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             throw new Error("Provided codeDetails are not IFluidCodeDetails");
         }
 
-        return this.getQuorum().propose("code", codeDetails);
+        return this.getQuorum().propose("code", codeDetails)
+            .then(()=>true)
+            .catch(()=>false);
     }
 
     private async reloadContextCore(): Promise<void> {

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -16,12 +16,14 @@ import {
     IResponse,
     IFluidObject,
     IFluidRouter,
+    IFluidCodeDetails,
 } from "@fluidframework/core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import {
     IClientDetails,
     IDocumentMessage,
     IHelpMessage,
+    IPendingProposal,
     IQuorum,
     ISequencedDocumentMessage,
 } from "@fluidframework/protocol-definitions";
@@ -44,6 +46,7 @@ export interface IProvideContainerRuntime {
 }
 
 export interface IContainerRuntimeEvents extends IContainerRuntimeBaseEvents{
+    (event: "codeDetailsProposed", listener: (codeDetails: IFluidCodeDetails, proposal: IPendingProposal) => void);
     (
         event: "dirtyDocument" | "disconnected" | "dispose" | "savedDocument",
         listener: () => void);

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -835,6 +835,12 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             this.clearPartialChunks(clientId);
         });
 
+        this.context.quorum.on("addProposal",(proposal)=>{
+            if (proposal.key === "code" || proposal.key === "code2") {
+                this.emit("codeDetailsProposed", proposal.value, proposal);
+            }
+        });
+
         if (this.context.previousRuntimeState === undefined || this.context.previousRuntimeState.state === undefined) {
             this.previousState = {};
         } else {

--- a/packages/test/end-to-end-tests/src/test/codePropsal.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/codePropsal.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { ILoader } from "@fluidframework/container-definitions";
+import { IContainer, ILoader } from "@fluidframework/container-definitions";
 import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
 import { IChannelFactory } from "@fluidframework/datastore-definitions";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
@@ -35,7 +35,7 @@ describe("CodeProposal.EndToEnd", () => {
     let deltaConnectionServer: ILocalDeltaConnectionServer;
     let opProcessingController: OpProcessingController;
 
-    async function createContainer(factoryEntries: Iterable<[string, IChannelFactory]>): Promise<Container> {
+    async function createContainer(factoryEntries: Iterable<[string, IChannelFactory]>): Promise<IContainer> {
         const factory = new TestFluidObjectFactory(factoryEntries);
         const urlResolver = new LocalResolver();
         const loader: ILoader = createLocalLoader(
@@ -44,16 +44,16 @@ describe("CodeProposal.EndToEnd", () => {
         return createAndAttachContainer(documentId, codeDetails, loader, urlResolver) as any as Container;
     }
 
-    async function loadContainer(factoryEntries: Iterable<[string, IChannelFactory]>): Promise<Container> {
+    async function loadContainer(factoryEntries: Iterable<[string, IChannelFactory]>): Promise<IContainer> {
         const factory = new TestFluidObjectFactory(factoryEntries);
         const urlResolver = new LocalResolver();
         const loader: ILoader = createLocalLoader(
             [[codeDetails, factory],[codeDetails2,factory]],
              deltaConnectionServer, urlResolver);
-        return loader.resolve({ url: documentLoadUrl }) as any as Container;
+        return loader.resolve({ url: documentLoadUrl });
     }
 
-    let containers: Container[];
+    let containers: IContainer[];
     beforeEach(async () => {
         deltaConnectionServer = LocalDeltaConnectionServer.create();
         containers = [];
@@ -70,16 +70,13 @@ describe("CodeProposal.EndToEnd", () => {
         containers.push(await loadContainer([["map", SharedMap.getFactory()]]));
         opProcessingController.addDeltaManagers(containers[0].deltaManager);
 
-        const quorum1 = containers[0].getQuorum();
-        const quorum2 = containers[1].getQuorum();
-
         assert.deepStrictEqual(
-            quorum1.get("code"),
+            containers[0].codeDetails,
             codeDetails,
             "Code proposal in containers[0] doesn't match");
 
         assert.deepStrictEqual(
-            quorum2.get("code"),
+            containers[1].codeDetails,
             codeDetails,
             "Code proposal in containers[1] doesn't match");
 
@@ -87,13 +84,14 @@ describe("CodeProposal.EndToEnd", () => {
         const map1 = await dataObject1.getSharedObject<ISharedMap>("map");
 
         // BUG BUG quorum.propose doesn't handle readonly, so make sure connection is write
+        const container = containers[0] as unknown as Container;
         do {
             map1.set("foo","bar");
             await Promise.all([
-                new Promise((resolve) => containers[0].connected ? resolve() : containers[0].once("connect", resolve)),
+                new Promise((resolve) => container.connected ? resolve() : container.once("connect", resolve)),
                 opProcessingController.process(),
             ]);
-        } while (!containers[0].connected);
+        } while (!container.connected);
     });
 
     it("Code Proposal", async () => {
@@ -113,16 +111,17 @@ describe("CodeProposal.EndToEnd", () => {
             });
         }
 
-        await Promise.all([
-            containers[0].getQuorum().propose("code", codeDetails2),
+        const res = await Promise.all([
+            containers[0].proposeCodeDetails(codeDetails2),
             opProcessingController.process(),
         ]);
 
+        assert.strictEqual(res[0], true, "Code propsal should be accepted");
+
         for (let i = 0; i < containers.length; i++) {
             assert.strictEqual(containers[i].closed, false, `containers[${i}] should not be closed`);
-            const quorum = containers[i].getQuorum();
             assert.deepStrictEqual(
-                quorum.get("code"),
+                containers[i].codeDetails,
                 codeDetails2,
                 `containers[${i}] code details should update`);
         }
@@ -139,28 +138,25 @@ describe("CodeProposal.EndToEnd", () => {
             });
         }
 
-        containers[1].getQuorum().on("addProposal",(p)=>{
-            if (p.key === "code") {
+        containers[1].on("codeDetailsProposed",(c, p)=>{
                 assert.deepStrictEqual(
-                    p.value,
+                    c,
                     codeDetails2,
                     "codeDetails2 should have been proposed");
                 p.reject();
-            }
-        });
+            });
 
-        await Promise.all([
-            containers[0].getQuorum().propose("code", codeDetails2)
-                .then(()=>assert.fail("expected rejection"))
-                .catch(()=>{}),
+        const res = await Promise.all([
+            containers[0].proposeCodeDetails(codeDetails2),
             opProcessingController.process(),
         ]);
 
+        assert.strictEqual(res[0], false, "Code propsal should be rejected");
+
         for (let i = 0; i < containers.length; i++) {
             assert.strictEqual(containers[i].closed, false, `containers[${i}] should not be closed`);
-            const quorum = containers[i].getQuorum();
             assert.deepStrictEqual(
-                quorum.get("code"),
+                containers[i].codeDetails,
                 codeDetails,
                 `containers[${i}] code details should not update`);
         }
@@ -183,14 +179,15 @@ describe("CodeProposal.EndToEnd", () => {
             });
         });
 
-        await Promise.all([
-            containers[0].getQuorum().propose("code", codeDetails2),
+        const res = await Promise.all([
+            containers[0].proposeCodeDetails(codeDetails2),
             opProcessingController.process(),
         ]);
 
+        assert.strictEqual(res[0], true, "Code propsal should be accepted");
         assert.strictEqual(containers[0].closed, false, "containers[0] should not be closed");
         assert.deepStrictEqual(
-            containers[0].getQuorum().get("code"),
+            containers[0].codeDetails,
             codeDetails2,
             `containers[0] code details should update`);
 


### PR DESCRIPTION
Improve the Container's Api for dealing with code proposals. One of the goals here is to also make the code propsal key on the quorum an implmentatin detail of the container, rather than a magic key clients are expected to know.

- Add codeDetailsProposed event that will fire when a new code proposal arrives
- Add proposeCodeDetails for proposing code details on the container
- Expose codeDetails property for accessing the current code details.

related #3529
related #3479
