### PR TITLE
Fix parsing nested required dependencies in package lock file

### DIFF
--- a/tools/build-tools/src/genMonoRepoPackageJson/genMonoRepoPackageJson.ts
+++ b/tools/build-tools/src/genMonoRepoPackageJson/genMonoRepoPackageJson.ts
@@ -18,8 +18,11 @@ function printUsage() {
 Usage: fluid-gen-pkg-lock <options>
 Options:
 ${commonOptionString}
+     --server         Generate package lock for server mono repo (default: client)
 `);
 }
+
+let genServer = false;
 
 function parseOptions(argv: string[]) {
     let error = false;
@@ -39,6 +42,11 @@ function parseOptions(argv: string[]) {
         if (arg === "-?" || arg === "--help") {
             printUsage();
             process.exit(0);
+        }
+
+        if (arg === "--server") {
+            genServer = true;
+            continue;
         }
 
         console.error(`ERROR: Invalid arguments ${arg}`);
@@ -208,8 +216,9 @@ async function main() {
     const repo = new FluidRepo(resolvedRoot, false);
     timer.time("Package scan completed");
 
-    await generateMonoRepoInstallPackageJson(repo.clientMonoRepo);
-    if (repo.serverMonoRepo) {
+    if (!genServer) {
+        await generateMonoRepoInstallPackageJson(repo.clientMonoRepo);
+    } else if (repo.serverMonoRepo) {
         await generateMonoRepoInstallPackageJson(repo.serverMonoRepo);
     }
 };


### PR DESCRIPTION
This tools that generate a package-lock.json file from lerna-lock-file.json so that the component detection tools can find our dependencies.   The bug is in the code that mark package and its transitive closure of package dependencies as non-dev packages, The "requires" dependencies in package-lock.json can be resolve from its parent's dependencies set.   So keep track of it's nested scopes and check all of them before going to the top level.