### PR TITLE
Fix jsrsasign token signing.

### DIFF
--- a/examples/utils/get-tinylicious-container/src/insecureTinyliciousTokenProvider.ts
+++ b/examples/utils/get-tinylicious-container/src/insecureTinyliciousTokenProvider.ts
@@ -45,7 +45,9 @@ export class InsecureTinyliciousTokenProvider implements ITokenProvider {
             ver,
         };
 
+        // The type definition of jsrsasign library is wrong. Remove the casting once fix is available.
+        const key: string = ({ utf8: "12345" } as unknown) as string;
         // eslint-disable-next-line no-null/no-null
-        return jsrsasign.jws.JWS.sign(null, JSON.stringify({ alg:"HS256", typ: "JWT" }), claims, "12345");
+        return jsrsasign.jws.JWS.sign(null, JSON.stringify({ alg:"HS256", typ: "JWT" }), claims, key);
     }
 }

--- a/examples/utils/get-tinylicious-container/src/insecureTinyliciousUrlResolver.ts
+++ b/examples/utils/get-tinylicious-container/src/insecureTinyliciousUrlResolver.ts
@@ -63,7 +63,9 @@ export class InsecureTinyliciousUrlResolver implements IUrlResolver {
             ver: "1.0",
         };
 
+        // The type definition of jsrsasign library is wrong. Remove the casting once fix is available.
+        const key: string = ({ utf8: "12345" } as unknown) as string;
         // eslint-disable-next-line no-null/no-null
-        return jsrsasign.jws.JWS.sign(null, JSON.stringify({ alg:"HS256", typ: "JWT" }), claims, "12345");
+        return jsrsasign.jws.JWS.sign(null, JSON.stringify({ alg:"HS256", typ: "JWT" }), claims, key);
     }
 }

--- a/packages/drivers/local-driver/src/auth.ts
+++ b/packages/drivers/local-driver/src/auth.ts
@@ -40,8 +40,10 @@ export function generateToken(
         ver,
     };
 
+    // The type definition of jsrsasign library is wrong. Remove the casting once fix is available.
+    const utf8Key: string = ({ utf8: key } as unknown) as string;
     // eslint-disable-next-line no-null/no-null
-    return jsrsasign.jws.JWS.sign(null, JSON.stringify({ alg:"HS256", typ: "JWT" }), claims, key);
+    return jsrsasign.jws.JWS.sign(null, JSON.stringify({ alg:"HS256", typ: "JWT" }), claims, utf8Key);
 }
 
 export function generateUser(): IUser {

--- a/packages/runtime/test-runtime-utils/src/insecureTokenProvider.ts
+++ b/packages/runtime/test-runtime-utils/src/insecureTokenProvider.ts
@@ -49,6 +49,8 @@ export class InsecureTokenProvider implements ITokenProvider {
             ver,
         };
 
-        return jsrsasign.jws.JWS.sign(null, JSON.stringify({ alg:"HS256", typ: "JWT" }), claims, this.tenantKey);
+        // The type definition of jsrsasign library is wrong. Remove the casting once fix is available.
+        const key: string = ({ utf8: this.tenantKey } as unknown) as string;
+        return jsrsasign.jws.JWS.sign(null, JSON.stringify({ alg:"HS256", typ: "JWT" }), claims, key);
     }
 }

--- a/server/routerlicious/packages/local-server/src/test/localDeltaConnectionServer.spec.ts
+++ b/server/routerlicious/packages/local-server/src/test/localDeltaConnectionServer.spec.ts
@@ -47,8 +47,10 @@ describe("LocalDeltaConnectionServer", () => {
             ver: "1.0",
         };
 
+        // The type definition of jsrsasign library is wrong. Remove the casting once fix is available.
+        const key: string = ({ utf8: "key" } as unknown) as string;
          // eslint-disable-next-line no-null/no-null
-        const token = jsrsasign.jws.JWS.sign(null, JSON.stringify({ alg:"HS256", typ: "JWT" }), claims, "key");
+        const token = jsrsasign.jws.JWS.sign(null, JSON.stringify({ alg:"HS256", typ: "JWT" }), claims, key);
 
         return deltaConnectionServer.connectWebSocket(
             "tenant",

--- a/server/routerlicious/packages/services-client/src/auth.ts
+++ b/server/routerlicious/packages/services-client/src/auth.ts
@@ -71,8 +71,10 @@ export function generateToken(
         ver,
     };
 
+    // The type definition of jsrsasign library is wrong. Remove the casting once fix is available.
+    const utf8Key: string = ({ utf8: key } as unknown) as string;
     // eslint-disable-next-line no-null/no-null
-    return jsrsasign.jws.JWS.sign(null, JSON.stringify({ alg:"HS256", typ: "JWT" }), claims, key);
+    return jsrsasign.jws.JWS.sign(null, JSON.stringify({ alg:"HS256", typ: "JWT" }), claims, utf8Key);
 }
 
 export function generateUser(): IUser {


### PR DESCRIPTION
When using a signing key using hex characters (0-9, a-f), jsrsasign treats the key as hex. This caused the token validation failure. This PR fixes it.

The typing library of zsrsasign is not up to date so you are using unknown casting. Issue (https://github.com/DefinitelyTyped/DefinitelyTyped/issues/49266)