### PR TITLE
When doing concurrent fetch from cache & SPO, if SPO returns 401/403/404, we have to clear cache

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -359,7 +359,15 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
 
                 // No need to ask cache twice - if first request was unsuccessful, cache unlikely to have data on second turn.
                 if (tokenFetchOptions.refresh) {
-                    cachedSnapshot = await this.fetchSnapshot(snapshotOptions, tokenFetchOptions);
+                    cachedSnapshot = await this.fetchSnapshot(snapshotOptions, tokenFetchOptions).catch(async (error) => {
+                        const errorType = error.errorType;
+                        // Clear the cache on 401/403/404 on snapshot fetch from network because this means either the user doesn't have permissions
+                        // permissions for the file or it was deleted. So the user will again try to fetch from cache on any failure in future.
+                        if (this.hostPolicy.concurrentSnapshotFetch && (errorType === DriverErrorType.authorizationError || errorType === DriverErrorType.fileNotFoundOrAccessDeniedError)) {
+                            await this.cache.persistedCache.removeAllEntriesForDocId(this.documentId);
+                        }
+                        throw error;
+                    });
                 } else {
                     cachedSnapshot = await PerformanceEvent.timedExecAsync(
                         this.logger,
@@ -378,10 +386,9 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                             if (this.hostPolicy.concurrentSnapshotFetch && !this.hostPolicy.summarizerClient) {
                                 const snapshotP = this.fetchSnapshot(snapshotOptions, tokenFetchOptions);
                                 snapshotP.catch(async (error) => {
-                                    const errorType = error.errorType;
-                                    // Clear the cache on 401/403/404 on snapshot fetch from network because this means either the user doesn't have permissions
-                                    // permissions for the file or it was deleted. So the user will again try to fetch from cache on any failure in future.
-                                    if (errorType === DriverErrorType.authorizationError || errorType === DriverErrorType.fileNotFoundOrAccessDeniedError) {
+                                    // Clear the cache on 404 on snapshot fetch from network because this means that file was deleted.
+                                    // So the user will again try to fetch from cache on any failure in future if we don't clear it.
+                                    if (error.errorType === DriverErrorType.fileNotFoundOrAccessDeniedError) {
                                         await this.cache.persistedCache.removeAllEntriesForDocId(this.documentId);
                                     }
                                     throw error;

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -473,7 +473,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                 const errorType = error.errorType;
                 // Clear the cache on 401/403/404 on snapshot fetch from network because this means either the user doesn't have permissions
                 // permissions for the file or it was deleted. So the user will again try to fetch from cache on any failure in future.
-                if (this.hostPolicy.concurrentSnapshotFetch && (errorType === DriverErrorType.authorizationError || errorType === DriverErrorType.fileNotFoundOrAccessDeniedError)) {
+                if (errorType === DriverErrorType.authorizationError || errorType === DriverErrorType.fileNotFoundOrAccessDeniedError) {
                     await this.cache.persistedCache.removeAllEntriesForDocId(this.documentId);
                 }
                 throw error;


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/4145
1.) If we load from cache and later realize that user does not have permissions or file was deleted and then user tries to fetch again, it will fetch from cache and again it will face the same problem, so clear the cache.