### PR TITLE
Fix timeout and size restrictions handling for snapshot in odsp driver

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -114,6 +114,9 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
     private readonly sharingLinkP: Promise<string> | undefined;
     private readonly attachmentPOSTUrl: string | undefined;
     private readonly attachmentGETUrl: string | undefined;
+    // Driver specified limits for snapshot size and time.
+    private readonly maxSnapshotSizeLimit = 25000000; // 25 MB
+    private readonly maxSnapshotFetchTimeout = 30000; // 30 sec
 
     public set ops(ops: ISequencedDeltaOpMessage[] | undefined) {
         assert(this._ops === undefined);
@@ -339,9 +342,9 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                     deltas: 1,
                     channels: 1,
                     blobs: 2,
-                    mds: 25000000, // 25 MB
-                    timeout: 30000, // 30 sec
                     ...this.hostPolicy.snapshotOptions,
+                    mds: this.hostPolicy.snapshotOptions?.mds ? Math.min(this.hostPolicy.snapshotOptions.mds, this.maxSnapshotSizeLimit) : this.maxSnapshotSizeLimit,
+                    timeout: this.hostPolicy.snapshotOptions?.timeout ? Math.min(this.hostPolicy.snapshotOptions.timeout, this.maxSnapshotFetchTimeout) : this.maxSnapshotFetchTimeout,
                 };
 
                 // No limit on size of snapshot, as otherwise we fail all clients to summarize
@@ -541,8 +544,9 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
             const odspSnapshot = await this.fetchSnapshotCore(snapshotOptions, tokenFetchOptions, usePost, abortController);
             return odspSnapshot;
         } catch (error) {
-            // If the snapshot size is too big and the host specified the size limitation, then don't try to fetch the snapshot again.
-            if (error.errorType === OdspErrorType.snapshotTooBig && this.hostPolicy.snapshotOptions?.mds !== undefined) {
+            // If the snapshot size is too big and the host specified the size limitation which was lesser than driver specified limits,
+            // then don't try to fetch the snapshot again.
+            if (error.errorType === OdspErrorType.snapshotTooBig && this.hostPolicy.snapshotOptions?.mds !== undefined && this.hostPolicy.snapshotOptions?.mds < this.maxSnapshotSizeLimit) {
                 throw error;
             }
             // If the first snapshot request was with blobs and we either timed out or the size was too big, then try to fetch without blobs.

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -541,6 +541,10 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
             const odspSnapshot = await this.fetchSnapshotCore(snapshotOptions, tokenFetchOptions, usePost, abortController);
             return odspSnapshot;
         } catch (error) {
+            // If the snapshot size is too big and the host specified the size limitation, then don't try to fetch the snapshot again.
+            if (error.errorType === OdspErrorType.snapshotTooBig && this.hostPolicy.snapshotOptions?.mds !== undefined) {
+                throw error;
+            }
             // If the first snapshot request was with blobs and we either timed out or the size was too big, then try to fetch without blobs.
             if ((error.errorType === OdspErrorType.snapshotTooBig || error.errorType === OdspErrorType.fetchTimeout) && snapshotOptions.blobs) {
                 const snapshotOptionsWithoutBlobs: ISnapshotOptions = { ...snapshotOptions, blobs: undefined, mds: undefined };

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -342,8 +342,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                     deltas: 1,
                     channels: 1,
                     blobs: 2,
+                    mds: this.maxSnapshotSizeLimit,
                     ...this.hostPolicy.snapshotOptions,
-                    mds: this.hostPolicy.snapshotOptions?.mds ? Math.min(this.hostPolicy.snapshotOptions.mds, this.maxSnapshotSizeLimit) : this.maxSnapshotSizeLimit,
                     timeout: this.hostPolicy.snapshotOptions?.timeout ? Math.min(this.hostPolicy.snapshotOptions.timeout, this.maxSnapshotFetchTimeout) : this.maxSnapshotFetchTimeout,
                 };
 
@@ -544,9 +544,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
             const odspSnapshot = await this.fetchSnapshotCore(snapshotOptions, tokenFetchOptions, usePost, abortController);
             return odspSnapshot;
         } catch (error) {
-            // If the snapshot size is too big and the host specified the size limitation which was lesser than driver specified limits,
-            // then don't try to fetch the snapshot again.
-            if (error.errorType === OdspErrorType.snapshotTooBig && this.hostPolicy.snapshotOptions?.mds !== undefined && this.hostPolicy.snapshotOptions?.mds < this.maxSnapshotSizeLimit) {
+            // If the snapshot size is too big and the host specified the size limitation, then don't try to fetch the snapshot again.
+            if (error.errorType === OdspErrorType.snapshotTooBig && this.hostPolicy.snapshotOptions?.mds !== undefined) {
                 throw error;
             }
             // If the first snapshot request was with blobs and we either timed out or the size was too big, then try to fetch without blobs.


### PR DESCRIPTION
1.) Respect the host policy if specified.
2.) Remove size restriction for summarizer client.
3.) If the snpashot timeout or size was too big and we initially fetched with blobs, then try fetching without blobs.
4.) Clear the timeout if it goes out.