### PR TITLE
[release/0.28][bump] package version for eslint-config-fluid

### DIFF
--- a/common/build/eslint-config-fluid/package-lock.json
+++ b/common/build/eslint-config-fluid/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/eslint-config-fluid",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/eslint-config-fluid",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Shareable ESLint config for the Fluid Framework",
   "homepage": "https://fluidframework.com",
   "repository": "microsoft/FluidFramework",

--- a/common/lib/common-definitions/package-lock.json
+++ b/common/lib/common-definitions/package-lock.json
@@ -261,9 +261,9 @@
       "dev": true
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.20.0-5959",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.20.0-5959.tgz",
-      "integrity": "sha512-T7cJzCUt8jEEkZP+gYXkZPZgiR3STo049acHTJS4EBHUfMQxjIkHcyMZsCNxIhC3ZaROZf++GYuQyMlCbOY/EA==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.20.0.tgz",
+      "integrity": "sha512-sRtDAXMuaaDSyDUfuGZvHUa3tqw4QuQwyob9NlC4+Nj45E0arf+LAKHCNqPxQ5p15VCpIBNq48IZ5HkqNaO07Q==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "~2.17.0",
@@ -943,9 +943,9 @@
       }
     },
     "acorn": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true
     },
     "acorn-jsx": {
@@ -2616,12 +2616,11 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -35,7 +35,7 @@
   "dependencies": {},
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",

--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -408,9 +408,9 @@
       "integrity": "sha512-H+wEaxuIHODVNqyY8XSMY6ww7ndrRfht9CXKUAUzdQjUN1Oi++YonKcD3CXWZod6afxZ6abDmltIO9wLrjOJzg=="
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.20.0-5959",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.20.0-5959.tgz",
-      "integrity": "sha512-T7cJzCUt8jEEkZP+gYXkZPZgiR3STo049acHTJS4EBHUfMQxjIkHcyMZsCNxIhC3ZaROZf++GYuQyMlCbOY/EA==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.20.0.tgz",
+      "integrity": "sha512-sRtDAXMuaaDSyDUfuGZvHUa3tqw4QuQwyob9NlC4+Nj45E0arf+LAKHCNqPxQ5p15VCpIBNq48IZ5HkqNaO07Q==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "~2.17.0",
@@ -5241,12 +5241,11 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/base64-js": "^1.3.0",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/get-session-storage-container": "^0.28.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",

--- a/examples/apps/spaces/package.json
+++ b/examples/apps/spaces/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/get-session-storage-container": "^0.28.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/node": "^10.17.24",

--- a/examples/data-objects/badge/package.json
+++ b/examples/data-objects/badge/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/node": "^10.17.24",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker-react/clicker-context/package.json
+++ b/examples/data-objects/clicker-react/clicker-context/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",

--- a/examples/data-objects/clicker-react/clicker-function/package.json
+++ b/examples/data-objects/clicker-react/clicker-function/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",

--- a/examples/data-objects/clicker-react/clicker-react/package.json
+++ b/examples/data-objects/clicker-react/clicker-react/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker-react/clicker-reducer/package.json
+++ b/examples/data-objects/clicker-react/clicker-reducer/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",

--- a/examples/data-objects/clicker-react/clicker-with-hook/package.json
+++ b/examples/data-objects/clicker-react/clicker-with-hook/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -72,7 +72,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@types/assert": "^1.5.1",
     "@types/debug": "^4.1.5",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/flow-util-lib/package.json
+++ b/examples/data-objects/flow-util-lib/package.json
@@ -58,7 +58,7 @@
   "dependencies": {},
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@types/benchmark": "^1.0.31",
     "@types/mocha": "^5.2.5",

--- a/examples/data-objects/image-collection/package.json
+++ b/examples/data-objects/image-collection/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/image-gallery/package.json
+++ b/examples/data-objects/image-gallery/package.json
@@ -40,7 +40,7 @@
     "react-image-gallery": "^0.9.1"
   },
   "devDependencies": {
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/node": "^10.17.24",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/examples/data-objects/math/package.json
+++ b/examples/data-objects/math/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -29,7 +29,7 @@
   "dependencies": {},
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/node": "^10.17.24",
     "@types/puppeteer": "1.3.0",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/musica/package.json
+++ b/examples/data-objects/musica/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.4.4",
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/node": "^10.17.24",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/pond/package.json
+++ b/examples/data-objects/pond/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/primitives/package.json
+++ b/examples/data-objects/primitives/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/node": "^10.17.24",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/progress-bars/package.json
+++ b/examples/data-objects/progress-bars/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/examples/data-objects/react-inputs/package.json
+++ b/examples/data-objects/react-inputs/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/scribe/package.json
+++ b/examples/data-objects/scribe/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/async": "^2.0.50",
     "@types/lodash": "^4.14.118",

--- a/examples/data-objects/search-menu/package.json
+++ b/examples/data-objects/search-menu/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/simple-fluidobject-embed/package.json
+++ b/examples/data-objects/simple-fluidobject-embed/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/view-interfaces": "^0.28.0"
   },
   "devDependencies": {
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/local-driver": "^0.28.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@fluidframework/runtime-utils": "^0.28.0",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/node": "^10.17.24",

--- a/examples/data-objects/video-players/package.json
+++ b/examples/data-objects/video-players/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/node": "^10.17.24",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -81,7 +81,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/local-driver": "^0.28.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@fluidframework/runtime-utils": "^0.28.0",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",

--- a/examples/hosts/app-integration/external-views/package.json
+++ b/examples/hosts/app-integration/external-views/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",

--- a/examples/hosts/host-service-interfaces/package.json
+++ b/examples/hosts/host-service-interfaces/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/examples/hosts/hosts-sample/package.json
+++ b/examples/hosts/hosts-sample/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
     "concurrently": "^5.2.0",

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/examples/hosts/node-host/package.json
+++ b/examples/hosts/node-host/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
     "concurrently": "^5.2.0",

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -27,11 +27,11 @@
     "@fluidframework/map": "^0.28.0",
     "@fluidframework/matrix": "^0.28.0",
     "@fluidframework/odsp-driver": "^0.28.0",
-    "@fluidframework/sequence" : "^0.28.0"
+    "@fluidframework/sequence": "^0.28.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@mixer/webpack-bundle-compare": "^0.1.0",
     "@types/node": "^10.17.24",
     "@types/puppeteer": "1.3.0",

--- a/examples/utils/fluid-object-interfaces/package.json
+++ b/examples/utils/fluid-object-interfaces/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",

--- a/examples/utils/get-session-storage-container/package.json
+++ b/examples/utils/get-session-storage-container/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/examples/utils/get-tinylicious-container/package.json
+++ b/examples/utils/get-tinylicious-container/package.json
@@ -37,9 +37,9 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@types/jsrsasign" : "^8.0.7",
+    "@types/jsrsasign": "^8.0.7",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1282,9 +1282,9 @@
 			}
 		},
 		"@fluidframework/eslint-config-fluid": {
-			"version": "0.20.0-5959",
-			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.20.0-5959.tgz",
-			"integrity": "sha512-T7cJzCUt8jEEkZP+gYXkZPZgiR3STo049acHTJS4EBHUfMQxjIkHcyMZsCNxIhC3ZaROZf++GYuQyMlCbOY/EA==",
+			"version": "0.20.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.20.0.tgz",
+			"integrity": "sha512-sRtDAXMuaaDSyDUfuGZvHUa3tqw4QuQwyob9NlC4+Nj45E0arf+LAKHCNqPxQ5p15VCpIBNq48IZ5HkqNaO07Q==",
 			"requires": {
 				"@typescript-eslint/eslint-plugin": "~2.17.0",
 				"@typescript-eslint/parser": "~2.17.0",
@@ -1310,16 +1310,6 @@
 						"tsutils": "^3.17.1"
 					}
 				},
-				"@typescript-eslint/experimental-utils": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.17.0.tgz",
-					"integrity": "sha512-2bNf+mZ/3mj5/3CP56v+ldRK3vFy9jOvmCPs/Gr2DeSJh+asPZrhFniv4QmQsHWQFPJFWhFHgkGgJeRmK4m8iQ==",
-					"requires": {
-						"@types/json-schema": "^7.0.3",
-						"@typescript-eslint/typescript-estree": "2.17.0",
-						"eslint-scope": "^5.0.0"
-					}
-				},
 				"@typescript-eslint/parser": {
 					"version": "2.17.0",
 					"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.17.0.tgz",
@@ -1329,20 +1319,6 @@
 						"@typescript-eslint/experimental-utils": "2.17.0",
 						"@typescript-eslint/typescript-estree": "2.17.0",
 						"eslint-visitor-keys": "^1.1.0"
-					}
-				},
-				"@typescript-eslint/typescript-estree": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.17.0.tgz",
-					"integrity": "sha512-g0eVRULGnEEUakxRfJO0s0Hr1LLQqsI6OrkiCLpdHtdJJek+wyd8mb00vedqAoWldeDcOcP8plqw8/jx9Gr3Lw==",
-					"requires": {
-						"debug": "^4.1.1",
-						"eslint-visitor-keys": "^1.1.0",
-						"glob": "^7.1.6",
-						"is-glob": "^4.0.1",
-						"lodash": "^4.17.15",
-						"semver": "^6.3.0",
-						"tsutils": "^3.17.1"
 					}
 				},
 				"ansi-escapes": {
@@ -1656,30 +1632,12 @@
 						"escape-string-regexp": "^1.0.5"
 					}
 				},
-				"file-entry-cache": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-					"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
-					"requires": {
-						"flat-cache": "^2.0.1"
-					}
-				},
 				"find-up": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"requires": {
 						"locate-path": "^2.0.0"
-					}
-				},
-				"flat-cache": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-					"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
-					"requires": {
-						"flatted": "^2.0.0",
-						"rimraf": "2.6.3",
-						"write": "1.0.3"
 					}
 				},
 				"globals": {
@@ -1873,14 +1831,6 @@
 					"requires": {
 						"onetime": "^5.1.0",
 						"signal-exit": "^3.0.2"
-					}
-				},
-				"rimraf": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-					"requires": {
-						"glob": "^7.1.3"
 					}
 				},
 				"rxjs": {
@@ -6111,6 +6061,16 @@
 				}
 			}
 		},
+		"@typescript-eslint/experimental-utils": {
+			"version": "2.17.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.17.0.tgz",
+			"integrity": "sha512-2bNf+mZ/3mj5/3CP56v+ldRK3vFy9jOvmCPs/Gr2DeSJh+asPZrhFniv4QmQsHWQFPJFWhFHgkGgJeRmK4m8iQ==",
+			"requires": {
+				"@types/json-schema": "^7.0.3",
+				"@typescript-eslint/typescript-estree": "2.17.0",
+				"eslint-scope": "^5.0.0"
+			}
+		},
 		"@typescript-eslint/parser": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.2.0.tgz",
@@ -6254,6 +6214,27 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.2.0.tgz",
 			"integrity": "sha512-xkv5nIsxfI/Di9eVwN+G9reWl7Me9R5jpzmZUch58uQ7g0/hHVuGUbbn4NcxcM5y/R4wuJIIEPKPDb5l4Fdmwg=="
+		},
+		"@typescript-eslint/typescript-estree": {
+			"version": "2.17.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.17.0.tgz",
+			"integrity": "sha512-g0eVRULGnEEUakxRfJO0s0Hr1LLQqsI6OrkiCLpdHtdJJek+wyd8mb00vedqAoWldeDcOcP8plqw8/jx9Gr3Lw==",
+			"requires": {
+				"debug": "^4.1.1",
+				"eslint-visitor-keys": "^1.1.0",
+				"glob": "^7.1.6",
+				"is-glob": "^4.0.1",
+				"lodash": "^4.17.15",
+				"semver": "^6.3.0",
+				"tsutils": "^3.17.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				}
+			}
 		},
 		"@typescript-eslint/visitor-keys": {
 			"version": "4.2.0",
@@ -11665,6 +11646,14 @@
 				"escape-string-regexp": "^1.0.5"
 			}
 		},
+		"file-entry-cache": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+			"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+			"requires": {
+				"flat-cache": "^2.0.1"
+			}
+		},
 		"file-loader": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-3.0.1.tgz",
@@ -11945,6 +11934,26 @@
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
 			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
+		},
+		"flat-cache": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+			"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+			"requires": {
+				"flatted": "^2.0.0",
+				"rimraf": "2.6.3",
+				"write": "1.0.3"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
+			}
 		},
 		"flatted": {
 			"version": "2.0.2",

--- a/packages/agents/intelligence-runner-agent/package.json
+++ b/packages/agents/intelligence-runner-agent/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@types/node": "^10.17.24",
     "@types/request": "^2.47.1",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@fluidframework/test-runtime-utils": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@fluidframework/test-runtime-utils": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@fluidframework/test-runtime-utils": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@fluidframework/test-runtime-utils": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@fluidframework/test-runtime-utils": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@fluidframework/test-runtime-utils": "^0.28.0",
     "@types/assert": "^1.5.1",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@fluidframework/test-runtime-utils": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@fluidframework/test-runtime-utils": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/gitresources": "^0.1014.0-0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@fluidframework/server-services-client": "^0.1014.0-0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/debug": "^4.1.5",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@fluidframework/test-runtime-utils": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/mocha": "^5.2.5",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/debug": "^4.1.5",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/debug": "^4.1.5",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@types/assert": "^1.5.1",
     "@types/mocha": "^5.2.5",

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -69,10 +69,10 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@types/assert": "^1.5.1",
-    "@types/jsrsasign" : "^8.0.7",
+    "@types/jsrsasign": "^8.0.7",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@types/assert": "^1.5.1",
     "@types/mocha": "^5.2.5",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/debug": "^4.1.5",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/debug": "^4.1.5",

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@types/assert": "^1.5.1",
     "@types/mocha": "^5.2.5",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@types/assert": "^1.5.1",
     "@types/mocha": "^5.2.5",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/mocha": "^5.2.5",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@fluidframework/test-runtime-utils": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/framework/last-edited-experimental/package.json
+++ b/packages/framework/last-edited-experimental/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/mocha": "^5.2.5",

--- a/packages/framework/react/package.json
+++ b/packages/framework/react/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",
     "@types/react": "^16.9.15",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@fluidframework/test-runtime-utils": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
     "@fluidframework/datastore": "^0.28.0",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/mocha": "^5.2.5",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@fluidframework/test-runtime-utils": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/react": "^16.9.15",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",

--- a/packages/hosts/base-host/package.json
+++ b/packages/hosts/base-host/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@fluidframework/test-runtime-utils": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/loader/container-definitions/package.json
+++ b/packages/loader/container-definitions/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -72,7 +72,7 @@
   "devDependencies": {
     "@fluid-internal/test-loader-utils": "^0.28.0",
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",

--- a/packages/loader/core-interfaces/package.json
+++ b/packages/loader/core-interfaces/package.json
@@ -30,7 +30,7 @@
   "dependencies": {},
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/packages/loader/driver-definitions/package.json
+++ b/packages/loader/driver-definitions/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/mocha": "^5.2.5",

--- a/packages/loader/execution-context-loader/package.json
+++ b/packages/loader/execution-context-loader/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/debug": "^4.1.5",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
     "concurrently": "^5.2.0",

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/isomorphic-fetch": "^0.0.35",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@types/assert": "^1.5.1",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",

--- a/packages/runtime/client-api/package.json
+++ b/packages/runtime/client-api/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/debug": "^4.1.5",
     "@types/jwt-decode": "^2.2.1",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@fluidframework/test-runtime-utils": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -68,10 +68,10 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@types/assert": "^1.5.1",
-    "@types/jsrsasign" : "^8.0.7",
+    "@types/jsrsasign": "^8.0.7",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.17.24",
     "@types/uuid": "^3.4.4",

--- a/packages/test/end-to-end-tests/package.json
+++ b/packages/test/end-to-end-tests/package.json
@@ -75,7 +75,7 @@
     "@fluidframework/driver-base": "^0.28.0",
     "@fluidframework/driver-definitions": "^0.28.0",
     "@fluidframework/driver-utils": "^0.28.0",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/ink": "^0.28.0",
     "@fluidframework/local-driver": "^0.28.0",
     "@fluidframework/map": "^0.28.0",

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/common-utils": "^0.25.0-0",
     "@fluidframework/container-loader": "^0.28.0",
     "@fluidframework/container-runtime": "^0.28.0",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@fluidframework/protocol-definitions": "^0.1014.0-0",
     "@fluidframework/sequence": "^0.28.0",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -51,7 +51,7 @@
   "dependencies": {},
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/mocha": "^5.2.5",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/packages/test/service-load-test/package.json
+++ b/packages/test/service-load-test/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.17.24",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@types/assert": "^1.5.1",
     "@types/mocha": "^5.2.5",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/diff": "^3.5.1",

--- a/packages/test/version-test-1/package.json
+++ b/packages/test/version-test-1/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.28.0",
     "@types/jest": "22.2.3",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@types/assert": "^1.5.1",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/packages/tools/merge-tree-client-replay/package.json
+++ b/packages/tools/merge-tree-client-replay/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/node": "^10.17.24",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/node": "^10.17.24",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -86,7 +86,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@types/assert": "^1.5.1",
     "@types/express": "^4.11.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
     "concurrently": "^5.2.0",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.28.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/debug": "^4.1.5",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -204,9 +204,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.20.0-5959",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.20.0-5959.tgz",
-      "integrity": "sha512-T7cJzCUt8jEEkZP+gYXkZPZgiR3STo049acHTJS4EBHUfMQxjIkHcyMZsCNxIhC3ZaROZf++GYuQyMlCbOY/EA==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.20.0.tgz",
+      "integrity": "sha512-sRtDAXMuaaDSyDUfuGZvHUa3tqw4QuQwyob9NlC4+Nj45E0arf+LAKHCNqPxQ5p15VCpIBNq48IZ5HkqNaO07Q==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "~2.17.0",
@@ -3877,12 +3877,11 @@
           "dev": true
         },
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.20.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.20.0",
     "@fluidframework/mocha-test-setup": "^0.27.0",
     "@microsoft/api-extractor": "^7.7.7",
     "@types/bytes": "^3.1.0",


### PR DESCRIPTION
            @fluidframework/build-common:     0.20.0 (unchanged)
     @fluidframework/eslint-config-fluid:     0.20.0 -> 0.20.1
      @fluidframework/common-definitions:     0.20.0 (unchanged)
            @fluidframework/common-utils:     0.25.0 (unchanged)
                                  Server:   0.1014.0 (unchanged)
                                  Client:     0.28.0 (unchanged)
                         generator-fluid:      0.3.0 (unchanged)
                             tinylicious:      0.2.0 (unchanged)
                             dice-roller:      0.0.1 (unchanged)

Also remove pre-release dependencies for eslint-config-fluid
     @fluidframework/eslint-config-fluid -> ^0.20.0