### PR TITLE
Fix issue #2724 and forceReadonly API while connected

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -345,6 +345,9 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         return this._deltaManager.readonlyPermissions;
     }
 
+    /**
+     * {@inheritDoc DeltaManager.forceReadonly}
+     */
     public forceReadonly(readonly: boolean) {
         this._deltaManager.forceReadonly(readonly);
     }

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -472,7 +472,7 @@ export class DeltaManager
         return DeltaManager.detailsFromConnection(connection);
     }
 
-    public async connectCore(args: IConnectionArgs = {}): Promise<IDocumentDeltaConnection> {
+    private async connectCore(args: IConnectionArgs = {}): Promise<IDocumentDeltaConnection> {
         if (this.connection !== undefined) {
             return this.connection;
         }

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -325,6 +325,13 @@ export class DeltaManager
      * as in read-only permissions.
      * But this.active can be used by some DDSes to figure out if ops can be sent
      * (for example, read-only view still participates in code proposals / upgrades decisions)
+     *
+     * Forcing Readonly does not prevent DDS from generating ops. It is up to user code to honour
+     * the readonly flag. If ops are generated, they will accumulate locally and not be sent. If
+     * there are pending in the outbound queue, it will stop sending until force readonly is
+     * cleared.
+     *
+     * @param readonly - set or clear force readonly.
      */
     public forceReadonly(readonly: boolean) {
         const oldValue = this.readonly;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -803,8 +803,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 // Need to rip through snapshot.
                 const { pkg, snapshotFormatVersion, isRootDataStore }
                     = readAndParseFromBlobs<IFluidDataStoreAttributes>(
-                    snapshotTree.blobs,
-                    snapshotTree.blobs[".component"]);
+                        snapshotTree.blobs,
+                        snapshotTree.blobs[".component"]);
                 // Use the snapshotFormatVersion to determine how the pkg is encoded in the snapshot.
                 // For snapshotFormatVersion = "0.1", pkg is jsonified, otherwise it is just a string.
                 // However the feature of loading a detached container from snapshot, is added when the
@@ -856,7 +856,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             this.clearPartialChunks(clientId);
         });
 
-        this.context.quorum.on("addProposal",(proposal)=>{
+        this.context.quorum.on("addProposal", (proposal) => {
             if (proposal.key === "code" || proposal.key === "code2") {
                 this.emit("codeDetailsProposed", proposal.value, proposal);
             }
@@ -906,12 +906,12 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             // when we either never send an op, or attempted to send it but we know for sure it was not
             // sequenced by server and will never be sequenced (i.e. was lost)
             // For loss of connection, we wait for our own "join" op and use it a a barrier to know all the
-            // ops that maid it from previous connection, before switching clientId and raising "connected" event
+            // ops that made it from previous connection, before switching clientId and raising "connected" event
             // But with read-only permissions, if we transition between read-only and r/w states while on same
             // connection, then we have no good signal to tell us when it's safe to send ops we accumulated while
             // being in read-only state.
             // For that reason, we support getting to read-only state only when disconnected. This ensures that we
-            // can reply on same safety mechanism and resend ops only when we establish new connection.
+            // can rely on same safety mechanism and resend ops only when we establish new connection.
             // This is applicable for read-only permissions (event is raised before connection is properly registered),
             // but it's an extra requirement for Container.forceReadonly() API
             assert(!readonly || !this.connected, "Unsafe to transition to read-only state!");
@@ -1334,13 +1334,11 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         }
     }
 
-    public async createDataStore(pkg: string | string[]): Promise<IFluidRouter>
-    {
+    public async createDataStore(pkg: string | string[]): Promise<IFluidRouter> {
         return this._createDataStore(pkg, false /* isRoot */);
     }
 
-    public async createRootDataStore(pkg: string | string[], rootDataStoreId: string): Promise<IFluidRouter>
-    {
+    public async createRootDataStore(pkg: string | string[], rootDataStoreId: string): Promise<IFluidRouter> {
         const fluidDataStore = await this._createDataStore(pkg, true /* isRoot */, rootDataStoreId);
         fluidDataStore.bindToContext();
         return fluidDataStore;
@@ -1373,8 +1371,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         pkg: string | string[],
         isRoot: boolean,
         id = uuid(),
-        ): Promise<IFluidDataStoreChannel>
-    {
+    ): Promise<IFluidDataStoreChannel> {
         return this._createFluidDataStoreContext(Array.isArray(pkg) ? pkg : [pkg], id, isRoot).realize();
     }
 
@@ -1790,7 +1787,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             assert(
                 this.deltaManager.lastSequenceNumber === summaryRefSeqNum,
                 `lastSequenceNumber changed before the summary op could be submitted. `
-                    + `${this.deltaManager.lastSequenceNumber} !== ${summaryRefSeqNum}`,
+                + `${this.deltaManager.lastSequenceNumber} !== ${summaryRefSeqNum}`,
             );
 
             const clientSequenceNumber =

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1114,6 +1114,10 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         // We need to be able to send ops to replay states
         if (!this.canSendOps()) { return; }
 
+        // We need to temporary clear the dirty flags and disable
+        // dirty state change events to detect whether replaying ops
+        // has any effect.
+
         // Save the old state, reset to false, disable event emit
         const oldState = this.dirtyDocument;
         this.dirtyDocument = false;

--- a/packages/test/end-to-end-tests/src/test/documentDirty.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/documentDirty.spec.ts
@@ -47,7 +47,7 @@ describe("Document Dirty", () => {
         return new Promise((resolve) => c.once("connected", () => resolve()));
     }
 
-    async function ensureForContainerConnected(c: Container): Promise<void> {
+    async function ensureContainerConnected(c: Container): Promise<void> {
         if (!c.connected) {
             return waitForContainerReconnection(c);
         }
@@ -268,7 +268,7 @@ describe("Document Dirty", () => {
             async () => {
                 assert(container.clientId);
 
-                // Set batch values in DDSes in disconnected state.
+                // Set batch values in DDSes in connected state.
                 dataObject.context.containerRuntime.orderSequentially(() => {
                     sharedMap.set("key1", "value1");
                     sharedMap.set("key2", "value2");
@@ -299,9 +299,9 @@ describe("Document Dirty", () => {
     describe("Force readonly", () => {
         it(`sets operations when force readonly and then turn off force readonly to process them`, async () => {
             container.forceReadonly(true);
-            await ensureForContainerConnected(container);
+            await ensureContainerConnected(container);
 
-            // Set values in DDSes in disconnected state.
+            // Set values in DDSes in force read only state.
             sharedMap.set("key", "value");
 
             await opProcessingController.process();
@@ -310,7 +310,7 @@ describe("Document Dirty", () => {
             checkDirtyState("after value set while force readonly", true, 0);
 
             container.forceReadonly(false);
-            await ensureForContainerConnected(container);
+            await ensureContainerConnected(container);
 
             // Document should still be dirty right after turning off force readonly
             checkDirtyState("after clear readonly and replayed ops", true, 0);
@@ -323,13 +323,14 @@ describe("Document Dirty", () => {
 
         it(`sets ops then force readonly before sending ops, then turn off force readonly to process them`,
             async () => {
-                // Set values in DDSes in disconnected state.
+                // Set values in DDSes in write mode
                 sharedMap.set("key", "value");
 
                 checkDirtyState("after value set", true, 0);
 
+                // force readonly
                 container.forceReadonly(true);
-                await ensureForContainerConnected(container);
+                await ensureContainerConnected(container);
 
                 await opProcessingController.process();
 
@@ -337,7 +338,7 @@ describe("Document Dirty", () => {
                 checkDirtyState("after value set while force readonly", true, 0);
 
                 container.forceReadonly(false);
-                await ensureForContainerConnected(container);
+                await ensureContainerConnected(container);
 
                 // Document should still be dirty right after turning off force readonly
                 checkDirtyState("after reconnect and replayed ops", true, 0);


### PR DESCRIPTION
- Improve readability of documentDirty tests
- Add assert that we only get event when state changes (i.e. no double dirty or double save event)
- Fix issue #2724 by making the disable emitting the event while replay.
- forceReadonly(true) can't be set when it is connected.  So the API will implicit disconnect and reconnect if it was connected.
- Added test with forceReadonly, replay and document dirty state.  Identified and fixed replay op on changing force read only mode
    - There was an issue that documentDirty bit is clear but not being replayed when we transitioning to force read only mode.  
        - The fix is only to "clear" the flags if we are going to replay.
    - replay is different transition out of force readonly mode, where we don't clear the dirty flag first. So if there is a DDS that might cancel a pending up while replaying ops, we will not clear the dirty flag.  
        - The fix is reuse the same function in both case so they have the same behavior.

