### PR TITLE
Remove SharedLocalValue

### DIFF
--- a/packages/dds/map/src/localValues.ts
+++ b/packages/dds/map/src/localValues.ts
@@ -10,7 +10,6 @@ import {
 } from "@fluidframework/core-interfaces";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import {
-    ISharedObject,
     parseHandles,
     serializeHandles,
     SharedObject,
@@ -93,39 +92,6 @@ export class PlainLocalValue implements ILocalValue {
         return {
             type: this.type,
             value,
-        };
-    }
-}
-
-/**
- * SharedLocalValue exists for supporting older documents and is now deprecated.
- * @deprecated
- */
-export class SharedLocalValue implements ILocalValue {
-    /**
-     * Create a new SharedLocalValue.
-     * @param value - The shared object to store
-     * @deprecated
-     */
-    constructor(public readonly value: ISharedObject) {
-    }
-
-    /**
-     * {@inheritDoc ILocalValue."type"}
-     * @deprecated
-     */
-    public get type(): string {
-        return ValueType[ValueType.Shared];
-    }
-
-    /**
-     * {@inheritDoc ILocalValue.makeSerialized}
-     * @deprecated
-     */
-    public makeSerialized(): ISerializedValue {
-        return {
-            type: this.type,
-            value: this.value.id,
         };
     }
 }


### PR DESCRIPTION
~~Map/Directory/Cell haven't accepted SharedObject sets for over a year (commit 44f54a9872ac8156e144d664e63151b1e7f25c00) and all had code to upgrade existing documents to use handles, so seems safe to remove this back compat.~~

Backing this off to only remove `SharedLocalValue` as I don't have a ready solution for the snapshot tests.