### PR TITLE
Add more client packages bundle analysis

### DIFF
--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -24,6 +24,9 @@
   },
   "dependencies": {
     "@fluidframework/container-runtime": "^0.28.0",
+    "@fluidframework/map": "^0.28.0",
+    "@fluidframework/matrix": "^0.28.0",
+    "@fluidframework/odsp-driver": "^0.28.0",
     "@fluidframework/sequence" : "^0.28.0"
   },
   "devDependencies": {

--- a/examples/utils/bundle-size-tests/src/map.ts
+++ b/examples/utils/bundle-size-tests/src/map.ts
@@ -1,0 +1,9 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { SharedMap } from "@fluidframework/map";
+
+export function apisToBundle() {
+    SharedMap.getFactory();
+}

--- a/examples/utils/bundle-size-tests/src/matrix.ts
+++ b/examples/utils/bundle-size-tests/src/matrix.ts
@@ -1,0 +1,9 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { SharedMatrix } from "@fluidframework/matrix";
+
+export function apisToBundle() {
+    SharedMatrix.getFactory();
+}

--- a/examples/utils/bundle-size-tests/src/odspDriver.ts
+++ b/examples/utils/bundle-size-tests/src/odspDriver.ts
@@ -1,0 +1,10 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { OdspDocumentServiceFactory } from "@fluidframework/odsp-driver";
+
+export function apisToBundle() {
+     // Pass through dummy parameters, this file is only used for bundle analysis
+    new OdspDocumentServiceFactory(undefined as any, undefined as any);
+}

--- a/examples/utils/bundle-size-tests/webpack.config.js
+++ b/examples/utils/bundle-size-tests/webpack.config.js
@@ -51,11 +51,11 @@ module.exports = {
       exclude: (instance) =>
         // object-is depends on es-abstract 1.18.0-next, which does not satisfy the semver of other packages. We should be able to remove this when es-abstract moves to 1.18.0
         instance.name === 'es-abstract' ||
-        // socket.io and fluid framework do not use compatible versions of debug
+        // socket.io and Fluid Framework do not use compatible versions of debug
         instance.name === 'debug' ||
-        // socket.io and fluid framework do not use compatible versions of isarray
+        // socket.io and Fluid Framework do not use compatible versions of isarray
         instance.name === 'isarray' ||
-        // socket.io and fluid framework do not use compatible versions of ms
+        // socket.io and Fluid Framework do not use compatible versions of ms
         instance.name === 'ms'
     }),
     new BundleAnalyzerPlugin({

--- a/examples/utils/bundle-size-tests/webpack.config.js
+++ b/examples/utils/bundle-size-tests/webpack.config.js
@@ -11,6 +11,9 @@ const DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack
 module.exports = {
   entry: {
     'container': './src/container',
+    'map': './src/map',
+    'matrix': './src/matrix',
+    'odspDriver': './src/odspDriver',
     'sharedString': './src/sharedString'
   },
   mode: 'production',
@@ -47,7 +50,13 @@ module.exports = {
        */
       exclude: (instance) =>
         // object-is depends on es-abstract 1.18.0-next, which does not satisfy the semver of other packages. We should be able to remove this when es-abstract moves to 1.18.0
-        instance.name === 'es-abstract' 
+        instance.name === 'es-abstract' ||
+        // socket.io and fluid framework do not use compatible versions of debug
+        instance.name === 'debug' ||
+        // socket.io and fluid framework do not use compatible versions of isarray
+        instance.name === 'isarray' ||
+        // socket.io and fluid framework do not use compatible versions of ms
+        instance.name === 'ms'
     }),
     new BundleAnalyzerPlugin({
       analyzerMode: 'static',


### PR DESCRIPTION
Went through some more common dependencies of fluid to add them to bundle analysis.

Socket.io and Fluid have incompatible versions of debug, so I had to add duplicate package exceptions. These mirror the duplicate package exceptions we have in our downstream repo.