### PR TITLE
FetchTool: prefix blob file with numbers to avoid case-insensitive fs collision

### DIFF
--- a/packages/test/snapshots/src/replayMultipleFiles.ts
+++ b/packages/test/snapshots/src/replayMultipleFiles.ts
@@ -93,7 +93,7 @@ export async function processOneFile(args: IWorkerArgs) {
     if (args.mode === Mode.Validate) {
         const path = `${replayArgs.inDirName}/original_snapshots`;
         if (fs.existsSync(path)) {
-            replayArgs.initalizeFromSnapshotsDir = path;
+            replayArgs.initializeFromSnapshotsDir = path;
         } else {
             return;
         }

--- a/packages/tools/replay-tool/src/replayArgs.ts
+++ b/packages/tools/replay-tool/src/replayArgs.ts
@@ -16,7 +16,7 @@ export class ReplayArgs {
     public verbose = true;
     public overlappingContainers = 1;
     public validateStorageSnapshots = false;
-    public initalizeFromSnapshotsDir: string | undefined;
+    public initializeFromSnapshotsDir: string | undefined;
     public windiff = false;
     public incremental = false;
     public compare = false;

--- a/packages/tools/replay-tool/src/replayMessages.ts
+++ b/packages/tools/replay-tool/src/replayMessages.ts
@@ -454,8 +454,8 @@ export class ReplayTool {
             }
         }
 
-        if (this.args.initalizeFromSnapshotsDir) {
-            for (const node of fs.readdirSync(this.args.initalizeFromSnapshotsDir, { withFileTypes: true })) {
+        if (this.args.initializeFromSnapshotsDir) {
+            for (const node of fs.readdirSync(this.args.initializeFromSnapshotsDir, { withFileTypes: true })) {
                 let storage;
                 if (node.isDirectory()) {
                     // Did we load it already as main doc?
@@ -463,15 +463,16 @@ export class ReplayTool {
                         continue;
                     }
 
-                    const file = `${this.args.initalizeFromSnapshotsDir}/${node.name}/tree.json`;
+                    const file = `${this.args.initializeFromSnapshotsDir}/${node.name}/tree.json`;
                     if (!fs.existsSync(file)) {
                         console.error(`${file} does not exist, skipping ${node.name} snapshot`);
                         continue;
                     }
-                    storage = new FluidFetchReaderFileSnapshotWriter(this.args.initalizeFromSnapshotsDir, node.name);
+                    storage = new FluidFetchReaderFileSnapshotWriter(this.args.initializeFromSnapshotsDir, node.name);
                 } else {
                     if (node.name.startsWith("snapshot_")) {
-                        const content = fs.readFileSync(`${this.args.initalizeFromSnapshotsDir}/${node.name}`, "utf-8");
+                        const content = fs.readFileSync(
+                            `${this.args.initializeFromSnapshotsDir}/${node.name}`, "utf-8");
                         const snapshot = JSON.parse(content) as IFileSnapshot;
                         storage = new FileSnapshotReader(snapshot);
                     } else {

--- a/packages/tools/replay-tool/src/replayTool.ts
+++ b/packages/tools/replay-tool/src/replayTool.ts
@@ -123,9 +123,9 @@ class ReplayProcessArgs extends ReplayArgs {
                 case "--initialSnapshots":
                     if (process.argv[i + 1] && !process.argv[i + 1].startsWith("-")) {
                         i += 1;
-                        this.initalizeFromSnapshotsDir = this.parseStrArg(i);
+                        this.initializeFromSnapshotsDir = this.parseStrArg(i);
                     } else {
-                        this.initalizeFromSnapshotsDir = this.inDirName;
+                        this.initializeFromSnapshotsDir = this.inDirName;
                     }
                     break;
                 default:


### PR DESCRIPTION
Fix issue #4050 

Prefix each blob file name with a number, and generate a tree-*-patch.json file with the blob id replaced with the prefix.
