### PR TITLE
Update build-tools version in client

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -436,9 +436,9 @@
 			}
 		},
 		"@babel/polyfill": {
-			"version": "7.11.5",
-			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.11.5.tgz",
-			"integrity": "sha512-FunXnE0Sgpd61pKSj2OSOs1D44rKTD3pGOfGilZ6LGrrIH0QEtJlTjqOqdF8Bs98JmjfGhni2BBkTfv9KcKJ9g==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
+			"integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
 			"dev": true,
 			"requires": {
 				"core-js": "^2.6.5",
@@ -753,41 +753,41 @@
 			}
 		},
 		"@fluidframework/agent-scheduler": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.27.9.tgz",
-			"integrity": "sha512-HM1S4I52XV2vhAhn9ua5hHletfunOU+BxXEU4EFTsOQzfRjsj1NZNMP6pdNeraDQDBeKIZyeQJK7mpQgJ7kf8A==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.27.10.tgz",
+			"integrity": "sha512-NoWRshXOmBRWo8S1C/8zmE+5BIZ7TFW3RQNHxrk/XAceEIOelmDasaNhoCq+FS+LtpiBFXDsy1W3gwY1PlhjGA==",
 			"requires": {
-				"@fluidframework/container-definitions": "^0.27.9",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/datastore": "^0.27.9",
-				"@fluidframework/datastore-definitions": "^0.27.9",
-				"@fluidframework/map": "^0.27.9",
-				"@fluidframework/register-collection": "^0.27.9",
-				"@fluidframework/runtime-definitions": "^0.27.9",
+				"@fluidframework/container-definitions": "^0.27.10",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/datastore": "^0.27.10",
+				"@fluidframework/datastore-definitions": "^0.27.10",
+				"@fluidframework/map": "^0.27.10",
+				"@fluidframework/register-collection": "^0.27.10",
+				"@fluidframework/runtime-definitions": "^0.27.10",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.27.9.tgz",
-			"integrity": "sha512-jmLsStg4+GdnIy01+d5/50ut/ojIoijvzuF907S9cB9d1miTWfN252qSYBwoxZAJc9R7aMhQ4+1IV4zotRkKSg==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.27.10.tgz",
+			"integrity": "sha512-N2IAYot+2MogApLsS/V1zaDZu/zfQrb6laVMWef87pUIR8wynKimzTvU8HTgisWy/yPkimC63E6ef8HIP69Imw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.27.9",
-				"@fluidframework/container-loader": "^0.27.9",
-				"@fluidframework/container-runtime": "^0.27.9",
-				"@fluidframework/container-runtime-definitions": "^0.27.9",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/datastore": "^0.27.9",
-				"@fluidframework/datastore-definitions": "^0.27.9",
-				"@fluidframework/map": "^0.27.9",
-				"@fluidframework/request-handler": "^0.27.9",
-				"@fluidframework/runtime-definitions": "^0.27.9",
-				"@fluidframework/runtime-utils": "^0.27.9",
-				"@fluidframework/synthesize": "^0.27.9",
-				"@fluidframework/view-interfaces": "^0.27.9",
+				"@fluidframework/container-definitions": "^0.27.10",
+				"@fluidframework/container-loader": "^0.27.10",
+				"@fluidframework/container-runtime": "^0.27.10",
+				"@fluidframework/container-runtime-definitions": "^0.27.10",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/datastore": "^0.27.10",
+				"@fluidframework/datastore-definitions": "^0.27.10",
+				"@fluidframework/map": "^0.27.10",
+				"@fluidframework/request-handler": "^0.27.10",
+				"@fluidframework/runtime-definitions": "^0.27.10",
+				"@fluidframework/runtime-utils": "^0.27.10",
+				"@fluidframework/synthesize": "^0.27.10",
+				"@fluidframework/view-interfaces": "^0.27.10",
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
@@ -813,12 +813,12 @@
 			"integrity": "sha512-1pYGzO4NRlaMz+REq+YtzY8gmckZ9aCSzf0FpYsinEfSLOjPYRvgIvN6z4i4WDn5jocD3y8YH4RTSyVBgTtTtQ=="
 		},
 		"@fluidframework/build-tools": {
-			"version": "0.2.6623",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.6623.tgz",
-			"integrity": "sha512-N4UulVZrn8ndSl7QnnIWhJgPumuz5l2yPh5Cyus3l0k5IpEG/3fg5uUmx2UFWFzlz+4EFDAQ0JXd7LdC79pIxw==",
+			"version": "0.2.8708",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.8708.tgz",
+			"integrity": "sha512-X66CGv8/jil51crO1iggnSKhv+FK9kAqd4lOudhx1AooMikkF6JE0Ct6GzuBqUDw2TJQiAIwKw5bldv5VM1jdw==",
 			"dev": true,
 			"requires": {
-				"@fluidframework/bundle-size-tools": "^0.0.6611",
+				"@fluidframework/bundle-size-tools": "^0.0.8505",
 				"async": "^2.6.2",
 				"chalk": "^2.4.2",
 				"commander": "^2.20.0",
@@ -835,20 +835,6 @@
 				"typescript": "^3.7.4"
 			},
 			"dependencies": {
-				"@fluidframework/bundle-size-tools": {
-					"version": "0.0.6611",
-					"resolved": "https://registry.npmjs.org/@fluidframework/bundle-size-tools/-/bundle-size-tools-0.0.6611.tgz",
-					"integrity": "sha512-6aICkM/WjqKjDaTwMCxoDMCUXoyTWQOuw7YMFaBETQ5eIbyzdH8lTQlojn/mkV+1L5uNTal1Naymh9pqJ52W8g==",
-					"dev": true,
-					"requires": {
-						"assert": "^2.0.0",
-						"azure-devops-node-api": "^10.1.0",
-						"jszip": "^3.2.2",
-						"msgpack-lite": "^0.1.26",
-						"pako": "^1.0.10",
-						"typescript": "^3.7.4"
-					}
-				},
 				"commander": {
 					"version": "2.20.3",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -896,13 +882,13 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.27.9.tgz",
-			"integrity": "sha512-D4M2awBMXek/F0mTgKdETwmKbq9L+s5/prUoJjvK/+Ffr3q7/MqeFLAgubRUWwOHgmpDi4TjVqrPx7gnKscRPw==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.27.10.tgz",
+			"integrity": "sha512-6hRXto5xyeV5DaBL43w3wXAk7u7m9/4uybZTSvZjQV6AG8JLF/rZZUIIGtw80Twq/b+4aVT8jE24OC0IYGvHsA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/driver-definitions": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/driver-definitions": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0"
 			},
 			"dependencies": {
@@ -917,20 +903,20 @@
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.27.9.tgz",
-			"integrity": "sha512-obzZqFApU4PyWD4597BDhgj8Fi3hjnAWBcl5wnXHqByYtSg2mB3y8R28oD561c6pYINse3N+vETD9O+WXNxEvg==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.27.10.tgz",
+			"integrity": "sha512-aa0XdfpStpekPcR83jR0cPL3IcV0g9D8Y+ZJZR7T5hmzThA68xBUq7BThuxIllPfpzT/sSq5JGxFr4Fth90WSw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.27.9",
-				"@fluidframework/container-utils": "^0.27.9",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/driver-definitions": "^0.27.9",
-				"@fluidframework/driver-utils": "^0.27.9",
+				"@fluidframework/container-definitions": "^0.27.10",
+				"@fluidframework/container-utils": "^0.27.10",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/driver-definitions": "^0.27.10",
+				"@fluidframework/driver-utils": "^0.27.10",
 				"@fluidframework/protocol-base": "^0.1013.0",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/telemetry-utils": "^0.27.9",
+				"@fluidframework/telemetry-utils": "^0.27.10",
 				"@types/double-ended-queue": "^2.1.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -980,25 +966,25 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.27.9.tgz",
-			"integrity": "sha512-58a8WLongv1TJ9OOoCqLhPv5sKvVmXhDD3ywjjsbxdZ85AmLsVDn41SOlLuNk5B7pLxZxVvaSaPVPI4z5Ha38w==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.27.10.tgz",
+			"integrity": "sha512-GNje6y7zGiZ/n6Fy8jO17KFLhkrLiFDX7pTBRYvLGf0gaxDW9QqgnE06lgevC0ImANR8YQvmAikuq7MkRUn32A==",
 			"requires": {
-				"@fluidframework/agent-scheduler": "^0.27.9",
+				"@fluidframework/agent-scheduler": "^0.27.10",
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.27.9",
-				"@fluidframework/container-runtime-definitions": "^0.27.9",
-				"@fluidframework/container-utils": "^0.27.9",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/datastore": "^0.27.9",
-				"@fluidframework/driver-definitions": "^0.27.9",
-				"@fluidframework/driver-utils": "^0.27.9",
+				"@fluidframework/container-definitions": "^0.27.10",
+				"@fluidframework/container-runtime-definitions": "^0.27.10",
+				"@fluidframework/container-utils": "^0.27.10",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/datastore": "^0.27.10",
+				"@fluidframework/driver-definitions": "^0.27.10",
+				"@fluidframework/driver-utils": "^0.27.10",
 				"@fluidframework/protocol-base": "^0.1013.0",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/runtime-definitions": "^0.27.9",
-				"@fluidframework/runtime-utils": "^0.27.9",
-				"@fluidframework/telemetry-utils": "^0.27.9",
+				"@fluidframework/runtime-definitions": "^0.27.10",
+				"@fluidframework/runtime-utils": "^0.27.10",
+				"@fluidframework/telemetry-utils": "^0.27.10",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/node": "^10.17.24",
@@ -1050,15 +1036,15 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.27.9.tgz",
-			"integrity": "sha512-pTrvtywdy/97XmwpGbe8ZWKgH300/2iQPCAp1bKHGmBV6J7s4pt1yKyT+DG6naVmx5NxtiwwIN2AMIzF7nrFoA==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.27.10.tgz",
+			"integrity": "sha512-zNjCBOY8RzanxmDxpd7EqhhW9BkHhvookJljyJnNeINpH8UvjJd9zsVmS87q71lWgHEisO/TG4jWqs1F01AfhA==",
 			"requires": {
-				"@fluidframework/container-definitions": "^0.27.9",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/driver-definitions": "^0.27.9",
+				"@fluidframework/container-definitions": "^0.27.10",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/driver-definitions": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/runtime-definitions": "^0.27.9",
+				"@fluidframework/runtime-definitions": "^0.27.10",
 				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
@@ -1073,37 +1059,37 @@
 			}
 		},
 		"@fluidframework/container-utils": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.27.9.tgz",
-			"integrity": "sha512-t5T0vKgnzyiYcCJDsqxuRM+l5XAglo86t/TOqf/qS3BoKYK1AMY2dH6UDKktnH+8Em85+5rL8K7c8YhGBf9CsQ==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.27.10.tgz",
+			"integrity": "sha512-dmpaum9utwKVo/AWoC6tcaW2UTiBAniiOEVauFhgkmrKP0T0B8jPU/xpPeGljImUSIkw+ZjEUsxqleATZW234Q==",
 			"requires": {
-				"@fluidframework/container-definitions": "^0.27.9",
-				"@fluidframework/telemetry-utils": "^0.27.9"
+				"@fluidframework/container-definitions": "^0.27.10",
+				"@fluidframework/telemetry-utils": "^0.27.10"
 			}
 		},
 		"@fluidframework/core-interfaces": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.27.9.tgz",
-			"integrity": "sha512-PT+K83qAUPlt4cllR9sPvprqLD0tkD4Vtm9sWl8KPIRYF4TNaomHox2pTpBqax5d2NlteibP79b7sw6S7ueaJQ=="
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.27.10.tgz",
+			"integrity": "sha512-fuQD1ptwvEIlCBSSl039Yg1eKlq+15C30HoRgKA5iulNX5B94hOI43JBDPVjcNESr3x+XfthwEw8S2Ydkh7LLA=="
 		},
 		"@fluidframework/datastore": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.27.9.tgz",
-			"integrity": "sha512-4LmykrOWqh5bNbSQFDwgoW7pS3ScdASi1jLoBz1+WhMAneoPQHjF1sQckWaIeNXtijNNtYYpQeVz7t2a/aWG9A==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.27.10.tgz",
+			"integrity": "sha512-VfRm6HirQ9uunI+vHcBKQxu+GP6CfrSRSzjZHUnwXCZPZ12jJcfh6t7ntxsqbWb+NCwrRa7Ui/uLlbOseaEYYQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.27.9",
-				"@fluidframework/container-utils": "^0.27.9",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/datastore-definitions": "^0.27.9",
-				"@fluidframework/driver-definitions": "^0.27.9",
-				"@fluidframework/driver-utils": "^0.27.9",
+				"@fluidframework/container-definitions": "^0.27.10",
+				"@fluidframework/container-utils": "^0.27.10",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/datastore-definitions": "^0.27.10",
+				"@fluidframework/driver-definitions": "^0.27.10",
+				"@fluidframework/driver-utils": "^0.27.10",
 				"@fluidframework/protocol-base": "^0.1013.0",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/runtime-definitions": "^0.27.9",
-				"@fluidframework/runtime-utils": "^0.27.9",
-				"@fluidframework/telemetry-utils": "^0.27.9",
+				"@fluidframework/runtime-definitions": "^0.27.10",
+				"@fluidframework/runtime-utils": "^0.27.10",
+				"@fluidframework/telemetry-utils": "^0.27.10",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"lodash": "^4.17.19",
@@ -1152,16 +1138,16 @@
 			}
 		},
 		"@fluidframework/datastore-definitions": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.27.9.tgz",
-			"integrity": "sha512-nZC1570Jc+mPCFfL7rEAyDh5JCnIMMVjGfP05mWVn6PzOuU6iPaWqFysLMBsi04yYfp5BdfCNKiceAjLV9KmZQ==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.27.10.tgz",
+			"integrity": "sha512-4aBaoAi2PWvRgImJdlemm8mno182murcQrokvyEd3kZ9ROSumvgyh54rwABP4GGmTm2TOBC2WALjuAVfsJ6nZQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.27.9",
-				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/container-definitions": "^0.27.10",
+				"@fluidframework/core-interfaces": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/runtime-definitions": "^0.27.9",
+				"@fluidframework/runtime-definitions": "^0.27.10",
 				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
@@ -1190,13 +1176,13 @@
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.27.9.tgz",
-			"integrity": "sha512-aQXkYkzVkQBJzUI0UqNn3ecr2hZJ0FntwbmsGRxDAm0QVy6+vio0Pck5GKULiiFMs3nuI+K5C9k6aw6YQHlcAQ==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.27.10.tgz",
+			"integrity": "sha512-9o8h7/DTzO1CzvW0gNwrfhs+HpaIrPx0c0vjwlcC7oxTMe/DfoLRGAijdcqb/QWA05W0EuKPaHEb5vg9c99Q/g==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/driver-definitions": "^0.27.9",
-				"@fluidframework/driver-utils": "^0.27.9",
+				"@fluidframework/driver-definitions": "^0.27.10",
+				"@fluidframework/driver-utils": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
 				"@types/debug": "^4.1.5",
 				"@types/node": "^10.17.24",
@@ -1229,12 +1215,12 @@
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.27.9.tgz",
-			"integrity": "sha512-55yiu8FHhpgHPnzMSm7f1Ls01clPkaGj2Doz5VMLWx6Y7R6qHCAB/JG291csOHn47O3Bus9D+GD8sUrD9/AnFA==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.27.10.tgz",
+			"integrity": "sha512-nN9hx/NbDJ9IQwegeOcTYaw2ps5mrrnQP5Unr3cMbqMJZEK1FV41Dw/Vd2TJGHOJl2Sm9kdVWx6AhmM0tZDnWw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0"
 			},
 			"dependencies": {
@@ -1249,18 +1235,18 @@
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.27.9.tgz",
-			"integrity": "sha512-f1A+dtjeDmy6QoXOiIgcxyZWyvDn5Ufd8aWhxfo93uI/B3e+KVoA3P/v13ff8lIQC2IFcL0Rla1ebLo6otwWcg==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.27.10.tgz",
+			"integrity": "sha512-HHXEGIdgX5+UNmndVc/yJxmDnfuEEbKdYEz5Z+C77bE0voBATuBAxeJgoiz5Ib+KLr/euQU3x5xeqWLjoTHGBw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/driver-definitions": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/driver-definitions": "^0.27.10",
 				"@fluidframework/gitresources": "^0.1013.0",
 				"@fluidframework/protocol-base": "^0.1013.0",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/telemetry-utils": "^0.27.9"
+				"@fluidframework/telemetry-utils": "^0.27.10"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -1983,17 +1969,17 @@
 			"integrity": "sha512-NVv4Os7PAp54whyyRHdjRbWX3wsxPWiWNYwaURYKjZeOkfq2cA+TOe1Ng1odWbPHBCpYBPN/jG3b7yn6XKb64A=="
 		},
 		"@fluidframework/local-driver": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.27.9.tgz",
-			"integrity": "sha512-gjBgytObNaTezCISC9oY/0BdKO9Up45Hq3vhMGBndbPfW69ukKnrbvhKi43N/ST/kb25mkH0wk2370xkZQDZYw==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.27.10.tgz",
+			"integrity": "sha512-WcmyIXaS1K3ep5PoWvqTBlULDtGk7XNbydHm+1pptxbcdWB9i0CjejaLBdSDO7Qd0/zz31qx3GkbMD0fvdzBvA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/driver-definitions": "^0.27.9",
-				"@fluidframework/driver-utils": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/driver-definitions": "^0.27.10",
+				"@fluidframework/driver-utils": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/routerlicious-driver": "^0.27.9",
+				"@fluidframework/routerlicious-driver": "^0.27.10",
 				"@fluidframework/server-local-server": "^0.1013.0",
 				"@fluidframework/server-services-client": "^0.1013.0",
 				"@fluidframework/server-services-core": "^0.1013.0",
@@ -2159,17 +2145,17 @@
 			}
 		},
 		"@fluidframework/map": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.27.9.tgz",
-			"integrity": "sha512-2HpyWJNi7W3NgUKctKDBpMKwRmk562rNeBYccYhv3CL9OMYHE6umKzzVOkrHMx26JkNd8x441zLAePBojkmRww==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.27.10.tgz",
+			"integrity": "sha512-Z+WvsmceQukHO1ONjhxM86DIynGZ7EAwSTUjwo3eYRh9hYwASOBweEOAB6v+ZxZBFDOaRmMHMC0gTaL604oakg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/datastore-definitions": "^0.27.10",
 				"@fluidframework/protocol-base": "^0.1013.0",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/shared-object-base": "^0.27.9",
+				"@fluidframework/shared-object-base": "^0.27.10",
 				"debug": "^4.1.1",
 				"path-browserify": "^1.0.1"
 			},
@@ -2216,17 +2202,17 @@
 			}
 		},
 		"@fluidframework/merge-tree": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.27.9.tgz",
-			"integrity": "sha512-9fhdoZYVeKs2OlXY/Yn+b23Me8tALocmyGhUtdO68t8u8FQt0IlvrKLNmaf3e5slTkb/ShFUIr0bPJNZba5zag==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.27.10.tgz",
+			"integrity": "sha512-mjRtz2IqoWmGzfsCLcfCoCceNMS6GeSmF3owPUvcpujFXeCAe0j0AdHwZvCvnZk051oCI4kF4MnOktqqvfuEJw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.27.9",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/container-definitions": "^0.27.10",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/datastore-definitions": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/telemetry-utils": "^0.27.9"
+				"@fluidframework/telemetry-utils": "^0.27.10"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -2281,14 +2267,14 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.27.9.tgz",
-			"integrity": "sha512-iNCGzwnQed65Y3JytjL1BdPGgz1BQVbpNx1eWpydnixiYcg1ASPpcqZA3HuZQtOswIcn8wCl7lqBXo6H4/yd1A==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.27.10.tgz",
+			"integrity": "sha512-86fxS5U7tiEwperM0749o/Ik8nBsQFlhihJnGUGbdQ9KFIZFBqr2Bm8tr7EIVCdKQR6HQ92iq+BD0+Jvf73OVg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/datastore-definitions": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/shared-object-base": "^0.27.9",
+				"@fluidframework/shared-object-base": "^0.27.10",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
@@ -2317,26 +2303,26 @@
 			}
 		},
 		"@fluidframework/request-handler": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.27.9.tgz",
-			"integrity": "sha512-b6ujBkwJrqfCU1UOiyW4AOx68qk3UZobYGH6c+NkdLYH/LpQxD/C680hDhxLl3YD51ULfSPvkv8CCmJOhFXz0Q==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.27.10.tgz",
+			"integrity": "sha512-1+H3Wba334AAJd/rF06ecsg2+eupCB04G7T4hRdQsi42DOvqULcLzjOdMMcgstamOWCbVWOnlwr+YBKqdjHgvw==",
 			"requires": {
-				"@fluidframework/container-runtime-definitions": "^0.27.9",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/runtime-definitions": "^0.27.9",
-				"@fluidframework/runtime-utils": "^0.27.9"
+				"@fluidframework/container-runtime-definitions": "^0.27.10",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/runtime-definitions": "^0.27.10",
+				"@fluidframework/runtime-utils": "^0.27.10"
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.27.9.tgz",
-			"integrity": "sha512-3jnQwgqnFIX+naI/vHkDLlqf6azdTtyoHcCwI8fxCncZlEsU3O/4D4Lq0nypYHWFmH8reSb42BxORgTCBzjC6Q==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.27.10.tgz",
+			"integrity": "sha512-xavzjNRgjRXDdMC2YRkZpoRcwTvkXeXjOlsm6Mmdw6NDtRaey3Qmb0ceGRHaOeOsdjjtgqZZigw5IgQI4YoFow==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/driver-base": "^0.27.9",
-				"@fluidframework/driver-definitions": "^0.27.9",
-				"@fluidframework/driver-utils": "^0.27.9",
+				"@fluidframework/driver-base": "^0.27.10",
+				"@fluidframework/driver-definitions": "^0.27.10",
+				"@fluidframework/driver-utils": "^0.27.10",
 				"@fluidframework/gitresources": "^0.1013.0",
 				"@fluidframework/protocol-base": "^0.1013.0",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
@@ -2408,15 +2394,15 @@
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.27.9.tgz",
-			"integrity": "sha512-4DMoR36DA7hQgHo/tdAdE60KyjOfNztEHvhkZjtNz2jZIiAaxPvR/VlDE3v9jaVxx1gTtq2J4nsj4W6C6yotMw==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.27.10.tgz",
+			"integrity": "sha512-lGvSngkjNA8b+XfRThrXkteLVujOXZgJmQoR2KFhU5WwKWAjBIEKFIrYI2/7JvKAfVg5T9mPX/djlmAgJBaIGw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.27.9",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/driver-definitions": "^0.27.9",
+				"@fluidframework/container-definitions": "^0.27.10",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/driver-definitions": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
 				"@types/node": "^10.17.24"
 			},
@@ -2446,17 +2432,17 @@
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.27.9.tgz",
-			"integrity": "sha512-7OiqrH7Wu4n9LuyScShgdCMMrSLCoe+J+Lt9JQ7hopcxsibc1Fg7gfTlEVmfv3CuKy7XlqdLVIqpiyG4YqDvWQ==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.27.10.tgz",
+			"integrity": "sha512-gUQ+RgtI2nL9N4aV4CPp/6Q+wICr8D5LcCB5fGd1kRw3qHeKv/m3tOO51J/rUvwgNx3uKnP16Tgzyg3FUonnqA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/datastore-definitions": "^0.27.10",
 				"@fluidframework/protocol-base": "^0.1013.0",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/runtime-definitions": "^0.27.9"
+				"@fluidframework/runtime-definitions": "^0.27.10"
 			},
 			"dependencies": {
 				"@fluidframework/common-utils": {
@@ -2650,17 +2636,17 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.27.9.tgz",
-			"integrity": "sha512-diWgDrVLpZaIqtLIrEzA+sg0cnzzYyXL+TANY+sPJgQvMkGVlI/FNj4yJeZb8L3c/cmkco2edBTg/sf2ARDXoA==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.27.10.tgz",
+			"integrity": "sha512-rvtzwSmewi+qiL/BEIkbdm6PIbjaoVjoAwkCpwyffHKEmjBQ3ehC+Q5roHdWyi6Fi1gqe2QMuCM0dyqGVBvwGQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.27.9",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/datastore": "^0.27.9",
-				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/container-definitions": "^0.27.10",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/datastore": "^0.27.10",
+				"@fluidframework/datastore-definitions": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/telemetry-utils": "^0.27.9",
+				"@fluidframework/telemetry-utils": "^0.27.10",
 				"@types/debug": "^4.1.5",
 				"@types/node": "^10.17.24",
 				"debug": "^4.1.1",
@@ -2678,17 +2664,17 @@
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.27.9.tgz",
-			"integrity": "sha512-iN4y2iiRKEO4aRbG20t+Barw28OURFJUOat4lNJINh6l4sysqTdK0sKcWSAIU48d/jxMxFJgd2yOb9cJ5UcYGg==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.27.10.tgz",
+			"integrity": "sha512-0u8mrhHadZyx0GLpxjhasf8eCHfhFRyfU7RuJy+c2ATWPskNcMyDOBq9PTUgwzyn4XSMTWjmwp580kfIBbHP2g==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^0.27.9"
+				"@fluidframework/core-interfaces": "^0.27.10"
 			}
 		},
 		"@fluidframework/telemetry-utils": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.27.9.tgz",
-			"integrity": "sha512-PACWhHNpF630Y3TlUlagmzvv5kmzbM1/cWJFmqjozJLCZw4967sxiKxbo15B6h2AFZicO1Ulv2hd5IoM5R666A==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.27.10.tgz",
+			"integrity": "sha512-jXvlJ9IlwfekjIf/NQYetHfWHvG3uNyRYp3egRGqLTFBcMzxk6fndXtoFH/nyRBGB6P82GTlZsvLAj0SOYI6Qg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.24.0",
@@ -2719,11 +2705,11 @@
 			"dev": true
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.27.9.tgz",
-			"integrity": "sha512-5RGeKFbCWl2C2fmO7uaBK2LWtemy3LloLfGY9DyiiF4qBemqNtpE/Pc8tA+1tNrYkKqm+H5GTZIcQnhD4p5GrA==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.27.10.tgz",
+			"integrity": "sha512-l6FhIgrEAR285e3PlaS/vq0JVwF+7vsjTKvi2d3xCY9ArPqVUhJMM2aqSrGeOBrb3byH8ccGIQx92NQu8EgTAA==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^0.27.9"
+				"@fluidframework/core-interfaces": "^0.27.10"
 			}
 		},
 		"@hapi/address": {
@@ -4962,9 +4948,9 @@
 					}
 				},
 				"tslib": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.2.tgz",
-					"integrity": "sha512-wAH28hcEKwna96/UacuWaVspVLkg4x1aDM9JlzqaQTOFczCktkVAb5fmXChgandR1EraDPs2w8P+ozM+oafwxg==",
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
 					"dev": true
 				}
 			}
@@ -19760,25 +19746,25 @@
 			}
 		},
 		"old-aqueduct": {
-			"version": "npm:@fluidframework/aqueduct@0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.27.9.tgz",
-			"integrity": "sha512-jmLsStg4+GdnIy01+d5/50ut/ojIoijvzuF907S9cB9d1miTWfN252qSYBwoxZAJc9R7aMhQ4+1IV4zotRkKSg==",
+			"version": "npm:@fluidframework/aqueduct@0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.27.10.tgz",
+			"integrity": "sha512-N2IAYot+2MogApLsS/V1zaDZu/zfQrb6laVMWef87pUIR8wynKimzTvU8HTgisWy/yPkimC63E6ef8HIP69Imw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.27.9",
-				"@fluidframework/container-loader": "^0.27.9",
-				"@fluidframework/container-runtime": "^0.27.9",
-				"@fluidframework/container-runtime-definitions": "^0.27.9",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/datastore": "^0.27.9",
-				"@fluidframework/datastore-definitions": "^0.27.9",
-				"@fluidframework/map": "^0.27.9",
-				"@fluidframework/request-handler": "^0.27.9",
-				"@fluidframework/runtime-definitions": "^0.27.9",
-				"@fluidframework/runtime-utils": "^0.27.9",
-				"@fluidframework/synthesize": "^0.27.9",
-				"@fluidframework/view-interfaces": "^0.27.9",
+				"@fluidframework/container-definitions": "^0.27.10",
+				"@fluidframework/container-loader": "^0.27.10",
+				"@fluidframework/container-runtime": "^0.27.10",
+				"@fluidframework/container-runtime-definitions": "^0.27.10",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/datastore": "^0.27.10",
+				"@fluidframework/datastore-definitions": "^0.27.10",
+				"@fluidframework/map": "^0.27.10",
+				"@fluidframework/request-handler": "^0.27.10",
+				"@fluidframework/runtime-definitions": "^0.27.10",
+				"@fluidframework/runtime-utils": "^0.27.10",
+				"@fluidframework/synthesize": "^0.27.10",
+				"@fluidframework/view-interfaces": "^0.27.10",
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
@@ -19799,15 +19785,15 @@
 			}
 		},
 		"old-cell": {
-			"version": "npm:@fluidframework/cell@0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.27.9.tgz",
-			"integrity": "sha512-bkqZgoEBKzc4mWN6DPCdeL3dSWJgtNMfl89c/MYNtIP0P7xlTVFawuJMWJLJMjTptBiQZ93CiHg2RPOuFfzFDA==",
+			"version": "npm:@fluidframework/cell@0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.27.10.tgz",
+			"integrity": "sha512-JrXBwtO7ZHQmwUS6P3Faxzrig0xHK9gKJ+PvwFIzQegER1oToNzLFTJbOi5nWuQfqnXefx83vtSjuS+wXmV8Iw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/datastore-definitions": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/shared-object-base": "^0.27.9",
+				"@fluidframework/shared-object-base": "^0.27.10",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
@@ -19836,13 +19822,13 @@
 			}
 		},
 		"old-container-definitions": {
-			"version": "npm:@fluidframework/container-definitions@0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.27.9.tgz",
-			"integrity": "sha512-D4M2awBMXek/F0mTgKdETwmKbq9L+s5/prUoJjvK/+Ffr3q7/MqeFLAgubRUWwOHgmpDi4TjVqrPx7gnKscRPw==",
+			"version": "npm:@fluidframework/container-definitions@0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.27.10.tgz",
+			"integrity": "sha512-6hRXto5xyeV5DaBL43w3wXAk7u7m9/4uybZTSvZjQV6AG8JLF/rZZUIIGtw80Twq/b+4aVT8jE24OC0IYGvHsA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/driver-definitions": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/driver-definitions": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0"
 			},
 			"dependencies": {
@@ -19857,20 +19843,20 @@
 			}
 		},
 		"old-container-loader": {
-			"version": "npm:@fluidframework/container-loader@0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.27.9.tgz",
-			"integrity": "sha512-obzZqFApU4PyWD4597BDhgj8Fi3hjnAWBcl5wnXHqByYtSg2mB3y8R28oD561c6pYINse3N+vETD9O+WXNxEvg==",
+			"version": "npm:@fluidframework/container-loader@0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.27.10.tgz",
+			"integrity": "sha512-aa0XdfpStpekPcR83jR0cPL3IcV0g9D8Y+ZJZR7T5hmzThA68xBUq7BThuxIllPfpzT/sSq5JGxFr4Fth90WSw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.27.9",
-				"@fluidframework/container-utils": "^0.27.9",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/driver-definitions": "^0.27.9",
-				"@fluidframework/driver-utils": "^0.27.9",
+				"@fluidframework/container-definitions": "^0.27.10",
+				"@fluidframework/container-utils": "^0.27.10",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/driver-definitions": "^0.27.10",
+				"@fluidframework/driver-utils": "^0.27.10",
 				"@fluidframework/protocol-base": "^0.1013.0",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/telemetry-utils": "^0.27.9",
+				"@fluidframework/telemetry-utils": "^0.27.10",
 				"@types/double-ended-queue": "^2.1.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -19920,25 +19906,25 @@
 			}
 		},
 		"old-container-runtime": {
-			"version": "npm:@fluidframework/container-runtime@0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.27.9.tgz",
-			"integrity": "sha512-58a8WLongv1TJ9OOoCqLhPv5sKvVmXhDD3ywjjsbxdZ85AmLsVDn41SOlLuNk5B7pLxZxVvaSaPVPI4z5Ha38w==",
+			"version": "npm:@fluidframework/container-runtime@0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.27.10.tgz",
+			"integrity": "sha512-GNje6y7zGiZ/n6Fy8jO17KFLhkrLiFDX7pTBRYvLGf0gaxDW9QqgnE06lgevC0ImANR8YQvmAikuq7MkRUn32A==",
 			"requires": {
-				"@fluidframework/agent-scheduler": "^0.27.9",
+				"@fluidframework/agent-scheduler": "^0.27.10",
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.27.9",
-				"@fluidframework/container-runtime-definitions": "^0.27.9",
-				"@fluidframework/container-utils": "^0.27.9",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/datastore": "^0.27.9",
-				"@fluidframework/driver-definitions": "^0.27.9",
-				"@fluidframework/driver-utils": "^0.27.9",
+				"@fluidframework/container-definitions": "^0.27.10",
+				"@fluidframework/container-runtime-definitions": "^0.27.10",
+				"@fluidframework/container-utils": "^0.27.10",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/datastore": "^0.27.10",
+				"@fluidframework/driver-definitions": "^0.27.10",
+				"@fluidframework/driver-utils": "^0.27.10",
 				"@fluidframework/protocol-base": "^0.1013.0",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/runtime-definitions": "^0.27.9",
-				"@fluidframework/runtime-utils": "^0.27.9",
-				"@fluidframework/telemetry-utils": "^0.27.9",
+				"@fluidframework/runtime-definitions": "^0.27.10",
+				"@fluidframework/runtime-utils": "^0.27.10",
+				"@fluidframework/telemetry-utils": "^0.27.10",
 				"@types/debug": "^4.1.5",
 				"@types/double-ended-queue": "^2.1.0",
 				"@types/node": "^10.17.24",
@@ -19990,14 +19976,14 @@
 			}
 		},
 		"old-counter": {
-			"version": "npm:@fluidframework/counter@0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.27.9.tgz",
-			"integrity": "sha512-mh31VQEtzPIYeSj1DBQTmFcKrBlopF3aBmX/6YI8mDPSaEcVrLVjGxlq+j9RaOqtuB8YgUh8lIeZaV3pDvfl1g==",
+			"version": "npm:@fluidframework/counter@0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.27.10.tgz",
+			"integrity": "sha512-oVLq0XdeCeipASWFWYH4ntkVWpu0VMD4CiPequwxdHxjrvIligwlaPsmNlAIfas5yjBDYo8zOCfBGWF/eg/aRg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/datastore-definitions": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/shared-object-base": "^0.27.9",
+				"@fluidframework/shared-object-base": "^0.27.10",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
@@ -20026,16 +20012,16 @@
 			}
 		},
 		"old-datastore-definitions": {
-			"version": "npm:@fluidframework/datastore-definitions@0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.27.9.tgz",
-			"integrity": "sha512-nZC1570Jc+mPCFfL7rEAyDh5JCnIMMVjGfP05mWVn6PzOuU6iPaWqFysLMBsi04yYfp5BdfCNKiceAjLV9KmZQ==",
+			"version": "npm:@fluidframework/datastore-definitions@0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.27.10.tgz",
+			"integrity": "sha512-4aBaoAi2PWvRgImJdlemm8mno182murcQrokvyEd3kZ9ROSumvgyh54rwABP4GGmTm2TOBC2WALjuAVfsJ6nZQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.27.9",
-				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/container-definitions": "^0.27.10",
+				"@fluidframework/core-interfaces": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/runtime-definitions": "^0.27.9",
+				"@fluidframework/runtime-definitions": "^0.27.10",
 				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
@@ -20064,12 +20050,12 @@
 			}
 		},
 		"old-driver-definitions": {
-			"version": "npm:@fluidframework/driver-definitions@0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.27.9.tgz",
-			"integrity": "sha512-55yiu8FHhpgHPnzMSm7f1Ls01clPkaGj2Doz5VMLWx6Y7R6qHCAB/JG291csOHn47O3Bus9D+GD8sUrD9/AnFA==",
+			"version": "npm:@fluidframework/driver-definitions@0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.27.10.tgz",
+			"integrity": "sha512-nN9hx/NbDJ9IQwegeOcTYaw2ps5mrrnQP5Unr3cMbqMJZEK1FV41Dw/Vd2TJGHOJl2Sm9kdVWx6AhmM0tZDnWw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0"
 			},
 			"dependencies": {
@@ -20084,14 +20070,14 @@
 			}
 		},
 		"old-ink": {
-			"version": "npm:@fluidframework/ink@0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.27.9.tgz",
-			"integrity": "sha512-LsMVgUVl8ANgPbPRSM2F3SsP+OGLA73CVWCcvq2lEwUlt1hwUS27Xh/hCocujG/pyO2bVcQya7BG1//+9sb5ZQ==",
+			"version": "npm:@fluidframework/ink@0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.27.10.tgz",
+			"integrity": "sha512-tFqgzsdeNLGFX0S3Ql7Hmw0d2QyAHfE2xQBgoHn3Zo69KqoY0EHYNV8J6dSAk0MiRKgonEfnLDFEVHFe7fhpeQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/datastore-definitions": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/shared-object-base": "^0.27.9",
+				"@fluidframework/shared-object-base": "^0.27.10",
 				"@types/debug": "^4.1.5",
 				"debug": "^4.1.1",
 				"uuid": "^3.3.2"
@@ -20122,17 +20108,17 @@
 			}
 		},
 		"old-local-driver": {
-			"version": "npm:@fluidframework/local-driver@0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.27.9.tgz",
-			"integrity": "sha512-gjBgytObNaTezCISC9oY/0BdKO9Up45Hq3vhMGBndbPfW69ukKnrbvhKi43N/ST/kb25mkH0wk2370xkZQDZYw==",
+			"version": "npm:@fluidframework/local-driver@0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.27.10.tgz",
+			"integrity": "sha512-WcmyIXaS1K3ep5PoWvqTBlULDtGk7XNbydHm+1pptxbcdWB9i0CjejaLBdSDO7Qd0/zz31qx3GkbMD0fvdzBvA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/driver-definitions": "^0.27.9",
-				"@fluidframework/driver-utils": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/driver-definitions": "^0.27.10",
+				"@fluidframework/driver-utils": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/routerlicious-driver": "^0.27.9",
+				"@fluidframework/routerlicious-driver": "^0.27.10",
 				"@fluidframework/server-local-server": "^0.1013.0",
 				"@fluidframework/server-services-client": "^0.1013.0",
 				"@fluidframework/server-services-core": "^0.1013.0",
@@ -20298,17 +20284,17 @@
 			}
 		},
 		"old-map": {
-			"version": "npm:@fluidframework/map@0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.27.9.tgz",
-			"integrity": "sha512-2HpyWJNi7W3NgUKctKDBpMKwRmk562rNeBYccYhv3CL9OMYHE6umKzzVOkrHMx26JkNd8x441zLAePBojkmRww==",
+			"version": "npm:@fluidframework/map@0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.27.10.tgz",
+			"integrity": "sha512-Z+WvsmceQukHO1ONjhxM86DIynGZ7EAwSTUjwo3eYRh9hYwASOBweEOAB6v+ZxZBFDOaRmMHMC0gTaL604oakg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/datastore-definitions": "^0.27.10",
 				"@fluidframework/protocol-base": "^0.1013.0",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/shared-object-base": "^0.27.9",
+				"@fluidframework/shared-object-base": "^0.27.10",
 				"debug": "^4.1.1",
 				"path-browserify": "^1.0.1"
 			},
@@ -20355,19 +20341,19 @@
 			}
 		},
 		"old-matrix": {
-			"version": "npm:@fluidframework/matrix@0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.27.9.tgz",
-			"integrity": "sha512-IOleYhluOCQFQcCoptx3K1tR4Z3ES2IVoJfoLYA9ll85qd6/raGPlKtkM2zYiRf03iD2HtdAo5REV1/rRS4mdQ==",
+			"version": "npm:@fluidframework/matrix@0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.27.10.tgz",
+			"integrity": "sha512-qrIB56yE9H1vehvbPgVU1bmmDDvXXy5mv57FaGBP36yg/rWF01bqZcTMLXnAq7Wy7o8wMMKmqhn4ETjG+PLFUg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/datastore-definitions": "^0.27.9",
-				"@fluidframework/merge-tree": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/datastore-definitions": "^0.27.10",
+				"@fluidframework/merge-tree": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/runtime-utils": "^0.27.9",
-				"@fluidframework/shared-object-base": "^0.27.9",
-				"@fluidframework/telemetry-utils": "^0.27.9",
+				"@fluidframework/runtime-utils": "^0.27.10",
+				"@fluidframework/shared-object-base": "^0.27.10",
+				"@fluidframework/telemetry-utils": "^0.27.10",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"debug": "^4.1.1",
 				"tslib": "^1.10.0"
@@ -20398,14 +20384,14 @@
 			}
 		},
 		"old-ordered-collection": {
-			"version": "npm:@fluidframework/ordered-collection@0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.27.9.tgz",
-			"integrity": "sha512-sOKMJqGDEIjwojtRCljfdvbUfkwBnS2cwOOYZDewHMBCt1Cc6ctRNqIRncVaWfNIRW3kLFy+Jpw1NQwDFfoOsw==",
+			"version": "npm:@fluidframework/ordered-collection@0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.27.10.tgz",
+			"integrity": "sha512-h1H91G6HkA2s2mkqYa+/+N6FPkTwNNQY1lc8qi37HTJZKNWD7TgWpNzpGaF4wqy98DciACuSRFEjK15+FkylMQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/datastore-definitions": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/shared-object-base": "^0.27.9",
+				"@fluidframework/shared-object-base": "^0.27.10",
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
@@ -20434,14 +20420,14 @@
 			}
 		},
 		"old-register-collection": {
-			"version": "npm:@fluidframework/register-collection@0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.27.9.tgz",
-			"integrity": "sha512-iNCGzwnQed65Y3JytjL1BdPGgz1BQVbpNx1eWpydnixiYcg1ASPpcqZA3HuZQtOswIcn8wCl7lqBXo6H4/yd1A==",
+			"version": "npm:@fluidframework/register-collection@0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.27.10.tgz",
+			"integrity": "sha512-86fxS5U7tiEwperM0749o/Ik8nBsQFlhihJnGUGbdQ9KFIZFBqr2Bm8tr7EIVCdKQR6HQ92iq+BD0+Jvf73OVg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/datastore-definitions": "^0.27.9",
+				"@fluidframework/datastore-definitions": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/shared-object-base": "^0.27.9",
+				"@fluidframework/shared-object-base": "^0.27.10",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
@@ -20470,15 +20456,15 @@
 			}
 		},
 		"old-runtime-definitions": {
-			"version": "npm:@fluidframework/runtime-definitions@0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.27.9.tgz",
-			"integrity": "sha512-4DMoR36DA7hQgHo/tdAdE60KyjOfNztEHvhkZjtNz2jZIiAaxPvR/VlDE3v9jaVxx1gTtq2J4nsj4W6C6yotMw==",
+			"version": "npm:@fluidframework/runtime-definitions@0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.27.10.tgz",
+			"integrity": "sha512-lGvSngkjNA8b+XfRThrXkteLVujOXZgJmQoR2KFhU5WwKWAjBIEKFIrYI2/7JvKAfVg5T9mPX/djlmAgJBaIGw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/container-definitions": "^0.27.9",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/driver-definitions": "^0.27.9",
+				"@fluidframework/container-definitions": "^0.27.10",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/driver-definitions": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
 				"@types/node": "^10.17.24"
 			},
@@ -20508,20 +20494,20 @@
 			}
 		},
 		"old-sequence": {
-			"version": "npm:@fluidframework/sequence@0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.27.9.tgz",
-			"integrity": "sha512-AXZf6zdBpEeQOThmIGMyJDS0/ndwSErHkgI8E0fD/gH6Soefirs78FR+8SA5E32ugKPSJTh0XQGPewQy+bcn7g==",
+			"version": "npm:@fluidframework/sequence@0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.27.10.tgz",
+			"integrity": "sha512-Xa9tISBaNJ1rA/GHuoay/UiMZHHECxbYogujlIu5kExEOe+nehctusmqW0ViMjpt8+x1OCY1dwxxj0P4Wdtheg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.24.0",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/datastore-definitions": "^0.27.9",
-				"@fluidframework/map": "^0.27.9",
-				"@fluidframework/merge-tree": "^0.27.9",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/datastore-definitions": "^0.27.10",
+				"@fluidframework/map": "^0.27.10",
+				"@fluidframework/merge-tree": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/runtime-utils": "^0.27.9",
-				"@fluidframework/shared-object-base": "^0.27.9",
-				"@fluidframework/telemetry-utils": "^0.27.9",
+				"@fluidframework/runtime-utils": "^0.27.10",
+				"@fluidframework/shared-object-base": "^0.27.10",
+				"@fluidframework/telemetry-utils": "^0.27.10",
 				"debug": "^4.1.1",
 				"lodash": "^4.17.19"
 			},
@@ -20551,23 +20537,23 @@
 			}
 		},
 		"old-test-utils": {
-			"version": "npm:@fluidframework/test-utils@0.27.9",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.27.9.tgz",
-			"integrity": "sha512-99fCULpOEfwTl/T/CFHQ6cZeaITmhWW9ZuyhJMMqJB5dfKteNi5PvXvVykAE329aoJIoMmy1ZJ+JSxXzWN1ViQ==",
+			"version": "npm:@fluidframework/test-utils@0.27.10",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.27.10.tgz",
+			"integrity": "sha512-vu8VNdQVjypka7gAUL6B2PrP+PsJq1vP3RiNxz8h4BiSJi3FqQ2wGHKoPh7axVlaC/SdPZ3HcKUtklRE7hSMdg==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.27.9",
-				"@fluidframework/container-definitions": "^0.27.9",
-				"@fluidframework/container-loader": "^0.27.9",
-				"@fluidframework/container-runtime": "^0.27.9",
-				"@fluidframework/core-interfaces": "^0.27.9",
-				"@fluidframework/datastore": "^0.27.9",
-				"@fluidframework/datastore-definitions": "^0.27.9",
-				"@fluidframework/driver-definitions": "^0.27.9",
-				"@fluidframework/local-driver": "^0.27.9",
-				"@fluidframework/map": "^0.27.9",
+				"@fluidframework/aqueduct": "^0.27.10",
+				"@fluidframework/container-definitions": "^0.27.10",
+				"@fluidframework/container-loader": "^0.27.10",
+				"@fluidframework/container-runtime": "^0.27.10",
+				"@fluidframework/core-interfaces": "^0.27.10",
+				"@fluidframework/datastore": "^0.27.10",
+				"@fluidframework/datastore-definitions": "^0.27.10",
+				"@fluidframework/driver-definitions": "^0.27.10",
+				"@fluidframework/local-driver": "^0.27.10",
+				"@fluidframework/map": "^0.27.10",
 				"@fluidframework/protocol-definitions": "^0.1013.0",
-				"@fluidframework/request-handler": "^0.27.9",
-				"@fluidframework/runtime-definitions": "^0.27.9",
+				"@fluidframework/request-handler": "^0.27.10",
+				"@fluidframework/runtime-definitions": "^0.27.10",
 				"@fluidframework/server-local-server": "^0.1013.0"
 			},
 			"dependencies": {
@@ -22064,9 +22050,9 @@
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
 		},
 		"query-string": {
-			"version": "6.13.5",
-			"resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.5.tgz",
-			"integrity": "sha512-svk3xg9qHR39P3JlHuD7g3nRnyay5mHbrPctEBDUxUkHRifPHXJDhBUycdCC0NBjXoDf44Gb+IsOZL1Uwn8M/Q==",
+			"version": "6.13.6",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.6.tgz",
+			"integrity": "sha512-/WWZ7d9na6s2wMEGdVCVgKWE9Rt7nYyNIf7k8xmHXcesPMlEzicWo3lbYwHyA4wBktI2KrXxxZeACLbE84hvSQ==",
 			"dev": true,
 			"requires": {
 				"decode-uri-component": "^0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -208,9 +208,9 @@
       "dev": true
     },
     "@babel/polyfill": {
-      "version": "7.11.5",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.11.5.tgz",
-      "integrity": "sha512-FunXnE0Sgpd61pKSj2OSOs1D44rKTD3pGOfGilZ6LGrrIH0QEtJlTjqOqdF8Bs98JmjfGhni2BBkTfv9KcKJ9g==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
+      "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
       "dev": true,
       "requires": {
         "core-js": "^2.6.5",
@@ -386,12 +386,12 @@
       }
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.6623",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.6623.tgz",
-      "integrity": "sha512-N4UulVZrn8ndSl7QnnIWhJgPumuz5l2yPh5Cyus3l0k5IpEG/3fg5uUmx2UFWFzlz+4EFDAQ0JXd7LdC79pIxw==",
+      "version": "0.2.8708",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.8708.tgz",
+      "integrity": "sha512-X66CGv8/jil51crO1iggnSKhv+FK9kAqd4lOudhx1AooMikkF6JE0Ct6GzuBqUDw2TJQiAIwKw5bldv5VM1jdw==",
       "dev": true,
       "requires": {
-        "@fluidframework/bundle-size-tools": "^0.0.6611",
+        "@fluidframework/bundle-size-tools": "^0.0.8505",
         "async": "^2.6.2",
         "chalk": "^2.4.2",
         "commander": "^2.20.0",
@@ -417,9 +417,9 @@
       }
     },
     "@fluidframework/bundle-size-tools": {
-      "version": "0.0.6611",
-      "resolved": "https://registry.npmjs.org/@fluidframework/bundle-size-tools/-/bundle-size-tools-0.0.6611.tgz",
-      "integrity": "sha512-6aICkM/WjqKjDaTwMCxoDMCUXoyTWQOuw7YMFaBETQ5eIbyzdH8lTQlojn/mkV+1L5uNTal1Naymh9pqJ52W8g==",
+      "version": "0.0.8505",
+      "resolved": "https://registry.npmjs.org/@fluidframework/bundle-size-tools/-/bundle-size-tools-0.0.8505.tgz",
+      "integrity": "sha512-B99xAInCdQPtNdr42V7hezxyQQFWHbt1CoWcrOxJEL8w6qk/F1/fA/0x36H8LJdud+rywzEEenWYRdWs8J31dw==",
       "dev": true,
       "requires": {
         "assert": "^2.0.0",
@@ -2088,9 +2088,9 @@
           }
         },
         "tslib": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.2.tgz",
-          "integrity": "sha512-wAH28hcEKwna96/UacuWaVspVLkg4x1aDM9JlzqaQTOFczCktkVAb5fmXChgandR1EraDPs2w8P+ozM+oafwxg==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
           "dev": true
         }
       }
@@ -4850,9 +4850,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
-      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
+      "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -6125,9 +6125,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true
     },
     "iferr": {
@@ -9040,9 +9040,9 @@
       "dev": true
     },
     "query-string": {
-      "version": "6.13.5",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.5.tgz",
-      "integrity": "sha512-svk3xg9qHR39P3JlHuD7g3nRnyay5mHbrPctEBDUxUkHRifPHXJDhBUycdCC0NBjXoDf44Gb+IsOZL1Uwn8M/Q==",
+      "version": "6.13.6",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.6.tgz",
+      "integrity": "sha512-/WWZ7d9na6s2wMEGdVCVgKWE9Rt7nYyNIf7k8xmHXcesPMlEzicWo3lbYwHyA4wBktI2KrXxxZeACLbE84hvSQ==",
       "dev": true,
       "requires": {
         "decode-uri-component": "^0.2.0",
@@ -9595,9 +9595,9 @@
       "dev": true
     },
     "run-parallel": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
       "dev": true
     },
     "run-queue": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "devDependencies": {
-    "@fluidframework/build-tools": "^0.2.6623",
+    "@fluidframework/build-tools": "^0.2.8708",
     "@fluidframework/test-tools": "^0.2.3074",
     "@mattetti/custom-api-documenter": "^0.2.1",
     "@microsoft/api-extractor": "^7.7.2",


### PR DESCRIPTION
This pulls in the changes to the bundle size analysis comments, and changes that don't affect the bundle size will no longer receive notifications.

Fixes #4124 