### PR TITLE
Expose data/helpers to check for no changes in bundle sizes to reduce noise

### DIFF
--- a/tools/bundle-size-tools/src/BundleBuddyTypes.ts
+++ b/tools/bundle-size-tools/src/BundleBuddyTypes.ts
@@ -33,6 +33,15 @@ export interface BundleComparison {
 }
 
 /**
+ * The formatted message string of a bundle comparison along with the
+ * comparison data itself
+ */
+export type BundleComparisonResult = {
+  message: string,
+  comparison: BundleComparison[] | undefined,
+};
+
+/**
  * Functions used to process a webpack stats file and produce a set of metrics. Some processors may choose
  * to work off a bundle specific config file. Note that these config files are optional, so not all bundles
  * may have one associated with them.

--- a/tools/bundle-size-tools/src/compareBundles.ts
+++ b/tools/bundle-size-tools/src/compareBundles.ts
@@ -37,3 +37,22 @@ export function compareBundles(baseline: BundleSummaries, compare: BundleSummari
 
   return results;
 }
+
+/**
+ * Checks if a bundle comparison contains no size changes
+ * @param comparisons
+ */
+export function bundlesContainNoChanges(comparisons: BundleComparison[]): boolean {
+  for (let i = 0; i < comparisons.length; i++) {
+    const { commonBundleMetrics } = comparisons[i];
+    let metrics = Object.entries(commonBundleMetrics);
+    for (let j = 0; j < metrics.length; j++) {
+      const [ , { baseline, compare }] = metrics[j];
+      if (baseline.parsedSize !== compare.parsedSize) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}

--- a/tools/bundle-size-tools/src/compareBundles.ts
+++ b/tools/bundle-size-tools/src/compareBundles.ts
@@ -43,11 +43,9 @@ export function compareBundles(baseline: BundleSummaries, compare: BundleSummari
  * @param comparisons
  */
 export function bundlesContainNoChanges(comparisons: BundleComparison[]): boolean {
-  for (let i = 0; i < comparisons.length; i++) {
-    const { commonBundleMetrics } = comparisons[i];
-    let metrics = Object.entries(commonBundleMetrics);
-    for (let j = 0; j < metrics.length; j++) {
-      const [ , { baseline, compare }] = metrics[j];
+  for (const { commonBundleMetrics } of comparisons) {
+    let metrics = Object.values(commonBundleMetrics);
+    for (const { baseline, compare } of metrics) {
       if (baseline.parsedSize !== compare.parsedSize) {
         return false;
       }


### PR DESCRIPTION
First part of #4124 

Return the raw data from the bundle comparison in addition to the formatted output, and add a helper to check if that raw data represents no size changes.

Next steps are to publish the new version of this package, and update build-tools to make this check before posting a size comment.