### PR TITLE
Change redeem sharing link logic in odsp resolver

### DIFF
--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -37,7 +37,7 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl {
 
     // This is used to save the network calls while doing trees/latest call as if the client does not have permission
     // then this link can be redeemed for the permissions in the same network call.
-    redeemSharingLink?: string;
+    sharingLinkToRedeem?: string;
 
     codeHint?: {
         // containerPackageName is used for adding the package name to the request headers.
@@ -281,11 +281,13 @@ export interface OdspFluidDataStoreLocator {
 }
 
 export enum SharingLinkHeader {
-    isRedeemSharingLink = "isRedeemSharingLink",
+    // Can be used in request made to resolver, to tell the resolver that the passed in URL is a sharing link
+    // which can be redeemed at server to get permissions.
+    isSharingLinkToRedeem = "isSharingLinkToRedeem",
 }
 
 export interface ISharingLinkHeader {
-    [SharingLinkHeader.isRedeemSharingLink]: boolean;
+    [SharingLinkHeader.isSharingLinkToRedeem]: boolean;
 }
 
 declare module "@fluidframework/core-interfaces" {

--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -35,10 +35,7 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl {
 
     summarizer: boolean;
 
-    sharingLinkOptions?: {
-        sharingLinkP: Promise<string>;
-        appGeneratedSharingLink: boolean;
-    };
+    redeemSharingLink?: string;
 
     codeHint?: {
         // containerPackageName is used for adding the package name to the request headers.
@@ -282,11 +279,11 @@ export interface OdspFluidDataStoreLocator {
 }
 
 export enum SharingLinkHeader {
-    isSharingLink = "isSharingLink",
+    isRedeemSharingLink = "isRedeemSharingLink",
 }
 
 export interface ISharingLinkHeader {
-    [SharingLinkHeader.isSharingLink]: boolean;
+    [SharingLinkHeader.isRedeemSharingLink]: boolean;
 }
 
 declare module "@fluidframework/core-interfaces" {

--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -35,7 +35,10 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl {
 
     summarizer: boolean;
 
-    sharingLinkP?: Promise<string>;
+    sharingLinkOptions?: {
+        sharingLinkP: Promise<string>;
+        appGeneratedSharingLink: boolean;
+    };
 
     codeHint?: {
         // containerPackageName is used for adding the package name to the request headers.

--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -35,6 +35,8 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl {
 
     summarizer: boolean;
 
+    // This is used to save the network calls while doing trees/latest call as if the client does not have permission
+    // then this link can be redeemed for the permissions in the same network call.
     redeemSharingLink?: string;
 
     codeHint?: {

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -114,7 +114,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
 
     private readonly documentId: string;
     private readonly snapshotUrl: string | undefined;
-    private readonly appSharingLinkP: Promise<string> | undefined;
+    private readonly redeemSharingLink: string | undefined;
     private readonly attachmentPOSTUrl: string | undefined;
     private readonly attachmentGETUrl: string | undefined;
     // Driver specified limits for snapshot size and time.
@@ -151,10 +151,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
     ) {
         this.documentId = odspResolvedUrl.hashedDocumentId;
         this.snapshotUrl = odspResolvedUrl.endpoints.snapshotStorageUrl;
-        if (odspResolvedUrl.sharingLinkOptions?.appGeneratedSharingLink)
-        {
-            this.appSharingLinkP = odspResolvedUrl.sharingLinkOptions?.sharingLinkP;
-        }
+        this.redeemSharingLink = odspResolvedUrl.redeemSharingLink;
         this.attachmentPOSTUrl = odspResolvedUrl.endpoints.attachmentPOSTStorageUrl;
         this.attachmentGETUrl = odspResolvedUrl.endpoints.attachmentGETStorageUrl;
 
@@ -585,9 +582,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                     postBody += `${key}: ${value}\r\n`;
                 }
             });
-            const sharingLink = await this.appSharingLinkP;
-            if (sharingLink) {
-                postBody += `sl: ${sharingLink}\r\n`;
+            if (this.redeemSharingLink) {
+                postBody += `sl: ${this.redeemSharingLink}\r\n`;
             }
             postBody += `_post: 1\r\n`;
             postBody += `\r\n--${formBoundary}--`;

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -151,7 +151,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
     ) {
         this.documentId = odspResolvedUrl.hashedDocumentId;
         this.snapshotUrl = odspResolvedUrl.endpoints.snapshotStorageUrl;
-        this.redeemSharingLink = odspResolvedUrl.redeemSharingLink;
+        this.redeemSharingLink = odspResolvedUrl.sharingLinkToRedeem;
         this.attachmentPOSTUrl = odspResolvedUrl.endpoints.attachmentPOSTStorageUrl;
         this.attachmentGETUrl = odspResolvedUrl.endpoints.attachmentGETStorageUrl;
 

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -114,7 +114,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
 
     private readonly documentId: string;
     private readonly snapshotUrl: string | undefined;
-    private readonly sharingLinkP: Promise<string> | undefined;
+    private readonly appSharingLinkP: Promise<string> | undefined;
     private readonly attachmentPOSTUrl: string | undefined;
     private readonly attachmentGETUrl: string | undefined;
     // Driver specified limits for snapshot size and time.
@@ -151,7 +151,10 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
     ) {
         this.documentId = odspResolvedUrl.hashedDocumentId;
         this.snapshotUrl = odspResolvedUrl.endpoints.snapshotStorageUrl;
-        this.sharingLinkP = odspResolvedUrl.sharingLinkP;
+        if (odspResolvedUrl.sharingLinkOptions?.appGeneratedSharingLink)
+        {
+            this.appSharingLinkP = odspResolvedUrl.sharingLinkOptions?.sharingLinkP;
+        }
         this.attachmentPOSTUrl = odspResolvedUrl.endpoints.attachmentPOSTStorageUrl;
         this.attachmentGETUrl = odspResolvedUrl.endpoints.attachmentGETStorageUrl;
 
@@ -582,7 +585,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                     postBody += `${key}: ${value}\r\n`;
                 }
             });
-            const sharingLink = await this.sharingLinkP;
+            const sharingLink = await this.appSharingLinkP;
             if (sharingLink) {
                 postBody += `sl: ${sharingLink}\r\n`;
             }

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver2.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver2.ts
@@ -86,7 +86,7 @@ export class OdspDriverUrlResolver2 implements IUrlResolver {
      */
     public async resolve(request: IRequest): Promise<IOdspResolvedUrl> {
         const requestToBeResolved = { headers: request.headers, url: request.url };
-        const isRedeemSharingLink = requestToBeResolved.headers?.[SharingLinkHeader.isRedeemSharingLink];
+        const isSharingLinkToRedeem = requestToBeResolved.headers?.[SharingLinkHeader.isSharingLinkToRedeem];
         try {
             const url = new URL(request.url);
 
@@ -106,14 +106,13 @@ export class OdspDriverUrlResolver2 implements IUrlResolver {
 
         const odspResolvedUrl = await new OdspDriverUrlResolver().resolve(requestToBeResolved);
 
-        if (isRedeemSharingLink) {
-            odspResolvedUrl.redeemSharingLink = request.url.split("?")[0];
+        if (isSharingLinkToRedeem) {
+            odspResolvedUrl.sharingLinkToRedeem = request.url.split("?")[0];
         }
         if (odspResolvedUrl.itemId) {
             // Kick start the sharing link request if we don't already have it already as a performance optimization.
             // For detached create new, we don't have an item id yet and therefore cannot generate a share link
-            const key = this.getKey(odspResolvedUrl);
-            this.sharingLinkCache.add(key, async () => this.getShareLinkPromise(odspResolvedUrl));
+            this.getShareLinkPromise(odspResolvedUrl);
         }
         return odspResolvedUrl;
     }

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver2.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver2.ts
@@ -110,7 +110,10 @@ export class OdspDriverUrlResolver2 implements IUrlResolver {
             sharingLinkP = this.getShareLinkPromise(odspResolvedUrl);
         }
         if (sharingLinkP) {
-            odspResolvedUrl.sharingLinkP = sharingLinkP;
+            odspResolvedUrl.sharingLinkOptions = {
+                sharingLinkP,
+                appGeneratedSharingLink: isSharingLink,
+            };
         }
         return odspResolvedUrl;
     }
@@ -137,8 +140,8 @@ export class OdspDriverUrlResolver2 implements IUrlResolver {
             throw new Error("Failed to get share link because necessary information is missing " +
                 "(e.g. siteUrl, driveId or itemId)");
         }
-        if (resolvedUrl.sharingLinkP !== undefined) {
-            return resolvedUrl.sharingLinkP;
+        if (resolvedUrl.sharingLinkOptions !== undefined) {
+            return resolvedUrl.sharingLinkOptions.sharingLinkP;
         }
         const newLinkPromise = getShareLink(
             this.getSharingLinkToken,

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver2.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver2.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { PromiseCache } from "@fluidframework/common-utils";
 import { IFluidCodeDetails, IRequest, isFluidPackage } from "@fluidframework/core-interfaces";
 import { IResolvedUrl, IUrlResolver } from "@fluidframework/driver-definitions";
 import { ITelemetryBaseLogger, ITelemetryLogger } from "@fluidframework/common-definitions";
@@ -25,6 +26,7 @@ import {
 
 export class OdspDriverUrlResolver2 implements IUrlResolver {
     private readonly logger: ITelemetryLogger;
+    private readonly sharingLinkCache = new PromiseCache<string, string>();
     private readonly getSharingLinkToken:
         (options: TokenFetchOptions, scopeFor: SharingLinkScopeFor, siteUrl: string) => Promise<string | null>;
     public constructor(
@@ -75,19 +77,19 @@ export class OdspDriverUrlResolver2 implements IUrlResolver {
         return requestUrl.href;
     }
 
+    private getKey(resolvedUrl: IOdspResolvedUrl): string {
+        return `${resolvedUrl.siteUrl},${resolvedUrl.driveId},${resolvedUrl.itemId}`;
+    }
+
     /**
      * Resolves request URL into driver details
      */
     public async resolve(request: IRequest): Promise<IOdspResolvedUrl> {
         const requestToBeResolved = { headers: request.headers, url: request.url };
-        let sharingLinkP: Promise<string> | undefined;
-        const isSharingLink = requestToBeResolved.headers?.[SharingLinkHeader.isSharingLink];
+        const isRedeemSharingLink = requestToBeResolved.headers?.[SharingLinkHeader.isRedeemSharingLink];
         try {
             const url = new URL(request.url);
-            // Check if the url is the sharing link.
-            if (isSharingLink) {
-                sharingLinkP = Promise.resolve(request.url.split("?")[0]);
-            }
+
             const odspFluidInfo = getLocatorFromOdspUrl(url);
             if (odspFluidInfo) {
                 requestToBeResolved.url = createOdspUrl(
@@ -104,16 +106,14 @@ export class OdspDriverUrlResolver2 implements IUrlResolver {
 
         const odspResolvedUrl = await new OdspDriverUrlResolver().resolve(requestToBeResolved);
 
-        // Kick start the sharing link request if we don't already have it already as a performance optimization.
-        // For detached create new, we don't have an item id yet and therefore cannot generate a share link
-        if (!isSharingLink && odspResolvedUrl.itemId) {
-            sharingLinkP = this.getShareLinkPromise(odspResolvedUrl);
+        if (isRedeemSharingLink) {
+            odspResolvedUrl.redeemSharingLink = request.url.split("?")[0];
         }
-        if (sharingLinkP) {
-            odspResolvedUrl.sharingLinkOptions = {
-                sharingLinkP,
-                appGeneratedSharingLink: isSharingLink,
-            };
+        if (odspResolvedUrl.itemId) {
+            // Kick start the sharing link request if we don't already have it already as a performance optimization.
+            // For detached create new, we don't have an item id yet and therefore cannot generate a share link
+            const key = this.getKey(odspResolvedUrl);
+            this.sharingLinkCache.add(key, async () => this.getShareLinkPromise(odspResolvedUrl));
         }
         return odspResolvedUrl;
     }
@@ -140,8 +140,10 @@ export class OdspDriverUrlResolver2 implements IUrlResolver {
             throw new Error("Failed to get share link because necessary information is missing " +
                 "(e.g. siteUrl, driveId or itemId)");
         }
-        if (resolvedUrl.sharingLinkOptions !== undefined) {
-            return resolvedUrl.sharingLinkOptions.sharingLinkP;
+        const key = this.getKey(resolvedUrl);
+        const cachedLinkPromise = this.sharingLinkCache.get(key);
+        if (cachedLinkPromise) {
+            return cachedLinkPromise;
         }
         const newLinkPromise = getShareLink(
             this.getSharingLinkToken,
@@ -160,9 +162,10 @@ export class OdspDriverUrlResolver2 implements IUrlResolver {
             if (this.logger) {
                 this.logger.sendErrorEvent({ eventName: "FluidFileUrlError" }, error);
             }
+            this.sharingLinkCache.remove(key);
             throw error;
         });
-
+        this.sharingLinkCache.add(key, async () => newLinkPromise);
         return newLinkPromise;
     }
 

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver2.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver2.ts
@@ -112,7 +112,8 @@ export class OdspDriverUrlResolver2 implements IUrlResolver {
         if (odspResolvedUrl.itemId) {
             // Kick start the sharing link request if we don't already have it already as a performance optimization.
             // For detached create new, we don't have an item id yet and therefore cannot generate a share link
-            this.getShareLinkPromise(odspResolvedUrl);
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            this.getShareLinkPromise(odspResolvedUrl).catch(() => {});
         }
         return odspResolvedUrl;
     }


### PR DESCRIPTION
1.) Redeem sharing link is not a string instead of promise on resolved url so that when making the tress/latest call, we don't have to await on it as that can cause perf regression.
2.) Set the redeem sharing link on resolved url only if specified by host in request.
