### PR TITLE
Fix rdkafka consumer hang when closing

### DIFF
--- a/server/routerlicious/packages/services/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services/src/rdkafkaConsumer.ts
@@ -312,11 +312,6 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 			return;
 		}
 
-		if (this.closed) {
-			this.consumer.unassign();
-			return;
-		}
-
 		try {
 			if (err.code === kafka.CODES.ERRORS.ERR__ASSIGN_PARTITIONS) {
 				for (const assignment of assignments) {

--- a/server/routerlicious/packages/services/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services/src/rdkafkaConsumer.ts
@@ -209,14 +209,13 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 		}
 
 		await new Promise((resolve) => {
-			const consumer = this.consumer;
-			this.consumer = undefined;
-			if (consumer && consumer.isConnected()) {
-				consumer.disconnect(resolve);
+			if (this.consumer && this.consumer.isConnected()) {
+				this.consumer.disconnect(resolve);
 			} else {
 				resolve();
 			}
 		});
+		this.consumer = undefined;
 
 		if (this.zooKeeperClient) {
 			this.zooKeeperClient.close();
@@ -310,6 +309,11 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 	 */
 	private rebalance(err: kafkaTypes.LibrdKafkaError, assignments: kafkaTypes.Assignment[]) {
 		if (!this.consumer) {
+			return;
+		}
+
+		if (this.closed) {
+			this.consumer.unassign();
 			return;
 		}
 


### PR DESCRIPTION
When an rdkafka consumer closes, it fires off a final rebalance event in order to unassign all its partitions.  However we were setting `this.consumer` to `undefined` before calling `disconnect`, which results in the rebalance callback essentially being a no-op. This leads to rdkafka never disconnecting because it waits indefinitely for the rebalance to finish.

The fix is to set consumer to undefined after disconnecting. That way we can let the rebalance event unassign all the partitions since it's called with `ERR__REVOKE_PARTITIONS`.