### PR TITLE
revert strict as assert for exported code

### DIFF
--- a/common/lib/common-utils/src/promises.ts
+++ b/common/lib/common-utils/src/promises.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 
 /**
  * A deferred creates a promise and the ability to resolve or reject it

--- a/common/lib/common-utils/src/rangeTracker.ts
+++ b/common/lib/common-utils/src/rangeTracker.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 
 // eslint-disable-next-line import/no-internal-modules
 import cloneDeep from "lodash/cloneDeep";

--- a/common/lib/common-utils/src/timer.ts
+++ b/common/lib/common-utils/src/timer.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { Deferred } from "./promises";
 
 export interface ITimer {

--- a/examples/data-objects/client-ui-lib/src/controls/overlayCanvas.ts
+++ b/examples/data-objects/client-ui-lib/src/controls/overlayCanvas.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import * as api from "@fluid-internal/client-api";
 import * as ink from "@fluidframework/ink";
 import * as ui from "../ui";

--- a/examples/data-objects/key-value-cache/src/index.ts
+++ b/examples/data-objects/key-value-cache/src/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import {
     IFluidObject,
     IFluidRouter,

--- a/examples/data-objects/prosemirror/src/fluidBridge.ts
+++ b/examples/data-objects/prosemirror/src/fluidBridge.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import {
     createInsertSegmentOp,
     Marker,

--- a/examples/data-objects/prosemirror/src/fluidCollabManager.ts
+++ b/examples/data-objects/prosemirror/src/fluidCollabManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { EventEmitter } from "events";
 import { ILoader } from "@fluidframework/container-definitions";
 import {

--- a/examples/data-objects/smde/src/smde.ts
+++ b/examples/data-objects/smde/src/smde.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { EventEmitter } from "events";
 import {
     IFluidObject,

--- a/examples/data-objects/table-document/src/cellrange.ts
+++ b/examples/data-objects/table-document/src/cellrange.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { LocalReference } from "@fluidframework/merge-tree";
 import { SequenceInterval } from "@fluidframework/sequence";
 

--- a/examples/data-objects/table-document/src/interception/tableWithInterception.ts
+++ b/examples/data-objects/table-document/src/interception/tableWithInterception.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { PropertySet } from "@fluidframework/merge-tree";
 import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 import { ITable, TableDocumentItem } from "../table";

--- a/examples/data-objects/webflow/src/document/index.ts
+++ b/examples/data-objects/webflow/src/document/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { randomId, TokenList, TagName } from "@fluid-example/flow-util-lib";
 import { LazyLoadedDataObject, LazyLoadedDataObjectFactory } from "@fluidframework/data-object-base";
 import { IFluidHandle } from "@fluidframework/core-interfaces";

--- a/examples/data-objects/webflow/src/html/formatters.ts
+++ b/examples/data-objects/webflow/src/html/formatters.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { Caret as CaretUtil, Direction, Rect, TagName } from "@fluid-example/flow-util-lib";
 import { IFluidObject } from "@fluidframework/core-interfaces";
 import { Marker, TextSegment } from "@fluidframework/merge-tree";

--- a/examples/data-objects/webflow/src/view/layout.ts
+++ b/examples/data-objects/webflow/src/view/layout.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { EventEmitter } from "events";
 import { Dom, hasTagName, isTextNode, Scheduler, TagName } from "@fluid-example/flow-util-lib";
 import { IFluidObject } from "@fluidframework/core-interfaces";

--- a/packages/dds/cell/src/cell.ts
+++ b/packages/dds/cell/src/cell.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { ISerializedHandle } from "@fluidframework/core-interfaces";
 import { fromBase64ToUtf8 } from "@fluidframework/common-utils";
 import {

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { fromBase64ToUtf8 } from "@fluidframework/common-utils";
 import { addBlobToTree } from "@fluidframework/protocol-base";
 import {

--- a/packages/dds/map/src/mapKernel.ts
+++ b/packages/dds/map/src/mapKernel.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";

--- a/packages/dds/matrix/src/handlecache.ts
+++ b/packages/dds/matrix/src/handlecache.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable no-bitwise */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { IVectorConsumer } from "@tiny-calc/nano";
 import { Handle, isHandleValid } from "./handletable";
 import { PermutationVector, PermutationSegment } from "./permutationvector";

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import {
     FileMode,
     ISequencedDocumentMessage,

--- a/packages/dds/matrix/src/permutationvector.ts
+++ b/packages/dds/matrix/src/permutationvector.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
 import { IFluidDataStoreRuntime, IChannelStorageService } from "@fluidframework/datastore-definitions";
 import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";

--- a/packages/dds/matrix/src/undoprovider.ts
+++ b/packages/dds/matrix/src/undoprovider.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { Serializable } from "@fluidframework/datastore-definitions";
 import { TrackingGroup, MergeTreeDeltaOperationType, MergeTreeDeltaType } from "@fluidframework/merge-tree";
 import { SharedMatrix } from "./matrix";

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
 import { IFluidDataStoreRuntime, IChannelStorageService } from "@fluidframework/datastore-definitions";

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable @typescript-eslint/consistent-type-assertions, max-len, no-bitwise, no-param-reassign, no-shadow */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { Trace } from "@fluidframework/common-utils";
 import * as Base from "./base";
 import * as Collections from "./collections";

--- a/packages/dds/merge-tree/src/partialLengths.ts
+++ b/packages/dds/merge-tree/src/partialLengths.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { strict as assert } from "assert";
+import assert from "assert";
 import { Property } from "./base";
 import { RedBlackTree } from "./collections";
 import { UnassignedSequenceNumber } from "./constants";

--- a/packages/dds/merge-tree/src/segmentPropertiesManager.ts
+++ b/packages/dds/merge-tree/src/segmentPropertiesManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { UnassignedSequenceNumber } from "./constants";
 import { CollaborationWindow, ISegment } from "./mergeTree";
 import { ICombiningOp, IMergeTreeAnnotateMsg } from "./ops";

--- a/packages/dds/merge-tree/src/snapshotLoader.ts
+++ b/packages/dds/merge-tree/src/snapshotLoader.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { fromBase64ToUtf8 } from "@fluidframework/common-utils";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";

--- a/packages/dds/merge-tree/src/snapshotV1.ts
+++ b/packages/dds/merge-tree/src/snapshotV1.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import {
     IFluidHandle,

--- a/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
+++ b/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { fromBase64ToUtf8, unreachableCase } from "@fluidframework/common-utils";
 import {
     FileMode,

--- a/packages/dds/ordered-collection/src/snapshotableArray.ts
+++ b/packages/dds/ordered-collection/src/snapshotableArray.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 
 export class SnapshotableArray<T> extends Array {
     protected data: T[] = [];

--- a/packages/dds/register-collection/src/consensusRegisterCollection.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollection.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { fromBase64ToUtf8, unreachableCase } from "@fluidframework/common-utils";
 import {
     FileMode,

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 
 // eslint-disable-next-line import/no-internal-modules
 import cloneDeep from "lodash/cloneDeep";

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { ITelemetryErrorEvent, ITelemetryLogger } from "@fluidframework/common-definitions";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { ChildLogger, EventEmitterWithErrorHandling } from "@fluidframework/telemetry-utils";

--- a/packages/drivers/debugger/src/fluidDebuggerController.ts
+++ b/packages/drivers/debugger/src/fluidDebuggerController.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { Deferred } from "@fluidframework/common-utils";
 import {
     IDocumentService,

--- a/packages/drivers/debugger/src/fluidDebuggerUi.ts
+++ b/packages/drivers/debugger/src/fluidDebuggerUi.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { ISequencedDocumentMessage, IVersion } from "@fluidframework/protocol-definitions";
 
 export interface IDebuggerUI {

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { BatchManager, TypedEventEmitter } from "@fluidframework/common-utils";
 import {
     IDocumentDeltaConnection,

--- a/packages/drivers/file-driver/src/fileDeltaStorageService.ts
+++ b/packages/drivers/file-driver/src/fileDeltaStorageService.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import fs from "fs";
 import { IDocumentDeltaStorageService } from "@fluidframework/driver-definitions";
 import * as api from "@fluidframework/protocol-definitions";

--- a/packages/drivers/file-driver/src/fileDocumentStorageService.ts
+++ b/packages/drivers/file-driver/src/fileDocumentStorageService.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import fs from "fs";
 import { fromBase64ToUtf8 } from "@fluidframework/common-utils";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";

--- a/packages/drivers/fluidapp-odsp-urlResolver/src/urlResolver.ts
+++ b/packages/drivers/fluidapp-odsp-urlResolver/src/urlResolver.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { fromBase64ToUtf8 } from "@fluidframework/common-utils";
 import { IResolvedUrl, IUrlResolver } from "@fluidframework/driver-definitions";

--- a/packages/drivers/local-driver/src/localResolver.ts
+++ b/packages/drivers/local-driver/src/localResolver.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { parse } from "url";
 import { IRequest } from "@fluidframework/core-interfaces";
 import {

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import { DocumentDeltaConnection } from "@fluidframework/driver-base";

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import AbortController from "abort-controller";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { v4 as uuid } from "uuid";

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import {
     IFluidCodeDetails,
     IRequest,

--- a/packages/drivers/replay-driver/src/storageImplementations.ts
+++ b/packages/drivers/replay-driver/src/storageImplementations.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import {
     IDocumentDeltaConnection,
     IDocumentDeltaStorageService,

--- a/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import querystring from "querystring";
 import { fromUtf8ToBase64 } from "@fluidframework/common-utils";
 import { IDeltaStorageService, IDocumentDeltaStorageService } from "@fluidframework/driver-definitions";

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { parse } from "url";
 import {
     IDocumentService,

--- a/packages/drivers/routerlicious-driver/src/documentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentStorageService.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { gitHashFile, IsoBuffer, Uint8ArrayToString } from "@fluidframework/common-utils";
 import { IDocumentStorageService, ISummaryContext } from "@fluidframework/driver-definitions";
 import * as resources from "@fluidframework/gitresources";

--- a/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { IDirectory } from "@fluidframework/map";
 import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 

--- a/packages/framework/dds-interceptions/src/map/sharedMapWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/map/sharedMapWithInterception.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
 import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 

--- a/packages/framework/dds-interceptions/src/sequence/sharedStringWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/sequence/sharedStringWithInterception.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import * as MergeTree from "@fluidframework/merge-tree";
 import { SharedString } from "@fluidframework/sequence";
 import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";

--- a/packages/framework/request-handler/src/requestHandlers.ts
+++ b/packages/framework/request-handler/src/requestHandlers.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import {
     IFluidObject,
     IResponse,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 // eslint-disable-next-line import/no-internal-modules
 import merge from "lodash/merge";
 import uuid from "uuid";

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import {
     IFluidObject,

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { ITelemetryLogger, IEventProvider } from "@fluidframework/common-definitions";
 import {
     IConnectionDetails,

--- a/packages/loader/container-loader/src/deltaQueue.ts
+++ b/packages/loader/container-loader/src/deltaQueue.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { IDeltaQueue, IDeltaQueueEvents } from "@fluidframework/container-definitions";
 import { Deferred, TypedEventEmitter } from "@fluidframework/common-utils";
 import Deque from "double-ended-queue";

--- a/packages/loader/container-utils/src/error.ts
+++ b/packages/loader/container-utils/src/error.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { ContainerErrorType, IGenericError, ICriticalContainerError } from "@fluidframework/container-definitions";
 import { CustomErrorWithProps } from "@fluidframework/telemetry-utils";
 

--- a/packages/loader/driver-utils/src/buildSnapshotTree.ts
+++ b/packages/loader/driver-utils/src/buildSnapshotTree.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { gitHashFile, IsoBuffer } from "@fluidframework/common-utils";
 import * as git from "@fluidframework/gitresources";
 import {

--- a/packages/runtime/agent-scheduler/src/scheduler.ts
+++ b/packages/runtime/agent-scheduler/src/scheduler.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { EventEmitter } from "events";
 import {
     IFluidObject,

--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { ChildLogger, TelemetryLogger } from "@fluidframework/telemetry-utils";
 import { IDeltaManager } from "@fluidframework/container-definitions";

--- a/packages/runtime/container-runtime/src/containerHandleContext.ts
+++ b/packages/runtime/container-runtime/src/containerHandleContext.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import {
     IFluidHandleContext,
     IRequest,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { EventEmitter } from "events";
 import { TaskManagerFactory } from "@fluidframework/agent-scheduler";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import EventEmitter from "events";
 import { IDisposable } from "@fluidframework/common-definitions";
 import {

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { IErrorBase } from "@fluidframework/container-definitions";
 import { CustomErrorWithProps } from "@fluidframework/telemetry-utils";
 import { ITelemetryProperties } from "@fluidframework/common-definitions";

--- a/packages/runtime/container-runtime/src/summaryCollection.ts
+++ b/packages/runtime/container-runtime/src/summaryCollection.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { IDisposable } from "@fluidframework/common-definitions";
 import { Deferred } from "@fluidframework/common-utils";
 import {

--- a/packages/runtime/container-runtime/src/taskAnalyzer.ts
+++ b/packages/runtime/container-runtime/src/taskAnalyzer.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { ISequencedClient } from "@fluidframework/protocol-definitions";
 
 export interface IHelpTasks {

--- a/packages/runtime/datastore/src/channelDeltaConnection.ts
+++ b/packages/runtime/datastore/src/channelDeltaConnection.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { IDocumentMessage, ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { IDeltaConnection, IDeltaHandler } from "@fluidframework/datastore-definitions";
 

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { EventEmitter } from "events";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import {

--- a/packages/runtime/datastore/src/localChannelContext.ts
+++ b/packages/runtime/datastore/src/localChannelContext.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 // eslint-disable-next-line import/no-internal-modules
 import cloneDeep from "lodash/cloneDeep";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { CreateContainerError } from "@fluidframework/container-utils";
 import { readAndParse } from "@fluidframework/driver-utils";

--- a/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
+++ b/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { strict as assert } from "assert";
+import assert from "assert";
 import {
     IFluidObject,
     IFluidRouter,

--- a/packages/runtime/runtime-utils/src/objectstoragepartition.ts
+++ b/packages/runtime/runtime-utils/src/objectstoragepartition.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { IChannelStorageService } from "@fluidframework/datastore-definitions";
 
 /**

--- a/packages/runtime/runtime-utils/src/summarizerNode.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import {
     ISummarizerNode,
     ISummarizerNodeConfig,

--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { IsoBuffer } from "@fluidframework/common-utils";
 import {
     ITree,

--- a/packages/tools/fetch-tool/src/fluidAnalyzeMessages.ts
+++ b/packages/tools/fetch-tool/src/fluidAnalyzeMessages.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import {
     IBlob,
     ISequencedDocumentMessage,

--- a/packages/tools/fetch-tool/src/fluidFetchMessages.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchMessages.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import fs from "fs";
 import {
     IDocumentDeltaStorageService,

--- a/packages/tools/fetch-tool/src/fluidFetchSnapshot.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchSnapshot.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import fs from "fs";
 import util from "util";
 import { fromBase64ToUtf8 } from "@fluidframework/common-utils";

--- a/packages/tools/merge-tree-client-replay/src/clientReplayTool.ts
+++ b/packages/tools/merge-tree-client-replay/src/clientReplayTool.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import fs from "fs";
 import { FileDeltaStorageService } from "@fluidframework/file-driver";
 import {

--- a/packages/tools/replay-tool/src/replayMessages.ts
+++ b/packages/tools/replay-tool/src/replayMessages.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import child_process from "child_process";
 import fs from "fs";
 import * as API from "@fluid-internal/client-api";

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { EventEmitter } from "events";
 import { IContext, IQueuedMessage } from "@fluidframework/server-services-core";
 import { DocumentContext } from "./documentContext";

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { EventEmitter } from "events";
 import { IContext, IQueuedMessage, ILogger } from "@fluidframework/server-services-core";
 import * as winston from "winston";

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/checkpointManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/checkpointManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { Deferred } from "@fluidframework/common-utils";
 import { IConsumer, IQueuedMessage } from "@fluidframework/server-services-core";
 

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable no-null/no-null */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { RangeTracker } from "@fluidframework/common-utils";
 import { isSystemType } from "@fluidframework/protocol-base";
 import {

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable no-null/no-null */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { ProtocolOpHandler } from "@fluidframework/protocol-base";
 import {
     IDocumentMessage,

--- a/server/routerlicious/packages/memory-orderer/src/localNode.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localNode.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { EventEmitter } from "events";
 import { IDocumentMessage, IServiceConfiguration } from "@fluidframework/protocol-definitions";
 import {

--- a/server/routerlicious/packages/memory-orderer/src/localOrderManager.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { IOrderer } from "@fluidframework/server-services-core";
 import { IConcreteNode, IConcreteNodeFactory, IReservationManager } from "./interfaces";
 

--- a/server/routerlicious/packages/memory-orderer/src/nodeManager.ts
+++ b/server/routerlicious/packages/memory-orderer/src/nodeManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { EventEmitter } from "events";
 import { MongoManager } from "@fluidframework/server-services-core";
 import { IConcreteNode } from "./interfaces";

--- a/server/routerlicious/packages/memory-orderer/src/pubsub.ts
+++ b/server/routerlicious/packages/memory-orderer/src/pubsub.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { IWebSocket } from "@fluidframework/server-services-core";
 
 export interface ISubscriber {

--- a/server/routerlicious/packages/memory-orderer/src/remoteNode.ts
+++ b/server/routerlicious/packages/memory-orderer/src/remoteNode.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { EventEmitter } from "events";
 import { Deferred } from "@fluidframework/common-utils";
 import { IClient, IDocumentMessage, IServiceConfiguration } from "@fluidframework/protocol-definitions";

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 // eslint-disable-next-line import/no-internal-modules
 import cloneDeep from "lodash/cloneDeep";
 

--- a/server/routerlicious/packages/services-client/src/gitManager.ts
+++ b/server/routerlicious/packages/services-client/src/gitManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import * as resources from "@fluidframework/gitresources";
 import { buildHierarchy } from "@fluidframework/protocol-base";
 import * as api from "@fluidframework/protocol-definitions";

--- a/tools/build-tools/src/buildVersion/buildVersionTests.ts
+++ b/tools/build-tools/src/buildVersion/buildVersionTests.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { getSimpleVersion } from "./buildVersion";
 
 export function test() {

--- a/tools/build-tools/src/layerCheck/layerGraph.ts
+++ b/tools/build-tools/src/layerCheck/layerGraph.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import assert from "assert";
 import { logVerbose } from "../common/logging";
 import { Package, Packages } from "../common/npmPackage";
 import { EOL as newline } from "os";

--- a/tools/bundle-size-tools/src/ADO/AdoArtifactFileProvider.ts
+++ b/tools/bundle-size-tools/src/ADO/AdoArtifactFileProvider.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from 'assert';
+import assert from 'assert';
 import { WebApi } from 'azure-devops-node-api';
 import { decompressStatsFile, unzipStream } from '../utilities';
 import JSZip from 'jszip';

--- a/tools/bundle-size-tools/src/ADO/getCommentForBundleDiff.ts
+++ b/tools/bundle-size-tools/src/ADO/getCommentForBundleDiff.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from 'assert';
+import assert from 'assert';
 import { BundleComparison, BundleMetric } from '../BundleBuddyTypes';
 import { totalSizeMetricName } from './Constants';
 


### PR DESCRIPTION
we recently changed all of our uses of 'assert' to 'strict as assert' to improve testing. These changes were also made to exported dds/server code that used 'assert' to test some value at runtime. It appears that assert is often polyfilled to a smaller package at runtime (and the assert package excluded from runtime bundle), which probably means that trying to pull out 'strict' from assert will break those scenarios. 

So here's a PR returning the non spec/test/example code to simply user assert instead of strict for better polyfill support. 

fixes #4112