### PR TITLE
Fix blob attachment when using batches (Fixes #4166)

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -571,7 +571,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         type: ContainerMessageType,
         content: any,
         localOpMetadata: unknown,
-        opMetaData: Record<string, unknown> | undefined,
+        opMetadata: Record<string, unknown> | undefined,
     ) => void {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         return this.reSubmit;
@@ -2003,7 +2003,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         type: ContainerMessageType,
         content: any,
         localOpMetadata: unknown,
-        opMetaData: Record<string, unknown> | undefined,
+        opMetadata: Record<string, unknown> | undefined,
     ) {
         switch (type) {
             case ContainerMessageType.FluidDataStoreOp:
@@ -2017,7 +2017,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             case ContainerMessageType.ChunkedOp:
                 throw new Error(`chunkedOp not expected here`);
             case ContainerMessageType.BlobAttach:
-                this.submit(type, content, localOpMetadata, opMetaData);
+                this.submit(type, content, localOpMetadata, opMetadata);
                 break;
             default:
                 unreachableCase(type, `Unknown ContainerMessageType: ${type}`);

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -301,15 +301,15 @@ export class ScheduleManager {
                 return;
             }
 
-            // If only length one then clear
+            // If the batch contains only a single op, clear the batch flag.
             if (messages.length === 1) {
-                delete messages[0].metadata;
+                delete firstMessageMetadata.batch;
                 return;
             }
 
             // Set the batch flag to false on the last message to indicate the end of the send batch
             const lastMessage = messages[messages.length - 1];
-            lastMessage.metadata = { ...lastMessage.metadata, ...{ batch: false } };
+            lastMessage.metadata = { ...lastMessage.metadata, batch: false };
         });
 
         // Listen for updates and peek at the inbound
@@ -571,7 +571,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         type: ContainerMessageType,
         content: any,
         localOpMetadata: unknown,
-        opMetaData: unknown,
+        opMetaData: Record<string, unknown> | undefined,
     ) => void {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         return this.reSubmit;
@@ -1882,7 +1882,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         type: ContainerMessageType,
         content: any,
         localOpMetadata: unknown = undefined,
-        opMetadata: unknown = undefined): void {
+        opMetadata: Record<string, unknown> | undefined = undefined,
+    ): void {
         this.verifyNotClosed();
 
         let clientSequenceNumber: number = -1;
@@ -1892,9 +1893,9 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             const maxOpSize = this.context.deltaManager.maxMessageSize;
 
             // If in manual flush mode we will trigger a flush at the next turn break
-            let batchBegin = false;
             if (this.flushMode === FlushMode.Manual && !this.needsFlush) {
-                batchBegin = true;
+                // eslint-disable-next-line no-param-reassign
+                opMetadata = { ...opMetadata, batch: true };
                 this.needsFlush = true;
 
                 // Use Promise.resolve().then() to queue a microtask to detect the end of the turn and force a flush.
@@ -1914,8 +1915,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 clientSequenceNumber = this.submitRuntimeMessage(
                     type,
                     content,
-                    this._flushMode === FlushMode.Manual,
-                    batchBegin ? { batch: true } : opMetadata);
+                    /* batch: */ this._flushMode === FlushMode.Manual,
+                    opMetadata);
             } else {
                 clientSequenceNumber = this.submitChunkedMessage(type, serializedContent, maxOpSize);
             }
@@ -1998,7 +1999,12 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
      * @param content - The content of the original message.
      * @param localOpMetadata - The local metadata associated with the original message.
      */
-    private reSubmit(type: ContainerMessageType, content: any, localOpMetadata: unknown, opMetaData: unknown) {
+    private reSubmit(
+        type: ContainerMessageType,
+        content: any,
+        localOpMetadata: unknown,
+        opMetaData: Record<string, unknown> | undefined,
+    ) {
         switch (type) {
             case ContainerMessageType.FluidDataStoreOp:
                 // For Operations, call resubmitDataStoreOp which will find the right store

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -36,7 +36,7 @@ interface IPendingMessage {
     clientSequenceNumber: number;
     content: any;
     localOpMetadata: unknown;
-    opMetaData: Record<string, unknown> | undefined;
+    opMetadata: Record<string, unknown> | undefined;
 }
 
 /**
@@ -109,7 +109,7 @@ export class PendingStateManager {
         clientSequenceNumber: number,
         content: any,
         localOpMetadata: unknown,
-        opMetaData: Record<string, unknown> | undefined,
+        opMetadata: Record<string, unknown> | undefined,
     ) {
         const pendingMessage: IPendingMessage = {
             type: "message",
@@ -117,7 +117,7 @@ export class PendingStateManager {
             clientSequenceNumber,
             content,
             localOpMetadata,
-            opMetaData,
+            opMetadata,
         };
 
         this.pendingStates.push(pendingMessage);
@@ -333,7 +333,7 @@ export class PendingStateManager {
                             pendingState.messageType,
                             pendingState.content,
                             pendingState.localOpMetadata,
-                            pendingState.opMetaData);
+                            pendingState.opMetadata);
                     }
                     break;
                 case "flushMode":

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -36,7 +36,7 @@ interface IPendingMessage {
     clientSequenceNumber: number;
     content: any;
     localOpMetadata: unknown;
-    opMetaData: unknown;
+    opMetaData: Record<string, unknown> | undefined;
 }
 
 /**
@@ -109,7 +109,8 @@ export class PendingStateManager {
         clientSequenceNumber: number,
         content: any,
         localOpMetadata: unknown,
-        opMetaData: unknown) {
+        opMetaData: Record<string, unknown> | undefined,
+    ) {
         const pendingMessage: IPendingMessage = {
             type: "message",
             messageType: type,


### PR DESCRIPTION
When batching, the container runtime was clobbering the { blobId: * } metadata with { batch: true/false }.