### PR TITLE
Add browser friendly version of assert to common-utils

### DIFF
--- a/common/lib/common-utils/src/assert.ts
+++ b/common/lib/common-utils/src/assert.ts
@@ -1,0 +1,16 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * A browser friendly version of the node assert library. Use this instead of the 'assert' package, which has a big
+ * impact on bundle sizes.
+ * @param condition - The condition that should be truthy, if the condition is falsy an error will be thrown.
+ * @param message - The message to include in the error when the condition does not hold
+ */
+ export function assert(condition: any, message: string) {
+     if (!condition) {
+         throw new Error(message);
+     }
+ }

--- a/common/lib/common-utils/src/assert.ts
+++ b/common/lib/common-utils/src/assert.ts
@@ -6,7 +6,7 @@
 /**
  * A browser friendly version of the node assert library. Use this instead of the 'assert' package, which has a big
  * impact on bundle sizes.
- * @param condition - The condition that should be truthy, if the condition is falsy an error will be thrown.
+ * @param condition - The condition that should be true, if the condition is false an error will be thrown.
  * @param message - The message to include in the error when the condition does not hold
  */
  export function assert(condition: boolean, message?: string): asserts condition {

--- a/common/lib/common-utils/src/assert.ts
+++ b/common/lib/common-utils/src/assert.ts
@@ -9,7 +9,7 @@
  * @param condition - The condition that should be truthy, if the condition is falsy an error will be thrown.
  * @param message - The message to include in the error when the condition does not hold
  */
- export function assert(condition: any, message?: string) {
+ export function assert(condition: boolean, message?: string): asserts condition {
      if (!condition) {
          throw new Error(message);
      }

--- a/common/lib/common-utils/src/assert.ts
+++ b/common/lib/common-utils/src/assert.ts
@@ -9,7 +9,7 @@
  * @param condition - The condition that should be truthy, if the condition is falsy an error will be thrown.
  * @param message - The message to include in the error when the condition does not hold
  */
- export function assert(condition: any, message: string) {
+ export function assert(condition: any, message?: string) {
      if (!condition) {
          throw new Error(message);
      }

--- a/common/lib/common-utils/src/index.ts
+++ b/common/lib/common-utils/src/index.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+export * from "./assert";
 export * from "./indexNode";
 export * from "./base64Encoding";
 export * from "./batchManager";

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -73,153 +73,6 @@
 				}
 			}
 		},
-		"@babel/helper-create-class-features-plugin": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz",
-			"integrity": "sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==",
-			"requires": {
-				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-member-expression-to-functions": "^7.10.5",
-				"@babel/helper-optimise-call-expression": "^7.10.4",
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-replace-supers": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.10.4"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-					"requires": {
-						"@babel/highlight": "^7.10.4"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.11.6",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-					"integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
-					"requires": {
-						"@babel/types": "^7.11.5",
-						"jsesc": "^2.5.1",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-					"requires": {
-						"@babel/helper-get-function-arity": "^7.10.4",
-						"@babel/template": "^7.10.4",
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-					"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-					"requires": {
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-member-expression-to-functions": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-					"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
-					"requires": {
-						"@babel/types": "^7.11.0"
-					}
-				},
-				"@babel/helper-optimise-call-expression": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-					"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
-					"requires": {
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-replace-supers": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-					"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
-					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.10.4",
-						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/traverse": "^7.10.4",
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-					"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
-					"requires": {
-						"@babel/types": "^7.11.0"
-					}
-				},
-				"@babel/helper-validator-identifier": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-				},
-				"@babel/highlight": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
-						"chalk": "^2.0.0",
-						"js-tokens": "^4.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-					"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q=="
-				},
-				"@babel/template": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-					"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
-					"requires": {
-						"@babel/code-frame": "^7.10.4",
-						"@babel/parser": "^7.10.4",
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-					"integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
-					"requires": {
-						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.11.5",
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.11.5",
-						"@babel/types": "^7.11.5",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@babel/types": {
-					"version": "7.11.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
-						"lodash": "^4.17.19",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				}
-			}
-		},
 		"@babel/helper-function-name": {
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
@@ -340,12 +193,158 @@
 			"integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q=="
 		},
 		"@babel/plugin-proposal-class-properties": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz",
-			"integrity": "sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.1.tgz",
+			"integrity": "sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==",
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.10.4",
+				"@babel/helper-create-class-features-plugin": "^7.12.1",
 				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"requires": {
+						"@babel/highlight": "^7.10.4"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
+					"integrity": "sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==",
+					"requires": {
+						"@babel/types": "^7.12.1",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-create-class-features-plugin": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz",
+					"integrity": "sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==",
+					"requires": {
+						"@babel/helper-function-name": "^7.10.4",
+						"@babel/helper-member-expression-to-functions": "^7.12.1",
+						"@babel/helper-optimise-call-expression": "^7.10.4",
+						"@babel/helper-replace-supers": "^7.12.1",
+						"@babel/helper-split-export-declaration": "^7.10.4"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+					"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
+					"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
+					"requires": {
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+					"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.1.tgz",
+					"integrity": "sha512-zJjTvtNJnCFsCXVi5rUInstLd/EIVNmIKA1Q9ynESmMBWPWd+7sdR+G4/wdu+Mppfep0XLyG2m7EBPvjCeFyrw==",
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.12.1",
+						"@babel/helper-optimise-call-expression": "^7.10.4",
+						"@babel/traverse": "^7.12.1",
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+					"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+					"requires": {
+						"@babel/types": "^7.11.0"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+				},
+				"@babel/highlight": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.12.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.3.tgz",
+					"integrity": "sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw=="
+				},
+				"@babel/template": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+					"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/parser": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.1.tgz",
+					"integrity": "sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==",
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/generator": "^7.12.1",
+						"@babel/helper-function-name": "^7.10.4",
+						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/parser": "^7.12.1",
+						"@babel/types": "^7.12.1",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@babel/types": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+					"integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				}
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
@@ -365,9 +364,9 @@
 			}
 		},
 		"@babel/plugin-syntax-class-properties": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
-			"integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.1.tgz",
+			"integrity": "sha512-U40A76x5gTwmESz+qiqssqmeEsKvcSyvtgktrm0uzcARAmM9I1jR221f6Oq+GmHrcD+LvZDag1UTOTe2fL3TeA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
@@ -444,29 +443,14 @@
 			"requires": {
 				"core-js": "^2.6.5",
 				"regenerator-runtime": "^0.13.4"
-			},
-			"dependencies": {
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
+			"integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
-			},
-			"dependencies": {
-				"regenerator-runtime": {
-					"version": "0.13.7",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-				}
 			}
 		},
 		"@babel/template": {
@@ -547,9 +531,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "6.12.5",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-					"integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+					"version": "6.12.6",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
 						"fast-json-stable-stringify": "^2.0.0",
@@ -710,63 +694,61 @@
 			}
 		},
 		"@fluentui/date-time-utilities": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-7.8.0.tgz",
-			"integrity": "sha512-qzlTp3t+PghebJsLK9JwZr91qBRZ/fOml8TQCIjdtsEn4mH6/ciCwir7Fj8iOEkwwTC0iKsEr1jfsITtJKWSmA==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-7.9.0.tgz",
+			"integrity": "sha512-D8p5WWeonqRO1EgIvo7WSlX1rcm87r2VQd62zTJPQImx8rpwc77CRI+iAvfxyVHRZMdt4Qk6Jq99dUaudPWaZw==",
 			"requires": {
-				"@uifabric/set-version": "^7.0.22",
+				"@uifabric/set-version": "^7.0.23",
+				"tslib": "^1.10.0"
+			}
+		},
+		"@fluentui/dom-utilities": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-1.1.1.tgz",
+			"integrity": "sha512-w40gi8fzCpwa7U8cONiuu8rszPStkVOL/weDf5pCbYEb1gdaV7MDPSNkgM6IV0Kz+k017noDgK9Fv4ru1Dwz1g==",
+			"requires": {
+				"@uifabric/set-version": "^7.0.23",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@fluentui/keyboard-key": {
-			"version": "0.2.11",
-			"resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.2.11.tgz",
-			"integrity": "sha512-4iG5vNlRD3PrLaMfDTimHNOP1x6V3Dad0fXOwtvBBMsfdySPE9zlY+G+0aqCFcgjymOriFOk0ANZVBpK7XrnTg==",
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.2.12.tgz",
+			"integrity": "sha512-t3yIbbPKJubb22vQ/FIWwS9vFAzaPYzFxKWPHVWLtxs/P+5yL+LD3B16DRtYreWAdl9CZvEbos58ChLZ0KHwSQ==",
 			"requires": {
 				"tslib": "^1.10.0"
 			}
 		},
 		"@fluentui/react-focus": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.16.0.tgz",
-			"integrity": "sha512-TwB4Av7ID70ejisDIGkCZGKOxlquSazr6W+9Jv1JQAvsBLuj5XOspFJH4/Igjniw1LeO9QmAvFZeh/XRShiObw==",
+			"version": "7.16.13",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.16.13.tgz",
+			"integrity": "sha512-MWyI64GSEZigYe75aCy8VGGIr/tWwk+H8oqPxamoVOHef4kCqYm/70mhrDpBP1oAhJVmdY/Lia6dtkIz3J9wgw==",
 			"requires": {
-				"@fluentui/keyboard-key": "^0.2.11",
-				"@uifabric/merge-styles": "^7.18.0",
-				"@uifabric/set-version": "^7.0.22",
-				"@uifabric/styling": "^7.16.0",
-				"@uifabric/utilities": "^7.31.0",
-				"tslib": "^1.10.0"
-			}
-		},
-		"@fluentui/react-icons": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-0.3.0.tgz",
-			"integrity": "sha512-QDrIhLUpkxM5q5bFE4pkweJJsfaNswdfDoc+X6cmr22Dii+anDFTpOcePEJiTtILxdlEmH0968OcZ4BGZF/joQ==",
-			"requires": {
-				"@microsoft/load-themed-styles": "^1.10.26",
-				"@uifabric/set-version": "^7.0.22",
-				"@uifabric/utilities": "^7.31.0",
+				"@fluentui/keyboard-key": "^0.2.12",
+				"@uifabric/merge-styles": "^7.19.1",
+				"@uifabric/set-version": "^7.0.23",
+				"@uifabric/styling": "^7.16.13",
+				"@uifabric/utilities": "^7.32.4",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@fluentui/react-window-provider": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-0.3.0.tgz",
-			"integrity": "sha512-zHeH1PAmoFB3OkgU8f51E3oGHrL/CjuvdPBlb1SGpByUGNihAgH/CwvJohV9z0yPDkq+chfNUmxWA/oDVpbh6Q==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-0.3.3.tgz",
+			"integrity": "sha512-MVPf2hqOQ17LAZsuvGcr3oOHksAskUm+fCYdXFhbVoAgsCDVTIuH6i8XgHFd6YjBtzjZmI4+k/3NTQfDqBX8EQ==",
 			"requires": {
-				"@uifabric/set-version": "^7.0.22",
+				"@uifabric/set-version": "^7.0.23",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@fluentui/theme": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-0.2.0.tgz",
-			"integrity": "sha512-L5OwqymTdxTVwBa3ifkQLF1A3YU6WMkMTk6PFIMfOonjt8LJ3yMMqZgz+KQR3sF/tzgy4wzW4oBmrxtTfJS2EQ==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-1.5.1.tgz",
+			"integrity": "sha512-w5986/CN3hWuH44WmlQNxtndBx0khnb1xjISb/4bktRpehYxIlDBmQYRUOUYXr6zwdK7JXJaJPGjOJzSh2DCDg==",
 			"requires": {
-				"@uifabric/merge-styles": "^7.18.0",
-				"@uifabric/set-version": "^7.0.22",
-				"@uifabric/utilities": "^7.31.0",
+				"@uifabric/merge-styles": "^7.19.1",
+				"@uifabric/set-version": "^7.0.23",
+				"@uifabric/utilities": "^7.32.4",
 				"tslib": "^1.10.0"
 			}
 		},
@@ -888,9 +870,9 @@
 			"integrity": "sha512-H+wEaxuIHODVNqyY8XSMY6ww7ndrRfht9CXKUAUzdQjUN1Oi++YonKcD3CXWZod6afxZ6abDmltIO9wLrjOJzg=="
 		},
 		"@fluidframework/common-utils": {
-			"version": "0.24.0-5441",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0-5441.tgz",
-			"integrity": "sha512-8/Tsgr6ahR1k72Ac6h3aoTzNuXfS4ojbXIuJs7Gfl/uT8zgSzD537xKHgOZ2GtLCJrlVAei2n5Yaf74uOpmJRg==",
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+			"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@types/events": "^3.0.0",
@@ -1328,6 +1310,16 @@
 						"tsutils": "^3.17.1"
 					}
 				},
+				"@typescript-eslint/experimental-utils": {
+					"version": "2.17.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.17.0.tgz",
+					"integrity": "sha512-2bNf+mZ/3mj5/3CP56v+ldRK3vFy9jOvmCPs/Gr2DeSJh+asPZrhFniv4QmQsHWQFPJFWhFHgkGgJeRmK4m8iQ==",
+					"requires": {
+						"@types/json-schema": "^7.0.3",
+						"@typescript-eslint/typescript-estree": "2.17.0",
+						"eslint-scope": "^5.0.0"
+					}
+				},
 				"@typescript-eslint/parser": {
 					"version": "2.17.0",
 					"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.17.0.tgz",
@@ -1337,6 +1329,20 @@
 						"@typescript-eslint/experimental-utils": "2.17.0",
 						"@typescript-eslint/typescript-estree": "2.17.0",
 						"eslint-visitor-keys": "^1.1.0"
+					}
+				},
+				"@typescript-eslint/typescript-estree": {
+					"version": "2.17.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.17.0.tgz",
+					"integrity": "sha512-g0eVRULGnEEUakxRfJO0s0Hr1LLQqsI6OrkiCLpdHtdJJek+wyd8mb00vedqAoWldeDcOcP8plqw8/jx9Gr3Lw==",
+					"requires": {
+						"debug": "^4.1.1",
+						"eslint-visitor-keys": "^1.1.0",
+						"glob": "^7.1.6",
+						"is-glob": "^4.0.1",
+						"lodash": "^4.17.15",
+						"semver": "^6.3.0",
+						"tsutils": "^3.17.1"
 					}
 				},
 				"ansi-escapes": {
@@ -1360,11 +1366,10 @@
 					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -1651,12 +1656,30 @@
 						"escape-string-regexp": "^1.0.5"
 					}
 				},
+				"file-entry-cache": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+					"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+					"requires": {
+						"flat-cache": "^2.0.1"
+					}
+				},
 				"find-up": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"requires": {
 						"locate-path": "^2.0.0"
+					}
+				},
+				"flat-cache": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+					"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+					"requires": {
+						"flatted": "^2.0.0",
+						"rimraf": "2.6.3",
+						"write": "1.0.3"
 					}
 				},
 				"globals": {
@@ -1835,10 +1858,11 @@
 					"integrity": "sha512-kUUXjX4AnqnR8KRTCrayAo9PzYMRKmVoGgaz2tBuz0MF3g1ZbGebmtW0yFHfFK9CmBjQKeYIgoL22pFLBJY7sw=="
 				},
 				"resolve": {
-					"version": "1.17.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+					"version": "1.18.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
+					"integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
 					"requires": {
+						"is-core-module": "^2.0.0",
 						"path-parse": "^1.0.6"
 					}
 				},
@@ -1849,6 +1873,14 @@
 					"requires": {
 						"onetime": "^5.1.0",
 						"signal-exit": "^3.0.2"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+					"requires": {
+						"glob": "^7.1.3"
 					}
 				},
 				"rxjs": {
@@ -1923,9 +1955,9 @@
 			}
 		},
 		"@fluidframework/gitresources": {
-			"version": "0.1014.0-6368",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1014.0-6368.tgz",
-			"integrity": "sha512-StiRoivc79/obv8LA1LPcdzYWevzL3xbBftEjWV50w9hA86K1Mr6WSrBc0Hf7x+F6UuUer75O73Kpyo5MK9wwQ=="
+			"version": "0.1014.0-7764",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1014.0-7764.tgz",
+			"integrity": "sha512-NVv4Os7PAp54whyyRHdjRbWX3wsxPWiWNYwaURYKjZeOkfq2cA+TOe1Ng1odWbPHBCpYBPN/jG3b7yn6XKb64A=="
 		},
 		"@fluidframework/local-driver": {
 			"version": "0.26.9",
@@ -1987,28 +2019,6 @@
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
 				},
-				"@fluidframework/server-lambdas": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1012.2.tgz",
-					"integrity": "sha512-r/FPMZfami9yD/ZDo0BRvQwkcVlD2PnOgYeN5YP/9QeWyh3QUcZD688M4IxzzGMfDY6nAN8wVjI7Wn2ajqzLPQ==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-base": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
-						"@fluidframework/server-services-core": "^0.1012.2",
-						"@types/semver": "^6.0.1",
-						"async": "^2.6.1",
-						"double-ended-queue": "^2.1.0-0",
-						"json-stringify-safe": "^5.0.1",
-						"jsonwebtoken": "^8.4.0",
-						"lodash": "^4.17.19",
-						"nconf": "^0.10.0",
-						"semver": "^6.3.0",
-						"uuid": "^3.3.2"
-					}
-				},
 				"@fluidframework/server-local-server": {
 					"version": "0.1012.2",
 					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1012.2.tgz",
@@ -2022,30 +2032,6 @@
 						"@fluidframework/server-services-core": "^0.1012.2",
 						"@fluidframework/server-test-utils": "^0.1012.2",
 						"uuid": "^3.3.2"
-					}
-				},
-				"@fluidframework/server-memory-orderer": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1012.2.tgz",
-					"integrity": "sha512-6VDnXD0fj93SI9D3VIdxlKiNfnFjUsjZsNlDBlqyrGbTj7VYMIrsm9FbxjHuWxG/1pWxqdy4CQvbG3r5s0Me/g==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/protocol-base": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-lambdas": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
-						"@fluidframework/server-services-core": "^0.1012.2",
-						"@types/debug": "^4.1.5",
-						"@types/double-ended-queue": "^2.1.0",
-						"@types/lodash": "^4.14.118",
-						"@types/node": "^10.17.24",
-						"@types/ws": "^6.0.1",
-						"debug": "^4.1.1",
-						"double-ended-queue": "^2.1.0-0",
-						"lodash": "^4.17.19",
-						"moniker": "^0.1.2",
-						"uuid": "^3.3.2",
-						"ws": "^6.1.2"
 					}
 				},
 				"@fluidframework/server-services-client": {
@@ -2096,11 +2082,6 @@
 						"string-hash": "^1.1.3",
 						"uuid": "^3.3.2"
 					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -2201,21 +2182,21 @@
 			}
 		},
 		"@fluidframework/protocol-base": {
-			"version": "0.1014.0-6368",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1014.0-6368.tgz",
-			"integrity": "sha512-FLse61s5FWGhM6KwOoRZli02+8AT7h6I+7dEF78TMh4RaklNbqSxvvBa7YjPGhPanw7ZMVQaSzaUVy7S5cch0g==",
+			"version": "0.1014.0-7764",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1014.0-7764.tgz",
+			"integrity": "sha512-r9QvsMD6hcHFFVJvHXRHtI+mVYdgs5Ij7NIlbu//q+3TBPVLcmOOTUzcx0gMIJY3iEzLa1dU2/zVIXyq2HSWXQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0-0",
-				"@fluidframework/gitresources": "^0.1014.0-6368",
-				"@fluidframework/protocol-definitions": "^0.1014.0-6368",
+				"@fluidframework/gitresources": "^0.1014.0-7764",
+				"@fluidframework/protocol-definitions": "^0.1014.0-7764",
 				"assert": "^2.0.0",
 				"lodash": "^4.17.19"
 			}
 		},
 		"@fluidframework/protocol-definitions": {
-			"version": "0.1014.0-6368",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1014.0-6368.tgz",
-			"integrity": "sha512-tPqj48lAribjI89YDLHPDd5auRU2qUFbSPjX65lK649bvISzJl7pgXYZsSd9Y5lYsT0LJDaXbJApAYCSnJjQfQ==",
+			"version": "0.1014.0-7764",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1014.0-7764.tgz",
+			"integrity": "sha512-fVSKni8hbwd41pQ2gXLA7PPfBZXzsgP39D/dV8YLH7+Resx2Xyx3aE8m0e+O5bOCVya07Pyfh9QFe5hjZv6Yyw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1"
 			}
@@ -2429,16 +2410,16 @@
 			}
 		},
 		"@fluidframework/server-lambdas": {
-			"version": "0.1014.0-6368",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1014.0-6368.tgz",
-			"integrity": "sha512-iD0wEhZonTcWAByA2TkGXtWU3I6hyiFNXn8x/T2Ht6u+mMNex2SdLkJNYALcEamib4622f0jv35nyS0SL0ZwIw==",
+			"version": "0.1012.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1012.2.tgz",
+			"integrity": "sha512-r/FPMZfami9yD/ZDo0BRvQwkcVlD2PnOgYeN5YP/9QeWyh3QUcZD688M4IxzzGMfDY6nAN8wVjI7Wn2ajqzLPQ==",
 			"requires": {
-				"@fluidframework/common-utils": "^0.24.0-0",
-				"@fluidframework/gitresources": "^0.1014.0-6368",
-				"@fluidframework/protocol-base": "^0.1014.0-6368",
-				"@fluidframework/protocol-definitions": "^0.1014.0-6368",
-				"@fluidframework/server-services-client": "^0.1014.0-6368",
-				"@fluidframework/server-services-core": "^0.1014.0-6368",
+				"@fluidframework/common-utils": "^0.23.0",
+				"@fluidframework/gitresources": "^0.1012.2",
+				"@fluidframework/protocol-base": "^0.1012.2",
+				"@fluidframework/protocol-definitions": "^0.1012.2",
+				"@fluidframework/server-services-client": "^0.1012.2",
+				"@fluidframework/server-services-core": "^0.1012.2",
 				"@types/semver": "^6.0.1",
 				"async": "^2.6.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -2450,6 +2431,78 @@
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.23.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
+					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.19.1",
+						"@types/events": "^3.0.0",
+						"assert": "^2.0.0",
+						"base64-js": "^1.3.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.19",
+						"performance-now": "^2.1.0",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"@fluidframework/gitresources": {
+					"version": "0.1012.2",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.2.tgz",
+					"integrity": "sha512-ysb9skxUKtIUSNUFqqcTQBMpCDrPcezc4pvDLaBdxcK4BuP3Ak2gZGmIVeXfbsx40+isBQ8xGbJISIZlgtGlZw=="
+				},
+				"@fluidframework/protocol-base": {
+					"version": "0.1012.2",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.2.tgz",
+					"integrity": "sha512-K8YRUIvrlO+54hyzLgLhZ9tQNeyPd9/yX0h/6XEE4m0oazCcCOFihAFzBIQXxypv1zNH2fbKlsQ7xaHHDbZ6rA==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.23.0",
+						"@fluidframework/gitresources": "^0.1012.2",
+						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"assert": "^2.0.0",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@fluidframework/protocol-definitions": {
+					"version": "0.1012.2",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
+					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.19.1"
+					}
+				},
+				"@fluidframework/server-services-client": {
+					"version": "0.1012.2",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1012.2.tgz",
+					"integrity": "sha512-bmGRVX8V1s/bMapdUHnr8mhQq5NE1++AS3bGSVfzd7GQQPlTz8d26cJA5+4jPe/mJvBMb6MEXstENi3VZOcTNQ==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.23.0",
+						"@fluidframework/gitresources": "^0.1012.2",
+						"@fluidframework/protocol-base": "^0.1012.2",
+						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@types/node": "^10.17.24",
+						"axios": "^0.18.0",
+						"debug": "^4.1.1",
+						"jsonwebtoken": "^8.4.0",
+						"sillyname": "0.1.0",
+						"uuid": "^3.3.2"
+					}
+				},
+				"@fluidframework/server-services-core": {
+					"version": "0.1012.2",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1012.2.tgz",
+					"integrity": "sha512-E1Q/sDLgtQ7fIcaaXiZWWKOa3IRuZKE24fC0QmnmxUYDPUP1yT7kacr0r5wQTibn+eWhAyg/rRRfdRPEe9+YQg==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.23.0",
+						"@fluidframework/gitresources": "^0.1012.2",
+						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/server-services-client": "^0.1012.2",
+						"@types/nconf": "^0.0.37",
+						"@types/node": "^10.17.24",
+						"debug": "^4.1.1",
+						"nconf": "^0.10.0"
+					}
+				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -2458,31 +2511,85 @@
 			}
 		},
 		"@fluidframework/server-local-server": {
-			"version": "0.1014.0-6368",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1014.0-6368.tgz",
-			"integrity": "sha512-qmLFTM0g0LPk34ThmbU+KC5PK6CyazDWN9Nwg4+FLjzDUu1pVaCFuqb9bciY/mL4YJzua+pH6p1ZROvkNJRUDQ==",
+			"version": "0.1014.0-7764",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1014.0-7764.tgz",
+			"integrity": "sha512-zrFql2IKOExLbzNErMaj59BkI8/j80bQwYINBU9oFxJRu05c7cmdtSQKaupBtc2yJb6ZoCKgYJF+WDuG244L5A==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0-0",
-				"@fluidframework/protocol-definitions": "^0.1014.0-6368",
-				"@fluidframework/server-lambdas": "^0.1014.0-6368",
-				"@fluidframework/server-memory-orderer": "^0.1014.0-6368",
-				"@fluidframework/server-services-client": "^0.1014.0-6368",
-				"@fluidframework/server-services-core": "^0.1014.0-6368",
-				"@fluidframework/server-test-utils": "^0.1014.0-6368",
+				"@fluidframework/protocol-definitions": "^0.1014.0-7764",
+				"@fluidframework/server-lambdas": "^0.1014.0-7764",
+				"@fluidframework/server-memory-orderer": "^0.1014.0-7764",
+				"@fluidframework/server-services-client": "^0.1014.0-7764",
+				"@fluidframework/server-services-core": "^0.1014.0-7764",
+				"@fluidframework/server-test-utils": "^0.1014.0-7764",
+				"jsrsasign": "^10.0.2",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"@fluidframework/server-lambdas": {
+					"version": "0.1014.0-7764",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1014.0-7764.tgz",
+					"integrity": "sha512-MABJOSjenPwhH6ZHuoIJKXaiQnzyOFxGwCOBBsbmauvzgDBEy2lVjJSUXi6yxmqHfLMZsbY+ZOL27CrMlr0LIQ==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.24.0-0",
+						"@fluidframework/gitresources": "^0.1014.0-7764",
+						"@fluidframework/protocol-base": "^0.1014.0-7764",
+						"@fluidframework/protocol-definitions": "^0.1014.0-7764",
+						"@fluidframework/server-services-client": "^0.1014.0-7764",
+						"@fluidframework/server-services-core": "^0.1014.0-7764",
+						"@types/semver": "^6.0.1",
+						"async": "^2.6.1",
+						"double-ended-queue": "^2.1.0-0",
+						"json-stringify-safe": "^5.0.1",
+						"jsonwebtoken": "^8.4.0",
+						"lodash": "^4.17.19",
+						"nconf": "^0.10.0",
+						"semver": "^6.3.0",
+						"uuid": "^3.3.2"
+					}
+				},
+				"@fluidframework/server-memory-orderer": {
+					"version": "0.1014.0-7764",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1014.0-7764.tgz",
+					"integrity": "sha512-MO/ab/UFBFg9jFyPspNPLbWBxe2OgigwtKK++A5WMtzMvq3KhIAKtGluiZWE74Vg54luawVmlr0nE5PVtb9mCw==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.24.0-0",
+						"@fluidframework/protocol-base": "^0.1014.0-7764",
+						"@fluidframework/protocol-definitions": "^0.1014.0-7764",
+						"@fluidframework/server-lambdas": "^0.1014.0-7764",
+						"@fluidframework/server-services-client": "^0.1014.0-7764",
+						"@fluidframework/server-services-core": "^0.1014.0-7764",
+						"@types/debug": "^4.1.5",
+						"@types/double-ended-queue": "^2.1.0",
+						"@types/lodash": "^4.14.118",
+						"@types/node": "^10.17.24",
+						"@types/ws": "^6.0.1",
+						"debug": "^4.1.1",
+						"double-ended-queue": "^2.1.0-0",
+						"lodash": "^4.17.19",
+						"moniker": "^0.1.2",
+						"uuid": "^3.3.2",
+						"ws": "^6.1.2"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				}
 			}
 		},
 		"@fluidframework/server-memory-orderer": {
-			"version": "0.1014.0-6368",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1014.0-6368.tgz",
-			"integrity": "sha512-7JIXLRC2hhASZLepfeW4je3G89wvizMlXBl8rQiiBs+I0MOGJiV9lLCUv+gzwz8mkNVR6x84tYuVpfU2/zaTsQ==",
+			"version": "0.1012.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1012.2.tgz",
+			"integrity": "sha512-6VDnXD0fj93SI9D3VIdxlKiNfnFjUsjZsNlDBlqyrGbTj7VYMIrsm9FbxjHuWxG/1pWxqdy4CQvbG3r5s0Me/g==",
 			"requires": {
-				"@fluidframework/common-utils": "^0.24.0-0",
-				"@fluidframework/protocol-base": "^0.1014.0-6368",
-				"@fluidframework/protocol-definitions": "^0.1014.0-6368",
-				"@fluidframework/server-lambdas": "^0.1014.0-6368",
-				"@fluidframework/server-services-client": "^0.1014.0-6368",
-				"@fluidframework/server-services-core": "^0.1014.0-6368",
+				"@fluidframework/common-utils": "^0.23.0",
+				"@fluidframework/protocol-base": "^0.1012.2",
+				"@fluidframework/protocol-definitions": "^0.1012.2",
+				"@fluidframework/server-lambdas": "^0.1012.2",
+				"@fluidframework/server-services-client": "^0.1012.2",
+				"@fluidframework/server-services-core": "^0.1012.2",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/lodash": "^4.14.118",
@@ -2494,34 +2601,115 @@
 				"moniker": "^0.1.2",
 				"uuid": "^3.3.2",
 				"ws": "^6.1.2"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.23.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
+					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.19.1",
+						"@types/events": "^3.0.0",
+						"assert": "^2.0.0",
+						"base64-js": "^1.3.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.19",
+						"performance-now": "^2.1.0",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"@fluidframework/gitresources": {
+					"version": "0.1012.2",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.2.tgz",
+					"integrity": "sha512-ysb9skxUKtIUSNUFqqcTQBMpCDrPcezc4pvDLaBdxcK4BuP3Ak2gZGmIVeXfbsx40+isBQ8xGbJISIZlgtGlZw=="
+				},
+				"@fluidframework/protocol-base": {
+					"version": "0.1012.2",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.2.tgz",
+					"integrity": "sha512-K8YRUIvrlO+54hyzLgLhZ9tQNeyPd9/yX0h/6XEE4m0oazCcCOFihAFzBIQXxypv1zNH2fbKlsQ7xaHHDbZ6rA==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.23.0",
+						"@fluidframework/gitresources": "^0.1012.2",
+						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"assert": "^2.0.0",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@fluidframework/protocol-definitions": {
+					"version": "0.1012.2",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
+					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.19.1"
+					}
+				},
+				"@fluidframework/server-services-client": {
+					"version": "0.1012.2",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1012.2.tgz",
+					"integrity": "sha512-bmGRVX8V1s/bMapdUHnr8mhQq5NE1++AS3bGSVfzd7GQQPlTz8d26cJA5+4jPe/mJvBMb6MEXstENi3VZOcTNQ==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.23.0",
+						"@fluidframework/gitresources": "^0.1012.2",
+						"@fluidframework/protocol-base": "^0.1012.2",
+						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@types/node": "^10.17.24",
+						"axios": "^0.18.0",
+						"debug": "^4.1.1",
+						"jsonwebtoken": "^8.4.0",
+						"sillyname": "0.1.0",
+						"uuid": "^3.3.2"
+					}
+				},
+				"@fluidframework/server-services-core": {
+					"version": "0.1012.2",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1012.2.tgz",
+					"integrity": "sha512-E1Q/sDLgtQ7fIcaaXiZWWKOa3IRuZKE24fC0QmnmxUYDPUP1yT7kacr0r5wQTibn+eWhAyg/rRRfdRPEe9+YQg==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.23.0",
+						"@fluidframework/gitresources": "^0.1012.2",
+						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/server-services-client": "^0.1012.2",
+						"@types/nconf": "^0.0.37",
+						"@types/node": "^10.17.24",
+						"debug": "^4.1.1",
+						"nconf": "^0.10.0"
+					}
+				}
 			}
 		},
 		"@fluidframework/server-services-client": {
-			"version": "0.1014.0-6368",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1014.0-6368.tgz",
-			"integrity": "sha512-Pt1izj56bkx+Gh4Gh7ugCpdWWH+1zTndHzjd+vXCdmWj0MGwClAnMn4X0KFXc2ZnP2RhaZObPnDni4tiU4f8Ig==",
+			"version": "0.1014.0-7764",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1014.0-7764.tgz",
+			"integrity": "sha512-nhn0kPgoAktm2skjar2upolrttFwCz6j/OhWWVh0b2KUmF/ZW9oUv/kLahVV853xqL1TJY3wMEnejfY7fsZXrA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0-0",
-				"@fluidframework/gitresources": "^0.1014.0-6368",
-				"@fluidframework/protocol-base": "^0.1014.0-6368",
-				"@fluidframework/protocol-definitions": "^0.1014.0-6368",
+				"@fluidframework/gitresources": "^0.1014.0-7764",
+				"@fluidframework/protocol-base": "^0.1014.0-7764",
+				"@fluidframework/protocol-definitions": "^0.1014.0-7764",
 				"@types/node": "^10.17.24",
 				"axios": "^0.18.0",
 				"debug": "^4.1.1",
-				"jsonwebtoken": "^8.4.0",
+				"jwt-decode": "^3.0.0",
 				"sillyname": "0.1.0",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"jwt-decode": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.0.0.tgz",
+					"integrity": "sha512-RBQv2MTm3FNKQkdzhEyQwh5MbdNgMa+FyIJIK5RMWEn6hRgRHr7j55cRxGhRe6vGJDElyi6f6u/yfkP7AoXddA=="
+				}
 			}
 		},
 		"@fluidframework/server-services-core": {
-			"version": "0.1014.0-6368",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1014.0-6368.tgz",
-			"integrity": "sha512-AMzdqwNqTHQWF0Z8RBM8DiUcSofBmzdO4AGfnOeAp510D4g4NuCxRx9LtHWvrqzm9wtyjXtPfrlV3XvTPu/WBg==",
+			"version": "0.1014.0-7764",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1014.0-7764.tgz",
+			"integrity": "sha512-D1Hpi4Ake1MINSbBNfKcTfXOb8fHpnOBDrkOephE04mWh7f/qtBc/wyYEyA/Y2hVe+0GuACMGw37WilqscdA6g==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0-0",
-				"@fluidframework/gitresources": "^0.1014.0-6368",
-				"@fluidframework/protocol-definitions": "^0.1014.0-6368",
-				"@fluidframework/server-services-client": "^0.1014.0-6368",
+				"@fluidframework/gitresources": "^0.1014.0-7764",
+				"@fluidframework/protocol-definitions": "^0.1014.0-7764",
+				"@fluidframework/server-services-client": "^0.1014.0-7764",
 				"@types/nconf": "^0.0.37",
 				"@types/node": "^10.17.24",
 				"debug": "^4.1.1",
@@ -2529,16 +2717,16 @@
 			}
 		},
 		"@fluidframework/server-test-utils": {
-			"version": "0.1014.0-6368",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1014.0-6368.tgz",
-			"integrity": "sha512-uzEBZBYFZp37MO8LMfC7qh8gQ5wDirA7zyk5MpQpSTiNSmlng9pZHiKZuAYsDFFgRxRx59agrHteKUTrZp+btg==",
+			"version": "0.1014.0-7764",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1014.0-7764.tgz",
+			"integrity": "sha512-9vGNjW+2iIMYEUoSRbzsM1zs6D67WkPgZLbEFtG9cFY7xUVkCdqImS9C8ltZWbP9/jwmNvb5qbhjEau8GoBUhA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0-0",
-				"@fluidframework/gitresources": "^0.1014.0-6368",
-				"@fluidframework/protocol-base": "^0.1014.0-6368",
-				"@fluidframework/protocol-definitions": "^0.1014.0-6368",
-				"@fluidframework/server-services-client": "^0.1014.0-6368",
-				"@fluidframework/server-services-core": "^0.1014.0-6368",
+				"@fluidframework/gitresources": "^0.1014.0-7764",
+				"@fluidframework/protocol-base": "^0.1014.0-7764",
+				"@fluidframework/protocol-definitions": "^0.1014.0-7764",
+				"@fluidframework/server-services-client": "^0.1014.0-7764",
+				"@fluidframework/server-services-core": "^0.1014.0-7764",
 				"debug": "^4.1.1",
 				"lodash": "^4.17.19",
 				"string-hash": "^1.1.3",
@@ -2711,52 +2899,23 @@
 			"integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw=="
 		},
 		"@jest/console": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-26.3.0.tgz",
-			"integrity": "sha512-/5Pn6sJev0nPUcAdpJHMVIsA8sKizL2ZkcKPE5+dJrCccks7tcM7c9wbgHudBJbxXLoTbqsHkG1Dofoem4F09w==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-26.6.1.tgz",
+			"integrity": "sha512-cjqcXepwC5M+VeIhwT6Xpi/tT4AiNzlIx8SMJ9IihduHnsSrnWNvTBfKIpmqOOCNOPqtbBx6w2JqfoLOJguo8g==",
 			"requires": {
-				"@jest/types": "^26.3.0",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
-				"jest-message-util": "^26.3.0",
-				"jest-util": "^26.3.0",
+				"jest-message-util": "^26.6.1",
+				"jest-util": "^26.6.1",
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -2802,613 +2961,49 @@
 				}
 			}
 		},
-		"@jest/core": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-26.4.2.tgz",
-			"integrity": "sha512-sDva7YkeNprxJfepOctzS8cAk9TOekldh+5FhVuXS40+94SHbiicRO1VV2tSoRtgIo+POs/Cdyf8p76vPTd6dg==",
-			"requires": {
-				"@jest/console": "^26.3.0",
-				"@jest/reporters": "^26.4.1",
-				"@jest/test-result": "^26.3.0",
-				"@jest/transform": "^26.3.0",
-				"@jest/types": "^26.3.0",
-				"@types/node": "*",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.0.0",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.2.4",
-				"jest-changed-files": "^26.3.0",
-				"jest-config": "^26.4.2",
-				"jest-haste-map": "^26.3.0",
-				"jest-message-util": "^26.3.0",
-				"jest-regex-util": "^26.0.0",
-				"jest-resolve": "^26.4.0",
-				"jest-resolve-dependencies": "^26.4.2",
-				"jest-runner": "^26.4.2",
-				"jest-runtime": "^26.4.2",
-				"jest-snapshot": "^26.4.2",
-				"jest-util": "^26.3.0",
-				"jest-validate": "^26.4.2",
-				"jest-watcher": "^26.3.0",
-				"micromatch": "^4.0.2",
-				"p-each-series": "^2.1.0",
-				"rimraf": "^3.0.0",
-				"slash": "^3.0.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"ansi-escapes": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-					"requires": {
-						"type-fest": "^0.11.0"
-					}
-				},
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"requires": {
-						"fill-range": "^7.0.1"
-					}
-				},
-				"camelcase": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w=="
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-				},
-				"jest-get-type": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
-				},
-				"jest-validate": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.4.2.tgz",
-					"integrity": "sha512-blft+xDX7XXghfhY0mrsBCYhX365n8K5wNDC4XAcNKqqjEzsRUSXP44m6PL0QJEW2crxQFLLztVnJ4j7oPlQrQ==",
-					"requires": {
-						"@jest/types": "^26.3.0",
-						"camelcase": "^6.0.0",
-						"chalk": "^4.0.0",
-						"jest-get-type": "^26.3.0",
-						"leven": "^3.1.0",
-						"pretty-format": "^26.4.2"
-					}
-				},
-				"micromatch": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-					"requires": {
-						"braces": "^3.0.1",
-						"picomatch": "^2.0.5"
-					}
-				},
-				"pretty-format": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
-					"requires": {
-						"@jest/types": "^26.3.0",
-						"ansi-regex": "^5.0.0",
-						"ansi-styles": "^4.0.0",
-						"react-is": "^16.12.0"
-					}
-				},
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"requires": {
-						"is-number": "^7.0.0"
-					}
-				},
-				"type-fest": {
-					"version": "0.11.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-					"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
-				}
-			}
+		"@jest/create-cache-key-function": {
+			"version": "26.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-26.5.0.tgz",
+			"integrity": "sha512-DJ+pEBUIqarrbv1W/C39f9YH0rJ4wsXZ/VC6JafJPlHW2HOucKceeaqTOQj9MEDQZjySxMLkOq5mfXZXNZcmWw=="
 		},
 		"@jest/environment": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.3.0.tgz",
-			"integrity": "sha512-EW+MFEo0DGHahf83RAaiqQx688qpXgl99wdb8Fy67ybyzHwR1a58LHcO376xQJHfmoXTu89M09dH3J509cx2AA==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.1.tgz",
+			"integrity": "sha512-GNvHwkOFJtNgSwdzH9flUPzF9AYAZhUg124CBoQcwcZCM9s5TLz8Y3fMtiaWt4ffbigoetjGk5PU2Dd8nLrSEw==",
 			"requires": {
-				"@jest/fake-timers": "^26.3.0",
-				"@jest/types": "^26.3.0",
+				"@jest/fake-timers": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
-				"jest-mock": "^26.3.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
+				"jest-mock": "^26.6.1"
 			}
 		},
 		"@jest/fake-timers": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.3.0.tgz",
-			"integrity": "sha512-ZL9ytUiRwVP8ujfRepffokBvD2KbxbqMhrXSBhSdAhISCw3gOkuntisiSFv+A6HN0n0fF4cxzICEKZENLmW+1A==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.6.1.tgz",
+			"integrity": "sha512-T/SkMLgOquenw/nIisBRD6XAYpFir0kNuclYLkse5BpzeDUukyBr+K31xgAo9M0hgjU9ORlekAYPSzc0DKfmKg==",
 			"requires": {
-				"@jest/types": "^26.3.0",
+				"@jest/types": "^26.6.1",
 				"@sinonjs/fake-timers": "^6.0.1",
 				"@types/node": "*",
-				"jest-message-util": "^26.3.0",
-				"jest-mock": "^26.3.0",
-				"jest-util": "^26.3.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
+				"jest-message-util": "^26.6.1",
+				"jest-mock": "^26.6.1",
+				"jest-util": "^26.6.1"
 			}
 		},
 		"@jest/globals": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.4.2.tgz",
-			"integrity": "sha512-Ot5ouAlehhHLRhc+sDz2/9bmNv9p5ZWZ9LE1pXGGTCXBasmi5jnYjlgYcYt03FBwLmZXCZ7GrL29c33/XRQiow==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.6.1.tgz",
+			"integrity": "sha512-acxXsSguuLV/CeMYmBseefw6apO7NuXqpE+v5r3yD9ye2PY7h1nS20vY7Obk2w6S7eJO4OIAJeDnoGcLC/McEQ==",
 			"requires": {
-				"@jest/environment": "^26.3.0",
-				"@jest/types": "^26.3.0",
-				"expect": "^26.4.2"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"@jest/reporters": {
-			"version": "26.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.4.1.tgz",
-			"integrity": "sha512-aROTkCLU8++yiRGVxLsuDmZsQEKO6LprlrxtAuzvtpbIFl3eIjgIf3EUxDKgomkS25R9ZzwGEdB5weCcBZlrpQ==",
-			"requires": {
-				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "^26.3.0",
-				"@jest/test-result": "^26.3.0",
-				"@jest/transform": "^26.3.0",
-				"@jest/types": "^26.3.0",
-				"chalk": "^4.0.0",
-				"collect-v8-coverage": "^1.0.0",
-				"exit": "^0.1.2",
-				"glob": "^7.1.2",
-				"graceful-fs": "^4.2.4",
-				"istanbul-lib-coverage": "^3.0.0",
-				"istanbul-lib-instrument": "^4.0.3",
-				"istanbul-lib-report": "^3.0.0",
-				"istanbul-lib-source-maps": "^4.0.0",
-				"istanbul-reports": "^3.0.2",
-				"jest-haste-map": "^26.3.0",
-				"jest-resolve": "^26.4.0",
-				"jest-util": "^26.3.0",
-				"jest-worker": "^26.3.0",
-				"node-notifier": "^8.0.0",
-				"slash": "^3.0.0",
-				"source-map": "^0.6.0",
-				"string-length": "^4.0.1",
-				"terminal-link": "^2.0.0",
-				"v8-to-istanbul": "^5.0.1"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"istanbul-lib-instrument": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
-					"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
-					"requires": {
-						"@babel/core": "^7.7.5",
-						"@istanbuljs/schema": "^0.1.2",
-						"istanbul-lib-coverage": "^3.0.0",
-						"semver": "^6.3.0"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
+				"@jest/environment": "^26.6.1",
+				"@jest/types": "^26.6.1",
+				"expect": "^26.6.1"
 			}
 		},
 		"@jest/source-map": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.3.0.tgz",
-			"integrity": "sha512-hWX5IHmMDWe1kyrKl7IhFwqOuAreIwHhbe44+XH2ZRHjrKIh0LO5eLQ/vxHFeAfRwJapmxuqlGAEYLadDq6ZGQ==",
+			"version": "26.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.5.0.tgz",
+			"integrity": "sha512-jWAw9ZwYHJMe9eZq/WrsHlwF8E3hM9gynlcDpOyCb9bR8wEd9ZNBZCi7/jZyzHxC7t3thZ10gO2IDhu0bPKS5g==",
 			"requires": {
 				"callsites": "^3.0.0",
 				"graceful-fs": "^4.2.4",
@@ -3423,50 +3018,38 @@
 			}
 		},
 		"@jest/test-result": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.3.0.tgz",
-			"integrity": "sha512-a8rbLqzW/q7HWheFVMtghXV79Xk+GWwOK1FrtimpI5n1la2SY0qHri3/b0/1F0Ve0/yJmV8pEhxDfVwiUBGtgg==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.6.1.tgz",
+			"integrity": "sha512-wqAgIerIN2gSdT2A8WeA5+AFh9XQBqYGf8etK143yng3qYd0mF0ie2W5PVmgnjw4VDU6ammI9NdXrKgNhreawg==",
 			"requires": {
-				"@jest/console": "^26.3.0",
-				"@jest/types": "^26.3.0",
+				"@jest/console": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"collect-v8-coverage": "^1.0.0"
+			}
+		},
+		"@jest/test-sequencer": {
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.6.1.tgz",
+			"integrity": "sha512-0csqA/XApZiNeTIPYh6koIDCACSoR6hi29T61tKJMtCZdEC+tF3PoNt7MS0oK/zKC6daBgCbqXxia5ztr/NyCQ==",
+			"requires": {
+				"@jest/test-result": "^26.6.1",
+				"graceful-fs": "^4.2.4",
+				"jest-haste-map": "^26.6.1",
+				"jest-runner": "^26.6.1",
+				"jest-runtime": "^26.6.1"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -3477,6 +3060,16 @@
 					"requires": {
 						"ansi-styles": "^4.1.0",
 						"supports-color": "^7.1.0"
+					}
+				},
+				"cliui": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^6.2.0"
 					}
 				},
 				"color-convert": {
@@ -3492,10 +3085,140 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+				},
+				"jest-runtime": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.1.tgz",
+					"integrity": "sha512-7uOCNeezXDWgjEyzYbRN2ViY7xNZzusNVGAMmU0UHRUNXuY4j4GBHKGMqPo/cBPZA9bSYp+lwK2DRRBU5Dv6YQ==",
+					"requires": {
+						"@jest/console": "^26.6.1",
+						"@jest/environment": "^26.6.1",
+						"@jest/fake-timers": "^26.6.1",
+						"@jest/globals": "^26.6.1",
+						"@jest/source-map": "^26.5.0",
+						"@jest/test-result": "^26.6.1",
+						"@jest/transform": "^26.6.1",
+						"@jest/types": "^26.6.1",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0",
+						"cjs-module-lexer": "^0.4.2",
+						"collect-v8-coverage": "^1.0.0",
+						"exit": "^0.1.2",
+						"glob": "^7.1.3",
+						"graceful-fs": "^4.2.4",
+						"jest-config": "^26.6.1",
+						"jest-haste-map": "^26.6.1",
+						"jest-message-util": "^26.6.1",
+						"jest-mock": "^26.6.1",
+						"jest-regex-util": "^26.0.0",
+						"jest-resolve": "^26.6.1",
+						"jest-snapshot": "^26.6.1",
+						"jest-util": "^26.6.1",
+						"jest-validate": "^26.6.1",
+						"slash": "^3.0.0",
+						"strip-bom": "^4.0.0",
+						"yargs": "^15.4.1"
+					}
+				},
+				"jest-snapshot": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.1.tgz",
+					"integrity": "sha512-JA7bZp7HRTIJYAi85pJ/OZ2eur2dqmwIToA5/6d7Mn90isGEfeF9FvuhDLLEczgKP1ihreBzrJ6Vr7zteP5JNA==",
+					"requires": {
+						"@babel/types": "^7.0.0",
+						"@jest/types": "^26.6.1",
+						"@types/babel__traverse": "^7.0.4",
+						"@types/prettier": "^2.0.0",
+						"chalk": "^4.0.0",
+						"expect": "^26.6.1",
+						"graceful-fs": "^4.2.4",
+						"jest-diff": "^26.6.1",
+						"jest-get-type": "^26.3.0",
+						"jest-haste-map": "^26.6.1",
+						"jest-matcher-utils": "^26.6.1",
+						"jest-message-util": "^26.6.1",
+						"jest-resolve": "^26.6.1",
+						"natural-compare": "^1.4.0",
+						"pretty-format": "^26.6.1",
+						"semver": "^7.3.2"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+				},
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
 				},
 				"supports-color": {
 					"version": "7.2.0",
@@ -3504,36 +3227,61 @@
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"yargs": {
+					"version": "15.4.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+					"requires": {
+						"cliui": "^6.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^4.1.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^4.2.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^18.1.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
 				}
 			}
 		},
-		"@jest/test-sequencer": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.4.2.tgz",
-			"integrity": "sha512-83DRD8N3M0tOhz9h0bn6Kl6dSp+US6DazuVF8J9m21WAp5x7CqSMaNycMP0aemC/SH/pDQQddbsfHRTBXVUgog==",
-			"requires": {
-				"@jest/test-result": "^26.3.0",
-				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^26.3.0",
-				"jest-runner": "^26.4.2",
-				"jest-runtime": "^26.4.2"
-			}
-		},
 		"@jest/transform": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.3.0.tgz",
-			"integrity": "sha512-Isj6NB68QorGoFWvcOjlUhpkT56PqNIsXKR7XfvoDlCANn/IANlh8DrKAA2l2JKC3yWSMH5wS0GwuQM20w3b2A==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.1.tgz",
+			"integrity": "sha512-oNFAqVtqRxZRx6vXL3I4bPKUK0BIlEeaalkwxyQGGI8oXDQBtYQBpiMe5F7qPs4QdvvFYB42gPGIMMcxXaBBxQ==",
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/types": "^26.3.0",
+				"@jest/types": "^26.6.1",
 				"babel-plugin-istanbul": "^6.0.0",
 				"chalk": "^4.0.0",
 				"convert-source-map": "^1.4.0",
 				"fast-json-stable-stringify": "^2.0.0",
 				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^26.3.0",
+				"jest-haste-map": "^26.6.1",
 				"jest-regex-util": "^26.0.0",
-				"jest-util": "^26.3.0",
+				"jest-util": "^26.6.1",
 				"micromatch": "^4.0.2",
 				"pirates": "^4.0.1",
 				"slash": "^3.0.0",
@@ -3541,40 +3289,11 @@
 				"write-file-atomic": "^3.0.0"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -3670,13 +3389,60 @@
 			}
 		},
 		"@jest/types": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-			"integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+			"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^1.1.1",
-				"@types/yargs": "^13.0.0"
+				"@types/istanbul-reports": "^3.0.0",
+				"@types/node": "*",
+				"@types/yargs": "^15.0.0",
+				"chalk": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"@lerna/add": {
@@ -4976,9 +4742,9 @@
 			}
 		},
 		"@microsoft/load-themed-styles": {
-			"version": "1.10.89",
-			"resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.89.tgz",
-			"integrity": "sha512-nCL/fosGrCzDbr23cd9snWnRJZ3Hzy/0VmoOOqr3DH1mKqdE4EUmRE9GXn9CBSoqy9rK3+dFG5KOgxOIutylng=="
+			"version": "1.10.117",
+			"resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.117.tgz",
+			"integrity": "sha512-nEvUltTnpm4FnZ7TFHwQqL1Y5PDqXbAT1WGUXuUAF5RM8dgoRHQ72uIZJ2UBSQNKsY/+IwGWmHBFJVT1e1mzSQ=="
 		},
 		"@microsoft/tsdoc": {
 			"version": "0.12.19",
@@ -5108,15 +4874,6 @@
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^5.0.0"
-					}
-				},
-				"widest-line": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-					"integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
-					"dev": true,
-					"requires": {
-						"string-width": "^4.0.0"
 					}
 				},
 				"wrap-ansi": {
@@ -5258,15 +5015,6 @@
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 					"dev": true
 				},
-				"is-wsl": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-					"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-					"dev": true,
-					"requires": {
-						"is-docker": "^2.0.0"
-					}
-				},
 				"micromatch": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
@@ -5325,15 +5073,6 @@
 					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
 					"dev": true
 				},
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
 				"clean-stack": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.0.tgz",
@@ -5343,49 +5082,11 @@
 						"escape-string-regexp": "4.0.0"
 					}
 				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
-				},
 				"escape-string-regexp": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
 				},
 				"strip-ansi": {
 					"version": "6.0.0",
@@ -5394,17 +5095,6 @@
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^5.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-					"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0"
 					}
 				}
 			}
@@ -5467,6 +5157,42 @@
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^4.1.0"
+					}
+				},
+				"widest-line": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+					"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+					"dev": true,
+					"requires": {
+						"string-width": "^2.1.1"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+							"dev": true
+						},
+						"string-width": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+							"dev": true,
+							"requires": {
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^4.0.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
 					}
 				},
 				"wrap-ansi": {
@@ -5803,9 +5529,9 @@
 			"integrity": "sha512-bWBbC7VG2jdjbgZMX0qpds8U/3h3anfIqE81L8jmVrgFZw/urEDnBA78ymGGKTTK6ciBXmmJ/xlok+Re41S8ww=="
 		},
 		"@types/babel__core": {
-			"version": "7.1.9",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.9.tgz",
-			"integrity": "sha512-sY2RsIJ5rpER1u3/aQ8OFSI7qGIy8o1NEEbgb2UaJcvOtXOMpd39ko723NBpjQFg9SIX7TXtjejZVGeIMLhoOw==",
+			"version": "7.1.10",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.10.tgz",
+			"integrity": "sha512-x8OM8XzITIMyiwl5Vmo2B1cR1S1Ipkyv4mdlbJjMa1lmuKvKY9FrBbEANIaMlnWn5Rf7uO+rC/VgYabNkE17Hw==",
 			"requires": {
 				"@babel/parser": "^7.1.0",
 				"@babel/types": "^7.0.0",
@@ -5815,26 +5541,26 @@
 			}
 		},
 		"@types/babel__generator": {
-			"version": "7.6.1",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
-			"integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
+			"integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
 		},
 		"@types/babel__template": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
-			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.3.tgz",
+			"integrity": "sha512-uCoznIPDmnickEi6D0v11SBpW0OuVqHJCa7syXqQHy5uktSCreIlt0iglsCnmvz8yCb38hGcWeseA8cWJSwv5Q==",
 			"requires": {
 				"@babel/parser": "^7.1.0",
 				"@babel/types": "^7.0.0"
 			}
 		},
 		"@types/babel__traverse": {
-			"version": "7.0.14",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.14.tgz",
-			"integrity": "sha512-8w9szzKs14ZtBVuP6Wn7nMLRJ0D6dfB0VEBEyRgxrZ/Ln49aNMykrghM2FaNn4FJRzNppCSa0Rv9pBRM5Xc3wg==",
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.15.tgz",
+			"integrity": "sha512-Pzh9O3sTK8V6I1olsXpCfj2k/ygO2q1X0vhhnDrEQyYLHZesWz+zMZMVcwXLCYf0U36EtmyYaFGPfXlTtDHe3A==",
 			"requires": {
 				"@babel/types": "^7.3.0"
 			}
@@ -5869,7 +5595,8 @@
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+			"dev": true
 		},
 		"@types/connect": {
 			"version": "3.4.33",
@@ -5930,9 +5657,9 @@
 			}
 		},
 		"@types/express-serve-static-core": {
-			"version": "4.17.12",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.12.tgz",
-			"integrity": "sha512-EaEdY+Dty1jEU7U6J4CUWwxL+hyEGMkO5jan5gplfegUgCUsIUWqXxqw47uGjimeT4Qgkz/XUfwoau08+fgvKA==",
+			"version": "4.17.13",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz",
+			"integrity": "sha512-RgDi5a4nuzam073lRGKTUIaL3eF2+H7LJvJ8eUnCI0wA6SNjXc44DCmWNiTLs/AZ7QlsFWZiw/gTG3nSQGL0fA==",
 			"requires": {
 				"@types/node": "*",
 				"@types/qs": "*",
@@ -5950,17 +5677,17 @@
 			}
 		},
 		"@types/graceful-fs": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
-			"integrity": "sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.4.tgz",
+			"integrity": "sha512-mWA/4zFQhfvOA8zWkXobwJvBD7vzcxgrOQ0J5CH1votGqdq9m7+FwtGaqyCZqC3NyyBkc9z4m+iry4LlqcMWJg==",
 			"requires": {
 				"@types/node": "*"
 			}
 		},
 		"@types/html-minifier-terser": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.0.tgz",
-			"integrity": "sha512-iYCgjm1dGPRuo12+BStjd1HiVQqhlRhWDOQigNxn023HcjnhsiFz9pc6CzJj4HwDCSQca9bxTL4PxJDbkdm3PA=="
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
+			"integrity": "sha512-giAlZwstKbmvMk1OO7WXSj4OZ0keXAcl2TQq4LWHiiPH2ByaH7WeUzng+Qej8UPxxv+8lRTuouo0iaNDBuzIBA=="
 		},
 		"@types/isomorphic-fetch": {
 			"version": "0.0.35",
@@ -5981,11 +5708,10 @@
 			}
 		},
 		"@types/istanbul-reports": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-			"integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+			"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
 			"requires": {
-				"@types/istanbul-lib-coverage": "*",
 				"@types/istanbul-lib-report": "*"
 			}
 		},
@@ -6022,15 +5748,20 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
 		},
+		"@types/jsrsasign": {
+			"version": "8.0.7",
+			"resolved": "https://registry.npmjs.org/@types/jsrsasign/-/jsrsasign-8.0.7.tgz",
+			"integrity": "sha512-0SqXgSIJ0Co3FdUjaUUGoPx6VJpe0qFJ54S0QXFwcQ+VhXTqKIh9WrsumRzsCVnpmmoKi7d5dtukgraS7eTN+Q=="
+		},
 		"@types/jwt-decode": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@types/jwt-decode/-/jwt-decode-2.2.1.tgz",
 			"integrity": "sha512-aWw2YTtAdT7CskFyxEX2K21/zSDStuf/ikI3yBqmwpwJF0pS+/IX5DWv+1UFffZIbruP6cnT9/LAJV1gFwAT1A=="
 		},
 		"@types/lodash": {
-			"version": "4.14.161",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz",
-			"integrity": "sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA=="
+			"version": "4.14.162",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.162.tgz",
+			"integrity": "sha512-alvcho1kRUnnD1Gcl4J+hK0eencvzq9rmzvFPRmP5rPHx9VVsJj6bKLTATPVf9ktgv4ujzh7T+XWKp+jhuODig=="
 		},
 		"@types/mime": {
 			"version": "2.0.3",
@@ -6082,9 +5813,9 @@
 			"integrity": "sha512-dxKo80TqYx3YtBipHwA/SdFmMMyLCnP+5mkEqN0eMjcTBzHkiiX0ES118DsjDBjvD+zeSsSU9jULTZ+frog+Gw=="
 		},
 		"@types/prettier": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.0.tgz",
-			"integrity": "sha512-hiYA88aHiEIgDmeKlsyVsuQdcFn3Z2VuFd/Xm/HCnGnPD8UFU5BM128uzzRVVGEzKDKYUrRsRH9S2o+NUy/3IA=="
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.5.tgz",
+			"integrity": "sha512-UEyp8LwZ4Dg30kVU2Q3amHHyTn1jEdhCIE59ANed76GaT1Vp76DD3ZWSAxgCrw6wJ0TqeoBpqmfUHiUDPs//HQ=="
 		},
 		"@types/prop-types": {
 			"version": "15.7.3",
@@ -6092,9 +5823,9 @@
 			"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
 		},
 		"@types/prosemirror-model": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/@types/prosemirror-model/-/prosemirror-model-1.7.2.tgz",
-			"integrity": "sha512-2l+yXvidg3AUHN07mO4Jd8Q84fo6ksFsy7LHUurLYrZ74uTahBp2fzcO49AKZMzww2EulXJ40Kl/OFaQ/7A1fw==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@types/prosemirror-model/-/prosemirror-model-1.11.0.tgz",
+			"integrity": "sha512-R+vutu3AptoiXGJR0Jdpyr7BkJg24bce9ETUDOrBJZhRcsWeMEFGzidG19GHcY6Yny5zTILxlqXeDEIF3C5b7A==",
 			"requires": {
 				"@types/orderedmap": "*"
 			}
@@ -6128,9 +5859,9 @@
 			}
 		},
 		"@types/prosemirror-view": {
-			"version": "1.15.1",
-			"resolved": "https://registry.npmjs.org/@types/prosemirror-view/-/prosemirror-view-1.15.1.tgz",
-			"integrity": "sha512-ZdgIqDLWiO4wW4DhK8OjEVam3/DhBcggQeZ6zLts+UCflAZPnEk5dzRqFBVEyrvWqSAGLuPAoOgGAPjj/XwR8w==",
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/@types/prosemirror-view/-/prosemirror-view-1.16.1.tgz",
+			"integrity": "sha512-vsL7QB9Qmg9HcBTWsOkmBEGMF0CfA/SZgtqlUArQglnDWV40ZJYonkjBzyP+YhurMC/s4JT4T2vzfnv7rFF/cg==",
 			"requires": {
 				"@types/prosemirror-model": "*",
 				"@types/prosemirror-state": "*",
@@ -6147,9 +5878,9 @@
 			}
 		},
 		"@types/qs": {
-			"version": "6.9.4",
-			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.4.tgz",
-			"integrity": "sha512-+wYo+L6ZF6BMoEjtf8zB2esQsqdV6WsjRK/GP9WOgLPrq87PbNWgIxS76dS5uvl/QXtHGakZmwTznIfcPXcKlQ=="
+			"version": "6.9.5",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
+			"integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ=="
 		},
 		"@types/random-js": {
 			"version": "1.0.31",
@@ -6162,9 +5893,9 @@
 			"integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
 		},
 		"@types/react": {
-			"version": "16.9.49",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
-			"integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
+			"version": "16.9.53",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.53.tgz",
+			"integrity": "sha512-4nW60Sd4L7+WMXH1D6jCdVftuW7j4Za6zdp6tJ33Rqv0nk1ZAmQKML9ZLD4H0dehA3FZxXR/GM8gXplf82oNGw==",
 			"requires": {
 				"@types/prop-types": "*",
 				"csstype": "^3.0.2"
@@ -6215,12 +5946,12 @@
 			"integrity": "sha512-RxAwYt4rGwK5GyoRwuP0jT6ZHAVTdz2EqgsHmX0PYNjGsko+OeT4WFXXTs/lM3teJUJodM+SNtAL5/pXIJ61IQ=="
 		},
 		"@types/serve-static": {
-			"version": "1.13.5",
-			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.5.tgz",
-			"integrity": "sha512-6M64P58N+OXjU432WoLLBQxbA0LRGBCRm7aAGQJ+SMC1IMl0dgRVi9EFfoDcS2a7Xogygk/eGN94CfwU9UF7UQ==",
+			"version": "1.13.6",
+			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.6.tgz",
+			"integrity": "sha512-nuRJmv7jW7VmCVTn+IgYDkkbbDGyIINOeu/G0d74X3lm6E5KfMeQPJhxIt1ayQeQB3cSxvYs1RA/wipYoFB4EA==",
 			"requires": {
-				"@types/express-serve-static-core": "*",
-				"@types/mime": "*"
+				"@types/mime": "*",
+				"@types/node": "*"
 			}
 		},
 		"@types/sha.js": {
@@ -6242,9 +5973,9 @@
 			"integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg=="
 		},
 		"@types/socket.io-client": {
-			"version": "1.4.33",
-			"resolved": "https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-1.4.33.tgz",
-			"integrity": "sha512-m4LnxkljsI9fMsjwpW5QhRpMixo2BeeLpFmg0AE+sS4H1pzAd/cs/ftTiL60FLZgfFa8PFRPx5KsHu8O0bADKQ=="
+			"version": "1.4.34",
+			"resolved": "https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-1.4.34.tgz",
+			"integrity": "sha512-Lzia5OTQFJZJ5R4HsEEldywiiqT9+W2rDbyHJiiTGqOcju89sCsQ8aUXDljY6Ls33wKZZGC0bfMhr/VpOyjtXg=="
 		},
 		"@types/source-list-map": {
 			"version": "0.1.2",
@@ -6252,9 +5983,9 @@
 			"integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA=="
 		},
 		"@types/stack-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
-			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+			"integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw=="
 		},
 		"@types/tapable": {
 			"version": "1.0.6",
@@ -6275,9 +6006,9 @@
 			"integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
 		},
 		"@types/uglify-js": {
-			"version": "3.9.3",
-			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.3.tgz",
-			"integrity": "sha512-KswB5C7Kwduwjj04Ykz+AjvPcfgv/37Za24O2EDzYNbwyzOo8+ydtvzUfZ5UMguiVu29Gx44l1A6VsPPcmYu9w==",
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.11.0.tgz",
+			"integrity": "sha512-I0Yd8TUELTbgRHq2K65j8rnDPAzAP+DiaF/syLem7yXwYLsHZhPd+AM2iXsWmf9P2F2NlFCgl5erZPQx9IbM9Q==",
 			"requires": {
 				"source-map": "^0.6.1"
 			}
@@ -6288,9 +6019,9 @@
 			"integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ=="
 		},
 		"@types/webpack": {
-			"version": "4.41.22",
-			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.22.tgz",
-			"integrity": "sha512-JQDJK6pj8OMV9gWOnN1dcLCyU9Hzs6lux0wBO4lr1+gyEhIBR9U3FMrz12t2GPkg110XAxEAw2WHF6g7nZIbRQ==",
+			"version": "4.41.23",
+			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.23.tgz",
+			"integrity": "sha512-ojA4CupZg8RCzVJLugWlvqrHpT59GWhqFxbinlsnvk10MjQCWB+ot7XDACctbWhnhtdhYK7+HOH1JxkVLiZhMg==",
 			"requires": {
 				"@types/anymatch": "*",
 				"@types/node": "*",
@@ -6301,9 +6032,9 @@
 			}
 		},
 		"@types/webpack-sources": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-1.4.2.tgz",
-			"integrity": "sha512-77T++JyKow4BQB/m9O96n9d/UUHWLQHlcqXb9Vsf4F1+wKNrrlWNFPDLKNT92RJnCSL6CieTc+NDXtCVZswdTw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-2.0.0.tgz",
+			"integrity": "sha512-a5kPx98CNFRKQ+wqawroFunvFqv7GHm/3KOI52NY9xWADgc8smu4R6prt4EU/M4QfVjvgBkMqU4fBhw3QfMVkg==",
 			"requires": {
 				"@types/node": "*",
 				"@types/source-list-map": "*",
@@ -6326,14 +6057,14 @@
 			}
 		},
 		"@types/xmldoc": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@types/xmldoc/-/xmldoc-1.1.4.tgz",
-			"integrity": "sha512-a/ONNCf9itbmzEz1ohx0Fv5TLJzXIPQTapxFu+DlYlDtn9UcAa1OhnrOOMwbU8125hFjrkJKL3qllD7vO5Bivw=="
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@types/xmldoc/-/xmldoc-1.1.5.tgz",
+			"integrity": "sha512-31y8EoleGz/8+cA1ofgy1h8/yAXUjr6pfR2DSohWGa477UC7T2SQ2A+aafljRI2Pe64oE7mrJX8E3euWztC3sQ=="
 		},
 		"@types/yargs": {
-			"version": "13.0.10",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.10.tgz",
-			"integrity": "sha512-MU10TSgzNABgdzKvQVW1nuuT+sgBMWeXNc3XOs5YXV5SDAK+PPja2eUuBNB9iqElu03xyEDqlnGw0jgl4nbqGQ==",
+			"version": "15.0.9",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+			"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 			"requires": {
 				"@types/yargs-parser": "*"
 			}
@@ -6497,16 +6228,6 @@
 				}
 			}
 		},
-		"@typescript-eslint/experimental-utils": {
-			"version": "2.17.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.17.0.tgz",
-			"integrity": "sha512-2bNf+mZ/3mj5/3CP56v+ldRK3vFy9jOvmCPs/Gr2DeSJh+asPZrhFniv4QmQsHWQFPJFWhFHgkGgJeRmK4m8iQ==",
-			"requires": {
-				"@types/json-schema": "^7.0.3",
-				"@typescript-eslint/typescript-estree": "2.17.0",
-				"eslint-scope": "^5.0.0"
-			}
-		},
 		"@typescript-eslint/parser": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.2.0.tgz",
@@ -6651,27 +6372,6 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.2.0.tgz",
 			"integrity": "sha512-xkv5nIsxfI/Di9eVwN+G9reWl7Me9R5jpzmZUch58uQ7g0/hHVuGUbbn4NcxcM5y/R4wuJIIEPKPDb5l4Fdmwg=="
 		},
-		"@typescript-eslint/typescript-estree": {
-			"version": "2.17.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.17.0.tgz",
-			"integrity": "sha512-g0eVRULGnEEUakxRfJO0s0Hr1LLQqsI6OrkiCLpdHtdJJek+wyd8mb00vedqAoWldeDcOcP8plqw8/jx9Gr3Lw==",
-			"requires": {
-				"debug": "^4.1.1",
-				"eslint-visitor-keys": "^1.1.0",
-				"glob": "^7.1.6",
-				"is-glob": "^4.0.1",
-				"lodash": "^4.17.15",
-				"semver": "^6.3.0",
-				"tsutils": "^3.17.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				}
-			}
-		},
 		"@typescript-eslint/visitor-keys": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.2.0.tgz",
@@ -6689,102 +6389,108 @@
 			}
 		},
 		"@uifabric/fluent-theme": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/@uifabric/fluent-theme/-/fluent-theme-7.3.7.tgz",
-			"integrity": "sha512-L6tKSBCzIu98Mr6QZ2M9xdBMz+53tDz9anpfD+NsszOUaCzUT6v5O7pwb1zUEJRVrdRTX3m3aHx6792K/FEUcA==",
+			"version": "7.3.30",
+			"resolved": "https://registry.npmjs.org/@uifabric/fluent-theme/-/fluent-theme-7.3.30.tgz",
+			"integrity": "sha512-Abk1TBHPoR0J91jBphQlIeRzQFSu+zu/vZC5pHEnUFvPwk0CKW0SHKL3+bllmH26oaT0Y6sQnQNKjrMrn9HxNA==",
 			"requires": {
-				"@fluentui/theme": "^0.2.0",
-				"@uifabric/merge-styles": "^7.18.0",
-				"@uifabric/set-version": "^7.0.22",
-				"@uifabric/styling": "^7.16.0",
-				"@uifabric/variants": "^7.2.12",
-				"office-ui-fabric-react": "^7.137.1",
+				"@fluentui/theme": "^1.5.1",
+				"@uifabric/merge-styles": "^7.19.1",
+				"@uifabric/set-version": "^7.0.23",
+				"@uifabric/styling": "^7.16.13",
+				"@uifabric/variants": "^7.2.26",
+				"office-ui-fabric-react": "^7.148.0",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/foundation": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.9.0.tgz",
-			"integrity": "sha512-4gdPwx0HV59aWvPKIw6yIje60CYwJZmTJsdLRXqh8Np1tWp2EsbA8U/IHQL1V91rEN0DlQhASqCDFhfQoD1jUw==",
+			"version": "7.9.14",
+			"resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.9.14.tgz",
+			"integrity": "sha512-AWsSt28+mid44YPofHB8N1nm4C0QmLJ9WXFps5GyjaBHES6/4bfJ7rKzYioa5bN0TxElyK8rRHzwqKNQhWDBYA==",
 			"requires": {
-				"@uifabric/merge-styles": "^7.18.0",
-				"@uifabric/set-version": "^7.0.22",
-				"@uifabric/styling": "^7.16.0",
-				"@uifabric/utilities": "^7.31.0",
+				"@uifabric/merge-styles": "^7.19.1",
+				"@uifabric/set-version": "^7.0.23",
+				"@uifabric/styling": "^7.16.13",
+				"@uifabric/utilities": "^7.32.4",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/icons": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.5.0.tgz",
-			"integrity": "sha512-RINA9VkajlCnlwEBbqiwLBaaGn38Bf9UvjOuwrrja4B9lclLeQzZuGrG/kp7CnDtIO+LC19OYl/7E3jW7yIihA==",
+			"version": "7.5.12",
+			"resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.5.12.tgz",
+			"integrity": "sha512-VIqj4oMwi4HJPqH3+3RblLoYjPfYzjVyZ8Kk57dmA7tj+vbM38Zn9vObe+Xg/EVEfohD3kD0fyEqPmnEqY17Pg==",
 			"requires": {
-				"@uifabric/set-version": "^7.0.22",
-				"@uifabric/styling": "^7.16.0",
+				"@uifabric/set-version": "^7.0.23",
+				"@uifabric/styling": "^7.16.13",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/merge-styles": {
-			"version": "7.18.0",
-			"resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-7.18.0.tgz",
-			"integrity": "sha512-805WIbN7lAJATXKxZjjRbIgN7raRMwWYWeDkJJ52PCPuCesOvbpdr0GkH8rC6GQ7EB0MB7YM2i6Fiye7SFewbw==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-7.19.1.tgz",
+			"integrity": "sha512-yqUwmk62Kgu216QNPE9vOfS3h0kiSbTvoqM5QcZi+IzpqsBOlzZx3A9Er9UiDaqHRd5lsYF5pO/jeUULmBWF/A==",
 			"requires": {
-				"@uifabric/set-version": "^7.0.22",
+				"@uifabric/set-version": "^7.0.23",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/react-hooks": {
-			"version": "7.13.0",
-			"resolved": "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.13.0.tgz",
-			"integrity": "sha512-A7K0YFHHr10hB/txsqpPX6PhNhHEv8U7JpY3O81oqlZwSsHroJklQdd897JkAYJUUR+gWe2kQyXkkcaMDdqXjg==",
+			"version": "7.13.6",
+			"resolved": "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.13.6.tgz",
+			"integrity": "sha512-DvfphxrTsjo3oYioRZ0D8mXdpxWQhhIHeWk1cfdq0MVGqRyKM+cm++9pJpvItFvnTNba38jzKdggqRSUWi+clg==",
 			"requires": {
-				"@fluentui/react-window-provider": "^0.3.0",
-				"@uifabric/set-version": "^7.0.22",
-				"@uifabric/utilities": "^7.31.0",
+				"@fluentui/react-window-provider": "^0.3.3",
+				"@uifabric/set-version": "^7.0.23",
+				"@uifabric/utilities": "^7.32.4",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/set-version": {
-			"version": "7.0.22",
-			"resolved": "https://registry.npmjs.org/@uifabric/set-version/-/set-version-7.0.22.tgz",
-			"integrity": "sha512-IG35UNJNxqI7NC2eYuobGTD+v4W0VHQcC3bYd5Na9EgoC9jVgguS8n6EXUtP/lC1vJEYEyPEZdVwhPxKw4F4Sw==",
+			"version": "7.0.23",
+			"resolved": "https://registry.npmjs.org/@uifabric/set-version/-/set-version-7.0.23.tgz",
+			"integrity": "sha512-9E+YKtnH2kyMKnK9XZZsqyM8OCxEJIIfxtaThTlQpYOzrWAGJxQADFbZ7+Usi0U2xHnWNPFROjq+B9ocEzhqMA==",
 			"requires": {
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/styling": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.16.0.tgz",
-			"integrity": "sha512-yO404ws8Wl4fjBwG4T58TFJjeU/K+SpWJ4w+WeNMDlJcYe4zXaWn2lbOJtKtQiMl324RAEjFSOuNkXzPb0uOGQ==",
+			"version": "7.16.13",
+			"resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.16.13.tgz",
+			"integrity": "sha512-jj5FH7XuQXz8HgRhCXNApeUAynDBv2nfmTpzHawE55x7YR+oliQfsJSY8Ow4YbLAazIR5BuW1n9eKuGxxmIw1w==",
 			"requires": {
-				"@fluentui/theme": "^0.2.0",
+				"@fluentui/theme": "^1.5.1",
 				"@microsoft/load-themed-styles": "^1.10.26",
-				"@uifabric/merge-styles": "^7.18.0",
-				"@uifabric/set-version": "^7.0.22",
-				"@uifabric/utilities": "^7.31.0",
+				"@uifabric/merge-styles": "^7.19.1",
+				"@uifabric/set-version": "^7.0.23",
+				"@uifabric/utilities": "^7.32.4",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/utilities": {
-			"version": "7.31.0",
-			"resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.31.0.tgz",
-			"integrity": "sha512-m4Yeyn4gyW7xS8LvOnCesokPModYS2YuE9GQmO++MDZ/vC5RRNlvlyktUZDuxCZ84cNCiXyTQ8nImBaPGnxHVQ==",
+			"version": "7.32.4",
+			"resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.32.4.tgz",
+			"integrity": "sha512-IKZc03uyfTrgcCGSPAUWfFl9CyxzpSrxrYwAuO4NgDEySdOlkYBRwsRUh6UwWfM+sJdhg7Y3nupzNU3VSC/arg==",
 			"requires": {
-				"@uifabric/merge-styles": "^7.18.0",
-				"@uifabric/set-version": "^7.0.22",
+				"@fluentui/dom-utilities": "^1.1.1",
+				"@uifabric/merge-styles": "^7.19.1",
+				"@uifabric/set-version": "^7.0.23",
 				"prop-types": "^15.7.2",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/variants": {
-			"version": "7.2.12",
-			"resolved": "https://registry.npmjs.org/@uifabric/variants/-/variants-7.2.12.tgz",
-			"integrity": "sha512-gEicMZsDgSqW4Jgr8zY/HDJtyygNuJNCTsrbZhjQPMFdvbykrR92l8c7CtLXMqs73zrWvETED4eT/vPmkf7N6A==",
+			"version": "7.2.26",
+			"resolved": "https://registry.npmjs.org/@uifabric/variants/-/variants-7.2.26.tgz",
+			"integrity": "sha512-tSLiCP2aVT1Zn3gRBobvzvexJx0kzD/TJ2Il56WlVYLRD0X6wDDO5J+ort0rGUGlJNTvDNZas4v/aNu/96o/mw==",
 			"requires": {
-				"@uifabric/set-version": "^7.0.22",
-				"office-ui-fabric-react": "^7.137.1",
+				"@fluentui/theme": "^1.5.1",
+				"@uifabric/set-version": "^7.0.23",
 				"tslib": "^1.10.0"
 			}
+		},
+		"@ungap/promise-all-settled": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.9.0",
@@ -7002,25 +6708,9 @@
 			}
 		},
 		"acorn": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-			"integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w=="
-		},
-		"acorn-globals": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
-			"integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
-			"requires": {
-				"acorn": "^6.0.1",
-				"acorn-walk": "^6.0.1"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "6.4.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-					"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
-				}
-			}
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
 		},
 		"acorn-jsx": {
 			"version": "5.3.1",
@@ -7028,9 +6718,9 @@
 			"integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng=="
 		},
 		"acorn-walk": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
-			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+			"integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
 		},
 		"add-dom-event-listener": {
 			"version": "1.1.0",
@@ -7142,12 +6832,12 @@
 			"dev": true
 		},
 		"anymatch": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+			"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
 			"requires": {
-				"micromatch": "^3.1.4",
-				"normalize-path": "^2.1.1"
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
 			}
 		},
 		"append-transform": {
@@ -7313,17 +7003,6 @@
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.17.0-next.1",
 				"function-bind": "^1.1.1"
-			}
-		},
-		"array.prototype.map": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.2.tgz",
-			"integrity": "sha512-Az3OYxgsa1g7xDYp86l0nnN4bcmuEITGe1rbdEBVkrqkzMgDcbdQ2R7r41pNzti+4NMces3H8gMmuioZUilLgw==",
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1",
-				"es-array-method-boxes-properly": "^1.0.0",
-				"is-string": "^1.0.4"
 			}
 		},
 		"arraybuffer.slice": {
@@ -7575,64 +7254,36 @@
 			},
 			"dependencies": {
 				"resolve": {
-					"version": "1.17.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+					"version": "1.18.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
+					"integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
 					"requires": {
+						"is-core-module": "^2.0.0",
 						"path-parse": "^1.0.6"
 					}
 				}
 			}
 		},
 		"babel-jest": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.3.0.tgz",
-			"integrity": "sha512-sxPnQGEyHAOPF8NcUsD0g7hDCnvLL2XyblRBcgrzTWBB/mAIpWow3n1bEL+VghnnZfreLhFSBsFluRoK2tRK4g==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.1.tgz",
+			"integrity": "sha512-duMWEOKrSBYRVTTNpL2SipNIWnZOjP77auOBMPQ3zXAdnDbyZQWU8r/RxNWpUf9N6cgPFecQYelYLytTVXVDtA==",
 			"requires": {
-				"@jest/transform": "^26.3.0",
-				"@jest/types": "^26.3.0",
+				"@jest/transform": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/babel__core": "^7.1.7",
 				"babel-plugin-istanbul": "^6.0.0",
-				"babel-preset-jest": "^26.3.0",
+				"babel-preset-jest": "^26.5.0",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -7734,9 +7385,9 @@
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "26.2.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.2.0.tgz",
-			"integrity": "sha512-B/hVMRv8Nh1sQ1a3EY8I0n4Y1Wty3NrR5ebOyVT302op+DOAau+xNEImGMsUWOC3++ZlMooCytKz+NgN8aKGbA==",
+			"version": "26.5.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.5.0.tgz",
+			"integrity": "sha512-ck17uZFD3CDfuwCLATWZxkkuGGFhMij8quP8CNhwj8ek1mqFgbFzRJ30xwC04LLscj/aKsVFfRST+b5PT7rSuw==",
 			"requires": {
 				"@babel/template": "^7.3.3",
 				"@babel/types": "^7.3.3",
@@ -7745,9 +7396,9 @@
 			}
 		},
 		"babel-preset-current-node-syntax": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz",
-			"integrity": "sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==",
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.4.tgz",
+			"integrity": "sha512-5/INNCYhUGqw7VbVjT/hb3ucjgkVHKXY7lX3ZjlN4gm565VyFmJUrJ/h+h16ECVB38R/9SF6aACydpKMLZ/c9w==",
 			"requires": {
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
 				"@babel/plugin-syntax-bigint": "^7.8.3",
@@ -7763,11 +7414,11 @@
 			}
 		},
 		"babel-preset-jest": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.3.0.tgz",
-			"integrity": "sha512-5WPdf7nyYi2/eRxCbVrE1kKCWxgWY4RsPEbdJWFm7QsesFGqjdkyLeu1zRkwM1cxK6EPIlNd6d2AxLk7J+t4pw==",
+			"version": "26.5.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.5.0.tgz",
+			"integrity": "sha512-F2vTluljhqkiGSJGBg/jOruA8vIIIL11YrxRcO7nviNTMbbofPSHwnm8mgP7d/wS7wRSexRoI6X1A6T74d4LQA==",
 			"requires": {
-				"babel-plugin-jest-hoist": "^26.2.0",
+				"babel-plugin-jest-hoist": "^26.5.0",
 				"babel-preset-current-node-syntax": "^0.1.3"
 			}
 		},
@@ -7778,6 +7429,13 @@
 			"requires": {
 				"core-js": "^2.4.0",
 				"regenerator-runtime": "^0.11.0"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.11.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+				}
 			}
 		},
 		"backo2": {
@@ -7846,9 +7504,9 @@
 			"integrity": "sha512-V6YHUbjLxN1ymqNLb1DPHoU1CpfdL7d2YTIp5W3U4hhoG4hhxNmsFDs66M9EXxBiSEke5Bt5dwdfMwwZF70iLA=="
 		},
 		"base64-arraybuffer": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-			"integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
+			"integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI="
 		},
 		"base64-js": {
 			"version": "1.3.1",
@@ -7888,14 +7546,6 @@
 			"resolved": "https://registry.npmjs.org/best-random/-/best-random-1.0.3.tgz",
 			"integrity": "sha512-zrncs76CBFyhE7KVsq85lsc/TT5PUfGTS8arh2aJZcIzQU+WdGNwWYwFsn+w/nuedk04efQdqMy8g5C5pw4shQ=="
 		},
-		"better-assert": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-			"integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-			"requires": {
-				"callsite": "1.0.0"
-			}
-		},
 		"bfj": {
 			"version": "6.1.2",
 			"resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.2.tgz",
@@ -7916,15 +7566,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
 			"integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
-		},
-		"bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"optional": true,
-			"requires": {
-				"file-uri-to-path": "1.0.0"
-			}
 		},
 		"blob": {
 			"version": "0.0.5",
@@ -8034,6 +7675,14 @@
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
 					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"widest-line": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+					"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+					"requires": {
+						"string-width": "^2.1.1"
+					}
 				}
 			}
 		},
@@ -8381,11 +8030,6 @@
 				"caller-callsite": "^2.0.0"
 			}
 		},
-		"callsite": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-			"integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
-		},
 		"callsites": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
@@ -8494,9 +8138,9 @@
 			"integrity": "sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ=="
 		},
 		"chokidar": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
-			"integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+			"integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
 			"requires": {
 				"anymatch": "~3.1.1",
 				"braces": "~3.0.2",
@@ -8505,18 +8149,9 @@
 				"is-binary-path": "~2.1.0",
 				"is-glob": "~4.0.1",
 				"normalize-path": "~3.0.0",
-				"readdirp": "~3.4.0"
+				"readdirp": "~3.5.0"
 			},
 			"dependencies": {
-				"anymatch": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-					"requires": {
-						"normalize-path": "^3.0.0",
-						"picomatch": "^2.0.4"
-					}
-				},
 				"braces": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
@@ -8533,21 +8168,10 @@
 						"to-regex-range": "^5.0.1"
 					}
 				},
-				"fsevents": {
-					"version": "2.1.3",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-					"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-					"optional": true
-				},
 				"is-number": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-				},
-				"normalize-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
 				},
 				"to-regex-range": {
 					"version": "5.0.1",
@@ -8585,6 +8209,11 @@
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
 			}
+		},
+		"cjs-module-lexer": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.4.3.tgz",
+			"integrity": "sha512-5RLK0Qfs0PNDpEyBXIr3bIT1Muw3ojSlvpw6dAmkUcO0+uTrsBn7GuEIgx40u+OzbCBLDta7nvmud85P4EmTsQ=="
 		},
 		"class-utils": {
 			"version": "0.3.6",
@@ -8740,18 +8369,9 @@
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
 		"codemirror": {
-			"version": "5.57.0",
-			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.57.0.tgz",
-			"integrity": "sha512-WGc6UL7Hqt+8a6ZAsj/f1ApQl3NPvHY/UQSzG6fB6l4BjExgVdhFaxd7mRTw1UCiYe/6q86zHP+kfvBQcZGvUg=="
-		},
-		"codemirror-graphql": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/codemirror-graphql/-/codemirror-graphql-0.8.3.tgz",
-			"integrity": "sha512-ZipSnPXFKDMThfvfTKTAt1dQmuGctVNann8hTZg6017+vwOcGpIqCuQIZLRDw/Y3zZfCyydRARHgbSydSCXpow==",
-			"requires": {
-				"graphql-language-service-interface": "^1.3.2",
-				"graphql-language-service-parser": "^1.2.2"
-			}
+			"version": "5.58.2",
+			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.58.2.tgz",
+			"integrity": "sha512-K/hOh24cCwRutd1Mk3uLtjWzNISOkm4fvXiMO7LucCrqbh6aJDdtqUziim3MZUI6wOY0rvY1SlL1Ork01uMy6w=="
 		},
 		"codemirror-spell-checker": {
 			"version": "1.1.2",
@@ -8853,41 +8473,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
-		},
-		"commoner": {
-			"version": "0.10.8",
-			"resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
-			"integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
-			"requires": {
-				"commander": "^2.5.0",
-				"detective": "^4.3.1",
-				"glob": "^5.0.15",
-				"graceful-fs": "^4.1.2",
-				"iconv-lite": "^0.4.5",
-				"mkdirp": "^0.5.0",
-				"private": "^0.1.6",
-				"q": "^1.1.2",
-				"recast": "^0.11.17"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-				},
-				"glob": {
-					"version": "5.0.15",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-					"requires": {
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "2 || 3",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				}
-			}
 		},
 		"compare-func": {
 			"version": "2.0.0",
@@ -9889,22 +9474,29 @@
 			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
 		},
 		"cssom": {
-			"version": "0.3.8",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-			"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+			"integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw=="
 		},
 		"cssstyle": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
-			"integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+			"integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
 			"requires": {
-				"cssom": "0.3.x"
+				"cssom": "~0.3.6"
+			},
+			"dependencies": {
+				"cssom": {
+					"version": "0.3.8",
+					"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+					"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+				}
 			}
 		},
 		"csstype": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
-			"integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
+			"integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA=="
 		},
 		"currently-unhandled": {
 			"version": "0.4.1",
@@ -9988,45 +9580,6 @@
 					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
 					"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
 					"dev": true
-				},
-				"has-flag": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-					"dev": true
-				},
-				"node-fetch": {
-					"version": "2.6.1",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-					"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					},
-					"dependencies": {
-						"has-flag": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-							"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-							"dev": true
-						}
-					}
-				},
-				"supports-hyperlinks": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-1.0.1.tgz",
-					"integrity": "sha512-HHi5kVSefKaJkGYXbDuKbUGRVxqnWGn3J2e39CYcNJEfWciGq2zYtOhXLTlvrOZW1QU7VX67w7fMmWafHX9Pfw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^2.0.0",
-						"supports-color": "^5.0.0"
-					}
 				}
 			}
 		},
@@ -10048,13 +9601,38 @@
 			}
 		},
 		"data-urls": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
-			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+			"integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
 			"requires": {
-				"abab": "^2.0.0",
-				"whatwg-mimetype": "^2.2.0",
-				"whatwg-url": "^7.0.0"
+				"abab": "^2.0.3",
+				"whatwg-mimetype": "^2.3.0",
+				"whatwg-url": "^8.0.0"
+			},
+			"dependencies": {
+				"tr46": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+					"integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+					"requires": {
+						"punycode": "^2.1.1"
+					}
+				},
+				"webidl-conversions": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+					"integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
+				},
+				"whatwg-url": {
+					"version": "8.4.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.4.0.tgz",
+					"integrity": "sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==",
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^2.0.2",
+						"webidl-conversions": "^6.1.0"
+					}
+				}
 			}
 		},
 		"date-arithmetic": {
@@ -10075,11 +9653,11 @@
 			"dev": true
 		},
 		"debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+			"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 			"requires": {
-				"ms": "^2.1.1"
+				"ms": "2.1.2"
 			}
 		},
 		"debuglog": {
@@ -10110,9 +9688,9 @@
 			}
 		},
 		"decimal.js": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
-			"integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw=="
+			"version": "10.2.1",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+			"integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
 		},
 		"decode-uri-component": {
 			"version": "0.2.0",
@@ -10342,22 +9920,6 @@
 			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
 			"integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
 		},
-		"detective": {
-			"version": "4.7.1",
-			"resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
-			"integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
-			"requires": {
-				"acorn": "^5.2.1",
-				"defined": "^1.0.0"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "5.7.4",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-					"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
-				}
-			}
-		},
 		"dezalgo": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
@@ -10374,9 +9936,9 @@
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 		},
 		"diff-sequences": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
-			"integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig=="
+			"version": "26.5.0",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
+			"integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q=="
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
@@ -10464,14 +10026,14 @@
 			},
 			"dependencies": {
 				"domelementtype": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-					"integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
+					"integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA=="
 				},
 				"entities": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-					"integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+					"integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
 				}
 			}
 		},
@@ -10486,11 +10048,18 @@
 			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
 		},
 		"domexception": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
-			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+			"integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
 			"requires": {
-				"webidl-conversions": "^4.0.2"
+				"webidl-conversions": "^5.0.0"
+			},
+			"dependencies": {
+				"webidl-conversions": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+					"integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
+				}
 			}
 		},
 		"domhandler": {
@@ -10636,43 +10205,6 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"editorconfig": {
-			"version": "0.15.3",
-			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
-			"integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
-			"requires": {
-				"commander": "^2.19.0",
-				"lru-cache": "^4.1.5",
-				"semver": "^5.6.0",
-				"sigmund": "^1.0.1"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-				},
-				"lru-cache": {
-					"version": "4.1.5",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
-					}
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-				},
-				"yallist": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-				}
-			}
-		},
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -10705,9 +10237,9 @@
 			}
 		},
 		"emittery": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.1.tgz",
-			"integrity": "sha512-d34LN4L6h18Bzz9xpoku2nPwKxCPlPMr3EEKTkoEBi+1/+b0lcRkRJ1UVyyZaKNeqGR3swcGl6s390DNO4YVgQ=="
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",
+			"integrity": "sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ=="
 		},
 		"emoji-regex": {
 			"version": "7.0.3",
@@ -10741,23 +10273,36 @@
 			}
 		},
 		"engine.io-client": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.3.tgz",
-			"integrity": "sha512-0NGY+9hioejTEJCaSJZfWZLk4FPI9dN+1H1C4+wj2iuFba47UgZbJzfWs4aNFajnX/qAaYKbe2lLTfEEWzCmcw==",
+			"version": "3.4.4",
+			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.4.tgz",
+			"integrity": "sha512-iU4CRr38Fecj8HoZEnFtm2EiKGbYZcPn3cHxqNGl/tmdWRf60KhK+9vE0JeSjgnlS/0oynEfLgKbT9ALpim0sQ==",
 			"requires": {
 				"component-emitter": "~1.3.0",
 				"component-inherit": "0.0.3",
-				"debug": "~4.1.0",
+				"debug": "~3.1.0",
 				"engine.io-parser": "~2.2.0",
 				"has-cors": "1.1.0",
 				"indexof": "0.0.1",
-				"parseqs": "0.0.5",
-				"parseuri": "0.0.5",
+				"parseqs": "0.0.6",
+				"parseuri": "0.0.6",
 				"ws": "~6.1.0",
 				"xmlhttprequest-ssl": "~1.5.4",
 				"yeast": "0.1.2"
 			},
 			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
 				"ws": {
 					"version": "6.1.4",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
@@ -10769,13 +10314,13 @@
 			}
 		},
 		"engine.io-parser": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
-			"integrity": "sha512-6I3qD9iUxotsC5HEMuuGsKA0cXerGz+4uGcXQEkfBidgKf0amsjrrtwcbwK/nzpZBxclXlV7gGl9dgWvu4LF6w==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.1.tgz",
+			"integrity": "sha512-x+dN/fBH8Ro8TFwJ+rkB2AmuVw9Yu2mockR/p3W8f8YtExwFgDvBDi0GWyb4ZLkpahtDGZgtr3zLovanJghPqg==",
 			"requires": {
 				"after": "0.8.2",
 				"arraybuffer.slice": "~0.0.7",
-				"base64-arraybuffer": "0.1.5",
+				"base64-arraybuffer": "0.1.4",
 				"blob": "0.0.5",
 				"has-binary2": "~1.0.2"
 			}
@@ -10808,15 +10353,6 @@
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
 			"integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
 			"dev": true
-		},
-		"envify": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz",
-			"integrity": "sha1-1xIjKejfFoi6dxsSUBkXyc5cvOg=",
-			"requires": {
-				"jstransform": "^11.0.3",
-				"through": "~2.3.4"
-			}
 		},
 		"envinfo": {
 			"version": "7.5.1",
@@ -10864,32 +10400,6 @@
 				"string.prototype.trimright": "^2.1.1"
 			}
 		},
-		"es-array-method-boxes-properly": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
-		},
-		"es-get-iterator": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.0.tgz",
-			"integrity": "sha512-UfrmHuWQlNMTs35e1ypnvikg6jCz3SK8v8ImvmDsh36fCVUR1MqoFDiyn0/k52C8NqO3YsO8Oe0azeesNuqSsQ==",
-			"requires": {
-				"es-abstract": "^1.17.4",
-				"has-symbols": "^1.0.1",
-				"is-arguments": "^1.0.4",
-				"is-map": "^2.0.1",
-				"is-set": "^2.0.1",
-				"is-string": "^1.0.5",
-				"isarray": "^2.0.5"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-					"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-				}
-			}
-		},
 		"es-to-primitive": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
@@ -10922,15 +10432,6 @@
 			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
 			"requires": {
 				"es6-promise": "^4.0.3"
-			}
-		},
-		"es6-templates": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz",
-			"integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
-			"requires": {
-				"recast": "~0.11.12",
-				"through": "~2.3.6"
 			}
 		},
 		"escape-html": {
@@ -11005,11 +10506,10 @@
 					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -11061,6 +10561,24 @@
 						"acorn": "^7.4.0",
 						"acorn-jsx": "^5.2.0",
 						"eslint-visitor-keys": "^1.3.0"
+					}
+				},
+				"file-entry-cache": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+					"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+					"requires": {
+						"flat-cache": "^2.0.1"
+					}
+				},
+				"flat-cache": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+					"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+					"requires": {
+						"flatted": "^2.0.0",
+						"rimraf": "2.6.3",
+						"write": "1.0.3"
 					}
 				},
 				"globals": {
@@ -11116,6 +10634,14 @@
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 					"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
+				},
+				"rimraf": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
 				},
 				"semver": {
 					"version": "7.3.2",
@@ -11233,10 +10759,11 @@
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				},
 				"resolve": {
-					"version": "1.17.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+					"version": "1.18.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
+					"integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
 					"requires": {
+						"is-core-module": "^2.0.0",
 						"path-parse": "^1.0.6"
 					}
 				}
@@ -11378,6 +10905,14 @@
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
 				"load-json-file": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -11465,11 +11000,23 @@
 					}
 				},
 				"resolve": {
-					"version": "1.17.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+					"version": "1.18.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
+					"integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
 					"requires": {
+						"is-core-module": "^2.0.0",
 						"path-parse": "^1.0.6"
+					}
+				},
+				"tsconfig-paths": {
+					"version": "3.9.0",
+					"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+					"integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+					"requires": {
+						"@types/json5": "^0.0.29",
+						"json5": "^1.0.1",
+						"minimist": "^1.2.0",
+						"strip-bom": "^3.0.0"
 					}
 				}
 			}
@@ -11493,20 +11040,20 @@
 			"integrity": "sha512-C8YMhL+r8RMeMdYAw/rQtE6xNdMulj+zGWud/qIGnlmomiPRaLDGLMeskZ3alN6uMBojmooRimtdrXebLN4svQ=="
 		},
 		"eslint-plugin-react": {
-			"version": "7.21.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.2.tgz",
-			"integrity": "sha512-j3XKvrK3rpBzveKFbgAeGsWb9uz6iUOrR0jixRfjwdFeGSRsXvVTFtHDQYCjsd1/6Z/xvb8Vy3LiI5Reo7fDrg==",
+			"version": "7.21.5",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz",
+			"integrity": "sha512-8MaEggC2et0wSF6bUeywF7qQ46ER81irOdWS4QWxnnlAEsnzeBevk1sWh7fhpCghPpXb+8Ks7hvaft6L/xsR6g==",
 			"requires": {
 				"array-includes": "^3.1.1",
 				"array.prototype.flatmap": "^1.2.3",
 				"doctrine": "^2.1.0",
 				"has": "^1.0.3",
-				"jsx-ast-utils": "^2.4.1",
+				"jsx-ast-utils": "^2.4.1 || ^3.0.0",
 				"object.entries": "^1.1.2",
 				"object.fromentries": "^2.0.2",
 				"object.values": "^1.1.1",
 				"prop-types": "^15.7.2",
-				"resolve": "^1.17.0",
+				"resolve": "^1.18.1",
 				"string.prototype.matchall": "^4.0.2"
 			},
 			"dependencies": {
@@ -11519,10 +11066,11 @@
 					}
 				},
 				"resolve": {
-					"version": "1.17.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+					"version": "1.18.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
+					"integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
 					"requires": {
+						"is-core-module": "^2.0.0",
 						"path-parse": "^1.0.6"
 					}
 				}
@@ -11866,70 +11414,32 @@
 			}
 		},
 		"expand-tilde": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-			"integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
 			"requires": {
-				"os-homedir": "^1.0.1"
+				"homedir-polyfill": "^1.0.1"
 			}
 		},
 		"expect": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-26.4.2.tgz",
-			"integrity": "sha512-IlJ3X52Z0lDHm7gjEp+m76uX46ldH5VpqmU0006vqDju/285twh7zaWMRhs67VpQhBwjjMchk+p5aA0VkERCAA==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-26.6.1.tgz",
+			"integrity": "sha512-BRfxIBHagghMmr1D2MRY0Qv5d3Nc8HCqgbDwNXw/9izmM5eBb42a2YjLKSbsqle76ozGkAEPELQX4IdNHAKRNA==",
 			"requires": {
-				"@jest/types": "^26.3.0",
+				"@jest/types": "^26.6.1",
 				"ansi-styles": "^4.0.0",
 				"jest-get-type": "^26.3.0",
-				"jest-matcher-utils": "^26.4.2",
-				"jest-message-util": "^26.3.0",
+				"jest-matcher-utils": "^26.6.1",
+				"jest-message-util": "^26.6.1",
 				"jest-regex-util": "^26.0.0"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
 					}
 				},
 				"color-convert": {
@@ -11944,24 +11454,6 @@
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"jest-get-type": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
 				}
 			}
 		},
@@ -12281,14 +11773,6 @@
 				"escape-string-regexp": "^1.0.5"
 			}
 		},
-		"file-entry-cache": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-			"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
-			"requires": {
-				"flat-cache": "^2.0.1"
-			}
-		},
 		"file-loader": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-3.0.1.tgz",
@@ -12309,12 +11793,6 @@
 					}
 				}
 			}
-		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-			"optional": true
 		},
 		"filesize": {
 			"version": "3.6.1",
@@ -12460,32 +11938,57 @@
 			}
 		},
 		"find-process": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.3.tgz",
-			"integrity": "sha512-+IA+AUsQCf3uucawyTwMWcY+2M3FXq3BRvw3S+j5Jvydjk31f/+NPWpYZOJs+JUs2GvxH4Yfr6Wham0ZtRLlPA==",
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.4.tgz",
+			"integrity": "sha512-rRSuT1LE4b+BFK588D2V8/VG9liW0Ark1XJgroxZXI0LtwmQJOb490DvDYvbm+Hek9ETFzTutGfJ90gumITPhQ==",
 			"requires": {
-				"chalk": "^2.0.1",
-				"commander": "^2.11.0",
-				"debug": "^2.6.8"
+				"chalk": "^4.0.0",
+				"commander": "^5.1.0",
+				"debug": "^4.1.1"
 			},
 			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-				},
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"ms": "2.0.0"
+						"color-convert": "^2.0.1"
 					}
 				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
 				}
 			}
 		},
@@ -12513,14 +12016,6 @@
 				"resolve-dir": "^1.0.1"
 			},
 			"dependencies": {
-				"expand-tilde": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-					"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-					"requires": {
-						"homedir-polyfill": "^1.0.1"
-					}
-				},
 				"global-modules": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
@@ -12555,39 +12050,9 @@
 			}
 		},
 		"flat": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-			"integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
-			"requires": {
-				"is-buffer": "~2.0.3"
-			},
-			"dependencies": {
-				"is-buffer": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
-				}
-			}
-		},
-		"flat-cache": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-			"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
-			"requires": {
-				"flatted": "^2.0.0",
-				"rimraf": "2.6.3",
-				"write": "1.0.3"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
-			}
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
 		},
 		"flatted": {
 			"version": "2.0.2",
@@ -12867,14 +12332,10 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "1.2.13",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-			"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-			"optional": true,
-			"requires": {
-				"bindings": "^1.5.0",
-				"nan": "^2.12.1"
-			}
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+			"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+			"optional": true
 		},
 		"fstream": {
 			"version": "1.0.12",
@@ -13630,6 +13091,42 @@
 				"codemirror-graphql": "^0.8.3",
 				"copy-to-clipboard": "^3.2.0",
 				"markdown-it": "^8.4.0"
+			},
+			"dependencies": {
+				"codemirror-graphql": {
+					"version": "0.8.3",
+					"resolved": "https://registry.npmjs.org/codemirror-graphql/-/codemirror-graphql-0.8.3.tgz",
+					"integrity": "sha512-ZipSnPXFKDMThfvfTKTAt1dQmuGctVNann8hTZg6017+vwOcGpIqCuQIZLRDw/Y3zZfCyydRARHgbSydSCXpow==",
+					"requires": {
+						"graphql-language-service-interface": "^1.3.2",
+						"graphql-language-service-parser": "^1.2.2"
+					}
+				},
+				"graphql-language-service-interface": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/graphql-language-service-interface/-/graphql-language-service-interface-1.3.2.tgz",
+					"integrity": "sha512-sOxFV5sBSnYtKIFHtlmAHHVdhok7CRbvCPLcuHvL4Q1RSgKRsPpeHUDKU+yCbmlonOKn/RWEKaYWrUY0Sgv70A==",
+					"requires": {
+						"graphql-config": "2.0.1",
+						"graphql-language-service-parser": "^1.2.2",
+						"graphql-language-service-types": "^1.2.2",
+						"graphql-language-service-utils": "^1.2.2"
+					}
+				},
+				"graphql-language-service-parser": {
+					"version": "1.6.4",
+					"resolved": "https://registry.npmjs.org/graphql-language-service-parser/-/graphql-language-service-parser-1.6.4.tgz",
+					"integrity": "sha512-Y365zUFfJ1GJ9NeRHb5Z/HBo6EnbuTi187Gkuldwd1YIDc0QcD7kqz6U5g043zd7BI/UZQth13Zd7pElvbb2zw==",
+					"requires": {
+						"graphql-language-service-types": "^1.6.3",
+						"typescript": "^3.9.5"
+					}
+				},
+				"typescript": {
+					"version": "3.9.7",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+					"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
+				}
 			}
 		},
 		"graphql": {
@@ -13660,37 +13157,10 @@
 				"lodash": "^4.17.4"
 			}
 		},
-		"graphql-language-service-interface": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/graphql-language-service-interface/-/graphql-language-service-interface-1.3.2.tgz",
-			"integrity": "sha512-sOxFV5sBSnYtKIFHtlmAHHVdhok7CRbvCPLcuHvL4Q1RSgKRsPpeHUDKU+yCbmlonOKn/RWEKaYWrUY0Sgv70A==",
-			"requires": {
-				"graphql-config": "2.0.1",
-				"graphql-language-service-parser": "^1.2.2",
-				"graphql-language-service-types": "^1.2.2",
-				"graphql-language-service-utils": "^1.2.2"
-			}
-		},
-		"graphql-language-service-parser": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/graphql-language-service-parser/-/graphql-language-service-parser-1.6.3.tgz",
-			"integrity": "sha512-UjmVXcSN59pCkFDBIZav0rTdz7ISeYAgGshA/0OpFlrJ6ZkS3hlOBbu/QvLyjRvTcjKpx95qT299auL39kE+/g==",
-			"requires": {
-				"graphql-language-service-types": "^1.6.2",
-				"typescript": "^3.9.5"
-			},
-			"dependencies": {
-				"typescript": {
-					"version": "3.9.7",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-					"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
-				}
-			}
-		},
 		"graphql-language-service-types": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/graphql-language-service-types/-/graphql-language-service-types-1.6.2.tgz",
-			"integrity": "sha512-5cslPoUd8P7/EjJ5L3/zs0NBeDhvQHhjUMbjKQakwqu4tZXplriZ9KvvA+Q/n4w/Rn79+3cbr7maNtsTk6/TmQ=="
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/graphql-language-service-types/-/graphql-language-service-types-1.6.3.tgz",
+			"integrity": "sha512-VDtBhdan1iSe7ad7+eBbsO5rrzWQpC6aV4SxSHEi8AtEQOFXpnL9Lq5jSaN8O02pGvAUr4wNUPu0oRU5g2XmVA=="
 		},
 		"graphql-language-service-utils": {
 			"version": "1.2.2",
@@ -14026,11 +13496,11 @@
 			}
 		},
 		"html-encoding-sniffer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+			"integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
 			"requires": {
-				"whatwg-encoding": "^1.0.1"
+				"whatwg-encoding": "^1.0.5"
 			}
 		},
 		"html-entities": {
@@ -14053,26 +13523,56 @@
 				"html-minifier": "^3.5.8",
 				"loader-utils": "^1.1.0",
 				"object-assign": "^4.1.1"
-			}
-		},
-		"html-minifier": {
-			"version": "3.5.21",
-			"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
-			"integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
-			"requires": {
-				"camel-case": "3.0.x",
-				"clean-css": "4.2.x",
-				"commander": "2.17.x",
-				"he": "1.2.x",
-				"param-case": "2.1.x",
-				"relateurl": "0.2.x",
-				"uglify-js": "3.4.x"
 			},
 			"dependencies": {
 				"commander": {
 					"version": "2.17.1",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
 					"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+				},
+				"es6-templates": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz",
+					"integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
+					"requires": {
+						"recast": "~0.11.12",
+						"through": "~2.3.6"
+					}
+				},
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+				},
+				"html-minifier": {
+					"version": "3.5.21",
+					"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
+					"integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
+					"requires": {
+						"camel-case": "3.0.x",
+						"clean-css": "4.2.x",
+						"commander": "2.17.x",
+						"he": "1.2.x",
+						"param-case": "2.1.x",
+						"relateurl": "0.2.x",
+						"uglify-js": "3.4.x"
+					}
+				},
+				"recast": {
+					"version": "0.11.23",
+					"resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+					"integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
+					"requires": {
+						"ast-types": "0.9.6",
+						"esprima": "~3.1.0",
+						"private": "~0.1.5",
+						"source-map": "~0.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				},
 				"uglify-js": {
 					"version": "3.4.10",
@@ -14087,6 +13587,11 @@
 							"version": "2.19.0",
 							"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
 							"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+						},
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 						}
 					}
 				}
@@ -14132,9 +13637,9 @@
 			}
 		},
 		"html-webpack-plugin": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.4.1.tgz",
-			"integrity": "sha512-nEtdEIsIGXdXGG7MjTTZlmhqhpHU9pJFc1OYxcP36c5/ZKP6b0BJMww2QTvJGQYA9aMxUnjDujpZdYcVOXiBCQ==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.5.0.tgz",
+			"integrity": "sha512-MouoXEYSjTzCrjIxWwg8gxL5fE2X2WZJLmBYXlaJhQUH5K/b5OrqmV7T4dB7iu0xkmJ6JlUuV6fFVtnqbPopZw==",
 			"requires": {
 				"@types/html-minifier-terser": "^5.0.0",
 				"@types/tapable": "^1.0.5",
@@ -14649,6 +14154,14 @@
 				"ci-info": "^2.0.0"
 			}
 		},
+		"is-core-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.0.0.tgz",
+			"integrity": "sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==",
+			"requires": {
+				"has": "^1.0.3"
+			}
+		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -14757,11 +14270,6 @@
 				}
 			}
 		},
-		"is-map": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
-			"integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw=="
-		},
 		"is-nan": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.0.tgz",
@@ -14860,11 +14368,6 @@
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
 			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
 		},
-		"is-set": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
-			"integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA=="
-		},
 		"is-ssh": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
@@ -14928,9 +14431,12 @@
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
 		},
 		"is-wsl": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"requires": {
+				"is-docker": "^2.0.0"
+			}
 		},
 		"isarray": {
 			"version": "0.0.1",
@@ -15175,56 +14681,89 @@
 			"resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
 			"integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
 		},
-		"iterate-iterator": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.1.tgz",
-			"integrity": "sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw=="
-		},
-		"iterate-value": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
-			"integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
-			"requires": {
-				"es-get-iterator": "^1.0.2",
-				"iterate-iterator": "^1.0.1"
-			}
-		},
 		"jest": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-26.4.2.tgz",
-			"integrity": "sha512-LLCjPrUh98Ik8CzW8LLVnSCfLaiY+wbK53U7VxnFSX7Q+kWC4noVeDvGWIFw0Amfq1lq2VfGm7YHWSLBV62MJw==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-26.6.1.tgz",
+			"integrity": "sha512-f+ahfqw3Ffy+9vA7sWFGpTmhtKEMsNAZiWBVXDkrpIO73zIz22iimjirnV78kh/eWlylmvLh/0WxHN6fZraZdA==",
 			"requires": {
-				"@jest/core": "^26.4.2",
+				"@jest/core": "^26.6.1",
 				"import-local": "^3.0.2",
-				"jest-cli": "^26.4.2"
+				"jest-cli": "^26.6.1"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+				"@jest/core": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/core/-/core-26.6.1.tgz",
+					"integrity": "sha512-p4F0pgK3rKnoS9olXXXOkbus1Bsu6fd8pcvLMPsUy4CVXZ8WSeiwQ1lK5hwkCIqJ+amZOYPd778sbPha/S8Srw==",
 					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
+						"@jest/console": "^26.6.1",
+						"@jest/reporters": "^26.6.1",
+						"@jest/test-result": "^26.6.1",
+						"@jest/transform": "^26.6.1",
+						"@jest/types": "^26.6.1",
 						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
+						"ansi-escapes": "^4.2.1",
+						"chalk": "^4.0.0",
+						"exit": "^0.1.2",
+						"graceful-fs": "^4.2.4",
+						"jest-changed-files": "^26.6.1",
+						"jest-config": "^26.6.1",
+						"jest-haste-map": "^26.6.1",
+						"jest-message-util": "^26.6.1",
+						"jest-regex-util": "^26.0.0",
+						"jest-resolve": "^26.6.1",
+						"jest-resolve-dependencies": "^26.6.1",
+						"jest-runner": "^26.6.1",
+						"jest-runtime": "^26.6.1",
+						"jest-snapshot": "^26.6.1",
+						"jest-util": "^26.6.1",
+						"jest-validate": "^26.6.1",
+						"jest-watcher": "^26.6.1",
+						"micromatch": "^4.0.2",
+						"p-each-series": "^2.1.0",
+						"rimraf": "^3.0.0",
+						"slash": "^3.0.0",
+						"strip-ansi": "^6.0.0"
 					}
 				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+				"@jest/reporters": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.6.1.tgz",
+					"integrity": "sha512-J6OlXVFY3q1SXWJhjme5i7qT/BAZSikdOK2t8Ht5OS32BDo6KfG5CzIzzIFnAVd82/WWbc9Hb7SJ/jwSvVH9YA==",
 					"requires": {
-						"@types/istanbul-lib-report": "*"
+						"@bcoe/v8-coverage": "^0.2.3",
+						"@jest/console": "^26.6.1",
+						"@jest/test-result": "^26.6.1",
+						"@jest/transform": "^26.6.1",
+						"@jest/types": "^26.6.1",
+						"chalk": "^4.0.0",
+						"collect-v8-coverage": "^1.0.0",
+						"exit": "^0.1.2",
+						"glob": "^7.1.2",
+						"graceful-fs": "^4.2.4",
+						"istanbul-lib-coverage": "^3.0.0",
+						"istanbul-lib-instrument": "^4.0.3",
+						"istanbul-lib-report": "^3.0.0",
+						"istanbul-lib-source-maps": "^4.0.0",
+						"istanbul-reports": "^3.0.2",
+						"jest-haste-map": "^26.6.1",
+						"jest-resolve": "^26.6.1",
+						"jest-util": "^26.6.1",
+						"jest-worker": "^26.6.1",
+						"node-notifier": "^8.0.0",
+						"slash": "^3.0.0",
+						"source-map": "^0.6.0",
+						"string-length": "^4.0.1",
+						"terminal-link": "^2.0.0",
+						"v8-to-istanbul": "^6.0.1"
 					}
 				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+				"ansi-escapes": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
 					"requires": {
-						"@types/yargs-parser": "*"
+						"type-fest": "^0.11.0"
 					}
 				},
 				"ansi-regex": {
@@ -15233,18 +14772,520 @@
 					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
-				"camelcase": {
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"cliui": {
 					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w=="
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^6.2.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"cross-spawn": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+				},
+				"execa": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+					"integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+					"requires": {
+						"cross-spawn": "^7.0.0",
+						"get-stream": "^5.0.0",
+						"human-signals": "^1.1.1",
+						"is-stream": "^2.0.0",
+						"merge-stream": "^2.0.0",
+						"npm-run-path": "^4.0.0",
+						"onetime": "^5.1.0",
+						"signal-exit": "^3.0.2",
+						"strip-final-newline": "^2.0.0"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"import-local": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+					"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+					"requires": {
+						"pkg-dir": "^4.2.0",
+						"resolve-cwd": "^3.0.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+				},
+				"is-stream": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+				},
+				"istanbul-lib-instrument": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+					"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+					"requires": {
+						"@babel/core": "^7.7.5",
+						"@istanbuljs/schema": "^0.1.2",
+						"istanbul-lib-coverage": "^3.0.0",
+						"semver": "^6.3.0"
+					}
+				},
+				"jest-changed-files": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.1.tgz",
+					"integrity": "sha512-NhSdZ5F6b/rIN5V46x1l31vrmukD/bJUXgYAY8VtP1SknYdJwjYDRxuLt7Z8QryIdqCjMIn2C0Cd98EZ4umo8Q==",
+					"requires": {
+						"@jest/types": "^26.6.1",
+						"execa": "^4.0.0",
+						"throat": "^5.0.0"
+					}
+				},
+				"jest-cli": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.1.tgz",
+					"integrity": "sha512-aPLoEjlwFrCWhiPpW5NUxQA1X1kWsAnQcQ0SO/fHsCvczL3W75iVAcH9kP6NN+BNqZcHNEvkhxT5cDmBfEAh+w==",
+					"requires": {
+						"@jest/core": "^26.6.1",
+						"@jest/test-result": "^26.6.1",
+						"@jest/types": "^26.6.1",
+						"chalk": "^4.0.0",
+						"exit": "^0.1.2",
+						"graceful-fs": "^4.2.4",
+						"import-local": "^3.0.2",
+						"is-ci": "^2.0.0",
+						"jest-config": "^26.6.1",
+						"jest-util": "^26.6.1",
+						"jest-validate": "^26.6.1",
+						"prompts": "^2.0.1",
+						"yargs": "^15.4.1"
+					}
+				},
+				"jest-resolve-dependencies": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.1.tgz",
+					"integrity": "sha512-MN6lufbZJ3RBfTnJesZtHu3hUCBqPdHRe2+FhIt0yiqJ3fMgzWRqMRQyN/d/QwOE7KXwAG2ekZutbPhuD7s51A==",
+					"requires": {
+						"@jest/types": "^26.6.1",
+						"jest-regex-util": "^26.0.0",
+						"jest-snapshot": "^26.6.1"
+					}
+				},
+				"jest-runtime": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.1.tgz",
+					"integrity": "sha512-7uOCNeezXDWgjEyzYbRN2ViY7xNZzusNVGAMmU0UHRUNXuY4j4GBHKGMqPo/cBPZA9bSYp+lwK2DRRBU5Dv6YQ==",
+					"requires": {
+						"@jest/console": "^26.6.1",
+						"@jest/environment": "^26.6.1",
+						"@jest/fake-timers": "^26.6.1",
+						"@jest/globals": "^26.6.1",
+						"@jest/source-map": "^26.5.0",
+						"@jest/test-result": "^26.6.1",
+						"@jest/transform": "^26.6.1",
+						"@jest/types": "^26.6.1",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0",
+						"cjs-module-lexer": "^0.4.2",
+						"collect-v8-coverage": "^1.0.0",
+						"exit": "^0.1.2",
+						"glob": "^7.1.3",
+						"graceful-fs": "^4.2.4",
+						"jest-config": "^26.6.1",
+						"jest-haste-map": "^26.6.1",
+						"jest-message-util": "^26.6.1",
+						"jest-mock": "^26.6.1",
+						"jest-regex-util": "^26.0.0",
+						"jest-resolve": "^26.6.1",
+						"jest-snapshot": "^26.6.1",
+						"jest-util": "^26.6.1",
+						"jest-validate": "^26.6.1",
+						"slash": "^3.0.0",
+						"strip-bom": "^4.0.0",
+						"yargs": "^15.4.1"
+					}
+				},
+				"jest-snapshot": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.1.tgz",
+					"integrity": "sha512-JA7bZp7HRTIJYAi85pJ/OZ2eur2dqmwIToA5/6d7Mn90isGEfeF9FvuhDLLEczgKP1ihreBzrJ6Vr7zteP5JNA==",
+					"requires": {
+						"@babel/types": "^7.0.0",
+						"@jest/types": "^26.6.1",
+						"@types/babel__traverse": "^7.0.4",
+						"@types/prettier": "^2.0.0",
+						"chalk": "^4.0.0",
+						"expect": "^26.6.1",
+						"graceful-fs": "^4.2.4",
+						"jest-diff": "^26.6.1",
+						"jest-get-type": "^26.3.0",
+						"jest-haste-map": "^26.6.1",
+						"jest-matcher-utils": "^26.6.1",
+						"jest-message-util": "^26.6.1",
+						"jest-resolve": "^26.6.1",
+						"natural-compare": "^1.4.0",
+						"pretty-format": "^26.6.1",
+						"semver": "^7.3.2"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "7.3.2",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+							"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+						}
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"node-notifier": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.0.tgz",
+					"integrity": "sha512-46z7DUmcjoYdaWyXouuFNNfUo6eFa94t23c53c+lG/9Cvauk4a98rAUp9672X5dxGdQmLpPzTxzu8f/OeEPaFA==",
+					"optional": true,
+					"requires": {
+						"growly": "^1.3.0",
+						"is-wsl": "^2.2.0",
+						"semver": "^7.3.2",
+						"shellwords": "^0.1.1",
+						"uuid": "^8.3.0",
+						"which": "^2.0.2"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "7.3.2",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+							"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+							"optional": true
+						}
+					}
+				},
+				"npm-run-path": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+					"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+					"requires": {
+						"path-key": "^3.0.0"
+					}
+				},
+				"onetime": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+					"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+					"requires": {
+						"mimic-fn": "^2.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+				},
+				"pkg-dir": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+					"requires": {
+						"find-up": "^4.0.0"
+					}
+				},
+				"resolve-cwd": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+					"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+					"requires": {
+						"resolve-from": "^5.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				},
+				"type-fest": {
+					"version": "0.11.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+					"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
+				},
+				"uuid": {
+					"version": "8.3.1",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+					"integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
+					"optional": true
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"yargs": {
+					"version": "15.4.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+					"requires": {
+						"cliui": "^6.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^4.1.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^4.2.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^18.1.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
+		},
+		"jest-config": {
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.6.1.tgz",
+			"integrity": "sha512-mtJzIynIwW1d1nMlKCNCQiSgWaqFn8cH/fOSNY97xG7Y9tBCZbCSuW2GTX0RPmceSJGO7l27JgwC18LEg0Vg+g==",
+			"requires": {
+				"@babel/core": "^7.1.0",
+				"@jest/test-sequencer": "^26.6.1",
+				"@jest/types": "^26.6.1",
+				"babel-jest": "^26.6.1",
+				"chalk": "^4.0.0",
+				"deepmerge": "^4.2.2",
+				"glob": "^7.1.1",
+				"graceful-fs": "^4.2.4",
+				"jest-environment-jsdom": "^26.6.1",
+				"jest-environment-node": "^26.6.1",
+				"jest-get-type": "^26.3.0",
+				"jest-jasmine2": "^26.6.1",
+				"jest-regex-util": "^26.0.0",
+				"jest-resolve": "^26.6.1",
+				"jest-util": "^26.6.1",
+				"jest-validate": "^26.6.1",
+				"micromatch": "^4.0.2",
+				"pretty-format": "^26.6.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
 				},
 				"chalk": {
 					"version": "4.1.0",
@@ -15283,6 +15324,14 @@
 					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
 				"find-up": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -15297,56 +15346,96 @@
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
-				"import-local": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
-					"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
-					"requires": {
-						"pkg-dir": "^4.2.0",
-						"resolve-cwd": "^3.0.0"
-					}
-				},
 				"is-fullwidth-code-point": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
 				},
-				"jest-cli": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.4.2.tgz",
-					"integrity": "sha512-zb+lGd/SfrPvoRSC/0LWdaWCnscXc1mGYW//NP4/tmBvRPT3VntZ2jtKUONsRi59zc5JqmsSajA9ewJKFYp8Cw==",
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+				},
+				"jest-jasmine2": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.6.1.tgz",
+					"integrity": "sha512-2uYdT32o/ZzSxYAPduAgokO8OlAL1YdG/9oxcEY138EDNpIK5XRRJDaGzTZdIBWSxk0aR8XxN44FvfXtHB+Fiw==",
 					"requires": {
-						"@jest/core": "^26.4.2",
-						"@jest/test-result": "^26.3.0",
-						"@jest/types": "^26.3.0",
+						"@babel/traverse": "^7.1.0",
+						"@jest/environment": "^26.6.1",
+						"@jest/source-map": "^26.5.0",
+						"@jest/test-result": "^26.6.1",
+						"@jest/types": "^26.6.1",
+						"@types/node": "*",
 						"chalk": "^4.0.0",
-						"exit": "^0.1.2",
-						"graceful-fs": "^4.2.4",
-						"import-local": "^3.0.2",
-						"is-ci": "^2.0.0",
-						"jest-config": "^26.4.2",
-						"jest-util": "^26.3.0",
-						"jest-validate": "^26.4.2",
-						"prompts": "^2.0.1",
-						"yargs": "^15.3.1"
+						"co": "^4.6.0",
+						"expect": "^26.6.1",
+						"is-generator-fn": "^2.0.0",
+						"jest-each": "^26.6.1",
+						"jest-matcher-utils": "^26.6.1",
+						"jest-message-util": "^26.6.1",
+						"jest-runtime": "^26.6.1",
+						"jest-snapshot": "^26.6.1",
+						"jest-util": "^26.6.1",
+						"pretty-format": "^26.6.1",
+						"throat": "^5.0.0"
 					}
 				},
-				"jest-get-type": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
-				},
-				"jest-validate": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.4.2.tgz",
-					"integrity": "sha512-blft+xDX7XXghfhY0mrsBCYhX365n8K5wNDC4XAcNKqqjEzsRUSXP44m6PL0QJEW2crxQFLLztVnJ4j7oPlQrQ==",
+				"jest-runtime": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.1.tgz",
+					"integrity": "sha512-7uOCNeezXDWgjEyzYbRN2ViY7xNZzusNVGAMmU0UHRUNXuY4j4GBHKGMqPo/cBPZA9bSYp+lwK2DRRBU5Dv6YQ==",
 					"requires": {
-						"@jest/types": "^26.3.0",
-						"camelcase": "^6.0.0",
+						"@jest/console": "^26.6.1",
+						"@jest/environment": "^26.6.1",
+						"@jest/fake-timers": "^26.6.1",
+						"@jest/globals": "^26.6.1",
+						"@jest/source-map": "^26.5.0",
+						"@jest/test-result": "^26.6.1",
+						"@jest/transform": "^26.6.1",
+						"@jest/types": "^26.6.1",
+						"@types/yargs": "^15.0.0",
 						"chalk": "^4.0.0",
+						"cjs-module-lexer": "^0.4.2",
+						"collect-v8-coverage": "^1.0.0",
+						"exit": "^0.1.2",
+						"glob": "^7.1.3",
+						"graceful-fs": "^4.2.4",
+						"jest-config": "^26.6.1",
+						"jest-haste-map": "^26.6.1",
+						"jest-message-util": "^26.6.1",
+						"jest-mock": "^26.6.1",
+						"jest-regex-util": "^26.0.0",
+						"jest-resolve": "^26.6.1",
+						"jest-snapshot": "^26.6.1",
+						"jest-util": "^26.6.1",
+						"jest-validate": "^26.6.1",
+						"slash": "^3.0.0",
+						"strip-bom": "^4.0.0",
+						"yargs": "^15.4.1"
+					}
+				},
+				"jest-snapshot": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.1.tgz",
+					"integrity": "sha512-JA7bZp7HRTIJYAi85pJ/OZ2eur2dqmwIToA5/6d7Mn90isGEfeF9FvuhDLLEczgKP1ihreBzrJ6Vr7zteP5JNA==",
+					"requires": {
+						"@babel/types": "^7.0.0",
+						"@jest/types": "^26.6.1",
+						"@types/babel__traverse": "^7.0.4",
+						"@types/prettier": "^2.0.0",
+						"chalk": "^4.0.0",
+						"expect": "^26.6.1",
+						"graceful-fs": "^4.2.4",
+						"jest-diff": "^26.6.1",
 						"jest-get-type": "^26.3.0",
-						"leven": "^3.1.0",
-						"pretty-format": "^26.4.2"
+						"jest-haste-map": "^26.6.1",
+						"jest-matcher-utils": "^26.6.1",
+						"jest-message-util": "^26.6.1",
+						"jest-resolve": "^26.6.1",
+						"natural-compare": "^1.4.0",
+						"pretty-format": "^26.6.1",
+						"semver": "^7.3.2"
 					}
 				},
 				"locate-path": {
@@ -15355,6 +15444,15 @@
 					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 					"requires": {
 						"p-locate": "^4.1.0"
+					}
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
 					}
 				},
 				"p-locate": {
@@ -15370,37 +15468,15 @@
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
 				},
-				"pkg-dir": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-					"requires": {
-						"find-up": "^4.0.0"
-					}
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
 				},
-				"pretty-format": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
-					"requires": {
-						"@jest/types": "^26.3.0",
-						"ansi-regex": "^5.0.0",
-						"ansi-styles": "^4.0.0",
-						"react-is": "^16.12.0"
-					}
-				},
-				"resolve-cwd": {
+				"slash": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
-					"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-					"requires": {
-						"resolve-from": "^5.0.0"
-					}
-				},
-				"resolve-from": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
 				},
 				"string-width": {
 					"version": "4.2.0",
@@ -15420,12 +15496,35 @@
 						"ansi-regex": "^5.0.0"
 					}
 				},
+				"strip-bom": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
+				},
 				"supports-color": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"requires": {
 						"has-flag": "^4.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
 					}
 				},
 				"yargs": {
@@ -15453,354 +15552,6 @@
 					"requires": {
 						"camelcase": "^5.0.0",
 						"decamelize": "^1.2.0"
-					},
-					"dependencies": {
-						"camelcase": {
-							"version": "5.3.1",
-							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-							"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-						}
-					}
-				}
-			}
-		},
-		"jest-changed-files": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.3.0.tgz",
-			"integrity": "sha512-1C4R4nijgPltX6fugKxM4oQ18zimS7LqQ+zTTY8lMCMFPrxqBFb7KJH0Z2fRQJvw2Slbaipsqq7s1mgX5Iot+g==",
-			"requires": {
-				"@jest/types": "^26.3.0",
-				"execa": "^4.0.0",
-				"throat": "^5.0.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"cross-spawn": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-					"requires": {
-						"path-key": "^3.1.0",
-						"shebang-command": "^2.0.0",
-						"which": "^2.0.1"
-					}
-				},
-				"execa": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
-					"integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
-					"requires": {
-						"cross-spawn": "^7.0.0",
-						"get-stream": "^5.0.0",
-						"human-signals": "^1.1.1",
-						"is-stream": "^2.0.0",
-						"merge-stream": "^2.0.0",
-						"npm-run-path": "^4.0.0",
-						"onetime": "^5.1.0",
-						"signal-exit": "^3.0.2",
-						"strip-final-newline": "^2.0.0"
-					}
-				},
-				"get-stream": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"is-stream": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
-				},
-				"npm-run-path": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-					"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-					"requires": {
-						"path-key": "^3.0.0"
-					}
-				},
-				"onetime": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-					"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-					"requires": {
-						"mimic-fn": "^2.1.0"
-					}
-				},
-				"path-key": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
-				},
-				"shebang-command": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-					"requires": {
-						"shebang-regex": "^3.0.0"
-					}
-				},
-				"shebang-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				}
-			}
-		},
-		"jest-config": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.4.2.tgz",
-			"integrity": "sha512-QBf7YGLuToiM8PmTnJEdRxyYy3mHWLh24LJZKVdXZ2PNdizSe1B/E8bVm+HYcjbEzGuVXDv/di+EzdO/6Gq80A==",
-			"requires": {
-				"@babel/core": "^7.1.0",
-				"@jest/test-sequencer": "^26.4.2",
-				"@jest/types": "^26.3.0",
-				"babel-jest": "^26.3.0",
-				"chalk": "^4.0.0",
-				"deepmerge": "^4.2.2",
-				"glob": "^7.1.1",
-				"graceful-fs": "^4.2.4",
-				"jest-environment-jsdom": "^26.3.0",
-				"jest-environment-node": "^26.3.0",
-				"jest-get-type": "^26.3.0",
-				"jest-jasmine2": "^26.4.2",
-				"jest-regex-util": "^26.0.0",
-				"jest-resolve": "^26.4.0",
-				"jest-util": "^26.3.0",
-				"jest-validate": "^26.4.2",
-				"micromatch": "^4.0.2",
-				"pretty-format": "^26.4.2"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"requires": {
-						"fill-range": "^7.0.1"
-					}
-				},
-				"camelcase": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w=="
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-				},
-				"jest-get-type": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
-				},
-				"jest-validate": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.4.2.tgz",
-					"integrity": "sha512-blft+xDX7XXghfhY0mrsBCYhX365n8K5wNDC4XAcNKqqjEzsRUSXP44m6PL0QJEW2crxQFLLztVnJ4j7oPlQrQ==",
-					"requires": {
-						"@jest/types": "^26.3.0",
-						"camelcase": "^6.0.0",
-						"chalk": "^4.0.0",
-						"jest-get-type": "^26.3.0",
-						"leven": "^3.1.0",
-						"pretty-format": "^26.4.2"
-					}
-				},
-				"micromatch": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-					"requires": {
-						"braces": "^3.0.1",
-						"picomatch": "^2.0.5"
-					}
-				},
-				"pretty-format": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
-					"requires": {
-						"@jest/types": "^26.3.0",
-						"ansi-regex": "^5.0.0",
-						"ansi-styles": "^4.0.0",
-						"react-is": "^16.12.0"
-					}
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"requires": {
-						"is-number": "^7.0.0"
 					}
 				}
 			}
@@ -15820,11 +15571,10 @@
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -15866,55 +15616,21 @@
 			}
 		},
 		"jest-diff": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
-			"integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.1.tgz",
+			"integrity": "sha512-BBNy/zin2m4kG5In126O8chOBxLLS/XMTuuM2+YhgyHk87ewPzKTuTJcqj3lOWOi03NNgrl+DkMeV/exdvG9gg==",
 			"requires": {
 				"chalk": "^4.0.0",
-				"diff-sequences": "^26.3.0",
+				"diff-sequences": "^26.5.0",
 				"jest-get-type": "^26.3.0",
-				"pretty-format": "^26.4.2"
+				"pretty-format": "^26.6.1"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -15944,22 +15660,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"jest-get-type": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
-				},
-				"pretty-format": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
-					"requires": {
-						"@jest/types": "^26.3.0",
-						"ansi-regex": "^5.0.0",
-						"ansi-styles": "^4.0.0",
-						"react-is": "^16.12.0"
-					}
 				},
 				"supports-color": {
 					"version": "7.2.0",
@@ -15980,56 +15680,22 @@
 			}
 		},
 		"jest-each": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.4.2.tgz",
-			"integrity": "sha512-p15rt8r8cUcRY0Mvo1fpkOGYm7iI8S6ySxgIdfh3oOIv+gHwrHTy5VWCGOecWUhDsit4Nz8avJWdT07WLpbwDA==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.6.1.tgz",
+			"integrity": "sha512-gSn8eB3buchuq45SU7pLB7qmCGax1ZSxfaWuEFblCyNMtyokYaKFh9dRhYPujK6xYL57dLIPhLKatjmB5XWzGA==",
 			"requires": {
-				"@jest/types": "^26.3.0",
+				"@jest/types": "^26.6.1",
 				"chalk": "^4.0.0",
 				"jest-get-type": "^26.3.0",
-				"jest-util": "^26.3.0",
-				"pretty-format": "^26.4.2"
+				"jest-util": "^26.6.1",
+				"pretty-format": "^26.6.1"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -16059,22 +15725,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"jest-get-type": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
-				},
-				"pretty-format": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
-					"requires": {
-						"@jest/types": "^26.3.0",
-						"ansi-regex": "^5.0.0",
-						"ansi-styles": "^4.0.0",
-						"react-is": "^16.12.0"
-					}
 				},
 				"supports-color": {
 					"version": "7.2.0",
@@ -16087,47 +15737,19 @@
 			}
 		},
 		"jest-environment-jsdom": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.3.0.tgz",
-			"integrity": "sha512-zra8He2btIMJkAzvLaiZ9QwEPGEetbxqmjEBQwhH3CA+Hhhu0jSiEJxnJMbX28TGUvPLxBt/zyaTLrOPF4yMJA==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.6.1.tgz",
+			"integrity": "sha512-A17RiXuHYNVlkM+3QNcQ6n5EZyAc6eld8ra9TW26luounGWpku4tj03uqRgHJCI1d4uHr5rJiuCH5JFRtdmrcA==",
 			"requires": {
-				"@jest/environment": "^26.3.0",
-				"@jest/fake-timers": "^26.3.0",
-				"@jest/types": "^26.3.0",
+				"@jest/environment": "^26.6.1",
+				"@jest/fake-timers": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
-				"jest-mock": "^26.3.0",
-				"jest-util": "^26.3.0",
-				"jsdom": "^16.2.2"
+				"jest-mock": "^26.6.1",
+				"jest-util": "^26.6.1",
+				"jsdom": "^16.4.0"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
 				"acorn-globals": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
@@ -16135,100 +15757,6 @@
 					"requires": {
 						"acorn": "^7.1.1",
 						"acorn-walk": "^7.1.1"
-					}
-				},
-				"acorn-walk": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-					"integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"cssom": {
-					"version": "0.4.4",
-					"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
-					"integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw=="
-				},
-				"cssstyle": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-					"integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
-					"requires": {
-						"cssom": "~0.3.6"
-					},
-					"dependencies": {
-						"cssom": {
-							"version": "0.3.8",
-							"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-							"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
-						}
-					}
-				},
-				"data-urls": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
-					"integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
-					"requires": {
-						"abab": "^2.0.3",
-						"whatwg-mimetype": "^2.3.0",
-						"whatwg-url": "^8.0.0"
-					}
-				},
-				"domexception": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
-					"integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
-					"requires": {
-						"webidl-conversions": "^5.0.0"
-					},
-					"dependencies": {
-						"webidl-conversions": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-							"integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
-						}
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"html-encoding-sniffer": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
-					"integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
-					"requires": {
-						"whatwg-encoding": "^1.0.5"
 					}
 				},
 				"jsdom": {
@@ -16269,22 +15797,6 @@
 					"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
 					"integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
 				},
-				"saxes": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
-					"integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
-					"requires": {
-						"xmlchars": "^2.2.0"
-					}
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
 				"tough-cookie": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
@@ -16309,9 +15821,9 @@
 					"integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
 				},
 				"whatwg-url": {
-					"version": "8.2.2",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.2.2.tgz",
-					"integrity": "sha512-PcVnO6NiewhkmzV0qn7A+UZ9Xx4maNTI+O+TShmfE4pqjoCMwUMjkvoNhNHPTvgR7QH9Xt3R13iHuWy2sToFxQ==",
+					"version": "8.4.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.4.0.tgz",
+					"integrity": "sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==",
 					"requires": {
 						"lodash.sortby": "^4.7.0",
 						"tr46": "^2.0.2",
@@ -16326,90 +15838,16 @@
 			}
 		},
 		"jest-environment-node": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.3.0.tgz",
-			"integrity": "sha512-c9BvYoo+FGcMj5FunbBgtBnbR5qk3uky8PKyRVpSfe2/8+LrNQMiXX53z6q2kY+j15SkjQCOSL/6LHnCPLVHNw==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.1.tgz",
+			"integrity": "sha512-YffaCp6h0j1kbcf1NVZ7umC6CPgD67YS+G1BeornfuSkx5s3xdhuwG0DCxSiHPXyT81FfJzA1L7nXvhq50OWIg==",
 			"requires": {
-				"@jest/environment": "^26.3.0",
-				"@jest/fake-timers": "^26.3.0",
-				"@jest/types": "^26.3.0",
+				"@jest/environment": "^26.6.1",
+				"@jest/fake-timers": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
-				"jest-mock": "^26.3.0",
-				"jest-util": "^26.3.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
+				"jest-mock": "^26.6.1",
+				"jest-util": "^26.6.1"
 			}
 		},
 		"jest-environment-puppeteer": {
@@ -16424,11 +15862,10 @@
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -16470,16 +15907,16 @@
 			}
 		},
 		"jest-get-type": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
-			"integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q=="
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+			"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
 		},
 		"jest-haste-map": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.3.0.tgz",
-			"integrity": "sha512-DHWBpTJgJhLLGwE5Z1ZaqLTYqeODQIZpby0zMBsCU9iRFHYyhklYqP4EiG73j5dkbaAdSZhgB938mL51Q5LeZA==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.1.tgz",
+			"integrity": "sha512-9kPafkv0nX6ta1PrshnkiyhhoQoFWncrU/uUBt3/AP1r78WSCU5iLceYRTwDvJl67H3RrXqSlSVDDa/AsUB7OQ==",
 			"requires": {
-				"@jest/types": "^26.3.0",
+				"@jest/types": "^26.6.1",
 				"@types/graceful-fs": "^4.1.2",
 				"@types/node": "*",
 				"anymatch": "^3.0.3",
@@ -16487,60 +15924,14 @@
 				"fsevents": "^2.1.2",
 				"graceful-fs": "^4.2.4",
 				"jest-regex-util": "^26.0.0",
-				"jest-serializer": "^26.3.0",
-				"jest-util": "^26.3.0",
-				"jest-worker": "^26.3.0",
+				"jest-serializer": "^26.5.0",
+				"jest-util": "^26.6.1",
+				"jest-worker": "^26.6.1",
 				"micromatch": "^4.0.2",
 				"sane": "^4.0.3",
 				"walker": "^1.0.7"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"anymatch": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-					"requires": {
-						"normalize-path": "^3.0.0",
-						"picomatch": "^2.0.4"
-					}
-				},
 				"braces": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
@@ -16549,28 +15940,6 @@
 						"fill-range": "^7.0.1"
 					}
 				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
 				"fill-range": {
 					"version": "7.0.1",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -16578,17 +15947,6 @@
 					"requires": {
 						"to-regex-range": "^5.0.1"
 					}
-				},
-				"fsevents": {
-					"version": "2.1.3",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-					"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-					"optional": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
 				"is-number": {
 					"version": "7.0.0",
@@ -16604,140 +15962,12 @@
 						"picomatch": "^2.0.5"
 					}
 				},
-				"normalize-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
 				"to-regex-range": {
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 					"requires": {
 						"is-number": "^7.0.0"
-					}
-				}
-			}
-		},
-		"jest-jasmine2": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.4.2.tgz",
-			"integrity": "sha512-z7H4EpCldHN1J8fNgsja58QftxBSL+JcwZmaXIvV9WKIM+x49F4GLHu/+BQh2kzRKHAgaN/E82od+8rTOBPyPA==",
-			"requires": {
-				"@babel/traverse": "^7.1.0",
-				"@jest/environment": "^26.3.0",
-				"@jest/source-map": "^26.3.0",
-				"@jest/test-result": "^26.3.0",
-				"@jest/types": "^26.3.0",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"co": "^4.6.0",
-				"expect": "^26.4.2",
-				"is-generator-fn": "^2.0.0",
-				"jest-each": "^26.4.2",
-				"jest-matcher-utils": "^26.4.2",
-				"jest-message-util": "^26.3.0",
-				"jest-runtime": "^26.4.2",
-				"jest-snapshot": "^26.4.2",
-				"jest-util": "^26.3.0",
-				"pretty-format": "^26.4.2",
-				"throat": "^5.0.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"pretty-format": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
-					"requires": {
-						"@jest/types": "^26.3.0",
-						"ansi-regex": "^5.0.0",
-						"ansi-styles": "^4.0.0",
-						"react-is": "^16.12.0"
-					}
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
 					}
 				}
 			}
@@ -16754,10 +15984,66 @@
 				"xml": "^1.0.1"
 			},
 			"dependencies": {
+				"@jest/types": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+					"integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^1.1.1",
+						"@types/yargs": "^13.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+					"integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+					"requires": {
+						"@types/istanbul-lib-coverage": "*",
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "13.0.11",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
+					"integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
 				"ansi-regex": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
 					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+				},
+				"jest-get-type": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+					"integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q=="
+				},
+				"jest-validate": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
+					"integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
+					"requires": {
+						"@jest/types": "^24.9.0",
+						"camelcase": "^5.3.1",
+						"chalk": "^2.0.1",
+						"jest-get-type": "^24.9.0",
+						"leven": "^3.1.0",
+						"pretty-format": "^24.9.0"
+					}
+				},
+				"pretty-format": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+					"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+					"requires": {
+						"@jest/types": "^24.9.0",
+						"ansi-regex": "^4.0.0",
+						"ansi-styles": "^3.2.0",
+						"react-is": "^16.8.4"
+					}
 				},
 				"strip-ansi": {
 					"version": "5.2.0",
@@ -16770,159 +16056,30 @@
 			}
 		},
 		"jest-leak-detector": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.4.2.tgz",
-			"integrity": "sha512-akzGcxwxtE+9ZJZRW+M2o+nTNnmQZxrHJxX/HjgDaU5+PLmY1qnQPnMjgADPGCRPhB+Yawe1iij0REe+k/aHoA==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.1.tgz",
+			"integrity": "sha512-j9ZOtJSJKlHjrs4aIxWjiQUjyrffPdiAQn2Iw0916w7qZE5Lk0T2KhIH6E9vfhzP6sw0Q0jtnLLb4vQ71o1HlA==",
 			"requires": {
 				"jest-get-type": "^26.3.0",
-				"pretty-format": "^26.4.2"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"jest-get-type": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
-				},
-				"pretty-format": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
-					"requires": {
-						"@jest/types": "^26.3.0",
-						"ansi-regex": "^5.0.0",
-						"ansi-styles": "^4.0.0",
-						"react-is": "^16.12.0"
-					}
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
+				"pretty-format": "^26.6.1"
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
-			"integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.1.tgz",
+			"integrity": "sha512-9iu3zrsYlUnl8pByhREF9rr5eYoiEb1F7ymNKg6lJr/0qD37LWS5FSW/JcoDl8UdMX2+zAzabDs7sTO+QFKjCg==",
 			"requires": {
 				"chalk": "^4.0.0",
-				"jest-diff": "^26.4.2",
+				"jest-diff": "^26.6.1",
 				"jest-get-type": "^26.3.0",
-				"pretty-format": "^26.4.2"
+				"pretty-format": "^26.6.1"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -16952,22 +16109,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"jest-get-type": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
-				},
-				"pretty-format": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
-					"requires": {
-						"@jest/types": "^26.3.0",
-						"ansi-regex": "^5.0.0",
-						"ansi-styles": "^4.0.0",
-						"react-is": "^16.12.0"
-					}
 				},
 				"supports-color": {
 					"version": "7.2.0",
@@ -16980,13 +16121,13 @@
 			}
 		},
 		"jest-message-util": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.3.0.tgz",
-			"integrity": "sha512-xIavRYqr4/otGOiLxLZGj3ieMmjcNE73Ui+LdSW/Y790j5acqCsAdDiLIbzHCZMpN07JOENRWX5DcU+OQ+TjTA==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.1.tgz",
+			"integrity": "sha512-cqM4HnqncIebBNdTKrBoWR/4ufHTll0pK/FWwX0YasK+TlBQEMqw3IEdynuuOTjDPFO3ONlFn37280X48beByw==",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@jest/types": "^26.3.0",
-				"@types/stack-utils": "^1.0.1",
+				"@jest/types": "^26.6.1",
+				"@types/stack-utils": "^2.0.0",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
 				"micromatch": "^4.0.2",
@@ -16994,40 +16135,11 @@
 				"stack-utils": "^2.0.2"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -17112,86 +16224,12 @@
 			}
 		},
 		"jest-mock": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.3.0.tgz",
-			"integrity": "sha512-PeaRrg8Dc6mnS35gOo/CbZovoDPKAeB1FICZiuagAgGvbWdNNyjQjkOaGUa/3N3JtpQ/Mh9P4A2D4Fv51NnP8Q==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.1.tgz",
+			"integrity": "sha512-my0lPTBu1awY8iVG62sB2sx9qf8zxNDVX+5aFgoB8Vbqjb6LqIOsfyFA8P1z6H2IsqMbvOX9oCJnK67Y3yUIMA==",
 			"requires": {
-				"@jest/types": "^26.3.0",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"jest-pnp-resolver": {
@@ -17214,54 +16252,25 @@
 			"integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A=="
 		},
 		"jest-resolve": {
-			"version": "26.4.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.4.0.tgz",
-			"integrity": "sha512-bn/JoZTEXRSlEx3+SfgZcJAVuTMOksYq9xe9O6s4Ekg84aKBObEaVXKOEilULRqviSLAYJldnoWV9c07kwtiCg==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.1.tgz",
+			"integrity": "sha512-hiHfQH6rrcpAmw9xCQ0vD66SDuU+7ZulOuKwc4jpbmFFsz0bQG/Ib92K+9/489u5rVw0btr/ZhiHqBpmkbCvuQ==",
 			"requires": {
-				"@jest/types": "^26.3.0",
+				"@jest/types": "^26.6.1",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
 				"jest-pnp-resolver": "^1.2.2",
-				"jest-util": "^26.3.0",
+				"jest-util": "^26.6.1",
 				"read-pkg-up": "^7.0.1",
-				"resolve": "^1.17.0",
+				"resolve": "^1.18.1",
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -17362,10 +16371,11 @@
 					}
 				},
 				"resolve": {
-					"version": "1.17.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+					"version": "1.18.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
+					"integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
 					"requires": {
+						"is-core-module": "^2.0.0",
 						"path-parse": "^1.0.6"
 					}
 				},
@@ -17389,270 +16399,45 @@
 				}
 			}
 		},
-		"jest-resolve-dependencies": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.4.2.tgz",
-			"integrity": "sha512-ADHaOwqEcVc71uTfySzSowA/RdxUpCxhxa2FNLiin9vWLB1uLPad3we+JSSROq5+SrL9iYPdZZF8bdKM7XABTQ==",
-			"requires": {
-				"@jest/types": "^26.3.0",
-				"jest-regex-util": "^26.0.0",
-				"jest-snapshot": "^26.4.2"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
 		"jest-runner": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.4.2.tgz",
-			"integrity": "sha512-FgjDHeVknDjw1gRAYaoUoShe1K3XUuFMkIaXbdhEys+1O4bEJS8Avmn4lBwoMfL8O5oFTdWYKcf3tEJyyYyk8g==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.1.tgz",
+			"integrity": "sha512-DmpNGdgsbl5s0FGkmsInmqnmqCtliCSnjWA2TFAJS1m1mL5atwfPsf+uoZ8uYQ2X0uDj4NM+nPcDnUpbNTRMBA==",
 			"requires": {
-				"@jest/console": "^26.3.0",
-				"@jest/environment": "^26.3.0",
-				"@jest/test-result": "^26.3.0",
-				"@jest/types": "^26.3.0",
+				"@jest/console": "^26.6.1",
+				"@jest/environment": "^26.6.1",
+				"@jest/test-result": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"emittery": "^0.7.1",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.2.4",
-				"jest-config": "^26.4.2",
+				"jest-config": "^26.6.1",
 				"jest-docblock": "^26.0.0",
-				"jest-haste-map": "^26.3.0",
-				"jest-leak-detector": "^26.4.2",
-				"jest-message-util": "^26.3.0",
-				"jest-resolve": "^26.4.0",
-				"jest-runtime": "^26.4.2",
-				"jest-util": "^26.3.0",
-				"jest-worker": "^26.3.0",
+				"jest-haste-map": "^26.6.1",
+				"jest-leak-detector": "^26.6.1",
+				"jest-message-util": "^26.6.1",
+				"jest-resolve": "^26.6.1",
+				"jest-runtime": "^26.6.1",
+				"jest-util": "^26.6.1",
+				"jest-worker": "^26.6.1",
 				"source-map-support": "^0.5.6",
 				"throat": "^5.0.0"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"jest-runtime": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.4.2.tgz",
-			"integrity": "sha512-4Pe7Uk5a80FnbHwSOk7ojNCJvz3Ks2CNQWT5Z7MJo4tX0jb3V/LThKvD9tKPNVNyeMH98J/nzGlcwc00R2dSHQ==",
-			"requires": {
-				"@jest/console": "^26.3.0",
-				"@jest/environment": "^26.3.0",
-				"@jest/fake-timers": "^26.3.0",
-				"@jest/globals": "^26.4.2",
-				"@jest/source-map": "^26.3.0",
-				"@jest/test-result": "^26.3.0",
-				"@jest/transform": "^26.3.0",
-				"@jest/types": "^26.3.0",
-				"@types/yargs": "^15.0.0",
-				"chalk": "^4.0.0",
-				"collect-v8-coverage": "^1.0.0",
-				"exit": "^0.1.2",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.4",
-				"jest-config": "^26.4.2",
-				"jest-haste-map": "^26.3.0",
-				"jest-message-util": "^26.3.0",
-				"jest-mock": "^26.3.0",
-				"jest-regex-util": "^26.0.0",
-				"jest-resolve": "^26.4.0",
-				"jest-snapshot": "^26.4.2",
-				"jest-util": "^26.3.0",
-				"jest-validate": "^26.4.2",
-				"slash": "^3.0.0",
-				"strip-bom": "^4.0.0",
-				"yargs": "^15.3.1"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
 				"ansi-regex": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
 					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
-				},
-				"camelcase": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w=="
 				},
 				"chalk": {
 					"version": "4.1.0",
@@ -17710,22 +16495,61 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
 				},
-				"jest-get-type": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
-				},
-				"jest-validate": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.4.2.tgz",
-					"integrity": "sha512-blft+xDX7XXghfhY0mrsBCYhX365n8K5wNDC4XAcNKqqjEzsRUSXP44m6PL0QJEW2crxQFLLztVnJ4j7oPlQrQ==",
+				"jest-runtime": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.1.tgz",
+					"integrity": "sha512-7uOCNeezXDWgjEyzYbRN2ViY7xNZzusNVGAMmU0UHRUNXuY4j4GBHKGMqPo/cBPZA9bSYp+lwK2DRRBU5Dv6YQ==",
 					"requires": {
-						"@jest/types": "^26.3.0",
-						"camelcase": "^6.0.0",
+						"@jest/console": "^26.6.1",
+						"@jest/environment": "^26.6.1",
+						"@jest/fake-timers": "^26.6.1",
+						"@jest/globals": "^26.6.1",
+						"@jest/source-map": "^26.5.0",
+						"@jest/test-result": "^26.6.1",
+						"@jest/transform": "^26.6.1",
+						"@jest/types": "^26.6.1",
+						"@types/yargs": "^15.0.0",
 						"chalk": "^4.0.0",
+						"cjs-module-lexer": "^0.4.2",
+						"collect-v8-coverage": "^1.0.0",
+						"exit": "^0.1.2",
+						"glob": "^7.1.3",
+						"graceful-fs": "^4.2.4",
+						"jest-config": "^26.6.1",
+						"jest-haste-map": "^26.6.1",
+						"jest-message-util": "^26.6.1",
+						"jest-mock": "^26.6.1",
+						"jest-regex-util": "^26.0.0",
+						"jest-resolve": "^26.6.1",
+						"jest-snapshot": "^26.6.1",
+						"jest-util": "^26.6.1",
+						"jest-validate": "^26.6.1",
+						"slash": "^3.0.0",
+						"strip-bom": "^4.0.0",
+						"yargs": "^15.4.1"
+					}
+				},
+				"jest-snapshot": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.1.tgz",
+					"integrity": "sha512-JA7bZp7HRTIJYAi85pJ/OZ2eur2dqmwIToA5/6d7Mn90isGEfeF9FvuhDLLEczgKP1ihreBzrJ6Vr7zteP5JNA==",
+					"requires": {
+						"@babel/types": "^7.0.0",
+						"@jest/types": "^26.6.1",
+						"@types/babel__traverse": "^7.0.4",
+						"@types/prettier": "^2.0.0",
+						"chalk": "^4.0.0",
+						"expect": "^26.6.1",
+						"graceful-fs": "^4.2.4",
+						"jest-diff": "^26.6.1",
 						"jest-get-type": "^26.3.0",
-						"leven": "^3.1.0",
-						"pretty-format": "^26.4.2"
+						"jest-haste-map": "^26.6.1",
+						"jest-matcher-utils": "^26.6.1",
+						"jest-message-util": "^26.6.1",
+						"jest-resolve": "^26.6.1",
+						"natural-compare": "^1.4.0",
+						"pretty-format": "^26.6.1",
+						"semver": "^7.3.2"
 					}
 				},
 				"locate-path": {
@@ -17749,16 +16573,10 @@
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
 				},
-				"pretty-format": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
-					"requires": {
-						"@jest/types": "^26.3.0",
-						"ansi-regex": "^5.0.0",
-						"ansi-styles": "^4.0.0",
-						"react-is": "^16.12.0"
-					}
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
 				},
 				"slash": {
 					"version": "3.0.0",
@@ -17796,6 +16614,16 @@
 						"has-flag": "^4.0.0"
 					}
 				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
 				"yargs": {
 					"version": "15.4.1",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
@@ -17821,154 +16649,25 @@
 					"requires": {
 						"camelcase": "^5.0.0",
 						"decamelize": "^1.2.0"
-					},
-					"dependencies": {
-						"camelcase": {
-							"version": "5.3.1",
-							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-							"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-						}
 					}
 				}
 			}
 		},
 		"jest-serializer": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.3.0.tgz",
-			"integrity": "sha512-IDRBQBLPlKa4flg77fqg0n/pH87tcRKwe8zxOVTWISxGpPHYkRZ1dXKyh04JOja7gppc60+soKVZ791mruVdow==",
+			"version": "26.5.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.5.0.tgz",
+			"integrity": "sha512-+h3Gf5CDRlSLdgTv7y0vPIAoLgX/SI7T4v6hy+TEXMgYbv+ztzbg5PSN6mUXAT/hXYHvZRWm+MaObVfqkhCGxA==",
 			"requires": {
 				"@types/node": "*",
 				"graceful-fs": "^4.2.4"
 			}
 		},
-		"jest-snapshot": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.4.2.tgz",
-			"integrity": "sha512-N6Uub8FccKlf5SBFnL2Ri/xofbaA68Cc3MGjP/NuwgnsvWh+9hLIR/DhrxbSiKXMY9vUW5dI6EW1eHaDHqe9sg==",
-			"requires": {
-				"@babel/types": "^7.0.0",
-				"@jest/types": "^26.3.0",
-				"@types/prettier": "^2.0.0",
-				"chalk": "^4.0.0",
-				"expect": "^26.4.2",
-				"graceful-fs": "^4.2.4",
-				"jest-diff": "^26.4.2",
-				"jest-get-type": "^26.3.0",
-				"jest-haste-map": "^26.3.0",
-				"jest-matcher-utils": "^26.4.2",
-				"jest-message-util": "^26.3.0",
-				"jest-resolve": "^26.4.0",
-				"natural-compare": "^1.4.0",
-				"pretty-format": "^26.4.2",
-				"semver": "^7.3.2"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"jest-get-type": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
-				},
-				"pretty-format": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
-					"requires": {
-						"@jest/types": "^26.3.0",
-						"ansi-regex": "^5.0.0",
-						"ansi-styles": "^4.0.0",
-						"react-is": "^16.12.0"
-					}
-				},
-				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
 		"jest-util": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.3.0.tgz",
-			"integrity": "sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.1.tgz",
+			"integrity": "sha512-xCLZUqVoqhquyPLuDXmH7ogceGctbW8SMyQVjD9o+1+NPWI7t0vO08udcFLVPLgKWcvc+zotaUv/RuaR6l8HIA==",
 			"requires": {
-				"@jest/types": "^26.3.0",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
@@ -17976,40 +16675,11 @@
 				"micromatch": "^4.0.2"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -18089,60 +16759,82 @@
 			}
 		},
 		"jest-validate": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
-			"integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.1.tgz",
+			"integrity": "sha512-BEFpGbylKocnNPZULcnk+TGaz1oFZQH/wcaXlaXABbu0zBwkOGczuWgdLucUouuQqn7VadHZZeTvo8VSFDLMOA==",
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"camelcase": "^5.3.1",
-				"chalk": "^2.0.1",
-				"jest-get-type": "^24.9.0",
+				"@jest/types": "^26.6.1",
+				"camelcase": "^6.0.0",
+				"chalk": "^4.0.0",
+				"jest-get-type": "^26.3.0",
 				"leven": "^3.1.0",
-				"pretty-format": "^24.9.0"
+				"pretty-format": "^26.6.1"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"camelcase": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.1.0.tgz",
+					"integrity": "sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ=="
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"jest-watcher": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.3.0.tgz",
-			"integrity": "sha512-XnLdKmyCGJ3VoF6G/p5ohbJ04q/vv5aH9ENI+i6BL0uu9WWB6Z7Z2lhQQk0d2AVZcRGp1yW+/TsoToMhBFPRdQ==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.1.tgz",
+			"integrity": "sha512-0LBIPPncNi9CaLKK15bnxyd2E8OMl4kJg0PTiNOI+MXztXw1zVdtX/x9Pr6pXaQYps+eS/ts43O4+HByZ7yJSw==",
 			"requires": {
-				"@jest/test-result": "^26.3.0",
-				"@jest/types": "^26.3.0",
+				"@jest/test-result": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^4.0.0",
-				"jest-util": "^26.3.0",
+				"jest-util": "^26.6.1",
 				"string-length": "^4.0.1"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/istanbul-reports": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-					"requires": {
-						"@types/istanbul-lib-report": "*"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
 				"ansi-escapes": {
 					"version": "4.3.1",
 					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
@@ -18152,11 +16844,10 @@
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -18203,9 +16894,9 @@
 			}
 		},
 		"jest-worker": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
-			"integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.1.tgz",
+			"integrity": "sha512-R5IE3qSGz+QynJx8y+ICEkdI2OJ3RJjRQVEyCcFAd3yVhQSEtquziPO29Mlzgn07LOVE8u8jhJ1FqcwegiXWOw==",
 			"requires": {
 				"@types/node": "*",
 				"merge-stream": "^2.0.0",
@@ -18290,14 +16981,75 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.4.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-					"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
+					"version": "6.4.2",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+					"integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
+				},
+				"acorn-globals": {
+					"version": "4.3.4",
+					"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+					"integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+					"requires": {
+						"acorn": "^6.0.1",
+						"acorn-walk": "^6.0.1"
+					}
+				},
+				"acorn-walk": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+					"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
+				},
+				"cssom": {
+					"version": "0.3.8",
+					"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+					"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+				},
+				"cssstyle": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
+					"integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
+					"requires": {
+						"cssom": "0.3.x"
+					}
+				},
+				"data-urls": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+					"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+					"requires": {
+						"abab": "^2.0.0",
+						"whatwg-mimetype": "^2.2.0",
+						"whatwg-url": "^7.0.0"
+					}
+				},
+				"domexception": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+					"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+					"requires": {
+						"webidl-conversions": "^4.0.2"
+					}
+				},
+				"html-encoding-sniffer": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+					"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+					"requires": {
+						"whatwg-encoding": "^1.0.1"
+					}
 				},
 				"parse5": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
 					"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
+				},
+				"saxes": {
+					"version": "3.1.11",
+					"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
+					"integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
+					"requires": {
+						"xmlchars": "^2.1.1"
+					}
 				}
 			}
 		},
@@ -18376,9 +17128,9 @@
 			"dev": true
 		},
 		"jsonschema": {
-			"version": "1.2.11",
-			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.11.tgz",
-			"integrity": "sha512-XNZHs3N1IOa3lPKm//npxMhOdaoPw+MvEV0NIgxcER83GTJcG13rehtWmpBCfEt8DrtYwIkMTs8bdXoYs4fvnQ=="
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.0.tgz",
+			"integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw=="
 		},
 		"jsonwebtoken": {
 			"version": "8.5.1",
@@ -18415,37 +17167,10 @@
 				"verror": "1.10.0"
 			}
 		},
-		"jstransform": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
-			"integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
-			"requires": {
-				"base62": "^1.1.0",
-				"commoner": "^0.10.1",
-				"esprima-fb": "^15001.1.0-dev-harmony-fb",
-				"object-assign": "^2.0.0",
-				"source-map": "^0.4.2"
-			},
-			"dependencies": {
-				"esprima-fb": {
-					"version": "15001.1.0-dev-harmony-fb",
-					"resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
-					"integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE="
-				},
-				"object-assign": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-					"integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
-				},
-				"source-map": {
-					"version": "0.4.4",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-					"requires": {
-						"amdefine": ">=0.0.4"
-					}
-				}
-			}
+		"jsrsasign": {
+			"version": "10.0.4",
+			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.0.4.tgz",
+			"integrity": "sha512-G08GDeAwgVkN5PGE9TnJ/4ixV3zkq560RigOoqrRvVc8H4GjfPVTz54/qGPLHK1KGHGP36/2eaLU1HuXmOJgug=="
 		},
 		"jsx-ast-utils": {
 			"version": "2.4.1",
@@ -18501,9 +17226,9 @@
 			}
 		},
 		"just-extend": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
-			"integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA=="
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+			"integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA=="
 		},
 		"just-range": {
 			"version": "2.1.0",
@@ -18957,11 +17682,10 @@
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -19600,14 +18324,15 @@
 			}
 		},
 		"mocha": {
-			"version": "8.1.3",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.1.3.tgz",
-			"integrity": "sha512-ZbaYib4hT4PpF4bdSO2DohooKXIn4lDeiYqB+vTmCdr6l2woW0b6H3pf5x4sM5nwQMru9RvjjHYWVGltR50ZBw==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.0.tgz",
+			"integrity": "sha512-lEWEMq2LMfNJMKeuEwb5UELi+OgFDollXaytR5ggQcHpzG3NP/R7rvixAvF+9/lLsTWhWG+4yD2M70GsM06nxw==",
 			"requires": {
+				"@ungap/promise-all-settled": "1.1.2",
 				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
-				"chokidar": "3.4.2",
-				"debug": "4.1.1",
+				"chokidar": "3.4.3",
+				"debug": "4.2.0",
 				"diff": "4.0.2",
 				"escape-string-regexp": "4.0.0",
 				"find-up": "5.0.0",
@@ -19618,17 +18343,16 @@
 				"log-symbols": "4.0.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.2",
-				"object.assign": "4.1.0",
-				"promise.allsettled": "1.0.2",
-				"serialize-javascript": "4.0.0",
-				"strip-json-comments": "3.0.1",
-				"supports-color": "7.1.0",
+				"nanoid": "3.1.12",
+				"serialize-javascript": "5.0.1",
+				"strip-json-comments": "3.1.1",
+				"supports-color": "7.2.0",
 				"which": "2.0.2",
 				"wide-align": "1.1.3",
-				"workerpool": "6.0.0",
+				"workerpool": "6.0.2",
 				"yargs": "13.3.2",
 				"yargs-parser": "13.1.2",
-				"yargs-unparser": "1.6.1"
+				"yargs-unparser": "2.0.0"
 			},
 			"dependencies": {
 				"diff": {
@@ -19693,15 +18417,10 @@
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
 				},
-				"strip-json-comments": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-					"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
-				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
@@ -19755,9 +18474,9 @@
 			"integrity": "sha512-JoU9V9k6KqT9R9Tiw1RTU8ohZ+Xnf9DMg6Ktqqw5hILumwmq7xqa/KLXw513uTUsWbhtnHoSJYYR++u3pkyxJg=="
 		},
 		"monaco-editor-webpack-plugin": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-1.9.0.tgz",
-			"integrity": "sha512-tOiiToc94E1sb50BgZ8q8WK/bxus77SRrwCqIpAB5er3cpX78SULbEBY4YPOB8kDolOzKRt30WIHG/D6gz69Ww==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-1.9.1.tgz",
+			"integrity": "sha512-x7fx1w3i/uwZERIgztHAAK3VQMsL8+ku0lFXXbO81hKDg8IieACqjGEa2mqEueg0c/fX+wd0oI+75wB19KJAsA==",
 			"requires": {
 				"loader-utils": "^1.2.3"
 			}
@@ -19852,9 +18571,14 @@
 			}
 		},
 		"nan": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+			"version": "2.14.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+			"integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+		},
+		"nanoid": {
+			"version": "3.1.12",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
+			"integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -20054,9 +18778,9 @@
 			"dev": true
 		},
 		"node-fetch": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
 		},
 		"node-fetch-npm": {
 			"version": "2.0.4",
@@ -20070,9 +18794,9 @@
 			}
 		},
 		"node-forge": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-			"integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ=="
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+			"integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
 		},
 		"node-gyp": {
 			"version": "5.1.0",
@@ -20121,6 +18845,7 @@
 				"events": "^3.0.0",
 				"https-browserify": "^1.0.0",
 				"os-browserify": "^0.3.0",
+				"path-browserify": "0.0.1",
 				"process": "^0.11.10",
 				"punycode": "^1.2.4",
 				"querystring-es3": "^0.2.0",
@@ -20163,6 +18888,11 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"path-browserify": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+					"integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
 				},
 				"punycode": {
 					"version": "1.4.1",
@@ -20234,52 +18964,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
 			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
-		},
-		"node-notifier": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.0.tgz",
-			"integrity": "sha512-46z7DUmcjoYdaWyXouuFNNfUo6eFa94t23c53c+lG/9Cvauk4a98rAUp9672X5dxGdQmLpPzTxzu8f/OeEPaFA==",
-			"optional": true,
-			"requires": {
-				"growly": "^1.3.0",
-				"is-wsl": "^2.2.0",
-				"semver": "^7.3.2",
-				"shellwords": "^0.1.1",
-				"uuid": "^8.3.0",
-				"which": "^2.0.2"
-			},
-			"dependencies": {
-				"is-wsl": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-					"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-					"optional": true,
-					"requires": {
-						"is-docker": "^2.0.0"
-					}
-				},
-				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-					"optional": true
-				},
-				"uuid": {
-					"version": "8.3.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-					"integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
-					"optional": true
-				},
-				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"optional": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				}
-			}
 		},
 		"node-preload": {
 			"version": "0.2.1",
@@ -20598,12 +19282,9 @@
 			}
 		},
 		"normalize-path": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"requires": {
-				"remove-trailing-separator": "^1.0.1"
-			}
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
 		},
 		"normalize-url": {
 			"version": "3.3.0",
@@ -20974,11 +19655,6 @@
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
-		"object-component": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
-			"integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
-		},
 		"object-copy": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -21013,12 +19689,62 @@
 			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
 		},
 		"object-is": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
-			"integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.3.tgz",
+			"integrity": "sha512-teyqLvFWzLkq5B9ki8FVWA902UER2qkxmdA4nLf+wjOLAWgxzCWZNCxpDq9MvE8MmhWNr+I8w3BN49Vx36Y6Xg==",
 			"requires": {
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5"
+				"es-abstract": "^1.18.0-next.1"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.2.2",
+						"is-negative-zero": "^2.0.0",
+						"is-regex": "^1.1.1",
+						"object-inspect": "^1.8.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.1",
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
+					}
+				},
+				"is-callable": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+					"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
+				},
+				"is-regex": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+					"integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+					"requires": {
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"object-inspect": {
+					"version": "1.8.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+					"integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
+				},
+				"object.assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+					"integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
+					"requires": {
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.18.0-next.0",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				}
 			}
 		},
 		"object-keys": {
@@ -21106,22 +19832,21 @@
 			"dev": true
 		},
 		"office-ui-fabric-react": {
-			"version": "7.137.1",
-			"resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.137.1.tgz",
-			"integrity": "sha512-6m1M9m5psaJqhWwroVp1L0G8q66scLMsQRi+gQ/fY3f75ipGSABGeQ86d4P0ilKaYcLVYIzosocPIZKLbBVpnQ==",
+			"version": "7.148.0",
+			"resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.148.0.tgz",
+			"integrity": "sha512-HD7OH9vfBBdxzdXE5Ce6c8m//KOWmkNCKfBmB64YsBaSYDoy+hGhyK8JWjYn/5n9Y9XeP4ee6ALPBcXHw76AQg==",
 			"requires": {
-				"@fluentui/date-time-utilities": "^7.8.0",
-				"@fluentui/react-focus": "^7.16.0",
-				"@fluentui/react-icons": "^0.3.0",
-				"@fluentui/react-window-provider": "^0.3.0",
+				"@fluentui/date-time-utilities": "^7.9.0",
+				"@fluentui/react-focus": "^7.16.13",
+				"@fluentui/react-window-provider": "^0.3.3",
 				"@microsoft/load-themed-styles": "^1.10.26",
-				"@uifabric/foundation": "^7.9.0",
-				"@uifabric/icons": "^7.5.0",
-				"@uifabric/merge-styles": "^7.18.0",
-				"@uifabric/react-hooks": "^7.13.0",
-				"@uifabric/set-version": "^7.0.22",
-				"@uifabric/styling": "^7.16.0",
-				"@uifabric/utilities": "^7.31.0",
+				"@uifabric/foundation": "^7.9.14",
+				"@uifabric/icons": "^7.5.12",
+				"@uifabric/merge-styles": "^7.19.1",
+				"@uifabric/react-hooks": "^7.13.6",
+				"@uifabric/set-version": "^7.0.23",
+				"@uifabric/styling": "^7.16.13",
+				"@uifabric/utilities": "^7.32.4",
 				"prop-types": "^15.7.2",
 				"tslib": "^1.10.0"
 			}
@@ -21539,28 +20264,6 @@
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
 				},
-				"@fluidframework/server-lambdas": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1012.2.tgz",
-					"integrity": "sha512-r/FPMZfami9yD/ZDo0BRvQwkcVlD2PnOgYeN5YP/9QeWyh3QUcZD688M4IxzzGMfDY6nAN8wVjI7Wn2ajqzLPQ==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-base": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
-						"@fluidframework/server-services-core": "^0.1012.2",
-						"@types/semver": "^6.0.1",
-						"async": "^2.6.1",
-						"double-ended-queue": "^2.1.0-0",
-						"json-stringify-safe": "^5.0.1",
-						"jsonwebtoken": "^8.4.0",
-						"lodash": "^4.17.19",
-						"nconf": "^0.10.0",
-						"semver": "^6.3.0",
-						"uuid": "^3.3.2"
-					}
-				},
 				"@fluidframework/server-local-server": {
 					"version": "0.1012.2",
 					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1012.2.tgz",
@@ -21574,30 +20277,6 @@
 						"@fluidframework/server-services-core": "^0.1012.2",
 						"@fluidframework/server-test-utils": "^0.1012.2",
 						"uuid": "^3.3.2"
-					}
-				},
-				"@fluidframework/server-memory-orderer": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1012.2.tgz",
-					"integrity": "sha512-6VDnXD0fj93SI9D3VIdxlKiNfnFjUsjZsNlDBlqyrGbTj7VYMIrsm9FbxjHuWxG/1pWxqdy4CQvbG3r5s0Me/g==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/protocol-base": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-lambdas": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
-						"@fluidframework/server-services-core": "^0.1012.2",
-						"@types/debug": "^4.1.5",
-						"@types/double-ended-queue": "^2.1.0",
-						"@types/lodash": "^4.14.118",
-						"@types/node": "^10.17.24",
-						"@types/ws": "^6.0.1",
-						"debug": "^4.1.1",
-						"double-ended-queue": "^2.1.0-0",
-						"lodash": "^4.17.19",
-						"moniker": "^0.1.2",
-						"uuid": "^3.3.2",
-						"ws": "^6.1.2"
 					}
 				},
 				"@fluidframework/server-services-client": {
@@ -21648,11 +20327,6 @@
 						"string-hash": "^1.1.3",
 						"uuid": "^3.3.2"
 					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -21960,28 +20634,6 @@
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
 				},
-				"@fluidframework/server-lambdas": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1012.2.tgz",
-					"integrity": "sha512-r/FPMZfami9yD/ZDo0BRvQwkcVlD2PnOgYeN5YP/9QeWyh3QUcZD688M4IxzzGMfDY6nAN8wVjI7Wn2ajqzLPQ==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-base": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
-						"@fluidframework/server-services-core": "^0.1012.2",
-						"@types/semver": "^6.0.1",
-						"async": "^2.6.1",
-						"double-ended-queue": "^2.1.0-0",
-						"json-stringify-safe": "^5.0.1",
-						"jsonwebtoken": "^8.4.0",
-						"lodash": "^4.17.19",
-						"nconf": "^0.10.0",
-						"semver": "^6.3.0",
-						"uuid": "^3.3.2"
-					}
-				},
 				"@fluidframework/server-local-server": {
 					"version": "0.1012.2",
 					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1012.2.tgz",
@@ -21995,30 +20647,6 @@
 						"@fluidframework/server-services-core": "^0.1012.2",
 						"@fluidframework/server-test-utils": "^0.1012.2",
 						"uuid": "^3.3.2"
-					}
-				},
-				"@fluidframework/server-memory-orderer": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1012.2.tgz",
-					"integrity": "sha512-6VDnXD0fj93SI9D3VIdxlKiNfnFjUsjZsNlDBlqyrGbTj7VYMIrsm9FbxjHuWxG/1pWxqdy4CQvbG3r5s0Me/g==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/protocol-base": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-lambdas": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
-						"@fluidframework/server-services-core": "^0.1012.2",
-						"@types/debug": "^4.1.5",
-						"@types/double-ended-queue": "^2.1.0",
-						"@types/lodash": "^4.14.118",
-						"@types/node": "^10.17.24",
-						"@types/ws": "^6.0.1",
-						"debug": "^4.1.1",
-						"double-ended-queue": "^2.1.0-0",
-						"lodash": "^4.17.19",
-						"moniker": "^0.1.2",
-						"uuid": "^3.3.2",
-						"ws": "^6.1.2"
 					}
 				},
 				"@fluidframework/server-services-client": {
@@ -22069,11 +20697,6 @@
 						"string-hash": "^1.1.3",
 						"uuid": "^3.3.2"
 					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -22126,6 +20749,13 @@
 			"integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
 			"requires": {
 				"is-wsl": "^1.1.0"
+			},
+			"dependencies": {
+				"is-wsl": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+					"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+				}
 			}
 		},
 		"optionator": {
@@ -22472,6 +21102,17 @@
 						"has-flag": "^4.0.0"
 					}
 				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
 				"yargs": {
 					"version": "15.4.1",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
@@ -22597,17 +21238,6 @@
 				"expand-tilde": "^2.0.2",
 				"git-config-path": "^1.0.1",
 				"ini": "^1.3.5"
-			},
-			"dependencies": {
-				"expand-tilde": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-					"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-					"dev": true,
-					"requires": {
-						"homedir-polyfill": "^1.0.1"
-					}
-				}
 			}
 		},
 		"parse-github-repo-url": {
@@ -22673,20 +21303,14 @@
 			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
 		},
 		"parseqs": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
-			"integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-			"requires": {
-				"better-assert": "~1.0.0"
-			}
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
+			"integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w=="
 		},
 		"parseuri": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
-			"integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-			"requires": {
-				"better-assert": "~1.0.0"
-			}
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
+			"integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow=="
 		},
 		"parseurl": {
 			"version": "1.3.3",
@@ -22965,29 +21589,62 @@
 			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
 		},
 		"pretty-error": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
-			"integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.2.tgz",
+			"integrity": "sha512-EY5oDzmsX5wvuynAByrmY0P0hcp+QpnAKbJng2A2MPjVKXCxrDSUkzghVJ4ZGPIv+JC4gX8fPUWscC0RtjsWGw==",
 			"requires": {
-				"renderkid": "^2.0.1",
-				"utila": "~0.4"
+				"lodash": "^4.17.20",
+				"renderkid": "^2.0.4"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+				}
 			}
 		},
 		"pretty-format": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
-			"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.1.tgz",
+			"integrity": "sha512-MeqqsP5PYcRBbGMvwzsyBdmAJ4EFX7pWFyl7x4+dMVg5pE0ZDdBIvEH2ergvIO+Gvwv1wh64YuOY9y5LuyY/GA==",
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"ansi-regex": "^4.0.0",
-				"ansi-styles": "^3.2.0",
-				"react-is": "^16.8.4"
+				"@jest/types": "^26.6.1",
+				"ansi-regex": "^5.0.0",
+				"ansi-styles": "^4.0.0",
+				"react-is": "^17.0.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"react-is": {
+					"version": "17.0.1",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+					"integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA=="
 				}
 			}
 		},
@@ -23053,25 +21710,13 @@
 				"retry": "^0.10.0"
 			}
 		},
-		"promise.allsettled": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.2.tgz",
-			"integrity": "sha512-UpcYW5S1RaNKT6pd+s9jp9K9rlQge1UXKskec0j6Mmuq7UJCvlS2J2/s/yuPN8ehftf9HXMxWlKiPbGGUzpoRg==",
-			"requires": {
-				"array.prototype.map": "^1.0.1",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1",
-				"function-bind": "^1.1.1",
-				"iterate-value": "^1.0.0"
-			}
-		},
 		"prompts": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
-			"integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
+			"integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
 			"requires": {
 				"kleur": "^3.0.3",
-				"sisteransi": "^1.0.4"
+				"sisteransi": "^1.0.5"
 			}
 		},
 		"promzard": {
@@ -23182,9 +21827,9 @@
 			}
 		},
 		"prosemirror-inputrules": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.2.tgz",
-			"integrity": "sha512-Ja5Z3BWestlHYGvtSGqyvxMeB8QEuBjlHM8YnKtLGUXMDp965qdDV4goV8lJb17kIWHk7e7JNj6Catuoa3302g==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
+			"integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
 			"requires": {
 				"prosemirror-state": "^1.0.0",
 				"prosemirror-transform": "^1.0.0"
@@ -23211,9 +21856,9 @@
 			}
 		},
 		"prosemirror-model": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.11.1.tgz",
-			"integrity": "sha512-cscne7s40lTQbZrU8fHBGI5awS2qX91w9wChl3HicKG2lkPS6cdGQADXbDCIU8SFl6lQYEsmIzn8F66Wm19YhA==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.12.0.tgz",
+			"integrity": "sha512-B5syrXluQwEPfih8PqZcVg2VWRUf8Rj97K/VNSkQtjUPL1BCoTUgdLERIlxdWHkwqvujFsT3Pw5ubc4/ofF1jQ==",
 			"requires": {
 				"orderedmap": "^1.1.0"
 			}
@@ -23245,9 +21890,9 @@
 			}
 		},
 		"prosemirror-view": {
-			"version": "1.15.7",
-			"resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.15.7.tgz",
-			"integrity": "sha512-fSSXphXg+82qb4xNsHT0mX6ro0Wu1/l+WIFO5jYfyjd42r6ZWSg0gFItLgqOVPxoKQOlrPJUhrozTxiqx0EXOg==",
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.16.1.tgz",
+			"integrity": "sha512-7iDdRf2PAIgOnstcxqUxzf8IbHGfxygQs5covfxOHLWKyx7SSLRnBIlwVda54Hr6N26F4t5Kj2jfK7uIBcAKAw==",
 			"requires": {
 				"prosemirror-model": "^1.1.0",
 				"prosemirror-state": "^1.0.0",
@@ -23564,9 +22209,9 @@
 			}
 		},
 		"react": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-			"integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+			"version": "16.14.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+			"integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -23574,9 +22219,9 @@
 			}
 		},
 		"react-collapsible": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/react-collapsible/-/react-collapsible-2.8.0.tgz",
-			"integrity": "sha512-QTxGyp4iL8N57FcU1RGt4wD7vqOTRYAHNukxtSeVMkZ+/d1WNWXRIakzhYhC/5TDERihPdp1IvKIJlrLLPyQ/A=="
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/react-collapsible/-/react-collapsible-2.8.1.tgz",
+			"integrity": "sha512-ykV+EpCBYC6UoOsZLtBxrs/kFVgJc2gFMU1/SS2JLG+LrMHSOERpWSG+fexyFYk44hdfJRmc/If+HlSjXcbCiw=="
 		},
 		"react-component-managers": {
 			"version": "3.2.2",
@@ -23588,9 +22233,9 @@
 			}
 		},
 		"react-dom": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
-			"integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
+			"version": "16.14.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+			"integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -23871,9 +22516,9 @@
 			}
 		},
 		"readdirp": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-			"integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+			"integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
 			"requires": {
 				"picomatch": "^2.2.1"
 			}
@@ -23883,29 +22528,6 @@
 			"resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
 			"integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
 			"dev": true
-		},
-		"recast": {
-			"version": "0.11.23",
-			"resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-			"integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-			"requires": {
-				"ast-types": "0.9.6",
-				"esprima": "~3.1.0",
-				"private": "~0.1.5",
-				"source-map": "~0.5.0"
-			},
-			"dependencies": {
-				"esprima": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				}
-			}
 		},
 		"rechoir": {
 			"version": "0.6.2",
@@ -23927,9 +22549,9 @@
 			}
 		},
 		"regenerator-runtime": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+			"version": "0.13.7",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+			"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
 		},
 		"regex-not": {
 			"version": "1.0.2",
@@ -23996,21 +22618,26 @@
 			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
 		},
 		"renderkid": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.3.tgz",
-			"integrity": "sha512-z8CLQp7EZBPCwCnncgf9C4XAi3WR0dv+uWu/PjIyhhAb5d6IJ/QZqlHFprHeKT+59//V6BNUsLbvN8+2LarxGA==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.4.tgz",
+			"integrity": "sha512-K2eXrSOJdq+HuKzlcjOlGoOarUu5SDguDEhE7+Ah4zuOWL40j8A/oHvLlLob9PSTNvVnBd+/q0Er1QfpEuem5g==",
 			"requires": {
 				"css-select": "^1.1.0",
 				"dom-converter": "^0.2",
 				"htmlparser2": "^3.3.0",
-				"strip-ansi": "^3.0.0",
-				"utila": "^0.4.0"
+				"lodash": "^4.17.20",
+				"strip-ansi": "^3.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
@@ -24183,6 +22810,17 @@
 						"has-flag": "^4.0.0"
 					}
 				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
 				"yargs": {
 					"version": "15.4.1",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
@@ -24320,6 +22958,16 @@
 			"requires": {
 				"expand-tilde": "^1.2.2",
 				"global-modules": "^0.2.3"
+			},
+			"dependencies": {
+				"expand-tilde": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+					"integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+					"requires": {
+						"os-homedir": "^1.0.1"
+					}
+				}
 			}
 		},
 		"resolve-from": {
@@ -24455,6 +23103,25 @@
 				"micromatch": "^3.1.4",
 				"minimist": "^1.1.1",
 				"walker": "~1.0.5"
+			},
+			"dependencies": {
+				"anymatch": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+					"requires": {
+						"micromatch": "^3.1.4",
+						"normalize-path": "^2.1.1"
+					}
+				},
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"requires": {
+						"remove-trailing-separator": "^1.0.1"
+					}
+				}
 			}
 		},
 		"sass-graph": {
@@ -24498,11 +23165,11 @@
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
 		"saxes": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
-			"integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+			"integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
 			"requires": {
-				"xmlchars": "^2.1.1"
+				"xmlchars": "^2.2.0"
 			}
 		},
 		"scheduler": {
@@ -24525,9 +23192,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "6.12.4",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
-					"integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+					"version": "6.12.6",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
 						"fast-json-stable-stringify": "^2.0.0",
@@ -24567,11 +23234,11 @@
 			"integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
 		},
 		"selfsigned": {
-			"version": "1.10.7",
-			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-			"integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+			"version": "1.10.8",
+			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+			"integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
 			"requires": {
-				"node-forge": "0.9.0"
+				"node-forge": "^0.10.0"
 			}
 		},
 		"semver": {
@@ -24630,9 +23297,9 @@
 			}
 		},
 		"serialize-javascript": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-			"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+			"integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
 			"requires": {
 				"randombytes": "^2.1.0"
 			}
@@ -24807,20 +23474,20 @@
 			},
 			"dependencies": {
 				"es-abstract": {
-					"version": "1.18.0-next.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
-					"integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
+					"version": "1.18.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
 					"requires": {
 						"es-to-primitive": "^1.2.1",
 						"function-bind": "^1.1.1",
 						"has": "^1.0.3",
 						"has-symbols": "^1.0.1",
-						"is-callable": "^1.2.0",
+						"is-callable": "^1.2.2",
 						"is-negative-zero": "^2.0.0",
 						"is-regex": "^1.1.1",
 						"object-inspect": "^1.8.0",
 						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.0",
+						"object.assign": "^4.1.1",
 						"string.prototype.trimend": "^1.0.1",
 						"string.prototype.trimstart": "^1.0.1"
 					}
@@ -24842,6 +23509,17 @@
 					"version": "1.8.0",
 					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
 					"integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
+				},
+				"object.assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+					"integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
+					"requires": {
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.18.0-next.0",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
 				}
 			}
 		},
@@ -25042,48 +23720,48 @@
 			}
 		},
 		"socket.io-client": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.0.tgz",
-			"integrity": "sha512-cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.1.tgz",
+			"integrity": "sha512-YXmXn3pA8abPOY//JtYxou95Ihvzmg8U6kQyolArkIyLd0pgVhrfor/iMsox8cn07WCOOvvuJ6XKegzIucPutQ==",
 			"requires": {
 				"backo2": "1.0.2",
-				"base64-arraybuffer": "0.1.5",
 				"component-bind": "1.0.0",
-				"component-emitter": "1.2.1",
-				"debug": "~4.1.0",
+				"component-emitter": "~1.3.0",
+				"debug": "~3.1.0",
 				"engine.io-client": "~3.4.0",
 				"has-binary2": "~1.0.2",
-				"has-cors": "1.1.0",
 				"indexof": "0.0.1",
-				"object-component": "0.0.3",
-				"parseqs": "0.0.5",
-				"parseuri": "0.0.5",
+				"parseqs": "0.0.6",
+				"parseuri": "0.0.6",
 				"socket.io-parser": "~3.3.0",
 				"to-array": "0.1.4"
 			},
 			"dependencies": {
-				"component-emitter": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
 		"socket.io-parser": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
-			"integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.1.tgz",
+			"integrity": "sha512-1QLvVAe8dTz+mKmZ07Swxt+LAo4Y1ff50rlyoEx00TQmDFVQYPfcqGvIDJLGaBdhdNCecXtyKpD+EgKGcmmbuQ==",
 			"requires": {
-				"component-emitter": "1.2.1",
+				"component-emitter": "~1.3.0",
 				"debug": "~3.1.0",
 				"isarray": "2.0.1"
 			},
 			"dependencies": {
-				"component-emitter": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -25915,12 +24593,12 @@
 			}
 		},
 		"style-loader": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.2.1.tgz",
-			"integrity": "sha512-ByHSTQvHLkWE9Ir5+lGbVOXhxX10fbprhLvdg96wedFZb4NDekDPxVKv5Fwmio+QcMlkkNfuK+5W1peQ5CUhZg==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.3.0.tgz",
+			"integrity": "sha512-V7TCORko8rs9rIqkSrlMfkqA63DfoGBBJmK1kKGCcSi+BWb4cqz0SRsnp4l6rU5iwOEd0/2ePv68SV22VXon4Q==",
 			"requires": {
 				"loader-utils": "^2.0.0",
-				"schema-utils": "^2.6.6"
+				"schema-utils": "^2.7.0"
 			},
 			"dependencies": {
 				"loader-utils": {
@@ -25944,25 +24622,36 @@
 			}
 		},
 		"supports-hyperlinks": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
-			"integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-1.0.1.tgz",
+			"integrity": "sha512-HHi5kVSefKaJkGYXbDuKbUGRVxqnWGn3J2e39CYcNJEfWciGq2zYtOhXLTlvrOZW1QU7VX67w7fMmWafHX9Pfw==",
+			"dev": true,
 			"requires": {
-				"has-flag": "^4.0.0",
-				"supports-color": "^7.0.0"
+				"has-flag": "^2.0.0",
+				"supports-color": "^5.0.0"
 			},
 			"dependencies": {
 				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"dev": true
 				},
 				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
 					"requires": {
-						"has-flag": "^4.0.0"
+						"has-flag": "^3.0.0"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+							"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+							"dev": true
+						}
 					}
 				}
 			}
@@ -26118,6 +24807,28 @@
 						"type-fest": "^0.11.0"
 					}
 				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"supports-hyperlinks": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
+					"integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
+					"requires": {
+						"has-flag": "^4.0.0",
+						"supports-color": "^7.0.0"
+					}
+				},
 				"type-fest": {
 					"version": "0.11.0",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
@@ -26139,63 +24850,6 @@
 					"version": "2.20.3",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-				}
-			}
-		},
-		"terser-webpack-plugin": {
-			"version": "1.4.5",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
-			"integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
-			"requires": {
-				"cacache": "^12.0.2",
-				"find-cache-dir": "^2.1.0",
-				"is-wsl": "^1.1.0",
-				"schema-utils": "^1.0.0",
-				"serialize-javascript": "^4.0.0",
-				"source-map": "^0.6.1",
-				"terser": "^4.1.2",
-				"webpack-sources": "^1.4.0",
-				"worker-farm": "^1.7.0"
-			},
-			"dependencies": {
-				"find-cache-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-					"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-					"requires": {
-						"commondir": "^1.0.1",
-						"make-dir": "^2.0.0",
-						"pkg-dir": "^3.0.0"
-					}
-				},
-				"make-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-					"requires": {
-						"pify": "^4.0.1",
-						"semver": "^5.6.0"
-					}
-				},
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
-				},
-				"schema-utils": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-errors": "^1.0.0",
-						"ajv-keywords": "^3.1.0"
-					}
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				}
 			}
 		},
@@ -26434,185 +25088,31 @@
 			"integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
 		},
 		"ts-jest": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.3.0.tgz",
-			"integrity": "sha512-Jq2uKfx6bPd9+JDpZNMBJMdMQUC3sJ08acISj8NXlVgR2d5OqslEHOR2KHMgwymu8h50+lKIm0m0xj/ioYdW2Q==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.2.tgz",
+			"integrity": "sha512-0+MynTTzzbuy5rGjzsCKjxHJk5gY906c/FSaqQ3081+G7dp2Yygfa9hVlbrtNNcztffh1mC6Rs9jb/yHpcjsoQ==",
 			"requires": {
+				"@jest/create-cache-key-function": "^26.5.0",
 				"@types/jest": "26.x",
 				"bs-logger": "0.x",
 				"buffer-from": "1.x",
 				"fast-json-stable-stringify": "2.x",
-				"jest-util": "26.x",
+				"jest-util": "^26.1.0",
 				"json5": "2.x",
 				"lodash.memoize": "4.x",
 				"make-error": "1.x",
 				"mkdirp": "1.x",
 				"semver": "7.x",
-				"yargs-parser": "18.x"
+				"yargs-parser": "20.x"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "25.5.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-					"integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
-					}
-				},
 				"@types/jest": {
-					"version": "26.0.13",
-					"resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.13.tgz",
-					"integrity": "sha512-sCzjKow4z9LILc6DhBvn5AkIfmQzDZkgtVVKmGwVrs5tuid38ws281D4l+7x1kP487+FlKDh5kfMZ8WSPAdmdA==",
+					"version": "26.0.15",
+					"resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.15.tgz",
+					"integrity": "sha512-s2VMReFXRg9XXxV+CW9e5Nz8fH2K1aEhwgjUqPPbQd7g95T0laAcvLv032EhFHIa5GHsZ8W7iJEQVaJq6k3Gog==",
 					"requires": {
-						"jest-diff": "^25.2.1",
-						"pretty-format": "^25.2.1"
-					}
-				},
-				"@types/yargs": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"requires": {
-						"fill-range": "^7.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"diff-sequences": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
-					"integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg=="
-				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-				},
-				"jest-diff": {
-					"version": "25.5.0",
-					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
-					"integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
-					"requires": {
-						"chalk": "^3.0.0",
-						"diff-sequences": "^25.2.6",
-						"jest-get-type": "^25.2.6",
-						"pretty-format": "^25.5.0"
-					}
-				},
-				"jest-get-type": {
-					"version": "25.2.6",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
-					"integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig=="
-				},
-				"jest-util": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.3.0.tgz",
-					"integrity": "sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==",
-					"requires": {
-						"@jest/types": "^26.3.0",
-						"@types/node": "*",
-						"chalk": "^4.0.0",
-						"graceful-fs": "^4.2.4",
-						"is-ci": "^2.0.0",
-						"micromatch": "^4.0.2"
-					},
-					"dependencies": {
-						"@jest/types": {
-							"version": "26.3.0",
-							"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-							"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-							"requires": {
-								"@types/istanbul-lib-coverage": "^2.0.0",
-								"@types/istanbul-reports": "^3.0.0",
-								"@types/node": "*",
-								"@types/yargs": "^15.0.0",
-								"chalk": "^4.0.0"
-							}
-						},
-						"@types/istanbul-reports": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-							"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-							"requires": {
-								"@types/istanbul-lib-report": "*"
-							}
-						},
-						"chalk": {
-							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-							"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-							"requires": {
-								"ansi-styles": "^4.1.0",
-								"supports-color": "^7.1.0"
-							}
-						}
-					}
-				},
-				"micromatch": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-					"requires": {
-						"braces": "^3.0.1",
-						"picomatch": "^2.0.5"
+						"jest-diff": "^26.0.0",
+						"pretty-format": "^26.0.0"
 					}
 				},
 				"mkdirp": {
@@ -26620,46 +25120,15 @@
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
 					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
 				},
-				"pretty-format": {
-					"version": "25.5.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
-					"integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
-					"requires": {
-						"@jest/types": "^25.5.0",
-						"ansi-regex": "^5.0.0",
-						"ansi-styles": "^4.0.0",
-						"react-is": "^16.12.0"
-					}
-				},
 				"semver": {
 					"version": "7.3.2",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
 					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
 				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"requires": {
-						"is-number": "^7.0.0"
-					}
-				},
 				"yargs-parser": {
-					"version": "18.1.3",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
+					"version": "20.2.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.3.tgz",
+					"integrity": "sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww=="
 				}
 			}
 		},
@@ -26727,6 +25196,29 @@
 			"requires": {
 				"ts-node": "7.0.1",
 				"tsconfig-paths": "^3.5.0"
+			},
+			"dependencies": {
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"optional": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"tsconfig-paths": {
+					"version": "3.9.0",
+					"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+					"integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+					"optional": true,
+					"requires": {
+						"@types/json5": "^0.0.29",
+						"json5": "^1.0.1",
+						"minimist": "^1.2.0",
+						"strip-bom": "^3.0.0"
+					}
+				}
 			}
 		},
 		"ts-node": {
@@ -26742,27 +25234,6 @@
 				"mkdirp": "^0.5.1",
 				"source-map-support": "^0.5.6",
 				"yn": "^2.0.0"
-			}
-		},
-		"tsconfig-paths": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
-			"integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
-			"requires": {
-				"@types/json5": "^0.0.29",
-				"json5": "^1.0.1",
-				"minimist": "^1.2.0",
-				"strip-bom": "^3.0.0"
-			},
-			"dependencies": {
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				}
 			}
 		},
 		"tsd": {
@@ -26793,6 +25264,11 @@
 						"quick-lru": "^1.0.0"
 					}
 				},
+				"ci-info": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+					"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
+				},
 				"find-up": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -26805,6 +25281,14 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
 					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+				},
+				"is-ci": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+					"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+					"requires": {
+						"ci-info": "^1.5.0"
+					}
 				},
 				"load-json-file": {
 					"version": "4.0.0",
@@ -26971,6 +25455,23 @@
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
 					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
 				},
+				"update-notifier": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+					"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+					"requires": {
+						"boxen": "^1.2.1",
+						"chalk": "^2.0.1",
+						"configstore": "^3.0.0",
+						"import-lazy": "^2.1.0",
+						"is-ci": "^1.0.10",
+						"is-installed-globally": "^0.1.0",
+						"is-npm": "^1.0.0",
+						"latest-version": "^3.0.0",
+						"semver-diff": "^2.0.0",
+						"xdg-basedir": "^3.0.0"
+					}
+				},
 				"yargs-parser": {
 					"version": "10.1.0",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
@@ -27091,6 +25592,43 @@
 			"requires": {
 				"commandpost": "^1.0.0",
 				"editorconfig": "^0.15.0"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+				},
+				"editorconfig": {
+					"version": "0.15.3",
+					"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+					"integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+					"requires": {
+						"commander": "^2.19.0",
+						"lru-cache": "^4.1.5",
+						"semver": "^5.6.0",
+						"sigmund": "^1.0.1"
+					}
+				},
+				"lru-cache": {
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+				}
 			}
 		},
 		"typings-for-css-modules-loader": {
@@ -27142,9 +25680,9 @@
 			"integrity": "sha512-W3kLbx+ML9PBl5Bzso/lTvVxk4BCveSNAtQeht59FEtxCdGThmn6wSHA4Xq3eQYAK24NHdisMM4JmsK0GFy/pg=="
 		},
 		"ua-parser-js": {
-			"version": "0.7.21",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-			"integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
+			"version": "0.7.22",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
+			"integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q=="
 		},
 		"uc.micro": {
 			"version": "1.0.6",
@@ -27303,38 +25841,6 @@
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
 			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
 		},
-		"update-notifier": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
-			"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
-			"requires": {
-				"boxen": "^1.2.1",
-				"chalk": "^2.0.1",
-				"configstore": "^3.0.0",
-				"import-lazy": "^2.1.0",
-				"is-ci": "^1.0.10",
-				"is-installed-globally": "^0.1.0",
-				"is-npm": "^1.0.0",
-				"latest-version": "^3.0.0",
-				"semver-diff": "^2.0.0",
-				"xdg-basedir": "^3.0.0"
-			},
-			"dependencies": {
-				"ci-info": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-					"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
-				},
-				"is-ci": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-					"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
-					"requires": {
-						"ci-info": "^1.5.0"
-					}
-				}
-			}
-		},
 		"upper-case": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
@@ -27465,9 +25971,9 @@
 			"integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ=="
 		},
 		"v8-to-istanbul": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-5.0.1.tgz",
-			"integrity": "sha512-mbDNjuDajqYe3TXFk5qxcQy8L1msXNE37WTlLoqqpBfRsimbNcrlhQlDPntmECEcUvdC+AQ8CyMMf6EUx1r74Q==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-6.0.1.tgz",
+			"integrity": "sha512-PzM1WlqquhBvsV+Gco6WSFeg1AGdD53ccMRkFeyHRE/KRZaVacPOmQYP3EeVgDBtKD2BJ8kgynBQ5OtKiHCH+w==",
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.1",
 				"convert-source-map": "^1.6.0",
@@ -27611,6 +26117,27 @@
 				"chokidar": "^2.1.8"
 			},
 			"dependencies": {
+				"anymatch": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+					"optional": true,
+					"requires": {
+						"micromatch": "^3.1.4",
+						"normalize-path": "^2.1.1"
+					},
+					"dependencies": {
+						"normalize-path": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+							"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+							"optional": true,
+							"requires": {
+								"remove-trailing-separator": "^1.0.1"
+							}
+						}
+					}
+				},
 				"binary-extensions": {
 					"version": "1.13.1",
 					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
@@ -27635,6 +26162,15 @@
 						"path-is-absolute": "^1.0.0",
 						"readdirp": "^2.2.1",
 						"upath": "^1.1.1"
+					}
+				},
+				"fsevents": {
+					"version": "1.2.13",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+					"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+					"optional": true,
+					"requires": {
+						"nan": "^2.12.1"
 					}
 				},
 				"glob-parent": {
@@ -27671,12 +26207,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"optional": true
-				},
-				"normalize-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 					"optional": true
 				},
 				"readable-stream": {
@@ -27739,9 +26269,9 @@
 			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
 		},
 		"webpack": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.1.tgz",
-			"integrity": "sha512-4UOGAohv/VGUNQJstzEywwNxqX417FnjZgZJpJQegddzPmTvph37eBIRbRTfdySXzVtJXLJfbMN3mMYhM6GdmQ==",
+			"version": "4.44.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.2.tgz",
+			"integrity": "sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==",
 			"requires": {
 				"@webassemblyjs/ast": "1.9.0",
 				"@webassemblyjs/helper-module-context": "1.9.0",
@@ -27769,9 +26299,9 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.4.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-					"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
+					"version": "6.4.2",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+					"integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
 				},
 				"eslint-scope": {
 					"version": "4.0.3",
@@ -27782,10 +26312,34 @@
 						"estraverse": "^4.1.1"
 					}
 				},
+				"find-cache-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+					"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^2.0.0",
+						"pkg-dir": "^3.0.0"
+					}
+				},
+				"is-wsl": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+					"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+				},
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
 				},
 				"memory-fs": {
 					"version": "0.4.1",
@@ -27795,6 +26349,11 @@
 						"errno": "^0.1.3",
 						"readable-stream": "^2.0.1"
 					}
+				},
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
 				},
 				"readable-stream": {
 					"version": "2.3.7",
@@ -27820,6 +26379,19 @@
 						"ajv-keywords": "^3.1.0"
 					}
 				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				},
+				"serialize-javascript": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+					"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+					"requires": {
+						"randombytes": "^2.1.0"
+					}
+				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -27827,13 +26399,29 @@
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
+				},
+				"terser-webpack-plugin": {
+					"version": "1.4.5",
+					"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+					"integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
+					"requires": {
+						"cacache": "^12.0.2",
+						"find-cache-dir": "^2.1.0",
+						"is-wsl": "^1.1.0",
+						"schema-utils": "^1.0.0",
+						"serialize-javascript": "^4.0.0",
+						"source-map": "^0.6.1",
+						"terser": "^4.1.2",
+						"webpack-sources": "^1.4.0",
+						"worker-farm": "^1.7.0"
+					}
 				}
 			}
 		},
 		"webpack-bundle-analyzer": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.8.0.tgz",
-			"integrity": "sha512-PODQhAYVEourCcOuU+NiYI7WdR8QyELZGgPvB1y2tjbUpbmcQOt5Q7jEK+ttd5se0KSBKD9SXHCEozS++Wllmw==",
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.9.0.tgz",
+			"integrity": "sha512-Ob8amZfCm3rMB1ScjQVlbYYUEJyEjdEtQ92jqiFUYt5VkEeO2v5UMbv49P/gnmCZm3A6yaFQzCBvpZqN4MUsdA==",
 			"requires": {
 				"acorn": "^7.1.1",
 				"acorn-walk": "^7.1.1",
@@ -27844,17 +26432,12 @@
 				"express": "^4.16.3",
 				"filesize": "^3.6.1",
 				"gzip-size": "^5.0.0",
-				"lodash": "^4.17.15",
+				"lodash": "^4.17.19",
 				"mkdirp": "^0.5.1",
 				"opener": "^1.5.1",
 				"ws": "^6.0.0"
 			},
 			"dependencies": {
-				"acorn-walk": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-					"integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
-				},
 				"commander": {
 					"version": "2.20.3",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -27896,61 +26479,6 @@
 						"ini": "^1.3.5",
 						"kind-of": "^6.0.2",
 						"which": "^1.3.1"
-					}
-				}
-			}
-		},
-		"webpack-dev-middleware": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
-			"integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
-			"requires": {
-				"memory-fs": "^0.4.1",
-				"mime": "^2.4.4",
-				"mkdirp": "^0.5.1",
-				"range-parser": "^1.2.1",
-				"webpack-log": "^2.0.0"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				},
-				"memory-fs": {
-					"version": "0.4.1",
-					"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
-					"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-					"requires": {
-						"errno": "^0.1.3",
-						"readable-stream": "^2.0.1"
-					}
-				},
-				"mime": {
-					"version": "2.4.6",
-					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-					"integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
-				},
-				"readable-stream": {
-					"version": "2.3.7",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"requires": {
-						"safe-buffer": "~5.1.0"
 					}
 				}
 			}
@@ -28000,6 +26528,25 @@
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
+				"anymatch": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+					"requires": {
+						"micromatch": "^3.1.4",
+						"normalize-path": "^2.1.1"
+					},
+					"dependencies": {
+						"normalize-path": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+							"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+							"requires": {
+								"remove-trailing-separator": "^1.0.1"
+							}
+						}
+					}
+				},
 				"binary-extensions": {
 					"version": "1.13.1",
 					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
@@ -28022,6 +26569,15 @@
 						"path-is-absolute": "^1.0.0",
 						"readdirp": "^2.2.1",
 						"upath": "^1.1.1"
+					}
+				},
+				"fsevents": {
+					"version": "1.2.13",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+					"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+					"optional": true,
+					"requires": {
+						"nan": "^2.12.1"
 					}
 				},
 				"glob-parent": {
@@ -28056,10 +26612,19 @@
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
-				"normalize-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+				"memory-fs": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+					"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+					"requires": {
+						"errno": "^0.1.3",
+						"readable-stream": "^2.0.1"
+					}
+				},
+				"mime": {
+					"version": "2.4.6",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+					"integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
 				},
 				"readable-stream": {
 					"version": "2.3.7",
@@ -28115,6 +26680,18 @@
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
+				},
+				"webpack-dev-middleware": {
+					"version": "3.7.2",
+					"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
+					"integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
+					"requires": {
+						"memory-fs": "^0.4.1",
+						"mime": "^2.4.4",
+						"mkdirp": "^0.5.1",
+						"range-parser": "^1.2.1",
+						"webpack-log": "^2.0.0"
+					}
 				}
 			}
 		},
@@ -28162,19 +26739,128 @@
 				"react-dom": "^0.14.0"
 			},
 			"dependencies": {
+				"acorn": {
+					"version": "5.7.4",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+					"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
+				},
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+				},
+				"commoner": {
+					"version": "0.10.8",
+					"resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
+					"integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
+					"requires": {
+						"commander": "^2.5.0",
+						"detective": "^4.3.1",
+						"glob": "^5.0.15",
+						"graceful-fs": "^4.1.2",
+						"iconv-lite": "^0.4.5",
+						"mkdirp": "^0.5.0",
+						"private": "^0.1.6",
+						"q": "^1.1.2",
+						"recast": "^0.11.17"
+					}
+				},
+				"detective": {
+					"version": "4.7.1",
+					"resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+					"integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
+					"requires": {
+						"acorn": "^5.2.1",
+						"defined": "^1.0.0"
+					}
+				},
+				"envify": {
+					"version": "3.4.1",
+					"resolved": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz",
+					"integrity": "sha1-1xIjKejfFoi6dxsSUBkXyc5cvOg=",
+					"requires": {
+						"jstransform": "^11.0.3",
+						"through": "~2.3.4"
+					}
+				},
+				"esprima-fb": {
+					"version": "15001.1.0-dev-harmony-fb",
+					"resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
+					"integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE="
+				},
+				"glob": {
+					"version": "5.0.15",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"requires": {
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "2 || 3",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"jstransform": {
+					"version": "11.0.3",
+					"resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
+					"integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
+					"requires": {
+						"base62": "^1.1.0",
+						"commoner": "^0.10.1",
+						"esprima-fb": "^15001.1.0-dev-harmony-fb",
+						"object-assign": "^2.0.0",
+						"source-map": "^0.4.2"
+					}
+				},
+				"object-assign": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+					"integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+				},
 				"react": {
-					"version": "0.14.9",
-					"resolved": "https://registry.npmjs.org/react/-/react-0.14.9.tgz",
-					"integrity": "sha1-kRCmSXxJ1EuhwO3TF67CnC4NkdE=",
+					"version": "0.14.10",
+					"resolved": "https://registry.npmjs.org/react/-/react-0.14.10.tgz",
+					"integrity": "sha512-yxMw5aorZG4qsLVBfjae4wGFvd5708DhcxaXLJ3IOTgr1TCs8k9+ZheGgLGr5OfwWMhSahNbGvvoEDzrxVWouA==",
 					"requires": {
 						"envify": "^3.0.0",
 						"fbjs": "^0.6.1"
 					}
 				},
 				"react-dom": {
-					"version": "0.14.9",
-					"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.9.tgz",
-					"integrity": "sha1-BQZKPc8PsYgKOyv8nVjFXY2fYpM="
+					"version": "0.14.10",
+					"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.10.tgz",
+					"integrity": "sha512-kDs8SWFb8Sry4NAplhpJbZEeAnTPir/m+s9s+lkdqA2a89BzmWGnEgGG/CfmhULjv1ogc4oHrjMfAvFNruT3jQ=="
+				},
+				"recast": {
+					"version": "0.11.23",
+					"resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+					"integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
+					"requires": {
+						"ast-types": "0.9.6",
+						"esprima": "~3.1.0",
+						"private": "~0.1.5",
+						"source-map": "~0.5.0"
+					},
+					"dependencies": {
+						"esprima": {
+							"version": "3.1.3",
+							"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+							"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						}
+					}
+				},
+				"source-map": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+					"requires": {
+						"amdefine": ">=0.0.4"
+					}
 				}
 			}
 		},
@@ -28254,11 +26940,52 @@
 			}
 		},
 		"widest-line": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-			"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+			"integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+			"dev": true,
 			"requires": {
-				"string-width": "^2.1.1"
+				"string-width": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				}
 			}
 		},
 		"window-size": {
@@ -28295,14 +27022,15 @@
 			}
 		},
 		"workerpool": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.0.tgz",
-			"integrity": "sha512-fU2OcNA/GVAJLLyKUoHkAgIhKb0JoCpSjLC/G2vYKxUjVmQwGbRVeoPJ1a8U4pnVofz4AQV5Y/NEw8oKqxEBtA=="
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.2.tgz",
+			"integrity": "sha512-DSNyvOpFKrNusaaUwk+ej6cBj1bmhLcBfj80elGk+ZIo5JSkq+unB1dLKEOcNfJDZgjGICfhQ0Q5TbP0PvF4+Q=="
 		},
 		"wrap-ansi": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -28312,14 +27040,15 @@
 				"ansi-regex": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -28327,6 +27056,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
 					"requires": {
 						"color-name": "~1.1.4"
 					}
@@ -28334,22 +27064,26 @@
 				"color-name": {
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
 				},
 				"emoji-regex": {
 					"version": "8.0.0",
 					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
 				},
 				"string-width": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
 					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"dev": true,
 					"requires": {
 						"emoji-regex": "^8.0.0",
 						"is-fullwidth-code-point": "^3.0.0",
@@ -28360,6 +27094,7 @@
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
 					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^5.0.0"
 					}
@@ -28571,66 +27306,30 @@
 			}
 		},
 		"yargs-unparser": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.1.tgz",
-			"integrity": "sha512-qZV14lK9MWsGCmcr7u5oXGH0dbGqZAIxTDrWXZDo5zUr6b6iUmelNKO6x6R1dQT24AH3LgRxJpr8meWy2unolA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
 			"requires": {
-				"camelcase": "^5.3.1",
-				"decamelize": "^1.2.0",
-				"flat": "^4.1.0",
-				"is-plain-obj": "^1.1.0",
-				"yargs": "^14.2.3"
+				"camelcase": "^6.0.0",
+				"decamelize": "^4.0.0",
+				"flat": "^5.0.2",
+				"is-plain-obj": "^2.1.0"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+				"camelcase": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.1.0.tgz",
+					"integrity": "sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ=="
 				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
+				"decamelize": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+					"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ=="
 				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				},
-				"yargs": {
-					"version": "14.2.3",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
-					"integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
-					"requires": {
-						"cliui": "^5.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^3.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^15.0.1"
-					}
-				},
-				"yargs-parser": {
-					"version": "15.0.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-					"integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
+				"is-plain-obj": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+					"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
 				}
 			}
 		},

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -73,6 +73,153 @@
 				}
 			}
 		},
+		"@babel/helper-create-class-features-plugin": {
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz",
+			"integrity": "sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==",
+			"requires": {
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-member-expression-to-functions": "^7.10.5",
+				"@babel/helper-optimise-call-expression": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.10.4",
+				"@babel/helper-split-export-declaration": "^7.10.4"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"requires": {
+						"@babel/highlight": "^7.10.4"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.11.6",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
+					"integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+					"requires": {
+						"@babel/types": "^7.11.5",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+					"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+					"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+					"requires": {
+						"@babel/types": "^7.11.0"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+					"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+					"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.10.4",
+						"@babel/helper-optimise-call-expression": "^7.10.4",
+						"@babel/traverse": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+					"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+					"requires": {
+						"@babel/types": "^7.11.0"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+				},
+				"@babel/highlight": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.11.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+					"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q=="
+				},
+				"@babel/template": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+					"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/parser": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.11.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
+					"integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/generator": "^7.11.5",
+						"@babel/helper-function-name": "^7.10.4",
+						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/parser": "^7.11.5",
+						"@babel/types": "^7.11.5",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@babel/types": {
+					"version": "7.11.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+					"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				}
+			}
+		},
 		"@babel/helper-function-name": {
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
@@ -193,158 +340,12 @@
 			"integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q=="
 		},
 		"@babel/plugin-proposal-class-properties": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.1.tgz",
-			"integrity": "sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz",
+			"integrity": "sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==",
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.12.1",
+				"@babel/helper-create-class-features-plugin": "^7.10.4",
 				"@babel/helper-plugin-utils": "^7.10.4"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-					"requires": {
-						"@babel/highlight": "^7.10.4"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
-					"integrity": "sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==",
-					"requires": {
-						"@babel/types": "^7.12.1",
-						"jsesc": "^2.5.1",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/helper-create-class-features-plugin": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz",
-					"integrity": "sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==",
-					"requires": {
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/helper-member-expression-to-functions": "^7.12.1",
-						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/helper-replace-supers": "^7.12.1",
-						"@babel/helper-split-export-declaration": "^7.10.4"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-					"requires": {
-						"@babel/helper-get-function-arity": "^7.10.4",
-						"@babel/template": "^7.10.4",
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-					"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-					"requires": {
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-member-expression-to-functions": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
-					"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
-					"requires": {
-						"@babel/types": "^7.12.1"
-					}
-				},
-				"@babel/helper-optimise-call-expression": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-					"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
-					"requires": {
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-replace-supers": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.1.tgz",
-					"integrity": "sha512-zJjTvtNJnCFsCXVi5rUInstLd/EIVNmIKA1Q9ynESmMBWPWd+7sdR+G4/wdu+Mppfep0XLyG2m7EBPvjCeFyrw==",
-					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.12.1",
-						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/traverse": "^7.12.1",
-						"@babel/types": "^7.12.1"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-					"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
-					"requires": {
-						"@babel/types": "^7.11.0"
-					}
-				},
-				"@babel/helper-validator-identifier": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-				},
-				"@babel/highlight": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
-						"chalk": "^2.0.0",
-						"js-tokens": "^4.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.12.3",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.3.tgz",
-					"integrity": "sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw=="
-				},
-				"@babel/template": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-					"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
-					"requires": {
-						"@babel/code-frame": "^7.10.4",
-						"@babel/parser": "^7.10.4",
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.1.tgz",
-					"integrity": "sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==",
-					"requires": {
-						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.12.1",
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.12.1",
-						"@babel/types": "^7.12.1",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@babel/types": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
-					"integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
-						"lodash": "^4.17.19",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				}
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
@@ -364,9 +365,9 @@
 			}
 		},
 		"@babel/plugin-syntax-class-properties": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.1.tgz",
-			"integrity": "sha512-U40A76x5gTwmESz+qiqssqmeEsKvcSyvtgktrm0uzcARAmM9I1jR221f6Oq+GmHrcD+LvZDag1UTOTe2fL3TeA==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
+			"integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
@@ -443,14 +444,29 @@
 			"requires": {
 				"core-js": "^2.6.5",
 				"regenerator-runtime": "^0.13.4"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.13.7",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
-			"integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.13.7",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+					"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+				}
 			}
 		},
 		"@babel/template": {
@@ -531,9 +547,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "6.12.6",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+					"version": "6.12.5",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+					"integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
 						"fast-json-stable-stringify": "^2.0.0",
@@ -694,61 +710,63 @@
 			}
 		},
 		"@fluentui/date-time-utilities": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-7.9.0.tgz",
-			"integrity": "sha512-D8p5WWeonqRO1EgIvo7WSlX1rcm87r2VQd62zTJPQImx8rpwc77CRI+iAvfxyVHRZMdt4Qk6Jq99dUaudPWaZw==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-7.8.0.tgz",
+			"integrity": "sha512-qzlTp3t+PghebJsLK9JwZr91qBRZ/fOml8TQCIjdtsEn4mH6/ciCwir7Fj8iOEkwwTC0iKsEr1jfsITtJKWSmA==",
 			"requires": {
-				"@uifabric/set-version": "^7.0.23",
-				"tslib": "^1.10.0"
-			}
-		},
-		"@fluentui/dom-utilities": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-1.1.1.tgz",
-			"integrity": "sha512-w40gi8fzCpwa7U8cONiuu8rszPStkVOL/weDf5pCbYEb1gdaV7MDPSNkgM6IV0Kz+k017noDgK9Fv4ru1Dwz1g==",
-			"requires": {
-				"@uifabric/set-version": "^7.0.23",
+				"@uifabric/set-version": "^7.0.22",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@fluentui/keyboard-key": {
-			"version": "0.2.12",
-			"resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.2.12.tgz",
-			"integrity": "sha512-t3yIbbPKJubb22vQ/FIWwS9vFAzaPYzFxKWPHVWLtxs/P+5yL+LD3B16DRtYreWAdl9CZvEbos58ChLZ0KHwSQ==",
+			"version": "0.2.11",
+			"resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.2.11.tgz",
+			"integrity": "sha512-4iG5vNlRD3PrLaMfDTimHNOP1x6V3Dad0fXOwtvBBMsfdySPE9zlY+G+0aqCFcgjymOriFOk0ANZVBpK7XrnTg==",
 			"requires": {
 				"tslib": "^1.10.0"
 			}
 		},
 		"@fluentui/react-focus": {
-			"version": "7.16.13",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.16.13.tgz",
-			"integrity": "sha512-MWyI64GSEZigYe75aCy8VGGIr/tWwk+H8oqPxamoVOHef4kCqYm/70mhrDpBP1oAhJVmdY/Lia6dtkIz3J9wgw==",
+			"version": "7.16.0",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.16.0.tgz",
+			"integrity": "sha512-TwB4Av7ID70ejisDIGkCZGKOxlquSazr6W+9Jv1JQAvsBLuj5XOspFJH4/Igjniw1LeO9QmAvFZeh/XRShiObw==",
 			"requires": {
-				"@fluentui/keyboard-key": "^0.2.12",
-				"@uifabric/merge-styles": "^7.19.1",
-				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/styling": "^7.16.13",
-				"@uifabric/utilities": "^7.32.4",
+				"@fluentui/keyboard-key": "^0.2.11",
+				"@uifabric/merge-styles": "^7.18.0",
+				"@uifabric/set-version": "^7.0.22",
+				"@uifabric/styling": "^7.16.0",
+				"@uifabric/utilities": "^7.31.0",
+				"tslib": "^1.10.0"
+			}
+		},
+		"@fluentui/react-icons": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-0.3.0.tgz",
+			"integrity": "sha512-QDrIhLUpkxM5q5bFE4pkweJJsfaNswdfDoc+X6cmr22Dii+anDFTpOcePEJiTtILxdlEmH0968OcZ4BGZF/joQ==",
+			"requires": {
+				"@microsoft/load-themed-styles": "^1.10.26",
+				"@uifabric/set-version": "^7.0.22",
+				"@uifabric/utilities": "^7.31.0",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@fluentui/react-window-provider": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-0.3.3.tgz",
-			"integrity": "sha512-MVPf2hqOQ17LAZsuvGcr3oOHksAskUm+fCYdXFhbVoAgsCDVTIuH6i8XgHFd6YjBtzjZmI4+k/3NTQfDqBX8EQ==",
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-0.3.0.tgz",
+			"integrity": "sha512-zHeH1PAmoFB3OkgU8f51E3oGHrL/CjuvdPBlb1SGpByUGNihAgH/CwvJohV9z0yPDkq+chfNUmxWA/oDVpbh6Q==",
 			"requires": {
-				"@uifabric/set-version": "^7.0.23",
+				"@uifabric/set-version": "^7.0.22",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@fluentui/theme": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-1.5.1.tgz",
-			"integrity": "sha512-w5986/CN3hWuH44WmlQNxtndBx0khnb1xjISb/4bktRpehYxIlDBmQYRUOUYXr6zwdK7JXJaJPGjOJzSh2DCDg==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-0.2.0.tgz",
+			"integrity": "sha512-L5OwqymTdxTVwBa3ifkQLF1A3YU6WMkMTk6PFIMfOonjt8LJ3yMMqZgz+KQR3sF/tzgy4wzW4oBmrxtTfJS2EQ==",
 			"requires": {
-				"@uifabric/merge-styles": "^7.19.1",
-				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/utilities": "^7.32.4",
+				"@uifabric/merge-styles": "^7.18.0",
+				"@uifabric/set-version": "^7.0.22",
+				"@uifabric/utilities": "^7.31.0",
 				"tslib": "^1.10.0"
 			}
 		},
@@ -870,9 +888,9 @@
 			"integrity": "sha512-H+wEaxuIHODVNqyY8XSMY6ww7ndrRfht9CXKUAUzdQjUN1Oi++YonKcD3CXWZod6afxZ6abDmltIO9wLrjOJzg=="
 		},
 		"@fluidframework/common-utils": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
-			"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
+			"version": "0.24.0-5441",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0-5441.tgz",
+			"integrity": "sha512-8/Tsgr6ahR1k72Ac6h3aoTzNuXfS4ojbXIuJs7Gfl/uT8zgSzD537xKHgOZ2GtLCJrlVAei2n5Yaf74uOpmJRg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@types/events": "^3.0.0",
@@ -1310,16 +1328,6 @@
 						"tsutils": "^3.17.1"
 					}
 				},
-				"@typescript-eslint/experimental-utils": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.17.0.tgz",
-					"integrity": "sha512-2bNf+mZ/3mj5/3CP56v+ldRK3vFy9jOvmCPs/Gr2DeSJh+asPZrhFniv4QmQsHWQFPJFWhFHgkGgJeRmK4m8iQ==",
-					"requires": {
-						"@types/json-schema": "^7.0.3",
-						"@typescript-eslint/typescript-estree": "2.17.0",
-						"eslint-scope": "^5.0.0"
-					}
-				},
 				"@typescript-eslint/parser": {
 					"version": "2.17.0",
 					"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.17.0.tgz",
@@ -1329,20 +1337,6 @@
 						"@typescript-eslint/experimental-utils": "2.17.0",
 						"@typescript-eslint/typescript-estree": "2.17.0",
 						"eslint-visitor-keys": "^1.1.0"
-					}
-				},
-				"@typescript-eslint/typescript-estree": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.17.0.tgz",
-					"integrity": "sha512-g0eVRULGnEEUakxRfJO0s0Hr1LLQqsI6OrkiCLpdHtdJJek+wyd8mb00vedqAoWldeDcOcP8plqw8/jx9Gr3Lw==",
-					"requires": {
-						"debug": "^4.1.1",
-						"eslint-visitor-keys": "^1.1.0",
-						"glob": "^7.1.6",
-						"is-glob": "^4.0.1",
-						"lodash": "^4.17.15",
-						"semver": "^6.3.0",
-						"tsutils": "^3.17.1"
 					}
 				},
 				"ansi-escapes": {
@@ -1366,10 +1360,11 @@
 					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 				},
 				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
 					"requires": {
+						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -1656,30 +1651,12 @@
 						"escape-string-regexp": "^1.0.5"
 					}
 				},
-				"file-entry-cache": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-					"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
-					"requires": {
-						"flat-cache": "^2.0.1"
-					}
-				},
 				"find-up": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"requires": {
 						"locate-path": "^2.0.0"
-					}
-				},
-				"flat-cache": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-					"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
-					"requires": {
-						"flatted": "^2.0.0",
-						"rimraf": "2.6.3",
-						"write": "1.0.3"
 					}
 				},
 				"globals": {
@@ -1858,11 +1835,10 @@
 					"integrity": "sha512-kUUXjX4AnqnR8KRTCrayAo9PzYMRKmVoGgaz2tBuz0MF3g1ZbGebmtW0yFHfFK9CmBjQKeYIgoL22pFLBJY7sw=="
 				},
 				"resolve": {
-					"version": "1.18.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
-					"integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
+					"version": "1.17.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
 					"requires": {
-						"is-core-module": "^2.0.0",
 						"path-parse": "^1.0.6"
 					}
 				},
@@ -1873,14 +1849,6 @@
 					"requires": {
 						"onetime": "^5.1.0",
 						"signal-exit": "^3.0.2"
-					}
-				},
-				"rimraf": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-					"requires": {
-						"glob": "^7.1.3"
 					}
 				},
 				"rxjs": {
@@ -1955,9 +1923,9 @@
 			}
 		},
 		"@fluidframework/gitresources": {
-			"version": "0.1014.0-7764",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1014.0-7764.tgz",
-			"integrity": "sha512-NVv4Os7PAp54whyyRHdjRbWX3wsxPWiWNYwaURYKjZeOkfq2cA+TOe1Ng1odWbPHBCpYBPN/jG3b7yn6XKb64A=="
+			"version": "0.1014.0-6368",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1014.0-6368.tgz",
+			"integrity": "sha512-StiRoivc79/obv8LA1LPcdzYWevzL3xbBftEjWV50w9hA86K1Mr6WSrBc0Hf7x+F6UuUer75O73Kpyo5MK9wwQ=="
 		},
 		"@fluidframework/local-driver": {
 			"version": "0.26.9",
@@ -2019,6 +1987,28 @@
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
 				},
+				"@fluidframework/server-lambdas": {
+					"version": "0.1012.2",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1012.2.tgz",
+					"integrity": "sha512-r/FPMZfami9yD/ZDo0BRvQwkcVlD2PnOgYeN5YP/9QeWyh3QUcZD688M4IxzzGMfDY6nAN8wVjI7Wn2ajqzLPQ==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.23.0",
+						"@fluidframework/gitresources": "^0.1012.2",
+						"@fluidframework/protocol-base": "^0.1012.2",
+						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/server-services-client": "^0.1012.2",
+						"@fluidframework/server-services-core": "^0.1012.2",
+						"@types/semver": "^6.0.1",
+						"async": "^2.6.1",
+						"double-ended-queue": "^2.1.0-0",
+						"json-stringify-safe": "^5.0.1",
+						"jsonwebtoken": "^8.4.0",
+						"lodash": "^4.17.19",
+						"nconf": "^0.10.0",
+						"semver": "^6.3.0",
+						"uuid": "^3.3.2"
+					}
+				},
 				"@fluidframework/server-local-server": {
 					"version": "0.1012.2",
 					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1012.2.tgz",
@@ -2032,6 +2022,30 @@
 						"@fluidframework/server-services-core": "^0.1012.2",
 						"@fluidframework/server-test-utils": "^0.1012.2",
 						"uuid": "^3.3.2"
+					}
+				},
+				"@fluidframework/server-memory-orderer": {
+					"version": "0.1012.2",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1012.2.tgz",
+					"integrity": "sha512-6VDnXD0fj93SI9D3VIdxlKiNfnFjUsjZsNlDBlqyrGbTj7VYMIrsm9FbxjHuWxG/1pWxqdy4CQvbG3r5s0Me/g==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.23.0",
+						"@fluidframework/protocol-base": "^0.1012.2",
+						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/server-lambdas": "^0.1012.2",
+						"@fluidframework/server-services-client": "^0.1012.2",
+						"@fluidframework/server-services-core": "^0.1012.2",
+						"@types/debug": "^4.1.5",
+						"@types/double-ended-queue": "^2.1.0",
+						"@types/lodash": "^4.14.118",
+						"@types/node": "^10.17.24",
+						"@types/ws": "^6.0.1",
+						"debug": "^4.1.1",
+						"double-ended-queue": "^2.1.0-0",
+						"lodash": "^4.17.19",
+						"moniker": "^0.1.2",
+						"uuid": "^3.3.2",
+						"ws": "^6.1.2"
 					}
 				},
 				"@fluidframework/server-services-client": {
@@ -2082,6 +2096,11 @@
 						"string-hash": "^1.1.3",
 						"uuid": "^3.3.2"
 					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -2182,21 +2201,21 @@
 			}
 		},
 		"@fluidframework/protocol-base": {
-			"version": "0.1014.0-7764",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1014.0-7764.tgz",
-			"integrity": "sha512-r9QvsMD6hcHFFVJvHXRHtI+mVYdgs5Ij7NIlbu//q+3TBPVLcmOOTUzcx0gMIJY3iEzLa1dU2/zVIXyq2HSWXQ==",
+			"version": "0.1014.0-6368",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1014.0-6368.tgz",
+			"integrity": "sha512-FLse61s5FWGhM6KwOoRZli02+8AT7h6I+7dEF78TMh4RaklNbqSxvvBa7YjPGhPanw7ZMVQaSzaUVy7S5cch0g==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0-0",
-				"@fluidframework/gitresources": "^0.1014.0-7764",
-				"@fluidframework/protocol-definitions": "^0.1014.0-7764",
+				"@fluidframework/gitresources": "^0.1014.0-6368",
+				"@fluidframework/protocol-definitions": "^0.1014.0-6368",
 				"assert": "^2.0.0",
 				"lodash": "^4.17.19"
 			}
 		},
 		"@fluidframework/protocol-definitions": {
-			"version": "0.1014.0-7764",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1014.0-7764.tgz",
-			"integrity": "sha512-fVSKni8hbwd41pQ2gXLA7PPfBZXzsgP39D/dV8YLH7+Resx2Xyx3aE8m0e+O5bOCVya07Pyfh9QFe5hjZv6Yyw==",
+			"version": "0.1014.0-6368",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1014.0-6368.tgz",
+			"integrity": "sha512-tPqj48lAribjI89YDLHPDd5auRU2qUFbSPjX65lK649bvISzJl7pgXYZsSd9Y5lYsT0LJDaXbJApAYCSnJjQfQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1"
 			}
@@ -2410,16 +2429,16 @@
 			}
 		},
 		"@fluidframework/server-lambdas": {
-			"version": "0.1012.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1012.2.tgz",
-			"integrity": "sha512-r/FPMZfami9yD/ZDo0BRvQwkcVlD2PnOgYeN5YP/9QeWyh3QUcZD688M4IxzzGMfDY6nAN8wVjI7Wn2ajqzLPQ==",
+			"version": "0.1014.0-6368",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1014.0-6368.tgz",
+			"integrity": "sha512-iD0wEhZonTcWAByA2TkGXtWU3I6hyiFNXn8x/T2Ht6u+mMNex2SdLkJNYALcEamib4622f0jv35nyS0SL0ZwIw==",
 			"requires": {
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/gitresources": "^0.1012.2",
-				"@fluidframework/protocol-base": "^0.1012.2",
-				"@fluidframework/protocol-definitions": "^0.1012.2",
-				"@fluidframework/server-services-client": "^0.1012.2",
-				"@fluidframework/server-services-core": "^0.1012.2",
+				"@fluidframework/common-utils": "^0.24.0-0",
+				"@fluidframework/gitresources": "^0.1014.0-6368",
+				"@fluidframework/protocol-base": "^0.1014.0-6368",
+				"@fluidframework/protocol-definitions": "^0.1014.0-6368",
+				"@fluidframework/server-services-client": "^0.1014.0-6368",
+				"@fluidframework/server-services-core": "^0.1014.0-6368",
 				"@types/semver": "^6.0.1",
 				"async": "^2.6.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -2431,78 +2450,6 @@
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
-				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@types/events": "^3.0.0",
-						"assert": "^2.0.0",
-						"base64-js": "^1.3.1",
-						"events": "^3.1.0",
-						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
-						"sha.js": "^2.4.11"
-					}
-				},
-				"@fluidframework/gitresources": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.2.tgz",
-					"integrity": "sha512-ysb9skxUKtIUSNUFqqcTQBMpCDrPcezc4pvDLaBdxcK4BuP3Ak2gZGmIVeXfbsx40+isBQ8xGbJISIZlgtGlZw=="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.2.tgz",
-					"integrity": "sha512-K8YRUIvrlO+54hyzLgLhZ9tQNeyPd9/yX0h/6XEE4m0oazCcCOFihAFzBIQXxypv1zNH2fbKlsQ7xaHHDbZ6rA==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
-					}
-				},
-				"@fluidframework/server-services-client": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1012.2.tgz",
-					"integrity": "sha512-bmGRVX8V1s/bMapdUHnr8mhQq5NE1++AS3bGSVfzd7GQQPlTz8d26cJA5+4jPe/mJvBMb6MEXstENi3VZOcTNQ==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-base": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@types/node": "^10.17.24",
-						"axios": "^0.18.0",
-						"debug": "^4.1.1",
-						"jsonwebtoken": "^8.4.0",
-						"sillyname": "0.1.0",
-						"uuid": "^3.3.2"
-					}
-				},
-				"@fluidframework/server-services-core": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1012.2.tgz",
-					"integrity": "sha512-E1Q/sDLgtQ7fIcaaXiZWWKOa3IRuZKE24fC0QmnmxUYDPUP1yT7kacr0r5wQTibn+eWhAyg/rRRfdRPEe9+YQg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
-						"@types/nconf": "^0.0.37",
-						"@types/node": "^10.17.24",
-						"debug": "^4.1.1",
-						"nconf": "^0.10.0"
-					}
-				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -2511,85 +2458,31 @@
 			}
 		},
 		"@fluidframework/server-local-server": {
-			"version": "0.1014.0-7764",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1014.0-7764.tgz",
-			"integrity": "sha512-zrFql2IKOExLbzNErMaj59BkI8/j80bQwYINBU9oFxJRu05c7cmdtSQKaupBtc2yJb6ZoCKgYJF+WDuG244L5A==",
+			"version": "0.1014.0-6368",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1014.0-6368.tgz",
+			"integrity": "sha512-qmLFTM0g0LPk34ThmbU+KC5PK6CyazDWN9Nwg4+FLjzDUu1pVaCFuqb9bciY/mL4YJzua+pH6p1ZROvkNJRUDQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0-0",
-				"@fluidframework/protocol-definitions": "^0.1014.0-7764",
-				"@fluidframework/server-lambdas": "^0.1014.0-7764",
-				"@fluidframework/server-memory-orderer": "^0.1014.0-7764",
-				"@fluidframework/server-services-client": "^0.1014.0-7764",
-				"@fluidframework/server-services-core": "^0.1014.0-7764",
-				"@fluidframework/server-test-utils": "^0.1014.0-7764",
-				"jsrsasign": "^10.0.2",
+				"@fluidframework/protocol-definitions": "^0.1014.0-6368",
+				"@fluidframework/server-lambdas": "^0.1014.0-6368",
+				"@fluidframework/server-memory-orderer": "^0.1014.0-6368",
+				"@fluidframework/server-services-client": "^0.1014.0-6368",
+				"@fluidframework/server-services-core": "^0.1014.0-6368",
+				"@fluidframework/server-test-utils": "^0.1014.0-6368",
 				"uuid": "^3.3.2"
-			},
-			"dependencies": {
-				"@fluidframework/server-lambdas": {
-					"version": "0.1014.0-7764",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1014.0-7764.tgz",
-					"integrity": "sha512-MABJOSjenPwhH6ZHuoIJKXaiQnzyOFxGwCOBBsbmauvzgDBEy2lVjJSUXi6yxmqHfLMZsbY+ZOL27CrMlr0LIQ==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.24.0-0",
-						"@fluidframework/gitresources": "^0.1014.0-7764",
-						"@fluidframework/protocol-base": "^0.1014.0-7764",
-						"@fluidframework/protocol-definitions": "^0.1014.0-7764",
-						"@fluidframework/server-services-client": "^0.1014.0-7764",
-						"@fluidframework/server-services-core": "^0.1014.0-7764",
-						"@types/semver": "^6.0.1",
-						"async": "^2.6.1",
-						"double-ended-queue": "^2.1.0-0",
-						"json-stringify-safe": "^5.0.1",
-						"jsonwebtoken": "^8.4.0",
-						"lodash": "^4.17.19",
-						"nconf": "^0.10.0",
-						"semver": "^6.3.0",
-						"uuid": "^3.3.2"
-					}
-				},
-				"@fluidframework/server-memory-orderer": {
-					"version": "0.1014.0-7764",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1014.0-7764.tgz",
-					"integrity": "sha512-MO/ab/UFBFg9jFyPspNPLbWBxe2OgigwtKK++A5WMtzMvq3KhIAKtGluiZWE74Vg54luawVmlr0nE5PVtb9mCw==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.24.0-0",
-						"@fluidframework/protocol-base": "^0.1014.0-7764",
-						"@fluidframework/protocol-definitions": "^0.1014.0-7764",
-						"@fluidframework/server-lambdas": "^0.1014.0-7764",
-						"@fluidframework/server-services-client": "^0.1014.0-7764",
-						"@fluidframework/server-services-core": "^0.1014.0-7764",
-						"@types/debug": "^4.1.5",
-						"@types/double-ended-queue": "^2.1.0",
-						"@types/lodash": "^4.14.118",
-						"@types/node": "^10.17.24",
-						"@types/ws": "^6.0.1",
-						"debug": "^4.1.1",
-						"double-ended-queue": "^2.1.0-0",
-						"lodash": "^4.17.19",
-						"moniker": "^0.1.2",
-						"uuid": "^3.3.2",
-						"ws": "^6.1.2"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				}
 			}
 		},
 		"@fluidframework/server-memory-orderer": {
-			"version": "0.1012.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1012.2.tgz",
-			"integrity": "sha512-6VDnXD0fj93SI9D3VIdxlKiNfnFjUsjZsNlDBlqyrGbTj7VYMIrsm9FbxjHuWxG/1pWxqdy4CQvbG3r5s0Me/g==",
+			"version": "0.1014.0-6368",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1014.0-6368.tgz",
+			"integrity": "sha512-7JIXLRC2hhASZLepfeW4je3G89wvizMlXBl8rQiiBs+I0MOGJiV9lLCUv+gzwz8mkNVR6x84tYuVpfU2/zaTsQ==",
 			"requires": {
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/protocol-base": "^0.1012.2",
-				"@fluidframework/protocol-definitions": "^0.1012.2",
-				"@fluidframework/server-lambdas": "^0.1012.2",
-				"@fluidframework/server-services-client": "^0.1012.2",
-				"@fluidframework/server-services-core": "^0.1012.2",
+				"@fluidframework/common-utils": "^0.24.0-0",
+				"@fluidframework/protocol-base": "^0.1014.0-6368",
+				"@fluidframework/protocol-definitions": "^0.1014.0-6368",
+				"@fluidframework/server-lambdas": "^0.1014.0-6368",
+				"@fluidframework/server-services-client": "^0.1014.0-6368",
+				"@fluidframework/server-services-core": "^0.1014.0-6368",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/lodash": "^4.14.118",
@@ -2601,115 +2494,34 @@
 				"moniker": "^0.1.2",
 				"uuid": "^3.3.2",
 				"ws": "^6.1.2"
-			},
-			"dependencies": {
-				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@types/events": "^3.0.0",
-						"assert": "^2.0.0",
-						"base64-js": "^1.3.1",
-						"events": "^3.1.0",
-						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
-						"sha.js": "^2.4.11"
-					}
-				},
-				"@fluidframework/gitresources": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.2.tgz",
-					"integrity": "sha512-ysb9skxUKtIUSNUFqqcTQBMpCDrPcezc4pvDLaBdxcK4BuP3Ak2gZGmIVeXfbsx40+isBQ8xGbJISIZlgtGlZw=="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.2.tgz",
-					"integrity": "sha512-K8YRUIvrlO+54hyzLgLhZ9tQNeyPd9/yX0h/6XEE4m0oazCcCOFihAFzBIQXxypv1zNH2fbKlsQ7xaHHDbZ6rA==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
-					}
-				},
-				"@fluidframework/server-services-client": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1012.2.tgz",
-					"integrity": "sha512-bmGRVX8V1s/bMapdUHnr8mhQq5NE1++AS3bGSVfzd7GQQPlTz8d26cJA5+4jPe/mJvBMb6MEXstENi3VZOcTNQ==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-base": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@types/node": "^10.17.24",
-						"axios": "^0.18.0",
-						"debug": "^4.1.1",
-						"jsonwebtoken": "^8.4.0",
-						"sillyname": "0.1.0",
-						"uuid": "^3.3.2"
-					}
-				},
-				"@fluidframework/server-services-core": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1012.2.tgz",
-					"integrity": "sha512-E1Q/sDLgtQ7fIcaaXiZWWKOa3IRuZKE24fC0QmnmxUYDPUP1yT7kacr0r5wQTibn+eWhAyg/rRRfdRPEe9+YQg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
-						"@types/nconf": "^0.0.37",
-						"@types/node": "^10.17.24",
-						"debug": "^4.1.1",
-						"nconf": "^0.10.0"
-					}
-				}
 			}
 		},
 		"@fluidframework/server-services-client": {
-			"version": "0.1014.0-7764",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1014.0-7764.tgz",
-			"integrity": "sha512-nhn0kPgoAktm2skjar2upolrttFwCz6j/OhWWVh0b2KUmF/ZW9oUv/kLahVV853xqL1TJY3wMEnejfY7fsZXrA==",
+			"version": "0.1014.0-6368",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1014.0-6368.tgz",
+			"integrity": "sha512-Pt1izj56bkx+Gh4Gh7ugCpdWWH+1zTndHzjd+vXCdmWj0MGwClAnMn4X0KFXc2ZnP2RhaZObPnDni4tiU4f8Ig==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0-0",
-				"@fluidframework/gitresources": "^0.1014.0-7764",
-				"@fluidframework/protocol-base": "^0.1014.0-7764",
-				"@fluidframework/protocol-definitions": "^0.1014.0-7764",
+				"@fluidframework/gitresources": "^0.1014.0-6368",
+				"@fluidframework/protocol-base": "^0.1014.0-6368",
+				"@fluidframework/protocol-definitions": "^0.1014.0-6368",
 				"@types/node": "^10.17.24",
 				"axios": "^0.18.0",
 				"debug": "^4.1.1",
-				"jwt-decode": "^3.0.0",
+				"jsonwebtoken": "^8.4.0",
 				"sillyname": "0.1.0",
 				"uuid": "^3.3.2"
-			},
-			"dependencies": {
-				"jwt-decode": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.0.0.tgz",
-					"integrity": "sha512-RBQv2MTm3FNKQkdzhEyQwh5MbdNgMa+FyIJIK5RMWEn6hRgRHr7j55cRxGhRe6vGJDElyi6f6u/yfkP7AoXddA=="
-				}
 			}
 		},
 		"@fluidframework/server-services-core": {
-			"version": "0.1014.0-7764",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1014.0-7764.tgz",
-			"integrity": "sha512-D1Hpi4Ake1MINSbBNfKcTfXOb8fHpnOBDrkOephE04mWh7f/qtBc/wyYEyA/Y2hVe+0GuACMGw37WilqscdA6g==",
+			"version": "0.1014.0-6368",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1014.0-6368.tgz",
+			"integrity": "sha512-AMzdqwNqTHQWF0Z8RBM8DiUcSofBmzdO4AGfnOeAp510D4g4NuCxRx9LtHWvrqzm9wtyjXtPfrlV3XvTPu/WBg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0-0",
-				"@fluidframework/gitresources": "^0.1014.0-7764",
-				"@fluidframework/protocol-definitions": "^0.1014.0-7764",
-				"@fluidframework/server-services-client": "^0.1014.0-7764",
+				"@fluidframework/gitresources": "^0.1014.0-6368",
+				"@fluidframework/protocol-definitions": "^0.1014.0-6368",
+				"@fluidframework/server-services-client": "^0.1014.0-6368",
 				"@types/nconf": "^0.0.37",
 				"@types/node": "^10.17.24",
 				"debug": "^4.1.1",
@@ -2717,16 +2529,16 @@
 			}
 		},
 		"@fluidframework/server-test-utils": {
-			"version": "0.1014.0-7764",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1014.0-7764.tgz",
-			"integrity": "sha512-9vGNjW+2iIMYEUoSRbzsM1zs6D67WkPgZLbEFtG9cFY7xUVkCdqImS9C8ltZWbP9/jwmNvb5qbhjEau8GoBUhA==",
+			"version": "0.1014.0-6368",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1014.0-6368.tgz",
+			"integrity": "sha512-uzEBZBYFZp37MO8LMfC7qh8gQ5wDirA7zyk5MpQpSTiNSmlng9pZHiKZuAYsDFFgRxRx59agrHteKUTrZp+btg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0-0",
-				"@fluidframework/gitresources": "^0.1014.0-7764",
-				"@fluidframework/protocol-base": "^0.1014.0-7764",
-				"@fluidframework/protocol-definitions": "^0.1014.0-7764",
-				"@fluidframework/server-services-client": "^0.1014.0-7764",
-				"@fluidframework/server-services-core": "^0.1014.0-7764",
+				"@fluidframework/gitresources": "^0.1014.0-6368",
+				"@fluidframework/protocol-base": "^0.1014.0-6368",
+				"@fluidframework/protocol-definitions": "^0.1014.0-6368",
+				"@fluidframework/server-services-client": "^0.1014.0-6368",
+				"@fluidframework/server-services-core": "^0.1014.0-6368",
 				"debug": "^4.1.1",
 				"lodash": "^4.17.19",
 				"string-hash": "^1.1.3",
@@ -2899,23 +2711,52 @@
 			"integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw=="
 		},
 		"@jest/console": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-26.6.1.tgz",
-			"integrity": "sha512-cjqcXepwC5M+VeIhwT6Xpi/tT4AiNzlIx8SMJ9IihduHnsSrnWNvTBfKIpmqOOCNOPqtbBx6w2JqfoLOJguo8g==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-26.3.0.tgz",
+			"integrity": "sha512-/5Pn6sJev0nPUcAdpJHMVIsA8sKizL2ZkcKPE5+dJrCccks7tcM7c9wbgHudBJbxXLoTbqsHkG1Dofoem4F09w==",
 			"requires": {
-				"@jest/types": "^26.6.1",
+				"@jest/types": "^26.3.0",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
-				"jest-message-util": "^26.6.1",
-				"jest-util": "^26.6.1",
+				"jest-message-util": "^26.3.0",
+				"jest-util": "^26.3.0",
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -2961,49 +2802,613 @@
 				}
 			}
 		},
-		"@jest/create-cache-key-function": {
-			"version": "26.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-26.5.0.tgz",
-			"integrity": "sha512-DJ+pEBUIqarrbv1W/C39f9YH0rJ4wsXZ/VC6JafJPlHW2HOucKceeaqTOQj9MEDQZjySxMLkOq5mfXZXNZcmWw=="
+		"@jest/core": {
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-26.4.2.tgz",
+			"integrity": "sha512-sDva7YkeNprxJfepOctzS8cAk9TOekldh+5FhVuXS40+94SHbiicRO1VV2tSoRtgIo+POs/Cdyf8p76vPTd6dg==",
+			"requires": {
+				"@jest/console": "^26.3.0",
+				"@jest/reporters": "^26.4.1",
+				"@jest/test-result": "^26.3.0",
+				"@jest/transform": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"@types/node": "*",
+				"ansi-escapes": "^4.2.1",
+				"chalk": "^4.0.0",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.2.4",
+				"jest-changed-files": "^26.3.0",
+				"jest-config": "^26.4.2",
+				"jest-haste-map": "^26.3.0",
+				"jest-message-util": "^26.3.0",
+				"jest-regex-util": "^26.0.0",
+				"jest-resolve": "^26.4.0",
+				"jest-resolve-dependencies": "^26.4.2",
+				"jest-runner": "^26.4.2",
+				"jest-runtime": "^26.4.2",
+				"jest-snapshot": "^26.4.2",
+				"jest-util": "^26.3.0",
+				"jest-validate": "^26.4.2",
+				"jest-watcher": "^26.3.0",
+				"micromatch": "^4.0.2",
+				"p-each-series": "^2.1.0",
+				"rimraf": "^3.0.0",
+				"slash": "^3.0.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-escapes": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+					"requires": {
+						"type-fest": "^0.11.0"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"camelcase": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w=="
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+				},
+				"jest-get-type": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
+				},
+				"jest-validate": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.4.2.tgz",
+					"integrity": "sha512-blft+xDX7XXghfhY0mrsBCYhX365n8K5wNDC4XAcNKqqjEzsRUSXP44m6PL0QJEW2crxQFLLztVnJ4j7oPlQrQ==",
+					"requires": {
+						"@jest/types": "^26.3.0",
+						"camelcase": "^6.0.0",
+						"chalk": "^4.0.0",
+						"jest-get-type": "^26.3.0",
+						"leven": "^3.1.0",
+						"pretty-format": "^26.4.2"
+					}
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"pretty-format": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"requires": {
+						"@jest/types": "^26.3.0",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^4.0.0",
+						"react-is": "^16.12.0"
+					}
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				},
+				"type-fest": {
+					"version": "0.11.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+					"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
+				}
+			}
 		},
 		"@jest/environment": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.1.tgz",
-			"integrity": "sha512-GNvHwkOFJtNgSwdzH9flUPzF9AYAZhUg124CBoQcwcZCM9s5TLz8Y3fMtiaWt4ffbigoetjGk5PU2Dd8nLrSEw==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.3.0.tgz",
+			"integrity": "sha512-EW+MFEo0DGHahf83RAaiqQx688qpXgl99wdb8Fy67ybyzHwR1a58LHcO376xQJHfmoXTu89M09dH3J509cx2AA==",
 			"requires": {
-				"@jest/fake-timers": "^26.6.1",
-				"@jest/types": "^26.6.1",
+				"@jest/fake-timers": "^26.3.0",
+				"@jest/types": "^26.3.0",
 				"@types/node": "*",
-				"jest-mock": "^26.6.1"
+				"jest-mock": "^26.3.0"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"@jest/fake-timers": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.6.1.tgz",
-			"integrity": "sha512-T/SkMLgOquenw/nIisBRD6XAYpFir0kNuclYLkse5BpzeDUukyBr+K31xgAo9M0hgjU9ORlekAYPSzc0DKfmKg==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.3.0.tgz",
+			"integrity": "sha512-ZL9ytUiRwVP8ujfRepffokBvD2KbxbqMhrXSBhSdAhISCw3gOkuntisiSFv+A6HN0n0fF4cxzICEKZENLmW+1A==",
 			"requires": {
-				"@jest/types": "^26.6.1",
+				"@jest/types": "^26.3.0",
 				"@sinonjs/fake-timers": "^6.0.1",
 				"@types/node": "*",
-				"jest-message-util": "^26.6.1",
-				"jest-mock": "^26.6.1",
-				"jest-util": "^26.6.1"
+				"jest-message-util": "^26.3.0",
+				"jest-mock": "^26.3.0",
+				"jest-util": "^26.3.0"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"@jest/globals": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.6.1.tgz",
-			"integrity": "sha512-acxXsSguuLV/CeMYmBseefw6apO7NuXqpE+v5r3yD9ye2PY7h1nS20vY7Obk2w6S7eJO4OIAJeDnoGcLC/McEQ==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.4.2.tgz",
+			"integrity": "sha512-Ot5ouAlehhHLRhc+sDz2/9bmNv9p5ZWZ9LE1pXGGTCXBasmi5jnYjlgYcYt03FBwLmZXCZ7GrL29c33/XRQiow==",
 			"requires": {
-				"@jest/environment": "^26.6.1",
-				"@jest/types": "^26.6.1",
-				"expect": "^26.6.1"
+				"@jest/environment": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"expect": "^26.4.2"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"@jest/reporters": {
+			"version": "26.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.4.1.tgz",
+			"integrity": "sha512-aROTkCLU8++yiRGVxLsuDmZsQEKO6LprlrxtAuzvtpbIFl3eIjgIf3EUxDKgomkS25R9ZzwGEdB5weCcBZlrpQ==",
+			"requires": {
+				"@bcoe/v8-coverage": "^0.2.3",
+				"@jest/console": "^26.3.0",
+				"@jest/test-result": "^26.3.0",
+				"@jest/transform": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"chalk": "^4.0.0",
+				"collect-v8-coverage": "^1.0.0",
+				"exit": "^0.1.2",
+				"glob": "^7.1.2",
+				"graceful-fs": "^4.2.4",
+				"istanbul-lib-coverage": "^3.0.0",
+				"istanbul-lib-instrument": "^4.0.3",
+				"istanbul-lib-report": "^3.0.0",
+				"istanbul-lib-source-maps": "^4.0.0",
+				"istanbul-reports": "^3.0.2",
+				"jest-haste-map": "^26.3.0",
+				"jest-resolve": "^26.4.0",
+				"jest-util": "^26.3.0",
+				"jest-worker": "^26.3.0",
+				"node-notifier": "^8.0.0",
+				"slash": "^3.0.0",
+				"source-map": "^0.6.0",
+				"string-length": "^4.0.1",
+				"terminal-link": "^2.0.0",
+				"v8-to-istanbul": "^5.0.1"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"istanbul-lib-instrument": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+					"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+					"requires": {
+						"@babel/core": "^7.7.5",
+						"@istanbuljs/schema": "^0.1.2",
+						"istanbul-lib-coverage": "^3.0.0",
+						"semver": "^6.3.0"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"@jest/source-map": {
-			"version": "26.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.5.0.tgz",
-			"integrity": "sha512-jWAw9ZwYHJMe9eZq/WrsHlwF8E3hM9gynlcDpOyCb9bR8wEd9ZNBZCi7/jZyzHxC7t3thZ10gO2IDhu0bPKS5g==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.3.0.tgz",
+			"integrity": "sha512-hWX5IHmMDWe1kyrKl7IhFwqOuAreIwHhbe44+XH2ZRHjrKIh0LO5eLQ/vxHFeAfRwJapmxuqlGAEYLadDq6ZGQ==",
 			"requires": {
 				"callsites": "^3.0.0",
 				"graceful-fs": "^4.2.4",
@@ -3018,38 +3423,50 @@
 			}
 		},
 		"@jest/test-result": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.6.1.tgz",
-			"integrity": "sha512-wqAgIerIN2gSdT2A8WeA5+AFh9XQBqYGf8etK143yng3qYd0mF0ie2W5PVmgnjw4VDU6ammI9NdXrKgNhreawg==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.3.0.tgz",
+			"integrity": "sha512-a8rbLqzW/q7HWheFVMtghXV79Xk+GWwOK1FrtimpI5n1la2SY0qHri3/b0/1F0Ve0/yJmV8pEhxDfVwiUBGtgg==",
 			"requires": {
-				"@jest/console": "^26.6.1",
-				"@jest/types": "^26.6.1",
+				"@jest/console": "^26.3.0",
+				"@jest/types": "^26.3.0",
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"collect-v8-coverage": "^1.0.0"
-			}
-		},
-		"@jest/test-sequencer": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.6.1.tgz",
-			"integrity": "sha512-0csqA/XApZiNeTIPYh6koIDCACSoR6hi29T61tKJMtCZdEC+tF3PoNt7MS0oK/zKC6daBgCbqXxia5ztr/NyCQ==",
-			"requires": {
-				"@jest/test-result": "^26.6.1",
-				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^26.6.1",
-				"jest-runner": "^26.6.1",
-				"jest-runtime": "^26.6.1"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
 				},
 				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
 					"requires": {
+						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -3060,16 +3477,6 @@
 					"requires": {
 						"ansi-styles": "^4.1.0",
 						"supports-color": "^7.1.0"
-					}
-				},
-				"cliui": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-					"requires": {
-						"string-width": "^4.2.0",
-						"strip-ansi": "^6.0.0",
-						"wrap-ansi": "^6.2.0"
 					}
 				},
 				"color-convert": {
@@ -3085,140 +3492,10 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-				},
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-				},
-				"jest-runtime": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.1.tgz",
-					"integrity": "sha512-7uOCNeezXDWgjEyzYbRN2ViY7xNZzusNVGAMmU0UHRUNXuY4j4GBHKGMqPo/cBPZA9bSYp+lwK2DRRBU5Dv6YQ==",
-					"requires": {
-						"@jest/console": "^26.6.1",
-						"@jest/environment": "^26.6.1",
-						"@jest/fake-timers": "^26.6.1",
-						"@jest/globals": "^26.6.1",
-						"@jest/source-map": "^26.5.0",
-						"@jest/test-result": "^26.6.1",
-						"@jest/transform": "^26.6.1",
-						"@jest/types": "^26.6.1",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0",
-						"cjs-module-lexer": "^0.4.2",
-						"collect-v8-coverage": "^1.0.0",
-						"exit": "^0.1.2",
-						"glob": "^7.1.3",
-						"graceful-fs": "^4.2.4",
-						"jest-config": "^26.6.1",
-						"jest-haste-map": "^26.6.1",
-						"jest-message-util": "^26.6.1",
-						"jest-mock": "^26.6.1",
-						"jest-regex-util": "^26.0.0",
-						"jest-resolve": "^26.6.1",
-						"jest-snapshot": "^26.6.1",
-						"jest-util": "^26.6.1",
-						"jest-validate": "^26.6.1",
-						"slash": "^3.0.0",
-						"strip-bom": "^4.0.0",
-						"yargs": "^15.4.1"
-					}
-				},
-				"jest-snapshot": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.1.tgz",
-					"integrity": "sha512-JA7bZp7HRTIJYAi85pJ/OZ2eur2dqmwIToA5/6d7Mn90isGEfeF9FvuhDLLEczgKP1ihreBzrJ6Vr7zteP5JNA==",
-					"requires": {
-						"@babel/types": "^7.0.0",
-						"@jest/types": "^26.6.1",
-						"@types/babel__traverse": "^7.0.4",
-						"@types/prettier": "^2.0.0",
-						"chalk": "^4.0.0",
-						"expect": "^26.6.1",
-						"graceful-fs": "^4.2.4",
-						"jest-diff": "^26.6.1",
-						"jest-get-type": "^26.3.0",
-						"jest-haste-map": "^26.6.1",
-						"jest-matcher-utils": "^26.6.1",
-						"jest-message-util": "^26.6.1",
-						"jest-resolve": "^26.6.1",
-						"natural-compare": "^1.4.0",
-						"pretty-format": "^26.6.1",
-						"semver": "^7.3.2"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-				},
-				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
-				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
-				},
-				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
 				},
 				"supports-color": {
 					"version": "7.2.0",
@@ -3227,61 +3504,36 @@
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
-				},
-				"wrap-ansi": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"yargs": {
-					"version": "15.4.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-					"requires": {
-						"cliui": "^6.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^4.1.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^4.2.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^18.1.2"
-					}
-				},
-				"yargs-parser": {
-					"version": "18.1.3",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
 				}
 			}
 		},
+		"@jest/test-sequencer": {
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.4.2.tgz",
+			"integrity": "sha512-83DRD8N3M0tOhz9h0bn6Kl6dSp+US6DazuVF8J9m21WAp5x7CqSMaNycMP0aemC/SH/pDQQddbsfHRTBXVUgog==",
+			"requires": {
+				"@jest/test-result": "^26.3.0",
+				"graceful-fs": "^4.2.4",
+				"jest-haste-map": "^26.3.0",
+				"jest-runner": "^26.4.2",
+				"jest-runtime": "^26.4.2"
+			}
+		},
 		"@jest/transform": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.1.tgz",
-			"integrity": "sha512-oNFAqVtqRxZRx6vXL3I4bPKUK0BIlEeaalkwxyQGGI8oXDQBtYQBpiMe5F7qPs4QdvvFYB42gPGIMMcxXaBBxQ==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.3.0.tgz",
+			"integrity": "sha512-Isj6NB68QorGoFWvcOjlUhpkT56PqNIsXKR7XfvoDlCANn/IANlh8DrKAA2l2JKC3yWSMH5wS0GwuQM20w3b2A==",
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/types": "^26.6.1",
+				"@jest/types": "^26.3.0",
 				"babel-plugin-istanbul": "^6.0.0",
 				"chalk": "^4.0.0",
 				"convert-source-map": "^1.4.0",
 				"fast-json-stable-stringify": "^2.0.0",
 				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^26.6.1",
+				"jest-haste-map": "^26.3.0",
 				"jest-regex-util": "^26.0.0",
-				"jest-util": "^26.6.1",
+				"jest-util": "^26.3.0",
 				"micromatch": "^4.0.2",
 				"pirates": "^4.0.1",
 				"slash": "^3.0.0",
@@ -3289,11 +3541,40 @@
 				"write-file-atomic": "^3.0.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -3389,60 +3670,13 @@
 			}
 		},
 		"@jest/types": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
-			"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+			"integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^15.0.0",
-				"chalk": "^4.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
+				"@types/istanbul-reports": "^1.1.1",
+				"@types/yargs": "^13.0.0"
 			}
 		},
 		"@lerna/add": {
@@ -4742,9 +4976,9 @@
 			}
 		},
 		"@microsoft/load-themed-styles": {
-			"version": "1.10.117",
-			"resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.117.tgz",
-			"integrity": "sha512-nEvUltTnpm4FnZ7TFHwQqL1Y5PDqXbAT1WGUXuUAF5RM8dgoRHQ72uIZJ2UBSQNKsY/+IwGWmHBFJVT1e1mzSQ=="
+			"version": "1.10.89",
+			"resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.89.tgz",
+			"integrity": "sha512-nCL/fosGrCzDbr23cd9snWnRJZ3Hzy/0VmoOOqr3DH1mKqdE4EUmRE9GXn9CBSoqy9rK3+dFG5KOgxOIutylng=="
 		},
 		"@microsoft/tsdoc": {
 			"version": "0.12.19",
@@ -4874,6 +5108,15 @@
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^5.0.0"
+					}
+				},
+				"widest-line": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+					"integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.0.0"
 					}
 				},
 				"wrap-ansi": {
@@ -5015,6 +5258,15 @@
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 					"dev": true
 				},
+				"is-wsl": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+					"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+					"dev": true,
+					"requires": {
+						"is-docker": "^2.0.0"
+					}
+				},
 				"micromatch": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
@@ -5073,6 +5325,15 @@
 					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
 					"dev": true
 				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
 				"clean-stack": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.0.tgz",
@@ -5082,11 +5343,49 @@
 						"escape-string-regexp": "4.0.0"
 					}
 				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
 				"escape-string-regexp": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
 				},
 				"strip-ansi": {
 					"version": "6.0.0",
@@ -5095,6 +5394,17 @@
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^5.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+					"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
 					}
 				}
 			}
@@ -5157,42 +5467,6 @@
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^4.1.0"
-					}
-				},
-				"widest-line": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-					"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
-					"dev": true,
-					"requires": {
-						"string-width": "^2.1.1"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-							"dev": true
-						},
-						"string-width": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-							"dev": true,
-							"requires": {
-								"is-fullwidth-code-point": "^2.0.0",
-								"strip-ansi": "^4.0.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^3.0.0"
-							}
-						}
 					}
 				},
 				"wrap-ansi": {
@@ -5529,9 +5803,9 @@
 			"integrity": "sha512-bWBbC7VG2jdjbgZMX0qpds8U/3h3anfIqE81L8jmVrgFZw/urEDnBA78ymGGKTTK6ciBXmmJ/xlok+Re41S8ww=="
 		},
 		"@types/babel__core": {
-			"version": "7.1.10",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.10.tgz",
-			"integrity": "sha512-x8OM8XzITIMyiwl5Vmo2B1cR1S1Ipkyv4mdlbJjMa1lmuKvKY9FrBbEANIaMlnWn5Rf7uO+rC/VgYabNkE17Hw==",
+			"version": "7.1.9",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.9.tgz",
+			"integrity": "sha512-sY2RsIJ5rpER1u3/aQ8OFSI7qGIy8o1NEEbgb2UaJcvOtXOMpd39ko723NBpjQFg9SIX7TXtjejZVGeIMLhoOw==",
 			"requires": {
 				"@babel/parser": "^7.1.0",
 				"@babel/types": "^7.0.0",
@@ -5541,26 +5815,26 @@
 			}
 		},
 		"@types/babel__generator": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
-			"integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
+			"integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
 		},
 		"@types/babel__template": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.3.tgz",
-			"integrity": "sha512-uCoznIPDmnickEi6D0v11SBpW0OuVqHJCa7syXqQHy5uktSCreIlt0iglsCnmvz8yCb38hGcWeseA8cWJSwv5Q==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
+			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
 			"requires": {
 				"@babel/parser": "^7.1.0",
 				"@babel/types": "^7.0.0"
 			}
 		},
 		"@types/babel__traverse": {
-			"version": "7.0.15",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.15.tgz",
-			"integrity": "sha512-Pzh9O3sTK8V6I1olsXpCfj2k/ygO2q1X0vhhnDrEQyYLHZesWz+zMZMVcwXLCYf0U36EtmyYaFGPfXlTtDHe3A==",
+			"version": "7.0.14",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.14.tgz",
+			"integrity": "sha512-8w9szzKs14ZtBVuP6Wn7nMLRJ0D6dfB0VEBEyRgxrZ/Ln49aNMykrghM2FaNn4FJRzNppCSa0Rv9pBRM5Xc3wg==",
 			"requires": {
 				"@babel/types": "^7.3.0"
 			}
@@ -5595,8 +5869,7 @@
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-			"dev": true
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
 		},
 		"@types/connect": {
 			"version": "3.4.33",
@@ -5657,9 +5930,9 @@
 			}
 		},
 		"@types/express-serve-static-core": {
-			"version": "4.17.13",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz",
-			"integrity": "sha512-RgDi5a4nuzam073lRGKTUIaL3eF2+H7LJvJ8eUnCI0wA6SNjXc44DCmWNiTLs/AZ7QlsFWZiw/gTG3nSQGL0fA==",
+			"version": "4.17.12",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.12.tgz",
+			"integrity": "sha512-EaEdY+Dty1jEU7U6J4CUWwxL+hyEGMkO5jan5gplfegUgCUsIUWqXxqw47uGjimeT4Qgkz/XUfwoau08+fgvKA==",
 			"requires": {
 				"@types/node": "*",
 				"@types/qs": "*",
@@ -5677,17 +5950,17 @@
 			}
 		},
 		"@types/graceful-fs": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.4.tgz",
-			"integrity": "sha512-mWA/4zFQhfvOA8zWkXobwJvBD7vzcxgrOQ0J5CH1votGqdq9m7+FwtGaqyCZqC3NyyBkc9z4m+iry4LlqcMWJg==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
+			"integrity": "sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==",
 			"requires": {
 				"@types/node": "*"
 			}
 		},
 		"@types/html-minifier-terser": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
-			"integrity": "sha512-giAlZwstKbmvMk1OO7WXSj4OZ0keXAcl2TQq4LWHiiPH2ByaH7WeUzng+Qej8UPxxv+8lRTuouo0iaNDBuzIBA=="
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.0.tgz",
+			"integrity": "sha512-iYCgjm1dGPRuo12+BStjd1HiVQqhlRhWDOQigNxn023HcjnhsiFz9pc6CzJj4HwDCSQca9bxTL4PxJDbkdm3PA=="
 		},
 		"@types/isomorphic-fetch": {
 			"version": "0.0.35",
@@ -5708,10 +5981,11 @@
 			}
 		},
 		"@types/istanbul-reports": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-			"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+			"integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
 			"requires": {
+				"@types/istanbul-lib-coverage": "*",
 				"@types/istanbul-lib-report": "*"
 			}
 		},
@@ -5748,20 +6022,15 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
 		},
-		"@types/jsrsasign": {
-			"version": "8.0.7",
-			"resolved": "https://registry.npmjs.org/@types/jsrsasign/-/jsrsasign-8.0.7.tgz",
-			"integrity": "sha512-0SqXgSIJ0Co3FdUjaUUGoPx6VJpe0qFJ54S0QXFwcQ+VhXTqKIh9WrsumRzsCVnpmmoKi7d5dtukgraS7eTN+Q=="
-		},
 		"@types/jwt-decode": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@types/jwt-decode/-/jwt-decode-2.2.1.tgz",
 			"integrity": "sha512-aWw2YTtAdT7CskFyxEX2K21/zSDStuf/ikI3yBqmwpwJF0pS+/IX5DWv+1UFffZIbruP6cnT9/LAJV1gFwAT1A=="
 		},
 		"@types/lodash": {
-			"version": "4.14.162",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.162.tgz",
-			"integrity": "sha512-alvcho1kRUnnD1Gcl4J+hK0eencvzq9rmzvFPRmP5rPHx9VVsJj6bKLTATPVf9ktgv4ujzh7T+XWKp+jhuODig=="
+			"version": "4.14.161",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz",
+			"integrity": "sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA=="
 		},
 		"@types/mime": {
 			"version": "2.0.3",
@@ -5813,9 +6082,9 @@
 			"integrity": "sha512-dxKo80TqYx3YtBipHwA/SdFmMMyLCnP+5mkEqN0eMjcTBzHkiiX0ES118DsjDBjvD+zeSsSU9jULTZ+frog+Gw=="
 		},
 		"@types/prettier": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.5.tgz",
-			"integrity": "sha512-UEyp8LwZ4Dg30kVU2Q3amHHyTn1jEdhCIE59ANed76GaT1Vp76DD3ZWSAxgCrw6wJ0TqeoBpqmfUHiUDPs//HQ=="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.0.tgz",
+			"integrity": "sha512-hiYA88aHiEIgDmeKlsyVsuQdcFn3Z2VuFd/Xm/HCnGnPD8UFU5BM128uzzRVVGEzKDKYUrRsRH9S2o+NUy/3IA=="
 		},
 		"@types/prop-types": {
 			"version": "15.7.3",
@@ -5823,9 +6092,9 @@
 			"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
 		},
 		"@types/prosemirror-model": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/@types/prosemirror-model/-/prosemirror-model-1.11.0.tgz",
-			"integrity": "sha512-R+vutu3AptoiXGJR0Jdpyr7BkJg24bce9ETUDOrBJZhRcsWeMEFGzidG19GHcY6Yny5zTILxlqXeDEIF3C5b7A==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/@types/prosemirror-model/-/prosemirror-model-1.7.2.tgz",
+			"integrity": "sha512-2l+yXvidg3AUHN07mO4Jd8Q84fo6ksFsy7LHUurLYrZ74uTahBp2fzcO49AKZMzww2EulXJ40Kl/OFaQ/7A1fw==",
 			"requires": {
 				"@types/orderedmap": "*"
 			}
@@ -5859,9 +6128,9 @@
 			}
 		},
 		"@types/prosemirror-view": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@types/prosemirror-view/-/prosemirror-view-1.16.1.tgz",
-			"integrity": "sha512-vsL7QB9Qmg9HcBTWsOkmBEGMF0CfA/SZgtqlUArQglnDWV40ZJYonkjBzyP+YhurMC/s4JT4T2vzfnv7rFF/cg==",
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/@types/prosemirror-view/-/prosemirror-view-1.15.1.tgz",
+			"integrity": "sha512-ZdgIqDLWiO4wW4DhK8OjEVam3/DhBcggQeZ6zLts+UCflAZPnEk5dzRqFBVEyrvWqSAGLuPAoOgGAPjj/XwR8w==",
 			"requires": {
 				"@types/prosemirror-model": "*",
 				"@types/prosemirror-state": "*",
@@ -5878,9 +6147,9 @@
 			}
 		},
 		"@types/qs": {
-			"version": "6.9.5",
-			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
-			"integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ=="
+			"version": "6.9.4",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.4.tgz",
+			"integrity": "sha512-+wYo+L6ZF6BMoEjtf8zB2esQsqdV6WsjRK/GP9WOgLPrq87PbNWgIxS76dS5uvl/QXtHGakZmwTznIfcPXcKlQ=="
 		},
 		"@types/random-js": {
 			"version": "1.0.31",
@@ -5893,9 +6162,9 @@
 			"integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
 		},
 		"@types/react": {
-			"version": "16.9.53",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.53.tgz",
-			"integrity": "sha512-4nW60Sd4L7+WMXH1D6jCdVftuW7j4Za6zdp6tJ33Rqv0nk1ZAmQKML9ZLD4H0dehA3FZxXR/GM8gXplf82oNGw==",
+			"version": "16.9.49",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
+			"integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
 			"requires": {
 				"@types/prop-types": "*",
 				"csstype": "^3.0.2"
@@ -5946,12 +6215,12 @@
 			"integrity": "sha512-RxAwYt4rGwK5GyoRwuP0jT6ZHAVTdz2EqgsHmX0PYNjGsko+OeT4WFXXTs/lM3teJUJodM+SNtAL5/pXIJ61IQ=="
 		},
 		"@types/serve-static": {
-			"version": "1.13.6",
-			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.6.tgz",
-			"integrity": "sha512-nuRJmv7jW7VmCVTn+IgYDkkbbDGyIINOeu/G0d74X3lm6E5KfMeQPJhxIt1ayQeQB3cSxvYs1RA/wipYoFB4EA==",
+			"version": "1.13.5",
+			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.5.tgz",
+			"integrity": "sha512-6M64P58N+OXjU432WoLLBQxbA0LRGBCRm7aAGQJ+SMC1IMl0dgRVi9EFfoDcS2a7Xogygk/eGN94CfwU9UF7UQ==",
 			"requires": {
-				"@types/mime": "*",
-				"@types/node": "*"
+				"@types/express-serve-static-core": "*",
+				"@types/mime": "*"
 			}
 		},
 		"@types/sha.js": {
@@ -5973,9 +6242,9 @@
 			"integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg=="
 		},
 		"@types/socket.io-client": {
-			"version": "1.4.34",
-			"resolved": "https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-1.4.34.tgz",
-			"integrity": "sha512-Lzia5OTQFJZJ5R4HsEEldywiiqT9+W2rDbyHJiiTGqOcju89sCsQ8aUXDljY6Ls33wKZZGC0bfMhr/VpOyjtXg=="
+			"version": "1.4.33",
+			"resolved": "https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-1.4.33.tgz",
+			"integrity": "sha512-m4LnxkljsI9fMsjwpW5QhRpMixo2BeeLpFmg0AE+sS4H1pzAd/cs/ftTiL60FLZgfFa8PFRPx5KsHu8O0bADKQ=="
 		},
 		"@types/source-list-map": {
 			"version": "0.1.2",
@@ -5983,9 +6252,9 @@
 			"integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA=="
 		},
 		"@types/stack-utils": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
-			"integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw=="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
 		},
 		"@types/tapable": {
 			"version": "1.0.6",
@@ -6006,9 +6275,9 @@
 			"integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
 		},
 		"@types/uglify-js": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.11.0.tgz",
-			"integrity": "sha512-I0Yd8TUELTbgRHq2K65j8rnDPAzAP+DiaF/syLem7yXwYLsHZhPd+AM2iXsWmf9P2F2NlFCgl5erZPQx9IbM9Q==",
+			"version": "3.9.3",
+			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.3.tgz",
+			"integrity": "sha512-KswB5C7Kwduwjj04Ykz+AjvPcfgv/37Za24O2EDzYNbwyzOo8+ydtvzUfZ5UMguiVu29Gx44l1A6VsPPcmYu9w==",
 			"requires": {
 				"source-map": "^0.6.1"
 			}
@@ -6019,9 +6288,9 @@
 			"integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ=="
 		},
 		"@types/webpack": {
-			"version": "4.41.23",
-			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.23.tgz",
-			"integrity": "sha512-ojA4CupZg8RCzVJLugWlvqrHpT59GWhqFxbinlsnvk10MjQCWB+ot7XDACctbWhnhtdhYK7+HOH1JxkVLiZhMg==",
+			"version": "4.41.22",
+			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.22.tgz",
+			"integrity": "sha512-JQDJK6pj8OMV9gWOnN1dcLCyU9Hzs6lux0wBO4lr1+gyEhIBR9U3FMrz12t2GPkg110XAxEAw2WHF6g7nZIbRQ==",
 			"requires": {
 				"@types/anymatch": "*",
 				"@types/node": "*",
@@ -6032,9 +6301,9 @@
 			}
 		},
 		"@types/webpack-sources": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-2.0.0.tgz",
-			"integrity": "sha512-a5kPx98CNFRKQ+wqawroFunvFqv7GHm/3KOI52NY9xWADgc8smu4R6prt4EU/M4QfVjvgBkMqU4fBhw3QfMVkg==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-1.4.2.tgz",
+			"integrity": "sha512-77T++JyKow4BQB/m9O96n9d/UUHWLQHlcqXb9Vsf4F1+wKNrrlWNFPDLKNT92RJnCSL6CieTc+NDXtCVZswdTw==",
 			"requires": {
 				"@types/node": "*",
 				"@types/source-list-map": "*",
@@ -6057,14 +6326,14 @@
 			}
 		},
 		"@types/xmldoc": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@types/xmldoc/-/xmldoc-1.1.5.tgz",
-			"integrity": "sha512-31y8EoleGz/8+cA1ofgy1h8/yAXUjr6pfR2DSohWGa477UC7T2SQ2A+aafljRI2Pe64oE7mrJX8E3euWztC3sQ=="
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@types/xmldoc/-/xmldoc-1.1.4.tgz",
+			"integrity": "sha512-a/ONNCf9itbmzEz1ohx0Fv5TLJzXIPQTapxFu+DlYlDtn9UcAa1OhnrOOMwbU8125hFjrkJKL3qllD7vO5Bivw=="
 		},
 		"@types/yargs": {
-			"version": "15.0.9",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
-			"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
+			"version": "13.0.10",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.10.tgz",
+			"integrity": "sha512-MU10TSgzNABgdzKvQVW1nuuT+sgBMWeXNc3XOs5YXV5SDAK+PPja2eUuBNB9iqElu03xyEDqlnGw0jgl4nbqGQ==",
 			"requires": {
 				"@types/yargs-parser": "*"
 			}
@@ -6228,6 +6497,16 @@
 				}
 			}
 		},
+		"@typescript-eslint/experimental-utils": {
+			"version": "2.17.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.17.0.tgz",
+			"integrity": "sha512-2bNf+mZ/3mj5/3CP56v+ldRK3vFy9jOvmCPs/Gr2DeSJh+asPZrhFniv4QmQsHWQFPJFWhFHgkGgJeRmK4m8iQ==",
+			"requires": {
+				"@types/json-schema": "^7.0.3",
+				"@typescript-eslint/typescript-estree": "2.17.0",
+				"eslint-scope": "^5.0.0"
+			}
+		},
 		"@typescript-eslint/parser": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.2.0.tgz",
@@ -6372,6 +6651,27 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.2.0.tgz",
 			"integrity": "sha512-xkv5nIsxfI/Di9eVwN+G9reWl7Me9R5jpzmZUch58uQ7g0/hHVuGUbbn4NcxcM5y/R4wuJIIEPKPDb5l4Fdmwg=="
 		},
+		"@typescript-eslint/typescript-estree": {
+			"version": "2.17.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.17.0.tgz",
+			"integrity": "sha512-g0eVRULGnEEUakxRfJO0s0Hr1LLQqsI6OrkiCLpdHtdJJek+wyd8mb00vedqAoWldeDcOcP8plqw8/jx9Gr3Lw==",
+			"requires": {
+				"debug": "^4.1.1",
+				"eslint-visitor-keys": "^1.1.0",
+				"glob": "^7.1.6",
+				"is-glob": "^4.0.1",
+				"lodash": "^4.17.15",
+				"semver": "^6.3.0",
+				"tsutils": "^3.17.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				}
+			}
+		},
 		"@typescript-eslint/visitor-keys": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.2.0.tgz",
@@ -6389,108 +6689,102 @@
 			}
 		},
 		"@uifabric/fluent-theme": {
-			"version": "7.3.30",
-			"resolved": "https://registry.npmjs.org/@uifabric/fluent-theme/-/fluent-theme-7.3.30.tgz",
-			"integrity": "sha512-Abk1TBHPoR0J91jBphQlIeRzQFSu+zu/vZC5pHEnUFvPwk0CKW0SHKL3+bllmH26oaT0Y6sQnQNKjrMrn9HxNA==",
+			"version": "7.3.7",
+			"resolved": "https://registry.npmjs.org/@uifabric/fluent-theme/-/fluent-theme-7.3.7.tgz",
+			"integrity": "sha512-L6tKSBCzIu98Mr6QZ2M9xdBMz+53tDz9anpfD+NsszOUaCzUT6v5O7pwb1zUEJRVrdRTX3m3aHx6792K/FEUcA==",
 			"requires": {
-				"@fluentui/theme": "^1.5.1",
-				"@uifabric/merge-styles": "^7.19.1",
-				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/styling": "^7.16.13",
-				"@uifabric/variants": "^7.2.26",
-				"office-ui-fabric-react": "^7.148.0",
+				"@fluentui/theme": "^0.2.0",
+				"@uifabric/merge-styles": "^7.18.0",
+				"@uifabric/set-version": "^7.0.22",
+				"@uifabric/styling": "^7.16.0",
+				"@uifabric/variants": "^7.2.12",
+				"office-ui-fabric-react": "^7.137.1",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/foundation": {
-			"version": "7.9.14",
-			"resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.9.14.tgz",
-			"integrity": "sha512-AWsSt28+mid44YPofHB8N1nm4C0QmLJ9WXFps5GyjaBHES6/4bfJ7rKzYioa5bN0TxElyK8rRHzwqKNQhWDBYA==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.9.0.tgz",
+			"integrity": "sha512-4gdPwx0HV59aWvPKIw6yIje60CYwJZmTJsdLRXqh8Np1tWp2EsbA8U/IHQL1V91rEN0DlQhASqCDFhfQoD1jUw==",
 			"requires": {
-				"@uifabric/merge-styles": "^7.19.1",
-				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/styling": "^7.16.13",
-				"@uifabric/utilities": "^7.32.4",
+				"@uifabric/merge-styles": "^7.18.0",
+				"@uifabric/set-version": "^7.0.22",
+				"@uifabric/styling": "^7.16.0",
+				"@uifabric/utilities": "^7.31.0",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/icons": {
-			"version": "7.5.12",
-			"resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.5.12.tgz",
-			"integrity": "sha512-VIqj4oMwi4HJPqH3+3RblLoYjPfYzjVyZ8Kk57dmA7tj+vbM38Zn9vObe+Xg/EVEfohD3kD0fyEqPmnEqY17Pg==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.5.0.tgz",
+			"integrity": "sha512-RINA9VkajlCnlwEBbqiwLBaaGn38Bf9UvjOuwrrja4B9lclLeQzZuGrG/kp7CnDtIO+LC19OYl/7E3jW7yIihA==",
 			"requires": {
-				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/styling": "^7.16.13",
+				"@uifabric/set-version": "^7.0.22",
+				"@uifabric/styling": "^7.16.0",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/merge-styles": {
-			"version": "7.19.1",
-			"resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-7.19.1.tgz",
-			"integrity": "sha512-yqUwmk62Kgu216QNPE9vOfS3h0kiSbTvoqM5QcZi+IzpqsBOlzZx3A9Er9UiDaqHRd5lsYF5pO/jeUULmBWF/A==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-7.18.0.tgz",
+			"integrity": "sha512-805WIbN7lAJATXKxZjjRbIgN7raRMwWYWeDkJJ52PCPuCesOvbpdr0GkH8rC6GQ7EB0MB7YM2i6Fiye7SFewbw==",
 			"requires": {
-				"@uifabric/set-version": "^7.0.23",
+				"@uifabric/set-version": "^7.0.22",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/react-hooks": {
-			"version": "7.13.6",
-			"resolved": "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.13.6.tgz",
-			"integrity": "sha512-DvfphxrTsjo3oYioRZ0D8mXdpxWQhhIHeWk1cfdq0MVGqRyKM+cm++9pJpvItFvnTNba38jzKdggqRSUWi+clg==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.13.0.tgz",
+			"integrity": "sha512-A7K0YFHHr10hB/txsqpPX6PhNhHEv8U7JpY3O81oqlZwSsHroJklQdd897JkAYJUUR+gWe2kQyXkkcaMDdqXjg==",
 			"requires": {
-				"@fluentui/react-window-provider": "^0.3.3",
-				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/utilities": "^7.32.4",
+				"@fluentui/react-window-provider": "^0.3.0",
+				"@uifabric/set-version": "^7.0.22",
+				"@uifabric/utilities": "^7.31.0",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/set-version": {
-			"version": "7.0.23",
-			"resolved": "https://registry.npmjs.org/@uifabric/set-version/-/set-version-7.0.23.tgz",
-			"integrity": "sha512-9E+YKtnH2kyMKnK9XZZsqyM8OCxEJIIfxtaThTlQpYOzrWAGJxQADFbZ7+Usi0U2xHnWNPFROjq+B9ocEzhqMA==",
+			"version": "7.0.22",
+			"resolved": "https://registry.npmjs.org/@uifabric/set-version/-/set-version-7.0.22.tgz",
+			"integrity": "sha512-IG35UNJNxqI7NC2eYuobGTD+v4W0VHQcC3bYd5Na9EgoC9jVgguS8n6EXUtP/lC1vJEYEyPEZdVwhPxKw4F4Sw==",
 			"requires": {
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/styling": {
-			"version": "7.16.13",
-			"resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.16.13.tgz",
-			"integrity": "sha512-jj5FH7XuQXz8HgRhCXNApeUAynDBv2nfmTpzHawE55x7YR+oliQfsJSY8Ow4YbLAazIR5BuW1n9eKuGxxmIw1w==",
+			"version": "7.16.0",
+			"resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.16.0.tgz",
+			"integrity": "sha512-yO404ws8Wl4fjBwG4T58TFJjeU/K+SpWJ4w+WeNMDlJcYe4zXaWn2lbOJtKtQiMl324RAEjFSOuNkXzPb0uOGQ==",
 			"requires": {
-				"@fluentui/theme": "^1.5.1",
+				"@fluentui/theme": "^0.2.0",
 				"@microsoft/load-themed-styles": "^1.10.26",
-				"@uifabric/merge-styles": "^7.19.1",
-				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/utilities": "^7.32.4",
+				"@uifabric/merge-styles": "^7.18.0",
+				"@uifabric/set-version": "^7.0.22",
+				"@uifabric/utilities": "^7.31.0",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/utilities": {
-			"version": "7.32.4",
-			"resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.32.4.tgz",
-			"integrity": "sha512-IKZc03uyfTrgcCGSPAUWfFl9CyxzpSrxrYwAuO4NgDEySdOlkYBRwsRUh6UwWfM+sJdhg7Y3nupzNU3VSC/arg==",
+			"version": "7.31.0",
+			"resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.31.0.tgz",
+			"integrity": "sha512-m4Yeyn4gyW7xS8LvOnCesokPModYS2YuE9GQmO++MDZ/vC5RRNlvlyktUZDuxCZ84cNCiXyTQ8nImBaPGnxHVQ==",
 			"requires": {
-				"@fluentui/dom-utilities": "^1.1.1",
-				"@uifabric/merge-styles": "^7.19.1",
-				"@uifabric/set-version": "^7.0.23",
+				"@uifabric/merge-styles": "^7.18.0",
+				"@uifabric/set-version": "^7.0.22",
 				"prop-types": "^15.7.2",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/variants": {
-			"version": "7.2.26",
-			"resolved": "https://registry.npmjs.org/@uifabric/variants/-/variants-7.2.26.tgz",
-			"integrity": "sha512-tSLiCP2aVT1Zn3gRBobvzvexJx0kzD/TJ2Il56WlVYLRD0X6wDDO5J+ort0rGUGlJNTvDNZas4v/aNu/96o/mw==",
+			"version": "7.2.12",
+			"resolved": "https://registry.npmjs.org/@uifabric/variants/-/variants-7.2.12.tgz",
+			"integrity": "sha512-gEicMZsDgSqW4Jgr8zY/HDJtyygNuJNCTsrbZhjQPMFdvbykrR92l8c7CtLXMqs73zrWvETED4eT/vPmkf7N6A==",
 			"requires": {
-				"@fluentui/theme": "^1.5.1",
-				"@uifabric/set-version": "^7.0.23",
+				"@uifabric/set-version": "^7.0.22",
+				"office-ui-fabric-react": "^7.137.1",
 				"tslib": "^1.10.0"
 			}
-		},
-		"@ungap/promise-all-settled": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.9.0",
@@ -6708,9 +7002,25 @@
 			}
 		},
 		"acorn": {
-			"version": "7.4.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+			"integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w=="
+		},
+		"acorn-globals": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+			"integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+			"requires": {
+				"acorn": "^6.0.1",
+				"acorn-walk": "^6.0.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+					"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
+				}
+			}
 		},
 		"acorn-jsx": {
 			"version": "5.3.1",
@@ -6718,9 +7028,9 @@
 			"integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng=="
 		},
 		"acorn-walk": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-			"integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
 		},
 		"add-dom-event-listener": {
 			"version": "1.1.0",
@@ -6832,12 +7142,12 @@
 			"dev": true
 		},
 		"anymatch": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-			"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"requires": {
-				"normalize-path": "^3.0.0",
-				"picomatch": "^2.0.4"
+				"micromatch": "^3.1.4",
+				"normalize-path": "^2.1.1"
 			}
 		},
 		"append-transform": {
@@ -7003,6 +7313,17 @@
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.17.0-next.1",
 				"function-bind": "^1.1.1"
+			}
+		},
+		"array.prototype.map": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.2.tgz",
+			"integrity": "sha512-Az3OYxgsa1g7xDYp86l0nnN4bcmuEITGe1rbdEBVkrqkzMgDcbdQ2R7r41pNzti+4NMces3H8gMmuioZUilLgw==",
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1",
+				"es-array-method-boxes-properly": "^1.0.0",
+				"is-string": "^1.0.4"
 			}
 		},
 		"arraybuffer.slice": {
@@ -7254,36 +7575,64 @@
 			},
 			"dependencies": {
 				"resolve": {
-					"version": "1.18.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
-					"integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
+					"version": "1.17.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
 					"requires": {
-						"is-core-module": "^2.0.0",
 						"path-parse": "^1.0.6"
 					}
 				}
 			}
 		},
 		"babel-jest": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.1.tgz",
-			"integrity": "sha512-duMWEOKrSBYRVTTNpL2SipNIWnZOjP77auOBMPQ3zXAdnDbyZQWU8r/RxNWpUf9N6cgPFecQYelYLytTVXVDtA==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.3.0.tgz",
+			"integrity": "sha512-sxPnQGEyHAOPF8NcUsD0g7hDCnvLL2XyblRBcgrzTWBB/mAIpWow3n1bEL+VghnnZfreLhFSBsFluRoK2tRK4g==",
 			"requires": {
-				"@jest/transform": "^26.6.1",
-				"@jest/types": "^26.6.1",
+				"@jest/transform": "^26.3.0",
+				"@jest/types": "^26.3.0",
 				"@types/babel__core": "^7.1.7",
 				"babel-plugin-istanbul": "^6.0.0",
-				"babel-preset-jest": "^26.5.0",
+				"babel-preset-jest": "^26.3.0",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -7385,9 +7734,9 @@
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "26.5.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.5.0.tgz",
-			"integrity": "sha512-ck17uZFD3CDfuwCLATWZxkkuGGFhMij8quP8CNhwj8ek1mqFgbFzRJ30xwC04LLscj/aKsVFfRST+b5PT7rSuw==",
+			"version": "26.2.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.2.0.tgz",
+			"integrity": "sha512-B/hVMRv8Nh1sQ1a3EY8I0n4Y1Wty3NrR5ebOyVT302op+DOAau+xNEImGMsUWOC3++ZlMooCytKz+NgN8aKGbA==",
 			"requires": {
 				"@babel/template": "^7.3.3",
 				"@babel/types": "^7.3.3",
@@ -7396,9 +7745,9 @@
 			}
 		},
 		"babel-preset-current-node-syntax": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.4.tgz",
-			"integrity": "sha512-5/INNCYhUGqw7VbVjT/hb3ucjgkVHKXY7lX3ZjlN4gm565VyFmJUrJ/h+h16ECVB38R/9SF6aACydpKMLZ/c9w==",
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz",
+			"integrity": "sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==",
 			"requires": {
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
 				"@babel/plugin-syntax-bigint": "^7.8.3",
@@ -7414,11 +7763,11 @@
 			}
 		},
 		"babel-preset-jest": {
-			"version": "26.5.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.5.0.tgz",
-			"integrity": "sha512-F2vTluljhqkiGSJGBg/jOruA8vIIIL11YrxRcO7nviNTMbbofPSHwnm8mgP7d/wS7wRSexRoI6X1A6T74d4LQA==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.3.0.tgz",
+			"integrity": "sha512-5WPdf7nyYi2/eRxCbVrE1kKCWxgWY4RsPEbdJWFm7QsesFGqjdkyLeu1zRkwM1cxK6EPIlNd6d2AxLk7J+t4pw==",
 			"requires": {
-				"babel-plugin-jest-hoist": "^26.5.0",
+				"babel-plugin-jest-hoist": "^26.2.0",
 				"babel-preset-current-node-syntax": "^0.1.3"
 			}
 		},
@@ -7429,13 +7778,6 @@
 			"requires": {
 				"core-js": "^2.4.0",
 				"regenerator-runtime": "^0.11.0"
-			},
-			"dependencies": {
-				"regenerator-runtime": {
-					"version": "0.11.1",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-				}
 			}
 		},
 		"backo2": {
@@ -7504,9 +7846,9 @@
 			"integrity": "sha512-V6YHUbjLxN1ymqNLb1DPHoU1CpfdL7d2YTIp5W3U4hhoG4hhxNmsFDs66M9EXxBiSEke5Bt5dwdfMwwZF70iLA=="
 		},
 		"base64-arraybuffer": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
-			"integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI="
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+			"integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
 		},
 		"base64-js": {
 			"version": "1.3.1",
@@ -7546,6 +7888,14 @@
 			"resolved": "https://registry.npmjs.org/best-random/-/best-random-1.0.3.tgz",
 			"integrity": "sha512-zrncs76CBFyhE7KVsq85lsc/TT5PUfGTS8arh2aJZcIzQU+WdGNwWYwFsn+w/nuedk04efQdqMy8g5C5pw4shQ=="
 		},
+		"better-assert": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+			"integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+			"requires": {
+				"callsite": "1.0.0"
+			}
+		},
 		"bfj": {
 			"version": "6.1.2",
 			"resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.2.tgz",
@@ -7566,6 +7916,15 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
 			"integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
+		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"optional": true,
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
 		},
 		"blob": {
 			"version": "0.0.5",
@@ -7675,14 +8034,6 @@
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
 					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				},
-				"widest-line": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-					"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
-					"requires": {
-						"string-width": "^2.1.1"
-					}
 				}
 			}
 		},
@@ -8030,6 +8381,11 @@
 				"caller-callsite": "^2.0.0"
 			}
 		},
+		"callsite": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+			"integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
+		},
 		"callsites": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
@@ -8138,9 +8494,9 @@
 			"integrity": "sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ=="
 		},
 		"chokidar": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-			"integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
+			"integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
 			"requires": {
 				"anymatch": "~3.1.1",
 				"braces": "~3.0.2",
@@ -8149,9 +8505,18 @@
 				"is-binary-path": "~2.1.0",
 				"is-glob": "~4.0.1",
 				"normalize-path": "~3.0.0",
-				"readdirp": "~3.5.0"
+				"readdirp": "~3.4.0"
 			},
 			"dependencies": {
+				"anymatch": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+					"requires": {
+						"normalize-path": "^3.0.0",
+						"picomatch": "^2.0.4"
+					}
+				},
 				"braces": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
@@ -8168,10 +8533,21 @@
 						"to-regex-range": "^5.0.1"
 					}
 				},
+				"fsevents": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+					"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+					"optional": true
+				},
 				"is-number": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+				},
+				"normalize-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
 				},
 				"to-regex-range": {
 					"version": "5.0.1",
@@ -8209,11 +8585,6 @@
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
 			}
-		},
-		"cjs-module-lexer": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.4.3.tgz",
-			"integrity": "sha512-5RLK0Qfs0PNDpEyBXIr3bIT1Muw3ojSlvpw6dAmkUcO0+uTrsBn7GuEIgx40u+OzbCBLDta7nvmud85P4EmTsQ=="
 		},
 		"class-utils": {
 			"version": "0.3.6",
@@ -8369,9 +8740,18 @@
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
 		"codemirror": {
-			"version": "5.58.2",
-			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.58.2.tgz",
-			"integrity": "sha512-K/hOh24cCwRutd1Mk3uLtjWzNISOkm4fvXiMO7LucCrqbh6aJDdtqUziim3MZUI6wOY0rvY1SlL1Ork01uMy6w=="
+			"version": "5.57.0",
+			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.57.0.tgz",
+			"integrity": "sha512-WGc6UL7Hqt+8a6ZAsj/f1ApQl3NPvHY/UQSzG6fB6l4BjExgVdhFaxd7mRTw1UCiYe/6q86zHP+kfvBQcZGvUg=="
+		},
+		"codemirror-graphql": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/codemirror-graphql/-/codemirror-graphql-0.8.3.tgz",
+			"integrity": "sha512-ZipSnPXFKDMThfvfTKTAt1dQmuGctVNann8hTZg6017+vwOcGpIqCuQIZLRDw/Y3zZfCyydRARHgbSydSCXpow==",
+			"requires": {
+				"graphql-language-service-interface": "^1.3.2",
+				"graphql-language-service-parser": "^1.2.2"
+			}
 		},
 		"codemirror-spell-checker": {
 			"version": "1.1.2",
@@ -8473,6 +8853,41 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+		},
+		"commoner": {
+			"version": "0.10.8",
+			"resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
+			"integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
+			"requires": {
+				"commander": "^2.5.0",
+				"detective": "^4.3.1",
+				"glob": "^5.0.15",
+				"graceful-fs": "^4.1.2",
+				"iconv-lite": "^0.4.5",
+				"mkdirp": "^0.5.0",
+				"private": "^0.1.6",
+				"q": "^1.1.2",
+				"recast": "^0.11.17"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+				},
+				"glob": {
+					"version": "5.0.15",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"requires": {
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "2 || 3",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				}
+			}
 		},
 		"compare-func": {
 			"version": "2.0.0",
@@ -9474,29 +9889,22 @@
 			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
 		},
 		"cssom": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
-			"integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw=="
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+			"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
 		},
 		"cssstyle": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-			"integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
+			"integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
 			"requires": {
-				"cssom": "~0.3.6"
-			},
-			"dependencies": {
-				"cssom": {
-					"version": "0.3.8",
-					"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-					"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
-				}
+				"cssom": "0.3.x"
 			}
 		},
 		"csstype": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
-			"integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA=="
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
+			"integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
 		},
 		"currently-unhandled": {
 			"version": "0.4.1",
@@ -9580,6 +9988,45 @@
 					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
 					"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
 					"dev": true
+				},
+				"has-flag": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"dev": true
+				},
+				"node-fetch": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+					"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+							"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+							"dev": true
+						}
+					}
+				},
+				"supports-hyperlinks": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-1.0.1.tgz",
+					"integrity": "sha512-HHi5kVSefKaJkGYXbDuKbUGRVxqnWGn3J2e39CYcNJEfWciGq2zYtOhXLTlvrOZW1QU7VX67w7fMmWafHX9Pfw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^2.0.0",
+						"supports-color": "^5.0.0"
+					}
 				}
 			}
 		},
@@ -9601,38 +10048,13 @@
 			}
 		},
 		"data-urls": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
-			"integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
 			"requires": {
-				"abab": "^2.0.3",
-				"whatwg-mimetype": "^2.3.0",
-				"whatwg-url": "^8.0.0"
-			},
-			"dependencies": {
-				"tr46": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
-					"integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
-					"requires": {
-						"punycode": "^2.1.1"
-					}
-				},
-				"webidl-conversions": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-					"integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
-				},
-				"whatwg-url": {
-					"version": "8.4.0",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.4.0.tgz",
-					"integrity": "sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==",
-					"requires": {
-						"lodash.sortby": "^4.7.0",
-						"tr46": "^2.0.2",
-						"webidl-conversions": "^6.1.0"
-					}
-				}
+				"abab": "^2.0.0",
+				"whatwg-mimetype": "^2.2.0",
+				"whatwg-url": "^7.0.0"
 			}
 		},
 		"date-arithmetic": {
@@ -9653,11 +10075,11 @@
 			"dev": true
 		},
 		"debug": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-			"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 			"requires": {
-				"ms": "2.1.2"
+				"ms": "^2.1.1"
 			}
 		},
 		"debuglog": {
@@ -9688,9 +10110,9 @@
 			}
 		},
 		"decimal.js": {
-			"version": "10.2.1",
-			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
-			"integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
+			"integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw=="
 		},
 		"decode-uri-component": {
 			"version": "0.2.0",
@@ -9920,6 +10342,22 @@
 			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
 			"integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
 		},
+		"detective": {
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+			"integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
+			"requires": {
+				"acorn": "^5.2.1",
+				"defined": "^1.0.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "5.7.4",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+					"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
+				}
+			}
+		},
 		"dezalgo": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
@@ -9936,9 +10374,9 @@
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 		},
 		"diff-sequences": {
-			"version": "26.5.0",
-			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
-			"integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q=="
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
+			"integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig=="
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
@@ -10026,14 +10464,14 @@
 			},
 			"dependencies": {
 				"domelementtype": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
-					"integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA=="
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+					"integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
 				},
 				"entities": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-					"integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+					"integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
 				}
 			}
 		},
@@ -10048,18 +10486,11 @@
 			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
 		},
 		"domexception": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
-			"integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
 			"requires": {
-				"webidl-conversions": "^5.0.0"
-			},
-			"dependencies": {
-				"webidl-conversions": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-					"integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
-				}
+				"webidl-conversions": "^4.0.2"
 			}
 		},
 		"domhandler": {
@@ -10205,6 +10636,43 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"editorconfig": {
+			"version": "0.15.3",
+			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+			"integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+			"requires": {
+				"commander": "^2.19.0",
+				"lru-cache": "^4.1.5",
+				"semver": "^5.6.0",
+				"sigmund": "^1.0.1"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+				},
+				"lru-cache": {
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+				}
+			}
+		},
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -10237,9 +10705,9 @@
 			}
 		},
 		"emittery": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",
-			"integrity": "sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ=="
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.1.tgz",
+			"integrity": "sha512-d34LN4L6h18Bzz9xpoku2nPwKxCPlPMr3EEKTkoEBi+1/+b0lcRkRJ1UVyyZaKNeqGR3swcGl6s390DNO4YVgQ=="
 		},
 		"emoji-regex": {
 			"version": "7.0.3",
@@ -10273,36 +10741,23 @@
 			}
 		},
 		"engine.io-client": {
-			"version": "3.4.4",
-			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.4.tgz",
-			"integrity": "sha512-iU4CRr38Fecj8HoZEnFtm2EiKGbYZcPn3cHxqNGl/tmdWRf60KhK+9vE0JeSjgnlS/0oynEfLgKbT9ALpim0sQ==",
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.3.tgz",
+			"integrity": "sha512-0NGY+9hioejTEJCaSJZfWZLk4FPI9dN+1H1C4+wj2iuFba47UgZbJzfWs4aNFajnX/qAaYKbe2lLTfEEWzCmcw==",
 			"requires": {
 				"component-emitter": "~1.3.0",
 				"component-inherit": "0.0.3",
-				"debug": "~3.1.0",
+				"debug": "~4.1.0",
 				"engine.io-parser": "~2.2.0",
 				"has-cors": "1.1.0",
 				"indexof": "0.0.1",
-				"parseqs": "0.0.6",
-				"parseuri": "0.0.6",
+				"parseqs": "0.0.5",
+				"parseuri": "0.0.5",
 				"ws": "~6.1.0",
 				"xmlhttprequest-ssl": "~1.5.4",
 				"yeast": "0.1.2"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				},
 				"ws": {
 					"version": "6.1.4",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
@@ -10314,13 +10769,13 @@
 			}
 		},
 		"engine.io-parser": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.1.tgz",
-			"integrity": "sha512-x+dN/fBH8Ro8TFwJ+rkB2AmuVw9Yu2mockR/p3W8f8YtExwFgDvBDi0GWyb4ZLkpahtDGZgtr3zLovanJghPqg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
+			"integrity": "sha512-6I3qD9iUxotsC5HEMuuGsKA0cXerGz+4uGcXQEkfBidgKf0amsjrrtwcbwK/nzpZBxclXlV7gGl9dgWvu4LF6w==",
 			"requires": {
 				"after": "0.8.2",
 				"arraybuffer.slice": "~0.0.7",
-				"base64-arraybuffer": "0.1.4",
+				"base64-arraybuffer": "0.1.5",
 				"blob": "0.0.5",
 				"has-binary2": "~1.0.2"
 			}
@@ -10353,6 +10808,15 @@
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
 			"integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
 			"dev": true
+		},
+		"envify": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz",
+			"integrity": "sha1-1xIjKejfFoi6dxsSUBkXyc5cvOg=",
+			"requires": {
+				"jstransform": "^11.0.3",
+				"through": "~2.3.4"
+			}
 		},
 		"envinfo": {
 			"version": "7.5.1",
@@ -10400,6 +10864,32 @@
 				"string.prototype.trimright": "^2.1.1"
 			}
 		},
+		"es-array-method-boxes-properly": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
+		},
+		"es-get-iterator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.0.tgz",
+			"integrity": "sha512-UfrmHuWQlNMTs35e1ypnvikg6jCz3SK8v8ImvmDsh36fCVUR1MqoFDiyn0/k52C8NqO3YsO8Oe0azeesNuqSsQ==",
+			"requires": {
+				"es-abstract": "^1.17.4",
+				"has-symbols": "^1.0.1",
+				"is-arguments": "^1.0.4",
+				"is-map": "^2.0.1",
+				"is-set": "^2.0.1",
+				"is-string": "^1.0.5",
+				"isarray": "^2.0.5"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+					"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+				}
+			}
+		},
 		"es-to-primitive": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
@@ -10432,6 +10922,15 @@
 			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
 			"requires": {
 				"es6-promise": "^4.0.3"
+			}
+		},
+		"es6-templates": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz",
+			"integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
+			"requires": {
+				"recast": "~0.11.12",
+				"through": "~2.3.6"
 			}
 		},
 		"escape-html": {
@@ -10506,10 +11005,11 @@
 					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 				},
 				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
 					"requires": {
+						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -10561,24 +11061,6 @@
 						"acorn": "^7.4.0",
 						"acorn-jsx": "^5.2.0",
 						"eslint-visitor-keys": "^1.3.0"
-					}
-				},
-				"file-entry-cache": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-					"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
-					"requires": {
-						"flat-cache": "^2.0.1"
-					}
-				},
-				"flat-cache": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-					"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
-					"requires": {
-						"flatted": "^2.0.0",
-						"rimraf": "2.6.3",
-						"write": "1.0.3"
 					}
 				},
 				"globals": {
@@ -10634,14 +11116,6 @@
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 					"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
-				},
-				"rimraf": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
 				},
 				"semver": {
 					"version": "7.3.2",
@@ -10759,11 +11233,10 @@
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				},
 				"resolve": {
-					"version": "1.18.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
-					"integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
+					"version": "1.17.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
 					"requires": {
-						"is-core-module": "^2.0.0",
 						"path-parse": "^1.0.6"
 					}
 				}
@@ -10905,14 +11378,6 @@
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
 				"load-json-file": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -11000,23 +11465,11 @@
 					}
 				},
 				"resolve": {
-					"version": "1.18.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
-					"integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
+					"version": "1.17.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
 					"requires": {
-						"is-core-module": "^2.0.0",
 						"path-parse": "^1.0.6"
-					}
-				},
-				"tsconfig-paths": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
-					"integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
-					"requires": {
-						"@types/json5": "^0.0.29",
-						"json5": "^1.0.1",
-						"minimist": "^1.2.0",
-						"strip-bom": "^3.0.0"
 					}
 				}
 			}
@@ -11040,20 +11493,20 @@
 			"integrity": "sha512-C8YMhL+r8RMeMdYAw/rQtE6xNdMulj+zGWud/qIGnlmomiPRaLDGLMeskZ3alN6uMBojmooRimtdrXebLN4svQ=="
 		},
 		"eslint-plugin-react": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz",
-			"integrity": "sha512-8MaEggC2et0wSF6bUeywF7qQ46ER81irOdWS4QWxnnlAEsnzeBevk1sWh7fhpCghPpXb+8Ks7hvaft6L/xsR6g==",
+			"version": "7.21.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.2.tgz",
+			"integrity": "sha512-j3XKvrK3rpBzveKFbgAeGsWb9uz6iUOrR0jixRfjwdFeGSRsXvVTFtHDQYCjsd1/6Z/xvb8Vy3LiI5Reo7fDrg==",
 			"requires": {
 				"array-includes": "^3.1.1",
 				"array.prototype.flatmap": "^1.2.3",
 				"doctrine": "^2.1.0",
 				"has": "^1.0.3",
-				"jsx-ast-utils": "^2.4.1 || ^3.0.0",
+				"jsx-ast-utils": "^2.4.1",
 				"object.entries": "^1.1.2",
 				"object.fromentries": "^2.0.2",
 				"object.values": "^1.1.1",
 				"prop-types": "^15.7.2",
-				"resolve": "^1.18.1",
+				"resolve": "^1.17.0",
 				"string.prototype.matchall": "^4.0.2"
 			},
 			"dependencies": {
@@ -11066,11 +11519,10 @@
 					}
 				},
 				"resolve": {
-					"version": "1.18.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
-					"integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
+					"version": "1.17.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
 					"requires": {
-						"is-core-module": "^2.0.0",
 						"path-parse": "^1.0.6"
 					}
 				}
@@ -11414,32 +11866,70 @@
 			}
 		},
 		"expand-tilde": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+			"integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
 			"requires": {
-				"homedir-polyfill": "^1.0.1"
+				"os-homedir": "^1.0.1"
 			}
 		},
 		"expect": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-26.6.1.tgz",
-			"integrity": "sha512-BRfxIBHagghMmr1D2MRY0Qv5d3Nc8HCqgbDwNXw/9izmM5eBb42a2YjLKSbsqle76ozGkAEPELQX4IdNHAKRNA==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-26.4.2.tgz",
+			"integrity": "sha512-IlJ3X52Z0lDHm7gjEp+m76uX46ldH5VpqmU0006vqDju/285twh7zaWMRhs67VpQhBwjjMchk+p5aA0VkERCAA==",
 			"requires": {
-				"@jest/types": "^26.6.1",
+				"@jest/types": "^26.3.0",
 				"ansi-styles": "^4.0.0",
 				"jest-get-type": "^26.3.0",
-				"jest-matcher-utils": "^26.6.1",
-				"jest-message-util": "^26.6.1",
+				"jest-matcher-utils": "^26.4.2",
+				"jest-message-util": "^26.3.0",
 				"jest-regex-util": "^26.0.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
 				},
 				"color-convert": {
@@ -11454,6 +11944,24 @@
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"jest-get-type": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
 				}
 			}
 		},
@@ -11773,6 +12281,14 @@
 				"escape-string-regexp": "^1.0.5"
 			}
 		},
+		"file-entry-cache": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+			"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+			"requires": {
+				"flat-cache": "^2.0.1"
+			}
+		},
 		"file-loader": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-3.0.1.tgz",
@@ -11793,6 +12309,12 @@
 					}
 				}
 			}
+		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"optional": true
 		},
 		"filesize": {
 			"version": "3.6.1",
@@ -11938,57 +12460,32 @@
 			}
 		},
 		"find-process": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.4.tgz",
-			"integrity": "sha512-rRSuT1LE4b+BFK588D2V8/VG9liW0Ark1XJgroxZXI0LtwmQJOb490DvDYvbm+Hek9ETFzTutGfJ90gumITPhQ==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.3.tgz",
+			"integrity": "sha512-+IA+AUsQCf3uucawyTwMWcY+2M3FXq3BRvw3S+j5Jvydjk31f/+NPWpYZOJs+JUs2GvxH4Yfr6Wham0ZtRLlPA==",
 			"requires": {
-				"chalk": "^4.0.0",
-				"commander": "^5.1.0",
-				"debug": "^4.1.1"
+				"chalk": "^2.0.1",
+				"commander": "^2.11.0",
+				"debug": "^2.6.8"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"requires": {
-						"color-convert": "^2.0.1"
+						"ms": "2.0.0"
 					}
 				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -12016,6 +12513,14 @@
 				"resolve-dir": "^1.0.1"
 			},
 			"dependencies": {
+				"expand-tilde": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+					"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+					"requires": {
+						"homedir-polyfill": "^1.0.1"
+					}
+				},
 				"global-modules": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
@@ -12050,9 +12555,39 @@
 			}
 		},
 		"flat": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+			"integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+			"requires": {
+				"is-buffer": "~2.0.3"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+				}
+			}
+		},
+		"flat-cache": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+			"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+			"requires": {
+				"flatted": "^2.0.0",
+				"rimraf": "2.6.3",
+				"write": "1.0.3"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
+			}
 		},
 		"flatted": {
 			"version": "2.0.2",
@@ -12332,10 +12867,14 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-			"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-			"optional": true
+			"version": "1.2.13",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+			"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+			"optional": true,
+			"requires": {
+				"bindings": "^1.5.0",
+				"nan": "^2.12.1"
+			}
 		},
 		"fstream": {
 			"version": "1.0.12",
@@ -13091,42 +13630,6 @@
 				"codemirror-graphql": "^0.8.3",
 				"copy-to-clipboard": "^3.2.0",
 				"markdown-it": "^8.4.0"
-			},
-			"dependencies": {
-				"codemirror-graphql": {
-					"version": "0.8.3",
-					"resolved": "https://registry.npmjs.org/codemirror-graphql/-/codemirror-graphql-0.8.3.tgz",
-					"integrity": "sha512-ZipSnPXFKDMThfvfTKTAt1dQmuGctVNann8hTZg6017+vwOcGpIqCuQIZLRDw/Y3zZfCyydRARHgbSydSCXpow==",
-					"requires": {
-						"graphql-language-service-interface": "^1.3.2",
-						"graphql-language-service-parser": "^1.2.2"
-					}
-				},
-				"graphql-language-service-interface": {
-					"version": "1.3.2",
-					"resolved": "https://registry.npmjs.org/graphql-language-service-interface/-/graphql-language-service-interface-1.3.2.tgz",
-					"integrity": "sha512-sOxFV5sBSnYtKIFHtlmAHHVdhok7CRbvCPLcuHvL4Q1RSgKRsPpeHUDKU+yCbmlonOKn/RWEKaYWrUY0Sgv70A==",
-					"requires": {
-						"graphql-config": "2.0.1",
-						"graphql-language-service-parser": "^1.2.2",
-						"graphql-language-service-types": "^1.2.2",
-						"graphql-language-service-utils": "^1.2.2"
-					}
-				},
-				"graphql-language-service-parser": {
-					"version": "1.6.4",
-					"resolved": "https://registry.npmjs.org/graphql-language-service-parser/-/graphql-language-service-parser-1.6.4.tgz",
-					"integrity": "sha512-Y365zUFfJ1GJ9NeRHb5Z/HBo6EnbuTi187Gkuldwd1YIDc0QcD7kqz6U5g043zd7BI/UZQth13Zd7pElvbb2zw==",
-					"requires": {
-						"graphql-language-service-types": "^1.6.3",
-						"typescript": "^3.9.5"
-					}
-				},
-				"typescript": {
-					"version": "3.9.7",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-					"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
-				}
 			}
 		},
 		"graphql": {
@@ -13157,10 +13660,37 @@
 				"lodash": "^4.17.4"
 			}
 		},
-		"graphql-language-service-types": {
+		"graphql-language-service-interface": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/graphql-language-service-interface/-/graphql-language-service-interface-1.3.2.tgz",
+			"integrity": "sha512-sOxFV5sBSnYtKIFHtlmAHHVdhok7CRbvCPLcuHvL4Q1RSgKRsPpeHUDKU+yCbmlonOKn/RWEKaYWrUY0Sgv70A==",
+			"requires": {
+				"graphql-config": "2.0.1",
+				"graphql-language-service-parser": "^1.2.2",
+				"graphql-language-service-types": "^1.2.2",
+				"graphql-language-service-utils": "^1.2.2"
+			}
+		},
+		"graphql-language-service-parser": {
 			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/graphql-language-service-types/-/graphql-language-service-types-1.6.3.tgz",
-			"integrity": "sha512-VDtBhdan1iSe7ad7+eBbsO5rrzWQpC6aV4SxSHEi8AtEQOFXpnL9Lq5jSaN8O02pGvAUr4wNUPu0oRU5g2XmVA=="
+			"resolved": "https://registry.npmjs.org/graphql-language-service-parser/-/graphql-language-service-parser-1.6.3.tgz",
+			"integrity": "sha512-UjmVXcSN59pCkFDBIZav0rTdz7ISeYAgGshA/0OpFlrJ6ZkS3hlOBbu/QvLyjRvTcjKpx95qT299auL39kE+/g==",
+			"requires": {
+				"graphql-language-service-types": "^1.6.2",
+				"typescript": "^3.9.5"
+			},
+			"dependencies": {
+				"typescript": {
+					"version": "3.9.7",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+					"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
+				}
+			}
+		},
+		"graphql-language-service-types": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/graphql-language-service-types/-/graphql-language-service-types-1.6.2.tgz",
+			"integrity": "sha512-5cslPoUd8P7/EjJ5L3/zs0NBeDhvQHhjUMbjKQakwqu4tZXplriZ9KvvA+Q/n4w/Rn79+3cbr7maNtsTk6/TmQ=="
 		},
 		"graphql-language-service-utils": {
 			"version": "1.2.2",
@@ -13496,11 +14026,11 @@
 			}
 		},
 		"html-encoding-sniffer": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
-			"integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
 			"requires": {
-				"whatwg-encoding": "^1.0.5"
+				"whatwg-encoding": "^1.0.1"
 			}
 		},
 		"html-entities": {
@@ -13523,56 +14053,26 @@
 				"html-minifier": "^3.5.8",
 				"loader-utils": "^1.1.0",
 				"object-assign": "^4.1.1"
+			}
+		},
+		"html-minifier": {
+			"version": "3.5.21",
+			"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
+			"integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
+			"requires": {
+				"camel-case": "3.0.x",
+				"clean-css": "4.2.x",
+				"commander": "2.17.x",
+				"he": "1.2.x",
+				"param-case": "2.1.x",
+				"relateurl": "0.2.x",
+				"uglify-js": "3.4.x"
 			},
 			"dependencies": {
 				"commander": {
 					"version": "2.17.1",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
 					"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
-				},
-				"es6-templates": {
-					"version": "0.2.3",
-					"resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz",
-					"integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
-					"requires": {
-						"recast": "~0.11.12",
-						"through": "~2.3.6"
-					}
-				},
-				"esprima": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-				},
-				"html-minifier": {
-					"version": "3.5.21",
-					"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
-					"integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
-					"requires": {
-						"camel-case": "3.0.x",
-						"clean-css": "4.2.x",
-						"commander": "2.17.x",
-						"he": "1.2.x",
-						"param-case": "2.1.x",
-						"relateurl": "0.2.x",
-						"uglify-js": "3.4.x"
-					}
-				},
-				"recast": {
-					"version": "0.11.23",
-					"resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-					"integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-					"requires": {
-						"ast-types": "0.9.6",
-						"esprima": "~3.1.0",
-						"private": "~0.1.5",
-						"source-map": "~0.5.0"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				},
 				"uglify-js": {
 					"version": "3.4.10",
@@ -13587,11 +14087,6 @@
 							"version": "2.19.0",
 							"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
 							"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
-						},
-						"source-map": {
-							"version": "0.6.1",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 						}
 					}
 				}
@@ -13637,9 +14132,9 @@
 			}
 		},
 		"html-webpack-plugin": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.5.0.tgz",
-			"integrity": "sha512-MouoXEYSjTzCrjIxWwg8gxL5fE2X2WZJLmBYXlaJhQUH5K/b5OrqmV7T4dB7iu0xkmJ6JlUuV6fFVtnqbPopZw==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.4.1.tgz",
+			"integrity": "sha512-nEtdEIsIGXdXGG7MjTTZlmhqhpHU9pJFc1OYxcP36c5/ZKP6b0BJMww2QTvJGQYA9aMxUnjDujpZdYcVOXiBCQ==",
 			"requires": {
 				"@types/html-minifier-terser": "^5.0.0",
 				"@types/tapable": "^1.0.5",
@@ -14154,14 +14649,6 @@
 				"ci-info": "^2.0.0"
 			}
 		},
-		"is-core-module": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.0.0.tgz",
-			"integrity": "sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==",
-			"requires": {
-				"has": "^1.0.3"
-			}
-		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -14270,6 +14757,11 @@
 				}
 			}
 		},
+		"is-map": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
+			"integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw=="
+		},
 		"is-nan": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.0.tgz",
@@ -14368,6 +14860,11 @@
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
 			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
 		},
+		"is-set": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
+			"integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA=="
+		},
 		"is-ssh": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
@@ -14431,12 +14928,9 @@
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
 		},
 		"is-wsl": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-			"requires": {
-				"is-docker": "^2.0.0"
-			}
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
 		},
 		"isarray": {
 			"version": "0.0.1",
@@ -14681,89 +15175,56 @@
 			"resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
 			"integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
 		},
-		"jest": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-26.6.1.tgz",
-			"integrity": "sha512-f+ahfqw3Ffy+9vA7sWFGpTmhtKEMsNAZiWBVXDkrpIO73zIz22iimjirnV78kh/eWlylmvLh/0WxHN6fZraZdA==",
+		"iterate-iterator": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.1.tgz",
+			"integrity": "sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw=="
+		},
+		"iterate-value": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
+			"integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
 			"requires": {
-				"@jest/core": "^26.6.1",
+				"es-get-iterator": "^1.0.2",
+				"iterate-iterator": "^1.0.1"
+			}
+		},
+		"jest": {
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-26.4.2.tgz",
+			"integrity": "sha512-LLCjPrUh98Ik8CzW8LLVnSCfLaiY+wbK53U7VxnFSX7Q+kWC4noVeDvGWIFw0Amfq1lq2VfGm7YHWSLBV62MJw==",
+			"requires": {
+				"@jest/core": "^26.4.2",
 				"import-local": "^3.0.2",
-				"jest-cli": "^26.6.1"
+				"jest-cli": "^26.4.2"
 			},
 			"dependencies": {
-				"@jest/core": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/@jest/core/-/core-26.6.1.tgz",
-					"integrity": "sha512-p4F0pgK3rKnoS9olXXXOkbus1Bsu6fd8pcvLMPsUy4CVXZ8WSeiwQ1lK5hwkCIqJ+amZOYPd778sbPha/S8Srw==",
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"requires": {
-						"@jest/console": "^26.6.1",
-						"@jest/reporters": "^26.6.1",
-						"@jest/test-result": "^26.6.1",
-						"@jest/transform": "^26.6.1",
-						"@jest/types": "^26.6.1",
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
 						"@types/node": "*",
-						"ansi-escapes": "^4.2.1",
-						"chalk": "^4.0.0",
-						"exit": "^0.1.2",
-						"graceful-fs": "^4.2.4",
-						"jest-changed-files": "^26.6.1",
-						"jest-config": "^26.6.1",
-						"jest-haste-map": "^26.6.1",
-						"jest-message-util": "^26.6.1",
-						"jest-regex-util": "^26.0.0",
-						"jest-resolve": "^26.6.1",
-						"jest-resolve-dependencies": "^26.6.1",
-						"jest-runner": "^26.6.1",
-						"jest-runtime": "^26.6.1",
-						"jest-snapshot": "^26.6.1",
-						"jest-util": "^26.6.1",
-						"jest-validate": "^26.6.1",
-						"jest-watcher": "^26.6.1",
-						"micromatch": "^4.0.2",
-						"p-each-series": "^2.1.0",
-						"rimraf": "^3.0.0",
-						"slash": "^3.0.0",
-						"strip-ansi": "^6.0.0"
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
 					}
 				},
-				"@jest/reporters": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.6.1.tgz",
-					"integrity": "sha512-J6OlXVFY3q1SXWJhjme5i7qT/BAZSikdOK2t8Ht5OS32BDo6KfG5CzIzzIFnAVd82/WWbc9Hb7SJ/jwSvVH9YA==",
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
 					"requires": {
-						"@bcoe/v8-coverage": "^0.2.3",
-						"@jest/console": "^26.6.1",
-						"@jest/test-result": "^26.6.1",
-						"@jest/transform": "^26.6.1",
-						"@jest/types": "^26.6.1",
-						"chalk": "^4.0.0",
-						"collect-v8-coverage": "^1.0.0",
-						"exit": "^0.1.2",
-						"glob": "^7.1.2",
-						"graceful-fs": "^4.2.4",
-						"istanbul-lib-coverage": "^3.0.0",
-						"istanbul-lib-instrument": "^4.0.3",
-						"istanbul-lib-report": "^3.0.0",
-						"istanbul-lib-source-maps": "^4.0.0",
-						"istanbul-reports": "^3.0.2",
-						"jest-haste-map": "^26.6.1",
-						"jest-resolve": "^26.6.1",
-						"jest-util": "^26.6.1",
-						"jest-worker": "^26.6.1",
-						"node-notifier": "^8.0.0",
-						"slash": "^3.0.0",
-						"source-map": "^0.6.0",
-						"string-length": "^4.0.1",
-						"terminal-link": "^2.0.0",
-						"v8-to-istanbul": "^6.0.1"
+						"@types/istanbul-lib-report": "*"
 					}
 				},
-				"ansi-escapes": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
 					"requires": {
-						"type-fest": "^0.11.0"
+						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-regex": {
@@ -14772,20 +15233,18 @@
 					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 				},
 				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
 					"requires": {
+						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"requires": {
-						"fill-range": "^7.0.1"
-					}
+				"camelcase": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w=="
 				},
 				"chalk": {
 					"version": "4.1.0",
@@ -14804,6 +15263,261 @@
 						"string-width": "^4.2.0",
 						"strip-ansi": "^6.0.0",
 						"wrap-ansi": "^6.2.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"import-local": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+					"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+					"requires": {
+						"pkg-dir": "^4.2.0",
+						"resolve-cwd": "^3.0.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+				},
+				"jest-cli": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.4.2.tgz",
+					"integrity": "sha512-zb+lGd/SfrPvoRSC/0LWdaWCnscXc1mGYW//NP4/tmBvRPT3VntZ2jtKUONsRi59zc5JqmsSajA9ewJKFYp8Cw==",
+					"requires": {
+						"@jest/core": "^26.4.2",
+						"@jest/test-result": "^26.3.0",
+						"@jest/types": "^26.3.0",
+						"chalk": "^4.0.0",
+						"exit": "^0.1.2",
+						"graceful-fs": "^4.2.4",
+						"import-local": "^3.0.2",
+						"is-ci": "^2.0.0",
+						"jest-config": "^26.4.2",
+						"jest-util": "^26.3.0",
+						"jest-validate": "^26.4.2",
+						"prompts": "^2.0.1",
+						"yargs": "^15.3.1"
+					}
+				},
+				"jest-get-type": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
+				},
+				"jest-validate": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.4.2.tgz",
+					"integrity": "sha512-blft+xDX7XXghfhY0mrsBCYhX365n8K5wNDC4XAcNKqqjEzsRUSXP44m6PL0QJEW2crxQFLLztVnJ4j7oPlQrQ==",
+					"requires": {
+						"@jest/types": "^26.3.0",
+						"camelcase": "^6.0.0",
+						"chalk": "^4.0.0",
+						"jest-get-type": "^26.3.0",
+						"leven": "^3.1.0",
+						"pretty-format": "^26.4.2"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+				},
+				"pkg-dir": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+					"requires": {
+						"find-up": "^4.0.0"
+					}
+				},
+				"pretty-format": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"requires": {
+						"@jest/types": "^26.3.0",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^4.0.0",
+						"react-is": "^16.12.0"
+					}
+				},
+				"resolve-cwd": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+					"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+					"requires": {
+						"resolve-from": "^5.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"yargs": {
+					"version": "15.4.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+					"requires": {
+						"cliui": "^6.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^4.1.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^4.2.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^18.1.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "5.3.1",
+							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+							"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+						}
+					}
+				}
+			}
+		},
+		"jest-changed-files": {
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.3.0.tgz",
+			"integrity": "sha512-1C4R4nijgPltX6fugKxM4oQ18zimS7LqQ+zTTY8lMCMFPrxqBFb7KJH0Z2fRQJvw2Slbaipsqq7s1mgX5Iot+g==",
+			"requires": {
+				"@jest/types": "^26.3.0",
+				"execa": "^4.0.0",
+				"throat": "^5.0.0"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
 				},
 				"color-convert": {
@@ -14829,11 +15543,6 @@
 						"which": "^2.0.1"
 					}
 				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-				},
 				"execa": {
 					"version": "4.0.3",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
@@ -14850,23 +15559,6 @@
 						"strip-final-newline": "^2.0.0"
 					}
 				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
 				"get-stream": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
@@ -14880,183 +15572,10 @@
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
-				"import-local": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
-					"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
-					"requires": {
-						"pkg-dir": "^4.2.0",
-						"resolve-cwd": "^3.0.0"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-				},
 				"is-stream": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
 					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
-				},
-				"istanbul-lib-instrument": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
-					"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
-					"requires": {
-						"@babel/core": "^7.7.5",
-						"@istanbuljs/schema": "^0.1.2",
-						"istanbul-lib-coverage": "^3.0.0",
-						"semver": "^6.3.0"
-					}
-				},
-				"jest-changed-files": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.1.tgz",
-					"integrity": "sha512-NhSdZ5F6b/rIN5V46x1l31vrmukD/bJUXgYAY8VtP1SknYdJwjYDRxuLt7Z8QryIdqCjMIn2C0Cd98EZ4umo8Q==",
-					"requires": {
-						"@jest/types": "^26.6.1",
-						"execa": "^4.0.0",
-						"throat": "^5.0.0"
-					}
-				},
-				"jest-cli": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.1.tgz",
-					"integrity": "sha512-aPLoEjlwFrCWhiPpW5NUxQA1X1kWsAnQcQ0SO/fHsCvczL3W75iVAcH9kP6NN+BNqZcHNEvkhxT5cDmBfEAh+w==",
-					"requires": {
-						"@jest/core": "^26.6.1",
-						"@jest/test-result": "^26.6.1",
-						"@jest/types": "^26.6.1",
-						"chalk": "^4.0.0",
-						"exit": "^0.1.2",
-						"graceful-fs": "^4.2.4",
-						"import-local": "^3.0.2",
-						"is-ci": "^2.0.0",
-						"jest-config": "^26.6.1",
-						"jest-util": "^26.6.1",
-						"jest-validate": "^26.6.1",
-						"prompts": "^2.0.1",
-						"yargs": "^15.4.1"
-					}
-				},
-				"jest-resolve-dependencies": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.1.tgz",
-					"integrity": "sha512-MN6lufbZJ3RBfTnJesZtHu3hUCBqPdHRe2+FhIt0yiqJ3fMgzWRqMRQyN/d/QwOE7KXwAG2ekZutbPhuD7s51A==",
-					"requires": {
-						"@jest/types": "^26.6.1",
-						"jest-regex-util": "^26.0.0",
-						"jest-snapshot": "^26.6.1"
-					}
-				},
-				"jest-runtime": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.1.tgz",
-					"integrity": "sha512-7uOCNeezXDWgjEyzYbRN2ViY7xNZzusNVGAMmU0UHRUNXuY4j4GBHKGMqPo/cBPZA9bSYp+lwK2DRRBU5Dv6YQ==",
-					"requires": {
-						"@jest/console": "^26.6.1",
-						"@jest/environment": "^26.6.1",
-						"@jest/fake-timers": "^26.6.1",
-						"@jest/globals": "^26.6.1",
-						"@jest/source-map": "^26.5.0",
-						"@jest/test-result": "^26.6.1",
-						"@jest/transform": "^26.6.1",
-						"@jest/types": "^26.6.1",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0",
-						"cjs-module-lexer": "^0.4.2",
-						"collect-v8-coverage": "^1.0.0",
-						"exit": "^0.1.2",
-						"glob": "^7.1.3",
-						"graceful-fs": "^4.2.4",
-						"jest-config": "^26.6.1",
-						"jest-haste-map": "^26.6.1",
-						"jest-message-util": "^26.6.1",
-						"jest-mock": "^26.6.1",
-						"jest-regex-util": "^26.0.0",
-						"jest-resolve": "^26.6.1",
-						"jest-snapshot": "^26.6.1",
-						"jest-util": "^26.6.1",
-						"jest-validate": "^26.6.1",
-						"slash": "^3.0.0",
-						"strip-bom": "^4.0.0",
-						"yargs": "^15.4.1"
-					}
-				},
-				"jest-snapshot": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.1.tgz",
-					"integrity": "sha512-JA7bZp7HRTIJYAi85pJ/OZ2eur2dqmwIToA5/6d7Mn90isGEfeF9FvuhDLLEczgKP1ihreBzrJ6Vr7zteP5JNA==",
-					"requires": {
-						"@babel/types": "^7.0.0",
-						"@jest/types": "^26.6.1",
-						"@types/babel__traverse": "^7.0.4",
-						"@types/prettier": "^2.0.0",
-						"chalk": "^4.0.0",
-						"expect": "^26.6.1",
-						"graceful-fs": "^4.2.4",
-						"jest-diff": "^26.6.1",
-						"jest-get-type": "^26.3.0",
-						"jest-haste-map": "^26.6.1",
-						"jest-matcher-utils": "^26.6.1",
-						"jest-message-util": "^26.6.1",
-						"jest-resolve": "^26.6.1",
-						"natural-compare": "^1.4.0",
-						"pretty-format": "^26.6.1",
-						"semver": "^7.3.2"
-					},
-					"dependencies": {
-						"semver": {
-							"version": "7.3.2",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-							"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
-						}
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"micromatch": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-					"requires": {
-						"braces": "^3.0.1",
-						"picomatch": "^2.0.5"
-					}
-				},
-				"node-notifier": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.0.tgz",
-					"integrity": "sha512-46z7DUmcjoYdaWyXouuFNNfUo6eFa94t23c53c+lG/9Cvauk4a98rAUp9672X5dxGdQmLpPzTxzu8f/OeEPaFA==",
-					"optional": true,
-					"requires": {
-						"growly": "^1.3.0",
-						"is-wsl": "^2.2.0",
-						"semver": "^7.3.2",
-						"shellwords": "^0.1.1",
-						"uuid": "^8.3.0",
-						"which": "^2.0.2"
-					},
-					"dependencies": {
-						"semver": {
-							"version": "7.3.2",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-							"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-							"optional": true
-						}
-					}
 				},
 				"npm-run-path": {
 					"version": "4.0.1",
@@ -15074,57 +15593,10 @@
 						"mimic-fn": "^2.1.0"
 					}
 				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-				},
 				"path-key": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
-				},
-				"pkg-dir": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-					"requires": {
-						"find-up": "^4.0.0"
-					}
-				},
-				"resolve-cwd": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
-					"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-					"requires": {
-						"resolve-from": "^5.0.0"
-					}
-				},
-				"resolve-from": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
-				},
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				},
 				"shebang-command": {
 					"version": "2.0.0",
@@ -15139,34 +15611,6 @@
 					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
 				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
-				},
-				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
-				},
 				"supports-color": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -15175,25 +15619,6 @@
 						"has-flag": "^4.0.0"
 					}
 				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"requires": {
-						"is-number": "^7.0.0"
-					}
-				},
-				"type-fest": {
-					"version": "0.11.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-					"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
-				},
-				"uuid": {
-					"version": "8.3.1",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-					"integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
-					"optional": true
-				},
 				"which": {
 					"version": "2.0.2",
 					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -15201,81 +15626,73 @@
 					"requires": {
 						"isexe": "^2.0.0"
 					}
-				},
-				"wrap-ansi": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"yargs": {
-					"version": "15.4.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-					"requires": {
-						"cliui": "^6.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^4.1.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^4.2.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^18.1.2"
-					}
-				},
-				"yargs-parser": {
-					"version": "18.1.3",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
 				}
 			}
 		},
 		"jest-config": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.6.1.tgz",
-			"integrity": "sha512-mtJzIynIwW1d1nMlKCNCQiSgWaqFn8cH/fOSNY97xG7Y9tBCZbCSuW2GTX0RPmceSJGO7l27JgwC18LEg0Vg+g==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.4.2.tgz",
+			"integrity": "sha512-QBf7YGLuToiM8PmTnJEdRxyYy3mHWLh24LJZKVdXZ2PNdizSe1B/E8bVm+HYcjbEzGuVXDv/di+EzdO/6Gq80A==",
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/test-sequencer": "^26.6.1",
-				"@jest/types": "^26.6.1",
-				"babel-jest": "^26.6.1",
+				"@jest/test-sequencer": "^26.4.2",
+				"@jest/types": "^26.3.0",
+				"babel-jest": "^26.3.0",
 				"chalk": "^4.0.0",
 				"deepmerge": "^4.2.2",
 				"glob": "^7.1.1",
 				"graceful-fs": "^4.2.4",
-				"jest-environment-jsdom": "^26.6.1",
-				"jest-environment-node": "^26.6.1",
+				"jest-environment-jsdom": "^26.3.0",
+				"jest-environment-node": "^26.3.0",
 				"jest-get-type": "^26.3.0",
-				"jest-jasmine2": "^26.6.1",
+				"jest-jasmine2": "^26.4.2",
 				"jest-regex-util": "^26.0.0",
-				"jest-resolve": "^26.6.1",
-				"jest-util": "^26.6.1",
-				"jest-validate": "^26.6.1",
+				"jest-resolve": "^26.4.0",
+				"jest-util": "^26.3.0",
+				"jest-validate": "^26.4.2",
 				"micromatch": "^4.0.2",
-				"pretty-format": "^26.6.1"
+				"pretty-format": "^26.4.2"
 			},
 			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
 				"ansi-regex": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
 					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 				},
 				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
 					"requires": {
+						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -15287,6 +15704,11 @@
 						"fill-range": "^7.0.1"
 					}
 				},
+				"camelcase": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w=="
+				},
 				"chalk": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -15294,16 +15716,6 @@
 					"requires": {
 						"ansi-styles": "^4.1.0",
 						"supports-color": "^7.1.0"
-					}
-				},
-				"cliui": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-					"requires": {
-						"string-width": "^4.2.0",
-						"strip-ansi": "^6.0.0",
-						"wrap-ansi": "^6.2.0"
 					}
 				},
 				"color-convert": {
@@ -15319,11 +15731,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-				},
 				"fill-range": {
 					"version": "7.0.1",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -15332,118 +15739,32 @@
 						"to-regex-range": "^5.0.1"
 					}
 				},
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
 				},
 				"is-number": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
 				},
-				"jest-jasmine2": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.6.1.tgz",
-					"integrity": "sha512-2uYdT32o/ZzSxYAPduAgokO8OlAL1YdG/9oxcEY138EDNpIK5XRRJDaGzTZdIBWSxk0aR8XxN44FvfXtHB+Fiw==",
-					"requires": {
-						"@babel/traverse": "^7.1.0",
-						"@jest/environment": "^26.6.1",
-						"@jest/source-map": "^26.5.0",
-						"@jest/test-result": "^26.6.1",
-						"@jest/types": "^26.6.1",
-						"@types/node": "*",
-						"chalk": "^4.0.0",
-						"co": "^4.6.0",
-						"expect": "^26.6.1",
-						"is-generator-fn": "^2.0.0",
-						"jest-each": "^26.6.1",
-						"jest-matcher-utils": "^26.6.1",
-						"jest-message-util": "^26.6.1",
-						"jest-runtime": "^26.6.1",
-						"jest-snapshot": "^26.6.1",
-						"jest-util": "^26.6.1",
-						"pretty-format": "^26.6.1",
-						"throat": "^5.0.0"
-					}
+				"jest-get-type": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
 				},
-				"jest-runtime": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.1.tgz",
-					"integrity": "sha512-7uOCNeezXDWgjEyzYbRN2ViY7xNZzusNVGAMmU0UHRUNXuY4j4GBHKGMqPo/cBPZA9bSYp+lwK2DRRBU5Dv6YQ==",
+				"jest-validate": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.4.2.tgz",
+					"integrity": "sha512-blft+xDX7XXghfhY0mrsBCYhX365n8K5wNDC4XAcNKqqjEzsRUSXP44m6PL0QJEW2crxQFLLztVnJ4j7oPlQrQ==",
 					"requires": {
-						"@jest/console": "^26.6.1",
-						"@jest/environment": "^26.6.1",
-						"@jest/fake-timers": "^26.6.1",
-						"@jest/globals": "^26.6.1",
-						"@jest/source-map": "^26.5.0",
-						"@jest/test-result": "^26.6.1",
-						"@jest/transform": "^26.6.1",
-						"@jest/types": "^26.6.1",
-						"@types/yargs": "^15.0.0",
+						"@jest/types": "^26.3.0",
+						"camelcase": "^6.0.0",
 						"chalk": "^4.0.0",
-						"cjs-module-lexer": "^0.4.2",
-						"collect-v8-coverage": "^1.0.0",
-						"exit": "^0.1.2",
-						"glob": "^7.1.3",
-						"graceful-fs": "^4.2.4",
-						"jest-config": "^26.6.1",
-						"jest-haste-map": "^26.6.1",
-						"jest-message-util": "^26.6.1",
-						"jest-mock": "^26.6.1",
-						"jest-regex-util": "^26.0.0",
-						"jest-resolve": "^26.6.1",
-						"jest-snapshot": "^26.6.1",
-						"jest-util": "^26.6.1",
-						"jest-validate": "^26.6.1",
-						"slash": "^3.0.0",
-						"strip-bom": "^4.0.0",
-						"yargs": "^15.4.1"
-					}
-				},
-				"jest-snapshot": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.1.tgz",
-					"integrity": "sha512-JA7bZp7HRTIJYAi85pJ/OZ2eur2dqmwIToA5/6d7Mn90isGEfeF9FvuhDLLEczgKP1ihreBzrJ6Vr7zteP5JNA==",
-					"requires": {
-						"@babel/types": "^7.0.0",
-						"@jest/types": "^26.6.1",
-						"@types/babel__traverse": "^7.0.4",
-						"@types/prettier": "^2.0.0",
-						"chalk": "^4.0.0",
-						"expect": "^26.6.1",
-						"graceful-fs": "^4.2.4",
-						"jest-diff": "^26.6.1",
 						"jest-get-type": "^26.3.0",
-						"jest-haste-map": "^26.6.1",
-						"jest-matcher-utils": "^26.6.1",
-						"jest-message-util": "^26.6.1",
-						"jest-resolve": "^26.6.1",
-						"natural-compare": "^1.4.0",
-						"pretty-format": "^26.6.1",
-						"semver": "^7.3.2"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"requires": {
-						"p-locate": "^4.1.0"
+						"leven": "^3.1.0",
+						"pretty-format": "^26.4.2"
 					}
 				},
 				"micromatch": {
@@ -15455,51 +15776,16 @@
 						"picomatch": "^2.0.5"
 					}
 				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+				"pretty-format": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
 					"requires": {
-						"p-limit": "^2.2.0"
+						"@jest/types": "^26.3.0",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^4.0.0",
+						"react-is": "^16.12.0"
 					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-				},
-				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
-				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
-				},
-				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
 				},
 				"supports-color": {
 					"version": "7.2.0",
@@ -15515,43 +15801,6 @@
 					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 					"requires": {
 						"is-number": "^7.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"yargs": {
-					"version": "15.4.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-					"requires": {
-						"cliui": "^6.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^4.1.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^4.2.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^18.1.2"
-					}
-				},
-				"yargs-parser": {
-					"version": "18.1.3",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
 					}
 				}
 			}
@@ -15571,10 +15820,11 @@
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
 					"requires": {
+						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -15616,21 +15866,55 @@
 			}
 		},
 		"jest-diff": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.1.tgz",
-			"integrity": "sha512-BBNy/zin2m4kG5In126O8chOBxLLS/XMTuuM2+YhgyHk87ewPzKTuTJcqj3lOWOi03NNgrl+DkMeV/exdvG9gg==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
+			"integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
 			"requires": {
 				"chalk": "^4.0.0",
-				"diff-sequences": "^26.5.0",
+				"diff-sequences": "^26.3.0",
 				"jest-get-type": "^26.3.0",
-				"pretty-format": "^26.6.1"
+				"pretty-format": "^26.4.2"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -15660,6 +15944,22 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"jest-get-type": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
+				},
+				"pretty-format": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"requires": {
+						"@jest/types": "^26.3.0",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^4.0.0",
+						"react-is": "^16.12.0"
+					}
 				},
 				"supports-color": {
 					"version": "7.2.0",
@@ -15680,22 +15980,56 @@
 			}
 		},
 		"jest-each": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.6.1.tgz",
-			"integrity": "sha512-gSn8eB3buchuq45SU7pLB7qmCGax1ZSxfaWuEFblCyNMtyokYaKFh9dRhYPujK6xYL57dLIPhLKatjmB5XWzGA==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.4.2.tgz",
+			"integrity": "sha512-p15rt8r8cUcRY0Mvo1fpkOGYm7iI8S6ySxgIdfh3oOIv+gHwrHTy5VWCGOecWUhDsit4Nz8avJWdT07WLpbwDA==",
 			"requires": {
-				"@jest/types": "^26.6.1",
+				"@jest/types": "^26.3.0",
 				"chalk": "^4.0.0",
 				"jest-get-type": "^26.3.0",
-				"jest-util": "^26.6.1",
-				"pretty-format": "^26.6.1"
+				"jest-util": "^26.3.0",
+				"pretty-format": "^26.4.2"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -15726,6 +16060,22 @@
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
+				"jest-get-type": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
+				},
+				"pretty-format": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"requires": {
+						"@jest/types": "^26.3.0",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^4.0.0",
+						"react-is": "^16.12.0"
+					}
+				},
 				"supports-color": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -15737,19 +16087,47 @@
 			}
 		},
 		"jest-environment-jsdom": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.6.1.tgz",
-			"integrity": "sha512-A17RiXuHYNVlkM+3QNcQ6n5EZyAc6eld8ra9TW26luounGWpku4tj03uqRgHJCI1d4uHr5rJiuCH5JFRtdmrcA==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.3.0.tgz",
+			"integrity": "sha512-zra8He2btIMJkAzvLaiZ9QwEPGEetbxqmjEBQwhH3CA+Hhhu0jSiEJxnJMbX28TGUvPLxBt/zyaTLrOPF4yMJA==",
 			"requires": {
-				"@jest/environment": "^26.6.1",
-				"@jest/fake-timers": "^26.6.1",
-				"@jest/types": "^26.6.1",
+				"@jest/environment": "^26.3.0",
+				"@jest/fake-timers": "^26.3.0",
+				"@jest/types": "^26.3.0",
 				"@types/node": "*",
-				"jest-mock": "^26.6.1",
-				"jest-util": "^26.6.1",
-				"jsdom": "^16.4.0"
+				"jest-mock": "^26.3.0",
+				"jest-util": "^26.3.0",
+				"jsdom": "^16.2.2"
 			},
 			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
 				"acorn-globals": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
@@ -15757,6 +16135,100 @@
 					"requires": {
 						"acorn": "^7.1.1",
 						"acorn-walk": "^7.1.1"
+					}
+				},
+				"acorn-walk": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+					"integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"cssom": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+					"integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw=="
+				},
+				"cssstyle": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+					"integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+					"requires": {
+						"cssom": "~0.3.6"
+					},
+					"dependencies": {
+						"cssom": {
+							"version": "0.3.8",
+							"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+							"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+						}
+					}
+				},
+				"data-urls": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+					"integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+					"requires": {
+						"abab": "^2.0.3",
+						"whatwg-mimetype": "^2.3.0",
+						"whatwg-url": "^8.0.0"
+					}
+				},
+				"domexception": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+					"integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+					"requires": {
+						"webidl-conversions": "^5.0.0"
+					},
+					"dependencies": {
+						"webidl-conversions": {
+							"version": "5.0.0",
+							"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+							"integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
+						}
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"html-encoding-sniffer": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+					"integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+					"requires": {
+						"whatwg-encoding": "^1.0.5"
 					}
 				},
 				"jsdom": {
@@ -15797,6 +16269,22 @@
 					"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
 					"integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
 				},
+				"saxes": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+					"integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+					"requires": {
+						"xmlchars": "^2.2.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
 				"tough-cookie": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
@@ -15821,9 +16309,9 @@
 					"integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
 				},
 				"whatwg-url": {
-					"version": "8.4.0",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.4.0.tgz",
-					"integrity": "sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==",
+					"version": "8.2.2",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.2.2.tgz",
+					"integrity": "sha512-PcVnO6NiewhkmzV0qn7A+UZ9Xx4maNTI+O+TShmfE4pqjoCMwUMjkvoNhNHPTvgR7QH9Xt3R13iHuWy2sToFxQ==",
 					"requires": {
 						"lodash.sortby": "^4.7.0",
 						"tr46": "^2.0.2",
@@ -15838,16 +16326,90 @@
 			}
 		},
 		"jest-environment-node": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.1.tgz",
-			"integrity": "sha512-YffaCp6h0j1kbcf1NVZ7umC6CPgD67YS+G1BeornfuSkx5s3xdhuwG0DCxSiHPXyT81FfJzA1L7nXvhq50OWIg==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.3.0.tgz",
+			"integrity": "sha512-c9BvYoo+FGcMj5FunbBgtBnbR5qk3uky8PKyRVpSfe2/8+LrNQMiXX53z6q2kY+j15SkjQCOSL/6LHnCPLVHNw==",
 			"requires": {
-				"@jest/environment": "^26.6.1",
-				"@jest/fake-timers": "^26.6.1",
-				"@jest/types": "^26.6.1",
+				"@jest/environment": "^26.3.0",
+				"@jest/fake-timers": "^26.3.0",
+				"@jest/types": "^26.3.0",
 				"@types/node": "*",
-				"jest-mock": "^26.6.1",
-				"jest-util": "^26.6.1"
+				"jest-mock": "^26.3.0",
+				"jest-util": "^26.3.0"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"jest-environment-puppeteer": {
@@ -15862,10 +16424,11 @@
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
 					"requires": {
+						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -15907,16 +16470,16 @@
 			}
 		},
 		"jest-get-type": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-			"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+			"integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q=="
 		},
 		"jest-haste-map": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.1.tgz",
-			"integrity": "sha512-9kPafkv0nX6ta1PrshnkiyhhoQoFWncrU/uUBt3/AP1r78WSCU5iLceYRTwDvJl67H3RrXqSlSVDDa/AsUB7OQ==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.3.0.tgz",
+			"integrity": "sha512-DHWBpTJgJhLLGwE5Z1ZaqLTYqeODQIZpby0zMBsCU9iRFHYyhklYqP4EiG73j5dkbaAdSZhgB938mL51Q5LeZA==",
 			"requires": {
-				"@jest/types": "^26.6.1",
+				"@jest/types": "^26.3.0",
 				"@types/graceful-fs": "^4.1.2",
 				"@types/node": "*",
 				"anymatch": "^3.0.3",
@@ -15924,14 +16487,60 @@
 				"fsevents": "^2.1.2",
 				"graceful-fs": "^4.2.4",
 				"jest-regex-util": "^26.0.0",
-				"jest-serializer": "^26.5.0",
-				"jest-util": "^26.6.1",
-				"jest-worker": "^26.6.1",
+				"jest-serializer": "^26.3.0",
+				"jest-util": "^26.3.0",
+				"jest-worker": "^26.3.0",
 				"micromatch": "^4.0.2",
 				"sane": "^4.0.3",
 				"walker": "^1.0.7"
 			},
 			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"anymatch": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+					"requires": {
+						"normalize-path": "^3.0.0",
+						"picomatch": "^2.0.4"
+					}
+				},
 				"braces": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
@@ -15940,6 +16549,28 @@
 						"fill-range": "^7.0.1"
 					}
 				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
 				"fill-range": {
 					"version": "7.0.1",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -15947,6 +16578,17 @@
 					"requires": {
 						"to-regex-range": "^5.0.1"
 					}
+				},
+				"fsevents": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+					"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+					"optional": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
 				"is-number": {
 					"version": "7.0.0",
@@ -15962,6 +16604,19 @@
 						"picomatch": "^2.0.5"
 					}
 				},
+				"normalize-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
 				"to-regex-range": {
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -15972,114 +16627,70 @@
 				}
 			}
 		},
-		"jest-junit": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-10.0.0.tgz",
-			"integrity": "sha512-dbOVRyxHprdSpwSAR9/YshLwmnwf+RSl5hf0kCGlhAcEeZY9aRqo4oNmaT0tLC16Zy9D0zekDjWkjHGjXlglaQ==",
+		"jest-jasmine2": {
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.4.2.tgz",
+			"integrity": "sha512-z7H4EpCldHN1J8fNgsja58QftxBSL+JcwZmaXIvV9WKIM+x49F4GLHu/+BQh2kzRKHAgaN/E82od+8rTOBPyPA==",
 			"requires": {
-				"jest-validate": "^24.9.0",
-				"mkdirp": "^0.5.1",
-				"strip-ansi": "^5.2.0",
-				"uuid": "^3.3.3",
-				"xml": "^1.0.1"
+				"@babel/traverse": "^7.1.0",
+				"@jest/environment": "^26.3.0",
+				"@jest/source-map": "^26.3.0",
+				"@jest/test-result": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"co": "^4.6.0",
+				"expect": "^26.4.2",
+				"is-generator-fn": "^2.0.0",
+				"jest-each": "^26.4.2",
+				"jest-matcher-utils": "^26.4.2",
+				"jest-message-util": "^26.3.0",
+				"jest-runtime": "^26.4.2",
+				"jest-snapshot": "^26.4.2",
+				"jest-util": "^26.3.0",
+				"pretty-format": "^26.4.2",
+				"throat": "^5.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "24.9.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-					"integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
-						"@types/yargs": "^13.0.0"
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
 					}
 				},
 				"@types/istanbul-reports": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-					"integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
 					"requires": {
-						"@types/istanbul-lib-coverage": "*",
 						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.11",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-					"integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 				},
-				"jest-get-type": {
-					"version": "24.9.0",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
-					"integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q=="
-				},
-				"jest-validate": {
-					"version": "24.9.0",
-					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
-					"integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
-					"requires": {
-						"@jest/types": "^24.9.0",
-						"camelcase": "^5.3.1",
-						"chalk": "^2.0.1",
-						"jest-get-type": "^24.9.0",
-						"leven": "^3.1.0",
-						"pretty-format": "^24.9.0"
-					}
-				},
-				"pretty-format": {
-					"version": "24.9.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
-					"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
-					"requires": {
-						"@jest/types": "^24.9.0",
-						"ansi-regex": "^4.0.0",
-						"ansi-styles": "^3.2.0",
-						"react-is": "^16.8.4"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				}
-			}
-		},
-		"jest-leak-detector": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.1.tgz",
-			"integrity": "sha512-j9ZOtJSJKlHjrs4aIxWjiQUjyrffPdiAQn2Iw0916w7qZE5Lk0T2KhIH6E9vfhzP6sw0Q0jtnLLb4vQ71o1HlA==",
-			"requires": {
-				"jest-get-type": "^26.3.0",
-				"pretty-format": "^26.6.1"
-			}
-		},
-		"jest-matcher-utils": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.1.tgz",
-			"integrity": "sha512-9iu3zrsYlUnl8pByhREF9rr5eYoiEb1F7ymNKg6lJr/0qD37LWS5FSW/JcoDl8UdMX2+zAzabDs7sTO+QFKjCg==",
-			"requires": {
-				"chalk": "^4.0.0",
-				"jest-diff": "^26.6.1",
-				"jest-get-type": "^26.3.0",
-				"pretty-format": "^26.6.1"
-			},
-			"dependencies": {
 				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
 					"requires": {
+						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -16110,6 +16721,254 @@
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
+				"pretty-format": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"requires": {
+						"@jest/types": "^26.3.0",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^4.0.0",
+						"react-is": "^16.12.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"jest-junit": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-10.0.0.tgz",
+			"integrity": "sha512-dbOVRyxHprdSpwSAR9/YshLwmnwf+RSl5hf0kCGlhAcEeZY9aRqo4oNmaT0tLC16Zy9D0zekDjWkjHGjXlglaQ==",
+			"requires": {
+				"jest-validate": "^24.9.0",
+				"mkdirp": "^0.5.1",
+				"strip-ansi": "^5.2.0",
+				"uuid": "^3.3.3",
+				"xml": "^1.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				}
+			}
+		},
+		"jest-leak-detector": {
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.4.2.tgz",
+			"integrity": "sha512-akzGcxwxtE+9ZJZRW+M2o+nTNnmQZxrHJxX/HjgDaU5+PLmY1qnQPnMjgADPGCRPhB+Yawe1iij0REe+k/aHoA==",
+			"requires": {
+				"jest-get-type": "^26.3.0",
+				"pretty-format": "^26.4.2"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"jest-get-type": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
+				},
+				"pretty-format": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"requires": {
+						"@jest/types": "^26.3.0",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^4.0.0",
+						"react-is": "^16.12.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"jest-matcher-utils": {
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
+			"integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
+			"requires": {
+				"chalk": "^4.0.0",
+				"jest-diff": "^26.4.2",
+				"jest-get-type": "^26.3.0",
+				"pretty-format": "^26.4.2"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"jest-get-type": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
+				},
+				"pretty-format": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"requires": {
+						"@jest/types": "^26.3.0",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^4.0.0",
+						"react-is": "^16.12.0"
+					}
+				},
 				"supports-color": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -16121,13 +16980,13 @@
 			}
 		},
 		"jest-message-util": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.1.tgz",
-			"integrity": "sha512-cqM4HnqncIebBNdTKrBoWR/4ufHTll0pK/FWwX0YasK+TlBQEMqw3IEdynuuOTjDPFO3ONlFn37280X48beByw==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.3.0.tgz",
+			"integrity": "sha512-xIavRYqr4/otGOiLxLZGj3ieMmjcNE73Ui+LdSW/Y790j5acqCsAdDiLIbzHCZMpN07JOENRWX5DcU+OQ+TjTA==",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@jest/types": "^26.6.1",
-				"@types/stack-utils": "^2.0.0",
+				"@jest/types": "^26.3.0",
+				"@types/stack-utils": "^1.0.1",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
 				"micromatch": "^4.0.2",
@@ -16135,11 +16994,40 @@
 				"stack-utils": "^2.0.2"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -16224,12 +17112,86 @@
 			}
 		},
 		"jest-mock": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.1.tgz",
-			"integrity": "sha512-my0lPTBu1awY8iVG62sB2sx9qf8zxNDVX+5aFgoB8Vbqjb6LqIOsfyFA8P1z6H2IsqMbvOX9oCJnK67Y3yUIMA==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.3.0.tgz",
+			"integrity": "sha512-PeaRrg8Dc6mnS35gOo/CbZovoDPKAeB1FICZiuagAgGvbWdNNyjQjkOaGUa/3N3JtpQ/Mh9P4A2D4Fv51NnP8Q==",
 			"requires": {
-				"@jest/types": "^26.6.1",
+				"@jest/types": "^26.3.0",
 				"@types/node": "*"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"jest-pnp-resolver": {
@@ -16252,25 +17214,54 @@
 			"integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A=="
 		},
 		"jest-resolve": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.1.tgz",
-			"integrity": "sha512-hiHfQH6rrcpAmw9xCQ0vD66SDuU+7ZulOuKwc4jpbmFFsz0bQG/Ib92K+9/489u5rVw0btr/ZhiHqBpmkbCvuQ==",
+			"version": "26.4.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.4.0.tgz",
+			"integrity": "sha512-bn/JoZTEXRSlEx3+SfgZcJAVuTMOksYq9xe9O6s4Ekg84aKBObEaVXKOEilULRqviSLAYJldnoWV9c07kwtiCg==",
 			"requires": {
-				"@jest/types": "^26.6.1",
+				"@jest/types": "^26.3.0",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
 				"jest-pnp-resolver": "^1.2.2",
-				"jest-util": "^26.6.1",
+				"jest-util": "^26.3.0",
 				"read-pkg-up": "^7.0.1",
-				"resolve": "^1.18.1",
+				"resolve": "^1.17.0",
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -16371,11 +17362,10 @@
 					}
 				},
 				"resolve": {
-					"version": "1.18.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
-					"integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
+					"version": "1.17.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
 					"requires": {
-						"is-core-module": "^2.0.0",
 						"path-parse": "^1.0.6"
 					}
 				},
@@ -16399,45 +17389,270 @@
 				}
 			}
 		},
-		"jest-runner": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.1.tgz",
-			"integrity": "sha512-DmpNGdgsbl5s0FGkmsInmqnmqCtliCSnjWA2TFAJS1m1mL5atwfPsf+uoZ8uYQ2X0uDj4NM+nPcDnUpbNTRMBA==",
+		"jest-resolve-dependencies": {
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.4.2.tgz",
+			"integrity": "sha512-ADHaOwqEcVc71uTfySzSowA/RdxUpCxhxa2FNLiin9vWLB1uLPad3we+JSSROq5+SrL9iYPdZZF8bdKM7XABTQ==",
 			"requires": {
-				"@jest/console": "^26.6.1",
-				"@jest/environment": "^26.6.1",
-				"@jest/test-result": "^26.6.1",
-				"@jest/types": "^26.6.1",
+				"@jest/types": "^26.3.0",
+				"jest-regex-util": "^26.0.0",
+				"jest-snapshot": "^26.4.2"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"jest-runner": {
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.4.2.tgz",
+			"integrity": "sha512-FgjDHeVknDjw1gRAYaoUoShe1K3XUuFMkIaXbdhEys+1O4bEJS8Avmn4lBwoMfL8O5oFTdWYKcf3tEJyyYyk8g==",
+			"requires": {
+				"@jest/console": "^26.3.0",
+				"@jest/environment": "^26.3.0",
+				"@jest/test-result": "^26.3.0",
+				"@jest/types": "^26.3.0",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"emittery": "^0.7.1",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.2.4",
-				"jest-config": "^26.6.1",
+				"jest-config": "^26.4.2",
 				"jest-docblock": "^26.0.0",
-				"jest-haste-map": "^26.6.1",
-				"jest-leak-detector": "^26.6.1",
-				"jest-message-util": "^26.6.1",
-				"jest-resolve": "^26.6.1",
-				"jest-runtime": "^26.6.1",
-				"jest-util": "^26.6.1",
-				"jest-worker": "^26.6.1",
+				"jest-haste-map": "^26.3.0",
+				"jest-leak-detector": "^26.4.2",
+				"jest-message-util": "^26.3.0",
+				"jest-resolve": "^26.4.0",
+				"jest-runtime": "^26.4.2",
+				"jest-util": "^26.3.0",
+				"jest-worker": "^26.3.0",
 				"source-map-support": "^0.5.6",
 				"throat": "^5.0.0"
 			},
 			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"jest-runtime": {
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.4.2.tgz",
+			"integrity": "sha512-4Pe7Uk5a80FnbHwSOk7ojNCJvz3Ks2CNQWT5Z7MJo4tX0jb3V/LThKvD9tKPNVNyeMH98J/nzGlcwc00R2dSHQ==",
+			"requires": {
+				"@jest/console": "^26.3.0",
+				"@jest/environment": "^26.3.0",
+				"@jest/fake-timers": "^26.3.0",
+				"@jest/globals": "^26.4.2",
+				"@jest/source-map": "^26.3.0",
+				"@jest/test-result": "^26.3.0",
+				"@jest/transform": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"@types/yargs": "^15.0.0",
+				"chalk": "^4.0.0",
+				"collect-v8-coverage": "^1.0.0",
+				"exit": "^0.1.2",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.2.4",
+				"jest-config": "^26.4.2",
+				"jest-haste-map": "^26.3.0",
+				"jest-message-util": "^26.3.0",
+				"jest-mock": "^26.3.0",
+				"jest-regex-util": "^26.0.0",
+				"jest-resolve": "^26.4.0",
+				"jest-snapshot": "^26.4.2",
+				"jest-util": "^26.3.0",
+				"jest-validate": "^26.4.2",
+				"slash": "^3.0.0",
+				"strip-bom": "^4.0.0",
+				"yargs": "^15.3.1"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
 				"ansi-regex": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
 					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 				},
 				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
 					"requires": {
+						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
+				},
+				"camelcase": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w=="
 				},
 				"chalk": {
 					"version": "4.1.0",
@@ -16495,61 +17710,22 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
 				},
-				"jest-runtime": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.1.tgz",
-					"integrity": "sha512-7uOCNeezXDWgjEyzYbRN2ViY7xNZzusNVGAMmU0UHRUNXuY4j4GBHKGMqPo/cBPZA9bSYp+lwK2DRRBU5Dv6YQ==",
-					"requires": {
-						"@jest/console": "^26.6.1",
-						"@jest/environment": "^26.6.1",
-						"@jest/fake-timers": "^26.6.1",
-						"@jest/globals": "^26.6.1",
-						"@jest/source-map": "^26.5.0",
-						"@jest/test-result": "^26.6.1",
-						"@jest/transform": "^26.6.1",
-						"@jest/types": "^26.6.1",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0",
-						"cjs-module-lexer": "^0.4.2",
-						"collect-v8-coverage": "^1.0.0",
-						"exit": "^0.1.2",
-						"glob": "^7.1.3",
-						"graceful-fs": "^4.2.4",
-						"jest-config": "^26.6.1",
-						"jest-haste-map": "^26.6.1",
-						"jest-message-util": "^26.6.1",
-						"jest-mock": "^26.6.1",
-						"jest-regex-util": "^26.0.0",
-						"jest-resolve": "^26.6.1",
-						"jest-snapshot": "^26.6.1",
-						"jest-util": "^26.6.1",
-						"jest-validate": "^26.6.1",
-						"slash": "^3.0.0",
-						"strip-bom": "^4.0.0",
-						"yargs": "^15.4.1"
-					}
+				"jest-get-type": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
 				},
-				"jest-snapshot": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.1.tgz",
-					"integrity": "sha512-JA7bZp7HRTIJYAi85pJ/OZ2eur2dqmwIToA5/6d7Mn90isGEfeF9FvuhDLLEczgKP1ihreBzrJ6Vr7zteP5JNA==",
+				"jest-validate": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.4.2.tgz",
+					"integrity": "sha512-blft+xDX7XXghfhY0mrsBCYhX365n8K5wNDC4XAcNKqqjEzsRUSXP44m6PL0QJEW2crxQFLLztVnJ4j7oPlQrQ==",
 					"requires": {
-						"@babel/types": "^7.0.0",
-						"@jest/types": "^26.6.1",
-						"@types/babel__traverse": "^7.0.4",
-						"@types/prettier": "^2.0.0",
+						"@jest/types": "^26.3.0",
+						"camelcase": "^6.0.0",
 						"chalk": "^4.0.0",
-						"expect": "^26.6.1",
-						"graceful-fs": "^4.2.4",
-						"jest-diff": "^26.6.1",
 						"jest-get-type": "^26.3.0",
-						"jest-haste-map": "^26.6.1",
-						"jest-matcher-utils": "^26.6.1",
-						"jest-message-util": "^26.6.1",
-						"jest-resolve": "^26.6.1",
-						"natural-compare": "^1.4.0",
-						"pretty-format": "^26.6.1",
-						"semver": "^7.3.2"
+						"leven": "^3.1.0",
+						"pretty-format": "^26.4.2"
 					}
 				},
 				"locate-path": {
@@ -16573,10 +17749,16 @@
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
 				},
-				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+				"pretty-format": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"requires": {
+						"@jest/types": "^26.3.0",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^4.0.0",
+						"react-is": "^16.12.0"
+					}
 				},
 				"slash": {
 					"version": "3.0.0",
@@ -16614,16 +17796,6 @@
 						"has-flag": "^4.0.0"
 					}
 				},
-				"wrap-ansi": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
 				"yargs": {
 					"version": "15.4.1",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
@@ -16649,25 +17821,154 @@
 					"requires": {
 						"camelcase": "^5.0.0",
 						"decamelize": "^1.2.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "5.3.1",
+							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+							"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+						}
 					}
 				}
 			}
 		},
 		"jest-serializer": {
-			"version": "26.5.0",
-			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.5.0.tgz",
-			"integrity": "sha512-+h3Gf5CDRlSLdgTv7y0vPIAoLgX/SI7T4v6hy+TEXMgYbv+ztzbg5PSN6mUXAT/hXYHvZRWm+MaObVfqkhCGxA==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.3.0.tgz",
+			"integrity": "sha512-IDRBQBLPlKa4flg77fqg0n/pH87tcRKwe8zxOVTWISxGpPHYkRZ1dXKyh04JOja7gppc60+soKVZ791mruVdow==",
 			"requires": {
 				"@types/node": "*",
 				"graceful-fs": "^4.2.4"
 			}
 		},
-		"jest-util": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.1.tgz",
-			"integrity": "sha512-xCLZUqVoqhquyPLuDXmH7ogceGctbW8SMyQVjD9o+1+NPWI7t0vO08udcFLVPLgKWcvc+zotaUv/RuaR6l8HIA==",
+		"jest-snapshot": {
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.4.2.tgz",
+			"integrity": "sha512-N6Uub8FccKlf5SBFnL2Ri/xofbaA68Cc3MGjP/NuwgnsvWh+9hLIR/DhrxbSiKXMY9vUW5dI6EW1eHaDHqe9sg==",
 			"requires": {
-				"@jest/types": "^26.6.1",
+				"@babel/types": "^7.0.0",
+				"@jest/types": "^26.3.0",
+				"@types/prettier": "^2.0.0",
+				"chalk": "^4.0.0",
+				"expect": "^26.4.2",
+				"graceful-fs": "^4.2.4",
+				"jest-diff": "^26.4.2",
+				"jest-get-type": "^26.3.0",
+				"jest-haste-map": "^26.3.0",
+				"jest-matcher-utils": "^26.4.2",
+				"jest-message-util": "^26.3.0",
+				"jest-resolve": "^26.4.0",
+				"natural-compare": "^1.4.0",
+				"pretty-format": "^26.4.2",
+				"semver": "^7.3.2"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"jest-get-type": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
+				},
+				"pretty-format": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"requires": {
+						"@jest/types": "^26.3.0",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^4.0.0",
+						"react-is": "^16.12.0"
+					}
+				},
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"jest-util": {
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.3.0.tgz",
+			"integrity": "sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==",
+			"requires": {
+				"@jest/types": "^26.3.0",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
@@ -16675,11 +17976,40 @@
 				"micromatch": "^4.0.2"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -16759,82 +18089,60 @@
 			}
 		},
 		"jest-validate": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.1.tgz",
-			"integrity": "sha512-BEFpGbylKocnNPZULcnk+TGaz1oFZQH/wcaXlaXABbu0zBwkOGczuWgdLucUouuQqn7VadHZZeTvo8VSFDLMOA==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
+			"integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
 			"requires": {
-				"@jest/types": "^26.6.1",
-				"camelcase": "^6.0.0",
-				"chalk": "^4.0.0",
-				"jest-get-type": "^26.3.0",
+				"@jest/types": "^24.9.0",
+				"camelcase": "^5.3.1",
+				"chalk": "^2.0.1",
+				"jest-get-type": "^24.9.0",
 				"leven": "^3.1.0",
-				"pretty-format": "^26.6.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"camelcase": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.1.0.tgz",
-					"integrity": "sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ=="
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
+				"pretty-format": "^24.9.0"
 			}
 		},
 		"jest-watcher": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.1.tgz",
-			"integrity": "sha512-0LBIPPncNi9CaLKK15bnxyd2E8OMl4kJg0PTiNOI+MXztXw1zVdtX/x9Pr6pXaQYps+eS/ts43O4+HByZ7yJSw==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.3.0.tgz",
+			"integrity": "sha512-XnLdKmyCGJ3VoF6G/p5ohbJ04q/vv5aH9ENI+i6BL0uu9WWB6Z7Z2lhQQk0d2AVZcRGp1yW+/TsoToMhBFPRdQ==",
 			"requires": {
-				"@jest/test-result": "^26.6.1",
-				"@jest/types": "^26.6.1",
+				"@jest/test-result": "^26.3.0",
+				"@jest/types": "^26.3.0",
 				"@types/node": "*",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^4.0.0",
-				"jest-util": "^26.6.1",
+				"jest-util": "^26.3.0",
 				"string-length": "^4.0.1"
 			},
 			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
 				"ansi-escapes": {
 					"version": "4.3.1",
 					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
@@ -16844,10 +18152,11 @@
 					}
 				},
 				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
 					"requires": {
+						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -16894,9 +18203,9 @@
 			}
 		},
 		"jest-worker": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.1.tgz",
-			"integrity": "sha512-R5IE3qSGz+QynJx8y+ICEkdI2OJ3RJjRQVEyCcFAd3yVhQSEtquziPO29Mlzgn07LOVE8u8jhJ1FqcwegiXWOw==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
+			"integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
 			"requires": {
 				"@types/node": "*",
 				"merge-stream": "^2.0.0",
@@ -16981,75 +18290,14 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.4.2",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-					"integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
-				},
-				"acorn-globals": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
-					"integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
-					"requires": {
-						"acorn": "^6.0.1",
-						"acorn-walk": "^6.0.1"
-					}
-				},
-				"acorn-walk": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
-					"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
-				},
-				"cssom": {
-					"version": "0.3.8",
-					"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-					"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
-				},
-				"cssstyle": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
-					"integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
-					"requires": {
-						"cssom": "0.3.x"
-					}
-				},
-				"data-urls": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
-					"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
-					"requires": {
-						"abab": "^2.0.0",
-						"whatwg-mimetype": "^2.2.0",
-						"whatwg-url": "^7.0.0"
-					}
-				},
-				"domexception": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
-					"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
-					"requires": {
-						"webidl-conversions": "^4.0.2"
-					}
-				},
-				"html-encoding-sniffer": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-					"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
-					"requires": {
-						"whatwg-encoding": "^1.0.1"
-					}
+					"version": "6.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+					"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
 				},
 				"parse5": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
 					"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
-				},
-				"saxes": {
-					"version": "3.1.11",
-					"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
-					"integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
-					"requires": {
-						"xmlchars": "^2.1.1"
-					}
 				}
 			}
 		},
@@ -17128,9 +18376,9 @@
 			"dev": true
 		},
 		"jsonschema": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.0.tgz",
-			"integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw=="
+			"version": "1.2.11",
+			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.11.tgz",
+			"integrity": "sha512-XNZHs3N1IOa3lPKm//npxMhOdaoPw+MvEV0NIgxcER83GTJcG13rehtWmpBCfEt8DrtYwIkMTs8bdXoYs4fvnQ=="
 		},
 		"jsonwebtoken": {
 			"version": "8.5.1",
@@ -17167,10 +18415,37 @@
 				"verror": "1.10.0"
 			}
 		},
-		"jsrsasign": {
-			"version": "10.0.4",
-			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.0.4.tgz",
-			"integrity": "sha512-G08GDeAwgVkN5PGE9TnJ/4ixV3zkq560RigOoqrRvVc8H4GjfPVTz54/qGPLHK1KGHGP36/2eaLU1HuXmOJgug=="
+		"jstransform": {
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
+			"integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
+			"requires": {
+				"base62": "^1.1.0",
+				"commoner": "^0.10.1",
+				"esprima-fb": "^15001.1.0-dev-harmony-fb",
+				"object-assign": "^2.0.0",
+				"source-map": "^0.4.2"
+			},
+			"dependencies": {
+				"esprima-fb": {
+					"version": "15001.1.0-dev-harmony-fb",
+					"resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
+					"integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE="
+				},
+				"object-assign": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+					"integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+				},
+				"source-map": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+					"requires": {
+						"amdefine": ">=0.0.4"
+					}
+				}
+			}
 		},
 		"jsx-ast-utils": {
 			"version": "2.4.1",
@@ -17226,9 +18501,9 @@
 			}
 		},
 		"just-extend": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
-			"integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA=="
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+			"integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA=="
 		},
 		"just-range": {
 			"version": "2.1.0",
@@ -17682,10 +18957,11 @@
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
 					"requires": {
+						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -18324,15 +19600,14 @@
 			}
 		},
 		"mocha": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.0.tgz",
-			"integrity": "sha512-lEWEMq2LMfNJMKeuEwb5UELi+OgFDollXaytR5ggQcHpzG3NP/R7rvixAvF+9/lLsTWhWG+4yD2M70GsM06nxw==",
+			"version": "8.1.3",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.1.3.tgz",
+			"integrity": "sha512-ZbaYib4hT4PpF4bdSO2DohooKXIn4lDeiYqB+vTmCdr6l2woW0b6H3pf5x4sM5nwQMru9RvjjHYWVGltR50ZBw==",
 			"requires": {
-				"@ungap/promise-all-settled": "1.1.2",
 				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
-				"chokidar": "3.4.3",
-				"debug": "4.2.0",
+				"chokidar": "3.4.2",
+				"debug": "4.1.1",
 				"diff": "4.0.2",
 				"escape-string-regexp": "4.0.0",
 				"find-up": "5.0.0",
@@ -18343,16 +19618,17 @@
 				"log-symbols": "4.0.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.2",
-				"nanoid": "3.1.12",
-				"serialize-javascript": "5.0.1",
-				"strip-json-comments": "3.1.1",
-				"supports-color": "7.2.0",
+				"object.assign": "4.1.0",
+				"promise.allsettled": "1.0.2",
+				"serialize-javascript": "4.0.0",
+				"strip-json-comments": "3.0.1",
+				"supports-color": "7.1.0",
 				"which": "2.0.2",
 				"wide-align": "1.1.3",
-				"workerpool": "6.0.2",
+				"workerpool": "6.0.0",
 				"yargs": "13.3.2",
 				"yargs-parser": "13.1.2",
-				"yargs-unparser": "2.0.0"
+				"yargs-unparser": "1.6.1"
 			},
 			"dependencies": {
 				"diff": {
@@ -18417,10 +19693,15 @@
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
 				},
+				"strip-json-comments": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+					"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
+				},
 				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
@@ -18474,9 +19755,9 @@
 			"integrity": "sha512-JoU9V9k6KqT9R9Tiw1RTU8ohZ+Xnf9DMg6Ktqqw5hILumwmq7xqa/KLXw513uTUsWbhtnHoSJYYR++u3pkyxJg=="
 		},
 		"monaco-editor-webpack-plugin": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-1.9.1.tgz",
-			"integrity": "sha512-x7fx1w3i/uwZERIgztHAAK3VQMsL8+ku0lFXXbO81hKDg8IieACqjGEa2mqEueg0c/fX+wd0oI+75wB19KJAsA==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-1.9.0.tgz",
+			"integrity": "sha512-tOiiToc94E1sb50BgZ8q8WK/bxus77SRrwCqIpAB5er3cpX78SULbEBY4YPOB8kDolOzKRt30WIHG/D6gz69Ww==",
 			"requires": {
 				"loader-utils": "^1.2.3"
 			}
@@ -18571,14 +19852,9 @@
 			}
 		},
 		"nan": {
-			"version": "2.14.2",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-			"integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
-		},
-		"nanoid": {
-			"version": "3.1.12",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
-			"integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -18778,9 +20054,9 @@
 			"dev": true
 		},
 		"node-fetch": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
 		},
 		"node-fetch-npm": {
 			"version": "2.0.4",
@@ -18794,9 +20070,9 @@
 			}
 		},
 		"node-forge": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-			"integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
+			"integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ=="
 		},
 		"node-gyp": {
 			"version": "5.1.0",
@@ -18845,7 +20121,6 @@
 				"events": "^3.0.0",
 				"https-browserify": "^1.0.0",
 				"os-browserify": "^0.3.0",
-				"path-browserify": "0.0.1",
 				"process": "^0.11.10",
 				"punycode": "^1.2.4",
 				"querystring-es3": "^0.2.0",
@@ -18888,11 +20163,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				},
-				"path-browserify": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
-					"integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
 				},
 				"punycode": {
 					"version": "1.4.1",
@@ -18964,6 +20234,52 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
 			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
+		},
+		"node-notifier": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.0.tgz",
+			"integrity": "sha512-46z7DUmcjoYdaWyXouuFNNfUo6eFa94t23c53c+lG/9Cvauk4a98rAUp9672X5dxGdQmLpPzTxzu8f/OeEPaFA==",
+			"optional": true,
+			"requires": {
+				"growly": "^1.3.0",
+				"is-wsl": "^2.2.0",
+				"semver": "^7.3.2",
+				"shellwords": "^0.1.1",
+				"uuid": "^8.3.0",
+				"which": "^2.0.2"
+			},
+			"dependencies": {
+				"is-wsl": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+					"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+					"optional": true,
+					"requires": {
+						"is-docker": "^2.0.0"
+					}
+				},
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+					"optional": true
+				},
+				"uuid": {
+					"version": "8.3.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+					"integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
+					"optional": true
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"optional": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
 		},
 		"node-preload": {
 			"version": "0.2.1",
@@ -19282,9 +20598,12 @@
 			}
 		},
 		"normalize-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"requires": {
+				"remove-trailing-separator": "^1.0.1"
+			}
 		},
 		"normalize-url": {
 			"version": "3.3.0",
@@ -19655,6 +20974,11 @@
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
+		"object-component": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+			"integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
+		},
 		"object-copy": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -19689,62 +21013,12 @@
 			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
 		},
 		"object-is": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.3.tgz",
-			"integrity": "sha512-teyqLvFWzLkq5B9ki8FVWA902UER2qkxmdA4nLf+wjOLAWgxzCWZNCxpDq9MvE8MmhWNr+I8w3BN49Vx36Y6Xg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
+			"integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
 			"requires": {
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.0-next.1"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.18.0-next.1",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-					"requires": {
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.1",
-						"is-callable": "^1.2.2",
-						"is-negative-zero": "^2.0.0",
-						"is-regex": "^1.1.1",
-						"object-inspect": "^1.8.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.1",
-						"string.prototype.trimend": "^1.0.1",
-						"string.prototype.trimstart": "^1.0.1"
-					}
-				},
-				"is-callable": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-					"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
-				},
-				"is-regex": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-					"integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
-					"requires": {
-						"has-symbols": "^1.0.1"
-					}
-				},
-				"object-inspect": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-					"integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
-				},
-				"object.assign": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
-					"integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
-					"requires": {
-						"define-properties": "^1.1.3",
-						"es-abstract": "^1.18.0-next.0",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				}
+				"es-abstract": "^1.17.5"
 			}
 		},
 		"object-keys": {
@@ -19832,21 +21106,22 @@
 			"dev": true
 		},
 		"office-ui-fabric-react": {
-			"version": "7.148.0",
-			"resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.148.0.tgz",
-			"integrity": "sha512-HD7OH9vfBBdxzdXE5Ce6c8m//KOWmkNCKfBmB64YsBaSYDoy+hGhyK8JWjYn/5n9Y9XeP4ee6ALPBcXHw76AQg==",
+			"version": "7.137.1",
+			"resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.137.1.tgz",
+			"integrity": "sha512-6m1M9m5psaJqhWwroVp1L0G8q66scLMsQRi+gQ/fY3f75ipGSABGeQ86d4P0ilKaYcLVYIzosocPIZKLbBVpnQ==",
 			"requires": {
-				"@fluentui/date-time-utilities": "^7.9.0",
-				"@fluentui/react-focus": "^7.16.13",
-				"@fluentui/react-window-provider": "^0.3.3",
+				"@fluentui/date-time-utilities": "^7.8.0",
+				"@fluentui/react-focus": "^7.16.0",
+				"@fluentui/react-icons": "^0.3.0",
+				"@fluentui/react-window-provider": "^0.3.0",
 				"@microsoft/load-themed-styles": "^1.10.26",
-				"@uifabric/foundation": "^7.9.14",
-				"@uifabric/icons": "^7.5.12",
-				"@uifabric/merge-styles": "^7.19.1",
-				"@uifabric/react-hooks": "^7.13.6",
-				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/styling": "^7.16.13",
-				"@uifabric/utilities": "^7.32.4",
+				"@uifabric/foundation": "^7.9.0",
+				"@uifabric/icons": "^7.5.0",
+				"@uifabric/merge-styles": "^7.18.0",
+				"@uifabric/react-hooks": "^7.13.0",
+				"@uifabric/set-version": "^7.0.22",
+				"@uifabric/styling": "^7.16.0",
+				"@uifabric/utilities": "^7.31.0",
 				"prop-types": "^15.7.2",
 				"tslib": "^1.10.0"
 			}
@@ -20264,6 +21539,28 @@
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
 				},
+				"@fluidframework/server-lambdas": {
+					"version": "0.1012.2",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1012.2.tgz",
+					"integrity": "sha512-r/FPMZfami9yD/ZDo0BRvQwkcVlD2PnOgYeN5YP/9QeWyh3QUcZD688M4IxzzGMfDY6nAN8wVjI7Wn2ajqzLPQ==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.23.0",
+						"@fluidframework/gitresources": "^0.1012.2",
+						"@fluidframework/protocol-base": "^0.1012.2",
+						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/server-services-client": "^0.1012.2",
+						"@fluidframework/server-services-core": "^0.1012.2",
+						"@types/semver": "^6.0.1",
+						"async": "^2.6.1",
+						"double-ended-queue": "^2.1.0-0",
+						"json-stringify-safe": "^5.0.1",
+						"jsonwebtoken": "^8.4.0",
+						"lodash": "^4.17.19",
+						"nconf": "^0.10.0",
+						"semver": "^6.3.0",
+						"uuid": "^3.3.2"
+					}
+				},
 				"@fluidframework/server-local-server": {
 					"version": "0.1012.2",
 					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1012.2.tgz",
@@ -20277,6 +21574,30 @@
 						"@fluidframework/server-services-core": "^0.1012.2",
 						"@fluidframework/server-test-utils": "^0.1012.2",
 						"uuid": "^3.3.2"
+					}
+				},
+				"@fluidframework/server-memory-orderer": {
+					"version": "0.1012.2",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1012.2.tgz",
+					"integrity": "sha512-6VDnXD0fj93SI9D3VIdxlKiNfnFjUsjZsNlDBlqyrGbTj7VYMIrsm9FbxjHuWxG/1pWxqdy4CQvbG3r5s0Me/g==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.23.0",
+						"@fluidframework/protocol-base": "^0.1012.2",
+						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/server-lambdas": "^0.1012.2",
+						"@fluidframework/server-services-client": "^0.1012.2",
+						"@fluidframework/server-services-core": "^0.1012.2",
+						"@types/debug": "^4.1.5",
+						"@types/double-ended-queue": "^2.1.0",
+						"@types/lodash": "^4.14.118",
+						"@types/node": "^10.17.24",
+						"@types/ws": "^6.0.1",
+						"debug": "^4.1.1",
+						"double-ended-queue": "^2.1.0-0",
+						"lodash": "^4.17.19",
+						"moniker": "^0.1.2",
+						"uuid": "^3.3.2",
+						"ws": "^6.1.2"
 					}
 				},
 				"@fluidframework/server-services-client": {
@@ -20327,6 +21648,11 @@
 						"string-hash": "^1.1.3",
 						"uuid": "^3.3.2"
 					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -20634,6 +21960,28 @@
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
 				},
+				"@fluidframework/server-lambdas": {
+					"version": "0.1012.2",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1012.2.tgz",
+					"integrity": "sha512-r/FPMZfami9yD/ZDo0BRvQwkcVlD2PnOgYeN5YP/9QeWyh3QUcZD688M4IxzzGMfDY6nAN8wVjI7Wn2ajqzLPQ==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.23.0",
+						"@fluidframework/gitresources": "^0.1012.2",
+						"@fluidframework/protocol-base": "^0.1012.2",
+						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/server-services-client": "^0.1012.2",
+						"@fluidframework/server-services-core": "^0.1012.2",
+						"@types/semver": "^6.0.1",
+						"async": "^2.6.1",
+						"double-ended-queue": "^2.1.0-0",
+						"json-stringify-safe": "^5.0.1",
+						"jsonwebtoken": "^8.4.0",
+						"lodash": "^4.17.19",
+						"nconf": "^0.10.0",
+						"semver": "^6.3.0",
+						"uuid": "^3.3.2"
+					}
+				},
 				"@fluidframework/server-local-server": {
 					"version": "0.1012.2",
 					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1012.2.tgz",
@@ -20647,6 +21995,30 @@
 						"@fluidframework/server-services-core": "^0.1012.2",
 						"@fluidframework/server-test-utils": "^0.1012.2",
 						"uuid": "^3.3.2"
+					}
+				},
+				"@fluidframework/server-memory-orderer": {
+					"version": "0.1012.2",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1012.2.tgz",
+					"integrity": "sha512-6VDnXD0fj93SI9D3VIdxlKiNfnFjUsjZsNlDBlqyrGbTj7VYMIrsm9FbxjHuWxG/1pWxqdy4CQvbG3r5s0Me/g==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.23.0",
+						"@fluidframework/protocol-base": "^0.1012.2",
+						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/server-lambdas": "^0.1012.2",
+						"@fluidframework/server-services-client": "^0.1012.2",
+						"@fluidframework/server-services-core": "^0.1012.2",
+						"@types/debug": "^4.1.5",
+						"@types/double-ended-queue": "^2.1.0",
+						"@types/lodash": "^4.14.118",
+						"@types/node": "^10.17.24",
+						"@types/ws": "^6.0.1",
+						"debug": "^4.1.1",
+						"double-ended-queue": "^2.1.0-0",
+						"lodash": "^4.17.19",
+						"moniker": "^0.1.2",
+						"uuid": "^3.3.2",
+						"ws": "^6.1.2"
 					}
 				},
 				"@fluidframework/server-services-client": {
@@ -20697,6 +22069,11 @@
 						"string-hash": "^1.1.3",
 						"uuid": "^3.3.2"
 					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -20749,13 +22126,6 @@
 			"integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
 			"requires": {
 				"is-wsl": "^1.1.0"
-			},
-			"dependencies": {
-				"is-wsl": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-					"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
-				}
 			}
 		},
 		"optionator": {
@@ -21102,17 +22472,6 @@
 						"has-flag": "^4.0.0"
 					}
 				},
-				"wrap-ansi": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
 				"yargs": {
 					"version": "15.4.1",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
@@ -21238,6 +22597,17 @@
 				"expand-tilde": "^2.0.2",
 				"git-config-path": "^1.0.1",
 				"ini": "^1.3.5"
+			},
+			"dependencies": {
+				"expand-tilde": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+					"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+					"dev": true,
+					"requires": {
+						"homedir-polyfill": "^1.0.1"
+					}
+				}
 			}
 		},
 		"parse-github-repo-url": {
@@ -21303,14 +22673,20 @@
 			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
 		},
 		"parseqs": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
-			"integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w=="
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+			"integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+			"requires": {
+				"better-assert": "~1.0.0"
+			}
 		},
 		"parseuri": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
-			"integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow=="
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+			"integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+			"requires": {
+				"better-assert": "~1.0.0"
+			}
 		},
 		"parseurl": {
 			"version": "1.3.3",
@@ -21589,62 +22965,29 @@
 			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
 		},
 		"pretty-error": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.2.tgz",
-			"integrity": "sha512-EY5oDzmsX5wvuynAByrmY0P0hcp+QpnAKbJng2A2MPjVKXCxrDSUkzghVJ4ZGPIv+JC4gX8fPUWscC0RtjsWGw==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
+			"integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
 			"requires": {
-				"lodash": "^4.17.20",
-				"renderkid": "^2.0.4"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.20",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
-				}
+				"renderkid": "^2.0.1",
+				"utila": "~0.4"
 			}
 		},
 		"pretty-format": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.1.tgz",
-			"integrity": "sha512-MeqqsP5PYcRBbGMvwzsyBdmAJ4EFX7pWFyl7x4+dMVg5pE0ZDdBIvEH2ergvIO+Gvwv1wh64YuOY9y5LuyY/GA==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+			"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
 			"requires": {
-				"@jest/types": "^26.6.1",
-				"ansi-regex": "^5.0.0",
-				"ansi-styles": "^4.0.0",
-				"react-is": "^17.0.1"
+				"@jest/types": "^24.9.0",
+				"ansi-regex": "^4.0.0",
+				"ansi-styles": "^3.2.0",
+				"react-is": "^16.8.4"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-				},
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"react-is": {
-					"version": "17.0.1",
-					"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
-					"integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA=="
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
 				}
 			}
 		},
@@ -21710,13 +23053,25 @@
 				"retry": "^0.10.0"
 			}
 		},
+		"promise.allsettled": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.2.tgz",
+			"integrity": "sha512-UpcYW5S1RaNKT6pd+s9jp9K9rlQge1UXKskec0j6Mmuq7UJCvlS2J2/s/yuPN8ehftf9HXMxWlKiPbGGUzpoRg==",
+			"requires": {
+				"array.prototype.map": "^1.0.1",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1",
+				"function-bind": "^1.1.1",
+				"iterate-value": "^1.0.0"
+			}
+		},
 		"prompts": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
-			"integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
+			"integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
 			"requires": {
 				"kleur": "^3.0.3",
-				"sisteransi": "^1.0.5"
+				"sisteransi": "^1.0.4"
 			}
 		},
 		"promzard": {
@@ -21827,9 +23182,9 @@
 			}
 		},
 		"prosemirror-inputrules": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.3.tgz",
-			"integrity": "sha512-ZaHCLyBtvbyIHv0f5p6boQTIJjlD6o2NPZiEaZWT2DA+j591zS29QQEMT4lBqwcLW3qRSf7ZvoKNbf05YrsStw==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.1.2.tgz",
+			"integrity": "sha512-Ja5Z3BWestlHYGvtSGqyvxMeB8QEuBjlHM8YnKtLGUXMDp965qdDV4goV8lJb17kIWHk7e7JNj6Catuoa3302g==",
 			"requires": {
 				"prosemirror-state": "^1.0.0",
 				"prosemirror-transform": "^1.0.0"
@@ -21856,9 +23211,9 @@
 			}
 		},
 		"prosemirror-model": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.12.0.tgz",
-			"integrity": "sha512-B5syrXluQwEPfih8PqZcVg2VWRUf8Rj97K/VNSkQtjUPL1BCoTUgdLERIlxdWHkwqvujFsT3Pw5ubc4/ofF1jQ==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.11.1.tgz",
+			"integrity": "sha512-cscne7s40lTQbZrU8fHBGI5awS2qX91w9wChl3HicKG2lkPS6cdGQADXbDCIU8SFl6lQYEsmIzn8F66Wm19YhA==",
 			"requires": {
 				"orderedmap": "^1.1.0"
 			}
@@ -21890,9 +23245,9 @@
 			}
 		},
 		"prosemirror-view": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.16.1.tgz",
-			"integrity": "sha512-7iDdRf2PAIgOnstcxqUxzf8IbHGfxygQs5covfxOHLWKyx7SSLRnBIlwVda54Hr6N26F4t5Kj2jfK7uIBcAKAw==",
+			"version": "1.15.7",
+			"resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.15.7.tgz",
+			"integrity": "sha512-fSSXphXg+82qb4xNsHT0mX6ro0Wu1/l+WIFO5jYfyjd42r6ZWSg0gFItLgqOVPxoKQOlrPJUhrozTxiqx0EXOg==",
 			"requires": {
 				"prosemirror-model": "^1.1.0",
 				"prosemirror-state": "^1.0.0",
@@ -22209,9 +23564,9 @@
 			}
 		},
 		"react": {
-			"version": "16.14.0",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-			"integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
+			"integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -22219,9 +23574,9 @@
 			}
 		},
 		"react-collapsible": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/react-collapsible/-/react-collapsible-2.8.1.tgz",
-			"integrity": "sha512-ykV+EpCBYC6UoOsZLtBxrs/kFVgJc2gFMU1/SS2JLG+LrMHSOERpWSG+fexyFYk44hdfJRmc/If+HlSjXcbCiw=="
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/react-collapsible/-/react-collapsible-2.8.0.tgz",
+			"integrity": "sha512-QTxGyp4iL8N57FcU1RGt4wD7vqOTRYAHNukxtSeVMkZ+/d1WNWXRIakzhYhC/5TDERihPdp1IvKIJlrLLPyQ/A=="
 		},
 		"react-component-managers": {
 			"version": "3.2.2",
@@ -22233,9 +23588,9 @@
 			}
 		},
 		"react-dom": {
-			"version": "16.14.0",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-			"integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+			"integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -22516,9 +23871,9 @@
 			}
 		},
 		"readdirp": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-			"integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+			"integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
 			"requires": {
 				"picomatch": "^2.2.1"
 			}
@@ -22528,6 +23883,29 @@
 			"resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
 			"integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
 			"dev": true
+		},
+		"recast": {
+			"version": "0.11.23",
+			"resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+			"integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
+			"requires": {
+				"ast-types": "0.9.6",
+				"esprima": "~3.1.0",
+				"private": "~0.1.5",
+				"source-map": "~0.5.0"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				}
+			}
 		},
 		"rechoir": {
 			"version": "0.6.2",
@@ -22549,9 +23927,9 @@
 			}
 		},
 		"regenerator-runtime": {
-			"version": "0.13.7",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-			"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 		},
 		"regex-not": {
 			"version": "1.0.2",
@@ -22618,26 +23996,21 @@
 			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
 		},
 		"renderkid": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.4.tgz",
-			"integrity": "sha512-K2eXrSOJdq+HuKzlcjOlGoOarUu5SDguDEhE7+Ah4zuOWL40j8A/oHvLlLob9PSTNvVnBd+/q0Er1QfpEuem5g==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.3.tgz",
+			"integrity": "sha512-z8CLQp7EZBPCwCnncgf9C4XAi3WR0dv+uWu/PjIyhhAb5d6IJ/QZqlHFprHeKT+59//V6BNUsLbvN8+2LarxGA==",
 			"requires": {
 				"css-select": "^1.1.0",
 				"dom-converter": "^0.2",
 				"htmlparser2": "^3.3.0",
-				"lodash": "^4.17.20",
-				"strip-ansi": "^3.0.0"
+				"strip-ansi": "^3.0.0",
+				"utila": "^0.4.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"lodash": {
-					"version": "4.17.20",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
@@ -22810,17 +24183,6 @@
 						"has-flag": "^4.0.0"
 					}
 				},
-				"wrap-ansi": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
 				"yargs": {
 					"version": "15.4.1",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
@@ -22958,16 +24320,6 @@
 			"requires": {
 				"expand-tilde": "^1.2.2",
 				"global-modules": "^0.2.3"
-			},
-			"dependencies": {
-				"expand-tilde": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-					"integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
-					"requires": {
-						"os-homedir": "^1.0.1"
-					}
-				}
 			}
 		},
 		"resolve-from": {
@@ -23103,25 +24455,6 @@
 				"micromatch": "^3.1.4",
 				"minimist": "^1.1.1",
 				"walker": "~1.0.5"
-			},
-			"dependencies": {
-				"anymatch": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-					"requires": {
-						"micromatch": "^3.1.4",
-						"normalize-path": "^2.1.1"
-					}
-				},
-				"normalize-path": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-					"requires": {
-						"remove-trailing-separator": "^1.0.1"
-					}
-				}
 			}
 		},
 		"sass-graph": {
@@ -23165,11 +24498,11 @@
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
 		"saxes": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
-			"integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
+			"integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
 			"requires": {
-				"xmlchars": "^2.2.0"
+				"xmlchars": "^2.1.1"
 			}
 		},
 		"scheduler": {
@@ -23192,9 +24525,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "6.12.6",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+					"version": "6.12.4",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+					"integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
 						"fast-json-stable-stringify": "^2.0.0",
@@ -23234,11 +24567,11 @@
 			"integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
 		},
 		"selfsigned": {
-			"version": "1.10.8",
-			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
-			"integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
+			"version": "1.10.7",
+			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
+			"integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
 			"requires": {
-				"node-forge": "^0.10.0"
+				"node-forge": "0.9.0"
 			}
 		},
 		"semver": {
@@ -23297,9 +24630,9 @@
 			}
 		},
 		"serialize-javascript": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-			"integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+			"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
 			"requires": {
 				"randombytes": "^2.1.0"
 			}
@@ -23474,20 +24807,20 @@
 			},
 			"dependencies": {
 				"es-abstract": {
-					"version": "1.18.0-next.1",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+					"version": "1.18.0-next.0",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
+					"integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
 					"requires": {
 						"es-to-primitive": "^1.2.1",
 						"function-bind": "^1.1.1",
 						"has": "^1.0.3",
 						"has-symbols": "^1.0.1",
-						"is-callable": "^1.2.2",
+						"is-callable": "^1.2.0",
 						"is-negative-zero": "^2.0.0",
 						"is-regex": "^1.1.1",
 						"object-inspect": "^1.8.0",
 						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.1",
+						"object.assign": "^4.1.0",
 						"string.prototype.trimend": "^1.0.1",
 						"string.prototype.trimstart": "^1.0.1"
 					}
@@ -23509,17 +24842,6 @@
 					"version": "1.8.0",
 					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
 					"integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
-				},
-				"object.assign": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
-					"integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
-					"requires": {
-						"define-properties": "^1.1.3",
-						"es-abstract": "^1.18.0-next.0",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
 				}
 			}
 		},
@@ -23720,48 +25042,48 @@
 			}
 		},
 		"socket.io-client": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.1.tgz",
-			"integrity": "sha512-YXmXn3pA8abPOY//JtYxou95Ihvzmg8U6kQyolArkIyLd0pgVhrfor/iMsox8cn07WCOOvvuJ6XKegzIucPutQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.0.tgz",
+			"integrity": "sha512-cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==",
 			"requires": {
 				"backo2": "1.0.2",
+				"base64-arraybuffer": "0.1.5",
 				"component-bind": "1.0.0",
-				"component-emitter": "~1.3.0",
-				"debug": "~3.1.0",
+				"component-emitter": "1.2.1",
+				"debug": "~4.1.0",
 				"engine.io-client": "~3.4.0",
 				"has-binary2": "~1.0.2",
+				"has-cors": "1.1.0",
 				"indexof": "0.0.1",
-				"parseqs": "0.0.6",
-				"parseuri": "0.0.6",
+				"object-component": "0.0.3",
+				"parseqs": "0.0.5",
+				"parseuri": "0.0.5",
 				"socket.io-parser": "~3.3.0",
 				"to-array": "0.1.4"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				"component-emitter": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
 				}
 			}
 		},
 		"socket.io-parser": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.1.tgz",
-			"integrity": "sha512-1QLvVAe8dTz+mKmZ07Swxt+LAo4Y1ff50rlyoEx00TQmDFVQYPfcqGvIDJLGaBdhdNCecXtyKpD+EgKGcmmbuQ==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+			"integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
 			"requires": {
-				"component-emitter": "~1.3.0",
+				"component-emitter": "1.2.1",
 				"debug": "~3.1.0",
 				"isarray": "2.0.1"
 			},
 			"dependencies": {
+				"component-emitter": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -24593,12 +25915,12 @@
 			}
 		},
 		"style-loader": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.3.0.tgz",
-			"integrity": "sha512-V7TCORko8rs9rIqkSrlMfkqA63DfoGBBJmK1kKGCcSi+BWb4cqz0SRsnp4l6rU5iwOEd0/2ePv68SV22VXon4Q==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.2.1.tgz",
+			"integrity": "sha512-ByHSTQvHLkWE9Ir5+lGbVOXhxX10fbprhLvdg96wedFZb4NDekDPxVKv5Fwmio+QcMlkkNfuK+5W1peQ5CUhZg==",
 			"requires": {
 				"loader-utils": "^2.0.0",
-				"schema-utils": "^2.7.0"
+				"schema-utils": "^2.6.6"
 			},
 			"dependencies": {
 				"loader-utils": {
@@ -24622,36 +25944,25 @@
 			}
 		},
 		"supports-hyperlinks": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-1.0.1.tgz",
-			"integrity": "sha512-HHi5kVSefKaJkGYXbDuKbUGRVxqnWGn3J2e39CYcNJEfWciGq2zYtOhXLTlvrOZW1QU7VX67w7fMmWafHX9Pfw==",
-			"dev": true,
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
+			"integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
 			"requires": {
-				"has-flag": "^2.0.0",
-				"supports-color": "^5.0.0"
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
 			},
 			"dependencies": {
 				"has-flag": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-					"dev": true
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
 				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"requires": {
-						"has-flag": "^3.0.0"
-					},
-					"dependencies": {
-						"has-flag": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-							"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-							"dev": true
-						}
+						"has-flag": "^4.0.0"
 					}
 				}
 			}
@@ -24807,28 +26118,6 @@
 						"type-fest": "^0.11.0"
 					}
 				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"supports-hyperlinks": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
-					"integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
-					"requires": {
-						"has-flag": "^4.0.0",
-						"supports-color": "^7.0.0"
-					}
-				},
 				"type-fest": {
 					"version": "0.11.0",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
@@ -24850,6 +26139,63 @@
 					"version": "2.20.3",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+				}
+			}
+		},
+		"terser-webpack-plugin": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+			"integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
+			"requires": {
+				"cacache": "^12.0.2",
+				"find-cache-dir": "^2.1.0",
+				"is-wsl": "^1.1.0",
+				"schema-utils": "^1.0.0",
+				"serialize-javascript": "^4.0.0",
+				"source-map": "^0.6.1",
+				"terser": "^4.1.2",
+				"webpack-sources": "^1.4.0",
+				"worker-farm": "^1.7.0"
+			},
+			"dependencies": {
+				"find-cache-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+					"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^2.0.0",
+						"pkg-dir": "^3.0.0"
+					}
+				},
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
+				},
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+				},
+				"schema-utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"requires": {
+						"ajv": "^6.1.0",
+						"ajv-errors": "^1.0.0",
+						"ajv-keywords": "^3.1.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				}
 			}
 		},
@@ -25088,31 +26434,185 @@
 			"integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
 		},
 		"ts-jest": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.2.tgz",
-			"integrity": "sha512-0+MynTTzzbuy5rGjzsCKjxHJk5gY906c/FSaqQ3081+G7dp2Yygfa9hVlbrtNNcztffh1mC6Rs9jb/yHpcjsoQ==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.3.0.tgz",
+			"integrity": "sha512-Jq2uKfx6bPd9+JDpZNMBJMdMQUC3sJ08acISj8NXlVgR2d5OqslEHOR2KHMgwymu8h50+lKIm0m0xj/ioYdW2Q==",
 			"requires": {
-				"@jest/create-cache-key-function": "^26.5.0",
 				"@types/jest": "26.x",
 				"bs-logger": "0.x",
 				"buffer-from": "1.x",
 				"fast-json-stable-stringify": "2.x",
-				"jest-util": "^26.1.0",
+				"jest-util": "26.x",
 				"json5": "2.x",
 				"lodash.memoize": "4.x",
 				"make-error": "1.x",
 				"mkdirp": "1.x",
 				"semver": "7.x",
-				"yargs-parser": "20.x"
+				"yargs-parser": "18.x"
 			},
 			"dependencies": {
-				"@types/jest": {
-					"version": "26.0.15",
-					"resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.15.tgz",
-					"integrity": "sha512-s2VMReFXRg9XXxV+CW9e5Nz8fH2K1aEhwgjUqPPbQd7g95T0laAcvLv032EhFHIa5GHsZ8W7iJEQVaJq6k3Gog==",
+				"@jest/types": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+					"integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
 					"requires": {
-						"jest-diff": "^26.0.0",
-						"pretty-format": "^26.0.0"
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^1.1.1",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^3.0.0"
+					}
+				},
+				"@types/jest": {
+					"version": "26.0.13",
+					"resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.13.tgz",
+					"integrity": "sha512-sCzjKow4z9LILc6DhBvn5AkIfmQzDZkgtVVKmGwVrs5tuid38ws281D4l+7x1kP487+FlKDh5kfMZ8WSPAdmdA==",
+					"requires": {
+						"jest-diff": "^25.2.1",
+						"pretty-format": "^25.2.1"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+					"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"diff-sequences": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+					"integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg=="
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+				},
+				"jest-diff": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+					"integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+					"requires": {
+						"chalk": "^3.0.0",
+						"diff-sequences": "^25.2.6",
+						"jest-get-type": "^25.2.6",
+						"pretty-format": "^25.5.0"
+					}
+				},
+				"jest-get-type": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+					"integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig=="
+				},
+				"jest-util": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.3.0.tgz",
+					"integrity": "sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==",
+					"requires": {
+						"@jest/types": "^26.3.0",
+						"@types/node": "*",
+						"chalk": "^4.0.0",
+						"graceful-fs": "^4.2.4",
+						"is-ci": "^2.0.0",
+						"micromatch": "^4.0.2"
+					},
+					"dependencies": {
+						"@jest/types": {
+							"version": "26.3.0",
+							"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+							"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+							"requires": {
+								"@types/istanbul-lib-coverage": "^2.0.0",
+								"@types/istanbul-reports": "^3.0.0",
+								"@types/node": "*",
+								"@types/yargs": "^15.0.0",
+								"chalk": "^4.0.0"
+							}
+						},
+						"@types/istanbul-reports": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+							"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+							"requires": {
+								"@types/istanbul-lib-report": "*"
+							}
+						},
+						"chalk": {
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+							"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						}
+					}
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
 					}
 				},
 				"mkdirp": {
@@ -25120,15 +26620,46 @@
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
 					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
 				},
+				"pretty-format": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+					"integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+					"requires": {
+						"@jest/types": "^25.5.0",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^4.0.0",
+						"react-is": "^16.12.0"
+					}
+				},
 				"semver": {
 					"version": "7.3.2",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
 					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
 				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				},
 				"yargs-parser": {
-					"version": "20.2.3",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.3.tgz",
-					"integrity": "sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww=="
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
 				}
 			}
 		},
@@ -25196,29 +26727,6 @@
 			"requires": {
 				"ts-node": "7.0.1",
 				"tsconfig-paths": "^3.5.0"
-			},
-			"dependencies": {
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"optional": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"tsconfig-paths": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
-					"integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
-					"optional": true,
-					"requires": {
-						"@types/json5": "^0.0.29",
-						"json5": "^1.0.1",
-						"minimist": "^1.2.0",
-						"strip-bom": "^3.0.0"
-					}
-				}
 			}
 		},
 		"ts-node": {
@@ -25234,6 +26742,27 @@
 				"mkdirp": "^0.5.1",
 				"source-map-support": "^0.5.6",
 				"yn": "^2.0.0"
+			}
+		},
+		"tsconfig-paths": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+			"integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+			"requires": {
+				"@types/json5": "^0.0.29",
+				"json5": "^1.0.1",
+				"minimist": "^1.2.0",
+				"strip-bom": "^3.0.0"
+			},
+			"dependencies": {
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				}
 			}
 		},
 		"tsd": {
@@ -25264,11 +26793,6 @@
 						"quick-lru": "^1.0.0"
 					}
 				},
-				"ci-info": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-					"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
-				},
 				"find-up": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -25281,14 +26805,6 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
 					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
-				},
-				"is-ci": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-					"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
-					"requires": {
-						"ci-info": "^1.5.0"
-					}
 				},
 				"load-json-file": {
 					"version": "4.0.0",
@@ -25455,23 +26971,6 @@
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
 					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
 				},
-				"update-notifier": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
-					"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
-					"requires": {
-						"boxen": "^1.2.1",
-						"chalk": "^2.0.1",
-						"configstore": "^3.0.0",
-						"import-lazy": "^2.1.0",
-						"is-ci": "^1.0.10",
-						"is-installed-globally": "^0.1.0",
-						"is-npm": "^1.0.0",
-						"latest-version": "^3.0.0",
-						"semver-diff": "^2.0.0",
-						"xdg-basedir": "^3.0.0"
-					}
-				},
 				"yargs-parser": {
 					"version": "10.1.0",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
@@ -25592,43 +27091,6 @@
 			"requires": {
 				"commandpost": "^1.0.0",
 				"editorconfig": "^0.15.0"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-				},
-				"editorconfig": {
-					"version": "0.15.3",
-					"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
-					"integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
-					"requires": {
-						"commander": "^2.19.0",
-						"lru-cache": "^4.1.5",
-						"semver": "^5.6.0",
-						"sigmund": "^1.0.1"
-					}
-				},
-				"lru-cache": {
-					"version": "4.1.5",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
-					}
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-				},
-				"yallist": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-				}
 			}
 		},
 		"typings-for-css-modules-loader": {
@@ -25680,9 +27142,9 @@
 			"integrity": "sha512-W3kLbx+ML9PBl5Bzso/lTvVxk4BCveSNAtQeht59FEtxCdGThmn6wSHA4Xq3eQYAK24NHdisMM4JmsK0GFy/pg=="
 		},
 		"ua-parser-js": {
-			"version": "0.7.22",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
-			"integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q=="
+			"version": "0.7.21",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
+			"integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
 		},
 		"uc.micro": {
 			"version": "1.0.6",
@@ -25841,6 +27303,38 @@
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
 			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
 		},
+		"update-notifier": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+			"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+			"requires": {
+				"boxen": "^1.2.1",
+				"chalk": "^2.0.1",
+				"configstore": "^3.0.0",
+				"import-lazy": "^2.1.0",
+				"is-ci": "^1.0.10",
+				"is-installed-globally": "^0.1.0",
+				"is-npm": "^1.0.0",
+				"latest-version": "^3.0.0",
+				"semver-diff": "^2.0.0",
+				"xdg-basedir": "^3.0.0"
+			},
+			"dependencies": {
+				"ci-info": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+					"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
+				},
+				"is-ci": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+					"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+					"requires": {
+						"ci-info": "^1.5.0"
+					}
+				}
+			}
+		},
 		"upper-case": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
@@ -25971,9 +27465,9 @@
 			"integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ=="
 		},
 		"v8-to-istanbul": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-6.0.1.tgz",
-			"integrity": "sha512-PzM1WlqquhBvsV+Gco6WSFeg1AGdD53ccMRkFeyHRE/KRZaVacPOmQYP3EeVgDBtKD2BJ8kgynBQ5OtKiHCH+w==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-5.0.1.tgz",
+			"integrity": "sha512-mbDNjuDajqYe3TXFk5qxcQy8L1msXNE37WTlLoqqpBfRsimbNcrlhQlDPntmECEcUvdC+AQ8CyMMf6EUx1r74Q==",
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.1",
 				"convert-source-map": "^1.6.0",
@@ -26117,27 +27611,6 @@
 				"chokidar": "^2.1.8"
 			},
 			"dependencies": {
-				"anymatch": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-					"optional": true,
-					"requires": {
-						"micromatch": "^3.1.4",
-						"normalize-path": "^2.1.1"
-					},
-					"dependencies": {
-						"normalize-path": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-							"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-							"optional": true,
-							"requires": {
-								"remove-trailing-separator": "^1.0.1"
-							}
-						}
-					}
-				},
 				"binary-extensions": {
 					"version": "1.13.1",
 					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
@@ -26162,15 +27635,6 @@
 						"path-is-absolute": "^1.0.0",
 						"readdirp": "^2.2.1",
 						"upath": "^1.1.1"
-					}
-				},
-				"fsevents": {
-					"version": "1.2.13",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-					"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-					"optional": true,
-					"requires": {
-						"nan": "^2.12.1"
 					}
 				},
 				"glob-parent": {
@@ -26207,6 +27671,12 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+					"optional": true
+				},
+				"normalize-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 					"optional": true
 				},
 				"readable-stream": {
@@ -26269,9 +27739,9 @@
 			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
 		},
 		"webpack": {
-			"version": "4.44.2",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.2.tgz",
-			"integrity": "sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==",
+			"version": "4.44.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.1.tgz",
+			"integrity": "sha512-4UOGAohv/VGUNQJstzEywwNxqX417FnjZgZJpJQegddzPmTvph37eBIRbRTfdySXzVtJXLJfbMN3mMYhM6GdmQ==",
 			"requires": {
 				"@webassemblyjs/ast": "1.9.0",
 				"@webassemblyjs/helper-module-context": "1.9.0",
@@ -26299,9 +27769,9 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.4.2",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-					"integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
+					"version": "6.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+					"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
 				},
 				"eslint-scope": {
 					"version": "4.0.3",
@@ -26312,34 +27782,10 @@
 						"estraverse": "^4.1.1"
 					}
 				},
-				"find-cache-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-					"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-					"requires": {
-						"commondir": "^1.0.1",
-						"make-dir": "^2.0.0",
-						"pkg-dir": "^3.0.0"
-					}
-				},
-				"is-wsl": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-					"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
-				},
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				},
-				"make-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-					"requires": {
-						"pify": "^4.0.1",
-						"semver": "^5.6.0"
-					}
 				},
 				"memory-fs": {
 					"version": "0.4.1",
@@ -26349,11 +27795,6 @@
 						"errno": "^0.1.3",
 						"readable-stream": "^2.0.1"
 					}
-				},
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
 				},
 				"readable-stream": {
 					"version": "2.3.7",
@@ -26379,19 +27820,6 @@
 						"ajv-keywords": "^3.1.0"
 					}
 				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-				},
-				"serialize-javascript": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-					"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-					"requires": {
-						"randombytes": "^2.1.0"
-					}
-				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -26399,29 +27827,13 @@
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
-				},
-				"terser-webpack-plugin": {
-					"version": "1.4.5",
-					"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
-					"integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
-					"requires": {
-						"cacache": "^12.0.2",
-						"find-cache-dir": "^2.1.0",
-						"is-wsl": "^1.1.0",
-						"schema-utils": "^1.0.0",
-						"serialize-javascript": "^4.0.0",
-						"source-map": "^0.6.1",
-						"terser": "^4.1.2",
-						"webpack-sources": "^1.4.0",
-						"worker-farm": "^1.7.0"
-					}
 				}
 			}
 		},
 		"webpack-bundle-analyzer": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.9.0.tgz",
-			"integrity": "sha512-Ob8amZfCm3rMB1ScjQVlbYYUEJyEjdEtQ92jqiFUYt5VkEeO2v5UMbv49P/gnmCZm3A6yaFQzCBvpZqN4MUsdA==",
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.8.0.tgz",
+			"integrity": "sha512-PODQhAYVEourCcOuU+NiYI7WdR8QyELZGgPvB1y2tjbUpbmcQOt5Q7jEK+ttd5se0KSBKD9SXHCEozS++Wllmw==",
 			"requires": {
 				"acorn": "^7.1.1",
 				"acorn-walk": "^7.1.1",
@@ -26432,12 +27844,17 @@
 				"express": "^4.16.3",
 				"filesize": "^3.6.1",
 				"gzip-size": "^5.0.0",
-				"lodash": "^4.17.19",
+				"lodash": "^4.17.15",
 				"mkdirp": "^0.5.1",
 				"opener": "^1.5.1",
 				"ws": "^6.0.0"
 			},
 			"dependencies": {
+				"acorn-walk": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+					"integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
+				},
 				"commander": {
 					"version": "2.20.3",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -26479,6 +27896,61 @@
 						"ini": "^1.3.5",
 						"kind-of": "^6.0.2",
 						"which": "^1.3.1"
+					}
+				}
+			}
+		},
+		"webpack-dev-middleware": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
+			"integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
+			"requires": {
+				"memory-fs": "^0.4.1",
+				"mime": "^2.4.4",
+				"mkdirp": "^0.5.1",
+				"range-parser": "^1.2.1",
+				"webpack-log": "^2.0.0"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"memory-fs": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+					"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+					"requires": {
+						"errno": "^0.1.3",
+						"readable-stream": "^2.0.1"
+					}
+				},
+				"mime": {
+					"version": "2.4.6",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+					"integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+				},
+				"readable-stream": {
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"requires": {
+						"safe-buffer": "~5.1.0"
 					}
 				}
 			}
@@ -26528,25 +28000,6 @@
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
-				"anymatch": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-					"requires": {
-						"micromatch": "^3.1.4",
-						"normalize-path": "^2.1.1"
-					},
-					"dependencies": {
-						"normalize-path": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-							"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-							"requires": {
-								"remove-trailing-separator": "^1.0.1"
-							}
-						}
-					}
-				},
 				"binary-extensions": {
 					"version": "1.13.1",
 					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
@@ -26569,15 +28022,6 @@
 						"path-is-absolute": "^1.0.0",
 						"readdirp": "^2.2.1",
 						"upath": "^1.1.1"
-					}
-				},
-				"fsevents": {
-					"version": "1.2.13",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-					"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-					"optional": true,
-					"requires": {
-						"nan": "^2.12.1"
 					}
 				},
 				"glob-parent": {
@@ -26612,19 +28056,10 @@
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
-				"memory-fs": {
-					"version": "0.4.1",
-					"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
-					"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-					"requires": {
-						"errno": "^0.1.3",
-						"readable-stream": "^2.0.1"
-					}
-				},
-				"mime": {
-					"version": "2.4.6",
-					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-					"integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+				"normalize-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
 				},
 				"readable-stream": {
 					"version": "2.3.7",
@@ -26680,18 +28115,6 @@
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
-				},
-				"webpack-dev-middleware": {
-					"version": "3.7.2",
-					"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
-					"integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
-					"requires": {
-						"memory-fs": "^0.4.1",
-						"mime": "^2.4.4",
-						"mkdirp": "^0.5.1",
-						"range-parser": "^1.2.1",
-						"webpack-log": "^2.0.0"
-					}
 				}
 			}
 		},
@@ -26739,128 +28162,19 @@
 				"react-dom": "^0.14.0"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "5.7.4",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-					"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
-				},
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-				},
-				"commoner": {
-					"version": "0.10.8",
-					"resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
-					"integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
-					"requires": {
-						"commander": "^2.5.0",
-						"detective": "^4.3.1",
-						"glob": "^5.0.15",
-						"graceful-fs": "^4.1.2",
-						"iconv-lite": "^0.4.5",
-						"mkdirp": "^0.5.0",
-						"private": "^0.1.6",
-						"q": "^1.1.2",
-						"recast": "^0.11.17"
-					}
-				},
-				"detective": {
-					"version": "4.7.1",
-					"resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
-					"integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
-					"requires": {
-						"acorn": "^5.2.1",
-						"defined": "^1.0.0"
-					}
-				},
-				"envify": {
-					"version": "3.4.1",
-					"resolved": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz",
-					"integrity": "sha1-1xIjKejfFoi6dxsSUBkXyc5cvOg=",
-					"requires": {
-						"jstransform": "^11.0.3",
-						"through": "~2.3.4"
-					}
-				},
-				"esprima-fb": {
-					"version": "15001.1.0-dev-harmony-fb",
-					"resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
-					"integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE="
-				},
-				"glob": {
-					"version": "5.0.15",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-					"requires": {
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "2 || 3",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"jstransform": {
-					"version": "11.0.3",
-					"resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
-					"integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
-					"requires": {
-						"base62": "^1.1.0",
-						"commoner": "^0.10.1",
-						"esprima-fb": "^15001.1.0-dev-harmony-fb",
-						"object-assign": "^2.0.0",
-						"source-map": "^0.4.2"
-					}
-				},
-				"object-assign": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-					"integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
-				},
 				"react": {
-					"version": "0.14.10",
-					"resolved": "https://registry.npmjs.org/react/-/react-0.14.10.tgz",
-					"integrity": "sha512-yxMw5aorZG4qsLVBfjae4wGFvd5708DhcxaXLJ3IOTgr1TCs8k9+ZheGgLGr5OfwWMhSahNbGvvoEDzrxVWouA==",
+					"version": "0.14.9",
+					"resolved": "https://registry.npmjs.org/react/-/react-0.14.9.tgz",
+					"integrity": "sha1-kRCmSXxJ1EuhwO3TF67CnC4NkdE=",
 					"requires": {
 						"envify": "^3.0.0",
 						"fbjs": "^0.6.1"
 					}
 				},
 				"react-dom": {
-					"version": "0.14.10",
-					"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.10.tgz",
-					"integrity": "sha512-kDs8SWFb8Sry4NAplhpJbZEeAnTPir/m+s9s+lkdqA2a89BzmWGnEgGG/CfmhULjv1ogc4oHrjMfAvFNruT3jQ=="
-				},
-				"recast": {
-					"version": "0.11.23",
-					"resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-					"integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-					"requires": {
-						"ast-types": "0.9.6",
-						"esprima": "~3.1.0",
-						"private": "~0.1.5",
-						"source-map": "~0.5.0"
-					},
-					"dependencies": {
-						"esprima": {
-							"version": "3.1.3",
-							"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-							"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-						},
-						"source-map": {
-							"version": "0.5.7",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-						}
-					}
-				},
-				"source-map": {
-					"version": "0.4.4",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-					"requires": {
-						"amdefine": ">=0.0.4"
-					}
+					"version": "0.14.9",
+					"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.9.tgz",
+					"integrity": "sha1-BQZKPc8PsYgKOyv8nVjFXY2fYpM="
 				}
 			}
 		},
@@ -26940,52 +28254,11 @@
 			}
 		},
 		"widest-line": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-			"integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
-			"dev": true,
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+			"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
 			"requires": {
-				"string-width": "^4.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-					"dev": true
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
-				}
+				"string-width": "^2.1.1"
 			}
 		},
 		"window-size": {
@@ -27022,15 +28295,14 @@
 			}
 		},
 		"workerpool": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.2.tgz",
-			"integrity": "sha512-DSNyvOpFKrNusaaUwk+ej6cBj1bmhLcBfj80elGk+ZIo5JSkq+unB1dLKEOcNfJDZgjGICfhQ0Q5TbP0PvF4+Q=="
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.0.tgz",
+			"integrity": "sha512-fU2OcNA/GVAJLLyKUoHkAgIhKb0JoCpSjLC/G2vYKxUjVmQwGbRVeoPJ1a8U4pnVofz4AQV5Y/NEw8oKqxEBtA=="
 		},
 		"wrap-ansi": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"dev": true,
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
 			"requires": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -27040,15 +28312,14 @@
 				"ansi-regex": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-					"dev": true
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 				},
 				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
 					"requires": {
+						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -27056,7 +28327,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
 					"requires": {
 						"color-name": "~1.1.4"
 					}
@@ -27064,26 +28334,22 @@
 				"color-name": {
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 				},
 				"emoji-regex": {
 					"version": "8.0.0",
 					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 				},
 				"is-fullwidth-code-point": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
 				},
 				"string-width": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
 					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-					"dev": true,
 					"requires": {
 						"emoji-regex": "^8.0.0",
 						"is-fullwidth-code-point": "^3.0.0",
@@ -27094,7 +28360,6 @@
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
 					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^5.0.0"
 					}
@@ -27306,30 +28571,66 @@
 			}
 		},
 		"yargs-unparser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.1.tgz",
+			"integrity": "sha512-qZV14lK9MWsGCmcr7u5oXGH0dbGqZAIxTDrWXZDo5zUr6b6iUmelNKO6x6R1dQT24AH3LgRxJpr8meWy2unolA==",
 			"requires": {
-				"camelcase": "^6.0.0",
-				"decamelize": "^4.0.0",
-				"flat": "^5.0.2",
-				"is-plain-obj": "^2.1.0"
+				"camelcase": "^5.3.1",
+				"decamelize": "^1.2.0",
+				"flat": "^4.1.0",
+				"is-plain-obj": "^1.1.0",
+				"yargs": "^14.2.3"
 			},
 			"dependencies": {
-				"camelcase": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.1.0.tgz",
-					"integrity": "sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ=="
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
 				},
-				"decamelize": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-					"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ=="
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
 				},
-				"is-plain-obj": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-					"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				},
+				"yargs": {
+					"version": "14.2.3",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+					"integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+					"requires": {
+						"cliui": "^5.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^3.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^15.0.1"
+					}
+				},
+				"yargs-parser": {
+					"version": "15.0.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+					"integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
 				}
 			}
 		},


### PR DESCRIPTION
#4070 calls out how a large portion of the Fluid overhead is due to the polyfill for the assert API in node. This is because the module cannot be tree shaken and assert is more optimized for unit test scenarios rather than runtime assertions.

This PR is the first step of the process, adding a utilitiy for assert to common-utils. After this is merged, we can start replacing usages of assert in browser code with the utility. We need to do this in two steps since common-utils is not symlinked in the repo

Rough estimation shows that assert is at least 15% of the FF code for a container
![image](https://user-images.githubusercontent.com/1581488/97327770-898bbd00-1832-11eb-8e7c-d02070c40f95.png)
