### PR TITLE
Revert removal of old package names from BREAKING.md

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -144,9 +144,9 @@ You can use handleFromLegacyUri() for creating handles from container-internal U
 
 ### Package Renames
 As a follow up to the changes in 0.24 we are updating a number of package names
-- `@fluidframework/core-interfaces` is renamed to `@fluidframework/core-interfaces`
-- `@fluidframework/datastore-definitions` is renamed to `@fluidframework/datastore-definitions`
-- `@fluidframework/datastore` is renamed to `@fluidframework/datastore`
+- `@fluidframework/component-core-interfaces` is renamed to `@fluidframework/core-interfaces`
+- `@fluidframework/component-runtime-definitions` is renamed to `@fluidframework/datastore-definitions`
+- `@fluidframework/component-runtime` is renamed to `@fluidframework/datastore`
 - `@fluidframework/webpack-component-loader` is renamed to `@fluidframework/webpack-fluid-loader`
 
 ### IComponent and IComponent Interfaces Removed


### PR DESCRIPTION
https://github.com/microsoft/FluidFramework/pull/2969 replaced the old package names with the new ones in BREAKING.md, making the note about the branch rename incorrect. This change restores the old package names in BREAKING.md.