### PR TITLE
[main > 0.27]: Change redeem sharing link logic in odsp resolver (#4234)

### DIFF
--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -34,7 +34,9 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl {
 
     summarizer: boolean;
 
-    sharingLinkP?: Promise<string>;
+    // This is used to save the network calls while doing trees/latest call as if the client does not have permission
+    // then this link can be redeemed for the permissions in the same network call.
+    sharingLinkToRedeem?: string;
 }
 
 /**
@@ -264,11 +266,13 @@ export interface OdspFluidDataStoreLocator {
 }
 
 export enum SharingLinkHeader {
-    isSharingLink = "isSharingLink",
+    // Can be used in request made to resolver, to tell the resolver that the passed in URL is a sharing link
+    // which can be redeemed at server to get permissions.
+    isSharingLinkToRedeem = "isSharingLinkToRedeem",
 }
 
 export interface ISharingLinkHeader {
-    [SharingLinkHeader.isSharingLink]: boolean;
+    [SharingLinkHeader.isSharingLinkToRedeem]: boolean;
 }
 
 declare module "@fluidframework/core-interfaces" {

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -108,7 +108,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
 
     private readonly documentId: string;
     private readonly snapshotUrl: string | undefined;
-    private readonly sharingLinkP: Promise<string> | undefined;
+    private readonly redeemSharingLink: string | undefined;
 
     public set ops(ops: ISequencedDeltaOpMessage[] | undefined) {
         assert(this._ops === undefined);
@@ -134,7 +134,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
     ) {
         this.documentId = odspResolvedUrl.hashedDocumentId;
         this.snapshotUrl = odspResolvedUrl.endpoints.snapshotStorageUrl;
-        this.sharingLinkP = odspResolvedUrl.sharingLinkP;
+        this.redeemSharingLink = odspResolvedUrl.sharingLinkToRedeem;
 
         this.fileEntry = {
             resolvedUrl: odspResolvedUrl,
@@ -502,9 +502,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
             Object.entries(snapshotOptions).forEach(([key, value]) => {
                 postBody += `${key}: ${value}\r\n`;
             });
-            const sharingLink = await this.sharingLinkP;
-            if (sharingLink) {
-                postBody += `sl: ${sharingLink}\r\n`;
+            if (this.redeemSharingLink) {
+                postBody += `sl: ${this.redeemSharingLink}\r\n`;
             }
             postBody += `_post: 1\r\n`;
             postBody += `\r\n--${formBoundary}--`;


### PR DESCRIPTION
1.) Redeem sharing link is not a string instead of promise on resolved url so that when making the tress/latest call, we don't have to await on it as that can cause perf regression.
2.) Set the redeem sharing link on resolved url only if specified by host in request.