### PR TITLE
Switch DeltaQueue pause/resume to use ref counting instead of toggle

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -771,41 +771,41 @@
 			}
 		},
 		"@fluidframework/agent-scheduler": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.26.3.tgz",
-			"integrity": "sha512-akXxw7XRU8sxELaTh78/hJaze3dm8wbSdLRKehHpLfdlzEMZ7BWR9XAMsPLRyMFKOpln1+0ZQJt95SNYGnl2dA==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.26.9.tgz",
+			"integrity": "sha512-tOQikNSqlmLVTYc45710HvxUU+IAbPIX3OWWg/3ry4NqYX547+ayrTqH0Vi4wHxeKArurgvoR5DmWdSjRP2CNg==",
 			"requires": {
-				"@fluidframework/container-definitions": "^0.26.3",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/datastore": "^0.26.3",
-				"@fluidframework/datastore-definitions": "^0.26.3",
-				"@fluidframework/map": "^0.26.3",
-				"@fluidframework/register-collection": "^0.26.3",
-				"@fluidframework/runtime-definitions": "^0.26.3",
+				"@fluidframework/container-definitions": "^0.26.9",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/datastore": "^0.26.9",
+				"@fluidframework/datastore-definitions": "^0.26.9",
+				"@fluidframework/map": "^0.26.9",
+				"@fluidframework/register-collection": "^0.26.9",
+				"@fluidframework/runtime-definitions": "^0.26.9",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.26.3.tgz",
-			"integrity": "sha512-/HOHn4GdOnjJnCOQgHR+dJx3QC7pgrx4xndnNaLa5bD5npFqtxj2ixOrq17uwDNh74+vjlq1oHaC3+dWtdnWgA==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.26.9.tgz",
+			"integrity": "sha512-B7U5F56eKoFb/9qhhxytQQgbpIGdsUHtQOCMZ8Y5y07w8xA8a20pmULOI5XscimNc0y06AoBNpVOBnJmm86Z5Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.3",
-				"@fluidframework/container-loader": "^0.26.3",
-				"@fluidframework/container-runtime": "^0.26.3",
-				"@fluidframework/container-runtime-definitions": "^0.26.3",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/datastore": "^0.26.3",
-				"@fluidframework/datastore-definitions": "^0.26.3",
-				"@fluidframework/map": "^0.26.3",
-				"@fluidframework/request-handler": "^0.26.3",
-				"@fluidframework/runtime-definitions": "^0.26.3",
-				"@fluidframework/runtime-utils": "^0.26.3",
-				"@fluidframework/synthesize": "^0.26.3",
-				"@fluidframework/view-interfaces": "^0.26.3",
+				"@fluidframework/container-definitions": "^0.26.9",
+				"@fluidframework/container-loader": "^0.26.9",
+				"@fluidframework/container-runtime": "^0.26.9",
+				"@fluidframework/container-runtime-definitions": "^0.26.9",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/datastore": "^0.26.9",
+				"@fluidframework/datastore-definitions": "^0.26.9",
+				"@fluidframework/map": "^0.26.9",
+				"@fluidframework/request-handler": "^0.26.9",
+				"@fluidframework/runtime-definitions": "^0.26.9",
+				"@fluidframework/runtime-utils": "^0.26.9",
+				"@fluidframework/synthesize": "^0.26.9",
+				"@fluidframework/view-interfaces": "^0.26.9",
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
@@ -902,13 +902,13 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.26.3.tgz",
-			"integrity": "sha512-UYm67C/32F3mRwC5kiKkkPx9I8OoBAs6c8HdGJRUS1zmeIJCbC06Zjc8ipVjY3vEl0QyCVhNIlEme10ZBFN1Eg==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.26.9.tgz",
+			"integrity": "sha512-WvdC8SkFnNDEOra+zdNRIUZJDWcpMAWifg1X9rLEL0rC0zclcMvQTcW1vPeRNhsVx4drWnwaWJ68nW1rIj0ekA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/driver-definitions": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/driver-definitions": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0"
 			},
 			"dependencies": {
@@ -923,20 +923,20 @@
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.26.3.tgz",
-			"integrity": "sha512-XWV+WsqKhXkrEqgWe77C76cSZHYMGw1PFR5E7qKs0qLoUvXYXWxYYRklCrY0H9SbpsyIVXD2c2YVaPiHLEsv7Q==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.26.9.tgz",
+			"integrity": "sha512-ijsJZqSKaB009zk95eQVsxDXl6VpFx4Emn3bLZr+qUBIn4Y+6FBb9jGtBmWq2XFh/AXMfOOPINkYjb1yssJx/w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.3",
-				"@fluidframework/container-utils": "^0.26.3",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/driver-definitions": "^0.26.3",
-				"@fluidframework/driver-utils": "^0.26.3",
+				"@fluidframework/container-definitions": "^0.26.9",
+				"@fluidframework/container-utils": "^0.26.9",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/driver-definitions": "^0.26.9",
+				"@fluidframework/driver-utils": "^0.26.9",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/telemetry-utils": "^0.26.3",
+				"@fluidframework/telemetry-utils": "^0.26.9",
 				"@types/double-ended-queue": "^2.1.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -987,25 +987,25 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.26.3.tgz",
-			"integrity": "sha512-v70FiyLtSTBrsJ1OHdh26Wt3tpVCz6J4xwbPNtTPcajdJcJIJmojEtK0HGVH6jXhCOiSXpJEpAbSEdVa6zDo5w==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.26.9.tgz",
+			"integrity": "sha512-vOb2P2zCXD2IgsC+CJuGo9+li2HLqO1NwQR7cgjkXa1t9RDPLN7z369sedAER0aK2Ry+ygahX2A1A3+Oymc+HQ==",
 			"requires": {
-				"@fluidframework/agent-scheduler": "^0.26.3",
+				"@fluidframework/agent-scheduler": "^0.26.9",
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.3",
-				"@fluidframework/container-runtime-definitions": "^0.26.3",
-				"@fluidframework/container-utils": "^0.26.3",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/datastore": "^0.26.3",
-				"@fluidframework/driver-definitions": "^0.26.3",
-				"@fluidframework/driver-utils": "^0.26.3",
+				"@fluidframework/container-definitions": "^0.26.9",
+				"@fluidframework/container-runtime-definitions": "^0.26.9",
+				"@fluidframework/container-utils": "^0.26.9",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/datastore": "^0.26.9",
+				"@fluidframework/driver-definitions": "^0.26.9",
+				"@fluidframework/driver-utils": "^0.26.9",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.3",
-				"@fluidframework/runtime-utils": "^0.26.3",
-				"@fluidframework/telemetry-utils": "^0.26.3",
+				"@fluidframework/runtime-definitions": "^0.26.9",
+				"@fluidframework/runtime-utils": "^0.26.9",
+				"@fluidframework/telemetry-utils": "^0.26.9",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/node": "^10.17.24",
@@ -1058,15 +1058,15 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.26.3.tgz",
-			"integrity": "sha512-uzIvb+X15YXd04/CkMjCMMkhjquZrkW2Cerl2oOW2VbGGB/N8uhyvjGdH41hjkeooEeHS8+kDFWO0mkNXclbZw==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.26.9.tgz",
+			"integrity": "sha512-o71OsrrZGB7dbCLQLxqpmCUCmEgeyKA1dbhGRpvOs+4bZQsRh4OJyOPEGwMNJYingfpWa6nxDutIs0zosovhQA==",
 			"requires": {
-				"@fluidframework/container-definitions": "^0.26.3",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/driver-definitions": "^0.26.3",
+				"@fluidframework/container-definitions": "^0.26.9",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/driver-definitions": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.3",
+				"@fluidframework/runtime-definitions": "^0.26.9",
 				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
@@ -1081,37 +1081,37 @@
 			}
 		},
 		"@fluidframework/container-utils": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.26.3.tgz",
-			"integrity": "sha512-wUYGQqPCrgIqRsCbo1BV6yPlQaHGColLdPcxq5RfGUeCyULW/+J8JQcPhsexn8iMFAvZJI69H6vtV39pmfskGw==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.26.9.tgz",
+			"integrity": "sha512-yp6x0HlVnBLDJHHBBTuylZPjggLhridblZcQ+rXBaB68Jwc00GwZneg+IzVKU5U87voCGHcuOjlaywqN0M4fBw==",
 			"requires": {
-				"@fluidframework/container-definitions": "^0.26.3",
-				"@fluidframework/telemetry-utils": "^0.26.3"
+				"@fluidframework/container-definitions": "^0.26.9",
+				"@fluidframework/telemetry-utils": "^0.26.9"
 			}
 		},
 		"@fluidframework/core-interfaces": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.26.3.tgz",
-			"integrity": "sha512-AeHoNrLi+Xiuaa+h7TvQ5Shn0qoKhfsnLUF9U4Y/2w/vMIEaU2TbVet4msAXVnfyMq+EkW7tU1k2c2GKVHDl1A=="
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.26.9.tgz",
+			"integrity": "sha512-16eq9YZFi97+vM9Oju/apfLsZCYu8qh7cKIjykwSbPKA7PDqGOIIowskZQNrLdjbBrzE+9mj85Jwqi8/ejCbTA=="
 		},
 		"@fluidframework/datastore": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.26.3.tgz",
-			"integrity": "sha512-w3r/kVZbAIcFr5L6PLfPAYwgLkbRo63RYhCw/GHsgtsm7cwplPgP1K8yJzNyr8D3Fem+Gs9h8QuRGedwZdmkfQ==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.26.9.tgz",
+			"integrity": "sha512-JFB+85xZmPTjVHr4lASRSK6Dh2jt3XfrxG00cDPv9Cgo2qlDJPa4foW4RK/ANXxgjnLRa4Pv1HUdEgPm1a7wRw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.3",
-				"@fluidframework/container-utils": "^0.26.3",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/datastore-definitions": "^0.26.3",
-				"@fluidframework/driver-definitions": "^0.26.3",
-				"@fluidframework/driver-utils": "^0.26.3",
+				"@fluidframework/container-definitions": "^0.26.9",
+				"@fluidframework/container-utils": "^0.26.9",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/datastore-definitions": "^0.26.9",
+				"@fluidframework/driver-definitions": "^0.26.9",
+				"@fluidframework/driver-utils": "^0.26.9",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.3",
-				"@fluidframework/runtime-utils": "^0.26.3",
-				"@fluidframework/telemetry-utils": "^0.26.3",
+				"@fluidframework/runtime-definitions": "^0.26.9",
+				"@fluidframework/runtime-utils": "^0.26.9",
+				"@fluidframework/telemetry-utils": "^0.26.9",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
@@ -1160,15 +1160,15 @@
 			}
 		},
 		"@fluidframework/datastore-definitions": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.26.3.tgz",
-			"integrity": "sha512-KsQBJZc+/uJFNJ6dgpNJbfLzcF9aL/VgD7DLVSLQ0AUsdkSyZ0hIYTHlGzjX7hN+7zyNI5GEpoZPkUj49uFtPA==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.26.9.tgz",
+			"integrity": "sha512-aaMQ0RUnVaJIdOpIO1lc4MH3D2qC5d+43qxwil32swf2LOdwYkJ9ph1v9F7qn4mRYop5Ywowipv1H/rPai+hxA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.26.3",
-				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/container-definitions": "^0.26.9",
+				"@fluidframework/core-interfaces": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.3",
+				"@fluidframework/runtime-definitions": "^0.26.9",
 				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
@@ -1183,13 +1183,13 @@
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.26.3.tgz",
-			"integrity": "sha512-2NONWqkxFrrAjYmtPn+rQKdFh5uCuN55wdc4qhEMznuJE1Ykf69ydJzapMMd4PfYTl0RscqV99SpfiP5rzI9UQ==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.26.9.tgz",
+			"integrity": "sha512-L1MQ0zleurw1isynGGv043Sq4xX0smbiXbfAixYiwqKSl4ZGumkAbE0VAowb6ZBFyxO3mitXf0ZGAioN64kgig==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/driver-definitions": "^0.26.3",
-				"@fluidframework/driver-utils": "^0.26.3",
+				"@fluidframework/driver-definitions": "^0.26.9",
+				"@fluidframework/driver-utils": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
 				"@types/debug": "^4.1.5",
 				"@types/node": "^10.17.24",
@@ -1223,12 +1223,12 @@
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.26.3.tgz",
-			"integrity": "sha512-dHlg1U9V+79KLtLAllB5wUrZ3GEaK+qXFxXXYoEKWlQZvTOhSBHuN/DUDVM/bsBq4NBCU2MKpnk4RirE/LO3bQ==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.26.9.tgz",
+			"integrity": "sha512-Rg8Q4vytwj3khp52I3F0SXUo8rcuCwDE+Xj3YtDBbdNVUM6sQ5LlGfeq0ZEoPZ9aeWoviP+YISHu7/U6olkShg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0"
 			},
 			"dependencies": {
@@ -1243,18 +1243,18 @@
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.26.3.tgz",
-			"integrity": "sha512-mFTnVsGMvUFAW9mRKWlhy6ZZ7TT6lcm25IcjFnyHbUCazuXyexW5cYWwNSHUL8eVfXPFLyGXYyLyBOCT4Py47g==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.26.9.tgz",
+			"integrity": "sha512-5LLVyUmSUT0/qtHSKIjuqKz5jgV8kAtJ+dUWU3fLnQ7y7i2I9VqKyCWbKTRjIsP/qzeLNEWV8gnVjQcYgO7xmg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/driver-definitions": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/driver-definitions": "^0.26.9",
 				"@fluidframework/gitresources": "^0.1012.0",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/telemetry-utils": "^0.26.3"
+				"@fluidframework/telemetry-utils": "^0.26.9"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -1928,17 +1928,17 @@
 			"integrity": "sha512-StiRoivc79/obv8LA1LPcdzYWevzL3xbBftEjWV50w9hA86K1Mr6WSrBc0Hf7x+F6UuUer75O73Kpyo5MK9wwQ=="
 		},
 		"@fluidframework/local-driver": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.26.3.tgz",
-			"integrity": "sha512-og6oLWYTH/RHyY11myzgqMZYbUzb/L8A0M1gvrlyFwkUnWHU5J+4tWPZ7F1hXGid7K+Y9E9KPE8F7Q0IG6nW2w==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.26.9.tgz",
+			"integrity": "sha512-MTBIVzTDNTgrlUh9kywoXYbossOk/EUjbmo1KVgcNkAoA8rLDXocCeHiOD3XZMq9QBv1R4hsueYoTWYAAL2fsw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/driver-definitions": "^0.26.3",
-				"@fluidframework/driver-utils": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/driver-definitions": "^0.26.9",
+				"@fluidframework/driver-utils": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/routerlicious-driver": "^0.26.3",
+				"@fluidframework/routerlicious-driver": "^0.26.9",
 				"@fluidframework/server-local-server": "^0.1012.0",
 				"@fluidframework/server-services-client": "^0.1012.0",
 				"@fluidframework/server-services-core": "^0.1012.0",
@@ -2105,17 +2105,17 @@
 			}
 		},
 		"@fluidframework/map": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.26.3.tgz",
-			"integrity": "sha512-7oUlh7edCzcN5WS8lkg3J/RoPY/drf4mtLmTU6xM7cG8Ij8uN3ORjJtLn0wXtMS6EqKydiMBV4hGCab5Z0YNLg==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.26.9.tgz",
+			"integrity": "sha512-OnAhVraL4jVk9Tew7LfgleveF4mz1K6hg0EZv1gJUezUjeG1nR3KW2dAZ0remEuCrQz99Uq85X/fbG7VAlxEdw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/datastore-definitions": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/datastore-definitions": "^0.26.9",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.3",
+				"@fluidframework/shared-object-base": "^0.26.9",
 				"debug": "^4.1.1",
 				"path-browserify": "^1.0.1"
 			},
@@ -2163,16 +2163,16 @@
 			}
 		},
 		"@fluidframework/merge-tree": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.26.3.tgz",
-			"integrity": "sha512-dShxdwaDEUFsPBj1iWyOhR23oEd6TT3uDCb3ZGvobdXoSKRijos4JZG4qKHnoV/D73AOxQwQpUvR3ONF4r8+ig==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.26.9.tgz",
+			"integrity": "sha512-u4Y7RxTpm+WEla+UmmF37iSV9KSqFovSHcZYnP7sZxULXcKpzcvXFR06jgSDN6QqR8qCS8hjxKXqKDA+f38DQw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/datastore-definitions": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/datastore-definitions": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/telemetry-utils": "^0.26.3"
+				"@fluidframework/telemetry-utils": "^0.26.9"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -2221,14 +2221,14 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.26.3.tgz",
-			"integrity": "sha512-6TeAiy0uR9F6LqxLznIHcQuV5R7j0ORk5dljGzpD9dbIlGVEugCYa2Ds5bLhF8NLtcL7cWffEHmx/8fJ1oIacw==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.26.9.tgz",
+			"integrity": "sha512-gbxGCbLCs5VVkr5DZ5XMdfDNchMfF+yVIQivSRitBS1k1wfUbezZe31GGiDbimRj0Hrj86WD56AEHrlSRZXWtg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/datastore-definitions": "^0.26.3",
+				"@fluidframework/datastore-definitions": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.3",
+				"@fluidframework/shared-object-base": "^0.26.9",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
@@ -2258,26 +2258,26 @@
 			}
 		},
 		"@fluidframework/request-handler": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.26.3.tgz",
-			"integrity": "sha512-2aSE4aHqkrSKcli/gHfBCed8bsQbfDGBTYfc73R4451OOjdig4+b09E5DYu6kDFlvZNRPWm0wQblR+dwpsJcTA==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.26.9.tgz",
+			"integrity": "sha512-WEY1Mjo1BmpOuB2p+l6QtxMhoh1NTNGVCeQ78KW0v4AIwXDr9YyBB91Inw+oJ9We3apeYfNsLwUxjF2+vMMtHw==",
 			"requires": {
-				"@fluidframework/container-runtime-definitions": "^0.26.3",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/runtime-definitions": "^0.26.3",
-				"@fluidframework/runtime-utils": "^0.26.3"
+				"@fluidframework/container-runtime-definitions": "^0.26.9",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/runtime-definitions": "^0.26.9",
+				"@fluidframework/runtime-utils": "^0.26.9"
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.26.3.tgz",
-			"integrity": "sha512-5G9ZRPAzQVnQAYNadJmXmCD8BK58hijAEqRNRN0JP4HI5O0bfoCEiUa1x399kFbMf8jbWo14LfYdQZEV8NqSNw==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.26.9.tgz",
+			"integrity": "sha512-7KGV6PxJ0r0ZEBmLpufBEBuc+glQEfeBtWVyl5RzTf0su0nqJkSMDM/JjuhLFFwkEADzikjNN+mSPoREIZDh4Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/driver-base": "^0.26.3",
-				"@fluidframework/driver-definitions": "^0.26.3",
-				"@fluidframework/driver-utils": "^0.26.3",
+				"@fluidframework/driver-base": "^0.26.9",
+				"@fluidframework/driver-definitions": "^0.26.9",
+				"@fluidframework/driver-utils": "^0.26.9",
 				"@fluidframework/gitresources": "^0.1012.0",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
@@ -2350,14 +2350,14 @@
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.26.3.tgz",
-			"integrity": "sha512-V6LmLaePMhcM6wfSDe99/t2ACViVSYec8X4o9VTVYbJjyEgDnISAxAIYzvzz3kkhTLB5mMeQ2vMjNFc8TPed8w==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.26.9.tgz",
+			"integrity": "sha512-lr3GkYLqEb8MmV9N6o7NKkN8jxIHAlr6CFRhGNyCUJ4LZKnzPam8XCfXSgbniwdiTTedilrn9tPnsfh0lcDV3w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.26.3",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/driver-definitions": "^0.26.3",
+				"@fluidframework/container-definitions": "^0.26.9",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/driver-definitions": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
 				"@types/node": "^10.17.24"
 			},
@@ -2373,17 +2373,17 @@
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.26.3.tgz",
-			"integrity": "sha512-lXEW1A88WVF3ZGkxQKXHdtcrNVxgRl0cJAILLoVSQFWBlZkStwp1HLywXyBrCbqZwHg4UsMLRNjvDuBmVBSVUg==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.26.9.tgz",
+			"integrity": "sha512-0fQ74zrP9DGDdCM7bn0S/g2hdBMU8cQgRzikcvG3xyvoIPw3QZBq0PEpATfNgt7U2CrEfEWm/KIGTTdnm/kDYg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/datastore-definitions": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/datastore-definitions": "^0.26.9",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.3"
+				"@fluidframework/runtime-definitions": "^0.26.9"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -2546,17 +2546,17 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.26.3.tgz",
-			"integrity": "sha512-Md2SzJabzero0p5FTBsnNag89XzD7ARJgHZhRY9FQ+Yw0CyDUaK3oemwpqHcUcl8fxqEz4c5GdabRufvuNrn6g==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.26.9.tgz",
+			"integrity": "sha512-wKkUi+foWsu1wmrIFFUdWGLkmiaLaRboHxNLHUqbhjPxB+LAgI4qSjuCWIqCYluLs/D2f5fw8RJjXGmwi/nSMg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.26.3",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/datastore": "^0.26.3",
-				"@fluidframework/datastore-definitions": "^0.26.3",
+				"@fluidframework/container-definitions": "^0.26.9",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/datastore": "^0.26.9",
+				"@fluidframework/datastore-definitions": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/telemetry-utils": "^0.26.3",
+				"@fluidframework/telemetry-utils": "^0.26.9",
 				"@types/debug": "^4.1.5",
 				"@types/node": "^10.17.24",
 				"debug": "^4.1.1",
@@ -2574,17 +2574,17 @@
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.26.3.tgz",
-			"integrity": "sha512-8HjlLWm/SF5T7zQmwQvvMRBllbDyGrBhae5v8uPjkxjm+hIB7/SdFIFJ4/e4UcXypZjQi4/8kECfHTWrp8ofug==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.26.9.tgz",
+			"integrity": "sha512-55g8YDZ1eSAOJEdqWicmfG4xjru2ZP8V0xQmXB6kqg+n/O+43EsDK0f0efxmOSNIgQA/hFnkG4UxPgRNSRmCtQ==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^0.26.3"
+				"@fluidframework/core-interfaces": "^0.26.9"
 			}
 		},
 		"@fluidframework/telemetry-utils": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.26.3.tgz",
-			"integrity": "sha512-8T3jspdMuUPTH81UvdavReue4C54Z31XdNd1kbRPM6or5lbXzzzopZReH/dNwPfwYUv7NOd32dm+8HsVKJZ+xw==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.26.9.tgz",
+			"integrity": "sha512-179sqn99ih7yel7W2Wl+t7PPpEq1YR5OgjgCsVK19vbOnD61U17edUGZGzcL0paivhB3eE7yBDRz2qSVZuLiPg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
@@ -2616,11 +2616,11 @@
 			"dev": true
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.26.3.tgz",
-			"integrity": "sha512-INQr+Px9JTHafLinlyyhLKvDLdpFj01uP186/r30d4A2YPSmtjhtCPj/ZOsoz8kGBfaLfo9xoSj5zyKniMTPaw==",
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.26.9.tgz",
+			"integrity": "sha512-gytaPqJKvX1OZJ+5L8cvZdYczi6SLgrWzcMS23UOelS7Zo8CPAZ2oSeOQCjricfES/dYJ4qMRX472+pe/3bcyQ==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^0.26.3"
+				"@fluidframework/core-interfaces": "^0.26.9"
 			}
 		},
 		"@hapi/address": {
@@ -6988,7 +6988,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
 			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-			"dev": true,
 			"requires": {
 				"event-target-shim": "^5.0.0"
 			}
@@ -11767,8 +11766,7 @@
 		"event-target-shim": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-			"dev": true
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
 		},
 		"eventemitter3": {
 			"version": "3.1.2",
@@ -21129,25 +21127,25 @@
 			}
 		},
 		"old-aqueduct": {
-			"version": "npm:@fluidframework/aqueduct@0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.26.3.tgz",
-			"integrity": "sha512-/HOHn4GdOnjJnCOQgHR+dJx3QC7pgrx4xndnNaLa5bD5npFqtxj2ixOrq17uwDNh74+vjlq1oHaC3+dWtdnWgA==",
+			"version": "npm:@fluidframework/aqueduct@0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.26.9.tgz",
+			"integrity": "sha512-B7U5F56eKoFb/9qhhxytQQgbpIGdsUHtQOCMZ8Y5y07w8xA8a20pmULOI5XscimNc0y06AoBNpVOBnJmm86Z5Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.3",
-				"@fluidframework/container-loader": "^0.26.3",
-				"@fluidframework/container-runtime": "^0.26.3",
-				"@fluidframework/container-runtime-definitions": "^0.26.3",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/datastore": "^0.26.3",
-				"@fluidframework/datastore-definitions": "^0.26.3",
-				"@fluidframework/map": "^0.26.3",
-				"@fluidframework/request-handler": "^0.26.3",
-				"@fluidframework/runtime-definitions": "^0.26.3",
-				"@fluidframework/runtime-utils": "^0.26.3",
-				"@fluidframework/synthesize": "^0.26.3",
-				"@fluidframework/view-interfaces": "^0.26.3",
+				"@fluidframework/container-definitions": "^0.26.9",
+				"@fluidframework/container-loader": "^0.26.9",
+				"@fluidframework/container-runtime": "^0.26.9",
+				"@fluidframework/container-runtime-definitions": "^0.26.9",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/datastore": "^0.26.9",
+				"@fluidframework/datastore-definitions": "^0.26.9",
+				"@fluidframework/map": "^0.26.9",
+				"@fluidframework/request-handler": "^0.26.9",
+				"@fluidframework/runtime-definitions": "^0.26.9",
+				"@fluidframework/runtime-utils": "^0.26.9",
+				"@fluidframework/synthesize": "^0.26.9",
+				"@fluidframework/view-interfaces": "^0.26.9",
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
@@ -21169,15 +21167,15 @@
 			}
 		},
 		"old-cell": {
-			"version": "npm:@fluidframework/cell@0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.26.3.tgz",
-			"integrity": "sha512-oP5jyhP8iMiR9WFY1px4fK92u5RxNj4xOMiYzBGY7Qjl2JBt5FCse9/pXA+yfTMdUPrIXiInSNR0wSvh7wn5Dg==",
+			"version": "npm:@fluidframework/cell@0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.26.9.tgz",
+			"integrity": "sha512-uGD7N/+J4MQDkHIrpdQ9amTgbsJHm+CaoV+cF6Z4IHJRdE0k24E3hm9bbmbgxALmfFKEsAqFcqDXePNmAR0IpQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/datastore-definitions": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/datastore-definitions": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.3",
+				"@fluidframework/shared-object-base": "^0.26.9",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
@@ -21207,13 +21205,13 @@
 			}
 		},
 		"old-container-definitions": {
-			"version": "npm:@fluidframework/container-definitions@0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.26.3.tgz",
-			"integrity": "sha512-UYm67C/32F3mRwC5kiKkkPx9I8OoBAs6c8HdGJRUS1zmeIJCbC06Zjc8ipVjY3vEl0QyCVhNIlEme10ZBFN1Eg==",
+			"version": "npm:@fluidframework/container-definitions@0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.26.9.tgz",
+			"integrity": "sha512-WvdC8SkFnNDEOra+zdNRIUZJDWcpMAWifg1X9rLEL0rC0zclcMvQTcW1vPeRNhsVx4drWnwaWJ68nW1rIj0ekA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/driver-definitions": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/driver-definitions": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0"
 			},
 			"dependencies": {
@@ -21228,20 +21226,20 @@
 			}
 		},
 		"old-container-loader": {
-			"version": "npm:@fluidframework/container-loader@0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.26.3.tgz",
-			"integrity": "sha512-XWV+WsqKhXkrEqgWe77C76cSZHYMGw1PFR5E7qKs0qLoUvXYXWxYYRklCrY0H9SbpsyIVXD2c2YVaPiHLEsv7Q==",
+			"version": "npm:@fluidframework/container-loader@0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.26.9.tgz",
+			"integrity": "sha512-ijsJZqSKaB009zk95eQVsxDXl6VpFx4Emn3bLZr+qUBIn4Y+6FBb9jGtBmWq2XFh/AXMfOOPINkYjb1yssJx/w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.3",
-				"@fluidframework/container-utils": "^0.26.3",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/driver-definitions": "^0.26.3",
-				"@fluidframework/driver-utils": "^0.26.3",
+				"@fluidframework/container-definitions": "^0.26.9",
+				"@fluidframework/container-utils": "^0.26.9",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/driver-definitions": "^0.26.9",
+				"@fluidframework/driver-utils": "^0.26.9",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/telemetry-utils": "^0.26.3",
+				"@fluidframework/telemetry-utils": "^0.26.9",
 				"@types/double-ended-queue": "^2.1.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -21292,25 +21290,25 @@
 			}
 		},
 		"old-container-runtime": {
-			"version": "npm:@fluidframework/container-runtime@0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.26.3.tgz",
-			"integrity": "sha512-v70FiyLtSTBrsJ1OHdh26Wt3tpVCz6J4xwbPNtTPcajdJcJIJmojEtK0HGVH6jXhCOiSXpJEpAbSEdVa6zDo5w==",
+			"version": "npm:@fluidframework/container-runtime@0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.26.9.tgz",
+			"integrity": "sha512-vOb2P2zCXD2IgsC+CJuGo9+li2HLqO1NwQR7cgjkXa1t9RDPLN7z369sedAER0aK2Ry+ygahX2A1A3+Oymc+HQ==",
 			"requires": {
-				"@fluidframework/agent-scheduler": "^0.26.3",
+				"@fluidframework/agent-scheduler": "^0.26.9",
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.3",
-				"@fluidframework/container-runtime-definitions": "^0.26.3",
-				"@fluidframework/container-utils": "^0.26.3",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/datastore": "^0.26.3",
-				"@fluidframework/driver-definitions": "^0.26.3",
-				"@fluidframework/driver-utils": "^0.26.3",
+				"@fluidframework/container-definitions": "^0.26.9",
+				"@fluidframework/container-runtime-definitions": "^0.26.9",
+				"@fluidframework/container-utils": "^0.26.9",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/datastore": "^0.26.9",
+				"@fluidframework/driver-definitions": "^0.26.9",
+				"@fluidframework/driver-utils": "^0.26.9",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.3",
-				"@fluidframework/runtime-utils": "^0.26.3",
-				"@fluidframework/telemetry-utils": "^0.26.3",
+				"@fluidframework/runtime-definitions": "^0.26.9",
+				"@fluidframework/runtime-utils": "^0.26.9",
+				"@fluidframework/telemetry-utils": "^0.26.9",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/node": "^10.17.24",
@@ -21363,14 +21361,14 @@
 			}
 		},
 		"old-counter": {
-			"version": "npm:@fluidframework/counter@0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.26.3.tgz",
-			"integrity": "sha512-7zd+AbOThZfGWOyIMyZJTQkGO6//AwfBmF6eO5Dhvn2ntlLOn1OO17dDnmfcFndm/sNFx6STtiLFBKAy9vC1aw==",
+			"version": "npm:@fluidframework/counter@0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.26.9.tgz",
+			"integrity": "sha512-Jbv9EjAZJJlI4Z7FQEHKmO9ZKGldobMu7JP1GWhmNYpSQ1Bkfotbu01WcXX/qIXFR9szHz3TQiotDr0tvzchTA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/datastore-definitions": "^0.26.3",
+				"@fluidframework/datastore-definitions": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.3",
+				"@fluidframework/shared-object-base": "^0.26.9",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
@@ -21400,15 +21398,15 @@
 			}
 		},
 		"old-datastore-definitions": {
-			"version": "npm:@fluidframework/datastore-definitions@0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.26.3.tgz",
-			"integrity": "sha512-KsQBJZc+/uJFNJ6dgpNJbfLzcF9aL/VgD7DLVSLQ0AUsdkSyZ0hIYTHlGzjX7hN+7zyNI5GEpoZPkUj49uFtPA==",
+			"version": "npm:@fluidframework/datastore-definitions@0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.26.9.tgz",
+			"integrity": "sha512-aaMQ0RUnVaJIdOpIO1lc4MH3D2qC5d+43qxwil32swf2LOdwYkJ9ph1v9F7qn4mRYop5Ywowipv1H/rPai+hxA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.26.3",
-				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/container-definitions": "^0.26.9",
+				"@fluidframework/core-interfaces": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.3",
+				"@fluidframework/runtime-definitions": "^0.26.9",
 				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
@@ -21423,12 +21421,12 @@
 			}
 		},
 		"old-driver-definitions": {
-			"version": "npm:@fluidframework/driver-definitions@0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.26.3.tgz",
-			"integrity": "sha512-dHlg1U9V+79KLtLAllB5wUrZ3GEaK+qXFxXXYoEKWlQZvTOhSBHuN/DUDVM/bsBq4NBCU2MKpnk4RirE/LO3bQ==",
+			"version": "npm:@fluidframework/driver-definitions@0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.26.9.tgz",
+			"integrity": "sha512-Rg8Q4vytwj3khp52I3F0SXUo8rcuCwDE+Xj3YtDBbdNVUM6sQ5LlGfeq0ZEoPZ9aeWoviP+YISHu7/U6olkShg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0"
 			},
 			"dependencies": {
@@ -21443,14 +21441,14 @@
 			}
 		},
 		"old-ink": {
-			"version": "npm:@fluidframework/ink@0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.26.3.tgz",
-			"integrity": "sha512-DRMloDUHwgG4t14QtHb6humixzZ0zWyvGhC0h5ODocwmmrStZtKvXz/ghBQYROqdfLjCv4vOU0t/Hu+Ys8y3sw==",
+			"version": "npm:@fluidframework/ink@0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.26.9.tgz",
+			"integrity": "sha512-FPPPgwOiEHUM3mpq9RHETJJYeuxRqRObbYvkepTyKWvVVqkQHOw1YZXAqEjP9oZlGW1vWboijEuk9EH08oNaHQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/datastore-definitions": "^0.26.3",
+				"@fluidframework/datastore-definitions": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.3",
+				"@fluidframework/shared-object-base": "^0.26.9",
 				"@types/debug": "^4.1.5",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
@@ -21482,17 +21480,17 @@
 			}
 		},
 		"old-local-driver": {
-			"version": "npm:@fluidframework/local-driver@0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.26.3.tgz",
-			"integrity": "sha512-og6oLWYTH/RHyY11myzgqMZYbUzb/L8A0M1gvrlyFwkUnWHU5J+4tWPZ7F1hXGid7K+Y9E9KPE8F7Q0IG6nW2w==",
+			"version": "npm:@fluidframework/local-driver@0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.26.9.tgz",
+			"integrity": "sha512-MTBIVzTDNTgrlUh9kywoXYbossOk/EUjbmo1KVgcNkAoA8rLDXocCeHiOD3XZMq9QBv1R4hsueYoTWYAAL2fsw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/driver-definitions": "^0.26.3",
-				"@fluidframework/driver-utils": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/driver-definitions": "^0.26.9",
+				"@fluidframework/driver-utils": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/routerlicious-driver": "^0.26.3",
+				"@fluidframework/routerlicious-driver": "^0.26.9",
 				"@fluidframework/server-local-server": "^0.1012.0",
 				"@fluidframework/server-services-client": "^0.1012.0",
 				"@fluidframework/server-services-core": "^0.1012.0",
@@ -21659,17 +21657,17 @@
 			}
 		},
 		"old-map": {
-			"version": "npm:@fluidframework/map@0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.26.3.tgz",
-			"integrity": "sha512-7oUlh7edCzcN5WS8lkg3J/RoPY/drf4mtLmTU6xM7cG8Ij8uN3ORjJtLn0wXtMS6EqKydiMBV4hGCab5Z0YNLg==",
+			"version": "npm:@fluidframework/map@0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.26.9.tgz",
+			"integrity": "sha512-OnAhVraL4jVk9Tew7LfgleveF4mz1K6hg0EZv1gJUezUjeG1nR3KW2dAZ0remEuCrQz99Uq85X/fbG7VAlxEdw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/datastore-definitions": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/datastore-definitions": "^0.26.9",
 				"@fluidframework/protocol-base": "^0.1012.0",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.3",
+				"@fluidframework/shared-object-base": "^0.26.9",
 				"debug": "^4.1.1",
 				"path-browserify": "^1.0.1"
 			},
@@ -21717,19 +21715,19 @@
 			}
 		},
 		"old-matrix": {
-			"version": "npm:@fluidframework/matrix@0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.26.3.tgz",
-			"integrity": "sha512-cKEBIVUNxKMI2+6alKXbL3wwaQB++EjcukzOz8fLf0Im7EdvNhWfQxoFBP5S7cNhB8BxoPU0H5iARkZluuiuEQ==",
+			"version": "npm:@fluidframework/matrix@0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.26.9.tgz",
+			"integrity": "sha512-n5l3mpTDk5gSVNth/0tzp1OFWLrhGN0ZOozw0K6sYtYZruDJTj9dCat2Zx5L2kc2UXl7ey5kJ0vH/5EPimJjxg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/datastore-definitions": "^0.26.3",
-				"@fluidframework/merge-tree": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/datastore-definitions": "^0.26.9",
+				"@fluidframework/merge-tree": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-utils": "^0.26.3",
-				"@fluidframework/shared-object-base": "^0.26.3",
-				"@fluidframework/telemetry-utils": "^0.26.3",
+				"@fluidframework/runtime-utils": "^0.26.9",
+				"@fluidframework/shared-object-base": "^0.26.9",
+				"@fluidframework/telemetry-utils": "^0.26.9",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"debug": "^4.1.1",
 				"tslib": "^1.10.0"
@@ -21761,14 +21759,14 @@
 			}
 		},
 		"old-ordered-collection": {
-			"version": "npm:@fluidframework/ordered-collection@0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.26.3.tgz",
-			"integrity": "sha512-X/9wnqq0HeE5cVe50P2yv5rc6vQ9nBnpZ9CoireGx3NBngWed0KsQtjzpL08TkuSo5I9nAVWLCSAXfJTi7uJEQ==",
+			"version": "npm:@fluidframework/ordered-collection@0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.26.9.tgz",
+			"integrity": "sha512-WS6krocrtCWqr44gmehRJaS7oket+eyMKvFP9GQ69Qswp7kc8sDU6OQRGjL+l8nokYOyvdf+LT8dco3zYUDFPA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/datastore-definitions": "^0.26.3",
+				"@fluidframework/datastore-definitions": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.3",
+				"@fluidframework/shared-object-base": "^0.26.9",
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
@@ -21798,14 +21796,14 @@
 			}
 		},
 		"old-register-collection": {
-			"version": "npm:@fluidframework/register-collection@0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.26.3.tgz",
-			"integrity": "sha512-6TeAiy0uR9F6LqxLznIHcQuV5R7j0ORk5dljGzpD9dbIlGVEugCYa2Ds5bLhF8NLtcL7cWffEHmx/8fJ1oIacw==",
+			"version": "npm:@fluidframework/register-collection@0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.26.9.tgz",
+			"integrity": "sha512-gbxGCbLCs5VVkr5DZ5XMdfDNchMfF+yVIQivSRitBS1k1wfUbezZe31GGiDbimRj0Hrj86WD56AEHrlSRZXWtg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/datastore-definitions": "^0.26.3",
+				"@fluidframework/datastore-definitions": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.3",
+				"@fluidframework/shared-object-base": "^0.26.9",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
@@ -21835,14 +21833,14 @@
 			}
 		},
 		"old-runtime-definitions": {
-			"version": "npm:@fluidframework/runtime-definitions@0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.26.3.tgz",
-			"integrity": "sha512-V6LmLaePMhcM6wfSDe99/t2ACViVSYec8X4o9VTVYbJjyEgDnISAxAIYzvzz3kkhTLB5mMeQ2vMjNFc8TPed8w==",
+			"version": "npm:@fluidframework/runtime-definitions@0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.26.9.tgz",
+			"integrity": "sha512-lr3GkYLqEb8MmV9N6o7NKkN8jxIHAlr6CFRhGNyCUJ4LZKnzPam8XCfXSgbniwdiTTedilrn9tPnsfh0lcDV3w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.26.3",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/driver-definitions": "^0.26.3",
+				"@fluidframework/container-definitions": "^0.26.9",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/driver-definitions": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
 				"@types/node": "^10.17.24"
 			},
@@ -21858,20 +21856,20 @@
 			}
 		},
 		"old-sequence": {
-			"version": "npm:@fluidframework/sequence@0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.26.3.tgz",
-			"integrity": "sha512-Vr8jY5Giqzwiu6eij5YwBJpU3dq/8HiiM2V6fFh7IwjEniq1a77ZxV8lLbWzibImdNEe/wvv3EgCsvdx8tRuUA==",
+			"version": "npm:@fluidframework/sequence@0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.26.9.tgz",
+			"integrity": "sha512-HiVLdn8nOET2NTNIjbcYAjqtguyApVGhz2Lyei/ccEo6I61NZWKufW8+o9DoFQN/pSakg3WByjwjG4O0B+r7lQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/datastore-definitions": "^0.26.3",
-				"@fluidframework/map": "^0.26.3",
-				"@fluidframework/merge-tree": "^0.26.3",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/datastore-definitions": "^0.26.9",
+				"@fluidframework/map": "^0.26.9",
+				"@fluidframework/merge-tree": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-utils": "^0.26.3",
-				"@fluidframework/shared-object-base": "^0.26.3",
-				"@fluidframework/telemetry-utils": "^0.26.3",
+				"@fluidframework/runtime-utils": "^0.26.9",
+				"@fluidframework/shared-object-base": "^0.26.9",
+				"@fluidframework/telemetry-utils": "^0.26.9",
 				"debug": "^4.1.1",
 				"lodash": "^4.17.19"
 			},
@@ -21902,23 +21900,23 @@
 			}
 		},
 		"old-test-utils": {
-			"version": "npm:@fluidframework/test-utils@0.26.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.26.3.tgz",
-			"integrity": "sha512-7eM5pP/6QS8SKJ+7vjG+MGtOVTT3Vqoif9lFpLpVRtVjyiGsk8Y3G0k+GxV8jcer5FWVZKdHI819eqYD1RYCfg==",
+			"version": "npm:@fluidframework/test-utils@0.26.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.26.9.tgz",
+			"integrity": "sha512-RmhhrtjcxJHg9HBS9XFNsIg/RfbfDVa+l9GymO2sJW+ESzmf64+NcVyLaIPKIH28N8dfp4gr9h9Jo0ACow0FMQ==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.26.3",
-				"@fluidframework/container-definitions": "^0.26.3",
-				"@fluidframework/container-loader": "^0.26.3",
-				"@fluidframework/container-runtime": "^0.26.3",
-				"@fluidframework/core-interfaces": "^0.26.3",
-				"@fluidframework/datastore": "^0.26.3",
-				"@fluidframework/datastore-definitions": "^0.26.3",
-				"@fluidframework/driver-definitions": "^0.26.3",
-				"@fluidframework/local-driver": "^0.26.3",
-				"@fluidframework/map": "^0.26.3",
+				"@fluidframework/aqueduct": "^0.26.9",
+				"@fluidframework/container-definitions": "^0.26.9",
+				"@fluidframework/container-loader": "^0.26.9",
+				"@fluidframework/container-runtime": "^0.26.9",
+				"@fluidframework/core-interfaces": "^0.26.9",
+				"@fluidframework/datastore": "^0.26.9",
+				"@fluidframework/datastore-definitions": "^0.26.9",
+				"@fluidframework/driver-definitions": "^0.26.9",
+				"@fluidframework/local-driver": "^0.26.9",
+				"@fluidframework/map": "^0.26.9",
 				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/request-handler": "^0.26.3",
-				"@fluidframework/runtime-definitions": "^0.26.3",
+				"@fluidframework/request-handler": "^0.26.9",
+				"@fluidframework/runtime-definitions": "^0.26.9",
 				"@fluidframework/server-local-server": "^0.1012.0"
 			},
 			"dependencies": {

--- a/packages/framework/request-handler/src/test/requestHandlers.spec.ts
+++ b/packages/framework/request-handler/src/test/requestHandlers.spec.ts
@@ -80,7 +80,7 @@ describe("RequestParser", () => {
             await assertRejected(responseP);
         });
 
-        it("Data store  request with wait", async () => {
+        it("Data store request with wait", async () => {
             const requestParser = RequestParser.create({ url: "/nonExistingUri", headers: { wait: true } });
             const responseP = innerRequestHandler(
                 requestParser,
@@ -88,14 +88,14 @@ describe("RequestParser", () => {
             await assertRejected(responseP);
         });
 
-        it("Data store  request with sub route", async () => {
+        it("Data store request with sub route", async () => {
             const requestParser = RequestParser.create({ url: "/objectId/route", headers: { wait: true } });
             const response = await innerRequestHandler(requestParser, runtime);
             assert.equal(response.status, 200);
             assert.equal(response.value.route, "route");
         });
 
-        it("Data store  request with non-existing sub route", async () => {
+        it("Data store request with non-existing sub route", async () => {
             const requestParser = RequestParser.create({ url: "/objectId/doesNotExist", headers: { wait: true } });
             const responseP = innerRequestHandler(requestParser, runtime);
             await assertRejected(responseP);

--- a/packages/loader/container-loader/src/deltaManagerProxy.ts
+++ b/packages/loader/container-loader/src/deltaManagerProxy.ts
@@ -36,9 +36,6 @@ export class DeltaQueueProxy<T> extends EventForwarder<IDeltaQueueEvents<T>> imp
         return this.queue.idle;
     }
 
-    private systemPaused = false;
-    private localPaused = false;
-
     constructor(private readonly queue: IDeltaQueue<T>) {
         super(queue);
     }
@@ -52,29 +49,19 @@ export class DeltaQueueProxy<T> extends EventForwarder<IDeltaQueueEvents<T>> imp
     }
 
     public async systemPause(): Promise<void> {
-        this.systemPaused = true;
-        return this.queue.pause();
+        return this.pause();
     }
 
     public async pause(): Promise<void> {
-        this.localPaused = true;
         return this.queue.pause();
     }
 
     public async systemResume(): Promise<void> {
-        this.systemPaused = false;
-        return this.updateResume();
+        return this.resume();
     }
 
     public async resume(): Promise<void> {
-        this.localPaused = false;
-        return this.updateResume();
-    }
-
-    private async updateResume(): Promise<void> {
-        if (!this.systemPaused && !this.localPaused) {
-            return this.queue.resume();
-        }
+        this.queue.resume();
     }
 }
 

--- a/packages/loader/container-loader/src/deltaQueue.ts
+++ b/packages/loader/container-loader/src/deltaQueue.ts
@@ -85,6 +85,11 @@ export class DeltaQueue<T> extends TypedEventEmitter<IDeltaQueueEvents<T>> imple
     }
 
     public async pause(): Promise<void> {
+        const e = { stack: "" };
+        // eslint-disable-next-line dot-notation
+        const c = Error["captureStackTrace"];
+        c(e);
+        console.log("pause", e.stack);
         this.userPause = true;
         // If called from within the processing loop, we are in the middle of processing an op. Return a promise
         // that will resolve when processing has actually stopped.
@@ -94,6 +99,11 @@ export class DeltaQueue<T> extends TypedEventEmitter<IDeltaQueueEvents<T>> imple
     }
 
     public resume(): void {
+        const e = { stack: "" };
+        // eslint-disable-next-line dot-notation
+        const c = Error["captureStackTrace"];
+        c(e);
+        console.log("resume", e.stack);
         this.userPause = false;
         if (!this.paused) {
             this.ensureProcessing();

--- a/packages/loader/container-loader/src/deltaQueue.ts
+++ b/packages/loader/container-loader/src/deltaQueue.ts
@@ -94,6 +94,7 @@ export class DeltaQueue<T> extends TypedEventEmitter<IDeltaQueueEvents<T>> imple
     }
 
     public resume(): void {
+        assert(this.userPause > 0);
         this.userPause--;
         if (!this.paused) {
             this.ensureProcessing();
@@ -110,6 +111,7 @@ export class DeltaQueue<T> extends TypedEventEmitter<IDeltaQueueEvents<T>> imple
     }
 
     public systemResume(): void {
+        assert(this.sysPause > 0);
         this.sysPause--;
         if (!this.paused) {
             this.ensureProcessing();

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1227,7 +1227,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const deferredContext = this.ensureContextDeferred(id);
 
         if (!wait && !deferredContext.isCompleted) {
-            return Promise.reject(`Process ${id} does not exist`);
+            return Promise.reject(new Error(`DataStore ${id} does not exist`));
         }
 
         const context = await deferredContext.promise;

--- a/packages/test/end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/batching.spec.ts
@@ -11,7 +11,6 @@ import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions"
 import { IEnvelope, FlushMode } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
-    OpProcessingController,
     ITestFluidObject,
     ChannelFactoryRegistry,
 } from "@fluidframework/test-utils";
@@ -29,7 +28,6 @@ const testContainerConfig: ITestContainerConfig = {
 };
 
 const tests = (args: ICompatLocalTestObjectProvider) => {
-    let opProcessingController: OpProcessingController;
     let dataObject1: ITestFluidObject;
     let dataObject2: ITestFluidObject;
     let dataObject1map1: SharedMap;
@@ -76,10 +74,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
         dataObject2map1 = await dataObject2.getSharedObject<SharedMap>(map1Id);
         dataObject2map2 = await dataObject2.getSharedObject<SharedMap>(map2Id);
 
-        opProcessingController = new OpProcessingController(args.deltaConnectionServer);
-        opProcessingController.addDeltaManagers(dataObject1.runtime.deltaManager, dataObject2.runtime.deltaManager);
-
-        await opProcessingController.process();
+        await args.opProcessingController.process();
     });
 
     describe("Local ops batch metadata verification", () => {
@@ -102,7 +97,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 });
 
                 // Wait for the ops to get processed by both the containers.
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 assert.equal(
                     dataObject1BatchMessages.length, 4, "Incorrect number of messages received on local client");
@@ -119,7 +114,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 });
 
                 // Wait for the ops to get processed by both the containers.
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 assert.equal(
                     dataObject1BatchMessages.length, 1, "Incorrect number of messages received on local client");
@@ -146,7 +141,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 });
 
                 // Wait for the ops to get processed by both the containers.
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 assert.equal(
                     dataObject1BatchMessages.length, 4, "Incorrect number of messages received on local client");
@@ -171,7 +166,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 });
 
                 // Wait for the ops to get processed by both the containers.
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 assert.equal(
                     dataObject1BatchMessages.length, 0, "Incorrect number of messages received on local client");
@@ -196,7 +191,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 });
 
                 // Wait for the ops to get processed by both the containers.
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 assert.equal(
                     dataObject1BatchMessages.length, 4, "Incorrect number of messages received on local client");
@@ -209,7 +204,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
         });
 
         describe("Manually flushed batches", () => {
-            it("can send and receive mulitple batch ops that are manually flushed", async () => {
+            it("can send and receive multiple batch ops that are manually flushed", async () => {
                 // Set the FlushMode to Manual.
                 dataObject1.context.containerRuntime.setFlushMode(FlushMode.Manual);
 
@@ -223,7 +218,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 (dataObject1.context.containerRuntime as IContainerRuntime).flush();
 
                 // Wait for the ops to get processed by both the containers.
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 assert.equal(
                     dataObject1BatchMessages.length, 4, "Incorrect number of messages received on local client");
@@ -244,7 +239,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 dataObject2.context.containerRuntime.setFlushMode(FlushMode.Automatic);
 
                 // Wait for the ops to get processed by both the containers.
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 assert.equal(
                     dataObject1BatchMessages.length, 1, "Incorrect number of messages received on local client");
@@ -289,7 +284,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 dataObject2.context.containerRuntime.setFlushMode(FlushMode.Automatic);
 
                 // Wait for the ops to get processed by both the containers.
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 assert.equal(
                     dataObject1BatchMessages.length, 6, "Incorrect number of messages received on local client");
@@ -332,7 +327,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 verifyDocumentDirtyState(dataObject1, true);
 
                 // Wait for the ops to get processed by both the containers.
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 // Verify that the document dirty state is cleaned after the ops are processed.
                 verifyDocumentDirtyState(dataObject1, false);
@@ -350,7 +345,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 verifyDocumentDirtyState(dataObject1, true);
 
                 // Wait for the ops to get processed by both the containers.
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 // Verify that the document dirty state is cleaned after the ops are processed.
                 verifyDocumentDirtyState(dataObject1, false);
@@ -372,7 +367,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 verifyDocumentDirtyState(dataObject1, true);
 
                 // Wait for the ops to get processed by both the containers.
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 // Check that the document dirty state is cleaned after the ops are processed.
                 // Verify that the document dirty state is cleaned after the ops are processed.
@@ -401,7 +396,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 verifyDocumentDirtyState(dataObject1, true);
 
                 // Wait for the ops to get processed by both the containers.
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 // Verify that the document dirty state is cleaned after the ops are processed.
                 verifyDocumentDirtyState(dataObject1, false);
@@ -419,7 +414,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 verifyDocumentDirtyState(dataObject1, true);
 
                 // Wait for the ops to get processed by both the containers.
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 // Verify that the document dirty state is cleaned after the ops are processed.
                 verifyDocumentDirtyState(dataObject1, false);
@@ -438,7 +433,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 verifyDocumentDirtyState(dataObject1, true);
 
                 // Wait for the ops to get processed by both the containers.
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 // Verify that the document dirty state is cleaned after the ops are processed.
                 verifyDocumentDirtyState(dataObject1, false);
@@ -459,7 +454,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 verifyDocumentDirtyState(dataObject1, true);
 
                 // Wait for the ops to get processed by both the containers.
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 // Check that the document dirty state is cleaned after the ops are processed.
                 // Verify that the document dirty state is cleaned after the ops are processed.
@@ -490,7 +485,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 verifyDocumentDirtyState(dataObject1, true);
 
                 // Wait for the ops to get processed by both the containers.
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 // Verify that the document dirty state is cleaned after the ops are processed.
                 verifyDocumentDirtyState(dataObject1, false);

--- a/packages/test/end-to-end-tests/src/test/cellEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/cellEndToEndTests.spec.ts
@@ -8,11 +8,11 @@ import { ISharedCell, SharedCell } from "@fluidframework/cell";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
-    OpProcessingController,
     ITestFluidObject,
     ChannelFactoryRegistry,
 } from "@fluidframework/test-utils";
 import { generateTestWithCompat, ICompatLocalTestObjectProvider, ITestContainerConfig } from "./compatUtils";
+import { Container } from "@fluidframework/container-loader";
 
 const cellId = "cellKey";
 const registry: ChannelFactoryRegistry = [[cellId, SharedCell.getFactory()]];
@@ -25,7 +25,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
     const initialCellValue = "Initial cell value";
     const newCellValue = "A new cell value";
 
-    let opProcessingController: OpProcessingController;
+    let container1: Container;
     let dataObject1: ITestFluidObject;
     let sharedCell1: ISharedCell;
     let sharedCell2: ISharedCell;
@@ -33,7 +33,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 
     beforeEach(async () => {
         // Create a Container for the first client.
-        const container1 = await args.makeTestContainer(testContainerConfig);
+        container1 = await args.makeTestContainer(testContainerConfig) as Container;
         dataObject1 = await requestFluidObject<ITestFluidObject>(container1, "default");
         sharedCell1 = await dataObject1.getSharedObject<SharedCell>(cellId);
 
@@ -47,16 +47,10 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
         const dataObject3 = await requestFluidObject<ITestFluidObject>(container3, "default");
         sharedCell3 = await dataObject3.getSharedObject<SharedCell>(cellId);
 
-        opProcessingController = new OpProcessingController(args.deltaConnectionServer);
-        opProcessingController.addDeltaManagers(
-            dataObject1.runtime.deltaManager,
-            dataObject2.runtime.deltaManager,
-            dataObject3.runtime.deltaManager);
-
         // Set a starting value in the cell
         sharedCell1.set(initialCellValue);
 
-        await opProcessingController.process();
+        await args.opProcessingController.process();
     });
 
     function verifyCellValue(cell: ISharedCell, expectedValue, index: number) {
@@ -95,7 +89,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
     it("can set and get cell data in 3 containers correctly", async () => {
         sharedCell2.set(newCellValue);
 
-        await opProcessingController.process();
+        await args.opProcessingController.process();
 
         verifyCellValues(newCellValue, newCellValue, newCellValue);
     });
@@ -103,7 +97,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
     it("can delete cell data in 3 containers correctly", async () => {
         sharedCell3.delete();
 
-        await opProcessingController.process();
+        await args.opProcessingController.process();
 
         verifyCellEmpty(true, true, true);
     });
@@ -129,7 +123,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 
         sharedCell1.set(newCellValue);
 
-        await opProcessingController.process();
+        await args.opProcessingController.process();
 
         assert.equal(user1ValueChangedCount, 1, "Incorrect number of valueChanged op received in container 1");
         assert.equal(user2ValueChangedCount, 1, "Incorrect number of valueChanged op received in container 2");
@@ -146,7 +140,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 
         verifyCellValues("value1", "value2", "value3");
 
-        await opProcessingController.process();
+        await args.opProcessingController.process();
 
         verifyCellValues("value3", "value3", "value3");
     });
@@ -159,24 +153,41 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 
         verifyCellValues("value1.1", undefined, "value1.3");
 
-        await opProcessingController.process();
+        await args.opProcessingController.process();
 
         verifyCellValues("value1.3", "value1.3", "value1.3");
     });
 
     it("Simultaneous delete/set on same cell should reach eventual consistency with the same value", async () => {
+        container1.deltaManager.inbound.on("push", (msg) => {
+            console.log("push", msg);
+            console.log(container1.deltaManager.inbound.paused);
+        });
+        container1.deltaManager.inbound.on("op", (msg) => {
+            console.log("op", msg);
+            console.log(container1.deltaManager.inbound.paused);
+        });
+        container1.deltaManager.outbound.on("push", (msg) => {
+            console.log("out push", msg);
+            console.log(container1.deltaManager.outbound.paused);
+        });
+        container1.deltaManager.outbound.on("op", (msg) => {
+            console.log("out op", msg);
+            console.log(container1.deltaManager.outbound.paused);
+        });
         // delete and then set on the same cell
         sharedCell1.set("value2.1");
         sharedCell2.delete();
         sharedCell3.set("value2.3");
 
+        console.log(sharedCell1.get());
         // drain the outgoing so that the next set will come after
-        await opProcessingController.processOutgoing();
-
+        await args.opProcessingController.processOutgoing();
+        console.log(sharedCell1.get());
         sharedCell2.set("value2.2");
         verifyCellValues("value2.1", "value2.2", "value2.3");
 
-        await opProcessingController.process();
+        await args.opProcessingController.process();
 
         verifyCellValues("value2.2", "value2.2", "value2.2");
     });
@@ -190,7 +201,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
         verifyCellValues("value3.1", "value3.2", undefined);
         verifyCellEmpty(false, false, true);
 
-        await opProcessingController.process();
+        await args.opProcessingController.process();
 
         verifyCellValues(undefined, undefined, undefined);
         verifyCellEmpty(true, true, true);
@@ -204,7 +215,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
         detachedCell1.set(detachedCell2.handle);
         sharedCell1.set(detachedCell1.handle);
 
-        await opProcessingController.process();
+        await args.opProcessingController.process();
 
         async function getCellDataStore(cellP: Promise<ISharedCell>): Promise<ISharedCell> {
             const cell = await cellP;

--- a/packages/test/end-to-end-tests/src/test/cellEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/cellEndToEndTests.spec.ts
@@ -5,7 +5,6 @@
 
 import { strict as assert } from "assert";
 import { ISharedCell, SharedCell } from "@fluidframework/cell";
-import { Container } from "@fluidframework/container-loader";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {

--- a/packages/test/end-to-end-tests/src/test/compat.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/compat.spec.ts
@@ -8,7 +8,7 @@ import { IContainer, IFluidModule } from "@fluidframework/container-definitions"
 import { IFluidRouter } from "@fluidframework/core-interfaces";
 import { ISummaryConfiguration } from "@fluidframework/protocol-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
-import { OpProcessingController, LocalTestObjectProvider, ChannelFactoryRegistry } from "@fluidframework/test-utils";
+import { LocalTestObjectProvider, ChannelFactoryRegistry } from "@fluidframework/test-utils";
 import { ILocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import {
     generateCompatTest,
@@ -44,7 +44,6 @@ describe("loader/runtime compatibility", () => {
     const tests = function(args: ICompatLocalTestObjectProvider) {
         let container: IContainer | old.IContainer;
         let dataObject: TestDataObject | OldTestDataObject;
-        let opProcessingController: OpProcessingController;
         let containerError: boolean = false;
 
         beforeEach(async function() {
@@ -54,9 +53,6 @@ describe("loader/runtime compatibility", () => {
             container.on("closed", (error) => containerError = containerError || error !== undefined);
 
             dataObject = await requestFluidObject<TestDataObject>(container as IFluidRouter, "default");
-
-            opProcessingController = new OpProcessingController(args.deltaConnectionServer);
-            opProcessingController.addDeltaManagers(dataObject._runtime.deltaManager);
         });
 
         afterEach(async function() {
@@ -64,7 +60,7 @@ describe("loader/runtime compatibility", () => {
         });
 
         it("loads", async function() {
-            await opProcessingController.process();
+            await args.opProcessingController.process();
         });
 
         it("can set/get on root directory", async function() {

--- a/packages/test/end-to-end-tests/src/test/compatUtils.ts
+++ b/packages/test/end-to-end-tests/src/test/compatUtils.ts
@@ -31,6 +31,7 @@ import {
     TestContainerRuntimeFactory,
     TestFluidObjectFactory,
     LocalTestObjectProvider,
+    OpProcessingController,
 } from "@fluidframework/test-utils";
 import * as old from "./oldVersion";
 
@@ -51,6 +52,7 @@ export interface ICompatLocalTestObjectProvider {
     documentServiceFactory: IDocumentServiceFactory | old.IDocumentServiceFactory,
     urlResolver: LocalResolver | old.LocalResolver,
     defaultCodeDetails: IFluidCodeDetails | old.IFluidCodeDetails,
+    opProcessingController: OpProcessingController | old.OpProcessingController,
 }
 
 export interface ICompatTestOptions {

--- a/packages/test/end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
@@ -9,7 +9,6 @@ import { ISharedDirectory, ISharedMap, SharedDirectory, SharedMap } from "@fluid
 import { MessageType } from "@fluidframework/protocol-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
-    OpProcessingController,
     ITestFluidObject,
     ChannelFactoryRegistry,
 } from "@fluidframework/test-utils";
@@ -23,7 +22,6 @@ const testContainerConfig: ITestContainerConfig = {
 };
 
 const tests = (args: ICompatLocalTestObjectProvider) => {
-    let opProcessingController: OpProcessingController;
     let dataObject1: ITestFluidObject;
     let sharedDirectory1: ISharedDirectory;
     let sharedDirectory2: ISharedDirectory;
@@ -45,13 +43,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
         const dataObject3 = await requestFluidObject<ITestFluidObject>(container3, "default");
         sharedDirectory3 = await dataObject3.getSharedObject<SharedDirectory>(directoryId);
 
-        opProcessingController = new OpProcessingController(args.deltaConnectionServer);
-        opProcessingController.addDeltaManagers(
-            dataObject1.runtime.deltaManager,
-            dataObject2.runtime.deltaManager,
-            dataObject3.runtime.deltaManager);
-
-        await opProcessingController.process();
+        await args.opProcessingController.process();
     });
 
     function expectAllValues(msg, key, path, value1, value2, value3) {
@@ -98,7 +90,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 
         it("should set a key in the directory in three containers correctly", async () => {
             sharedDirectory1.set("testKey1", "testValue1");
-            await opProcessingController.process();
+            await args.opProcessingController.process();
             expectAllAfterValues("testKey1", "/", "testValue1");
         });
     });
@@ -106,13 +98,13 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
     describe("Root operations", () => {
         beforeEach("Populate with a value under the root", async () => {
             sharedDirectory1.set("testKey1", "testValue1");
-            await opProcessingController.process();
+            await args.opProcessingController.process();
             expectAllAfterValues("testKey1", "/", "testValue1");
         });
 
         it("should delete a value in 3 containers correctly", async () => {
             sharedDirectory2.delete("testKey1");
-            await opProcessingController.process();
+            await args.opProcessingController.process();
 
             const hasKey1 = sharedDirectory1.has("testKey1");
             assert.equal(hasKey1, false, "testKey1 not deleted in container 1");
@@ -127,7 +119,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
         it("should have the correct size in three containers", async () => {
             sharedDirectory3.set("testKey3", true);
 
-            await opProcessingController.process();
+            await args.opProcessingController.process();
 
             // check the number of keys in the map (2 keys set)
             expectAllSize(2);
@@ -137,7 +129,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
             sharedDirectory2.set("testKey1", undefined);
             sharedDirectory2.set("testKey2", undefined);
 
-            await opProcessingController.process();
+            await args.opProcessingController.process();
 
             expectAllAfterValues("testKey1", "/", undefined);
             expectAllAfterValues("testKey2", "/", undefined);
@@ -174,7 +166,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 
             sharedDirectory1.set("testKey1", "updatedValue");
 
-            await opProcessingController.process();
+            await args.opProcessingController.process();
 
             assert.equal(user1ValueChangedCount, 0, "Incorrect number of valueChanged op received in container 1");
             assert.equal(user2ValueChangedCount, 1, "Incorrect number of valueChanged op received in container 2");
@@ -192,7 +184,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 
                 expectAllBeforeValues("testKey1", "/", "value1", "value2", "value3");
 
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 expectAllAfterValues("testKey1", "/", "value3");
             });
@@ -205,7 +197,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 
                 expectAllBeforeValues("testKey1", "/", "value1.1", undefined, "value1.3");
 
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 expectAllAfterValues("testKey1", "/", "value1.3");
             });
@@ -217,13 +209,13 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 sharedDirectory3.set("testKey2", "value2.3");
 
                 // drain the outgoing so that the next set will come after
-                await opProcessingController.processOutgoing();
+                await args.opProcessingController.processOutgoing();
 
                 sharedDirectory2.set("testKey2", "value2.2");
 
                 expectAllBeforeValues("testKey2", "/", "value2.1", "value2.2", "value2.3");
 
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 expectAllAfterValues("testKey2", "/", "value2.2");
             });
@@ -236,7 +228,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 
                 expectAllBeforeValues("testKey3", "/", "value3.1", "value3.2", undefined);
 
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 expectAllAfterValues("testKey3", "/", undefined);
             });
@@ -251,7 +243,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 
                 assert.equal(sharedDirectory3.size, 0, "Incorrect map size after clear");
 
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 expectAllAfterValues("testKey1", "/", undefined);
                 expectAllSize(0);
@@ -264,12 +256,12 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 sharedDirectory3.set("testKey2", "value2.3");
 
                 // drain the outgoing so that the next set will come after
-                await opProcessingController.processOutgoing();
+                await args.opProcessingController.processOutgoing();
 
                 sharedDirectory2.set("testKey2", "value2.2");
                 expectAllBeforeValues("testKey2", "/", "value2.1", "value2.2", "value2.3");
 
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 expectAllAfterValues("testKey2", "/", "value2.2");
                 expectAllSize(1);
@@ -282,7 +274,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 sharedDirectory3.set("testKey3", "value3.3");
                 expectAllBeforeValues("testKey3", "/", "value3.1", undefined, "value3.3");
 
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 expectAllAfterValues("testKey3", "/", "value3.3");
                 expectAllSize(1);
@@ -294,7 +286,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 const newMap = SharedMap.create(dataObject1.runtime);
                 sharedDirectory1.set("mapKey", newMap.handle);
 
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 const [map1, map2, map3] = await Promise.all([
                     sharedDirectory1.get<IFluidHandle<ISharedMap>>("mapKey").get(),
@@ -308,7 +300,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 
                 map2.set("testMapKey", "testMapValue");
 
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 assert.equal(map3.get("testMapKey"), "testMapValue", "Wrong values in map in container 3");
             });
@@ -319,7 +311,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
         it("should set a key in a SubDirectory in three containers correctly", async () => {
             sharedDirectory1.createSubDirectory("testSubDir1").set("testKey1", "testValue1");
 
-            await opProcessingController.process();
+            await args.opProcessingController.process();
 
             expectAllAfterValues("testKey1", "testSubDir1", "testValue1");
         });
@@ -327,13 +319,13 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
         it("should delete a key in a SubDirectory in three containers correctly", async () => {
             sharedDirectory2.createSubDirectory("testSubDir1").set("testKey1", "testValue1");
 
-            await opProcessingController.process();
+            await args.opProcessingController.process();
 
             expectAllAfterValues("testKey1", "testSubDir1", "testValue1");
             const subDir1 = sharedDirectory3.getWorkingDirectory("testSubDir1");
             subDir1.delete("testKey1");
 
-            await opProcessingController.process();
+            await args.opProcessingController.process();
 
             expectAllAfterValues("testKey1", "testSubDir1", undefined);
         });
@@ -341,12 +333,12 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
         it("should delete a child SubDirectory in a SubDirectory in three containers correctly", async () => {
             sharedDirectory2.createSubDirectory("testSubDir1").set("testKey1", "testValue1");
 
-            await opProcessingController.process();
+            await args.opProcessingController.process();
 
             expectAllAfterValues("testKey1", "testSubDir1", "testValue1");
             sharedDirectory3.deleteSubDirectory("testSubDir1");
 
-            await opProcessingController.process();
+            await args.opProcessingController.process();
 
             assert.equal(
                 sharedDirectory1.getWorkingDirectory("testSubDir1"),
@@ -367,12 +359,12 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
             sharedDirectory2.createSubDirectory("testSubDir1").set("testKey2", "testValue2");
             sharedDirectory3.createSubDirectory("otherSubDir2").set("testKey3", "testValue3");
 
-            await opProcessingController.process();
+            await args.opProcessingController.process();
 
             expectAllSize(2, "testSubDir1");
             sharedDirectory3.getWorkingDirectory("testSubDir1").clear();
 
-            await opProcessingController.process();
+            await args.opProcessingController.process();
 
             expectAllSize(0, "testSubDir1");
         });
@@ -411,7 +403,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 
             sharedDirectory1.createSubDirectory("testSubDir1").set("testKey1", "updatedValue");
 
-            await opProcessingController.process();
+            await args.opProcessingController.process();
 
             assert.equal(user1ValueChangedCount, 0, "Incorrect number of valueChanged op received in container 1");
             assert.equal(user2ValueChangedCount, 1, "Incorrect number of valueChanged op received in container 2");
@@ -427,7 +419,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
             beforeEach(async () => {
                 sharedDirectory1.createSubDirectory("testSubDir").set("dummyKey", "dummyValue");
 
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 root1SubDir = sharedDirectory1.getWorkingDirectory("testSubDir");
                 root2SubDir = sharedDirectory2.getWorkingDirectory("testSubDir");
@@ -442,7 +434,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 
                 expectAllBeforeValues("testKey1", "/testSubDir", "value1", "value2", "value3");
 
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 expectAllAfterValues("testKey1", "/testSubDir", "value3");
             });
@@ -455,7 +447,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 
                 expectAllBeforeValues("testKey1", "/testSubDir", "value1.1", undefined, "value1.3");
 
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 expectAllAfterValues("testKey1", "/testSubDir", "value1.3");
             });
@@ -467,12 +459,12 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 root3SubDir.set("testKey2", "value2.3");
 
                 // drain the outgoing so that the next set will come after
-                await opProcessingController.processOutgoing();
+                await args.opProcessingController.processOutgoing();
 
                 root2SubDir.set("testKey2", "value2.2");
                 expectAllBeforeValues("testKey2", "/testSubDir", "value2.1", "value2.2", "value2.3");
 
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 expectAllAfterValues("testKey2", "/testSubDir", "value2.2");
             });
@@ -485,7 +477,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
 
                 expectAllBeforeValues("testKey3", "/testSubDir", "value3.1", "value3.2", undefined);
 
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 expectAllAfterValues("testKey3", "/testSubDir", undefined);
             });
@@ -498,7 +490,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 expectAllBeforeValues("testKey1", "/testSubDir", "value1.1", "value1.2", undefined);
                 assert.equal(root3SubDir.size, 0, "Incorrect map size after clear");
 
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 expectAllAfterValues("testKey1", "/testSubDir", undefined);
                 expectAllSize(0, "/testSubDir");
@@ -511,12 +503,12 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 root3SubDir.set("testKey2", "value2.3");
 
                 // drain the outgoing so that the next set will come after
-                await opProcessingController.processOutgoing();
+                await args.opProcessingController.processOutgoing();
 
                 root2SubDir.set("testKey2", "value2.2");
                 expectAllBeforeValues("testKey2", "/testSubDir", "value2.1", "value2.2", "value2.3");
 
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 expectAllAfterValues("testKey2", "/testSubDir", "value2.2");
                 expectAllSize(1, "/testSubDir");
@@ -529,7 +521,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 root3SubDir.set("testKey3", "value3.3");
                 expectAllBeforeValues("testKey3", "/testSubDir", "value3.1", undefined, "value3.3");
 
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 expectAllAfterValues("testKey3", "/testSubDir", "value3.3");
                 expectAllSize(1, "/testSubDir");
@@ -562,7 +554,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 // Now add the handle to an attached directory so the new directory gets attached too.
                 sharedDirectory1.set("newSharedDirectory", newDirectory1.handle);
 
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 // The new directory should be availble in the remote client and it should contain that key that was
                 // set in local state.
@@ -576,7 +568,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 // Set a new value for the same key in the remote directory.
                 newDirectory2.set("newKey", "anotherNewValue");
 
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 // Verify that the new value is updated in both the directories.
                 assert.equal(
@@ -600,7 +592,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 // Now add the handle to an attached directory so the new directory gets attached too.
                 sharedDirectory1.set("newSharedDirectory", newDirectory1.handle);
 
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 // The new directory should be availble in the remote client and it should contain that key that was
                 // set in local state.
@@ -613,7 +605,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 // Delete the sub directory from the remote client.
                 newDirectory2.deleteSubDirectory(subDirName);
 
-                await opProcessingController.process();
+                await args.opProcessingController.process();
 
                 // Verify that the sub directory is deleted from both the directories.
                 assert.equal(

--- a/packages/test/end-to-end-tests/src/test/fluidObjectHandle.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/fluidObjectHandle.spec.ts
@@ -8,7 +8,6 @@ import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedMap } from "@fluidframework/map";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
-    OpProcessingController,
     TestFluidObject,
 } from "@fluidframework/test-utils";
 import {
@@ -18,7 +17,6 @@ import {
 } from "./compatUtils";
 
 const tests = (args: ICompatLocalTestObjectProvider) => {
-    let opProcessingController: OpProcessingController;
     let firstContainerObject1: TestDataObject;
     let firstContainerObject2: TestDataObject;
     let secondContainerObject1: TestDataObject;
@@ -35,11 +33,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
         const secondContainer = await args.loadTestContainer();
         secondContainerObject1 = await requestFluidObject<TestDataObject>(secondContainer, "default");
 
-        opProcessingController = new OpProcessingController(args.deltaConnectionServer);
-        opProcessingController.addDeltaManagers(
-            firstContainerObject1._runtime.deltaManager, secondContainerObject1._runtime.deltaManager);
-
-        await opProcessingController.process();
+        await args.opProcessingController.process();
     });
 
     it("should generate the absolute path for ContainerRuntime correctly", () => {
@@ -93,7 +87,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
         // Add the handle to the root DDS of `firstContainerObject1`.
         firstContainerObject1._root.set("sharedMap", sharedMapHandle);
 
-        await opProcessingController.process();
+        await args.opProcessingController.process();
 
         // Get the handle in the remote client.
         const remoteSharedMapHandle = secondContainerObject1._root.get<IFluidHandle<SharedMap>>("sharedMap");
@@ -123,7 +117,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
         // Add the handle to the root DDS of `firstContainerObject1` so that the FluidDataObjectRuntime is different.
         firstContainerObject1._root.set("sharedMap", sharedMap.handle);
 
-        await opProcessingController.process();
+        await args.opProcessingController.process();
 
         // Get the handle in the remote client.
         const remoteSharedMapHandle = secondContainerObject1._root.get<IFluidHandle<SharedMap>>("sharedMap");
@@ -150,7 +144,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
         // FluidDataObjectRuntime is different.
         firstContainerObject1._root.set("dataObject2", firstContainerObject2.handle);
 
-        await opProcessingController.process();
+        await args.opProcessingController.process();
 
         // Get the handle in the remote client.
         const remoteDataObjectHandle =

--- a/packages/test/end-to-end-tests/src/test/oldVersion.ts
+++ b/packages/test/end-to-end-tests/src/test/oldVersion.ts
@@ -22,6 +22,7 @@ export {
     TestContainerRuntimeFactory,
     LocalCodeLoader,
     ChannelFactoryRegistry,
+    OpProcessingController,
 } from "old-test-utils";
 export { SharedDirectory, SharedMap } from "old-map";
 export { SharedString, SparseMatrix } from "old-sequence";
@@ -41,8 +42,8 @@ import { Loader } from "old-container-loader";
 import { IDocumentServiceFactory } from "old-driver-definitions";
 import { LocalDocumentServiceFactory, LocalResolver } from "old-local-driver";
 import { IServiceConfiguration } from "@fluidframework/protocol-definitions";
+import { fluidEntryPoint, LocalCodeLoader, createAndAttachContainer, OpProcessingController } from "old-test-utils";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
-import { fluidEntryPoint, LocalCodeLoader, createAndAttachContainer } from "old-test-utils";
 
 const defaultDocumentId = "defaultDocumentId";
 const defaultDocumentLoadUrl = `fluid-test://localhost/${defaultDocumentId}`;
@@ -71,6 +72,7 @@ const defaultCodeDetails: IFluidCodeDetails = {
 export class LocalTestObjectProvider<TestContainerConfigType> {
     private _documentServiceFactory: IDocumentServiceFactory | undefined;
     private _defaultUrlResolver: LocalResolver | undefined;
+    private _opProcessingController: OpProcessingController | undefined;
 
     /**
      * Create a set of object to
@@ -112,6 +114,13 @@ export class LocalTestObjectProvider<TestContainerConfigType> {
         return this._defaultUrlResolver;
     }
 
+    get opProcessingController() {
+        if (!this._opProcessingController) {
+            this._opProcessingController = new OpProcessingController(this.deltaConnectionServer as any);
+        }
+        return this._opProcessingController;
+    }
+
     private createLoader(packageEntries: Iterable<[IFluidCodeDetails, fluidEntryPoint]>) {
         const codeLoader = new LocalCodeLoader(packageEntries);
         return new Loader(
@@ -137,7 +146,10 @@ export class LocalTestObjectProvider<TestContainerConfigType> {
      */
     public async makeTestContainer(testContainerConfig?: TestContainerConfigType) {
         const loader = this.makeTestLoader(testContainerConfig);
-        return createAndAttachContainer(defaultDocumentId, defaultCodeDetails, loader, this.urlResolver);
+        const container =
+            await createAndAttachContainer(defaultDocumentId, defaultCodeDetails, loader, this.urlResolver);
+        this.opProcessingController.addDeltaManagers(container.deltaManager);
+        return container;
     }
 
     /**
@@ -146,7 +158,9 @@ export class LocalTestObjectProvider<TestContainerConfigType> {
      */
     public async loadTestContainer(testContainerConfig?: TestContainerConfigType) {
         const loader = this.makeTestLoader(testContainerConfig);
-        return loader.resolve({ url: defaultDocumentLoadUrl });
+        const container = await loader.resolve({ url: defaultDocumentLoadUrl });
+        this.opProcessingController.addDeltaManagers(container.deltaManager);
+        return container;
     }
 
     /**
@@ -157,6 +171,7 @@ export class LocalTestObjectProvider<TestContainerConfigType> {
         await this._deltaConnectionServer?.webSocketServer.close();
         this._deltaConnectionServer = undefined;
         this._documentServiceFactory = undefined;
+        this._opProcessingController = undefined;
     }
 }
 

--- a/packages/test/end-to-end-tests/src/test/oldVersion.ts
+++ b/packages/test/end-to-end-tests/src/test/oldVersion.ts
@@ -148,7 +148,12 @@ export class LocalTestObjectProvider<TestContainerConfigType> {
         const loader = this.makeTestLoader(testContainerConfig);
         const container =
             await createAndAttachContainer(defaultDocumentId, defaultCodeDetails, loader, this.urlResolver);
-        this.opProcessingController.addDeltaManagers(container.deltaManager);
+
+        // TODO: the old version delta manager on the container doesn't do pause/resume count
+        // We can't use it to do pause/resume, or it will conflict with the call from the runtime's
+        // DeltaManagerProxy. Reach in to get in until > 0.28
+        const deltaManagerProxy = (container as any)._context.deltaManager;
+        this.opProcessingController.addDeltaManagers(deltaManagerProxy);
         return container;
     }
 
@@ -159,7 +164,12 @@ export class LocalTestObjectProvider<TestContainerConfigType> {
     public async loadTestContainer(testContainerConfig?: TestContainerConfigType) {
         const loader = this.makeTestLoader(testContainerConfig);
         const container = await loader.resolve({ url: defaultDocumentLoadUrl });
-        this.opProcessingController.addDeltaManagers(container.deltaManager);
+
+        // TODO: the old version delta manager on the container doesn't do pause/resume count
+        // We can't use it to do pause/resume, or it will conflict with the call from the runtime's
+        // DeltaManagerProxy. Reach in to get in until > 0.28
+        const deltaManagerProxy = (container as any)._context.deltaManager;
+        this.opProcessingController.addDeltaManagers(deltaManagerProxy);
         return container;
     }
 

--- a/packages/test/end-to-end-tests/src/test/sharedInterval.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/sharedInterval.spec.ts
@@ -16,7 +16,6 @@ import {
     SharedString,
 } from "@fluidframework/sequence";
 import {
-    OpProcessingController,
     ITestFluidObject,
     ChannelFactoryRegistry,
 } from "@fluidframework/test-utils";
@@ -50,8 +49,6 @@ const assertIntervalsHelper = (
 };
 
 const tests = (args: ICompatLocalTestObjectProvider) => {
-    let opProcessingController: OpProcessingController;
-
     describe("one client", () => {
         const stringId = "stringKey";
 
@@ -73,9 +70,6 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
             sharedString = await dataObject.getSharedObject<SharedString>(stringId);
             sharedString.insertText(0, "012");
             intervals = await sharedString.getIntervalCollection("intervals").getView();
-
-            opProcessingController = new OpProcessingController(args.deltaConnectionServer);
-            opProcessingController.addDeltaManagers(dataObject.runtime.deltaManager);
         });
 
         it("replace all is included", async () => {
@@ -171,7 +165,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                     assertIntervals([{ start: 0, end: 2 }]);
                 }
 
-                await opProcessingController.process();
+                await args.opProcessingController.process();
             }
         });
     });
@@ -184,7 +178,6 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
                 testFluidDataObject: true,
                 registry,
             };
-            opProcessingController = new OpProcessingController(args.deltaConnectionServer);
 
             // Create a Container for the first client.
             const container1 = await args.makeTestContainer(testContainerConfig);
@@ -200,11 +193,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
             const container2 = await args.loadTestContainer(testContainerConfig);
             const dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
 
-            opProcessingController.addDeltaManagers(
-                dataObject1.runtime.deltaManager,
-                dataObject2.runtime.deltaManager);
-
-            await opProcessingController.process();
+            await args.opProcessingController.process();
 
             const sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
             const intervals2 = await sharedString2.getIntervalCollection("intervals").getView();
@@ -216,7 +205,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
             sharedString2.insertText(4, "x");
             assertIntervalsHelper(sharedString2, intervals2, [{ start: 1, end: 7 }]);
 
-            await opProcessingController.process();
+            await args.opProcessingController.process();
             assertIntervalsHelper(sharedString1, intervals1, [{ start: 1, end: 7 }]);
         });
     });
@@ -254,18 +243,12 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
             const container3 = await args.loadTestContainer(testContainerConfig);
             const dataObject3 = await requestFluidObject<ITestFluidObject>(container3, "default");
             sharedMap3 = await dataObject3.getSharedObject<SharedMap>(mapId);
-
-            opProcessingController = new OpProcessingController(args.deltaConnectionServer);
-            opProcessingController.addDeltaManagers(
-                dataObject1.runtime.deltaManager,
-                dataObject2.runtime.deltaManager,
-                dataObject3.runtime.deltaManager);
         });
 
         // This functionality is used in Word and FlowView's "add comment" functionality.
         it("Can store shared objects in a shared string's interval collection via properties", async () => {
             sharedMap1.set("outerString", SharedString.create(dataObject1.runtime).handle);
-            await opProcessingController.process();
+            await args.opProcessingController.process();
 
             const outerString1 = await sharedMap1.get<IFluidHandle<SharedString>>("outerString").get();
             const outerString2 = await sharedMap2.get<IFluidHandle<SharedString>>("outerString").get();
@@ -277,7 +260,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
             outerString1.insertText(0, "outer string");
 
             const intervalCollection1 = outerString1.getIntervalCollection("comments");
-            await opProcessingController.process();
+            await args.opProcessingController.process();
 
             const intervalCollection2 = outerString2.getIntervalCollection("comments");
             const intervalCollection3 = outerString3.getIntervalCollection("comments");
@@ -294,7 +277,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
             const nestedMap = SharedMap.create(dataObject1.runtime);
             nestedMap.set("nestedKey", "nestedValue");
             intervalCollection1.add(8, 9, IntervalType.SlideOnRemove, { story: nestedMap.handle });
-            await opProcessingController.process();
+            await args.opProcessingController.process();
 
             const serialized1 = intervalCollection1.serializeInternal();
             const serialized2 = intervalCollection2.serializeInternal();

--- a/packages/test/end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
@@ -10,7 +10,6 @@ import { SharedString } from "@fluidframework/sequence";
 import {
     ChannelFactoryRegistry,
     ITestFluidObject,
-    OpProcessingController,
 } from "@fluidframework/test-utils";
 import { generateTestWithCompat, ICompatLocalTestObjectProvider, ITestContainerConfig } from "./compatUtils";
 
@@ -24,7 +23,6 @@ const testContainerConfig: ITestContainerConfig = {
 const tests = (args: ICompatLocalTestObjectProvider) => {
     let sharedString1: SharedString;
     let sharedString2: SharedString;
-    let opProcessingController: OpProcessingController;
 
     beforeEach(async () => {
         const container1 = await args.makeTestContainer(testContainerConfig) as Container;
@@ -34,9 +32,6 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
         const container2 = await args.loadTestContainer(testContainerConfig) as Container;
         const dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
         sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
-
-        opProcessingController = new OpProcessingController(args.deltaConnectionServer);
-        opProcessingController.addDeltaManagers(dataObject1.runtime.deltaManager, dataObject2.runtime.deltaManager);
     });
 
     it("can sync SharedString across multiple containers", async () => {
@@ -45,7 +40,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
         assert.equal(sharedString1.getText(), text, "The retrieved text should match the inserted text.");
 
         // Wait for the ops to to be submitted and processed across the containers.
-        await opProcessingController.process();
+        await args.opProcessingController.process();
 
         assert.equal(sharedString2.getText(), text, "The inserted text should have synced across the containers");
     });
@@ -56,7 +51,7 @@ const tests = (args: ICompatLocalTestObjectProvider) => {
         assert.equal(sharedString1.getText(), text, "The retrieved text should match the inserted text.");
 
         // Wait for the ops to to be submitted and processed across the containers.
-        await opProcessingController.process();
+        await args.opProcessingController.process();
 
         // Create a initialize a new container with the same id.
         const newContainer = await args.loadTestContainer(testContainerConfig) as Container;

--- a/packages/test/test-utils/src/localLoader.ts
+++ b/packages/test/test-utils/src/localLoader.ts
@@ -140,7 +140,8 @@ export class LocalTestObjectProvider<TestContainerConfigType> {
     }
 
     /**
-     * Make a test loader
+     * Make a test loader.  Container created/loaded thru this loader will not be automatically added
+     * to the OpProcessingController, and will need to be added manually if needed.
      * @param testContainerConfig - optional configuring the test Container
      */
     public makeTestLoader(testContainerConfig?: TestContainerConfigType) {
@@ -149,6 +150,7 @@ export class LocalTestObjectProvider<TestContainerConfigType> {
 
     /**
      * Make a container using a default document id and code details
+     * Container loaded is automatically added to the OpProcessingController to manage op flow
      * @param testContainerConfig - optional configuring the test Container
      */
     public async makeTestContainer(testContainerConfig?: TestContainerConfigType) {
@@ -160,7 +162,8 @@ export class LocalTestObjectProvider<TestContainerConfigType> {
     }
 
     /**
-     * Load a container using a default document id and code details
+     * Load a container using a default document id and code details.
+     * Container loaded is automatically added to the OpProcessingController to manage op flow
      * @param testContainerConfig - optional configuring the test Container
      */
     public async loadTestContainer(testContainerConfig?: TestContainerConfigType) {

--- a/packages/test/test-utils/src/opProcessingController.ts
+++ b/packages/test/test-utils/src/opProcessingController.ts
@@ -231,9 +231,16 @@ export class OpProcessingController {
      * Pauses the inbound and outbound queues of all the delta managers in our collection.
      */
     private async pauseAllDeltaManagerQueues() {
+        console.log("pausing");
+        const p: Promise<void>[] = [];
+
         for (const deltaManager of this.deltaManagers) {
-            await deltaManager.inbound.pause();
-            await deltaManager.outbound.pause();
+            p.push(deltaManager.inbound.pause());
+            p.push(deltaManager.outbound.pause());
         }
+
+        await Promise.all(p);
+        console.log("done");
+        return;
     }
 }

--- a/packages/test/test-utils/src/opProcessingController.ts
+++ b/packages/test/test-utils/src/opProcessingController.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { strict as assert } from "assert";
 import { IDeltaManager } from "@fluidframework/container-definitions";
 import { IDocumentMessage, ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { ILocalDeltaConnectionServer } from "@fluidframework/server-local-server";
@@ -212,10 +213,7 @@ export class OpProcessingController {
 
         return deltaMgrs.map((deltaManager) => {
             const toggle = this.deltaManagerToggles.get(deltaManager);
-            if (!toggle) {
-                throw new Error(
-                    "All delta managers must be added to deterministically control processing");
-            }
+            assert(toggle, "All delta managers must be added to deterministically control processing");
             return toggle;
         });
     }

--- a/packages/test/test-utils/src/opProcessingController.ts
+++ b/packages/test/test-utils/src/opProcessingController.ts
@@ -10,6 +10,49 @@ import { ILocalDeltaConnectionServer } from "@fluidframework/server-local-server
 // An IDeltaManager alias to be used within this class.
 export type DeltaManager = IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
 
+class DeltaManagerToggle {
+    private inboundPauseP: Promise<void> | undefined;
+    private outboundPauseP: Promise<void> | undefined;
+    constructor(public readonly deltaManager: DeltaManager) {
+    }
+
+    public async togglePauseAll() {
+        return Promise.all([this.togglePauseInbound(), this.togglePauseOutbound()]);
+    }
+
+    public toggleResumeAll() {
+        this.toggleResumeInbound();
+        this.toggleResumeOutbound();
+    }
+    public async togglePauseInbound() {
+        if (!this.inboundPauseP) {
+            this.inboundPauseP = this.deltaManager.inbound.pause();
+        }
+        return this.inboundPauseP;
+    }
+
+    public async togglePauseOutbound() {
+        if (!this.outboundPauseP) {
+            this.outboundPauseP = this.deltaManager.outbound.pause();
+        }
+        return this.outboundPauseP;
+    }
+
+    public toggleResumeInbound() {
+        if (this.inboundPauseP) {
+            this.inboundPauseP = undefined;
+            this.deltaManager.inbound.resume();
+        }
+    }
+
+    public toggleResumeOutbound() {
+        if (this.outboundPauseP) {
+            this.outboundPauseP = undefined;
+            this.deltaManager.outbound.resume();
+        }
+    }
+}
+
 /**
  * Class with access to the local delta connection server and delta managers that can control op processing.
  */
@@ -23,7 +66,7 @@ export class OpProcessingController {
         });
     }
 
-    private readonly deltaManagers: Set<DeltaManager> = new Set<DeltaManager>();
+    private readonly deltaManagerToggles = new Map<DeltaManager, DeltaManagerToggle>();
 
     private isNormalProcessingPaused = false;
 
@@ -44,38 +87,32 @@ export class OpProcessingController {
      * @param deltaManagers - Array of deltaManagers to add
      */
     public addDeltaManagers(...deltaManagers: DeltaManager[]) {
-        deltaManagers.forEach((doc) => {
-            this.deltaManagers.add(doc);
+        deltaManagers.forEach((deltaManager) => {
+            this.deltaManagerToggles.set(deltaManager, new DeltaManagerToggle(deltaManager));
         });
     }
 
     /**
-     * Processes incoming and outgoing op) of the given delta managers.
-     * It validates the delta managers and resumes its inbound and outbound queues. It then keeps yielding
-     * the JS event loop until all the ops have been processed by the server and by the delta managers.
-     *
-     * @param deltaMgrs - Array of delta managers whose ops to process. If no delta manager is provided, it
-     * processes the ops for all the delta managers in our collection.
-     */
+      * Processes incoming and outgoing op) of the given delta managers.
+      * It validates the delta managers and resumes its inbound and outbound queues. It then keeps yielding
+      * the JS event loop until all the ops have been processed by the server and by the delta managers.
+      *
+      * @param deltaMgrs - Array of delta managers whose ops to process. If no delta manager is provided, it
+      * processes the ops for all the delta managers in our collection.
+      */
     public async process(...deltaMgrs: DeltaManager[]): Promise<void> {
-        this.validateDeltaManagers(deltaMgrs);
+        const toggles = this.mapDeltaManagerToggle(deltaMgrs);
 
         // Pause the queues of all the delta managers in our collection to make sure that we only process the ops of
         // the requested delta managers.
         await this.pauseAllDeltaManagerQueues();
 
-        // If no delta managers are provided, process all delta managers in our collection.
-        const deltaManagers = deltaMgrs.length === 0 ? Array.from(this.deltaManagers) : deltaMgrs;
-
         // Resume the delta queues so that we can process incoming and outgoing ops.
-        deltaManagers.forEach((deltaManager) => {
-            deltaManager.inbound.resume();
-            deltaManager.outbound.resume();
-        });
+        toggles.forEach((toggle) => toggle.toggleResumeAll());
 
         // Wait for all pending ops to be processed.
         await this.yieldWhileDeltaManagersHaveWork(
-            deltaManagers,
+            toggles,
             (deltaManager) => !deltaManager.inbound.idle || !deltaManager.outbound.idle);
     }
 
@@ -88,23 +125,20 @@ export class OpProcessingController {
      * processes the ops for all the delta managers in our collection.
      */
     public async processIncoming(...deltaMgrs: DeltaManager[]): Promise<void> {
-        this.validateDeltaManagers(deltaMgrs);
+        const toggles = this.mapDeltaManagerToggle(deltaMgrs);
 
         // Pause the queues of all the delta managers in our collection to make sure that we only process the incoming
         // ops of the requested delta managers.
         await this.pauseAllDeltaManagerQueues();
 
-        // If no delta managers are provided, process all delta managers in our collection.
-        const deltaManagers = deltaMgrs.length === 0 ? Array.from(this.deltaManagers) : deltaMgrs;
-
         // Resume the inbound delta queue so that we can process incoming ops.
-        deltaManagers.forEach((deltaManager) => {
-            deltaManager.inbound.resume();
+        toggles.forEach((toggle) => {
+            toggle.toggleResumeInbound();
         });
 
         // Wait for all pending incoming ops to be processed.
         await this.yieldWhileDeltaManagersHaveWork(
-            deltaManagers,
+            toggles,
             (deltaManager) => !deltaManager.inbound.idle);
     }
 
@@ -117,23 +151,20 @@ export class OpProcessingController {
      * processes the ops for all the delta managers in our collection.
      */
     public async processOutgoing(...deltaMgrs: DeltaManager[]): Promise<void> {
-        this.validateDeltaManagers(deltaMgrs);
+        const toggles = this.mapDeltaManagerToggle(deltaMgrs);
 
         // Pause the queues of all the delta managers in our collection to make sure that we only process the outgoing
         // ops of the requested delta managers.
         await this.pauseAllDeltaManagerQueues();
 
-        // If no delta managers are provided, process all delta managers in our collection.
-        const deltaManagers = deltaMgrs.length === 0 ? Array.from(this.deltaManagers) : deltaMgrs;
-
         // Resume the outbound delta queue so that we can process outgoing ops.
-        deltaManagers.forEach((deltaManager) => {
-            deltaManager.outbound.resume();
+        toggles.forEach((toggle) => {
+            toggle.toggleResumeOutbound();
         });
 
         // Wait for all pending outgoing ops to be processed.
         await this.yieldWhileDeltaManagersHaveWork(
-            deltaManagers,
+            toggles,
             (deltaManager) => !deltaManager.outbound.idle);
     }
 
@@ -145,16 +176,10 @@ export class OpProcessingController {
      * pauses the processing of all the delta managers in our collection.
      */
     public async pauseProcessing(...deltaMgrs: DeltaManager[]) {
-        this.validateDeltaManagers(deltaMgrs);
-
-        // If no delta managers are provided, pause the queues of all delta managers in our collection.
-        const deltaManagers = deltaMgrs.length === 0 ? Array.from(this.deltaManagers) : deltaMgrs;
+        const toggles = this.mapDeltaManagerToggle(deltaMgrs);
 
         // Pause the inbound and outbound delta queues.
-        for (const deltaManager of deltaManagers) {
-            await deltaManager.inbound.pause();
-            await deltaManager.outbound.pause();
-        }
+        await this.pauseDeltaManagerQueues(toggles);
 
         this.isNormalProcessingPaused = true;
     }
@@ -167,41 +192,42 @@ export class OpProcessingController {
      * resumes the processing of all the delta managers in our collection.
      */
     public resumeProcessing(...deltaMgrs: DeltaManager[]) {
-        this.validateDeltaManagers(deltaMgrs);
-
-        // If no delta managers are provided, resume the queues of all delta managers in our collection.
-        const deltaManagers = deltaMgrs.length === 0 ? Array.from(this.deltaManagers) : deltaMgrs;
+        const toggles = this.mapDeltaManagerToggle(deltaMgrs);
 
         // Resume the inbound and outbound delta queues.
-        deltaManagers.forEach((deltaManager) => {
-            deltaManager.inbound.resume();
-            deltaManager.outbound.resume();
-        });
+        toggles.forEach((toggle) => toggle.toggleResumeAll());
 
         this.isNormalProcessingPaused = false;
     }
 
     /**
-     * Validates that the passed delta managers are added.
-     * @param deltaManagers - The delta managers to be validated.
+     * Map a list of DeltaManager to its toggle.  Throw an error if the delta manager is not in our collection
+     * @param deltaMgrs - The delta managers to get the toggles for
      */
-    private validateDeltaManagers(deltaManagers: DeltaManager[]) {
-        deltaManagers.forEach((deltaManager) => {
-            if (!this.deltaManagers.has(deltaManager)) {
+    private mapDeltaManagerToggle(deltaMgrs: DeltaManager[]) {
+        if (deltaMgrs.length === 0) {
+            // If no delta managers are provided, process all delta managers in our collection.
+            return Array.from(this.deltaManagerToggles.values());
+        }
+
+        return deltaMgrs.map((deltaManager) => {
+            const toggle = this.deltaManagerToggles.get(deltaManager);
+            if (!toggle) {
                 throw new Error(
                     "All delta managers must be added to deterministically control processing");
             }
+            return toggle;
         });
     }
 
     /**
      * It keeps yielding the JS event loop until  all the ops have been processed by the server and by the passed
      * delta managers.
-     * @param deltaManagers - The delta managers should ops have to be processed.
+     * @param toggles - The delta managers should ops have to be processed.
      * @param hasWork - Function that tells if the delta manager has pending work or not.
      */
     private async yieldWhileDeltaManagersHaveWork(
-        deltaManagers: Iterable<DeltaManager>,
+        toggles: Iterable<DeltaManagerToggle>,
         hasWork: (deltaManagers: DeltaManager) => boolean,
     ): Promise<void> {
         let working: boolean;
@@ -209,8 +235,8 @@ export class OpProcessingController {
             await OpProcessingController.yield();
             working = await this.localDeltaConnectionServer.hasPendingWork();
             if (!working) {
-                for (const deltaManager of deltaManagers) {
-                    if (hasWork(deltaManager)) {
+                for (const toggle of toggles) {
+                    if (hasWork(toggle.deltaManager)) {
                         working = true;
                         break;
                     }
@@ -220,27 +246,26 @@ export class OpProcessingController {
 
         // If deterministically controlling events, need to pause before continuing
         if (this.isNormalProcessingPaused) {
-            for (const deltaManager of deltaManagers) {
-                await deltaManager.inbound.pause();
-                await deltaManager.outbound.pause();
-            }
+            await this.pauseDeltaManagerQueues(toggles);
         }
+    }
+
+    /**
+     * Pauses the inbound and outbound queues of all the delta managers given
+     * @param toggles - The delta managers should ops have to be processed.
+     */
+    private async pauseDeltaManagerQueues(toggles: Iterable<DeltaManagerToggle>) {
+        const p: Promise<[void, void]>[] = [];
+        for (const toggle of toggles) {
+            p.push(toggle.togglePauseAll());
+        }
+        return Promise.all(p);
     }
 
     /**
      * Pauses the inbound and outbound queues of all the delta managers in our collection.
      */
     private async pauseAllDeltaManagerQueues() {
-        console.log("pausing");
-        const p: Promise<void>[] = [];
-
-        for (const deltaManager of this.deltaManagers) {
-            p.push(deltaManager.inbound.pause());
-            p.push(deltaManager.outbound.pause());
-        }
-
-        await Promise.all(p);
-        console.log("done");
-        return;
+        return this.pauseDeltaManagerQueues(this.deltaManagerToggles.values());
     }
 }


### PR DESCRIPTION
- prevents separate part of the code that calls pause/resume to interfere with each other.  
  - This caused trouble when `OpProcessingController` is using pause/resume to control op flow on the container's delta manager, and the runtime is doing it thru the proxy.
- Add test for use of LoaderHeader.pause flag
- Fold creation of `OpProcessingController` with the `LocalTestObjectProvider` so that compat test will use consistent version of the set of loader related objects.  This avoid unnecessary type error and force us to cast to `any` 