### PR TITLE
Use the banned modules plugin in the bundle size tests

### DIFF
--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
+    "@fluidframework/bundle-size-tools": "^0.0.8505",
     "@fluidframework/eslint-config-fluid": "^0.20.0-0",
     "@mixer/webpack-bundle-compare": "^0.1.0",
     "@types/node": "^10.17.24",

--- a/examples/utils/bundle-size-tests/webpack.config.js
+++ b/examples/utils/bundle-size-tests/webpack.config.js
@@ -42,7 +42,7 @@ module.exports = {
   plugins: [
     new BannedModulesPlugin({
         bannedModules: [{
-                mode: 'assert',
+                moduleName: 'assert',
                 reason: 'This module is very large when bundled in browser facing Javascript, instead use the assert API in @fluidframework/common-utils'
             }
         ]

--- a/examples/utils/bundle-size-tests/webpack.config.js
+++ b/examples/utils/bundle-size-tests/webpack.config.js
@@ -7,6 +7,7 @@ const path = require('path');
 const { BundleComparisonPlugin } = require('@mixer/webpack-bundle-compare/dist/plugin');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack-plugin');
+const { BannedModulesPlugin } = require('@fluidframework/bundle-size-tools')
 
 module.exports = {
   entry: {
@@ -39,6 +40,13 @@ module.exports = {
   },
   node: false,
   plugins: [
+    new BannedModulesPlugin({
+        bannedModules: [{
+                mode: 'assert',
+                reason: 'This module is very large when bundled in browser facing Javascript, instead use the assert API in @fluidframework/common-utils'
+            }
+        ]
+    }),
     new DuplicatePackageCheckerPlugin({
       // Also show module that is requiring each duplicate package
       verbose: true,

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -753,48 +753,48 @@
 			}
 		},
 		"@fluidframework/agent-scheduler": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.26.10.tgz",
-			"integrity": "sha512-gT6hnYlqoTwgpS+xy5krNMqBdJu4hVpp/AF0XnrMysLknFJ+iOU/J936owEM9A0SwF4MLS5Q3XjJ8b0juZUtEw==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.27.9.tgz",
+			"integrity": "sha512-HM1S4I52XV2vhAhn9ua5hHletfunOU+BxXEU4EFTsOQzfRjsj1NZNMP6pdNeraDQDBeKIZyeQJK7mpQgJ7kf8A==",
 			"requires": {
-				"@fluidframework/container-definitions": "^0.26.10",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/datastore": "^0.26.10",
-				"@fluidframework/datastore-definitions": "^0.26.10",
-				"@fluidframework/map": "^0.26.10",
-				"@fluidframework/register-collection": "^0.26.10",
-				"@fluidframework/runtime-definitions": "^0.26.10",
+				"@fluidframework/container-definitions": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/datastore": "^0.27.9",
+				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/map": "^0.27.9",
+				"@fluidframework/register-collection": "^0.27.9",
+				"@fluidframework/runtime-definitions": "^0.27.9",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.26.10.tgz",
-			"integrity": "sha512-0ZOy/jPUqnzf/YxLHtJZ02JT6EKCbn6AX3dS5+BsAzmgC0hwb9UzBa0mprM65YRX6q3Ut1DoDwbDxdGdpHjB9g==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.27.9.tgz",
+			"integrity": "sha512-jmLsStg4+GdnIy01+d5/50ut/ojIoijvzuF907S9cB9d1miTWfN252qSYBwoxZAJc9R7aMhQ4+1IV4zotRkKSg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.10",
-				"@fluidframework/container-loader": "^0.26.10",
-				"@fluidframework/container-runtime": "^0.26.10",
-				"@fluidframework/container-runtime-definitions": "^0.26.10",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/datastore": "^0.26.10",
-				"@fluidframework/datastore-definitions": "^0.26.10",
-				"@fluidframework/map": "^0.26.10",
-				"@fluidframework/request-handler": "^0.26.10",
-				"@fluidframework/runtime-definitions": "^0.26.10",
-				"@fluidframework/runtime-utils": "^0.26.10",
-				"@fluidframework/synthesize": "^0.26.10",
-				"@fluidframework/view-interfaces": "^0.26.10",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/container-definitions": "^0.27.9",
+				"@fluidframework/container-loader": "^0.27.9",
+				"@fluidframework/container-runtime": "^0.27.9",
+				"@fluidframework/container-runtime-definitions": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/datastore": "^0.27.9",
+				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/map": "^0.27.9",
+				"@fluidframework/request-handler": "^0.27.9",
+				"@fluidframework/runtime-definitions": "^0.27.9",
+				"@fluidframework/runtime-utils": "^0.27.9",
+				"@fluidframework/synthesize": "^0.27.9",
+				"@fluidframework/view-interfaces": "^0.27.9",
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -802,7 +802,6 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				}
@@ -836,6 +835,20 @@
 				"typescript": "^3.7.4"
 			},
 			"dependencies": {
+				"@fluidframework/bundle-size-tools": {
+					"version": "0.0.6611",
+					"resolved": "https://registry.npmjs.org/@fluidframework/bundle-size-tools/-/bundle-size-tools-0.0.6611.tgz",
+					"integrity": "sha512-6aICkM/WjqKjDaTwMCxoDMCUXoyTWQOuw7YMFaBETQ5eIbyzdH8lTQlojn/mkV+1L5uNTal1Naymh9pqJ52W8g==",
+					"dev": true,
+					"requires": {
+						"assert": "^2.0.0",
+						"azure-devops-node-api": "^10.1.0",
+						"jszip": "^3.2.2",
+						"msgpack-lite": "^0.1.26",
+						"pako": "^1.0.10",
+						"typescript": "^3.7.4"
+					}
+				},
 				"commander": {
 					"version": "2.20.3",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -851,10 +864,9 @@
 			}
 		},
 		"@fluidframework/bundle-size-tools": {
-			"version": "0.0.6611",
-			"resolved": "https://registry.npmjs.org/@fluidframework/bundle-size-tools/-/bundle-size-tools-0.0.6611.tgz",
-			"integrity": "sha512-6aICkM/WjqKjDaTwMCxoDMCUXoyTWQOuw7YMFaBETQ5eIbyzdH8lTQlojn/mkV+1L5uNTal1Naymh9pqJ52W8g==",
-			"dev": true,
+			"version": "0.0.8505",
+			"resolved": "https://registry.npmjs.org/@fluidframework/bundle-size-tools/-/bundle-size-tools-0.0.8505.tgz",
+			"integrity": "sha512-B99xAInCdQPtNdr42V7hezxyQQFWHbt1CoWcrOxJEL8w6qk/F1/fA/0x36H8LJdud+rywzEEenWYRdWs8J31dw==",
 			"requires": {
 				"assert": "^2.0.0",
 				"azure-devops-node-api": "^10.1.0",
@@ -884,20 +896,20 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.26.10.tgz",
-			"integrity": "sha512-iwHNUKPvf52ZICpNXPxhrYO/t2YWqB2vFg99TyqCuqSTPL7GcnkXb0zyxofOAw/DcR4rZOno1PXb+RdxDHp2pw==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.27.9.tgz",
+			"integrity": "sha512-D4M2awBMXek/F0mTgKdETwmKbq9L+s5/prUoJjvK/+Ffr3q7/MqeFLAgubRUWwOHgmpDi4TjVqrPx7gnKscRPw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/driver-definitions": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0"
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/driver-definitions": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -905,20 +917,20 @@
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.26.10.tgz",
-			"integrity": "sha512-YtG2nR+Lm8+MlG45VtxHpQsoHDYO/Q8cmxFjFcQjx921jkraKqoc1PrnKQXZ+fPgxluxEDHN340CZY4CCgrt7Q==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.27.9.tgz",
+			"integrity": "sha512-obzZqFApU4PyWD4597BDhgj8Fi3hjnAWBcl5wnXHqByYtSg2mB3y8R28oD561c6pYINse3N+vETD9O+WXNxEvg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.10",
-				"@fluidframework/container-utils": "^0.26.10",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/driver-definitions": "^0.26.10",
-				"@fluidframework/driver-utils": "^0.26.10",
-				"@fluidframework/protocol-base": "^0.1012.0",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/telemetry-utils": "^0.26.10",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/container-definitions": "^0.27.9",
+				"@fluidframework/container-utils": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/driver-definitions": "^0.27.9",
+				"@fluidframework/driver-utils": "^0.27.9",
+				"@fluidframework/protocol-base": "^0.1013.0",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/telemetry-utils": "^0.27.9",
 				"@types/double-ended-queue": "^2.1.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -927,9 +939,9 @@
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -937,31 +949,30 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.2.tgz",
-					"integrity": "sha512-ysb9skxUKtIUSNUFqqcTQBMpCDrPcezc4pvDLaBdxcK4BuP3Ak2gZGmIVeXfbsx40+isBQ8xGbJISIZlgtGlZw=="
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1013.0.tgz",
+					"integrity": "sha512-X1j5sUNcpWnmyXCQjPx0C2d5jed3OgHnq3vRVzPwVmvGhu7B+tofsbJEMExMHX/J+ambDHq40ipEA55sTuXdwQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.2.tgz",
-					"integrity": "sha512-K8YRUIvrlO+54hyzLgLhZ9tQNeyPd9/yX0h/6XEE4m0oazCcCOFihAFzBIQXxypv1zNH2fbKlsQ7xaHHDbZ6rA==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1013.0.tgz",
+					"integrity": "sha512-2Y6Iu3rQut21aFS+oTYeIKAyyRkYeqMYJ+xAP8wSW0R6eiZPz3q1EhcXpJkEW9f5y84FNjbNsfV9jqI29URMHg==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -969,25 +980,25 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.26.10.tgz",
-			"integrity": "sha512-Xye5T1brL5U4AzHHg90dz73XbzE2C5SYC5w4M3HVE7DbSXErphV48g7IWgdTpzhQMDG6mZ18P/FFPdMuS+kseQ==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.27.9.tgz",
+			"integrity": "sha512-58a8WLongv1TJ9OOoCqLhPv5sKvVmXhDD3ywjjsbxdZ85AmLsVDn41SOlLuNk5B7pLxZxVvaSaPVPI4z5Ha38w==",
 			"requires": {
-				"@fluidframework/agent-scheduler": "^0.26.10",
+				"@fluidframework/agent-scheduler": "^0.27.9",
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.10",
-				"@fluidframework/container-runtime-definitions": "^0.26.10",
-				"@fluidframework/container-utils": "^0.26.10",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/datastore": "^0.26.10",
-				"@fluidframework/driver-definitions": "^0.26.10",
-				"@fluidframework/driver-utils": "^0.26.10",
-				"@fluidframework/protocol-base": "^0.1012.0",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.10",
-				"@fluidframework/runtime-utils": "^0.26.10",
-				"@fluidframework/telemetry-utils": "^0.26.10",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/container-definitions": "^0.27.9",
+				"@fluidframework/container-runtime-definitions": "^0.27.9",
+				"@fluidframework/container-utils": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/datastore": "^0.27.9",
+				"@fluidframework/driver-definitions": "^0.27.9",
+				"@fluidframework/driver-utils": "^0.27.9",
+				"@fluidframework/protocol-base": "^0.1013.0",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/runtime-definitions": "^0.27.9",
+				"@fluidframework/runtime-utils": "^0.27.9",
+				"@fluidframework/telemetry-utils": "^0.27.9",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/node": "^10.17.24",
@@ -998,9 +1009,9 @@
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -1008,31 +1019,30 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.2.tgz",
-					"integrity": "sha512-ysb9skxUKtIUSNUFqqcTQBMpCDrPcezc4pvDLaBdxcK4BuP3Ak2gZGmIVeXfbsx40+isBQ8xGbJISIZlgtGlZw=="
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1013.0.tgz",
+					"integrity": "sha512-X1j5sUNcpWnmyXCQjPx0C2d5jed3OgHnq3vRVzPwVmvGhu7B+tofsbJEMExMHX/J+ambDHq40ipEA55sTuXdwQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.2.tgz",
-					"integrity": "sha512-K8YRUIvrlO+54hyzLgLhZ9tQNeyPd9/yX0h/6XEE4m0oazCcCOFihAFzBIQXxypv1zNH2fbKlsQ7xaHHDbZ6rA==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1013.0.tgz",
+					"integrity": "sha512-2Y6Iu3rQut21aFS+oTYeIKAyyRkYeqMYJ+xAP8wSW0R6eiZPz3q1EhcXpJkEW9f5y84FNjbNsfV9jqI29URMHg==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -1040,22 +1050,22 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.26.10.tgz",
-			"integrity": "sha512-fhYuuYuVYzfuYiR2W7e+2jwX/CLtaXqXjf8NKYdNGTnFjZk3Egm1quOFQj/TBBk+ckoVHKymyab7qYuliRZYZw==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.27.9.tgz",
+			"integrity": "sha512-pTrvtywdy/97XmwpGbe8ZWKgH300/2iQPCAp1bKHGmBV6J7s4pt1yKyT+DG6naVmx5NxtiwwIN2AMIzF7nrFoA==",
 			"requires": {
-				"@fluidframework/container-definitions": "^0.26.10",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/driver-definitions": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.10",
+				"@fluidframework/container-definitions": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/driver-definitions": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/runtime-definitions": "^0.27.9",
 				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -1063,46 +1073,47 @@
 			}
 		},
 		"@fluidframework/container-utils": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.26.10.tgz",
-			"integrity": "sha512-vSyQNjKkWENzJk5gNZEq08A7k4eDOOE4XbleWvX3elZXWYDpQj2EmyFVRiwXfha064FsPQrQGMXCqbC8YWfAaQ==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.27.9.tgz",
+			"integrity": "sha512-t5T0vKgnzyiYcCJDsqxuRM+l5XAglo86t/TOqf/qS3BoKYK1AMY2dH6UDKktnH+8Em85+5rL8K7c8YhGBf9CsQ==",
 			"requires": {
-				"@fluidframework/container-definitions": "^0.26.10",
-				"@fluidframework/telemetry-utils": "^0.26.10"
+				"@fluidframework/container-definitions": "^0.27.9",
+				"@fluidframework/telemetry-utils": "^0.27.9"
 			}
 		},
 		"@fluidframework/core-interfaces": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.26.10.tgz",
-			"integrity": "sha512-o/mgvdQZdk59ZrYRZqq2fmmnrpr5h5g7riA/faRNT4ALn60n7UGl383Ubo7RJUfl08j95aI4+MiGwEr3WpWkoA=="
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.27.9.tgz",
+			"integrity": "sha512-PT+K83qAUPlt4cllR9sPvprqLD0tkD4Vtm9sWl8KPIRYF4TNaomHox2pTpBqax5d2NlteibP79b7sw6S7ueaJQ=="
 		},
 		"@fluidframework/datastore": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.26.10.tgz",
-			"integrity": "sha512-XEGzS8VLwhFHcPc9XmmiWSuwa3KuUJTPCwd+a1z3DkvV9d3d+kAd3uOB52fqqcyM2YOWceSnqc0shcGkfO666Q==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.27.9.tgz",
+			"integrity": "sha512-4LmykrOWqh5bNbSQFDwgoW7pS3ScdASi1jLoBz1+WhMAneoPQHjF1sQckWaIeNXtijNNtYYpQeVz7t2a/aWG9A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.10",
-				"@fluidframework/container-utils": "^0.26.10",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/datastore-definitions": "^0.26.10",
-				"@fluidframework/driver-definitions": "^0.26.10",
-				"@fluidframework/driver-utils": "^0.26.10",
-				"@fluidframework/protocol-base": "^0.1012.0",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.10",
-				"@fluidframework/runtime-utils": "^0.26.10",
-				"@fluidframework/telemetry-utils": "^0.26.10",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/container-definitions": "^0.27.9",
+				"@fluidframework/container-utils": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/driver-definitions": "^0.27.9",
+				"@fluidframework/driver-utils": "^0.27.9",
+				"@fluidframework/protocol-base": "^0.1013.0",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/runtime-definitions": "^0.27.9",
+				"@fluidframework/runtime-utils": "^0.27.9",
+				"@fluidframework/telemetry-utils": "^0.27.9",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
+				"lodash": "^4.17.19",
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -1110,31 +1121,30 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.2.tgz",
-					"integrity": "sha512-ysb9skxUKtIUSNUFqqcTQBMpCDrPcezc4pvDLaBdxcK4BuP3Ak2gZGmIVeXfbsx40+isBQ8xGbJISIZlgtGlZw=="
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1013.0.tgz",
+					"integrity": "sha512-X1j5sUNcpWnmyXCQjPx0C2d5jed3OgHnq3vRVzPwVmvGhu7B+tofsbJEMExMHX/J+ambDHq40ipEA55sTuXdwQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.2.tgz",
-					"integrity": "sha512-K8YRUIvrlO+54hyzLgLhZ9tQNeyPd9/yX0h/6XEE4m0oazCcCOFihAFzBIQXxypv1zNH2fbKlsQ7xaHHDbZ6rA==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1013.0.tgz",
+					"integrity": "sha512-2Y6Iu3rQut21aFS+oTYeIKAyyRkYeqMYJ+xAP8wSW0R6eiZPz3q1EhcXpJkEW9f5y84FNjbNsfV9jqI29URMHg==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -1142,22 +1152,37 @@
 			}
 		},
 		"@fluidframework/datastore-definitions": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.26.10.tgz",
-			"integrity": "sha512-BMbfck/XYfx4PJLYWK9CHEmKStm+GZR/QQI9Og9gq3VXIZjRhxJZ5yCDl6HNbaMd8IriMKubukNTR5ottTVHEA==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.27.9.tgz",
+			"integrity": "sha512-nZC1570Jc+mPCFfL7rEAyDh5JCnIMMVjGfP05mWVn6PzOuU6iPaWqFysLMBsi04yYfp5BdfCNKiceAjLV9KmZQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.26.10",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.10",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/container-definitions": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/runtime-definitions": "^0.27.9",
 				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.19.1",
+						"@types/events": "^3.0.0",
+						"assert": "^2.0.0",
+						"base64-js": "^1.3.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.19",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -1165,14 +1190,14 @@
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.26.10.tgz",
-			"integrity": "sha512-TFBDZ/V7gKb4CUpdXftyia7ZihgKjsmrkbHQT1HbxZjUo+z1yCeAJD+4SeAIsP1s1WVzHNJySNhOZ37dlywwHA==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.27.9.tgz",
+			"integrity": "sha512-aQXkYkzVkQBJzUI0UqNn3ecr2hZJ0FntwbmsGRxDAm0QVy6+vio0Pck5GKULiiFMs3nuI+K5C9k6aw6YQHlcAQ==",
 			"requires": {
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/driver-definitions": "^0.26.10",
-				"@fluidframework/driver-utils": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/driver-definitions": "^0.27.9",
+				"@fluidframework/driver-utils": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
 				"@types/debug": "^4.1.5",
 				"@types/node": "^10.17.24",
 				"@types/socket.io-client": "^1.4.32",
@@ -1180,9 +1205,9 @@
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -1190,14 +1215,13 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -1205,19 +1229,19 @@
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.26.10.tgz",
-			"integrity": "sha512-nKAyvxz8bgqR0UhhiXjAppU33iajlgiga+dsqy94Uau8WDC5OqxAlfuv6Qmlduw22pz0MHDXP4VENMNrNkDXnQ==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.27.9.tgz",
+			"integrity": "sha512-55yiu8FHhpgHPnzMSm7f1Ls01clPkaGj2Doz5VMLWx6Y7R6qHCAB/JG291csOHn47O3Bus9D+GD8sUrD9/AnFA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0"
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -1225,24 +1249,24 @@
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.26.10.tgz",
-			"integrity": "sha512-NmxpRXnu05wpsm3QeHL6mhNKXHBoQGu8S0NvpEqjXdFB9VGNA4+LzYjAXxOoXcLwU+GZm1+e7yGebpNBEwczbw==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.27.9.tgz",
+			"integrity": "sha512-f1A+dtjeDmy6QoXOiIgcxyZWyvDn5Ufd8aWhxfo93uI/B3e+KVoA3P/v13ff8lIQC2IFcL0Rla1ebLo6otwWcg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/driver-definitions": "^0.26.10",
-				"@fluidframework/gitresources": "^0.1012.0",
-				"@fluidframework/protocol-base": "^0.1012.0",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/telemetry-utils": "^0.26.10"
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/driver-definitions": "^0.27.9",
+				"@fluidframework/gitresources": "^0.1013.0",
+				"@fluidframework/protocol-base": "^0.1013.0",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/telemetry-utils": "^0.27.9"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -1250,31 +1274,30 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.2.tgz",
-					"integrity": "sha512-ysb9skxUKtIUSNUFqqcTQBMpCDrPcezc4pvDLaBdxcK4BuP3Ak2gZGmIVeXfbsx40+isBQ8xGbJISIZlgtGlZw=="
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1013.0.tgz",
+					"integrity": "sha512-X1j5sUNcpWnmyXCQjPx0C2d5jed3OgHnq3vRVzPwVmvGhu7B+tofsbJEMExMHX/J+ambDHq40ipEA55sTuXdwQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.2.tgz",
-					"integrity": "sha512-K8YRUIvrlO+54hyzLgLhZ9tQNeyPd9/yX0h/6XEE4m0oazCcCOFihAFzBIQXxypv1zNH2fbKlsQ7xaHHDbZ6rA==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1013.0.tgz",
+					"integrity": "sha512-2Y6Iu3rQut21aFS+oTYeIKAyyRkYeqMYJ+xAP8wSW0R6eiZPz3q1EhcXpJkEW9f5y84FNjbNsfV9jqI29URMHg==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -1960,29 +1983,29 @@
 			"integrity": "sha512-NVv4Os7PAp54whyyRHdjRbWX3wsxPWiWNYwaURYKjZeOkfq2cA+TOe1Ng1odWbPHBCpYBPN/jG3b7yn6XKb64A=="
 		},
 		"@fluidframework/local-driver": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.26.10.tgz",
-			"integrity": "sha512-h+P7FPnTkTixM6KBHre3n3WLRuOpRcN16yNPF7JuVUhhPJmBa6Dmx1pdjECEQwvKFfddorWMF/WeQK3JyfXyRA==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.27.9.tgz",
+			"integrity": "sha512-gjBgytObNaTezCISC9oY/0BdKO9Up45Hq3vhMGBndbPfW69ukKnrbvhKi43N/ST/kb25mkH0wk2370xkZQDZYw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/driver-definitions": "^0.26.10",
-				"@fluidframework/driver-utils": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/routerlicious-driver": "^0.26.10",
-				"@fluidframework/server-local-server": "^0.1012.0",
-				"@fluidframework/server-services-client": "^0.1012.0",
-				"@fluidframework/server-services-core": "^0.1012.0",
-				"@fluidframework/server-test-utils": "^0.1012.0",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/driver-definitions": "^0.27.9",
+				"@fluidframework/driver-utils": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/routerlicious-driver": "^0.27.9",
+				"@fluidframework/server-local-server": "^0.1013.0",
+				"@fluidframework/server-services-client": "^0.1013.0",
+				"@fluidframework/server-services-core": "^0.1013.0",
+				"@fluidframework/server-test-utils": "^0.1013.0",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -1990,46 +2013,45 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.2.tgz",
-					"integrity": "sha512-ysb9skxUKtIUSNUFqqcTQBMpCDrPcezc4pvDLaBdxcK4BuP3Ak2gZGmIVeXfbsx40+isBQ8xGbJISIZlgtGlZw=="
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1013.0.tgz",
+					"integrity": "sha512-X1j5sUNcpWnmyXCQjPx0C2d5jed3OgHnq3vRVzPwVmvGhu7B+tofsbJEMExMHX/J+ambDHq40ipEA55sTuXdwQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.2.tgz",
-					"integrity": "sha512-K8YRUIvrlO+54hyzLgLhZ9tQNeyPd9/yX0h/6XEE4m0oazCcCOFihAFzBIQXxypv1zNH2fbKlsQ7xaHHDbZ6rA==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1013.0.tgz",
+					"integrity": "sha512-2Y6Iu3rQut21aFS+oTYeIKAyyRkYeqMYJ+xAP8wSW0R6eiZPz3q1EhcXpJkEW9f5y84FNjbNsfV9jqI29URMHg==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
 				},
 				"@fluidframework/server-lambdas": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1012.2.tgz",
-					"integrity": "sha512-r/FPMZfami9yD/ZDo0BRvQwkcVlD2PnOgYeN5YP/9QeWyh3QUcZD688M4IxzzGMfDY6nAN8wVjI7Wn2ajqzLPQ==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1013.0.tgz",
+					"integrity": "sha512-x125RhVhxc5iu1ijFOWBEiO8V59au2/ZH5eQtTXTqDmD8mm7XDlErIxCN7V/AucACX89ROnEtdD5CVuid4Poqg==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-base": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
-						"@fluidframework/server-services-core": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-base": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
+						"@fluidframework/server-services-client": "^0.1013.0",
+						"@fluidframework/server-services-core": "^0.1013.0",
 						"@types/semver": "^6.0.1",
 						"async": "^2.6.1",
 						"double-ended-queue": "^2.1.0-0",
@@ -2042,31 +2064,31 @@
 					}
 				},
 				"@fluidframework/server-local-server": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1012.2.tgz",
-					"integrity": "sha512-CWZcirCpqI7a2IW78GeEc26bwPTCiWXkAB9EdMo3ex3Eira5+EIfwFDsuRgb+MuSCbsg3tpXWZDmZm4QdJNZIQ==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1013.0.tgz",
+					"integrity": "sha512-ibzSUPia8pfOcgY4HAQFtBAWnAqR2nQ2wqvIGo5cILeCjrCOzKOQt5Pdbp4lS2Ll641uBFj4Ytl+ZGiQm9ooKg==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-lambdas": "^0.1012.2",
-						"@fluidframework/server-memory-orderer": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
-						"@fluidframework/server-services-core": "^0.1012.2",
-						"@fluidframework/server-test-utils": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
+						"@fluidframework/server-lambdas": "^0.1013.0",
+						"@fluidframework/server-memory-orderer": "^0.1013.0",
+						"@fluidframework/server-services-client": "^0.1013.0",
+						"@fluidframework/server-services-core": "^0.1013.0",
+						"@fluidframework/server-test-utils": "^0.1013.0",
 						"uuid": "^3.3.2"
 					}
 				},
 				"@fluidframework/server-memory-orderer": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1012.2.tgz",
-					"integrity": "sha512-6VDnXD0fj93SI9D3VIdxlKiNfnFjUsjZsNlDBlqyrGbTj7VYMIrsm9FbxjHuWxG/1pWxqdy4CQvbG3r5s0Me/g==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1013.0.tgz",
+					"integrity": "sha512-KqwwYGEChWF7KNRRSCJY/fyWANdenWM6ljtqn+iLIAEdlkQT1wjgUYCAQk0mD2PgjaybtKYpVx3nSwRz6DvRTA==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/protocol-base": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-lambdas": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
-						"@fluidframework/server-services-core": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/protocol-base": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
+						"@fluidframework/server-lambdas": "^0.1013.0",
+						"@fluidframework/server-services-client": "^0.1013.0",
+						"@fluidframework/server-services-core": "^0.1013.0",
 						"@types/debug": "^4.1.5",
 						"@types/double-ended-queue": "^2.1.0",
 						"@types/lodash": "^4.14.118",
@@ -2081,14 +2103,14 @@
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1012.2.tgz",
-					"integrity": "sha512-bmGRVX8V1s/bMapdUHnr8mhQq5NE1++AS3bGSVfzd7GQQPlTz8d26cJA5+4jPe/mJvBMb6MEXstENi3VZOcTNQ==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1013.0.tgz",
+					"integrity": "sha512-OotVg4R8w5jZ/pQT+xAy6JkrCNAegN+3DDZTLZKhRv/zSL2f5l2cMTiUg0kOVJpYhBUNNQ7oRadD0FlwtA837g==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-base": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-base": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
 						"@types/node": "^10.17.24",
 						"axios": "^0.18.0",
 						"debug": "^4.1.1",
@@ -2098,14 +2120,14 @@
 					}
 				},
 				"@fluidframework/server-services-core": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1012.2.tgz",
-					"integrity": "sha512-E1Q/sDLgtQ7fIcaaXiZWWKOa3IRuZKE24fC0QmnmxUYDPUP1yT7kacr0r5wQTibn+eWhAyg/rRRfdRPEe9+YQg==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1013.0.tgz",
+					"integrity": "sha512-LNV1Fvczjj/sT9ZN3g201oyBLL+m8p8zYkRrhRzcPoH6hVv6q1xiYmEbfAjpM7aAjQlVho7bHDu3a45tttdamQ==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
+						"@fluidframework/server-services-client": "^0.1013.0",
 						"@types/nconf": "^0.0.37",
 						"@types/node": "^10.17.24",
 						"debug": "^4.1.1",
@@ -2113,16 +2135,16 @@
 					}
 				},
 				"@fluidframework/server-test-utils": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1012.2.tgz",
-					"integrity": "sha512-jX/O+6EnSaU5YoAV4oj/gWe5weTmLhuvKrup1wFLIcselFycVTW1bc4pm+2JvZ21KhV16a8l54Ho9Vzz1JqvCA==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1013.0.tgz",
+					"integrity": "sha512-qxGIfLg050c/4zjcB3D/LfwHRPqwvx7djqVW7KppQ/QIu3uK1SrrT9jehC8SFkOuaIULG1tYMwEf/CeFbkEWnA==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-base": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
-						"@fluidframework/server-services-core": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-base": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
+						"@fluidframework/server-services-client": "^0.1013.0",
+						"@fluidframework/server-services-core": "^0.1013.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
 						"string-hash": "^1.1.3",
@@ -2137,25 +2159,25 @@
 			}
 		},
 		"@fluidframework/map": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.26.10.tgz",
-			"integrity": "sha512-AU0OS4Q76XNMTiMVxj+2w8EzV51suts2AUNHINvWK4h4YkiOx8W24+rFeZWmwHoxJbPICBnr4Xzp9m0qYEH5XA==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.27.9.tgz",
+			"integrity": "sha512-2HpyWJNi7W3NgUKctKDBpMKwRmk562rNeBYccYhv3CL9OMYHE6umKzzVOkrHMx26JkNd8x441zLAePBojkmRww==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/datastore-definitions": "^0.26.10",
-				"@fluidframework/protocol-base": "^0.1012.0",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.10",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/protocol-base": "^0.1013.0",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/shared-object-base": "^0.27.9",
 				"debug": "^4.1.1",
 				"path-browserify": "^1.0.1"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -2163,31 +2185,30 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.2.tgz",
-					"integrity": "sha512-ysb9skxUKtIUSNUFqqcTQBMpCDrPcezc4pvDLaBdxcK4BuP3Ak2gZGmIVeXfbsx40+isBQ8xGbJISIZlgtGlZw=="
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1013.0.tgz",
+					"integrity": "sha512-X1j5sUNcpWnmyXCQjPx0C2d5jed3OgHnq3vRVzPwVmvGhu7B+tofsbJEMExMHX/J+ambDHq40ipEA55sTuXdwQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.2.tgz",
-					"integrity": "sha512-K8YRUIvrlO+54hyzLgLhZ9tQNeyPd9/yX0h/6XEE4m0oazCcCOFihAFzBIQXxypv1zNH2fbKlsQ7xaHHDbZ6rA==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1013.0.tgz",
+					"integrity": "sha512-2Y6Iu3rQut21aFS+oTYeIKAyyRkYeqMYJ+xAP8wSW0R6eiZPz3q1EhcXpJkEW9f5y84FNjbNsfV9jqI29URMHg==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -2195,22 +2216,23 @@
 			}
 		},
 		"@fluidframework/merge-tree": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.26.10.tgz",
-			"integrity": "sha512-uQs5LN8G3Baf1BPSUjUta6KbdxVns6+un0vUKayDEhnlQhw0KnXNCZwHLyD6P2GY14e5lVFq42beW7S+wIbqsA==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.27.9.tgz",
+			"integrity": "sha512-9fhdoZYVeKs2OlXY/Yn+b23Me8tALocmyGhUtdO68t8u8FQt0IlvrKLNmaf3e5slTkb/ShFUIr0bPJNZba5zag==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/datastore-definitions": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/telemetry-utils": "^0.26.10"
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/container-definitions": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/telemetry-utils": "^0.27.9"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -2218,14 +2240,13 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -2260,21 +2281,21 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.26.10.tgz",
-			"integrity": "sha512-VV7BWQUVm5fIoYKDpvzj1R/cSAMyqPlLWqIBCD4i00CRP059ALPLLZWfoMV1stCW53rIC5/3FKpQAcF+APMclA==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.27.9.tgz",
+			"integrity": "sha512-iNCGzwnQed65Y3JytjL1BdPGgz1BQVbpNx1eWpydnixiYcg1ASPpcqZA3HuZQtOswIcn8wCl7lqBXo6H4/yd1A==",
 			"requires": {
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/datastore-definitions": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.10",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/shared-object-base": "^0.27.9",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -2282,14 +2303,13 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -2297,30 +2317,30 @@
 			}
 		},
 		"@fluidframework/request-handler": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.26.10.tgz",
-			"integrity": "sha512-TXKddv6WayDB8U3WSBlxvLaT3++09mftTwpdAeNm8ihvD1x2y7qEUbWP3GeiYHTsU3tA3uEqElM8F/9tH2hc5g==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.27.9.tgz",
+			"integrity": "sha512-b6ujBkwJrqfCU1UOiyW4AOx68qk3UZobYGH6c+NkdLYH/LpQxD/C680hDhxLl3YD51ULfSPvkv8CCmJOhFXz0Q==",
 			"requires": {
-				"@fluidframework/container-runtime-definitions": "^0.26.10",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/runtime-definitions": "^0.26.10",
-				"@fluidframework/runtime-utils": "^0.26.10"
+				"@fluidframework/container-runtime-definitions": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/runtime-definitions": "^0.27.9",
+				"@fluidframework/runtime-utils": "^0.27.9"
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.26.10.tgz",
-			"integrity": "sha512-NwmaMQesIrNQrQHMeREZ8saqek2nFj2W02wpZg2kG0MtrIrez2zWapnkTCY2eOoj5tfK1etArGttLUKBD8tEoQ==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.27.9.tgz",
+			"integrity": "sha512-3jnQwgqnFIX+naI/vHkDLlqf6azdTtyoHcCwI8fxCncZlEsU3O/4D4Lq0nypYHWFmH8reSb42BxORgTCBzjC6Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/driver-base": "^0.26.10",
-				"@fluidframework/driver-definitions": "^0.26.10",
-				"@fluidframework/driver-utils": "^0.26.10",
-				"@fluidframework/gitresources": "^0.1012.0",
-				"@fluidframework/protocol-base": "^0.1012.0",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/server-services-client": "^0.1012.0",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/driver-base": "^0.27.9",
+				"@fluidframework/driver-definitions": "^0.27.9",
+				"@fluidframework/driver-utils": "^0.27.9",
+				"@fluidframework/gitresources": "^0.1013.0",
+				"@fluidframework/protocol-base": "^0.1013.0",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/server-services-client": "^0.1013.0",
 				"axios": "^0.18.0",
 				"debug": "^4.1.1",
 				"isomorphic-ws": "^4.0.1",
@@ -2330,9 +2350,9 @@
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -2340,44 +2360,43 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.2.tgz",
-					"integrity": "sha512-ysb9skxUKtIUSNUFqqcTQBMpCDrPcezc4pvDLaBdxcK4BuP3Ak2gZGmIVeXfbsx40+isBQ8xGbJISIZlgtGlZw=="
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1013.0.tgz",
+					"integrity": "sha512-X1j5sUNcpWnmyXCQjPx0C2d5jed3OgHnq3vRVzPwVmvGhu7B+tofsbJEMExMHX/J+ambDHq40ipEA55sTuXdwQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.2.tgz",
-					"integrity": "sha512-K8YRUIvrlO+54hyzLgLhZ9tQNeyPd9/yX0h/6XEE4m0oazCcCOFihAFzBIQXxypv1zNH2fbKlsQ7xaHHDbZ6rA==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1013.0.tgz",
+					"integrity": "sha512-2Y6Iu3rQut21aFS+oTYeIKAyyRkYeqMYJ+xAP8wSW0R6eiZPz3q1EhcXpJkEW9f5y84FNjbNsfV9jqI29URMHg==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1012.2.tgz",
-					"integrity": "sha512-bmGRVX8V1s/bMapdUHnr8mhQq5NE1++AS3bGSVfzd7GQQPlTz8d26cJA5+4jPe/mJvBMb6MEXstENi3VZOcTNQ==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1013.0.tgz",
+					"integrity": "sha512-OotVg4R8w5jZ/pQT+xAy6JkrCNAegN+3DDZTLZKhRv/zSL2f5l2cMTiUg0kOVJpYhBUNNQ7oRadD0FlwtA837g==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-base": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-base": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
 						"@types/node": "^10.17.24",
 						"axios": "^0.18.0",
 						"debug": "^4.1.1",
@@ -2389,46 +2408,23 @@
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.26.10.tgz",
-			"integrity": "sha512-Q6eCn7FidM09Wk2nXmx9/EsPl2EX5JIrNBYdqcHrx2NVn9L3zOO6woecauG9Fet4NxDgJlGFXC2e7LQ6tqhTBg==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.27.9.tgz",
+			"integrity": "sha512-4DMoR36DA7hQgHo/tdAdE60KyjOfNztEHvhkZjtNz2jZIiAaxPvR/VlDE3v9jaVxx1gTtq2J4nsj4W6C6yotMw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.26.10",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/driver-definitions": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/container-definitions": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/driver-definitions": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
 				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
-					}
-				}
-			}
-		},
-		"@fluidframework/runtime-utils": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.26.10.tgz",
-			"integrity": "sha512-CQ1T+qLrPo6KekqA9qdFrp28w2xxQGJqdxrctVM2Z6ysMhwiNld42UntZxgdI7sTW7ob9cSHA4CnQo7ayjLUrA==",
-			"requires": {
-				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/datastore-definitions": "^0.26.10",
-				"@fluidframework/protocol-base": "^0.1012.0",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.10"
-			},
-			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -2436,31 +2432,68 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"@fluidframework/protocol-definitions": {
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.19.1"
+					}
+				}
+			}
+		},
+		"@fluidframework/runtime-utils": {
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.27.9.tgz",
+			"integrity": "sha512-7OiqrH7Wu4n9LuyScShgdCMMrSLCoe+J+Lt9JQ7hopcxsibc1Fg7gfTlEVmfv3CuKy7XlqdLVIqpiyG4YqDvWQ==",
+			"requires": {
+				"@fluidframework/common-definitions": "^0.19.1",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/protocol-base": "^0.1013.0",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/runtime-definitions": "^0.27.9"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.19.1",
+						"@types/events": "^3.0.0",
+						"assert": "^2.0.0",
+						"base64-js": "^1.3.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.19",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.2.tgz",
-					"integrity": "sha512-ysb9skxUKtIUSNUFqqcTQBMpCDrPcezc4pvDLaBdxcK4BuP3Ak2gZGmIVeXfbsx40+isBQ8xGbJISIZlgtGlZw=="
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1013.0.tgz",
+					"integrity": "sha512-X1j5sUNcpWnmyXCQjPx0C2d5jed3OgHnq3vRVzPwVmvGhu7B+tofsbJEMExMHX/J+ambDHq40ipEA55sTuXdwQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.2.tgz",
-					"integrity": "sha512-K8YRUIvrlO+54hyzLgLhZ9tQNeyPd9/yX0h/6XEE4m0oazCcCOFihAFzBIQXxypv1zNH2fbKlsQ7xaHHDbZ6rA==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1013.0.tgz",
+					"integrity": "sha512-2Y6Iu3rQut21aFS+oTYeIKAyyRkYeqMYJ+xAP8wSW0R6eiZPz3q1EhcXpJkEW9f5y84FNjbNsfV9jqI29URMHg==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -2617,17 +2650,17 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.26.10.tgz",
-			"integrity": "sha512-atMr7t7RdGA/dBsfhB2bIHJrRoDgGQgIFVL7JBcAHcKooiSMTsYJTYCxJFj1lKr20WIERS6JYXZYPlUxEAd3Ow==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.27.9.tgz",
+			"integrity": "sha512-diWgDrVLpZaIqtLIrEzA+sg0cnzzYyXL+TANY+sPJgQvMkGVlI/FNj4yJeZb8L3c/cmkco2edBTg/sf2ARDXoA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.26.10",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/datastore": "^0.26.10",
-				"@fluidframework/datastore-definitions": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/telemetry-utils": "^0.26.10",
+				"@fluidframework/container-definitions": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/datastore": "^0.27.9",
+				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/telemetry-utils": "^0.27.9",
 				"@types/debug": "^4.1.5",
 				"@types/node": "^10.17.24",
 				"debug": "^4.1.1",
@@ -2635,9 +2668,9 @@
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -2645,28 +2678,28 @@
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.26.10.tgz",
-			"integrity": "sha512-Gg9eSOu05vesLp9vQfnVjncs+10YXeoAAhu+EoiFMoxuFOS+qxTc15bSXWUSaeR5EzfMjVyx1KBeWrEemRI8ug==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.27.9.tgz",
+			"integrity": "sha512-iN4y2iiRKEO4aRbG20t+Barw28OURFJUOat4lNJINh6l4sysqTdK0sKcWSAIU48d/jxMxFJgd2yOb9cJ5UcYGg==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^0.26.10"
+				"@fluidframework/core-interfaces": "^0.27.9"
 			}
 		},
 		"@fluidframework/telemetry-utils": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.26.10.tgz",
-			"integrity": "sha512-AEbtpp+B04Vi08AdrOLKuM6tcY0Eo7bqq+cnNUZrC5CLta52Xa2vVWm8bn/b1bGz54kSekAMfcnhHACxZuuJMQ==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.27.9.tgz",
+			"integrity": "sha512-PACWhHNpF630Y3TlUlagmzvv5kmzbM1/cWJFmqjozJLCZw4967sxiKxbo15B6h2AFZicO1Ulv2hd5IoM5R666A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.23.0",
+				"@fluidframework/common-utils": "^0.24.0",
 				"debug": "^4.1.1",
 				"events": "^3.1.0"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -2674,7 +2707,6 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				}
@@ -2687,11 +2719,11 @@
 			"dev": true
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.26.10.tgz",
-			"integrity": "sha512-kHbXxBsxpRZFgVIDmfkUpHhYaNif/GoLGGsCPKujVc9ZR8v8UR8P+MocIQKVSbgoMEnt1EliriWB6Ewl06wYoA==",
+			"version": "0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.27.9.tgz",
+			"integrity": "sha512-5RGeKFbCWl2C2fmO7uaBK2LWtemy3LloLfGY9DyiiF4qBemqNtpE/Pc8tA+1tNrYkKqm+H5GTZIcQnhD4p5GrA==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^0.26.10"
+				"@fluidframework/core-interfaces": "^0.27.9"
 			}
 		},
 		"@hapi/address": {
@@ -4632,7 +4664,7 @@
 		"@microsoft/tsdoc": {
 			"version": "0.12.19",
 			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.19.tgz",
-			"integrity": "sha512-IpgPxHrNxZiMNUSXqR1l/gePKPkfAmIKoDRP9hp7OwjU29ZR8WCJsOJ8iBKgw0Qk+pFwR+8Y1cy8ImLY6e9m4A==",
+			"integrity": "sha1-IXPMuSRpqvYgMfqUmdIbFtB/m1c=",
 			"dev": true
 		},
 		"@mixer/webpack-bundle-compare": {
@@ -7064,7 +7096,6 @@
 			"version": "10.1.1",
 			"resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.1.1.tgz",
 			"integrity": "sha512-P4Hyrh/+Nzc2KXQk73z72/GsenSWIH5o8uiyELqykJYs9TWTVCxVwghoR7lPeiY6QVoXkq2S2KtvAgi5fyjl9w==",
-			"dev": true,
 			"requires": {
 				"tunnel": "0.0.6",
 				"typed-rest-client": "^1.7.3",
@@ -13777,8 +13808,7 @@
 		"immediate": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
-			"dev": true
+			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
 		},
 		"import-fresh": {
 			"version": "2.0.0",
@@ -17068,7 +17098,6 @@
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
 			"integrity": "sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==",
-			"dev": true,
 			"requires": {
 				"lie": "~3.3.0",
 				"pako": "~1.0.2",
@@ -17079,14 +17108,12 @@
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"dev": true
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"readable-stream": {
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -17101,7 +17128,6 @@
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -17299,7 +17325,6 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
 			"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-			"dev": true,
 			"requires": {
 				"immediate": "~3.0.5"
 			}
@@ -19735,32 +19760,32 @@
 			}
 		},
 		"old-aqueduct": {
-			"version": "npm:@fluidframework/aqueduct@0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.26.10.tgz",
-			"integrity": "sha512-0ZOy/jPUqnzf/YxLHtJZ02JT6EKCbn6AX3dS5+BsAzmgC0hwb9UzBa0mprM65YRX6q3Ut1DoDwbDxdGdpHjB9g==",
+			"version": "npm:@fluidframework/aqueduct@0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.27.9.tgz",
+			"integrity": "sha512-jmLsStg4+GdnIy01+d5/50ut/ojIoijvzuF907S9cB9d1miTWfN252qSYBwoxZAJc9R7aMhQ4+1IV4zotRkKSg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.10",
-				"@fluidframework/container-loader": "^0.26.10",
-				"@fluidframework/container-runtime": "^0.26.10",
-				"@fluidframework/container-runtime-definitions": "^0.26.10",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/datastore": "^0.26.10",
-				"@fluidframework/datastore-definitions": "^0.26.10",
-				"@fluidframework/map": "^0.26.10",
-				"@fluidframework/request-handler": "^0.26.10",
-				"@fluidframework/runtime-definitions": "^0.26.10",
-				"@fluidframework/runtime-utils": "^0.26.10",
-				"@fluidframework/synthesize": "^0.26.10",
-				"@fluidframework/view-interfaces": "^0.26.10",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/container-definitions": "^0.27.9",
+				"@fluidframework/container-loader": "^0.27.9",
+				"@fluidframework/container-runtime": "^0.27.9",
+				"@fluidframework/container-runtime-definitions": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/datastore": "^0.27.9",
+				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/map": "^0.27.9",
+				"@fluidframework/request-handler": "^0.27.9",
+				"@fluidframework/runtime-definitions": "^0.27.9",
+				"@fluidframework/runtime-utils": "^0.27.9",
+				"@fluidframework/synthesize": "^0.27.9",
+				"@fluidframework/view-interfaces": "^0.27.9",
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -19768,29 +19793,28 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				}
 			}
 		},
 		"old-cell": {
-			"version": "npm:@fluidframework/cell@0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.26.10.tgz",
-			"integrity": "sha512-bRDzrp70bFXWphGkZFjTTQtTWOApKTXsTXjZVdLjGRcxmEPiKDIC29JnEdwSFtH0yDvGlais/k7df/KR1dwt2g==",
+			"version": "npm:@fluidframework/cell@0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.27.9.tgz",
+			"integrity": "sha512-bkqZgoEBKzc4mWN6DPCdeL3dSWJgtNMfl89c/MYNtIP0P7xlTVFawuJMWJLJMjTptBiQZ93CiHg2RPOuFfzFDA==",
 			"requires": {
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/datastore-definitions": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.10",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/shared-object-base": "^0.27.9",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -19798,14 +19822,13 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -19813,20 +19836,20 @@
 			}
 		},
 		"old-container-definitions": {
-			"version": "npm:@fluidframework/container-definitions@0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.26.10.tgz",
-			"integrity": "sha512-iwHNUKPvf52ZICpNXPxhrYO/t2YWqB2vFg99TyqCuqSTPL7GcnkXb0zyxofOAw/DcR4rZOno1PXb+RdxDHp2pw==",
+			"version": "npm:@fluidframework/container-definitions@0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.27.9.tgz",
+			"integrity": "sha512-D4M2awBMXek/F0mTgKdETwmKbq9L+s5/prUoJjvK/+Ffr3q7/MqeFLAgubRUWwOHgmpDi4TjVqrPx7gnKscRPw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/driver-definitions": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0"
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/driver-definitions": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -19834,20 +19857,20 @@
 			}
 		},
 		"old-container-loader": {
-			"version": "npm:@fluidframework/container-loader@0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.26.10.tgz",
-			"integrity": "sha512-YtG2nR+Lm8+MlG45VtxHpQsoHDYO/Q8cmxFjFcQjx921jkraKqoc1PrnKQXZ+fPgxluxEDHN340CZY4CCgrt7Q==",
+			"version": "npm:@fluidframework/container-loader@0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.27.9.tgz",
+			"integrity": "sha512-obzZqFApU4PyWD4597BDhgj8Fi3hjnAWBcl5wnXHqByYtSg2mB3y8R28oD561c6pYINse3N+vETD9O+WXNxEvg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.10",
-				"@fluidframework/container-utils": "^0.26.10",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/driver-definitions": "^0.26.10",
-				"@fluidframework/driver-utils": "^0.26.10",
-				"@fluidframework/protocol-base": "^0.1012.0",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/telemetry-utils": "^0.26.10",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/container-definitions": "^0.27.9",
+				"@fluidframework/container-utils": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/driver-definitions": "^0.27.9",
+				"@fluidframework/driver-utils": "^0.27.9",
+				"@fluidframework/protocol-base": "^0.1013.0",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/telemetry-utils": "^0.27.9",
 				"@types/double-ended-queue": "^2.1.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -19856,9 +19879,9 @@
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -19866,31 +19889,30 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.2.tgz",
-					"integrity": "sha512-ysb9skxUKtIUSNUFqqcTQBMpCDrPcezc4pvDLaBdxcK4BuP3Ak2gZGmIVeXfbsx40+isBQ8xGbJISIZlgtGlZw=="
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1013.0.tgz",
+					"integrity": "sha512-X1j5sUNcpWnmyXCQjPx0C2d5jed3OgHnq3vRVzPwVmvGhu7B+tofsbJEMExMHX/J+ambDHq40ipEA55sTuXdwQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.2.tgz",
-					"integrity": "sha512-K8YRUIvrlO+54hyzLgLhZ9tQNeyPd9/yX0h/6XEE4m0oazCcCOFihAFzBIQXxypv1zNH2fbKlsQ7xaHHDbZ6rA==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1013.0.tgz",
+					"integrity": "sha512-2Y6Iu3rQut21aFS+oTYeIKAyyRkYeqMYJ+xAP8wSW0R6eiZPz3q1EhcXpJkEW9f5y84FNjbNsfV9jqI29URMHg==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -19898,25 +19920,25 @@
 			}
 		},
 		"old-container-runtime": {
-			"version": "npm:@fluidframework/container-runtime@0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.26.10.tgz",
-			"integrity": "sha512-Xye5T1brL5U4AzHHg90dz73XbzE2C5SYC5w4M3HVE7DbSXErphV48g7IWgdTpzhQMDG6mZ18P/FFPdMuS+kseQ==",
+			"version": "npm:@fluidframework/container-runtime@0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.27.9.tgz",
+			"integrity": "sha512-58a8WLongv1TJ9OOoCqLhPv5sKvVmXhDD3ywjjsbxdZ85AmLsVDn41SOlLuNk5B7pLxZxVvaSaPVPI4z5Ha38w==",
 			"requires": {
-				"@fluidframework/agent-scheduler": "^0.26.10",
+				"@fluidframework/agent-scheduler": "^0.27.9",
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/container-definitions": "^0.26.10",
-				"@fluidframework/container-runtime-definitions": "^0.26.10",
-				"@fluidframework/container-utils": "^0.26.10",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/datastore": "^0.26.10",
-				"@fluidframework/driver-definitions": "^0.26.10",
-				"@fluidframework/driver-utils": "^0.26.10",
-				"@fluidframework/protocol-base": "^0.1012.0",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.10",
-				"@fluidframework/runtime-utils": "^0.26.10",
-				"@fluidframework/telemetry-utils": "^0.26.10",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/container-definitions": "^0.27.9",
+				"@fluidframework/container-runtime-definitions": "^0.27.9",
+				"@fluidframework/container-utils": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/datastore": "^0.27.9",
+				"@fluidframework/driver-definitions": "^0.27.9",
+				"@fluidframework/driver-utils": "^0.27.9",
+				"@fluidframework/protocol-base": "^0.1013.0",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/runtime-definitions": "^0.27.9",
+				"@fluidframework/runtime-utils": "^0.27.9",
+				"@fluidframework/telemetry-utils": "^0.27.9",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/node": "^10.17.24",
@@ -19927,9 +19949,9 @@
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -19937,31 +19959,30 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.2.tgz",
-					"integrity": "sha512-ysb9skxUKtIUSNUFqqcTQBMpCDrPcezc4pvDLaBdxcK4BuP3Ak2gZGmIVeXfbsx40+isBQ8xGbJISIZlgtGlZw=="
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1013.0.tgz",
+					"integrity": "sha512-X1j5sUNcpWnmyXCQjPx0C2d5jed3OgHnq3vRVzPwVmvGhu7B+tofsbJEMExMHX/J+ambDHq40ipEA55sTuXdwQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.2.tgz",
-					"integrity": "sha512-K8YRUIvrlO+54hyzLgLhZ9tQNeyPd9/yX0h/6XEE4m0oazCcCOFihAFzBIQXxypv1zNH2fbKlsQ7xaHHDbZ6rA==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1013.0.tgz",
+					"integrity": "sha512-2Y6Iu3rQut21aFS+oTYeIKAyyRkYeqMYJ+xAP8wSW0R6eiZPz3q1EhcXpJkEW9f5y84FNjbNsfV9jqI29URMHg==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -19969,21 +19990,21 @@
 			}
 		},
 		"old-counter": {
-			"version": "npm:@fluidframework/counter@0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.26.10.tgz",
-			"integrity": "sha512-ToywQKpgxXxN/OXNv/vTx9ywCKfDo5wMLmUBi8nz/FcMvcMTPY8lbZMPqVGv7EpTFoTSIDtdtGqwTG70E1fSKA==",
+			"version": "npm:@fluidframework/counter@0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.27.9.tgz",
+			"integrity": "sha512-mh31VQEtzPIYeSj1DBQTmFcKrBlopF3aBmX/6YI8mDPSaEcVrLVjGxlq+j9RaOqtuB8YgUh8lIeZaV3pDvfl1g==",
 			"requires": {
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/datastore-definitions": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.10",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/shared-object-base": "^0.27.9",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -19991,14 +20012,13 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -20006,22 +20026,37 @@
 			}
 		},
 		"old-datastore-definitions": {
-			"version": "npm:@fluidframework/datastore-definitions@0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.26.10.tgz",
-			"integrity": "sha512-BMbfck/XYfx4PJLYWK9CHEmKStm+GZR/QQI9Og9gq3VXIZjRhxJZ5yCDl6HNbaMd8IriMKubukNTR5ottTVHEA==",
+			"version": "npm:@fluidframework/datastore-definitions@0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.27.9.tgz",
+			"integrity": "sha512-nZC1570Jc+mPCFfL7rEAyDh5JCnIMMVjGfP05mWVn6PzOuU6iPaWqFysLMBsi04yYfp5BdfCNKiceAjLV9KmZQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.26.10",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-definitions": "^0.26.10",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/container-definitions": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/runtime-definitions": "^0.27.9",
 				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.19.1",
+						"@types/events": "^3.0.0",
+						"assert": "^2.0.0",
+						"base64-js": "^1.3.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.19",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -20029,19 +20064,19 @@
 			}
 		},
 		"old-driver-definitions": {
-			"version": "npm:@fluidframework/driver-definitions@0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.26.10.tgz",
-			"integrity": "sha512-nKAyvxz8bgqR0UhhiXjAppU33iajlgiga+dsqy94Uau8WDC5OqxAlfuv6Qmlduw22pz0MHDXP4VENMNrNkDXnQ==",
+			"version": "npm:@fluidframework/driver-definitions@0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.27.9.tgz",
+			"integrity": "sha512-55yiu8FHhpgHPnzMSm7f1Ls01clPkaGj2Doz5VMLWx6Y7R6qHCAB/JG291csOHn47O3Bus9D+GD8sUrD9/AnFA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0"
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0"
 			},
 			"dependencies": {
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -20049,23 +20084,23 @@
 			}
 		},
 		"old-ink": {
-			"version": "npm:@fluidframework/ink@0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.26.10.tgz",
-			"integrity": "sha512-Gn/cvH10cd+I7lZ0XW6qLP536jwXaArLKjTGNtUUq0Tj0mEU6+BltiLKlKWusoLywIjJ2M27h5iFocNtI79N2A==",
+			"version": "npm:@fluidframework/ink@0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.27.9.tgz",
+			"integrity": "sha512-LsMVgUVl8ANgPbPRSM2F3SsP+OGLA73CVWCcvq2lEwUlt1hwUS27Xh/hCocujG/pyO2bVcQya7BG1//+9sb5ZQ==",
 			"requires": {
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/datastore-definitions": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.10",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/shared-object-base": "^0.27.9",
 				"@types/debug": "^4.1.5",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -20073,14 +20108,13 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -20088,29 +20122,29 @@
 			}
 		},
 		"old-local-driver": {
-			"version": "npm:@fluidframework/local-driver@0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.26.10.tgz",
-			"integrity": "sha512-h+P7FPnTkTixM6KBHre3n3WLRuOpRcN16yNPF7JuVUhhPJmBa6Dmx1pdjECEQwvKFfddorWMF/WeQK3JyfXyRA==",
+			"version": "npm:@fluidframework/local-driver@0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.27.9.tgz",
+			"integrity": "sha512-gjBgytObNaTezCISC9oY/0BdKO9Up45Hq3vhMGBndbPfW69ukKnrbvhKi43N/ST/kb25mkH0wk2370xkZQDZYw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/driver-definitions": "^0.26.10",
-				"@fluidframework/driver-utils": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/routerlicious-driver": "^0.26.10",
-				"@fluidframework/server-local-server": "^0.1012.0",
-				"@fluidframework/server-services-client": "^0.1012.0",
-				"@fluidframework/server-services-core": "^0.1012.0",
-				"@fluidframework/server-test-utils": "^0.1012.0",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/driver-definitions": "^0.27.9",
+				"@fluidframework/driver-utils": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/routerlicious-driver": "^0.27.9",
+				"@fluidframework/server-local-server": "^0.1013.0",
+				"@fluidframework/server-services-client": "^0.1013.0",
+				"@fluidframework/server-services-core": "^0.1013.0",
+				"@fluidframework/server-test-utils": "^0.1013.0",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -20118,46 +20152,45 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.2.tgz",
-					"integrity": "sha512-ysb9skxUKtIUSNUFqqcTQBMpCDrPcezc4pvDLaBdxcK4BuP3Ak2gZGmIVeXfbsx40+isBQ8xGbJISIZlgtGlZw=="
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1013.0.tgz",
+					"integrity": "sha512-X1j5sUNcpWnmyXCQjPx0C2d5jed3OgHnq3vRVzPwVmvGhu7B+tofsbJEMExMHX/J+ambDHq40ipEA55sTuXdwQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.2.tgz",
-					"integrity": "sha512-K8YRUIvrlO+54hyzLgLhZ9tQNeyPd9/yX0h/6XEE4m0oazCcCOFihAFzBIQXxypv1zNH2fbKlsQ7xaHHDbZ6rA==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1013.0.tgz",
+					"integrity": "sha512-2Y6Iu3rQut21aFS+oTYeIKAyyRkYeqMYJ+xAP8wSW0R6eiZPz3q1EhcXpJkEW9f5y84FNjbNsfV9jqI29URMHg==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
 				},
 				"@fluidframework/server-lambdas": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1012.2.tgz",
-					"integrity": "sha512-r/FPMZfami9yD/ZDo0BRvQwkcVlD2PnOgYeN5YP/9QeWyh3QUcZD688M4IxzzGMfDY6nAN8wVjI7Wn2ajqzLPQ==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1013.0.tgz",
+					"integrity": "sha512-x125RhVhxc5iu1ijFOWBEiO8V59au2/ZH5eQtTXTqDmD8mm7XDlErIxCN7V/AucACX89ROnEtdD5CVuid4Poqg==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-base": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
-						"@fluidframework/server-services-core": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-base": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
+						"@fluidframework/server-services-client": "^0.1013.0",
+						"@fluidframework/server-services-core": "^0.1013.0",
 						"@types/semver": "^6.0.1",
 						"async": "^2.6.1",
 						"double-ended-queue": "^2.1.0-0",
@@ -20170,31 +20203,31 @@
 					}
 				},
 				"@fluidframework/server-local-server": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1012.2.tgz",
-					"integrity": "sha512-CWZcirCpqI7a2IW78GeEc26bwPTCiWXkAB9EdMo3ex3Eira5+EIfwFDsuRgb+MuSCbsg3tpXWZDmZm4QdJNZIQ==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1013.0.tgz",
+					"integrity": "sha512-ibzSUPia8pfOcgY4HAQFtBAWnAqR2nQ2wqvIGo5cILeCjrCOzKOQt5Pdbp4lS2Ll641uBFj4Ytl+ZGiQm9ooKg==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-lambdas": "^0.1012.2",
-						"@fluidframework/server-memory-orderer": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
-						"@fluidframework/server-services-core": "^0.1012.2",
-						"@fluidframework/server-test-utils": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
+						"@fluidframework/server-lambdas": "^0.1013.0",
+						"@fluidframework/server-memory-orderer": "^0.1013.0",
+						"@fluidframework/server-services-client": "^0.1013.0",
+						"@fluidframework/server-services-core": "^0.1013.0",
+						"@fluidframework/server-test-utils": "^0.1013.0",
 						"uuid": "^3.3.2"
 					}
 				},
 				"@fluidframework/server-memory-orderer": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1012.2.tgz",
-					"integrity": "sha512-6VDnXD0fj93SI9D3VIdxlKiNfnFjUsjZsNlDBlqyrGbTj7VYMIrsm9FbxjHuWxG/1pWxqdy4CQvbG3r5s0Me/g==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1013.0.tgz",
+					"integrity": "sha512-KqwwYGEChWF7KNRRSCJY/fyWANdenWM6ljtqn+iLIAEdlkQT1wjgUYCAQk0mD2PgjaybtKYpVx3nSwRz6DvRTA==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/protocol-base": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-lambdas": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
-						"@fluidframework/server-services-core": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/protocol-base": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
+						"@fluidframework/server-lambdas": "^0.1013.0",
+						"@fluidframework/server-services-client": "^0.1013.0",
+						"@fluidframework/server-services-core": "^0.1013.0",
 						"@types/debug": "^4.1.5",
 						"@types/double-ended-queue": "^2.1.0",
 						"@types/lodash": "^4.14.118",
@@ -20209,14 +20242,14 @@
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1012.2.tgz",
-					"integrity": "sha512-bmGRVX8V1s/bMapdUHnr8mhQq5NE1++AS3bGSVfzd7GQQPlTz8d26cJA5+4jPe/mJvBMb6MEXstENi3VZOcTNQ==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1013.0.tgz",
+					"integrity": "sha512-OotVg4R8w5jZ/pQT+xAy6JkrCNAegN+3DDZTLZKhRv/zSL2f5l2cMTiUg0kOVJpYhBUNNQ7oRadD0FlwtA837g==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-base": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-base": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
 						"@types/node": "^10.17.24",
 						"axios": "^0.18.0",
 						"debug": "^4.1.1",
@@ -20226,14 +20259,14 @@
 					}
 				},
 				"@fluidframework/server-services-core": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1012.2.tgz",
-					"integrity": "sha512-E1Q/sDLgtQ7fIcaaXiZWWKOa3IRuZKE24fC0QmnmxUYDPUP1yT7kacr0r5wQTibn+eWhAyg/rRRfdRPEe9+YQg==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1013.0.tgz",
+					"integrity": "sha512-LNV1Fvczjj/sT9ZN3g201oyBLL+m8p8zYkRrhRzcPoH6hVv6q1xiYmEbfAjpM7aAjQlVho7bHDu3a45tttdamQ==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
+						"@fluidframework/server-services-client": "^0.1013.0",
 						"@types/nconf": "^0.0.37",
 						"@types/node": "^10.17.24",
 						"debug": "^4.1.1",
@@ -20241,16 +20274,16 @@
 					}
 				},
 				"@fluidframework/server-test-utils": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1012.2.tgz",
-					"integrity": "sha512-jX/O+6EnSaU5YoAV4oj/gWe5weTmLhuvKrup1wFLIcselFycVTW1bc4pm+2JvZ21KhV16a8l54Ho9Vzz1JqvCA==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1013.0.tgz",
+					"integrity": "sha512-qxGIfLg050c/4zjcB3D/LfwHRPqwvx7djqVW7KppQ/QIu3uK1SrrT9jehC8SFkOuaIULG1tYMwEf/CeFbkEWnA==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-base": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
-						"@fluidframework/server-services-core": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-base": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
+						"@fluidframework/server-services-client": "^0.1013.0",
+						"@fluidframework/server-services-core": "^0.1013.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
 						"string-hash": "^1.1.3",
@@ -20265,25 +20298,25 @@
 			}
 		},
 		"old-map": {
-			"version": "npm:@fluidframework/map@0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.26.10.tgz",
-			"integrity": "sha512-AU0OS4Q76XNMTiMVxj+2w8EzV51suts2AUNHINvWK4h4YkiOx8W24+rFeZWmwHoxJbPICBnr4Xzp9m0qYEH5XA==",
+			"version": "npm:@fluidframework/map@0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.27.9.tgz",
+			"integrity": "sha512-2HpyWJNi7W3NgUKctKDBpMKwRmk562rNeBYccYhv3CL9OMYHE6umKzzVOkrHMx26JkNd8x441zLAePBojkmRww==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/datastore-definitions": "^0.26.10",
-				"@fluidframework/protocol-base": "^0.1012.0",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.10",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/protocol-base": "^0.1013.0",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/shared-object-base": "^0.27.9",
 				"debug": "^4.1.1",
 				"path-browserify": "^1.0.1"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -20291,31 +20324,30 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.2.tgz",
-					"integrity": "sha512-ysb9skxUKtIUSNUFqqcTQBMpCDrPcezc4pvDLaBdxcK4BuP3Ak2gZGmIVeXfbsx40+isBQ8xGbJISIZlgtGlZw=="
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1013.0.tgz",
+					"integrity": "sha512-X1j5sUNcpWnmyXCQjPx0C2d5jed3OgHnq3vRVzPwVmvGhu7B+tofsbJEMExMHX/J+ambDHq40ipEA55sTuXdwQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.2.tgz",
-					"integrity": "sha512-K8YRUIvrlO+54hyzLgLhZ9tQNeyPd9/yX0h/6XEE4m0oazCcCOFihAFzBIQXxypv1zNH2fbKlsQ7xaHHDbZ6rA==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1013.0.tgz",
+					"integrity": "sha512-2Y6Iu3rQut21aFS+oTYeIKAyyRkYeqMYJ+xAP8wSW0R6eiZPz3q1EhcXpJkEW9f5y84FNjbNsfV9jqI29URMHg==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -20323,28 +20355,28 @@
 			}
 		},
 		"old-matrix": {
-			"version": "npm:@fluidframework/matrix@0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.26.10.tgz",
-			"integrity": "sha512-XzkZA6uN07K9l8ozer+MtZqoR6pbenRImuQPQeLVGtyANkBQgUtCp5WWj9sGsyVTamW72hFpKKsAi13XnC+GXQ==",
+			"version": "npm:@fluidframework/matrix@0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.27.9.tgz",
+			"integrity": "sha512-IOleYhluOCQFQcCoptx3K1tR4Z3ES2IVoJfoLYA9ll85qd6/raGPlKtkM2zYiRf03iD2HtdAo5REV1/rRS4mdQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/datastore-definitions": "^0.26.10",
-				"@fluidframework/merge-tree": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-utils": "^0.26.10",
-				"@fluidframework/shared-object-base": "^0.26.10",
-				"@fluidframework/telemetry-utils": "^0.26.10",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/merge-tree": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/runtime-utils": "^0.27.9",
+				"@fluidframework/shared-object-base": "^0.27.9",
+				"@fluidframework/telemetry-utils": "^0.27.9",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"debug": "^4.1.1",
 				"tslib": "^1.10.0"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -20352,14 +20384,13 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -20367,21 +20398,21 @@
 			}
 		},
 		"old-ordered-collection": {
-			"version": "npm:@fluidframework/ordered-collection@0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.26.10.tgz",
-			"integrity": "sha512-PGleO7nZQuUEI0KTPcw6V5QP18U9z/4TV2YX1TeXGzegjcYcCG64m/gBOOVD6Zxxr+4aepQFtFmB1Vu9YcUOLg==",
+			"version": "npm:@fluidframework/ordered-collection@0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.27.9.tgz",
+			"integrity": "sha512-sOKMJqGDEIjwojtRCljfdvbUfkwBnS2cwOOYZDewHMBCt1Cc6ctRNqIRncVaWfNIRW3kLFy+Jpw1NQwDFfoOsw==",
 			"requires": {
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/datastore-definitions": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.10",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/shared-object-base": "^0.27.9",
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -20389,14 +20420,13 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -20404,21 +20434,21 @@
 			}
 		},
 		"old-register-collection": {
-			"version": "npm:@fluidframework/register-collection@0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.26.10.tgz",
-			"integrity": "sha512-VV7BWQUVm5fIoYKDpvzj1R/cSAMyqPlLWqIBCD4i00CRP059ALPLLZWfoMV1stCW53rIC5/3FKpQAcF+APMclA==",
+			"version": "npm:@fluidframework/register-collection@0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.27.9.tgz",
+			"integrity": "sha512-iNCGzwnQed65Y3JytjL1BdPGgz1BQVbpNx1eWpydnixiYcg1ASPpcqZA3HuZQtOswIcn8wCl7lqBXo6H4/yd1A==",
 			"requires": {
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/datastore-definitions": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/shared-object-base": "^0.26.10",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/shared-object-base": "^0.27.9",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -20426,14 +20456,13 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -20441,22 +20470,37 @@
 			}
 		},
 		"old-runtime-definitions": {
-			"version": "npm:@fluidframework/runtime-definitions@0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.26.10.tgz",
-			"integrity": "sha512-Q6eCn7FidM09Wk2nXmx9/EsPl2EX5JIrNBYdqcHrx2NVn9L3zOO6woecauG9Fet4NxDgJlGFXC2e7LQ6tqhTBg==",
+			"version": "npm:@fluidframework/runtime-definitions@0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.27.9.tgz",
+			"integrity": "sha512-4DMoR36DA7hQgHo/tdAdE60KyjOfNztEHvhkZjtNz2jZIiAaxPvR/VlDE3v9jaVxx1gTtq2J4nsj4W6C6yotMw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.26.10",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/driver-definitions": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/container-definitions": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/driver-definitions": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
 				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.19.1",
+						"@types/events": "^3.0.0",
+						"assert": "^2.0.0",
+						"base64-js": "^1.3.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.19",
+						"sha.js": "^2.4.11"
+					}
+				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -20464,28 +20508,28 @@
 			}
 		},
 		"old-sequence": {
-			"version": "npm:@fluidframework/sequence@0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.26.10.tgz",
-			"integrity": "sha512-FGtxDp/k60KXhJzePIoaNC9EunZ1ceysYcHSj8oPT6fEmWNwCznnk4DTbpLz+JYlIJXXnDn4m2fIEvKBSX8XIQ==",
+			"version": "npm:@fluidframework/sequence@0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.27.9.tgz",
+			"integrity": "sha512-AXZf6zdBpEeQOThmIGMyJDS0/ndwSErHkgI8E0fD/gH6Soefirs78FR+8SA5E32ugKPSJTh0XQGPewQy+bcn7g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.23.0",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/datastore-definitions": "^0.26.10",
-				"@fluidframework/map": "^0.26.10",
-				"@fluidframework/merge-tree": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/runtime-utils": "^0.26.10",
-				"@fluidframework/shared-object-base": "^0.26.10",
-				"@fluidframework/telemetry-utils": "^0.26.10",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/map": "^0.27.9",
+				"@fluidframework/merge-tree": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/runtime-utils": "^0.27.9",
+				"@fluidframework/shared-object-base": "^0.27.9",
+				"@fluidframework/telemetry-utils": "^0.27.9",
 				"debug": "^4.1.1",
 				"lodash": "^4.17.19"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -20493,14 +20537,13 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
@@ -20508,30 +20551,30 @@
 			}
 		},
 		"old-test-utils": {
-			"version": "npm:@fluidframework/test-utils@0.26.10",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.26.10.tgz",
-			"integrity": "sha512-gydgsdk0DV8swEAO8+VW0lWohMKTDIQ4Qfqdx3ZmvH5eqPmzewSKY4GIIRk0eaKsBfQHQnmy+L68LJDw8Iw4Sg==",
+			"version": "npm:@fluidframework/test-utils@0.27.9",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.27.9.tgz",
+			"integrity": "sha512-99fCULpOEfwTl/T/CFHQ6cZeaITmhWW9ZuyhJMMqJB5dfKteNi5PvXvVykAE329aoJIoMmy1ZJ+JSxXzWN1ViQ==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.26.10",
-				"@fluidframework/container-definitions": "^0.26.10",
-				"@fluidframework/container-loader": "^0.26.10",
-				"@fluidframework/container-runtime": "^0.26.10",
-				"@fluidframework/core-interfaces": "^0.26.10",
-				"@fluidframework/datastore": "^0.26.10",
-				"@fluidframework/datastore-definitions": "^0.26.10",
-				"@fluidframework/driver-definitions": "^0.26.10",
-				"@fluidframework/local-driver": "^0.26.10",
-				"@fluidframework/map": "^0.26.10",
-				"@fluidframework/protocol-definitions": "^0.1012.0",
-				"@fluidframework/request-handler": "^0.26.10",
-				"@fluidframework/runtime-definitions": "^0.26.10",
-				"@fluidframework/server-local-server": "^0.1012.0"
+				"@fluidframework/aqueduct": "^0.27.9",
+				"@fluidframework/container-definitions": "^0.27.9",
+				"@fluidframework/container-loader": "^0.27.9",
+				"@fluidframework/container-runtime": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/datastore": "^0.27.9",
+				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/driver-definitions": "^0.27.9",
+				"@fluidframework/local-driver": "^0.27.9",
+				"@fluidframework/map": "^0.27.9",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/request-handler": "^0.27.9",
+				"@fluidframework/runtime-definitions": "^0.27.9",
+				"@fluidframework/server-local-server": "^0.1013.0"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
-					"version": "0.23.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.23.0.tgz",
-					"integrity": "sha512-4jawHuQhkIyhGCYhKfKCMbE6bufj95AoEQofJ0YMzWli66iDtj1cOIJexqM36dxPXWpFoXcr5DdEtqMXhX2ufw==",
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@types/events": "^3.0.0",
@@ -20539,46 +20582,45 @@
 						"base64-js": "^1.3.1",
 						"events": "^3.1.0",
 						"lodash": "^4.17.19",
-						"performance-now": "^2.1.0",
 						"sha.js": "^2.4.11"
 					}
 				},
 				"@fluidframework/gitresources": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1012.2.tgz",
-					"integrity": "sha512-ysb9skxUKtIUSNUFqqcTQBMpCDrPcezc4pvDLaBdxcK4BuP3Ak2gZGmIVeXfbsx40+isBQ8xGbJISIZlgtGlZw=="
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1013.0.tgz",
+					"integrity": "sha512-X1j5sUNcpWnmyXCQjPx0C2d5jed3OgHnq3vRVzPwVmvGhu7B+tofsbJEMExMHX/J+ambDHq40ipEA55sTuXdwQ=="
 				},
 				"@fluidframework/protocol-base": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1012.2.tgz",
-					"integrity": "sha512-K8YRUIvrlO+54hyzLgLhZ9tQNeyPd9/yX0h/6XEE4m0oazCcCOFihAFzBIQXxypv1zNH2fbKlsQ7xaHHDbZ6rA==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1013.0.tgz",
+					"integrity": "sha512-2Y6Iu3rQut21aFS+oTYeIKAyyRkYeqMYJ+xAP8wSW0R6eiZPz3q1EhcXpJkEW9f5y84FNjbNsfV9jqI29URMHg==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
 						"assert": "^2.0.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@fluidframework/protocol-definitions": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1012.2.tgz",
-					"integrity": "sha512-nwZtRr1Cty2Dw0Uav38brRf2ztwBfc++ix5Q11mdqJVSlfHvjCR91PWRoeaQnIS947xCs3MeahPhEavRW+60pw==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1"
 					}
 				},
 				"@fluidframework/server-lambdas": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1012.2.tgz",
-					"integrity": "sha512-r/FPMZfami9yD/ZDo0BRvQwkcVlD2PnOgYeN5YP/9QeWyh3QUcZD688M4IxzzGMfDY6nAN8wVjI7Wn2ajqzLPQ==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1013.0.tgz",
+					"integrity": "sha512-x125RhVhxc5iu1ijFOWBEiO8V59au2/ZH5eQtTXTqDmD8mm7XDlErIxCN7V/AucACX89ROnEtdD5CVuid4Poqg==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-base": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
-						"@fluidframework/server-services-core": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-base": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
+						"@fluidframework/server-services-client": "^0.1013.0",
+						"@fluidframework/server-services-core": "^0.1013.0",
 						"@types/semver": "^6.0.1",
 						"async": "^2.6.1",
 						"double-ended-queue": "^2.1.0-0",
@@ -20591,31 +20633,31 @@
 					}
 				},
 				"@fluidframework/server-local-server": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1012.2.tgz",
-					"integrity": "sha512-CWZcirCpqI7a2IW78GeEc26bwPTCiWXkAB9EdMo3ex3Eira5+EIfwFDsuRgb+MuSCbsg3tpXWZDmZm4QdJNZIQ==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1013.0.tgz",
+					"integrity": "sha512-ibzSUPia8pfOcgY4HAQFtBAWnAqR2nQ2wqvIGo5cILeCjrCOzKOQt5Pdbp4lS2Ll641uBFj4Ytl+ZGiQm9ooKg==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-lambdas": "^0.1012.2",
-						"@fluidframework/server-memory-orderer": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
-						"@fluidframework/server-services-core": "^0.1012.2",
-						"@fluidframework/server-test-utils": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
+						"@fluidframework/server-lambdas": "^0.1013.0",
+						"@fluidframework/server-memory-orderer": "^0.1013.0",
+						"@fluidframework/server-services-client": "^0.1013.0",
+						"@fluidframework/server-services-core": "^0.1013.0",
+						"@fluidframework/server-test-utils": "^0.1013.0",
 						"uuid": "^3.3.2"
 					}
 				},
 				"@fluidframework/server-memory-orderer": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1012.2.tgz",
-					"integrity": "sha512-6VDnXD0fj93SI9D3VIdxlKiNfnFjUsjZsNlDBlqyrGbTj7VYMIrsm9FbxjHuWxG/1pWxqdy4CQvbG3r5s0Me/g==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1013.0.tgz",
+					"integrity": "sha512-KqwwYGEChWF7KNRRSCJY/fyWANdenWM6ljtqn+iLIAEdlkQT1wjgUYCAQk0mD2PgjaybtKYpVx3nSwRz6DvRTA==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/protocol-base": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-lambdas": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
-						"@fluidframework/server-services-core": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/protocol-base": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
+						"@fluidframework/server-lambdas": "^0.1013.0",
+						"@fluidframework/server-services-client": "^0.1013.0",
+						"@fluidframework/server-services-core": "^0.1013.0",
 						"@types/debug": "^4.1.5",
 						"@types/double-ended-queue": "^2.1.0",
 						"@types/lodash": "^4.14.118",
@@ -20630,14 +20672,14 @@
 					}
 				},
 				"@fluidframework/server-services-client": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1012.2.tgz",
-					"integrity": "sha512-bmGRVX8V1s/bMapdUHnr8mhQq5NE1++AS3bGSVfzd7GQQPlTz8d26cJA5+4jPe/mJvBMb6MEXstENi3VZOcTNQ==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1013.0.tgz",
+					"integrity": "sha512-OotVg4R8w5jZ/pQT+xAy6JkrCNAegN+3DDZTLZKhRv/zSL2f5l2cMTiUg0kOVJpYhBUNNQ7oRadD0FlwtA837g==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-base": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-base": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
 						"@types/node": "^10.17.24",
 						"axios": "^0.18.0",
 						"debug": "^4.1.1",
@@ -20647,14 +20689,14 @@
 					}
 				},
 				"@fluidframework/server-services-core": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1012.2.tgz",
-					"integrity": "sha512-E1Q/sDLgtQ7fIcaaXiZWWKOa3IRuZKE24fC0QmnmxUYDPUP1yT7kacr0r5wQTibn+eWhAyg/rRRfdRPEe9+YQg==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1013.0.tgz",
+					"integrity": "sha512-LNV1Fvczjj/sT9ZN3g201oyBLL+m8p8zYkRrhRzcPoH6hVv6q1xiYmEbfAjpM7aAjQlVho7bHDu3a45tttdamQ==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
+						"@fluidframework/server-services-client": "^0.1013.0",
 						"@types/nconf": "^0.0.37",
 						"@types/node": "^10.17.24",
 						"debug": "^4.1.1",
@@ -20662,16 +20704,16 @@
 					}
 				},
 				"@fluidframework/server-test-utils": {
-					"version": "0.1012.2",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1012.2.tgz",
-					"integrity": "sha512-jX/O+6EnSaU5YoAV4oj/gWe5weTmLhuvKrup1wFLIcselFycVTW1bc4pm+2JvZ21KhV16a8l54Ho9Vzz1JqvCA==",
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1013.0.tgz",
+					"integrity": "sha512-qxGIfLg050c/4zjcB3D/LfwHRPqwvx7djqVW7KppQ/QIu3uK1SrrT9jehC8SFkOuaIULG1tYMwEf/CeFbkEWnA==",
 					"requires": {
-						"@fluidframework/common-utils": "^0.23.0",
-						"@fluidframework/gitresources": "^0.1012.2",
-						"@fluidframework/protocol-base": "^0.1012.2",
-						"@fluidframework/protocol-definitions": "^0.1012.2",
-						"@fluidframework/server-services-client": "^0.1012.2",
-						"@fluidframework/server-services-core": "^0.1012.2",
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-base": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
+						"@fluidframework/server-services-client": "^0.1013.0",
+						"@fluidframework/server-services-core": "^0.1013.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
 						"string-hash": "^1.1.3",
@@ -23358,8 +23400,7 @@
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-			"dev": true
+			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
 		},
 		"set-value": {
 			"version": "2.0.1",
@@ -25488,8 +25529,7 @@
 		"tunnel": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-			"integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-			"dev": true
+			"integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
@@ -25536,7 +25576,6 @@
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.7.3.tgz",
 			"integrity": "sha512-CwTpx/TkRHGZoHkJhBcp4X8K3/WtlzSHVQR0OIFnt10j4tgy4ypgq/SrrgVpA1s6tAL49Q6J3R5C0Cgfh2ddqA==",
-			"dev": true,
 			"requires": {
 				"qs": "^6.9.1",
 				"tunnel": "0.0.6",
@@ -25546,8 +25585,7 @@
 				"qs": {
 					"version": "6.9.4",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-					"integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
-					"dev": true
+					"integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
 				}
 			}
 		},
@@ -25567,8 +25605,7 @@
 		"typescript": {
 			"version": "3.7.5",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-			"integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
-			"dev": true
+			"integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw=="
 		},
 		"typescript-formatter": {
 			"version": "7.1.0",
@@ -25707,8 +25744,7 @@
 		"underscore": {
 			"version": "1.8.3",
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-			"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-			"dev": true
+			"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
 		},
 		"union-value": {
 			"version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1795,7 +1795,7 @@
     "@microsoft/tsdoc": {
       "version": "0.12.19",
       "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.19.tgz",
-      "integrity": "sha512-IpgPxHrNxZiMNUSXqR1l/gePKPkfAmIKoDRP9hp7OwjU29ZR8WCJsOJ8iBKgw0Qk+pFwR+8Y1cy8ImLY6e9m4A==",
+      "integrity": "sha1-IXPMuSRpqvYgMfqUmdIbFtB/m1c=",
       "dev": true
     },
     "@mrmlnc/readdir-enhanced": {


### PR DESCRIPTION
We had huge bundle size savings by removing the assert dependency. Let's make sure it doesn't come back!