### PR TITLE
IPersistedCache.removeAllEntriesForDocId should be async

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,3 +1,10 @@
+## 0.29 Breaking Changes
+
+- [removeAllEntriesForDocId api in host storage changed](#removeAllEntriesForDocId-api-in-host-storage-changed)
+
+### removeAllEntriesForDocId api in host storage changed
+`removeAllEntriesForDocId` api in host storage is now an async api.
+
 ## 0.28 Breaking Changes
 
 - [FileName should contain extension for ODSP driver create new path](#FileName-should-contain-extension-for-ODSP-driver-create-new-path)

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -48,7 +48,7 @@ export class EpochTracker {
             try {
                 this.validateEpochFromResponse(value.fluidEpoch);
             } catch (error) {
-                this.checkForEpochError(error);
+                await this.checkForEpochError(error);
                 throw error;
             }
             return value.value as T;
@@ -75,7 +75,7 @@ export class EpochTracker {
             this.validateEpochFromResponse(response.headers.get("x-fluid-epoch"));
             return response;
         } catch (error) {
-            this.checkForEpochError(error);
+            await this.checkForEpochError(error);
             throw error;
         }
     }
@@ -100,7 +100,7 @@ export class EpochTracker {
             this.validateEpochFromResponse(response.headers.get("x-fluid-epoch"));
             return response;
         } catch (error) {
-            this.checkForEpochError(error);
+            await this.checkForEpochError(error);
             throw error;
         }
     }
@@ -153,12 +153,12 @@ export class EpochTracker {
         }
     }
 
-    private checkForEpochError(error) {
+    private async checkForEpochError(error) {
         if (error.errorType === OdspErrorType.epochVersionMismatch) {
             this.logger.sendErrorEvent({ eventName: "EpochVersionMismatch" }, error);
             assert(!!this._hashedDocumentId, "DocId should be set to clear the cached entries!!");
             // If the epoch mismatches, then clear all entries for such document from cache.
-            this.persistedCache.removeAllEntriesForDocId(this._hashedDocumentId);
+            await this.persistedCache.removeAllEntriesForDocId(this._hashedDocumentId);
         }
     }
 }

--- a/packages/drivers/odsp-driver/src/odspCache.ts
+++ b/packages/drivers/odsp-driver/src/odspCache.ts
@@ -123,7 +123,7 @@ export interface IPersistedCache {
      * Removes all the entries from the cache for given docId.
      * @param docId - DocId for which all entries needs to be deleted from cache.
      */
-    removeAllEntriesForDocId(docId: string): void;
+    removeAllEntriesForDocId(docId: string): Promise<void>;
 }
 
 /**
@@ -194,9 +194,9 @@ export class PersistedCacheWithErrorHandling implements IPersistedCache {
         }
     }
 
-    removeAllEntriesForDocId(docId: string): void {
+    async removeAllEntriesForDocId(docId: string): Promise<void> {
         try {
-            this.cache.removeAllEntriesForDocId(docId);
+            await this.cache.removeAllEntriesForDocId(docId);
         } catch (error) {
             this.logger.sendErrorEvent({ eventName: "removeAllEntriesForDocId", docId }, error);
         }
@@ -233,7 +233,7 @@ export class LocalPersistentCache implements IPersistedCache {
     updateUsage(entry: ICacheEntry, seqNumber: number): void {
     }
 
-    removeAllEntriesForDocId(docId: string): void {
+    async removeAllEntriesForDocId(docId: string): Promise<void> {
         Array.from(this.cache)
         .filter(([key]) => {
             key.startsWith(docId);
@@ -328,7 +328,8 @@ export class LocalPersistentCacheAdapter implements IPersistedCache {
         this.cache.updateUsage(entry, seqNumber);
     }
 
-    removeAllEntriesForDocId(docId: string): void {
+    async removeAllEntriesForDocId(docId: string): Promise<void> {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.cache.removeAllEntriesForDocId(docId);
     }
 }

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver2.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver2.ts
@@ -112,7 +112,6 @@ export class OdspDriverUrlResolver2 implements IUrlResolver {
         if (odspResolvedUrl.itemId) {
             // Kick start the sharing link request if we don't already have it already as a performance optimization.
             // For detached create new, we don't have an item id yet and therefore cannot generate a share link
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             this.getShareLinkPromise(odspResolvedUrl).catch(() => {});
         }
         return odspResolvedUrl;


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/4236
Removal should be async from cache because one it takes time on host side to remove it and we need to make sure that we delete all entries before we continue on code path as other client may do the same thing at same time and we end up deleting new entries or fetching old entries again.