### PR TITLE
Remove legacy "content" path from service and client

### DIFF
--- a/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
@@ -4,7 +4,7 @@
  */
 
 import querystring from "querystring";
-import { assert, fromUtf8ToBase64 } from "@fluidframework/common-utils";
+import { fromUtf8ToBase64 } from "@fluidframework/common-utils";
 import { IDeltaStorageService, IDocumentDeltaStorageService } from "@fluidframework/driver-definitions";
 import * as api from "@fluidframework/protocol-definitions";
 import Axios from "axios";
@@ -49,28 +49,10 @@ export class DeltaStorageService implements IDeltaStorageService {
             };
         }
 
-        const opPromise = Axios.get<api.ISequencedDocumentMessage[]>(
+        const ops = await Axios.get<api.ISequencedDocumentMessage[]>(
             `${this.url}?${query}`, { headers });
 
-        const contentPromise = Axios.get<any[]>(
-            `${this.url}/content?${query}`, { headers });
-
-        const [opData, contentData] = await Promise.all([opPromise, contentPromise]);
-
-        const contents = contentData.data;
-        const ops = opData.data;
-        let contentIndex = 0;
-        for (const op of ops) {
-            if (op.contents === undefined) {
-                assert(contentIndex < contents.length, "Delta content not found");
-                const content = contents[contentIndex];
-                assert(op.sequenceNumber === content.sequenceNumber, "Invalid delta content order");
-                op.contents = content.op.contents;
-                ++contentIndex;
-            }
-        }
-
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        return ops;
+        return ops.data;
     }
 }

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
@@ -16,38 +16,6 @@ import { Provider } from "nconf";
 import { IAlfredTenant } from "@fluidframework/server-services-client";
 import { getParam } from "../../../utils";
 
-const sequenceNumber = "sequenceNumber";
-
-export async function getDeltaContents(
-    mongoManager: MongoManager,
-    collectionName: string,
-    tenantId: string,
-    documentId: string,
-    from?: number,
-    to?: number): Promise<any[]> {
-    // Create an optional filter to restrict the delta range
-    const query: any = { documentId, tenantId };
-    if (from !== undefined || to !== undefined) {
-        query[sequenceNumber] = {};
-
-        if (from !== undefined) {
-            query[sequenceNumber].$gt = from;
-        }
-
-        if (to !== undefined) {
-            query[sequenceNumber].$lt = to;
-        }
-    }
-
-    // Query for the deltas and return a filtered version of just the operations field
-    const db = await mongoManager.getDatabase();
-    // eslint-disable-next-line @typescript-eslint/await-thenable
-    const collection = await db.collection<any>(collectionName);
-    const dbDeltas = await collection.find(query, { sequenceNumber: 1 });
-
-    return dbDeltas;
-}
-
 export async function getDeltas(
     mongoManager: MongoManager,
     collectionName: string,
@@ -269,33 +237,6 @@ export function create(
             tenantManager,
             mongoManager,
             deltasCollectionName,
-            tenantId,
-            getParam(request.params, "id"),
-            from,
-            to);
-
-        deltasP.then(
-            (deltas) => {
-                response.status(200).json(deltas);
-            },
-            (error) => {
-                response.status(500).json(error);
-            });
-    });
-
-    /**
-     * Retrieves delta contents for the given document. With an optional from and to range (both exclusive) specified
-     * @deprecated path "/content:tenantId?/:id" currently kept for backwards compatibility
-     */
-    router.get(["/content/:tenantId?/:id", "/:tenantId?/:id/content"], (request, response, next) => {
-        const from = stringToSequenceNumber(request.query.from);
-        const to = stringToSequenceNumber(request.query.to);
-        const tenantId = getParam(request.params, "tenantId") || appTenants[0].id;
-
-        // Query for the deltas and return a filtered version of just the operations field
-        const deltasP = getDeltaContents(
-            mongoManager,
-            "content",
             tenantId,
             getParam(request.params, "id"),
             from,

--- a/server/tinylicious/src/routes/ordering/deltas.ts
+++ b/server/tinylicious/src/routes/ordering/deltas.ts
@@ -9,38 +9,6 @@ import { Router } from "express";
 import { Provider } from "nconf";
 import { getParam, queryParamToNumber } from "../../utils";
 
-const sequenceNumber = "sequenceNumber";
-
-export async function getDeltaContents(
-    mongoManager: MongoManager,
-    collectionName: string,
-    tenantId: string,
-    documentId: string,
-    from?: number,
-    to?: number): Promise<any[]> {
-    // Create an optional filter to restrict the delta range
-    const query: any = { documentId, tenantId };
-    if (from !== undefined || to !== undefined) {
-        query[sequenceNumber] = {};
-
-        if (from !== undefined) {
-            query[sequenceNumber].$gt = from;
-        }
-
-        if (to !== undefined) {
-            query[sequenceNumber].$lt = to;
-        }
-    }
-
-    // Query for the deltas and return a filtered version of just the operations field
-    const db = await mongoManager.getDatabase();
-    const collection = db.collection<any>(collectionName);
-    const dbDeltas = await collection.find(query, { sequenceNumber: 1 });
-
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return dbDeltas;
-}
-
 export async function getDeltas(
     mongoManager: MongoManager,
     collectionName: string,
@@ -87,33 +55,6 @@ export function create(config: Provider, mongoManager: MongoManager): Router {
         const deltasP = getDeltas(
             mongoManager,
             deltasCollectionName,
-            tenantId,
-            getParam(request.params, "id"),
-            from,
-            to);
-
-        deltasP.then(
-            (deltas) => {
-                response.status(200).json(deltas);
-            },
-            (error) => {
-                response.status(500).json(error);
-            });
-    });
-
-    /**
-     * Retrieves delta contents for the given document. With an optional from and to range (both exclusive) specified
-     * @deprecated path "/content:tenantId?/:id" currently kept for backwards compatibility
-     */
-    router.get(["/content/:tenantId/:id", "/:tenantId?/:id/content"], (request, response, next) => {
-        const from = queryParamToNumber(request.query.from);
-        const to = queryParamToNumber(request.query.to);
-        const tenantId = getParam(request.params, "tenantId");
-
-        // Query for the deltas and return a filtered version of just the operations field
-        const deltasP = getDeltaContents(
-            mongoManager,
-            "content",
             tenantId,
             getParam(request.params, "id"),
             from,


### PR DESCRIPTION
We deprecated submitAsync In #3818 . This PR removes the "/content" path from service and r11s driver  