### PR TITLE
[port #4183] Update tinylicous code for latest server changes.

### DIFF
--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -14,12 +14,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.11.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-      "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
+      "integrity": "sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.11.5",
+        "@babel/types": "^7.12.1",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -79,9 +79,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.11.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-      "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+      "version": "7.12.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.3.tgz",
+      "integrity": "sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw==",
       "dev": true
     },
     "@babel/template": {
@@ -96,17 +96,17 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.11.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-      "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.1.tgz",
+      "integrity": "sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.11.5",
+        "@babel/generator": "^7.12.1",
         "@babel/helper-function-name": "^7.10.4",
         "@babel/helper-split-export-declaration": "^7.11.0",
-        "@babel/parser": "^7.11.5",
-        "@babel/types": "^7.11.5",
+        "@babel/parser": "^7.12.1",
+        "@babel/types": "^7.12.1",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
@@ -121,9 +121,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.11.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-      "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+      "integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
@@ -547,47 +547,63 @@
       }
     },
     "@fluidframework/gitresources": {
-      "version": "0.1014.0-5564",
-      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1014.0-5564.tgz",
-      "integrity": "sha512-PqXhUPI8FiGlw2dB/VCb3ciHzm5a98DKkm+XvbcdTwtDT5AQyjfTpl7ivAqD75Xn40lAX/yZa6oJyl1K11LSBg=="
+      "version": "0.1014.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1014.0.tgz",
+      "integrity": "sha512-WkYdsTCVK97K7vKRQdD/sox5L8TVHyB00rajD3CIJRM3nwzQad7oQac5asmGv3CFTqYoN6r3NNaOcuBJDRVagA=="
     },
     "@fluidframework/mocha-test-setup": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-0.27.0.tgz",
-      "integrity": "sha512-JRP96K4DpP+TFlQkqsJbcBw+4RnbI0oaPPsHi0j06FQS3DhUHjoslM1mROBayTOtl2epKJRMlcV7DP0JA8XgkQ==",
+      "version": "0.27.9",
+      "resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-0.27.9.tgz",
+      "integrity": "sha512-ef7ovsM3vkv7HI5ODn04c/Vxrs0qqeGyPfps0D0Ysw8Zb2tGLYKFbg39mLFQyfb5kP7BjtKZhzBsneTghyAd8A==",
       "dev": true
     },
     "@fluidframework/protocol-base": {
-      "version": "0.1014.0-5564",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1014.0-5564.tgz",
-      "integrity": "sha512-QfQuERiahWAv9Rgm/R1zTZWLhX5DB3ikGmYpUGqRHTWvwLQ0jkkhITUfeoE0vVhf2CbAlmSBFQF0J2Sh1VkUow==",
+      "version": "0.1014.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1014.0.tgz",
+      "integrity": "sha512-xpW/tExkmxKe7y0qIdiHWnZRdiwcpVnUT5WEgVsox0SdgKxtyKp6PTcY2ObT2S4MeR9AOCMgVdVyQzpbBWVtUg==",
       "requires": {
-        "@fluidframework/common-utils": "^0.24.0-0",
-        "@fluidframework/gitresources": "^0.1014.0-5564",
-        "@fluidframework/protocol-definitions": "^0.1014.0-5564",
+        "@fluidframework/common-utils": "^0.25.0",
+        "@fluidframework/gitresources": "^0.1014.0",
+        "@fluidframework/protocol-definitions": "^0.1014.0",
         "assert": "^2.0.0",
         "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.25.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.25.0.tgz",
+          "integrity": "sha512-kNhyn0dOBtpwfU4bak6Np3jcH2yZ6GJFbfZXG1i4A9Ftg+o93dukreYB38E6qACce7jygr3rbgB350tf1OqUDQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.19.1",
+            "@types/events": "^3.0.0",
+            "assert": "^2.0.0",
+            "base64-js": "^1.3.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.19",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/protocol-definitions": {
-      "version": "0.1014.0-5564",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1014.0-5564.tgz",
-      "integrity": "sha512-cHFjOd0dNvwcS4Cg80f77RD/ADEYlY+9POCa83ko/k10q7HMKOp96cZJs8QxNoZuE517mAfJppEMlF3drbsi8w==",
+      "version": "0.1014.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1014.0.tgz",
+      "integrity": "sha512-/ihtL1bEParOfynLyCI+4ibBPxC2CSx77C/CY+lU76Susuknvg5vHKQ+v4y93sXZd17qvaa5pqVECcR5KZ5m3w==",
       "requires": {
         "@fluidframework/common-definitions": "^0.19.1"
       }
     },
     "@fluidframework/server-lambdas": {
-      "version": "0.1014.0-5564",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1014.0-5564.tgz",
-      "integrity": "sha512-iLz5A6FPeJluroZ/InAlLPTDiq/+r1wL60atnwbH/Bt0OlHDeDtMfPATU5vZxRYIlLcpXNehI+CxAhkkgUsmHQ==",
+      "version": "0.1014.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1014.0.tgz",
+      "integrity": "sha512-bJCCvNTDS/7LBMKensRqAz42X247CgxLAlMrLRPhACSybPAYnFu9j6oD89t9KJ/H6KTtexLFDzqwyYfGGaGIgg==",
       "requires": {
-        "@fluidframework/common-utils": "^0.24.0-0",
-        "@fluidframework/gitresources": "^0.1014.0-5564",
-        "@fluidframework/protocol-base": "^0.1014.0-5564",
-        "@fluidframework/protocol-definitions": "^0.1014.0-5564",
-        "@fluidframework/server-services-client": "^0.1014.0-5564",
-        "@fluidframework/server-services-core": "^0.1014.0-5564",
+        "@fluidframework/common-utils": "^0.25.0",
+        "@fluidframework/gitresources": "^0.1014.0",
+        "@fluidframework/protocol-base": "^0.1014.0",
+        "@fluidframework/protocol-definitions": "^0.1014.0",
+        "@fluidframework/server-services-client": "^0.1014.0",
+        "@fluidframework/server-services-core": "^0.1014.0",
         "@types/semver": "^6.0.1",
         "async": "^2.6.1",
         "double-ended-queue": "^2.1.0-0",
@@ -597,34 +613,67 @@
         "nconf": "^0.10.0",
         "semver": "^6.3.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.25.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.25.0.tgz",
+          "integrity": "sha512-kNhyn0dOBtpwfU4bak6Np3jcH2yZ6GJFbfZXG1i4A9Ftg+o93dukreYB38E6qACce7jygr3rbgB350tf1OqUDQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.19.1",
+            "@types/events": "^3.0.0",
+            "assert": "^2.0.0",
+            "base64-js": "^1.3.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.19",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/server-local-server": {
-      "version": "0.1014.0-5564",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1014.0-5564.tgz",
-      "integrity": "sha512-Wk+mRum9pacNSS7R7iICYbHGk0ffpQs/N/WXpQiRUw2Gp8UIFuFL4T6VQdTT0qj2J3ntKzeHDgAve8dveApySA==",
+      "version": "0.1014.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1014.0.tgz",
+      "integrity": "sha512-En1X/0XvNfjrTGb1WrI21CGh+uyJUjGs/d/NA3I1Y6JyX1zFadvl+t2VwY4horCxt9FUxNPqYTu3ifa4rJk5EA==",
       "requires": {
-        "@fluidframework/common-utils": "^0.24.0-0",
-        "@fluidframework/protocol-definitions": "^0.1014.0-5564",
-        "@fluidframework/server-lambdas": "^0.1014.0-5564",
-        "@fluidframework/server-memory-orderer": "^0.1014.0-5564",
-        "@fluidframework/server-services-client": "^0.1014.0-5564",
-        "@fluidframework/server-services-core": "^0.1014.0-5564",
-        "@fluidframework/server-test-utils": "^0.1014.0-5564",
+        "@fluidframework/common-utils": "^0.25.0",
+        "@fluidframework/protocol-definitions": "^0.1014.0",
+        "@fluidframework/server-lambdas": "^0.1014.0",
+        "@fluidframework/server-memory-orderer": "^0.1014.0",
+        "@fluidframework/server-services-client": "^0.1014.0",
+        "@fluidframework/server-services-core": "^0.1014.0",
+        "@fluidframework/server-test-utils": "^0.1014.0",
+        "jsrsasign": "^10.0.2",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.25.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.25.0.tgz",
+          "integrity": "sha512-kNhyn0dOBtpwfU4bak6Np3jcH2yZ6GJFbfZXG1i4A9Ftg+o93dukreYB38E6qACce7jygr3rbgB350tf1OqUDQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.19.1",
+            "@types/events": "^3.0.0",
+            "assert": "^2.0.0",
+            "base64-js": "^1.3.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.19",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/server-memory-orderer": {
-      "version": "0.1014.0-5564",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1014.0-5564.tgz",
-      "integrity": "sha512-OA8o0C9Sr4Lb3svljitk314DbaE94rmJrrzLDdguV4YprkgO1JMpHJBuKkPFiiLvZ1jqE7GK2aNEIs7DA8GTSA==",
+      "version": "0.1014.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1014.0.tgz",
+      "integrity": "sha512-v+T8+9JXbH+7GJXrA52aSnRSGnwWO/g45eWF0UuVxERLosNCCX6qIxX6FlIaBRnw07QrP2er79ZbuHBM65g8vQ==",
       "requires": {
-        "@fluidframework/common-utils": "^0.24.0-0",
-        "@fluidframework/protocol-base": "^0.1014.0-5564",
-        "@fluidframework/protocol-definitions": "^0.1014.0-5564",
-        "@fluidframework/server-lambdas": "^0.1014.0-5564",
-        "@fluidframework/server-services-client": "^0.1014.0-5564",
-        "@fluidframework/server-services-core": "^0.1014.0-5564",
+        "@fluidframework/common-utils": "^0.25.0",
+        "@fluidframework/protocol-base": "^0.1014.0",
+        "@fluidframework/protocol-definitions": "^0.1014.0",
+        "@fluidframework/server-lambdas": "^0.1014.0",
+        "@fluidframework/server-services-client": "^0.1014.0",
+        "@fluidframework/server-services-core": "^0.1014.0",
         "@types/debug": "^4.1.5",
         "@types/double-ended-queue": "^2.1.0",
         "@types/lodash": "^4.14.118",
@@ -636,51 +685,99 @@
         "moniker": "^0.1.2",
         "uuid": "^3.3.2",
         "ws": "^6.1.2"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.25.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.25.0.tgz",
+          "integrity": "sha512-kNhyn0dOBtpwfU4bak6Np3jcH2yZ6GJFbfZXG1i4A9Ftg+o93dukreYB38E6qACce7jygr3rbgB350tf1OqUDQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.19.1",
+            "@types/events": "^3.0.0",
+            "assert": "^2.0.0",
+            "base64-js": "^1.3.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.19",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/server-services-client": {
-      "version": "0.1014.0-5564",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1014.0-5564.tgz",
-      "integrity": "sha512-YKYBmiwP8bsaegCH9DV6z3Vk8jPBoJXbGuXJlKw/1scjv3A18uR1DmliqSOjZuYBVVCVgS32G9j4hULg8HaZXw==",
+      "version": "0.1014.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1014.0.tgz",
+      "integrity": "sha512-SnEOUgznHXPEqkp9xtcNnHaQEDBKtVOMT46rT60wipRbYDKUjjFISk4ZIvnVWUH8DqsSERJEcQgUWGvRUKozQQ==",
       "requires": {
-        "@fluidframework/common-utils": "^0.24.0-0",
-        "@fluidframework/gitresources": "^0.1014.0-5564",
-        "@fluidframework/protocol-base": "^0.1014.0-5564",
-        "@fluidframework/protocol-definitions": "^0.1014.0-5564",
+        "@fluidframework/common-utils": "^0.25.0",
+        "@fluidframework/gitresources": "^0.1014.0",
+        "@fluidframework/protocol-base": "^0.1014.0",
+        "@fluidframework/protocol-definitions": "^0.1014.0",
         "@types/node": "^10.17.24",
         "axios": "^0.18.0",
         "debug": "^4.1.1",
-        "jsonwebtoken": "^8.4.0",
+        "jwt-decode": "^3.0.0",
         "sillyname": "0.1.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.25.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.25.0.tgz",
+          "integrity": "sha512-kNhyn0dOBtpwfU4bak6Np3jcH2yZ6GJFbfZXG1i4A9Ftg+o93dukreYB38E6qACce7jygr3rbgB350tf1OqUDQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.19.1",
+            "@types/events": "^3.0.0",
+            "assert": "^2.0.0",
+            "base64-js": "^1.3.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.19",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/server-services-core": {
-      "version": "0.1014.0-5564",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1014.0-5564.tgz",
-      "integrity": "sha512-xk90P7woO3t8WM3hwYUwfMl9bXrlSyinluwmq2pKhPrErdk0CX/E62+ofWY7Jz+5F/pUrDoC088/RufPEZ0xOA==",
+      "version": "0.1014.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1014.0.tgz",
+      "integrity": "sha512-V34D4CtGxUL06iSHQUN4uDNErOIBeJtGpT1KEpC0uixC++UsMl5g3/NUcnWuOjuloZke53s9QPSNsYuDk8hiew==",
       "requires": {
-        "@fluidframework/common-utils": "^0.24.0-0",
-        "@fluidframework/gitresources": "^0.1014.0-5564",
-        "@fluidframework/protocol-definitions": "^0.1014.0-5564",
-        "@fluidframework/server-services-client": "^0.1014.0-5564",
+        "@fluidframework/common-utils": "^0.25.0",
+        "@fluidframework/gitresources": "^0.1014.0",
+        "@fluidframework/protocol-definitions": "^0.1014.0",
+        "@fluidframework/server-services-client": "^0.1014.0",
         "@types/nconf": "^0.0.37",
         "@types/node": "^10.17.24",
         "debug": "^4.1.1",
         "nconf": "^0.10.0"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.25.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.25.0.tgz",
+          "integrity": "sha512-kNhyn0dOBtpwfU4bak6Np3jcH2yZ6GJFbfZXG1i4A9Ftg+o93dukreYB38E6qACce7jygr3rbgB350tf1OqUDQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.19.1",
+            "@types/events": "^3.0.0",
+            "assert": "^2.0.0",
+            "base64-js": "^1.3.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.19",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/server-services-shared": {
-      "version": "0.1014.0-5564",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1014.0-5564.tgz",
-      "integrity": "sha512-PJ1W13iXzBirWDkpuIpU+brnXcC8Y7Wov12hyaq2GPqmQUh8cQwklf/0S+jVGHCYO3qK5uDfoDAnImnvlJqZ7Q==",
+      "version": "0.1014.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1014.0.tgz",
+      "integrity": "sha512-7Up1bkE5IEdApZ5h2DZDyREhDv94F9P2UQSl4gA8tNTI3MJAEUN5LlnUGpwQfjdI5N7Xqwd1Gi3nCFHwwtr/gQ==",
       "requires": {
-        "@fluidframework/common-utils": "^0.24.0-0",
-        "@fluidframework/gitresources": "^0.1014.0-5564",
-        "@fluidframework/protocol-base": "^0.1014.0-5564",
-        "@fluidframework/protocol-definitions": "^0.1014.0-5564",
-        "@fluidframework/server-services-client": "^0.1014.0-5564",
-        "@fluidframework/server-services-core": "^0.1014.0-5564",
+        "@fluidframework/common-utils": "^0.25.0",
+        "@fluidframework/gitresources": "^0.1014.0",
+        "@fluidframework/protocol-base": "^0.1014.0",
+        "@fluidframework/protocol-definitions": "^0.1014.0",
+        "@fluidframework/server-services-client": "^0.1014.0",
+        "@fluidframework/server-services-core": "^0.1014.0",
         "debug": "^4.1.1",
         "lodash": "^4.17.19",
         "moniker": "^0.1.2",
@@ -688,53 +785,89 @@
         "socket.io": "^2.2.0",
         "socket.io-redis": "^5.2.0",
         "winston": "^3.1.0"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.25.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.25.0.tgz",
+          "integrity": "sha512-kNhyn0dOBtpwfU4bak6Np3jcH2yZ6GJFbfZXG1i4A9Ftg+o93dukreYB38E6qACce7jygr3rbgB350tf1OqUDQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.19.1",
+            "@types/events": "^3.0.0",
+            "assert": "^2.0.0",
+            "base64-js": "^1.3.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.19",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/server-services-utils": {
-      "version": "0.1014.0-5564",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1014.0-5564.tgz",
-      "integrity": "sha512-TZ92kQDBXxQSDHuBNjmtZFtml1obHdWFO6EUg6uTCTsYaNpc+s2qfztorFoiygtvVukTyaD3acUpivJ2OddYow==",
+      "version": "0.1014.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1014.0.tgz",
+      "integrity": "sha512-6rdH6W/P2EHQEHmZ+zg3NIyVQU/tyrjv+EIQK+O//+eHL7azmEm6Jk+Qs+rQEm9ql0FAY3dhyfxoxYd+MEIokA==",
       "requires": {
-        "@fluidframework/protocol-definitions": "^0.1014.0-5564",
+        "@fluidframework/protocol-definitions": "^0.1014.0",
         "@sentry/node": "^5.6.2",
         "debug": "^4.1.1",
+        "jsonwebtoken": "^8.4.0",
         "nconf": "^0.10.0",
+        "sillyname": "0.1.0",
+        "uuid": "^3.3.2",
         "winston": "^3.1.0"
       }
     },
     "@fluidframework/server-test-utils": {
-      "version": "0.1014.0-5564",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1014.0-5564.tgz",
-      "integrity": "sha512-BWoKA9sa5gzB3CeD14rIsXeBemfaa79WskMpDv/jgpMPNQNG8e7VUlTLTJUo7WiRO6p5519MxN4PEkUERIJQ2w==",
+      "version": "0.1014.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1014.0.tgz",
+      "integrity": "sha512-sb+g/rjz6lClasDhRdiuh8vBQoRawEbzFMc4yyYvfUoszsBSazlotx0VJ20L2+fDuCGa3iMlIskPENYqaqt76A==",
       "requires": {
-        "@fluidframework/common-utils": "^0.24.0-0",
-        "@fluidframework/gitresources": "^0.1014.0-5564",
-        "@fluidframework/protocol-base": "^0.1014.0-5564",
-        "@fluidframework/protocol-definitions": "^0.1014.0-5564",
-        "@fluidframework/server-services-client": "^0.1014.0-5564",
-        "@fluidframework/server-services-core": "^0.1014.0-5564",
+        "@fluidframework/common-utils": "^0.25.0",
+        "@fluidframework/gitresources": "^0.1014.0",
+        "@fluidframework/protocol-base": "^0.1014.0",
+        "@fluidframework/protocol-definitions": "^0.1014.0",
+        "@fluidframework/server-services-client": "^0.1014.0",
+        "@fluidframework/server-services-core": "^0.1014.0",
         "debug": "^4.1.1",
         "lodash": "^4.17.19",
         "string-hash": "^1.1.3",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.25.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.25.0.tgz",
+          "integrity": "sha512-kNhyn0dOBtpwfU4bak6Np3jcH2yZ6GJFbfZXG1i4A9Ftg+o93dukreYB38E6qACce7jygr3rbgB350tf1OqUDQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.19.1",
+            "@types/events": "^3.0.0",
+            "assert": "^2.0.0",
+            "base64-js": "^1.3.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.19",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@microsoft/api-extractor": {
-      "version": "7.9.15",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.9.15.tgz",
-      "integrity": "sha512-j3BrAXTc3M51vUe32hC47i4JoJBqbR2iJaV6Vhew1+BzBkg4bJJziT6V3EbCdKt60rbEWSV/30EMwwdXVyqL5A==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.11.2.tgz",
+      "integrity": "sha512-iZPv22j9K02cbwIDblOgF1MxZG+KWovp3CQpWCD6UC/+YYO4DfLxX5uZYVNzfgT4vU8fN0rugJmGm85rHX6Ouw==",
       "dev": true,
       "requires": {
-        "@microsoft/api-extractor-model": "7.9.0",
+        "@microsoft/api-extractor-model": "7.10.8",
         "@microsoft/tsdoc": "0.12.19",
-        "@rushstack/node-core-library": "3.32.0",
-        "@rushstack/ts-command-line": "4.6.4",
+        "@rushstack/node-core-library": "3.34.7",
+        "@rushstack/rig-package": "0.2.7",
+        "@rushstack/ts-command-line": "4.7.6",
         "colors": "~1.2.1",
         "lodash": "~4.17.15",
         "resolve": "~1.17.0",
         "semver": "~7.3.0",
         "source-map": "~0.6.1",
-        "typescript": "~3.9.5"
+        "typescript": "~4.0.5"
       },
       "dependencies": {
         "colors": {
@@ -743,6 +876,15 @@
           "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
           "dev": true
         },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
         "semver": {
           "version": "7.3.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
@@ -750,21 +892,21 @@
           "dev": true
         },
         "typescript": {
-          "version": "3.9.7",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-          "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
+          "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
           "dev": true
         }
       }
     },
     "@microsoft/api-extractor-model": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.9.0.tgz",
-      "integrity": "sha512-zXBA4D/gE7BkNU5jjiKSoXGK+h6N+TQHa47ut/a5CYcVzjxXWVdLpew+tGnyRW/7eRhbS6qzzdQ/dAgraDfReA==",
+      "version": "7.10.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.10.8.tgz",
+      "integrity": "sha512-9TfiCTPnkUeLaYywZeg9rYbVPX9Tj6AAkO6ThnjSE0tTPLjMcL3RiHkqn0BJ4+aGcl56APwo32zj5+kG+NqxYA==",
       "dev": true,
       "requires": {
         "@microsoft/tsdoc": "0.12.19",
-        "@rushstack/node-core-library": "3.32.0"
+        "@rushstack/node-core-library": "3.34.7"
       }
     },
     "@microsoft/tsdoc": {
@@ -800,9 +942,9 @@
       }
     },
     "@rushstack/node-core-library": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.32.0.tgz",
-      "integrity": "sha512-7xM++fJNvCKjbnB4k6y52uCOOu1s7PNbcSup18yfml9q2e2c1qKULy/A41SFgdD2J0L6UP2SD9K5lbQt+OoWjQ==",
+      "version": "3.34.7",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.34.7.tgz",
+      "integrity": "sha512-7FwJ0jmZsh7bDIZ1IqDNphY9Kc6aAi1D2K8jiq+da4flMyL84HNeq2KxvwFLzjLwu3eMr88X+oBpgxCTD5Y57Q==",
       "dev": true,
       "requires": {
         "@types/node": "10.17.13",
@@ -828,6 +970,15 @@
           "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
           "dev": true
         },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
         "semver": {
           "version": "7.3.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
@@ -836,10 +987,38 @@
         }
       }
     },
+    "@rushstack/rig-package": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.2.7.tgz",
+      "integrity": "sha512-hI1L0IIzCHqH/uW64mKqEQ0/MANA/IklVId3jGpj1kt9RJcBdeNUIlzDtHl437LZRAuEA8CyotRHzG6YDgWlTw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "10.17.13",
+        "resolve": "~1.17.0",
+        "strip-json-comments": "~3.1.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.13",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
+          "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
     "@rushstack/ts-command-line": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.6.4.tgz",
-      "integrity": "sha512-ubIANZimyU07+ChU56LfiD36NJ8gvw1txlvUP20GYNQi4lf5N0xEnev4r+AtKkOdnowpGy60ObGmYxSUpSacpw==",
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.7.6.tgz",
+      "integrity": "sha512-falJVNfpJtsL3gJaY77JXXycfzhzB9VkKhqEfjRWD69/f6ezMUorPR6Nc90MnIaWgePTcdTJPZibxOQrNpu1Uw==",
       "dev": true,
       "requires": {
         "@types/argparse": "1.0.38",
@@ -857,47 +1036,47 @@
       }
     },
     "@sentry/core": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.24.2.tgz",
-      "integrity": "sha512-nuAwCGU1l9hgMinl5P/8nIQGRXDP2FI9cJnq5h1qiP/XIOvJkJz2yzBR6nTyqr4vBth0tvxQJbIpDNGd7vHJLg==",
+      "version": "5.27.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.27.2.tgz",
+      "integrity": "sha512-FMX0Aignhi9Rk4tZkjwSXCsFFQc8FIOgUTvfIKCdayLhKxfbY0H37b0fFNzaQ9v15SFzIZJ9uzw4PTmjzEh6Uw==",
       "requires": {
-        "@sentry/hub": "5.24.2",
-        "@sentry/minimal": "5.24.2",
-        "@sentry/types": "5.24.2",
-        "@sentry/utils": "5.24.2",
+        "@sentry/hub": "5.27.2",
+        "@sentry/minimal": "5.27.2",
+        "@sentry/types": "5.27.2",
+        "@sentry/utils": "5.27.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.24.2.tgz",
-      "integrity": "sha512-xmO1Ivvpb5Qr9WgekinuZZlpl9Iw7iPETUe84HQOhUrXf+2gKO+LaUYMMsYSVDwXQEmR6/tTMyOtS6iavldC6w==",
+      "version": "5.27.2",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.27.2.tgz",
+      "integrity": "sha512-KCAWF5oDXd/Pjzbcmfj53F5ZzOX53Rzi23a2mWyUXMdPXoXIiMrIcdC/DqrqKV787LvOJcSFaTychJCH3t15/A==",
       "requires": {
-        "@sentry/types": "5.24.2",
-        "@sentry/utils": "5.24.2",
+        "@sentry/types": "5.27.2",
+        "@sentry/utils": "5.27.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.24.2.tgz",
-      "integrity": "sha512-biFpux5bI3R8xiD/Zzvrk1kRE6bqPtfWXmZYAHRtaUMCAibprTKSY9Ta8QYHynOAEoJ5Akedy6HUsEkK5DoZfA==",
+      "version": "5.27.2",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.27.2.tgz",
+      "integrity": "sha512-n9SssI30rpS1tw6hH0ylxVlONdmZCqiPy60fotxUzql6mCo/nW7tcADsW15fvQlUQ160VaGf3iMj+hpHkRBerw==",
       "requires": {
-        "@sentry/hub": "5.24.2",
-        "@sentry/types": "5.24.2",
+        "@sentry/hub": "5.27.2",
+        "@sentry/types": "5.27.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.24.2.tgz",
-      "integrity": "sha512-ddfU2tLTvhnY+NqzLIA/gxMt/uxq7R204Nb2J5qqE0WAgbh0dtylNAzfKZTizLdbZfRnpeISmd+CBILh3tavog==",
+      "version": "5.27.2",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.27.2.tgz",
+      "integrity": "sha512-JHY+EYjq3iqVnTPIow7KzKX+lIqJXZGVT0xHdPrhaVcfBtUUBYTpjO7SSCkINPt6dPKVRq0QDzIfevd5nybR7A==",
       "requires": {
-        "@sentry/core": "5.24.2",
-        "@sentry/hub": "5.24.2",
-        "@sentry/tracing": "5.24.2",
-        "@sentry/types": "5.24.2",
-        "@sentry/utils": "5.24.2",
+        "@sentry/core": "5.27.2",
+        "@sentry/hub": "5.27.2",
+        "@sentry/tracing": "5.27.2",
+        "@sentry/types": "5.27.2",
+        "@sentry/utils": "5.27.2",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -912,28 +1091,28 @@
       }
     },
     "@sentry/tracing": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.24.2.tgz",
-      "integrity": "sha512-1uDgvGGVF8lb3hRXbhNnns+8DBUKjhRKOFR5Z3RExjrDFYTDbHmoNtV73Q12Ra+Iht9HTZnIBOqYD3oSZIbJ0w==",
+      "version": "5.27.2",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.27.2.tgz",
+      "integrity": "sha512-5Lptd32VtKBzIzTmFqcKgcetTMRraMvjPFTX8kFVX4aGDaUGOx0cCZeAURNoHDfHfjCazYK8yV6BkJfi6YJNww==",
       "requires": {
-        "@sentry/hub": "5.24.2",
-        "@sentry/minimal": "5.24.2",
-        "@sentry/types": "5.24.2",
-        "@sentry/utils": "5.24.2",
+        "@sentry/hub": "5.27.2",
+        "@sentry/minimal": "5.27.2",
+        "@sentry/types": "5.27.2",
+        "@sentry/utils": "5.27.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.24.2.tgz",
-      "integrity": "sha512-HcOK00R0tQG5vzrIrqQ0jC28+z76jWSgQCzXiessJ5SH/9uc6NzdO7sR7K8vqMP2+nweCHckFohC8G0T1DLzuQ=="
+      "version": "5.27.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.27.2.tgz",
+      "integrity": "sha512-oszEOlWJuySvGc2HJ2KLTgtYwRFnHWDu8YIZ99UhmO2PcGQ5HlZJpV2oC8n3x0g1YSSlAaThjKbliJEAT7fmPg=="
     },
     "@sentry/utils": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.24.2.tgz",
-      "integrity": "sha512-oPGde4tNEDHKk0Cg9q2p0qX649jLDUOwzJXHKpd0X65w3A6eJByDevMr8CSzKV9sesjrUpxqAv6f9WWlz185tA==",
+      "version": "5.27.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.27.2.tgz",
+      "integrity": "sha512-ZrdRgcFapi1NACbtvnPLOIXKjBPVTlhGzmXNCVao0uRBBRNJa5i2Mjp/U/Xy/fT0K1MGJQ+F9YZjZPnAMsDNbw==",
       "requires": {
-        "@sentry/types": "5.24.2",
+        "@sentry/types": "5.27.2",
         "tslib": "^1.9.3"
       }
     },
@@ -957,12 +1136,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-5YG1AiIC8HPPXRvYAIa7ehK3YMAwd0DWiPCtpuL9sgKceWLyWsVtLRA+lT4NkoanDNF9slwQ66lPizWDpgRlWA==",
-      "dev": true
-    },
-    "@types/color-name": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
     "@types/compression": {
@@ -993,9 +1166,9 @@
       }
     },
     "@types/cors": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.7.tgz",
-      "integrity": "sha512-sOdDRU3oRS7LBNTIqwDkPJyq0lpHYcbMTt0TrjzsXbk/e37hcLTH6eZX7CdbDeN0yJJvzw9hFBZkbtCSbk/jAQ==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.8.tgz",
+      "integrity": "sha512-fO3gf3DxU2Trcbr75O7obVndW/X5k8rJNZkLXlQWStTHhP71PkRqjwPIEI0yMnJdg9R9OasjU+Bsr+Hr1xy/0w==",
       "dev": true,
       "requires": {
         "@types/express": "*"
@@ -1050,9 +1223,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.12",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.12.tgz",
-      "integrity": "sha512-EaEdY+Dty1jEU7U6J4CUWwxL+hyEGMkO5jan5gplfegUgCUsIUWqXxqw47uGjimeT4Qgkz/XUfwoau08+fgvKA==",
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz",
+      "integrity": "sha512-RgDi5a4nuzam073lRGKTUIaL3eF2+H7LJvJ8eUnCI0wA6SNjXc44DCmWNiTLs/AZ7QlsFWZiw/gTG3nSQGL0fA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -1098,9 +1271,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.161",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz",
-      "integrity": "sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA=="
+      "version": "4.14.164",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.164.tgz",
+      "integrity": "sha512-fXCEmONnrtbYUc5014avwBeMdhHHO8YJCkOBflUL9EoJBSKZ1dei+VO74fA7JkTHZ1GvZack2TyIw5U+1lT8jg=="
     },
     "@types/mime": {
       "version": "2.0.3",
@@ -1121,9 +1294,9 @@
       "dev": true
     },
     "@types/morgan": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.1.tgz",
-      "integrity": "sha512-2j5IKrgJpEP6xw/uiVb2Xfga0W0sSVD9JP9t7EZLvpBENdB0OKgcnoKS8IsjNeNnZ/86robdZ61Orl0QCFGOXg==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.2.tgz",
+      "integrity": "sha512-edtGMEdit146JwwIeyQeHHg9yID4WSolQPxpEorHmN3KuytuCHyn2ELNr5Uxy8SerniFbbkmgKMrGM933am5BQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -1135,9 +1308,9 @@
       "integrity": "sha512-u1Nnvd2Ld6lPMJLxb4ueDa28DUCApT1q0PA5yCc8I3Ii72NssaMOGmnzjDYQ2OeOlGly9YgYmDQZSAtjxxdtTg=="
     },
     "@types/node": {
-      "version": "10.17.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
-      "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA=="
+      "version": "10.17.44",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.44.tgz",
+      "integrity": "sha512-vHPAyBX1ffLcy4fQHmDyIUMUb42gHZjPHU66nhvbMzAWJqHnySGZ6STwN3rwrnSd1FHB0DI/RWgGELgKSYRDmw=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1158,9 +1331,9 @@
       "dev": true
     },
     "@types/redis": {
-      "version": "2.8.27",
-      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.27.tgz",
-      "integrity": "sha512-RRHarqPp3mgqHz+qzLVuQCJAIVaB3JBaczoj24QVVYu08wiCmB8vbOeNeK9lIH+pyT7+R/bbEPghAZZuhbZm0g==",
+      "version": "2.8.28",
+      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.28.tgz",
+      "integrity": "sha512-8l2gr2OQ969ypa7hFOeKqtFoY70XkHxISV0pAwmQ2nm6CSPb1brmTmqJCGGrekCo+pAZyWlNXr+Kvo6L/1wijA==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -1182,13 +1355,13 @@
       "integrity": "sha512-RxAwYt4rGwK5GyoRwuP0jT6ZHAVTdz2EqgsHmX0PYNjGsko+OeT4WFXXTs/lM3teJUJodM+SNtAL5/pXIJ61IQ=="
     },
     "@types/serve-static": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.5.tgz",
-      "integrity": "sha512-6M64P58N+OXjU432WoLLBQxbA0LRGBCRm7aAGQJ+SMC1IMl0dgRVi9EFfoDcS2a7Xogygk/eGN94CfwU9UF7UQ==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.6.tgz",
+      "integrity": "sha512-nuRJmv7jW7VmCVTn+IgYDkkbbDGyIINOeu/G0d74X3lm6E5KfMeQPJhxIt1ayQeQB3cSxvYs1RA/wipYoFB4EA==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "*",
-        "@types/mime": "*"
+        "@types/mime": "*",
+        "@types/node": "*"
       }
     },
     "@types/socket.io": {
@@ -1414,6 +1587,12 @@
         }
       }
     },
+    "@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
     "abstract-leveldown": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
@@ -1436,9 +1615,9 @@
       }
     },
     "acorn": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true
     },
     "acorn-jsx": {
@@ -1458,17 +1637,17 @@
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
     },
     "agent-base": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
-      "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "requires": {
         "debug": "4"
       }
     },
     "ajv": {
-      "version": "6.12.5",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -1558,6 +1737,27 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0",
         "is-string": "^1.0.5"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "array-union": {
@@ -1574,6 +1774,27 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "array.prototype.flatmap": {
@@ -1585,18 +1806,27 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1"
-      }
-    },
-    "array.prototype.map": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.2.tgz",
-      "integrity": "sha512-Az3OYxgsa1g7xDYp86l0nnN4bcmuEITGe1rbdEBVkrqkzMgDcbdQ2R7r41pNzti+4NMces3H8gMmuioZUilLgw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "es-array-method-boxes-properly": "^1.0.0",
-        "is-string": "^1.0.4"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "arraybuffer.slice": {
@@ -1682,9 +1912,9 @@
       "dev": true
     },
     "base64-arraybuffer": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
+      "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI="
     },
     "base64-js": {
       "version": "1.3.1",
@@ -1799,12 +2029,12 @@
       "dev": true
     },
     "buffer": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.0.tgz",
+      "integrity": "sha512-cd+5r1VLBwUqTrmnzW+D7ABkJUM6mr7uv1dv+6jRw4Rcl7tFIFHDqHPL98LhpGFn3dbAt3gtLxtrWp4m1kFrqg==",
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-equal-constant-time": {
@@ -1879,9 +2109,9 @@
       "integrity": "sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw=="
     },
     "chokidar": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
-      "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+      "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
@@ -1891,7 +2121,7 @@
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.4.0"
+        "readdirp": "~3.5.0"
       }
     },
     "ci-info": {
@@ -1967,9 +2197,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
-      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
+      "integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -2344,11 +2574,11 @@
       "dev": true
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       },
       "dependencies": {
         "ms": {
@@ -2523,6 +2753,19 @@
         "ws": "^7.1.2"
       },
       "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
         "ws": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
@@ -2531,18 +2774,18 @@
       }
     },
     "engine.io-client": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.3.tgz",
-      "integrity": "sha512-0NGY+9hioejTEJCaSJZfWZLk4FPI9dN+1H1C4+wj2iuFba47UgZbJzfWs4aNFajnX/qAaYKbe2lLTfEEWzCmcw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.4.tgz",
+      "integrity": "sha512-iU4CRr38Fecj8HoZEnFtm2EiKGbYZcPn3cHxqNGl/tmdWRf60KhK+9vE0JeSjgnlS/0oynEfLgKbT9ALpim0sQ==",
       "requires": {
         "component-emitter": "~1.3.0",
         "component-inherit": "0.0.3",
-        "debug": "~4.1.0",
+        "debug": "~3.1.0",
         "engine.io-parser": "~2.2.0",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
+        "parseqs": "0.0.6",
+        "parseuri": "0.0.6",
         "ws": "~6.1.0",
         "xmlhttprequest-ssl": "~1.5.4",
         "yeast": "0.1.2"
@@ -2552,6 +2795,24 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
           "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "parseqs": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
+          "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w=="
+        },
+        "parseuri": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
+          "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow=="
         },
         "ws": {
           "version": "6.1.4",
@@ -2564,13 +2825,13 @@
       }
     },
     "engine.io-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
-      "integrity": "sha512-6I3qD9iUxotsC5HEMuuGsKA0cXerGz+4uGcXQEkfBidgKf0amsjrrtwcbwK/nzpZBxclXlV7gGl9dgWvu4LF6w==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.1.tgz",
+      "integrity": "sha512-x+dN/fBH8Ro8TFwJ+rkB2AmuVw9Yu2mockR/p3W8f8YtExwFgDvBDi0GWyb4ZLkpahtDGZgtr3zLovanJghPqg==",
       "requires": {
         "after": "0.8.2",
         "arraybuffer.slice": "~0.0.7",
-        "base64-arraybuffer": "0.1.5",
+        "base64-arraybuffer": "0.1.4",
         "blob": "0.0.5",
         "has-binary2": "~1.0.2"
       }
@@ -2610,50 +2871,22 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+      "version": "1.18.0-next.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+      "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.0",
-        "is-regex": "^1.1.0",
-        "object-inspect": "^1.7.0",
+        "is-callable": "^1.2.2",
+        "is-negative-zero": "^2.0.0",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
+        "object.assign": "^4.1.1",
         "string.prototype.trimend": "^1.0.1",
         "string.prototype.trimstart": "^1.0.1"
-      }
-    },
-    "es-array-method-boxes-properly": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-      "dev": true
-    },
-    "es-get-iterator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.0.tgz",
-      "integrity": "sha512-UfrmHuWQlNMTs35e1ypnvikg6jCz3SK8v8ImvmDsh36fCVUR1MqoFDiyn0/k52C8NqO3YsO8Oe0azeesNuqSsQ==",
-      "dev": true,
-      "requires": {
-        "es-abstract": "^1.17.4",
-        "has-symbols": "^1.0.1",
-        "is-arguments": "^1.0.4",
-        "is-map": "^2.0.1",
-        "is-set": "^2.0.1",
-        "is-string": "^1.0.5",
-        "isarray": "^2.0.5"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-          "dev": true
-        }
       }
     },
     "es-to-primitive": {
@@ -2734,12 +2967,11 @@
           "dev": true
         },
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -2969,9 +3201,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz",
-      "integrity": "sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==",
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
+      "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.1",
@@ -2979,7 +3211,7 @@
         "contains-path": "^0.1.0",
         "debug": "^2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.3",
+        "eslint-import-resolver-node": "^0.3.4",
         "eslint-module-utils": "^2.6.0",
         "has": "^1.0.3",
         "minimatch": "^3.0.4",
@@ -3038,21 +3270,21 @@
       "dev": true
     },
     "eslint-plugin-react": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.2.tgz",
-      "integrity": "sha512-j3XKvrK3rpBzveKFbgAeGsWb9uz6iUOrR0jixRfjwdFeGSRsXvVTFtHDQYCjsd1/6Z/xvb8Vy3LiI5Reo7fDrg==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz",
+      "integrity": "sha512-8MaEggC2et0wSF6bUeywF7qQ46ER81irOdWS4QWxnnlAEsnzeBevk1sWh7fhpCghPpXb+8Ks7hvaft6L/xsR6g==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.1",
         "array.prototype.flatmap": "^1.2.3",
         "doctrine": "^2.1.0",
         "has": "^1.0.3",
-        "jsx-ast-utils": "^2.4.1",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "object.entries": "^1.1.2",
         "object.fromentries": "^2.0.2",
         "object.values": "^1.1.1",
         "prop-types": "^15.7.2",
-        "resolve": "^1.17.0",
+        "resolve": "^1.18.1",
         "string.prototype.matchall": "^4.0.2"
       },
       "dependencies": {
@@ -3435,9 +3667,9 @@
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "fastq": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
-      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
+      "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -3509,13 +3741,10 @@
       }
     },
     "flat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
-      "dev": true,
-      "requires": {
-        "is-buffer": "~2.0.3"
-      }
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
     },
     "flat-cache": {
       "version": "2.0.1",
@@ -3782,9 +4011,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "5.1.8",
@@ -3962,6 +4191,27 @@
         "es-abstract": "^1.17.0-next.1",
         "has": "^1.0.3",
         "side-channel": "^1.0.2"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "invert-kv": {
@@ -3999,9 +4249,18 @@
       "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
     },
     "is-callable": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.1.tgz",
-      "integrity": "sha512-wliAfSzx6V+6WfMOmus1xy0XvSgf/dlStkvTfq7F0g4bOIW0PSUbnyse3NhDwdyYS1ozfUtAAySqTws3z9Eqgg=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
+    },
+    "is-core-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.0.0.tgz",
+      "integrity": "sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
     },
     "is-date-object": {
       "version": "1.0.2",
@@ -4036,12 +4295,6 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "is-map": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
-      "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==",
-      "dev": true
-    },
     "is-nan": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.0.tgz",
@@ -4062,9 +4315,9 @@
       "dev": true
     },
     "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true
     },
     "is-regex": {
@@ -4074,12 +4327,6 @@
       "requires": {
         "has-symbols": "^1.0.1"
       }
-    },
-    "is-set": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
-      "integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA==",
-      "dev": true
     },
     "is-stream": {
       "version": "2.0.0",
@@ -4109,6 +4356,26 @@
         "es-abstract": "^1.17.4",
         "foreach": "^2.0.5",
         "has-symbols": "^1.0.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "isarray": {
@@ -4142,22 +4409,6 @@
         "readable-stream": "^3.4.0",
         "sha.js": "^2.4.9",
         "simple-get": "^3.0.2"
-      }
-    },
-    "iterate-iterator": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.1.tgz",
-      "integrity": "sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw==",
-      "dev": true
-    },
-    "iterate-value": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
-      "integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
-      "dev": true,
-      "requires": {
-        "es-get-iterator": "^1.0.2",
-        "iterate-iterator": "^1.0.1"
       }
     },
     "jju": {
@@ -4264,6 +4515,11 @@
         }
       }
     },
+    "jsrsasign": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.0.4.tgz",
+      "integrity": "sha512-G08GDeAwgVkN5PGE9TnJ/4ixV3zkq560RigOoqrRvVc8H4GjfPVTz54/qGPLHK1KGHGP36/2eaLU1HuXmOJgug=="
+    },
     "jsx-ast-utils": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
@@ -4292,6 +4548,11 @@
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "jwt-decode": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.0.0.tgz",
+      "integrity": "sha512-RBQv2MTm3FNKQkdzhEyQwh5MbdNgMa+FyIJIK5RMWEn6hRgRHr7j55cRxGhRe6vGJDElyi6f6u/yfkP7AoXddA=="
     },
     "kuler": {
       "version": "2.0.0",
@@ -4615,12 +4876,11 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -4812,15 +5072,16 @@
       }
     },
     "mocha": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.1.3.tgz",
-      "integrity": "sha512-ZbaYib4hT4PpF4bdSO2DohooKXIn4lDeiYqB+vTmCdr6l2woW0b6H3pf5x4sM5nwQMru9RvjjHYWVGltR50ZBw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.0.tgz",
+      "integrity": "sha512-lEWEMq2LMfNJMKeuEwb5UELi+OgFDollXaytR5ggQcHpzG3NP/R7rvixAvF+9/lLsTWhWG+4yD2M70GsM06nxw==",
       "dev": true,
       "requires": {
+        "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.4.2",
-        "debug": "4.1.1",
+        "chokidar": "3.4.3",
+        "debug": "4.2.0",
         "diff": "4.0.2",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
@@ -4831,17 +5092,16 @@
         "log-symbols": "4.0.0",
         "minimatch": "3.0.4",
         "ms": "2.1.2",
-        "object.assign": "4.1.0",
-        "promise.allsettled": "1.0.2",
-        "serialize-javascript": "4.0.0",
-        "strip-json-comments": "3.0.1",
-        "supports-color": "7.1.0",
+        "nanoid": "3.1.12",
+        "serialize-javascript": "5.0.1",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "7.2.0",
         "which": "2.0.2",
         "wide-align": "1.1.3",
-        "workerpool": "6.0.0",
+        "workerpool": "6.0.2",
         "yargs": "13.3.2",
         "yargs-parser": "13.1.2",
-        "yargs-unparser": "1.6.1"
+        "yargs-unparser": "2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4910,18 +5170,6 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
-        "object.assign": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-          "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.2",
-            "function-bind": "^1.1.1",
-            "has-symbols": "^1.0.0",
-            "object-keys": "^1.0.11"
-          }
-        },
         "p-limit": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
@@ -4972,16 +5220,10 @@
             "ansi-regex": "^4.1.0"
           }
         },
-        "strip-json-comments": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-          "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
-          "dev": true
-        },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -5127,6 +5369,12 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "nanoid": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
+      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==",
+      "dev": true
+    },
     "napi-macros": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
@@ -5224,12 +5472,12 @@
       "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
     },
     "object-is": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
-      "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.3.tgz",
+      "integrity": "sha512-teyqLvFWzLkq5B9ki8FVWA902UER2qkxmdA4nLf+wjOLAWgxzCWZNCxpDq9MvE8MmhWNr+I8w3BN49Vx36Y6Xg==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "es-abstract": "^1.18.0-next.1"
       }
     },
     "object-keys": {
@@ -5246,27 +5494,6 @@
         "es-abstract": "^1.18.0-next.0",
         "has-symbols": "^1.0.1",
         "object-keys": "^1.1.1"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.0",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
-          "integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        }
       }
     },
     "object.entries": {
@@ -5278,6 +5505,27 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5",
         "has": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "object.fromentries": {
@@ -5290,6 +5538,27 @@
         "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "object.values": {
@@ -5302,6 +5571,27 @@
         "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "on-finished": {
@@ -5532,19 +5822,6 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
-    "promise.allsettled": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.2.tgz",
-      "integrity": "sha512-UpcYW5S1RaNKT6pd+s9jp9K9rlQge1UXKskec0j6Mmuq7UJCvlS2J2/s/yuPN8ehftf9HXMxWlKiPbGGUzpoRg==",
-      "dev": true,
-      "requires": {
-        "array.prototype.map": "^1.0.1",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "function-bind": "^1.1.1",
-        "iterate-value": "^1.0.0"
-      }
-    },
     "prop-types": {
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
@@ -5695,9 +5972,9 @@
       }
     },
     "readdirp": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-      "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
@@ -5742,6 +6019,27 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "regexpp": {
@@ -5769,11 +6067,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
+      "integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
       "dev": true,
       "requires": {
+        "is-core-module": "^2.0.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -5815,9 +6114,9 @@
       "dev": true
     },
     "run-parallel": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
       "dev": true
     },
     "rxjs": {
@@ -5901,9 +6200,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
@@ -5963,28 +6262,6 @@
       "requires": {
         "es-abstract": "^1.18.0-next.0",
         "object-inspect": "^1.8.0"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.0",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
-          "integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        }
       }
     },
     "signal-exit": {
@@ -6057,6 +6334,21 @@
         "socket.io-adapter": "~1.1.0",
         "socket.io-client": "2.3.0",
         "socket.io-parser": "~3.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "socket.io-adapter": {
@@ -6085,16 +6377,39 @@
         "to-array": "0.1.4"
       },
       "dependencies": {
-        "socket.io-parser": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
-          "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+        "base64-arraybuffer": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+          "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
-            "component-emitter": "1.2.1",
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "socket.io-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.1.tgz",
+          "integrity": "sha512-1QLvVAe8dTz+mKmZ07Swxt+LAo4Y1ff50rlyoEx00TQmDFVQYPfcqGvIDJLGaBdhdNCecXtyKpD+EgKGcmmbuQ==",
+          "requires": {
+            "component-emitter": "~1.3.0",
             "debug": "~3.1.0",
             "isarray": "2.0.1"
           },
           "dependencies": {
+            "component-emitter": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+              "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+            },
             "debug": {
               "version": "3.1.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -6102,6 +6417,11 @@
               "requires": {
                 "ms": "2.0.0"
               }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
         }
@@ -6115,6 +6435,21 @@
         "component-emitter": "1.2.1",
         "debug": "~4.1.0",
         "isarray": "2.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "socket.io-redis": {
@@ -6129,6 +6464,19 @@
         "uid2": "0.0.3"
       },
       "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
         "redis": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/redis/-/redis-3.0.2.tgz",
@@ -6277,24 +6625,45 @@
         "internal-slot": "^1.0.2",
         "regexp.prototype.flags": "^1.3.0",
         "side-channel": "^1.0.2"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
-      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.2.tgz",
+      "integrity": "sha512-8oAG/hi14Z4nOVP0z6mdiVZ/wqjDtWSLygMigTzAb+7aPEDTleeFf+WrF+alzecxIRkckkJVn+dTlwzJXORATw==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "es-abstract": "^1.18.0-next.1"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
-      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.2.tgz",
+      "integrity": "sha512-7F6CdBTl5zyu30BJFdzSTlSlLPwODC23Od+iLoVH8X6+3fvDPPuBVVj9iaB1GOsSTSIgVfsfm27R2FGrAPznWg==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "es-abstract": "^1.18.0-next.1"
       }
     },
     "string_decoder": {
@@ -6484,9 +6853,9 @@
       }
     },
     "tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tsutils": {
       "version": "3.17.1",
@@ -6599,9 +6968,9 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8-compile-cache": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -6656,6 +7025,26 @@
         "function-bind": "^1.1.1",
         "has-symbols": "^1.0.1",
         "is-typed-array": "^1.1.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "wide-align": {
@@ -6745,9 +7134,9 @@
       "dev": true
     },
     "workerpool": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.0.tgz",
-      "integrity": "sha512-fU2OcNA/GVAJLLyKUoHkAgIhKb0JoCpSjLC/G2vYKxUjVmQwGbRVeoPJ1a8U4pnVofz4AQV5Y/NEw8oKqxEBtA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.2.tgz",
+      "integrity": "sha512-DSNyvOpFKrNusaaUwk+ej6cBj1bmhLcBfj80elGk+ZIo5JSkq+unB1dLKEOcNfJDZgjGICfhQ0Q5TbP0PvF4+Q==",
       "dev": true
     },
     "wrap-ansi": {
@@ -6829,161 +7218,28 @@
       }
     },
     "yargs-unparser": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.1.tgz",
-      "integrity": "sha512-qZV14lK9MWsGCmcr7u5oXGH0dbGqZAIxTDrWXZDo5zUr6b6iUmelNKO6x6R1dQT24AH3LgRxJpr8meWy2unolA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
       "dev": true,
       "requires": {
-        "camelcase": "^5.3.1",
-        "decamelize": "^1.2.0",
-        "flat": "^4.1.0",
-        "is-plain-obj": "^1.1.0",
-        "yargs": "^14.2.3"
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
         "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
           "dev": true
         },
-        "cliui": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-          "dev": true,
-          "requires": {
-            "string-width": "^3.1.0",
-            "strip-ansi": "^5.2.0",
-            "wrap-ansi": "^5.1.0"
-          }
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
-        },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^3.0.0",
-            "strip-ansi": "^5.0.0"
-          }
-        },
-        "y18n": {
+        "decamelize": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+          "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
           "dev": true
-        },
-        "yargs": {
-          "version": "14.2.3",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
-          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
-          "dev": true,
-          "requires": {
-            "cliui": "^5.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^15.0.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "15.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
         }
       }
     },

--- a/server/tinylicious/src/resources.ts
+++ b/server/tinylicious/src/resources.ts
@@ -16,7 +16,6 @@ export class TinyliciousResources implements utils.IResources {
         public storage: core.IDocumentStorage,
         public mongoManager: core.MongoManager,
         public port: any,
-        public contentCollection: core.ICollection<any>,
         public webServerFactory: core.IWebServerFactory,
     ) {
     }

--- a/server/tinylicious/src/resourcesFactory.ts
+++ b/server/tinylicious/src/resourcesFactory.ts
@@ -63,10 +63,6 @@ export class TinyliciousResourcesFactory implements utils.IResourcesFactory<Tiny
             undefined /* serviceConfiguration */,
             pubsub);
 
-        // TODO would be nicer to just pass the mongoManager down
-        const db = await mongoManager.getDatabase();
-        const contentCollection = db.collection(collectionNames.content);
-
         return new TinyliciousResources(
             config,
             orderManager,
@@ -74,7 +70,6 @@ export class TinyliciousResourcesFactory implements utils.IResourcesFactory<Tiny
             storage,
             mongoManager,
             port,
-            contentCollection,
             webServerFactory);
     }
 }

--- a/server/tinylicious/src/runner.ts
+++ b/server/tinylicious/src/runner.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-    ICollection,
     IDocumentStorage,
     IOrdererManager,
     ITenantManager,
@@ -34,7 +33,6 @@ export class TinyliciousRunner implements utils.IRunner {
         private readonly tenantManager: ITenantManager,
         private readonly storage: IDocumentStorage,
         private readonly mongoManager: MongoManager,
-        private readonly contentCollection: ICollection<any>,
     ) {}
 
     public async start(): Promise<void> {
@@ -54,7 +52,6 @@ export class TinyliciousRunner implements utils.IRunner {
             this.orderManager,
             this.tenantManager,
             this.storage,
-            this.contentCollection,
             new TestClientManager(),
             new DefaultMetricClient(),
             winston,

--- a/server/tinylicious/src/runnerFactory.ts
+++ b/server/tinylicious/src/runnerFactory.ts
@@ -16,7 +16,6 @@ export class TinyliciousRunnerFactory implements utils.IRunnerFactory<Tinyliciou
             resources.orderManager,
             resources.tenantManager,
             resources.storage,
-            resources.mongoManager,
-            resources.contentCollection);
+            resources.mongoManager);
     }
 }

--- a/server/tinylicious/src/utils.ts
+++ b/server/tinylicious/src/utils.ts
@@ -9,7 +9,8 @@ import { IUser, ScopeType } from "@fluidframework/protocol-definitions";
 // eslint-disable-next-line import/no-unresolved
 import { Params } from "express-serve-static-core";
 import * as _ from "lodash";
-import { IAlfredTenant, generateToken } from "@fluidframework/server-services-client";
+import { IAlfredTenant } from "@fluidframework/server-services-client";
+import { generateToken } from "@fluidframework/server-services-utils";
 
 /**
  * Helper function to return tenant specific configuration


### PR DESCRIPTION
Update tinylicous code for latest server changes. (#4183)

Tinylicious was consuming pre-release dependencies (#3673) but it was not built after some recent changes to 0.1014.0 (#3818 and #3998 ). This caused the failure of recent release bump (#4181 ). This PR should fix the build failure.