### PR TITLE
Remove container creation in load flow for container

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,3 +1,15 @@
+## 0.29 Breaking Changes
+
+- [Remove creating new container in loader.resolve()](#Remove-creating-new-container-in-loader.resolve())
+- [LoaderHeader.version could not be null](#LoaderHeader.version-could-not-be-null)
+
+### - Remove creating new container in loader.resolve()
+Support for creating a new container in `loader.resolve()` if it doesn't exist has been removed. In order to create container,
+use detached new flow which is `loader.createDetached()`.
+
+### LoaderHeader.version could not be null
+`LoaderHeader.version` in ILoader cann't be null as we always load from existing snapshot in `container.load()`;
+
 ## 0.28 Breaking Changes
 
 - [FileName should contain extension for ODSP driver create new path](#FileName-should-contain-extension-for-ODSP-driver-create-new-path)

--- a/packages/loader/container-definitions/src/loader.ts
+++ b/packages/loader/container-definitions/src/loader.ts
@@ -239,7 +239,7 @@ export interface ILoaderHeader {
     [LoaderHeader.executionContext]: string;
     [LoaderHeader.sequenceNumber]: number;
     [LoaderHeader.reconnect]: boolean;
-    [LoaderHeader.version]: string | undefined | null;
+    [LoaderHeader.version]: string | undefined;
 }
 
 declare module "@fluidframework/core-interfaces" {

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -433,10 +433,6 @@ export class Loader extends EventEmitter implements ILoader {
         // If set in both query string and headers, use query string
         request.headers[LoaderHeader.version] = parsed.version ?? request.headers[LoaderHeader.version];
 
-        // Version === null means not use any snapshot.
-        if (request.headers[LoaderHeader.version] === "null") {
-            request.headers[LoaderHeader.version] = null;
-        }
         return {
             canCache: this.canUseCache(request),
             fromSequenceNumber,


### PR DESCRIPTION
1.) Remove creation of container in loader.resolve/container.load. Only use this flow for loading of an existing container.
2.) For creation of container only use loader.createDetached() flow.