### PR TITLE
Hotfix: Restrict token key length

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -88,6 +88,7 @@ data:
         "auth": {
             "endpoint": "http://{{ template "riddler.fullname" . }}",
             "maxTokenLifetimeSec": 3600,
+            "secretLength": 31,
             "enableTokenExpiration": false
         },
         "routemanager": {

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -88,7 +88,7 @@ data:
         "auth": {
             "endpoint": "http://{{ template "riddler.fullname" . }}",
             "maxTokenLifetimeSec": 3600,
-            "secretLength": 31,
+            "maxSecretLength": 31,
             "enableTokenExpiration": false
         },
         "routemanager": {

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
@@ -22,7 +22,7 @@ export function create(
     defaultHistorianUrl: string,
     defaultInternalHistorianUrl: string,
     secretManager: ISecretManager,
-    secretLength: number,
+    maxSecretLength: number,
 ): Router {
     const router: Router = Router();
     const manager = new TenantManager(
@@ -32,7 +32,7 @@ export function create(
         defaultHistorianUrl,
         defaultInternalHistorianUrl,
         secretManager,
-        secretLength);
+        maxSecretLength);
 
     function returnResponse<T>(resultP: Promise<T>, response: Response) {
         resultP.then(

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
@@ -22,6 +22,7 @@ export function create(
     defaultHistorianUrl: string,
     defaultInternalHistorianUrl: string,
     secretManager: ISecretManager,
+    secretLength: number,
 ): Router {
     const router: Router = Router();
     const manager = new TenantManager(
@@ -30,7 +31,8 @@ export function create(
         baseOrderUrl,
         defaultHistorianUrl,
         defaultInternalHistorianUrl,
-        secretManager);
+        secretManager,
+        secretLength);
 
     function returnResponse<T>(resultP: Promise<T>, response: Response) {
         resultP.then(

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/app.ts
@@ -31,6 +31,7 @@ export function create(
     defaultHistorianUrl: string,
     defaultInternalHistorianUrl: string,
     secretManager: ISecretManager,
+    secretLength: number,
 ) {
     // Express app configuration
     const app: express.Express = express();
@@ -68,7 +69,8 @@ export function create(
             baseOrdererUrl,
             defaultHistorianUrl,
             defaultInternalHistorianUrl,
-            secretManager));
+            secretManager,
+            secretLength));
 
     // Catch 404 and forward to error handler
     app.use((req, res, next) => {

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/app.ts
@@ -31,7 +31,7 @@ export function create(
     defaultHistorianUrl: string,
     defaultInternalHistorianUrl: string,
     secretManager: ISecretManager,
-    secretLength: number,
+    maxSecretLength: number,
 ) {
     // Express app configuration
     const app: express.Express = express();
@@ -70,7 +70,7 @@ export function create(
             defaultHistorianUrl,
             defaultInternalHistorianUrl,
             secretManager,
-            secretLength));
+            maxSecretLength));
 
     // Catch 404 and forward to error handler
     app.use((req, res, next) => {

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/runner.ts
@@ -23,6 +23,7 @@ export class RiddlerRunner implements utils.IRunner {
         private readonly defaultHistorianUrl: string,
         private readonly defaultInternalHistorianUrl: string,
         private readonly secretManager: ISecretManager,
+        private readonly secretLength: number,
     ) {
     }
 
@@ -38,7 +39,8 @@ export class RiddlerRunner implements utils.IRunner {
             this.baseOrdererUrl,
             this.defaultHistorianUrl,
             this.defaultInternalHistorianUrl,
-            this.secretManager);
+            this.secretManager,
+            this.secretLength);
         riddler.set("port", this.port);
 
         this.server = http.createServer(riddler);

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/runner.ts
@@ -23,7 +23,7 @@ export class RiddlerRunner implements utils.IRunner {
         private readonly defaultHistorianUrl: string,
         private readonly defaultInternalHistorianUrl: string,
         private readonly secretManager: ISecretManager,
-        private readonly secretLength: number,
+        private readonly maxSecretLength: number,
     ) {
     }
 
@@ -40,7 +40,7 @@ export class RiddlerRunner implements utils.IRunner {
             this.defaultHistorianUrl,
             this.defaultInternalHistorianUrl,
             this.secretManager,
-            this.secretLength);
+            this.maxSecretLength);
         riddler.set("port", this.port);
 
         this.server = http.createServer(riddler);

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
@@ -22,7 +22,7 @@ export class RiddlerResources implements utils.IResources {
         public readonly defaultHistorianUrl: string,
         public readonly defaultInternalHistorianUrl: string,
         public readonly secretManager: ISecretManager,
-        public readonly secretLength: number,
+        public readonly maxSecretLength: number,
     ) {
     }
 
@@ -40,11 +40,11 @@ export class RiddlerResourcesFactory implements utils.IResourcesFactory<RiddlerR
         const tenantsCollectionName = config.get("mongo:collectionNames:tenants");
         const secretManager = new services.SecretManager();
 
-        let secretLength: number = config.get("auth:secretLength");
-        if (!secretLength) {
-            secretLength = 31;
+        let maxSecretLength: number = config.get("auth:maxSecretLength");
+        if (!maxSecretLength) {
+            maxSecretLength = 31;
         } else {
-            secretLength = Math.min(secretLength, 31);
+            maxSecretLength = Math.min(maxSecretLength, 31);
         }
 
         // Load configs for default tenants
@@ -83,7 +83,7 @@ export class RiddlerResourcesFactory implements utils.IResourcesFactory<RiddlerR
             defaultHistorianUrl,
             defaultInternalHistorianUrl,
             secretManager,
-            secretLength);
+            maxSecretLength);
     }
 }
 
@@ -98,6 +98,6 @@ export class RiddlerRunnerFactory implements utils.IRunnerFactory<RiddlerResourc
             resources.defaultHistorianUrl,
             resources.defaultInternalHistorianUrl,
             resources.secretManager,
-            resources.secretLength);
+            resources.maxSecretLength);
     }
 }

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
@@ -22,6 +22,7 @@ export class RiddlerResources implements utils.IResources {
         public readonly defaultHistorianUrl: string,
         public readonly defaultInternalHistorianUrl: string,
         public readonly secretManager: ISecretManager,
+        public readonly secretLength: number,
     ) {
     }
 
@@ -38,6 +39,13 @@ export class RiddlerResourcesFactory implements utils.IResourcesFactory<RiddlerR
         const mongoManager = new MongoManager(mongoFactory);
         const tenantsCollectionName = config.get("mongo:collectionNames:tenants");
         const secretManager = new services.SecretManager();
+
+        let secretLength: number = config.get("auth:secretLength");
+        if (!secretLength) {
+            secretLength = 31;
+        } else {
+            secretLength = Math.min(secretLength, 31);
+        }
 
         // Load configs for default tenants
         const db = await mongoManager.getDatabase();
@@ -74,7 +82,8 @@ export class RiddlerResourcesFactory implements utils.IResourcesFactory<RiddlerR
             serverUrl,
             defaultHistorianUrl,
             defaultInternalHistorianUrl,
-            secretManager);
+            secretManager,
+            secretLength);
     }
 }
 
@@ -88,6 +97,7 @@ export class RiddlerRunnerFactory implements utils.IRunnerFactory<RiddlerResourc
             resources.baseOrdererUrl,
             resources.defaultHistorianUrl,
             resources.defaultInternalHistorianUrl,
-            resources.secretManager);
+            resources.secretManager,
+            resources.secretLength);
     }
 }

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
@@ -48,6 +48,7 @@ export class TenantManager {
         private readonly defaultHistorianUrl: string,
         private readonly defaultInternalHistorianUrl: string,
         private readonly secretManager: ISecretManager,
+        private readonly secretLength: number,
     ) {
     }
 
@@ -119,7 +120,7 @@ export class TenantManager {
         const db = await this.mongoManager.getDatabase();
         const collection = db.collection<ITenantDocument>(this.collectionName);
 
-        const tenantKey = this.generateTenantKey();
+        const tenantKey = this.generateTenantKey().substr(0, this.secretLength);
         const encryptedTenantKey = this.secretManager.encryptSecret(tenantKey);
         if (encryptedTenantKey == null) {
             winston.error("Tenant key encryption failed.");

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
@@ -48,7 +48,7 @@ export class TenantManager {
         private readonly defaultHistorianUrl: string,
         private readonly defaultInternalHistorianUrl: string,
         private readonly secretManager: ISecretManager,
-        private readonly secretLength: number,
+        private readonly maxSecretLength: number,
     ) {
     }
 
@@ -120,7 +120,7 @@ export class TenantManager {
         const db = await this.mongoManager.getDatabase();
         const collection = db.collection<ITenantDocument>(this.collectionName);
 
-        const tenantKey = this.generateTenantKey().substr(0, this.secretLength);
+        const tenantKey = this.generateTenantKey().substr(0, this.maxSecretLength);
         const encryptedTenantKey = this.secretManager.encryptSecret(tenantKey);
         if (encryptedTenantKey == null) {
             winston.error("Tenant key encryption failed.");

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -79,6 +79,7 @@
     "auth": {
         "endpoint": "http://riddler:5000",
         "maxTokenLifetimeSec": 3600,
+        "secretLength": 31,
         "enableTokenExpiration": false
     },
     "routemanager": {

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -79,7 +79,7 @@
     "auth": {
         "endpoint": "http://riddler:5000",
         "maxTokenLifetimeSec": 3600,
-        "secretLength": 31,
+        "maxSecretLength": 31,
         "enableTokenExpiration": false
     },
     "routemanager": {


### PR DESCRIPTION
The bug was introduced in #3998. Client libraries signs a token with jsrsassign and service verifies it using jsonwebtoken. When using an even key-length (without any '-' char), it causes the verification to fail. For upcoming FHL, we are restricting new tokens to be only 31 bit. Longer term, we need to figure out the core reason and decide whether to use jsrsassign or not.