### PR TITLE
Update Gateway JWT token generation

### DIFF
--- a/server/gateway/package-lock.json
+++ b/server/gateway/package-lock.json
@@ -1585,6 +1585,12 @@
         "@types/node": "*"
       }
     },
+    "@types/jsrsasign": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/@types/jsrsasign/-/jsrsasign-8.0.7.tgz",
+      "integrity": "sha512-0SqXgSIJ0Co3FdUjaUUGoPx6VJpe0qFJ54S0QXFwcQ+VhXTqKIh9WrsumRzsCVnpmmoKi7d5dtukgraS7eTN+Q==",
+      "dev": true
+    },
     "@types/lodash": {
       "version": "4.14.161",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz",

--- a/server/gateway/package-lock.json
+++ b/server/gateway/package-lock.json
@@ -8034,6 +8034,11 @@
         "verror": "1.10.0"
       }
     },
+    "jsrsasign": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.0.4.tgz",
+      "integrity": "sha512-G08GDeAwgVkN5PGE9TnJ/4ixV3zkq560RigOoqrRvVc8H4GjfPVTz54/qGPLHK1KGHGP36/2eaLU1HuXmOJgug=="
+    },
     "jssha": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jssha/-/jssha-2.4.2.tgz",

--- a/server/gateway/package.json
+++ b/server/gateway/package.json
@@ -132,6 +132,7 @@
     "@types/jquery": "^3.3.6",
     "@types/json-stringify-safe": "^5.0.0",
     "@types/jsonwebtoken": "^8.3.0",
+    "@types/jsrsasign": "^8.0.7",
     "@types/lodash": "^4.14.118",
     "@types/mocha": "^5.2.5",
     "@types/morgan": "^1.7.35",

--- a/server/gateway/package.json
+++ b/server/gateway/package.json
@@ -97,6 +97,7 @@
     "gitgraph.js": "^1.11.4",
     "hjs": "^0.0.6",
     "jquery": "^3.3.1",
+    "jsrsasign": "^10.0.2",
     "json-stringify-safe": "^5.0.1",
     "jsonwebtoken": "^8.4.0",
     "lodash": "^4.17.19",

--- a/server/gateway/src/routes/api/api.ts
+++ b/server/gateway/src/routes/api/api.ts
@@ -8,7 +8,7 @@ import { IResolvedUrl, IWebResolvedUrl } from "@fluidframework/driver-definition
 import { ScopeType } from "@fluidframework/protocol-definitions";
 // TODO: getR11sToken is going to be removed from routerlicious-urlresolver.
 // When that happens we should instead use generateToken from @fluidframework/server-services-utils.
-import { getR11sToken, IAlfredUser } from "@fluidframework/routerlicious-urlresolver";
+import { IAlfredUser } from "@fluidframework/routerlicious-urlresolver";
 import { IAlfredTenant } from "@fluidframework/server-services-client";
 import Axios from "axios";
 import { Request, Router } from "express";
@@ -17,7 +17,7 @@ import moniker from "moniker";
 import { Provider } from "nconf";
 import passport from "passport";
 import winston from "winston";
-import { IJWTClaims } from "../../utils";
+import { getR11SToken, IJWTClaims } from "../../utils";
 
 // Although probably the case we want a default behavior here. Maybe just the URL?
 async function getWebComponent(url: UrlWithStringQuery): Promise<IWebResolvedUrl> {
@@ -79,8 +79,7 @@ async function getInternalComponent(
     const orderer = internal ? config.get("worker:alfredUrl") : config.get("worker:serverUrl");
 
     const user: IAlfredUser = (request.user as IJWTClaims).user;
-
-    const token = getR11sToken(tenantId, documentId, appTenants, scopes, user);
+    const token = getR11SToken(tenantId, appTenants, documentId, scopes, user);
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     const fluidUrl = `fluid://${url.host}/${tenantId}/${documentId}${path}${url.hash ? url.hash : ""}`;
 

--- a/server/gateway/src/routes/api/api.ts
+++ b/server/gateway/src/routes/api/api.ts
@@ -79,7 +79,7 @@ async function getInternalComponent(
     const orderer = internal ? config.get("worker:alfredUrl") : config.get("worker:serverUrl");
 
     const user: IAlfredUser = (request.user as IJWTClaims).user;
-    const token = getR11SToken(tenantId, appTenants, documentId, scopes, user);
+    const token = getR11SToken(tenantId, documentId, appTenants, scopes, user);
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     const fluidUrl = `fluid://${url.host}/${tenantId}/${documentId}${path}${url.hash ? url.hash : ""}`;
 

--- a/server/gateway/src/routes/loaderFramed.ts
+++ b/server/gateway/src/routes/loaderFramed.ts
@@ -18,7 +18,7 @@ import dotenv from "dotenv";
 import { spoEnsureLoggedIn } from "../gatewayOdspUtils";
 import { resolveUrl } from "../gatewayUrlResolver";
 import { IAlfred, IKeyValueWrapper } from "../interfaces";
-import { generateToken, getConfig, getUserDetails, queryParamAsString } from "../utils";
+import { generateToken, getConfig, getUser, getUserDetails, queryParamAsString } from "../utils";
 
 dotenv.config();
 
@@ -74,7 +74,8 @@ export function create(
                 const scopes = [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite];
                 const [resolvedP, fullTreeP] =
                     resolveUrl(config, alfred, appTenants, tenantId, documentId, scopes, request);
-                const jwtToken = generateToken(tenantId, documentId, jwtKey, scopes, request.user);
+                const user = getUser(request);
+                const jwtToken = generateToken(tenantId, documentId, jwtKey, scopes, user);
 
                 const workerConfig = getConfig(
                     config.get("worker"),

--- a/server/gateway/src/routes/loaderFramed.ts
+++ b/server/gateway/src/routes/loaderFramed.ts
@@ -11,7 +11,6 @@ import { IAlfredTenant } from "@fluidframework/server-services-client";
 import { extractPackageIdentifierDetails, SemVerCdnCodeResolver } from "@fluidframework/web-code-loader";
 import { Router } from "express";
 import safeStringify from "json-stringify-safe";
-import jwt from "jsonwebtoken";
 import { Provider } from "nconf";
 import { v4 } from "uuid";
 import winston from "winston";
@@ -19,7 +18,7 @@ import dotenv from "dotenv";
 import { spoEnsureLoggedIn } from "../gatewayOdspUtils";
 import { resolveUrl } from "../gatewayUrlResolver";
 import { IAlfred, IKeyValueWrapper } from "../interfaces";
-import { getConfig, getUserDetails, queryParamAsString } from "../utils";
+import { generateToken, getConfig, getUserDetails, queryParamAsString } from "../utils";
 
 dotenv.config();
 
@@ -64,12 +63,6 @@ export function create(
                 winston.info(`Redirecting to ${redirectUrl}`);
                 response.redirect(redirectUrl);
             } else {
-                const jwtToken = jwt.sign(
-                    {
-                        user: request.user,
-                    },
-                    jwtKey);
-
                 const rawPath = request.params[0];
                 const slash = rawPath.indexOf("/");
                 const documentId = rawPath.substring(0, slash !== -1 ? slash : rawPath.length);
@@ -81,6 +74,7 @@ export function create(
                 const scopes = [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite];
                 const [resolvedP, fullTreeP] =
                     resolveUrl(config, alfred, appTenants, tenantId, documentId, scopes, request);
+                const jwtToken = generateToken(tenantId, documentId, jwtKey, scopes, request.user);
 
                 const workerConfig = getConfig(
                     config.get("worker"),

--- a/server/gateway/src/routes/loaderFrs.ts
+++ b/server/gateway/src/routes/loaderFrs.ts
@@ -18,7 +18,7 @@ import dotenv from "dotenv";
 import { spoEnsureLoggedIn } from "../gatewayOdspUtils";
 import { resolveUrl } from "../gatewayUrlResolver";
 import { IAlfred, IKeyValueWrapper } from "../interfaces";
-import { generateToken, getConfig, getUserDetails, queryParamAsString } from "../utils";
+import { generateToken, getConfig, getUser, getUserDetails, queryParamAsString } from "../utils";
 import { defaultPartials } from "./partials";
 
 dotenv.config();
@@ -59,7 +59,8 @@ export function create(
         const scopes = [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite];
         const [resolvedP, fullTreeP] =
             resolveUrl(config, alfred, appTenants, tenantId, documentId, scopes, request);
-        const jwtToken = generateToken(tenantId, documentId, jwtKey, scopes, request.user);
+        const user = getUser(request);
+        const jwtToken = generateToken(tenantId, documentId, jwtKey, scopes, user);
 
         const workerConfig = getConfig(
             config.get("worker"),

--- a/server/gateway/src/routes/loaderFrs.ts
+++ b/server/gateway/src/routes/loaderFrs.ts
@@ -59,7 +59,7 @@ export function create(
         const scopes = [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite];
         const [resolvedP, fullTreeP] =
             resolveUrl(config, alfred, appTenants, tenantId, documentId, scopes, request);
-            const jwtToken = generateToken(tenantId, documentId, jwtKey, scopes, request.user);
+        const jwtToken = generateToken(tenantId, documentId, jwtKey, scopes, request.user);
 
         const workerConfig = getConfig(
             config.get("worker"),

--- a/server/gateway/src/utils.ts
+++ b/server/gateway/src/utils.ts
@@ -84,20 +84,6 @@ export const queryParamAsString = (value: any): string => {
     return typeof value === "string" ? value : "";
 };
 
-export function getR11SToken(
-    tenantId: string,
-    documentId: string,
-    appTenants: IAlfredTenant[],
-    scopes: ScopeType[],
-    user?: IUser,
-): string {
-    const tenantKey = appTenants.find((tenant) => tenant.id === tenantId)?.key;
-    if (tenantKey === undefined) {
-        throw Error(`Unable to find requested tenant ${tenantId}`);
-    }
-    return generateToken(tenantId, documentId, tenantKey, scopes, user);
-}
-
 // TODO: Remove this once the changes have been made in services-utils to use jrsassign instead of jwt,
 // and the updated package is released
 // Changes should be similar to the ones made here for local driver
@@ -132,6 +118,20 @@ export function generateToken(
 
     // eslint-disable-next-line no-null/no-null
     return jsrsasign.jws.JWS.sign(null, JSON.stringify({ alg:"HS256", typ: "JWT" }), claims, key);
+}
+
+export function getR11SToken(
+    tenantId: string,
+    documentId: string,
+    appTenants: IAlfredTenant[],
+    scopes: ScopeType[],
+    user?: IUser,
+): string {
+    const tenantKey = appTenants.find((tenant) => tenant.id === tenantId)?.key;
+    if (tenantKey === undefined) {
+        throw Error(`Unable to find requested tenant ${tenantId}`);
+    }
+    return generateToken(tenantId, documentId, tenantKey, scopes, user);
 }
 
 export function generateUser(): IUser {

--- a/server/gateway/src/utils.ts
+++ b/server/gateway/src/utils.ts
@@ -1,11 +1,15 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
 /*!
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
 
-import { IClient } from "@fluidframework/protocol-definitions";
+import { IClient, IUser, ScopeType } from "@fluidframework/protocol-definitions";
+import { getRandomName, IAlfredTenant } from "@fluidframework/server-services-client";
 import { Request } from "express";
 import _ from "lodash";
+import uuid from "uuid";
+import { KJUR as jsrsasign } from "jsrsasign";
 
 export interface ICachedPackage {
     entrypoint: string;
@@ -55,8 +59,7 @@ export function getVersion() {
     return `${version.endsWith(".0") ? "^" : ""}${version}`;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-const getUser = (request: Request) => request.user ?? request.session?.guest;
+export const getUser = (request: Request) => request.user ?? request.session?.guest;
 
 export function getJWTClaims(request: Request): IJWTClaims {
     const user = getUser(request);
@@ -80,3 +83,62 @@ export const getUserDetails = (request: Request) => JSON.stringify(getUser(reque
 export const queryParamAsString = (value: any): string => {
     return typeof value === "string" ? value : "";
 };
+
+export function getR11SToken(
+    tenantId: string,
+    appTenants: IAlfredTenant[],
+    documentId: string,
+    scopes: ScopeType[],
+    user?: IUser,
+): string {
+    const tenantKey = appTenants.find((tenant) => tenant.id === tenantId)?.key;
+    if (tenantKey === undefined) {
+        throw Error(`Unable to find requested tenant ${tenantId}`);
+    }
+    return generateToken(tenantId, documentId, tenantKey, scopes, user);
+}
+
+// TODO: Remove this once the changes have been made in services-utils to use jrsassign instead of jwt,
+// and the updated package is released
+// Changes should be similar to the ones made here for local driver
+// https://github.com/microsoft/FluidFramework/pull/3989/files
+export function generateToken(
+    tenantId: string,
+    documentId: string,
+    key: string,
+    scopes: ScopeType[],
+    user?: IUser,
+    lifetime: number = 60 * 60,
+    ver: string = "1.0"): string {
+    // eslint-disable-next-line no-param-reassign
+    user = (user) ? user : generateUser();
+    if (user.id === "" || user.id === undefined) {
+        // eslint-disable-next-line no-param-reassign
+        user = generateUser();
+    }
+
+    // Current time in seconds
+    const now = Math.round((new Date()).getTime() / 1000);
+
+    const claims = {
+        documentId,
+        scopes,
+        tenantId,
+        user,
+        iat: now,
+        exp: now + lifetime,
+        ver,
+    };
+
+    // eslint-disable-next-line no-null/no-null
+    return jsrsasign.jws.JWS.sign(null, JSON.stringify({ alg:"HS256", typ: "JWT" }), claims, key);
+}
+
+export function generateUser(): IUser {
+    const randomUser = {
+        id: uuid(),
+        name: getRandomName(" ", true),
+    };
+
+    return randomUser;
+}

--- a/server/gateway/src/utils.ts
+++ b/server/gateway/src/utils.ts
@@ -86,8 +86,8 @@ export const queryParamAsString = (value: any): string => {
 
 export function getR11SToken(
     tenantId: string,
-    appTenants: IAlfredTenant[],
     documentId: string,
+    appTenants: IAlfredTenant[],
     scopes: ScopeType[],
     user?: IUser,
 ): string {


### PR DESCRIPTION
- Changes the token generation process for Gateway paths to use jsrsasign instead of JWT (similar to the changes here (https://github.com/microsoft/FluidFramework/pull/3989/files)
- This should be directly made in server\routerlicious\packages\services-utils\src\auth.ts. However, since Gateway does not build as part of the monorepo these changes cannot be consumed until after @fluidframework/server-services-utils is released

Waiting on review feedback: 
- Create an issue to track the addition of generateToken to server-services-utils if this approach is deemed okay to unblock Gateway temporarily
- Create a corollary PR with the change in server-services-utils so Gateway can pick it up in the next release