### PR TITLE
Add missing caret to dependencies in package.json of odsp-doclib-utils.

### DIFF
--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -34,7 +34,7 @@
     "@fluidframework/driver-definitions": "^0.28.0",
     "@fluidframework/driver-utils": "^0.28.0",
     "@fluidframework/protocol-definitions": "^0.1014.0-0",
-    "@fluidframework/telemetry-utils": "0.28.0",
+    "@fluidframework/telemetry-utils": "^0.28.0",
     "comlink": "^4.0.2",
     "debug": "^4.1.1"
   },

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -59,7 +59,7 @@
     "@fluidframework/driver-definitions": "^0.28.0",
     "@fluidframework/driver-utils": "^0.28.0",
     "@fluidframework/gitresources": "^0.1014.0-0",
-    "@fluidframework/odsp-doclib-utils": "0.28.0",
+    "@fluidframework/odsp-doclib-utils": "^0.28.0",
     "@fluidframework/protocol-base": "^0.1014.0-0",
     "@fluidframework/protocol-definitions": "^0.1014.0-0",
     "@fluidframework/telemetry-utils": "^0.28.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -26,8 +26,8 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/driver-definitions": "0.28.0",
-    "@fluidframework/driver-utils": "0.28.0",
+    "@fluidframework/driver-definitions": "^0.28.0",
+    "@fluidframework/driver-utils": "^0.28.0",
     "node-fetch": "^2.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Original context: the script that patches the repo for a minor release notices that these two dependencies are missing carets and fails.