### PR TITLE
Added IContainerRuntimeOptions optional param to runtime factories in aqueduct

### DIFF
--- a/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
@@ -5,6 +5,7 @@
 
 import { IContainerContext, IRuntime, IRuntimeFactory } from "@fluidframework/container-definitions";
 import {
+    IContainerRuntimeOptions,
     FluidDataStoreRegistry,
     ContainerRuntime,
 } from "@fluidframework/container-runtime";
@@ -39,11 +40,13 @@ export class BaseContainerRuntimeFactory implements
      * @param registryEntries - The data store registry for containers produced
      * @param serviceRegistry - The service registry for containers produced
      * @param requestHandlers - Request handlers for containers produced
+     * @param runtimeOptions - The runtime options passed to the ContainerRuntime when instantiating it
      */
     constructor(
         private readonly registryEntries: NamedFluidDataStoreRegistryEntries,
         private readonly providerEntries: DependencyContainerRegistry = [],
         private readonly requestHandlers: RuntimeRequestHandler[] = [],
+        private readonly runtimeOptions?: IContainerRuntimeOptions,
     ) {
         this.registry = new FluidDataStoreRegistry(registryEntries);
     }
@@ -71,7 +74,7 @@ export class BaseContainerRuntimeFactory implements
             buildRuntimeRequestHandler(
                 ...this.requestHandlers,
                 innerRequestHandler),
-            undefined,
+            this.runtimeOptions,
             scope);
 
         // we register the runtime so developers of providers can use it in the factory pattern.

--- a/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import { NamedFluidDataStoreRegistryEntries } from "@fluidframework/runtime-definitions";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { DependencyContainerRegistry } from "@fluidframework/synthesize";
@@ -29,6 +30,7 @@ export class ContainerRuntimeFactoryWithDefaultDataStore extends BaseContainerRu
         registryEntries: NamedFluidDataStoreRegistryEntries,
         providerEntries: DependencyContainerRegistry = [],
         requestHandlers: RuntimeRequestHandler[] = [],
+        runtimeOptions?: IContainerRuntimeOptions,
     ) {
         super(
             registryEntries,
@@ -38,6 +40,7 @@ export class ContainerRuntimeFactoryWithDefaultDataStore extends BaseContainerRu
                 defaultRouteRequestHandler(defaultDataStoreId),
                 innerRequestHandler,
             ],
+            runtimeOptions,
         );
     }
 


### PR DESCRIPTION
Fixes #4076

Added an optional param to BaseContainerRuntimeFactory and ContainerRuntimeFactoryWithDefaultDataStore to provide IContainerRuntimeOptions while creating ContainerRuntime.

I came across this when I was testing the data generated by summary under multiple scenarios. Each time I wanted to verify the summary data, I had to wait ~5 seconds which made the tests run for minutes.
IContainerRuntimeOptions gives an option to control the delay for the initial summary and it can be passed to ContainerRuntime.load. However, the runtime factories in aqueduct do not expose this.

Rather than changing the existing factories, I could have created a new one for testing. But I feel that we should expose this in aqueduct, at least in BaseContainerRuntimeFactory, so that I can extend it to write a new one for testing rather than having to re-write the whole thing.