### PR TITLE
Split debug logger into a different module

### DIFF
--- a/packages/utils/telemetry-utils/src/debugLogger.ts
+++ b/packages/utils/telemetry-utils/src/debugLogger.ts
@@ -15,7 +15,6 @@ import { TelemetryLogger, ITelemetryPropertyGetters, MultiSinkLogger, ChildLogge
 /**
  * Implementation of debug logger
  */
-
 export class DebugLogger extends TelemetryLogger {
     /**
      * Create debug logger - all events are output to debug npm library

--- a/packages/utils/telemetry-utils/src/debugLogger.ts
+++ b/packages/utils/telemetry-utils/src/debugLogger.ts
@@ -1,0 +1,125 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    ITelemetryBaseEvent,
+    ITelemetryBaseLogger,
+    ITelemetryProperties,
+} from "@fluidframework/common-definitions";
+import { performance } from "@fluidframework/common-utils";
+import { debug as registerDebug, IDebugger } from "debug";
+import { TelemetryLogger, ITelemetryPropertyGetters, MultiSinkLogger, ChildLogger } from "./logger";
+
+/**
+ * Implementation of debug logger
+ */
+
+export class DebugLogger extends TelemetryLogger {
+    /**
+     * Create debug logger - all events are output to debug npm library
+     * @param namespace - Telemetry event name prefix to add to all events
+     * @param properties - Base properties to add to all events
+     * @param propertyGetters - Getters to add additional properties to all events
+     */
+    public static create(
+        namespace: string,
+        properties?: ITelemetryProperties,
+        propertyGetters?: ITelemetryPropertyGetters,
+    ): TelemetryLogger {
+        // Setup base logger upfront, such that host can disable it (if needed)
+        const debug = registerDebug(namespace);
+
+        const debugErr = registerDebug(namespace);
+        debugErr.log = console.error.bind(console);
+        debugErr.enabled = true;
+
+        return new DebugLogger(debug, debugErr, properties, propertyGetters);
+    }
+
+    /**
+     * Mix in debug logger with another logger.
+     * Returned logger will output events to both newly created debug logger, as well as base logger
+     * @param namespace - Telemetry event name prefix to add to all events
+     * @param properties - Base properties to add to all events
+     * @param propertyGetters - Getters to add additional properties to all events
+     * @param baseLogger - Base logger to output events (in addition to debug logger being created). Can be undefined.
+     */
+    public static mixinDebugLogger(
+        namespace: string,
+        baseLogger?: ITelemetryBaseLogger,
+        properties?: ITelemetryProperties,
+        propertyGetters?: ITelemetryPropertyGetters,
+    ): TelemetryLogger {
+        if (!baseLogger) {
+            return DebugLogger.create(namespace, properties, propertyGetters);
+        }
+
+        const multiSinkLogger = new MultiSinkLogger(undefined, properties, propertyGetters);
+        multiSinkLogger.addLogger(DebugLogger.create(namespace));
+        multiSinkLogger.addLogger(ChildLogger.create(baseLogger, namespace));
+
+        return multiSinkLogger;
+    }
+
+    constructor(
+        private readonly debug: IDebugger,
+        private readonly debugErr: IDebugger,
+        properties?: ITelemetryProperties,
+        propertyGetters?: ITelemetryPropertyGetters,
+    ) {
+        super(undefined, properties, propertyGetters);
+    }
+
+    /**
+     * Send an event to debug loggers
+     *
+     * @param event - the event to send
+     */
+    public send(event: ITelemetryBaseEvent): void {
+        const newEvent: ITelemetryProperties = this.prepareEvent(event);
+        const isError = newEvent.category === "error";
+        let logger = isError ? this.debugErr : this.debug;
+
+        // Use debug's coloring schema for base of the event
+        const index = event.eventName.lastIndexOf(TelemetryLogger.eventNamespaceSeparator);
+        const name = event.eventName.substring(index + 1);
+        if (index > 0) {
+            logger = logger.extend(event.eventName.substring(0, index));
+        }
+        newEvent.eventName = undefined;
+
+        let tick = "";
+        if (event.category === "performance") {
+            tick = `tick=${TelemetryLogger.formatTick(performance.now())}`;
+        }
+
+        // Extract stack to put it last, but also to avoid escaping '\n' in it by JSON.stringify below
+        const stack = newEvent.stack ? newEvent.stack : "";
+        newEvent.stack = undefined;
+
+        // Watch out for circular references - they can come from two sources
+        // 1) error object - we do not control it and should remove it and retry
+        // 2) properties supplied by telemetry caller - that's a bug that should be addressed!
+        let payload: string;
+        try {
+            payload = JSON.stringify(newEvent);
+        } catch (error) {
+            newEvent.error = undefined;
+            payload = JSON.stringify(newEvent);
+        }
+
+        if (payload === "{}") {
+            payload = "";
+        }
+
+        // Force errors out, to help with diagnostics
+        if (isError) {
+            logger.enabled = true;
+        }
+
+        // Print multi-line.
+        logger(`${name} ${payload} ${tick} ${stack}`);
+    }
+}

--- a/packages/utils/telemetry-utils/src/index.ts
+++ b/packages/utils/telemetry-utils/src/index.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-
+export * from "./debugLogger";
 export * from "./eventEmitterWithErrorHandling";
 export * from "./events";
 export * from "./logger";

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -14,7 +14,6 @@ import {
     TelemetryEventPropertyType,
 } from "@fluidframework/common-definitions";
 import { BaseTelemetryNullLogger, performance } from "@fluidframework/common-utils";
-import { debug as registerDebug, IDebugger } from "debug";
 
 export interface ITelemetryPropertyGetters {
     [index: string]: () => TelemetryEventPropertyType;
@@ -316,117 +315,6 @@ export class MultiSinkLogger extends TelemetryLogger {
         this.loggers.forEach((logger: ITelemetryBaseLogger) => {
             logger.send(newEvent);
         });
-    }
-}
-
-/**
- * Implementation of debug logger
- */
-export class DebugLogger extends TelemetryLogger {
-    /**
-     * Create debug logger - all events are output to debug npm library
-     * @param namespace - Telemetry event name prefix to add to all events
-     * @param properties - Base properties to add to all events
-     * @param propertyGetters - Getters to add additional properties to all events
-     */
-    public static create(
-        namespace: string,
-        properties?: ITelemetryProperties,
-        propertyGetters?: ITelemetryPropertyGetters,
-    ): TelemetryLogger {
-        // Setup base logger upfront, such that host can disable it (if needed)
-        const debug = registerDebug(namespace);
-
-        const debugErr = registerDebug(namespace);
-        debugErr.log = console.error.bind(console);
-        debugErr.enabled = true;
-
-        return new DebugLogger(debug, debugErr, properties, propertyGetters);
-    }
-
-    /**
-     * Mix in debug logger with another logger.
-     * Returned logger will output events to both newly created debug logger, as well as base logger
-     * @param namespace - Telemetry event name prefix to add to all events
-     * @param properties - Base properties to add to all events
-     * @param propertyGetters - Getters to add additional properties to all events
-     * @param baseLogger - Base logger to output events (in addition to debug logger being created). Can be undefined.
-     */
-    public static mixinDebugLogger(
-        namespace: string,
-        baseLogger?: ITelemetryBaseLogger,
-        properties?: ITelemetryProperties,
-        propertyGetters?: ITelemetryPropertyGetters,
-    ): TelemetryLogger {
-        if (!baseLogger) {
-            return DebugLogger.create(namespace, properties, propertyGetters);
-        }
-
-        const multiSinkLogger = new MultiSinkLogger(undefined, properties, propertyGetters);
-        multiSinkLogger.addLogger(DebugLogger.create(namespace));
-        multiSinkLogger.addLogger(ChildLogger.create(baseLogger, namespace));
-
-        return multiSinkLogger;
-    }
-
-    constructor(
-        private readonly debug: IDebugger,
-        private readonly debugErr: IDebugger,
-        properties?: ITelemetryProperties,
-        propertyGetters?: ITelemetryPropertyGetters,
-    ) {
-        super(undefined, properties, propertyGetters);
-    }
-
-    /**
-     * Send an event to debug loggers
-     *
-     * @param event - the event to send
-     */
-    public send(event: ITelemetryBaseEvent): void {
-        const newEvent: ITelemetryProperties = this.prepareEvent(event);
-        const isError = newEvent.category === "error";
-        let logger = isError ? this.debugErr : this.debug;
-
-        // Use debug's coloring schema for base of the event
-        const index = event.eventName.lastIndexOf(TelemetryLogger.eventNamespaceSeparator);
-        const name = event.eventName.substring(index + 1);
-        if (index > 0) {
-            logger = logger.extend(event.eventName.substring(0, index));
-        }
-        newEvent.eventName = undefined;
-
-        let tick = "";
-        if (event.category === "performance") {
-            tick = `tick=${TelemetryLogger.formatTick(performance.now())}`;
-        }
-
-        // Extract stack to put it last, but also to avoid escaping '\n' in it by JSON.stringify below
-        const stack = newEvent.stack ? newEvent.stack : "";
-        newEvent.stack = undefined;
-
-        // Watch out for circular references - they can come from two sources
-        // 1) error object - we do not control it and should remove it and retry
-        // 2) properties supplied by telemetry caller - that's a bug that should be addressed!
-        let payload: string;
-        try {
-            payload = JSON.stringify(newEvent);
-        } catch (error) {
-            newEvent.error = undefined;
-            payload = JSON.stringify(newEvent);
-        }
-
-        if (payload === "{}") {
-            payload = "";
-        }
-
-        // Force errors out, to help with diagnostics
-        if (isError) {
-            logger.enabled = true;
-        }
-
-        // Print multi-line.
-        logger(`${name} ${payload} ${tick} ${stack}`);
     }
 }
 


### PR DESCRIPTION
Our bundle has multiple copies of debug in it. Some of it comes from Fluid directly, others through Fluid dependencies like socket.io. 

Unfortunately, the debug module is not tree shake eligible, so if it appears as an import in a module where any of the exports are used, it will be used in the module. To work around this limitation, we should put the usage of debug in it's own module, that way if the entire module is not used, it will be tree shaken. 

Debug is still heavily used in the Fluid repo, so more work will have to be done to fully solve this issue.