### PR TITLE
Add a check for odsp item id before trying to get a share link

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver2.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver2.ts
@@ -104,11 +104,10 @@ export class OdspDriverUrlResolver2 implements IUrlResolver {
 
         const odspResolvedUrl = await new OdspDriverUrlResolver().resolve(requestToBeResolved);
 
-        // Generate sharingLink only if main url is not sharing link.
-        if (!isSharingLink) {
-            try {
-                sharingLinkP = this.getShareLinkPromise(odspResolvedUrl);
-            } catch (error) {}
+        // Kick start the sharing link request if we don't already have it already as a performance optimization.
+        // For detached create new, we don't have an item id yet and therefore cannot generate a share link
+        if (!isSharingLink && odspResolvedUrl.itemId) {
+            sharingLinkP = this.getShareLinkPromise(odspResolvedUrl);
         }
         if (sharingLinkP) {
             odspResolvedUrl.sharingLinkP = sharingLinkP;


### PR DESCRIPTION
There is code in the v2 url resolver that kicks of an early prefetch of the share link for easy look up later. When we are creating a new file, we don't have an item id at the time the URL gets resolved and the method crashes to get a share link. It appears this logic when ported from the internal repo was changed, and the error is no longer caught.

Rather than catching the error, this PR prevents this specific type of error from being caught. 