### PR TITLE
Fix bug where get graphItemLite always returns undefined

### DIFF
--- a/packages/drivers/odsp-driver/src/graph.ts
+++ b/packages/drivers/odsp-driver/src/graph.ts
@@ -255,5 +255,5 @@ export async function getGraphItemLite(
         };
         graphItemLiteCache.add(cacheKey, valueGenerator);
     }
-    return graphItemLiteCache[cacheKey] as GraphItemLite;
+    return graphItemLiteCache.get(cacheKey);
 }


### PR DESCRIPTION
It seems there was a code change when porting code from the FFX repo into the open source repo turning the cache from an array into a map, but the return value was not updated