### PR TITLE
[main > 0.28]: Change redeem sharing link logic in odsp resolver (#4234)

### DIFF
--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -35,7 +35,9 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl {
 
     summarizer: boolean;
 
-    sharingLinkP?: Promise<string>;
+    // This is used to save the network calls while doing trees/latest call as if the client does not have permission
+    // then this link can be redeemed for the permissions in the same network call.
+    sharingLinkToRedeem?: string;
 
     codeHint?: {
         // containerPackageName is used for adding the package name to the request headers.
@@ -279,11 +281,13 @@ export interface OdspFluidDataStoreLocator {
 }
 
 export enum SharingLinkHeader {
-    isSharingLink = "isSharingLink",
+    // Can be used in request made to resolver, to tell the resolver that the passed in URL is a sharing link
+    // which can be redeemed at server to get permissions.
+    isSharingLinkToRedeem = "isSharingLinkToRedeem",
 }
 
 export interface ISharingLinkHeader {
-    [SharingLinkHeader.isSharingLink]: boolean;
+    [SharingLinkHeader.isSharingLinkToRedeem]: boolean;
 }
 
 declare module "@fluidframework/core-interfaces" {

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -114,7 +114,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
 
     private readonly documentId: string;
     private readonly snapshotUrl: string | undefined;
-    private readonly sharingLinkP: Promise<string> | undefined;
+    private readonly redeemSharingLink: string | undefined;
     private readonly attachmentPOSTUrl: string | undefined;
     private readonly attachmentGETUrl: string | undefined;
     // Driver specified limits for snapshot size and time.
@@ -151,7 +151,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
     ) {
         this.documentId = odspResolvedUrl.hashedDocumentId;
         this.snapshotUrl = odspResolvedUrl.endpoints.snapshotStorageUrl;
-        this.sharingLinkP = odspResolvedUrl.sharingLinkP;
+        this.redeemSharingLink = odspResolvedUrl.sharingLinkToRedeem;
         this.attachmentPOSTUrl = odspResolvedUrl.endpoints.attachmentPOSTStorageUrl;
         this.attachmentGETUrl = odspResolvedUrl.endpoints.attachmentGETStorageUrl;
 
@@ -581,9 +581,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                     postBody += `${key}: ${value}\r\n`;
                 }
             });
-            const sharingLink = await this.sharingLinkP;
-            if (sharingLink) {
-                postBody += `sl: ${sharingLink}\r\n`;
+            if (this.redeemSharingLink) {
+                postBody += `sl: ${this.redeemSharingLink}\r\n`;
             }
             postBody += `_post: 1\r\n`;
             postBody += `\r\n--${formBoundary}--`;

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver2.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver2.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { PromiseCache } from "@fluidframework/common-utils";
 import { IFluidCodeDetails, IRequest, isFluidPackage } from "@fluidframework/core-interfaces";
 import { IResolvedUrl, IUrlResolver } from "@fluidframework/driver-definitions";
 import { ITelemetryBaseLogger, ITelemetryLogger } from "@fluidframework/common-definitions";
@@ -25,6 +26,7 @@ import {
 
 export class OdspDriverUrlResolver2 implements IUrlResolver {
     private readonly logger: ITelemetryLogger;
+    private readonly sharingLinkCache = new PromiseCache<string, string>();
     private readonly getSharingLinkToken:
         (options: TokenFetchOptions, scopeFor: SharingLinkScopeFor, siteUrl: string) => Promise<string | null>;
     public constructor(
@@ -75,19 +77,19 @@ export class OdspDriverUrlResolver2 implements IUrlResolver {
         return requestUrl.href;
     }
 
+    private getKey(resolvedUrl: IOdspResolvedUrl): string {
+        return `${resolvedUrl.siteUrl},${resolvedUrl.driveId},${resolvedUrl.itemId}`;
+    }
+
     /**
      * Resolves request URL into driver details
      */
     public async resolve(request: IRequest): Promise<IOdspResolvedUrl> {
         const requestToBeResolved = { headers: request.headers, url: request.url };
-        let sharingLinkP: Promise<string> | undefined;
-        const isSharingLink = requestToBeResolved.headers?.[SharingLinkHeader.isSharingLink];
+        const isSharingLinkToRedeem = requestToBeResolved.headers?.[SharingLinkHeader.isSharingLinkToRedeem];
         try {
             const url = new URL(request.url);
-            // Check if the url is the sharing link.
-            if (isSharingLink) {
-                sharingLinkP = Promise.resolve(request.url.split("?")[0]);
-            }
+
             const odspFluidInfo = getLocatorFromOdspUrl(url);
             if (odspFluidInfo) {
                 requestToBeResolved.url = createOdspUrl(
@@ -104,13 +106,14 @@ export class OdspDriverUrlResolver2 implements IUrlResolver {
 
         const odspResolvedUrl = await new OdspDriverUrlResolver().resolve(requestToBeResolved);
 
-        // Kick start the sharing link request if we don't already have it already as a performance optimization.
-        // For detached create new, we don't have an item id yet and therefore cannot generate a share link
-        if (!isSharingLink && odspResolvedUrl.itemId) {
-            sharingLinkP = this.getShareLinkPromise(odspResolvedUrl);
+        if (isSharingLinkToRedeem) {
+            odspResolvedUrl.sharingLinkToRedeem = request.url.split("?")[0];
         }
-        if (sharingLinkP) {
-            odspResolvedUrl.sharingLinkP = sharingLinkP;
+        if (odspResolvedUrl.itemId) {
+            // Kick start the sharing link request if we don't already have it already as a performance optimization.
+            // For detached create new, we don't have an item id yet and therefore cannot generate a share link
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            this.getShareLinkPromise(odspResolvedUrl).catch(() => {});
         }
         return odspResolvedUrl;
     }
@@ -137,8 +140,10 @@ export class OdspDriverUrlResolver2 implements IUrlResolver {
             throw new Error("Failed to get share link because necessary information is missing " +
                 "(e.g. siteUrl, driveId or itemId)");
         }
-        if (resolvedUrl.sharingLinkP !== undefined) {
-            return resolvedUrl.sharingLinkP;
+        const key = this.getKey(resolvedUrl);
+        const cachedLinkPromise = this.sharingLinkCache.get(key);
+        if (cachedLinkPromise) {
+            return cachedLinkPromise;
         }
         const newLinkPromise = getShareLink(
             this.getSharingLinkToken,
@@ -157,9 +162,10 @@ export class OdspDriverUrlResolver2 implements IUrlResolver {
             if (this.logger) {
                 this.logger.sendErrorEvent({ eventName: "FluidFileUrlError" }, error);
             }
+            this.sharingLinkCache.remove(key);
             throw error;
         });
-
+        this.sharingLinkCache.add(key, async () => newLinkPromise);
         return newLinkPromise;
     }
 


### PR DESCRIPTION
1.) Redeem sharing link is not a string instead of promise on resolved url so that when making the tress/latest call, we don't have to await on it as that can cause perf regression.
2.) Set the redeem sharing link on resolved url only if specified by host in request.