### PR TITLE
No assert in common utils

### DIFF
--- a/common/lib/common-utils/src/promises.ts
+++ b/common/lib/common-utils/src/promises.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
-
 /**
  * A deferred creates a promise and the ability to resolve or reject it
  */
@@ -59,19 +57,6 @@ export class Deferred<T> {
             this.rej(error);
         }
     }
-}
-
-/**
- * Helper function that asserts that the given promise only resolves
- */
-// eslint-disable-next-line @typescript-eslint/promise-function-async
-export function assertNotRejected<T>(promise: Promise<T>): Promise<T> {
-    // Assert that the given promise only resolves
-    promise.catch((error) => {
-        assert.ok(false);
-    });
-
-    return promise;
 }
 
 /**

--- a/common/lib/common-utils/src/rangeTracker.ts
+++ b/common/lib/common-utils/src/rangeTracker.ts
@@ -3,10 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "./assert";
-
 // eslint-disable-next-line import/no-internal-modules
 import cloneDeep from "lodash/cloneDeep";
+import { assert } from "./assert";
 
 /**
  * A range in the RangeTracker

--- a/common/lib/common-utils/src/rangeTracker.ts
+++ b/common/lib/common-utils/src/rangeTracker.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { assert } from "./assert";
 
 // eslint-disable-next-line import/no-internal-modules
 import cloneDeep from "lodash/cloneDeep";
@@ -189,6 +189,6 @@ export class RangeTracker {
         this.ranges = index - 1 > 0 ? this.ranges.slice(index - 1) : this.ranges;
 
         // Assert that the lowest value is now the input to this method
-        assert.equal(primary, this.ranges[0].primary);
+        assert(primary === this.ranges[0].primary);
     }
 }

--- a/common/lib/common-utils/src/timer.ts
+++ b/common/lib/common-utils/src/timer.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { assert } from "./assert";
 import { Deferred } from "./promises";
 
 export interface ITimer {
@@ -148,7 +148,7 @@ export class Timer implements ITimer {
     }
 
     private handler() {
-        assert(this.runningState, "Running timer missing handler");
+        assert(!!this.runningState, "Running timer missing handler");
         const restart = this.runningState.restart;
         if (restart !== undefined) {
             // Restart with remaining time
@@ -222,7 +222,7 @@ export class PromiseTimer implements IPromiseTimer {
 
     protected wrapHandler(handler: () => void) {
         handler();
-        assert(this.deferred, "Handler executed without deferred");
+        assert(!!this.deferred, "Handler executed without deferred");
         this.deferred.resolve({ timerResult: "timeout" });
         this.deferred = undefined;
     }


### PR DESCRIPTION
I should have done this yesterday, but it's clear that common-utils has a few usages of assert that will be problematic. Removing these usages since there is a bit of friction doing package bumps.