### PR TITLE
Eslint: Turn on prefer-promise-reject-errors

### DIFF
--- a/common/build/eslint-config-fluid/eslint7.js
+++ b/common/build/eslint-config-fluid/eslint7.js
@@ -346,6 +346,7 @@ module.exports = {
         ],
         "prefer-const": "error",
         "prefer-object-spread": "error",
+        "prefer-promise-reject-errors": "error",
         "prefer-template": "error",
         "quote-props": [
             "error",


### PR DESCRIPTION
Part one of #3807, turning on prefer-promise-reject-errors in the config.
Will fix the repo once this is published as pre-release and we start depending on it.