### PR TITLE
Local token provider for r11s driver

### DIFF
--- a/examples/hosts/hosts-sample/src/index.ts
+++ b/examples/hosts/hosts-sample/src/index.ts
@@ -7,7 +7,7 @@ import { Loader } from "@fluidframework/container-loader";
 import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
 import { IUser } from "@fluidframework/protocol-definitions";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
-import { InsecureUrlResolver } from "@fluidframework/test-runtime-utils";
+import { InsecureTokenProvider, InsecureUrlResolver } from "@fluidframework/test-runtime-utils";
 import {
     extractPackageIdentifierDetails,
     SemVerCdnCodeResolver,
@@ -54,8 +54,13 @@ export async function start(url: string, code: string, createNew: boolean): Prom
         user,
         bearerSecret);
 
+    const parsedUrl = new URL(url);
+    const documentId = parsedUrl.pathname.substr(1).split("/")[0];
+
+    const tokenProvider = new InsecureTokenProvider(tenantId, documentId, tenantKey, user);
+
     // The RouterliciousDocumentServiceFactory creates the driver that allows connections to the Routerlicious service.
-    const documentServiceFactory = new RouterliciousDocumentServiceFactory();
+    const documentServiceFactory = new RouterliciousDocumentServiceFactory(tokenProvider);
 
     // The code loader provides the ability to load npm packages that have been quorumed on and that represent
     // the code for the document. The base WebCodeLoader supports both code on a CDN as well as those defined

--- a/examples/hosts/iframe-host/src/outer.ts
+++ b/examples/hosts/iframe-host/src/outer.ts
@@ -11,7 +11,7 @@ import {
     RouterliciousDocumentServiceFactory,
 } from "@fluidframework/routerlicious-driver";
 import { HTMLViewAdapter } from "@fluidframework/view-adapters";
-import { InsecureUrlResolver } from "@fluidframework/test-runtime-utils";
+import { InsecureTokenProvider, InsecureUrlResolver } from "@fluidframework/test-runtime-utils";
 import { IFrameOuterHost } from "./inframehost";
 
 let createNew = false;
@@ -22,7 +22,7 @@ const getDocumentId = () => {
     }
     return window.location.hash.substring(1);
 };
-const getDocumentUrl = () => `${window.location.origin}/${getDocumentId()}`;
+const getDocumentUrl = (documentId: string) => `${window.location.origin}/${documentId}`;
 const getTinyliciousUrlResolver =
     () => new InsecureUrlResolver(
         "http://localhost:3000",
@@ -34,11 +34,13 @@ const getTinyliciousUrlResolver =
         "bearer");
 
 export async function loadFrame(iframeId: string, logId: string) {
+    const documentId = getDocumentId();
     const iframe = document.getElementById(iframeId) as HTMLIFrameElement;
 
     const urlResolver = getTinyliciousUrlResolver();
 
-    const documentServiceFactory = new RouterliciousDocumentServiceFactory();
+    const tokenProvider = new InsecureTokenProvider("tinylicious", documentId, "12345", { id: "userid0" });
+    const documentServiceFactory = new RouterliciousDocumentServiceFactory(tokenProvider);
 
     const host = new IFrameOuterHost({
         urlResolver,
@@ -46,7 +48,7 @@ export async function loadFrame(iframeId: string, logId: string) {
     });
 
     const proxyContainer = await host.load(
-        { url: getDocumentUrl() },
+        { url: getDocumentUrl(documentId) },
         iframe,
     );
 

--- a/examples/hosts/node-host/package.json
+++ b/examples/hosts/node-host/package.json
@@ -31,6 +31,7 @@
     "@fluidframework/protocol-definitions": "^0.1014.0-0",
     "@fluidframework/routerlicious-driver": "^0.28.0",
     "@fluidframework/routerlicious-host": "^0.28.0",
+    "@fluidframework/test-runtime-utils": "^0.28.0",
     "jsonwebtoken": "^8.4.0",
     "uuid": "^3.3.2"
   },

--- a/examples/hosts/node-host/src/index.ts
+++ b/examples/hosts/node-host/src/index.ts
@@ -10,6 +10,7 @@ import { IFluidResolvedUrl } from "@fluidframework/driver-definitions";
 import { IUser } from "@fluidframework/protocol-definitions";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 import { ContainerUrlResolver } from "@fluidframework/routerlicious-host";
+import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
 import * as jwt from "jsonwebtoken";
 import { v4 as uuid } from "uuid";
 import { NodeCodeLoader } from "./nodeCodeloader";
@@ -83,10 +84,12 @@ export async function start(): Promise<void> {
     // Once installed, the loader returns an entry point to Fluid Container to invoke the code.
     const codeLoader = new NodeCodeLoader(installPath, timeoutMS);
 
+    const tokenProvider = new InsecureTokenProvider(tenantId, documentId, tenantKey, user);
+
     // Construct the loader
     const loader = new Loader({
         urlResolver,
-        documentServiceFactory: new RouterliciousDocumentServiceFactory(),
+        documentServiceFactory: new RouterliciousDocumentServiceFactory(tokenProvider),
         codeLoader,
     });
 

--- a/examples/utils/get-tinylicious-container/src/getTinyliciousContainer.ts
+++ b/examples/utils/get-tinylicious-container/src/getTinyliciousContainer.ts
@@ -9,6 +9,7 @@ import {
 import { Container } from "@fluidframework/container-loader";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 import { getContainer } from "./getContainer";
+import { InsecureTinyliciousTokenProvider } from "./insecureTinyliciousTokenProvider";
 import { InsecureTinyliciousUrlResolver } from "./insecureTinyliciousUrlResolver";
 /**
  * Connect to the Tinylicious service and retrieve a Container with the given ID running the given code.
@@ -20,7 +21,8 @@ export async function getTinyliciousContainer(
     containerRuntimeFactory: IRuntimeFactory,
     createNew: boolean,
 ): Promise<Container> {
-    const documentServiceFactory = new RouterliciousDocumentServiceFactory();
+    const tokenProvider = new InsecureTinyliciousTokenProvider(documentId);
+    const documentServiceFactory = new RouterliciousDocumentServiceFactory(tokenProvider);
 
     const urlResolver = new InsecureTinyliciousUrlResolver();
 

--- a/examples/utils/get-tinylicious-container/src/insecureTinyliciousTokenProvider.ts
+++ b/examples/utils/get-tinylicious-container/src/insecureTinyliciousTokenProvider.ts
@@ -1,0 +1,51 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ScopeType, ITokenClaims } from "@fluidframework/protocol-definitions";
+import { ITokenProvider, ITokenResponse } from "@fluidframework/routerlicious-driver";
+import { KJUR as jsrsasign } from "jsrsasign";
+import { v4 as uuid } from "uuid";
+
+/**
+ * As the name implies this is not secure and should not be used in production. It simply makes the example easier
+ * to get up and running.
+ */
+export class InsecureTinyliciousTokenProvider implements ITokenProvider {
+    constructor(private readonly documentId: string) {
+
+    }
+
+    public async fetchOrdererToken(): Promise<ITokenResponse> {
+        return {
+            fromCache: true,
+            jwt: this.getSignedToken(),
+        };
+    }
+
+    public async fetchStorageToken(): Promise<ITokenResponse> {
+        return {
+            fromCache: true,
+            jwt: this.getSignedToken(),
+        };
+    }
+
+    private getSignedToken(lifetime: number = 60 * 60, ver: string = "1.0"): string {
+        // Current time in seconds
+        const now = Math.round((new Date()).getTime() / 1000);
+
+        const claims: ITokenClaims = {
+            documentId: this.documentId,
+            scopes: [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite],
+            tenantId: "tinylicious",
+            user: { id: uuid() },
+            iat: now,
+            exp: now + lifetime,
+            ver,
+        };
+
+        // eslint-disable-next-line no-null/no-null
+        return jsrsasign.jws.JWS.sign(null, JSON.stringify({ alg:"HS256", typ: "JWT" }), claims, "12345");
+    }
+}

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -19,7 +19,6 @@ import {
     getQuorumValuesFromProtocolSummary,
 } from "@fluidframework/driver-utils";
 import Axios from "axios";
-import { DefaultTokenProvider } from "./defaultTokenProvider";
 import { DocumentService } from "./documentService";
 import { DocumentService2 } from "./documentService2";
 import { DefaultErrorTracking } from "./errorTracking";
@@ -32,7 +31,7 @@ import { ITokenProvider } from "./tokens";
 export class RouterliciousDocumentServiceFactory implements IDocumentServiceFactory {
     public readonly protocolName = "fluid:";
     constructor(
-        private readonly tokenProvider: ITokenProvider | undefined = undefined,
+        private readonly tokenProvider: ITokenProvider,
         private readonly useDocumentService2: boolean = false,
         private readonly errorTracking: IErrorTrackingService = new DefaultErrorTracking(),
         private readonly disableCache: boolean = false,
@@ -100,20 +99,6 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
                 `Couldn't parse documentId and/or tenantId. [documentId:${documentId}][tenantId:${tenantId}]`);
         }
 
-        let tokenProvider: ITokenProvider;
-
-        // Fall back to default provider if token provider is not provided.
-        if (this.tokenProvider === undefined) {
-            const jwtToken = fluidResolvedUrl.tokens.jwt;
-            if (!jwtToken) {
-                throw new Error(`No token or provider is present.`);
-            } else {
-                tokenProvider = new DefaultTokenProvider(jwtToken);
-            }
-        } else {
-            tokenProvider = this.tokenProvider;
-        }
-
         if (this.useDocumentService2) {
             return new DocumentService2(
                 fluidResolvedUrl,
@@ -124,7 +109,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
                 this.disableCache,
                 this.historianApi,
                 this.credentials,
-                tokenProvider,
+                this.tokenProvider,
                 tenantId,
                 documentId);
         } else {
@@ -138,7 +123,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
                 this.historianApi,
                 this.credentials,
                 this.gitCache,
-                tokenProvider,
+                this.tokenProvider,
                 tenantId,
                 documentId);
         }

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -57,6 +57,7 @@
     "@fluidframework/driver-definitions": "^0.28.0",
     "@fluidframework/driver-utils": "^0.28.0",
     "@fluidframework/protocol-definitions": "^0.1014.0-0",
+    "@fluidframework/routerlicious-driver": "^0.28.0",
     "@fluidframework/runtime-definitions": "^0.28.0",
     "@fluidframework/runtime-utils": "^0.28.0",
     "@fluidframework/telemetry-utils": "^0.28.0",

--- a/packages/runtime/test-runtime-utils/src/index.ts
+++ b/packages/runtime/test-runtime-utils/src/index.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+export * from "./insecureTokenProvider";
 export * from "./insecureUrlResolver";
 export * from "./mocks";
 export * from "./mockDeltas";

--- a/packages/runtime/test-runtime-utils/src/insecureTokenProvider.ts
+++ b/packages/runtime/test-runtime-utils/src/insecureTokenProvider.ts
@@ -1,0 +1,54 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ScopeType, ITokenClaims, IUser } from "@fluidframework/protocol-definitions";
+import { ITokenProvider, ITokenResponse } from "@fluidframework/routerlicious-driver";
+import { KJUR as jsrsasign } from "jsrsasign";
+
+/**
+ * As the name implies this is not secure and should not be used in production. It simply makes the example easier
+ * to get up and running.
+ */
+export class InsecureTokenProvider implements ITokenProvider {
+    constructor(
+        private readonly tenantId: string,
+        private readonly documentId: string,
+        private readonly tenantKey: string,
+        private readonly user: IUser,
+    ) {
+
+    }
+
+    public async fetchOrdererToken(): Promise<ITokenResponse> {
+        return {
+            fromCache: true,
+            jwt: this.getSignedToken(),
+        };
+    }
+
+    public async fetchStorageToken(): Promise<ITokenResponse> {
+        return {
+            fromCache: true,
+            jwt: this.getSignedToken(),
+        };
+    }
+
+    private getSignedToken(lifetime: number = 60 * 60, ver: string = "1.0"): string {
+        // Current time in seconds
+        const now = Math.round((new Date()).getTime() / 1000);
+
+        const claims: ITokenClaims = {
+            documentId: this.documentId,
+            scopes: [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite],
+            tenantId: this.tenantId,
+            user: this.user,
+            iat: now,
+            exp: now + lifetime,
+            ver,
+        };
+
+        return jsrsasign.jws.JWS.sign(null, JSON.stringify({ alg:"HS256", typ: "JWT" }), claims, this.tenantKey);
+    }
+}

--- a/packages/test/end-to-end-tests/src/real-service-tests/r11sEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/real-service-tests/r11sEndToEndTests.spec.ts
@@ -16,8 +16,11 @@ import {
     ITestFluidObject,
 } from "@fluidframework/test-utils";
 import { SharedMap } from "@fluidframework/map";
-import { RouterliciousDocumentServiceFactory, DefaultErrorTracking } from "@fluidframework/routerlicious-driver";
-import { InsecureUrlResolver } from "@fluidframework/test-runtime-utils";
+import {
+    RouterliciousDocumentServiceFactory,
+    DefaultErrorTracking,
+    ITokenProvider } from "@fluidframework/routerlicious-driver";
+import { InsecureTokenProvider, InsecureUrlResolver } from "@fluidframework/test-runtime-utils";
 import { IUser } from "@fluidframework/protocol-definitions";
 import { Deferred } from "@fluidframework/common-utils";
 import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
@@ -34,14 +37,21 @@ describe(`r11s End-To-End tests`, () => {
     let request: IRequest;
     let loader: Loader;
 
-    function createTestLoader(urlResolver: IUrlResolver): Loader {
+    interface ITestParameters {
+        fluidHost: string;
+        bearerSecret: string
+        tenantId: string;
+        tenantSecret: string;
+    }
+
+    function createTestLoader(urlResolver: IUrlResolver, tokenProvider: ITokenProvider): Loader {
         const factory: TestFluidObjectFactory = new TestFluidObjectFactory([
             [mapId1, SharedMap.getFactory()],
             [mapId2, SharedMap.getFactory()],
         ]);
         const codeLoader = new LocalCodeLoader([[codeDetails, factory]]);
         const documentServiceFactory = new RouterliciousDocumentServiceFactory(
-            undefined,
+            tokenProvider,
             false,
             new DefaultErrorTracking(),
             false,
@@ -68,7 +78,7 @@ describe(`r11s End-To-End tests`, () => {
         id: uuid(),
     });
 
-    function getResolver(): InsecureUrlResolver {
+    function getParameters(): ITestParameters {
         const bearerSecret = process.env.fluid__webpack__bearerSecret;
         const tenantId = process.env.fluid__webpack__tenantId ?? "fluid";
         const tenantSecret = process.env.fluid__webpack__tenantSecret;
@@ -79,22 +89,43 @@ describe(`r11s End-To-End tests`, () => {
         assert(tenantSecret, "Missing tenant secret");
         assert(fluidHost, "Missing Fluid host");
 
-        return new InsecureUrlResolver(
+        return {
             fluidHost,
-            fluidHost.replace("www", "alfred"),
-            fluidHost.replace("www", "historian"),
+            bearerSecret,
             tenantId,
             tenantSecret,
-            getUser(),
-            bearerSecret,
+        };
+    }
+
+    function getResolver(
+        params: ITestParameters,
+        user: IUser,
+    ): InsecureUrlResolver {
+        const urlResolver =  new InsecureUrlResolver(
+            params.fluidHost,
+            params.fluidHost.replace("www", "alfred"),
+            params.fluidHost.replace("www", "historian"),
+            params.tenantId,
+            params.tenantSecret,
+            user,
+            params.bearerSecret,
             true);
+        return urlResolver;
     }
 
     beforeEach(async () => {
-        const urlResolver = getResolver();
+        const params = getParameters();
+        const urlResolver = getResolver(params, getUser());
         const documentId = moniker.choose();
         request = urlResolver.createCreateNewRequest(documentId);
-        loader = createTestLoader(urlResolver);
+
+        const tokenProvider = new InsecureTokenProvider(
+            params.tenantId,
+            documentId,
+            params.tenantSecret,
+            getUser(),
+        );
+        loader = createTestLoader(urlResolver, tokenProvider);
     });
 
     it("Container creation in r11s", async () => {
@@ -121,8 +152,10 @@ describe(`r11s End-To-End tests`, () => {
         assert(container.resolvedUrl, "attached container should have resolved URL");
 
         // Now load the container from another loader.
-        const urlResolver2 = getResolver();
-        const loader2 = createTestLoader(urlResolver2);
+        const params = getParameters();
+        const urlResolver2 = getResolver(params, getUser());
+        const tokenProvider2 = new InsecureTokenProvider(params.tenantId, container.id, params.tenantSecret, getUser());
+        const loader2 = createTestLoader(urlResolver2, tokenProvider2);
         // Create a new request url from the resolvedUrl of the first container.
         const requestUrl2 = await urlResolver2.getAbsoluteUrl(container.resolvedUrl, "");
         const container2 = await loader2.resolve({ url: requestUrl2 });

--- a/packages/tools/webpack-fluid-loader/src/multiDocumentServiceFactory.ts
+++ b/packages/tools/webpack-fluid-loader/src/multiDocumentServiceFactory.ts
@@ -8,7 +8,11 @@ import { MultiDocumentServiceFactory } from "@fluidframework/driver-utils";
 import { LocalDocumentServiceFactory, LocalSessionStorageDbFactory } from "@fluidframework/local-driver";
 import { OdspDocumentServiceFactory } from "@fluidframework/odsp-driver";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
-import { RouteOptions } from "./loader";
+import { getRandomName } from "@fluidframework/server-services-client";
+import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
+// eslint-disable-next-line import/no-internal-modules
+import uuid from "uuid/v4";
+import { IDevServerUser, IRouterliciousRouteOptions, RouteOptions } from "./loader";
 
 export const deltaConns = new Map<string, ILocalDeltaConnectionServer>();
 
@@ -17,6 +21,17 @@ export function getDocumentServiceFactory(documentId: string, options: RouteOpti
         LocalDeltaConnectionServer.create(new LocalSessionStorageDbFactory(documentId));
     deltaConns.set(documentId, deltaConn);
 
+    const getUser = (): IDevServerUser => ({
+        id: uuid(),
+        name: getRandomName(),
+    });
+
+    const routerliciousTokenProvider = new InsecureTokenProvider(
+        (options as IRouterliciousRouteOptions).tenantId ,
+        documentId,
+        (options as IRouterliciousRouteOptions).tenantSecret,
+        getUser());
+
     return MultiDocumentServiceFactory.create([
         new LocalDocumentServiceFactory(deltaConn),
         // TODO: web socket token
@@ -24,6 +39,6 @@ export function getDocumentServiceFactory(documentId: string, options: RouteOpti
             async () => options.mode === "spo" || options.mode === "spo-df" ? options.odspAccessToken : undefined,
             async () => options.mode === "spo" || options.mode === "spo-df" ? options.pushAccessToken : undefined,
         ),
-        new RouterliciousDocumentServiceFactory(),
+        new RouterliciousDocumentServiceFactory(routerliciousTokenProvider),
     ]);
 }


### PR DESCRIPTION
Follow up of #3954. This PR adds a local token provider for r11s drivers to use. Following the model of InsecureUrlResolver, this one is called InsecureTokenProvider. The provider is meant to be used for testing and local running purposes.

InsecureUrlResolver still signs a jwt token. Next PR will remove the signing part from and drivers will only rely on token provider.