### PR TITLE
ContainerRuntimeFactoryWithDefaultDataStore takes factory, not symbolic name

### DIFF
--- a/examples/apps/collaborative-textarea/src/container.ts
+++ b/examples/apps/collaborative-textarea/src/container.ts
@@ -18,6 +18,6 @@ import { CollaborativeText } from "./fluid-object/";
  */
 
 export const CollaborativeTextContainer = new ContainerRuntimeFactoryWithDefaultDataStore(
-    CollaborativeText.Name,
+    CollaborativeText.getFactory(),
     [[CollaborativeText.Name, Promise.resolve(CollaborativeText.getFactory())]],
 );

--- a/examples/apps/likes-and-comments/src/container.ts
+++ b/examples/apps/likes-and-comments/src/container.ts
@@ -20,6 +20,6 @@ import { LikesAndComments } from "./fluidObject";
  * FluidObjects.
  */
 export const LikesAndCommentsContainer = new ContainerRuntimeFactoryWithDefaultDataStore(
-    LikesAndComments.Name,
+    LikesAndComments.factory,
     new Map([LikesAndComments.factory.registryEntry]),
 );

--- a/examples/apps/spaces/src/container.ts
+++ b/examples/apps/spaces/src/container.ts
@@ -18,6 +18,6 @@ import { Spaces } from "./fluid-object/";
  */
 
 export const SpacesContainer = new ContainerRuntimeFactoryWithDefaultDataStore(
-    Spaces.ComponentName,
+    Spaces.getFactory(),
     [[Spaces.ComponentName, Promise.resolve(Spaces.getFactory())]],
 );

--- a/examples/data-objects/canvas/src/index.ts
+++ b/examples/data-objects/canvas/src/index.ts
@@ -10,12 +10,8 @@ import {
 import { Ink } from "@fluidframework/ink";
 import { Canvas } from "./canvas";
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-const pkg = require("../package.json");
-export const CanvasName = pkg.name as string;
-
 export const CanvasInstantiationFactory = new DataObjectFactory(
-    CanvasName,
+    "Canvas",
     Canvas,
     [
         Ink.getFactory(),
@@ -24,8 +20,8 @@ export const CanvasInstantiationFactory = new DataObjectFactory(
 );
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    CanvasName,
+    CanvasInstantiationFactory,
     new Map([
-        [CanvasName, Promise.resolve(CanvasInstantiationFactory)],
+        [CanvasInstantiationFactory.type, Promise.resolve(CanvasInstantiationFactory)],
     ]),
 );

--- a/examples/data-objects/clicker/src/index.tsx
+++ b/examples/data-objects/clicker/src/index.tsx
@@ -12,9 +12,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { ClickerAgent } from "./agent";
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-const pkg = require("../package.json");
-export const ClickerName = pkg.name as string;
+export const ClickerName = "Clicker";
 
 const counterKey = "counter";
 

--- a/examples/data-objects/diceroller/src/index.ts
+++ b/examples/data-objects/diceroller/src/index.ts
@@ -23,7 +23,7 @@ export { DiceRoller, DiceRollerInstantiationFactory } from "./main";
  * Fluid objects.
  */
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    DiceRoller.Name,
+    DiceRollerInstantiationFactory,
     new Map([
         [DiceRoller.Name, Promise.resolve(DiceRollerInstantiationFactory)],
     ]),

--- a/examples/data-objects/image-gallery/src/index.tsx
+++ b/examples/data-objects/image-gallery/src/index.tsx
@@ -106,7 +106,7 @@ export const ImageGalleryInstantiationFactory = new DataObjectFactory(
 );
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    imageGalleryName,
+    ImageGalleryInstantiationFactory,
     new Map([
         [imageGalleryName, Promise.resolve(ImageGalleryInstantiationFactory)],
     ]),

--- a/examples/data-objects/key-value-cache/src/index.ts
+++ b/examples/data-objects/key-value-cache/src/index.ts
@@ -32,8 +32,6 @@ import {
 import { defaultRouteRequestHandler } from "@fluidframework/aqueduct";
 import { assert } from "@fluidframework/common-utils";
 
-export const ComponentName = "Key-Value-Cache";
-
 export const IKeyValue: keyof IProvideKeyValue = "IKeyValue";
 
 export interface IProvideKeyValue {
@@ -137,7 +135,7 @@ export class KeyValueFactoryComponent implements IRuntimeFactory, IFluidDataStor
     public async instantiateRuntime(context: IContainerContext): Promise<IRuntime> {
         const runtime: ContainerRuntime = await ContainerRuntime.load(
             context,
-            new Map([[ComponentName, Promise.resolve(this)]]),
+            new Map([[this.type, Promise.resolve(this)]]),
             buildRuntimeRequestHandler(
                 defaultRouteRequestHandler(this.defaultComponentId),
                 innerRequestHandler,
@@ -145,7 +143,7 @@ export class KeyValueFactoryComponent implements IRuntimeFactory, IFluidDataStor
         );
 
         if (!runtime.existing) {
-            await runtime.createRootDataStore(ComponentName, this.defaultComponentId);
+            await runtime.createRootDataStore(this.type, this.defaultComponentId);
         }
 
         return runtime;

--- a/examples/data-objects/key-value-cache/src/index.ts
+++ b/examples/data-objects/key-value-cache/src/index.ts
@@ -32,7 +32,7 @@ import {
 import { defaultRouteRequestHandler } from "@fluidframework/aqueduct";
 import { assert } from "@fluidframework/common-utils";
 
-export const ComponentName = "Key-Valye-Cache";
+export const ComponentName = "Key-Value-Cache";
 
 export const IKeyValue: keyof IProvideKeyValue = "IKeyValue";
 

--- a/examples/data-objects/key-value-cache/src/index.ts
+++ b/examples/data-objects/key-value-cache/src/index.ts
@@ -32,9 +32,7 @@ import {
 import { defaultRouteRequestHandler } from "@fluidframework/aqueduct";
 import { assert } from "@fluidframework/common-utils";
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-const pkg = require("../package.json");
-export const ComponentName = pkg.name;
+export const ComponentName = "Key-Valye-Cache";
 
 export const IKeyValue: keyof IProvideKeyValue = "IKeyValue";
 

--- a/examples/data-objects/monaco/src/index.ts
+++ b/examples/data-objects/monaco/src/index.ts
@@ -26,7 +26,7 @@ const componentFactory = new DataObjectFactory(
 );
 
 const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
-    monacoName,
+    componentFactory,
     new Map([
         [monacoName, Promise.resolve(componentFactory)],
     ]),

--- a/examples/data-objects/musica/src/index.tsx
+++ b/examples/data-objects/musica/src/index.tsx
@@ -108,7 +108,7 @@ export const MusicaInstantiationFactory = new DataObjectFactory(
 );
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    musicaName,
+    MusicaInstantiationFactory,
     new Map([
         [musicaName, Promise.resolve(MusicaInstantiationFactory)],
     ]),

--- a/examples/data-objects/pond/src/data-objects/clicker.tsx
+++ b/examples/data-objects/pond/src/data-objects/clicker.tsx
@@ -15,9 +15,6 @@ const storedMapKey = "storedMap";
 const counter1Key = "counter";
 const counter2Key = "counter2";
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-const pkg = require("../../package.json");
-
 /**
  * Basic Clicker example using new interfaces and stock component classes.
  */
@@ -27,7 +24,7 @@ export class Clicker extends DataObject implements IFluidHTMLView {
     private counter1: SharedCounter | undefined;
     private counter2: SharedCounter | undefined;
 
-    public static readonly ComponentName = `${pkg.name as string}-clicker`;
+    public static readonly ComponentName = `@fluid-example/pond-clicker`;
 
     /**
      * Do setup work here

--- a/examples/data-objects/pond/src/data-objects/exampleUsingProviders.tsx
+++ b/examples/data-objects/pond/src/data-objects/exampleUsingProviders.tsx
@@ -12,9 +12,6 @@ import ReactDOM from "react-dom";
 
 import { IFluidUserInformation } from "../interfaces";
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-const pkg = require("../../package.json");
-
 /**
  * Basic example that takes a container provider
  */
@@ -25,7 +22,7 @@ export class ExampleUsingProviders
 
     private userInformation: IFluidUserInformation | undefined;
 
-    public static readonly ComponentName = `${pkg.name as string}-example-using-provider`;
+    public static readonly ComponentName = `@fluid-example/pond-example-using-provider`;
 
     protected async hasInitialized() {
         this.userInformation = await this.providers.IFluidUserInformation;

--- a/examples/data-objects/pond/src/index.tsx
+++ b/examples/data-objects/pond/src/index.tsx
@@ -20,9 +20,7 @@ import {
 import { IFluidUserInformation } from "./interfaces";
 import { userInfoFactory } from "./providers";
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-const pkg = require("../package.json");
-export const PondName = pkg.name as string;
+export const PondName = "Pond";
 
 /**
  * Basic Pond example using stock component classes.
@@ -115,7 +113,7 @@ export class Pond extends DataObject implements IFluidHTMLView {
 // ----- CONTAINER SETUP STUFF -----
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    Pond.getFactory().type,
+    Pond.getFactory(),
     new Map([
         Pond.getFactory().registryEntry,
     ]),

--- a/examples/data-objects/primitives/src/index.ts
+++ b/examples/data-objects/primitives/src/index.ts
@@ -22,7 +22,7 @@ import { PrimitivesInstantiationFactory } from "./primitivesInstantiationFactory
  * components.
  */
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    PrimitivesName,
+    PrimitivesInstantiationFactory,
     new Map([
         [PrimitivesName, Promise.resolve(PrimitivesInstantiationFactory)],
     ]),

--- a/examples/data-objects/primitives/src/main.tsx
+++ b/examples/data-objects/primitives/src/main.tsx
@@ -12,9 +12,7 @@ import ReactDOM from "react-dom";
 import { SharedMap, IDirectory, IDirectoryValueChanged } from "@fluidframework/map";
 import { DdsCollectionComponent } from "./ddsCollection";
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-const pkg = require("../package.json");
-export const PrimitivesName = pkg.name as string;
+export const PrimitivesName = "PrimitivesCollection";
 
 /**
  * Basic DDS examples using view interfaces and stock component classes.

--- a/examples/data-objects/simple-fluidobject-embed/src/index.tsx
+++ b/examples/data-objects/simple-fluidobject-embed/src/index.tsx
@@ -58,7 +58,7 @@ export const SimpleFluidObjectEmbedInstantiationFactory = new DataObjectFactory(
 );
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    SimpleFluidObjectEmbedInstantiationFactory.type,
+    SimpleFluidObjectEmbedInstantiationFactory,
     new Map([
         SimpleFluidObjectEmbedInstantiationFactory.registryEntry,
         ClickerInstantiationFactory.registryEntry,

--- a/examples/data-objects/table-document/src/test/tableWithInterception.spec.ts
+++ b/examples/data-objects/table-document/src/test/tableWithInterception.spec.ts
@@ -67,7 +67,7 @@ describe("Table Document with Interception", () => {
 
         beforeEach(async () => {
             const factory = new ContainerRuntimeFactoryWithDefaultDataStore(
-                TableDocumentType,
+                TableDocument.getFactory(),
                 new Map([
                     [TableDocumentType, Promise.resolve(TableDocument.getFactory())],
                 ]),

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -40,7 +40,9 @@
     "@fluid-example/flow-util-lib": "^0.29.0",
     "@fluid-example/table-document": "^0.29.0",
     "@fluidframework/aqueduct": "^0.29.0",
+    "@fluidframework/container-definitions": "^0.29.0",
     "@fluidframework/core-interfaces": "^0.29.0",
+    "@fluidframework/runtime-utils": "^0.29.0",
     "@fluidframework/view-interfaces": "^0.29.0",
     "@tiny-calc/micro": "0.0.0-alpha.5"
   },

--- a/examples/data-objects/table-view/src/runtime.ts
+++ b/examples/data-objects/table-view/src/runtime.ts
@@ -3,13 +3,19 @@
  * Licensed under the MIT License.
  */
 
+import { createDataStoreFactory } from "@fluidframework/runtime-utils";
 import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
+import { IRuntimeFactory } from "@fluidframework/container-definitions";
 import { tableViewType } from "./tableview";
 
-export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
+const factory = createDataStoreFactory(
     tableViewType,
+    // eslint-disable-next-line max-len
+    import(/* webpackChunkName: "table-view", webpackPreload: true */ "./tableview").then((m) => m.TableView.getFactory()));
+
+export const fluidExport: IRuntimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
+    factory,
     new Map([
-        // eslint-disable-next-line max-len
-        [tableViewType, import(/* webpackChunkName: "table-view", webpackPreload: true */ "./tableview").then((m) => m.TableView.getFactory())],
+        [factory.type, Promise.resolve(factory)],
     ]),
 );

--- a/examples/data-objects/todo/src/Todo/Todo.tsx
+++ b/examples/data-objects/todo/src/Todo/Todo.tsx
@@ -12,9 +12,7 @@ import ReactDOM from "react-dom";
 import { ITodoItemInitialState, TodoItem } from "../TodoItem/index";
 import { TodoView } from "./TodoView";
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-const pkg = require("../../package.json");
-export const TodoName = `${pkg.name as string}-todo`;
+export const TodoName = "Todo";
 
 /**
  * Todo base component.

--- a/examples/data-objects/todo/src/Todo/todoInstantiationFactory.ts
+++ b/examples/data-objects/todo/src/Todo/todoInstantiationFactory.ts
@@ -6,14 +6,13 @@
 import { DataObjectFactory } from "@fluidframework/aqueduct";
 import { SharedCell } from "@fluidframework/cell";
 import { SharedMap } from "@fluidframework/map";
-import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 import { SharedObjectSequence, SharedString } from "@fluidframework/sequence";
 import { TodoItem } from "../TodoItem";
 
 import { TodoName } from "./Todo";
 import { Todo } from "./index";
 
-export const TodoInstantiationFactory: IFluidDataStoreFactory = new DataObjectFactory(
+export const TodoInstantiationFactory = new DataObjectFactory(
     TodoName,
     Todo,
     [

--- a/examples/data-objects/todo/src/index.tsx
+++ b/examples/data-objects/todo/src/index.tsx
@@ -7,7 +7,7 @@ import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqu
 import { TodoInstantiationFactory, TodoName } from "./Todo";
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    TodoName,
+    TodoInstantiationFactory,
     new Map([
         [TodoName, Promise.resolve(TodoInstantiationFactory)],
     ]),

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -51,6 +51,7 @@
     "@fluidframework/request-handler": "^0.29.0",
     "@fluidframework/runtime-definitions": "^0.29.0",
     "@fluidframework/runtime-utils": "^0.29.0",
+    "@fluidframework/synthesize": "^0.29.0",
     "@fluidframework/view-adapters": "^0.29.0",
     "@fluidframework/view-interfaces": "^0.29.0",
     "office-ui-fabric-react": "^7.28.1",

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -51,7 +51,6 @@
     "@fluidframework/request-handler": "^0.29.0",
     "@fluidframework/runtime-definitions": "^0.29.0",
     "@fluidframework/runtime-utils": "^0.29.0",
-    "@fluidframework/synthesize": "^0.29.0",
     "@fluidframework/view-adapters": "^0.29.0",
     "@fluidframework/view-interfaces": "^0.29.0",
     "office-ui-fabric-react": "^7.28.1",

--- a/examples/data-objects/vltava/src/index.ts
+++ b/examples/data-objects/vltava/src/index.ts
@@ -16,6 +16,7 @@ import {
     IFluidLastEditedTracker,
 } from "@fluidframework/last-edited-experimental";
 import {
+    IFluidDataStoreFactory,
     IFluidDataStoreRegistry,
     IProvideFluidDataStoreFactory,
     NamedFluidDataStoreRegistryEntries,
@@ -67,10 +68,10 @@ export class InternalRegistry implements IFluidDataStoreRegistry, IFluidObjectIn
 
 export class VltavaRuntimeFactory extends ContainerRuntimeFactoryWithDefaultDataStore {
     constructor(
-        defaultFluidObjectName: string,
+        defaultFactory: IFluidDataStoreFactory,
         registryEntries: NamedFluidDataStoreRegistryEntries,
     ) {
-        super(defaultFluidObjectName, registryEntries);
+        super(defaultFactory, registryEntries);
     }
 
     /**
@@ -129,7 +130,7 @@ const generateFactory = () => {
     // TODO: You should be able to specify the default registry instead of just a list of fluidObjects
     // and the default registry is already determined Issue:#1138
     return new VltavaRuntimeFactory(
-        Anchor.getFactory().type,
+        Anchor.getFactory(),
         [
             ...containerFluidObjects,
             LastEditedTrackerDataObject.getFactory().registryEntry,

--- a/examples/hosts/app-integration/container-views/src/containerCode.ts
+++ b/examples/hosts/app-integration/container-views/src/containerCode.ts
@@ -20,7 +20,7 @@ import { DiceRoller, DiceRollerInstantiationFactory } from "./model";
  * Fluid objects.
  */
 export const DiceRollerContainerRuntimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
-    DiceRoller.Name,
+    DiceRollerInstantiationFactory,
     new Map([
         [DiceRoller.Name, Promise.resolve(DiceRollerInstantiationFactory)],
     ]),

--- a/examples/hosts/app-integration/external-views/src/containerCode.ts
+++ b/examples/hosts/app-integration/external-views/src/containerCode.ts
@@ -18,7 +18,7 @@ import { DiceRollerInstantiationFactory } from "./dataObject";
  * Container with a URL of "/", so it can be retrieved via container.request("/").
  */
 export const DiceRollerContainerRuntimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
-    DiceRollerInstantiationFactory.type,
+    DiceRollerInstantiationFactory,
     new Map([
         DiceRollerInstantiationFactory.registryEntry,
     ]),

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -4538,7 +4538,7 @@
 		},
 		"@microsoft/api-extractor": {
 			"version": "7.8.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/api-extractor/-/api-extractor-7.8.0.tgz",
+			"resolved": "https://registry.npmjs.org@microsoft/api-extractor/-/api-extractor-7.8.0.tgz",
 			"integrity": "sha1-/qaOTyHBvxgCBWD9VyixX+RPCXY=",
 			"dev": true,
 			"requires": {
@@ -4555,7 +4555,7 @@
 		},
 		"@microsoft/api-extractor-model": {
 			"version": "7.8.0",
-			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/api-extractor-model/-/api-extractor-model-7.8.0.tgz",
+			"resolved": "https://registry.npmjs.org@microsoft/api-extractor-model/-/api-extractor-model-7.8.0.tgz",
 			"integrity": "sha1-X1MpmPARCfI9V7QigDu99a1lXYA=",
 			"dev": true,
 			"requires": {

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -73,6 +73,152 @@
 				}
 			}
 		},
+		"@babel/helper-create-class-features-plugin": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz",
+			"integrity": "sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==",
+			"requires": {
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-member-expression-to-functions": "^7.12.1",
+				"@babel/helper-optimise-call-expression": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.12.1",
+				"@babel/helper-split-export-declaration": "^7.10.4"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"requires": {
+						"@babel/highlight": "^7.10.4"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.12.5",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
+					"integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
+					"requires": {
+						"@babel/types": "^7.12.5",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+					"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
+					"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
+					"requires": {
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+					"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.12.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
+					"integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.12.1",
+						"@babel/helper-optimise-call-expression": "^7.10.4",
+						"@babel/traverse": "^7.12.5",
+						"@babel/types": "^7.12.5"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+					"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+					"requires": {
+						"@babel/types": "^7.11.0"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+				},
+				"@babel/highlight": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.12.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.5.tgz",
+					"integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ=="
+				},
+				"@babel/template": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+					"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/parser": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.12.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.5.tgz",
+					"integrity": "sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==",
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/generator": "^7.12.5",
+						"@babel/helper-function-name": "^7.10.4",
+						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/parser": "^7.12.5",
+						"@babel/types": "^7.12.5",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@babel/types": {
+					"version": "7.12.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
+					"integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				}
+			}
+		},
 		"@babel/helper-function-name": {
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
@@ -199,152 +345,6 @@
 			"requires": {
 				"@babel/helper-create-class-features-plugin": "^7.12.1",
 				"@babel/helper-plugin-utils": "^7.10.4"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-					"requires": {
-						"@babel/highlight": "^7.10.4"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
-					"integrity": "sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==",
-					"requires": {
-						"@babel/types": "^7.12.1",
-						"jsesc": "^2.5.1",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/helper-create-class-features-plugin": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz",
-					"integrity": "sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==",
-					"requires": {
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/helper-member-expression-to-functions": "^7.12.1",
-						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/helper-replace-supers": "^7.12.1",
-						"@babel/helper-split-export-declaration": "^7.10.4"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-					"requires": {
-						"@babel/helper-get-function-arity": "^7.10.4",
-						"@babel/template": "^7.10.4",
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-					"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-					"requires": {
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-member-expression-to-functions": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
-					"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
-					"requires": {
-						"@babel/types": "^7.12.1"
-					}
-				},
-				"@babel/helper-optimise-call-expression": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-					"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
-					"requires": {
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-replace-supers": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.1.tgz",
-					"integrity": "sha512-zJjTvtNJnCFsCXVi5rUInstLd/EIVNmIKA1Q9ynESmMBWPWd+7sdR+G4/wdu+Mppfep0XLyG2m7EBPvjCeFyrw==",
-					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.12.1",
-						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/traverse": "^7.12.1",
-						"@babel/types": "^7.12.1"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-					"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
-					"requires": {
-						"@babel/types": "^7.11.0"
-					}
-				},
-				"@babel/helper-validator-identifier": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-				},
-				"@babel/highlight": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
-						"chalk": "^2.0.0",
-						"js-tokens": "^4.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.12.3",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.3.tgz",
-					"integrity": "sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw=="
-				},
-				"@babel/template": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-					"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
-					"requires": {
-						"@babel/code-frame": "^7.10.4",
-						"@babel/parser": "^7.10.4",
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.1.tgz",
-					"integrity": "sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==",
-					"requires": {
-						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.12.1",
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.12.1",
-						"@babel/types": "^7.12.1",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@babel/types": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
-					"integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
-						"lodash": "^4.17.19",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				}
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
@@ -435,6 +435,14 @@
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
+		"@babel/plugin-syntax-top-level-await": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.1.tgz",
+			"integrity": "sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
 		"@babel/polyfill": {
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
@@ -446,9 +454,9 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
-			"integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+			"integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
@@ -560,9 +568,9 @@
 					}
 				},
 				"import-fresh": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-					"integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
+					"integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
 					"requires": {
 						"parent-module": "^1.0.0",
 						"resolve-from": "^4.0.0"
@@ -720,35 +728,35 @@
 			}
 		},
 		"@fluentui/react-focus": {
-			"version": "7.16.13",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.16.13.tgz",
-			"integrity": "sha512-MWyI64GSEZigYe75aCy8VGGIr/tWwk+H8oqPxamoVOHef4kCqYm/70mhrDpBP1oAhJVmdY/Lia6dtkIz3J9wgw==",
+			"version": "7.16.17",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.16.17.tgz",
+			"integrity": "sha512-Uioe+9tZoiXxp5aKam6Y+PyU46UDGMCF4xYctgP3tIpPyi7xfka7Aat6IyIFcTxN53UKea2IcCMzbOhpK0VTLg==",
 			"requires": {
 				"@fluentui/keyboard-key": "^0.2.12",
 				"@uifabric/merge-styles": "^7.19.1",
 				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/styling": "^7.16.13",
-				"@uifabric/utilities": "^7.32.4",
+				"@uifabric/styling": "^7.16.17",
+				"@uifabric/utilities": "^7.33.2",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@fluentui/react-window-provider": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-0.3.3.tgz",
-			"integrity": "sha512-MVPf2hqOQ17LAZsuvGcr3oOHksAskUm+fCYdXFhbVoAgsCDVTIuH6i8XgHFd6YjBtzjZmI4+k/3NTQfDqBX8EQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-1.0.1.tgz",
+			"integrity": "sha512-5hvruDyF0uE8+6YN6Y+d2sEzexBadxUNxUjDcDreTPsmtHPwF5FPBYLhoD7T84L5U4YNvKxKh25tYJm6E0GE2w==",
 			"requires": {
 				"@uifabric/set-version": "^7.0.23",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@fluentui/theme": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-1.5.1.tgz",
-			"integrity": "sha512-w5986/CN3hWuH44WmlQNxtndBx0khnb1xjISb/4bktRpehYxIlDBmQYRUOUYXr6zwdK7JXJaJPGjOJzSh2DCDg==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-1.6.0.tgz",
+			"integrity": "sha512-X+uJx7+9ChfM0SAq+eDLgL9t65ZA8NAc1Ifrw4eek6cS3c1eY95/tgf1EkX+hOE9+oIuEATujM9THzk+4yd1VQ==",
 			"requires": {
 				"@uifabric/merge-styles": "^7.19.1",
 				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/utilities": "^7.32.4",
+				"@uifabric/utilities": "^7.33.2",
 				"tslib": "^1.10.0"
 			}
 		},
@@ -2720,15 +2728,15 @@
 			"integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw=="
 		},
 		"@jest/console": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-26.6.1.tgz",
-			"integrity": "sha512-cjqcXepwC5M+VeIhwT6Xpi/tT4AiNzlIx8SMJ9IihduHnsSrnWNvTBfKIpmqOOCNOPqtbBx6w2JqfoLOJguo8g==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-26.6.2.tgz",
+			"integrity": "sha512-IY1R2i2aLsLr7Id3S6p2BA82GNWryt4oSvEXLAKc+L2zdi89dSkE8xC1C+0kpATG4JhBJREnQOH7/zmccM2B0g==",
 			"requires": {
-				"@jest/types": "^26.6.1",
+				"@jest/types": "^26.6.2",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
-				"jest-message-util": "^26.6.1",
-				"jest-util": "^26.6.1",
+				"jest-message-util": "^26.6.2",
+				"jest-util": "^26.6.2",
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
@@ -2782,90 +2790,229 @@
 				}
 			}
 		},
-		"@jest/create-cache-key-function": {
-			"version": "26.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-26.5.0.tgz",
-			"integrity": "sha512-DJ+pEBUIqarrbv1W/C39f9YH0rJ4wsXZ/VC6JafJPlHW2HOucKceeaqTOQj9MEDQZjySxMLkOq5mfXZXNZcmWw=="
-		},
-		"@jest/environment": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.1.tgz",
-			"integrity": "sha512-GNvHwkOFJtNgSwdzH9flUPzF9AYAZhUg124CBoQcwcZCM9s5TLz8Y3fMtiaWt4ffbigoetjGk5PU2Dd8nLrSEw==",
+		"@jest/core": {
+			"version": "26.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-26.6.3.tgz",
+			"integrity": "sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==",
 			"requires": {
-				"@jest/fake-timers": "^26.6.1",
-				"@jest/types": "^26.6.1",
+				"@jest/console": "^26.6.2",
+				"@jest/reporters": "^26.6.2",
+				"@jest/test-result": "^26.6.2",
+				"@jest/transform": "^26.6.2",
+				"@jest/types": "^26.6.2",
 				"@types/node": "*",
-				"jest-mock": "^26.6.1"
-			}
-		},
-		"@jest/fake-timers": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.6.1.tgz",
-			"integrity": "sha512-T/SkMLgOquenw/nIisBRD6XAYpFir0kNuclYLkse5BpzeDUukyBr+K31xgAo9M0hgjU9ORlekAYPSzc0DKfmKg==",
-			"requires": {
-				"@jest/types": "^26.6.1",
-				"@sinonjs/fake-timers": "^6.0.1",
-				"@types/node": "*",
-				"jest-message-util": "^26.6.1",
-				"jest-mock": "^26.6.1",
-				"jest-util": "^26.6.1"
-			}
-		},
-		"@jest/globals": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.6.1.tgz",
-			"integrity": "sha512-acxXsSguuLV/CeMYmBseefw6apO7NuXqpE+v5r3yD9ye2PY7h1nS20vY7Obk2w6S7eJO4OIAJeDnoGcLC/McEQ==",
-			"requires": {
-				"@jest/environment": "^26.6.1",
-				"@jest/types": "^26.6.1",
-				"expect": "^26.6.1"
-			}
-		},
-		"@jest/source-map": {
-			"version": "26.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.5.0.tgz",
-			"integrity": "sha512-jWAw9ZwYHJMe9eZq/WrsHlwF8E3hM9gynlcDpOyCb9bR8wEd9ZNBZCi7/jZyzHxC7t3thZ10gO2IDhu0bPKS5g==",
-			"requires": {
-				"callsites": "^3.0.0",
+				"ansi-escapes": "^4.2.1",
+				"chalk": "^4.0.0",
+				"exit": "^0.1.2",
 				"graceful-fs": "^4.2.4",
-				"source-map": "^0.6.0"
+				"jest-changed-files": "^26.6.2",
+				"jest-config": "^26.6.3",
+				"jest-haste-map": "^26.6.2",
+				"jest-message-util": "^26.6.2",
+				"jest-regex-util": "^26.0.0",
+				"jest-resolve": "^26.6.2",
+				"jest-resolve-dependencies": "^26.6.3",
+				"jest-runner": "^26.6.3",
+				"jest-runtime": "^26.6.3",
+				"jest-snapshot": "^26.6.2",
+				"jest-util": "^26.6.2",
+				"jest-validate": "^26.6.2",
+				"jest-watcher": "^26.6.2",
+				"micromatch": "^4.0.2",
+				"p-each-series": "^2.1.0",
+				"rimraf": "^3.0.0",
+				"slash": "^3.0.0",
+				"strip-ansi": "^6.0.0"
 			},
 			"dependencies": {
-				"callsites": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
-				}
-			}
-		},
-		"@jest/test-result": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.6.1.tgz",
-			"integrity": "sha512-wqAgIerIN2gSdT2A8WeA5+AFh9XQBqYGf8etK143yng3qYd0mF0ie2W5PVmgnjw4VDU6ammI9NdXrKgNhreawg==",
-			"requires": {
-				"@jest/console": "^26.6.1",
-				"@jest/types": "^26.6.1",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"collect-v8-coverage": "^1.0.0"
-			}
-		},
-		"@jest/test-sequencer": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.6.1.tgz",
-			"integrity": "sha512-0csqA/XApZiNeTIPYh6koIDCACSoR6hi29T61tKJMtCZdEC+tF3PoNt7MS0oK/zKC6daBgCbqXxia5ztr/NyCQ==",
-			"requires": {
-				"@jest/test-result": "^26.6.1",
-				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^26.6.1",
-				"jest-runner": "^26.6.1",
-				"jest-runtime": "^26.6.1"
-			},
-			"dependencies": {
+				"ansi-escapes": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+					"requires": {
+						"type-fest": "^0.11.0"
+					}
+				},
 				"ansi-regex": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
 					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				},
+				"type-fest": {
+					"version": "0.11.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+					"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
+				}
+			}
+		},
+		"@jest/environment": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.2.tgz",
+			"integrity": "sha512-nFy+fHl28zUrRsCeMB61VDThV1pVTtlEokBRgqPrcT1JNq4yRNIyTHfyht6PqtUvY9IsuLGTrbG8kPXjSZIZwA==",
+			"requires": {
+				"@jest/fake-timers": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"@types/node": "*",
+				"jest-mock": "^26.6.2"
+			}
+		},
+		"@jest/fake-timers": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.6.2.tgz",
+			"integrity": "sha512-14Uleatt7jdzefLPYM3KLcnUl1ZNikaKq34enpb5XG9i81JpppDb5muZvonvKyrl7ftEHkKS5L5/eB/kxJ+bvA==",
+			"requires": {
+				"@jest/types": "^26.6.2",
+				"@sinonjs/fake-timers": "^6.0.1",
+				"@types/node": "*",
+				"jest-message-util": "^26.6.2",
+				"jest-mock": "^26.6.2",
+				"jest-util": "^26.6.2"
+			}
+		},
+		"@jest/globals": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.6.2.tgz",
+			"integrity": "sha512-85Ltnm7HlB/KesBUuALwQ68YTU72w9H2xW9FjZ1eL1U3lhtefjjl5c2MiUbpXt/i6LaPRvoOFJ22yCBSfQ0JIA==",
+			"requires": {
+				"@jest/environment": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"expect": "^26.6.2"
+			}
+		},
+		"@jest/reporters": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.6.2.tgz",
+			"integrity": "sha512-h2bW53APG4HvkOnVMo8q3QXa6pcaNt1HkwVsOPMBV6LD/q9oSpxNSYZQYkAnjdMjrJ86UuYeLo+aEZClV6opnw==",
+			"requires": {
+				"@bcoe/v8-coverage": "^0.2.3",
+				"@jest/console": "^26.6.2",
+				"@jest/test-result": "^26.6.2",
+				"@jest/transform": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"chalk": "^4.0.0",
+				"collect-v8-coverage": "^1.0.0",
+				"exit": "^0.1.2",
+				"glob": "^7.1.2",
+				"graceful-fs": "^4.2.4",
+				"istanbul-lib-coverage": "^3.0.0",
+				"istanbul-lib-instrument": "^4.0.3",
+				"istanbul-lib-report": "^3.0.0",
+				"istanbul-lib-source-maps": "^4.0.0",
+				"istanbul-reports": "^3.0.2",
+				"jest-haste-map": "^26.6.2",
+				"jest-resolve": "^26.6.2",
+				"jest-util": "^26.6.2",
+				"jest-worker": "^26.6.2",
+				"node-notifier": "^8.0.0",
+				"slash": "^3.0.0",
+				"source-map": "^0.6.0",
+				"string-length": "^4.0.1",
+				"terminal-link": "^2.0.0",
+				"v8-to-istanbul": "^7.0.0"
+			},
+			"dependencies": {
 				"ansi-styles": {
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2883,16 +3030,6 @@
 						"supports-color": "^7.1.0"
 					}
 				},
-				"cliui": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-					"requires": {
-						"string-width": "^4.2.0",
-						"strip-ansi": "^6.0.0",
-						"wrap-ansi": "^6.2.0"
-					}
-				},
 				"color-convert": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2906,140 +3043,31 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-				},
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-				},
-				"jest-runtime": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.1.tgz",
-					"integrity": "sha512-7uOCNeezXDWgjEyzYbRN2ViY7xNZzusNVGAMmU0UHRUNXuY4j4GBHKGMqPo/cBPZA9bSYp+lwK2DRRBU5Dv6YQ==",
+				"istanbul-lib-instrument": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+					"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
 					"requires": {
-						"@jest/console": "^26.6.1",
-						"@jest/environment": "^26.6.1",
-						"@jest/fake-timers": "^26.6.1",
-						"@jest/globals": "^26.6.1",
-						"@jest/source-map": "^26.5.0",
-						"@jest/test-result": "^26.6.1",
-						"@jest/transform": "^26.6.1",
-						"@jest/types": "^26.6.1",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0",
-						"cjs-module-lexer": "^0.4.2",
-						"collect-v8-coverage": "^1.0.0",
-						"exit": "^0.1.2",
-						"glob": "^7.1.3",
-						"graceful-fs": "^4.2.4",
-						"jest-config": "^26.6.1",
-						"jest-haste-map": "^26.6.1",
-						"jest-message-util": "^26.6.1",
-						"jest-mock": "^26.6.1",
-						"jest-regex-util": "^26.0.0",
-						"jest-resolve": "^26.6.1",
-						"jest-snapshot": "^26.6.1",
-						"jest-util": "^26.6.1",
-						"jest-validate": "^26.6.1",
-						"slash": "^3.0.0",
-						"strip-bom": "^4.0.0",
-						"yargs": "^15.4.1"
+						"@babel/core": "^7.7.5",
+						"@istanbuljs/schema": "^0.1.2",
+						"istanbul-lib-coverage": "^3.0.0",
+						"semver": "^6.3.0"
 					}
-				},
-				"jest-snapshot": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.1.tgz",
-					"integrity": "sha512-JA7bZp7HRTIJYAi85pJ/OZ2eur2dqmwIToA5/6d7Mn90isGEfeF9FvuhDLLEczgKP1ihreBzrJ6Vr7zteP5JNA==",
-					"requires": {
-						"@babel/types": "^7.0.0",
-						"@jest/types": "^26.6.1",
-						"@types/babel__traverse": "^7.0.4",
-						"@types/prettier": "^2.0.0",
-						"chalk": "^4.0.0",
-						"expect": "^26.6.1",
-						"graceful-fs": "^4.2.4",
-						"jest-diff": "^26.6.1",
-						"jest-get-type": "^26.3.0",
-						"jest-haste-map": "^26.6.1",
-						"jest-matcher-utils": "^26.6.1",
-						"jest-message-util": "^26.6.1",
-						"jest-resolve": "^26.6.1",
-						"natural-compare": "^1.4.0",
-						"pretty-format": "^26.6.1",
-						"semver": "^7.3.2"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
 				},
 				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				},
 				"slash": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
-				},
-				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
 				},
 				"supports-color": {
 					"version": "7.2.0",
@@ -3048,61 +3076,64 @@
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
-				},
-				"wrap-ansi": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"yargs": {
-					"version": "15.4.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-					"requires": {
-						"cliui": "^6.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^4.1.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^4.2.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^18.1.2"
-					}
-				},
-				"yargs-parser": {
-					"version": "18.1.3",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
 				}
 			}
 		},
+		"@jest/source-map": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.6.2.tgz",
+			"integrity": "sha512-YwYcCwAnNmOVsZ8mr3GfnzdXDAl4LaenZP5z+G0c8bzC9/dugL8zRmxZzdoTl4IaS3CryS1uWnROLPFmb6lVvA==",
+			"requires": {
+				"callsites": "^3.0.0",
+				"graceful-fs": "^4.2.4",
+				"source-map": "^0.6.0"
+			},
+			"dependencies": {
+				"callsites": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+				}
+			}
+		},
+		"@jest/test-result": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.6.2.tgz",
+			"integrity": "sha512-5O7H5c/7YlojphYNrK02LlDIV2GNPYisKwHm2QTKjNZeEzezCbwYs9swJySv2UfPMyZ0VdsmMv7jIlD/IKYQpQ==",
+			"requires": {
+				"@jest/console": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"collect-v8-coverage": "^1.0.0"
+			}
+		},
+		"@jest/test-sequencer": {
+			"version": "26.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.6.3.tgz",
+			"integrity": "sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==",
+			"requires": {
+				"@jest/test-result": "^26.6.2",
+				"graceful-fs": "^4.2.4",
+				"jest-haste-map": "^26.6.2",
+				"jest-runner": "^26.6.3",
+				"jest-runtime": "^26.6.3"
+			}
+		},
 		"@jest/transform": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.1.tgz",
-			"integrity": "sha512-oNFAqVtqRxZRx6vXL3I4bPKUK0BIlEeaalkwxyQGGI8oXDQBtYQBpiMe5F7qPs4QdvvFYB42gPGIMMcxXaBBxQ==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.2.tgz",
+			"integrity": "sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==",
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/types": "^26.6.1",
+				"@jest/types": "^26.6.2",
 				"babel-plugin-istanbul": "^6.0.0",
 				"chalk": "^4.0.0",
 				"convert-source-map": "^1.4.0",
 				"fast-json-stable-stringify": "^2.0.0",
 				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^26.6.1",
+				"jest-haste-map": "^26.6.2",
 				"jest-regex-util": "^26.0.0",
-				"jest-util": "^26.6.1",
+				"jest-util": "^26.6.2",
 				"micromatch": "^4.0.2",
 				"pirates": "^4.0.1",
 				"slash": "^3.0.0",
@@ -3210,9 +3241,9 @@
 			}
 		},
 		"@jest/types": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
-			"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+			"integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"@types/istanbul-reports": "^3.0.0",
@@ -4564,9 +4595,9 @@
 			}
 		},
 		"@microsoft/load-themed-styles": {
-			"version": "1.10.117",
-			"resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.117.tgz",
-			"integrity": "sha512-nEvUltTnpm4FnZ7TFHwQqL1Y5PDqXbAT1WGUXuUAF5RM8dgoRHQ72uIZJ2UBSQNKsY/+IwGWmHBFJVT1e1mzSQ=="
+			"version": "1.10.127",
+			"resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.127.tgz",
+			"integrity": "sha512-Uc9+ZhdhrDPG7p3PhBF4ZjeinqECC2zzfE/aDKhUu7oC7XFHH+EhK6SfvMn/JCVVSiWtanaaam4eG3k7lQCmbg=="
 		},
 		"@microsoft/tsdoc": {
 			"version": "0.12.19",
@@ -5351,9 +5382,9 @@
 			"integrity": "sha512-bWBbC7VG2jdjbgZMX0qpds8U/3h3anfIqE81L8jmVrgFZw/urEDnBA78ymGGKTTK6ciBXmmJ/xlok+Re41S8ww=="
 		},
 		"@types/babel__core": {
-			"version": "7.1.10",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.10.tgz",
-			"integrity": "sha512-x8OM8XzITIMyiwl5Vmo2B1cR1S1Ipkyv4mdlbJjMa1lmuKvKY9FrBbEANIaMlnWn5Rf7uO+rC/VgYabNkE17Hw==",
+			"version": "7.1.12",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
+			"integrity": "sha512-wMTHiiTiBAAPebqaPiPDLFA4LYPKr6Ph0Xq/6rq1Ur3v66HXyG+clfR9CNETkD7MQS8ZHvpQOtA53DLws5WAEQ==",
 			"requires": {
 				"@babel/parser": "^7.1.0",
 				"@babel/types": "^7.0.0",
@@ -5581,9 +5612,9 @@
 			"integrity": "sha512-aWw2YTtAdT7CskFyxEX2K21/zSDStuf/ikI3yBqmwpwJF0pS+/IX5DWv+1UFffZIbruP6cnT9/LAJV1gFwAT1A=="
 		},
 		"@types/lodash": {
-			"version": "4.14.162",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.162.tgz",
-			"integrity": "sha512-alvcho1kRUnnD1Gcl4J+hK0eencvzq9rmzvFPRmP5rPHx9VVsJj6bKLTATPVf9ktgv4ujzh7T+XWKp+jhuODig=="
+			"version": "4.14.165",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.165.tgz",
+			"integrity": "sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg=="
 		},
 		"@types/mime": {
 			"version": "2.0.3",
@@ -5645,9 +5676,9 @@
 			"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
 		},
 		"@types/prosemirror-model": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/@types/prosemirror-model/-/prosemirror-model-1.11.0.tgz",
-			"integrity": "sha512-R+vutu3AptoiXGJR0Jdpyr7BkJg24bce9ETUDOrBJZhRcsWeMEFGzidG19GHcY6Yny5zTILxlqXeDEIF3C5b7A==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@types/prosemirror-model/-/prosemirror-model-1.11.1.tgz",
+			"integrity": "sha512-sAue1p9V/JjATX1JzQDFzW2ON8QEGUz3eMSpJX94oCr0CoAQgK4/kSM2funtQKy1GHd+xr7wZ509ykt49b+T1Q==",
 			"requires": {
 				"@types/orderedmap": "*"
 			}
@@ -5715,18 +5746,18 @@
 			"integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
 		},
 		"@types/react": {
-			"version": "16.9.53",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.53.tgz",
-			"integrity": "sha512-4nW60Sd4L7+WMXH1D6jCdVftuW7j4Za6zdp6tJ33Rqv0nk1ZAmQKML9ZLD4H0dehA3FZxXR/GM8gXplf82oNGw==",
+			"version": "16.9.56",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.56.tgz",
+			"integrity": "sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==",
 			"requires": {
 				"@types/prop-types": "*",
 				"csstype": "^3.0.2"
 			}
 		},
 		"@types/react-dom": {
-			"version": "16.9.8",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.8.tgz",
-			"integrity": "sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==",
+			"version": "16.9.9",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.9.tgz",
+			"integrity": "sha512-jE16FNWO3Logq/Lf+yvEAjKzhpST/Eac8EMd1i4dgZdMczfgqC8EjpxwNgEe3SExHYLliabXDh9DEhhqnlXJhg==",
 			"requires": {
 				"@types/react": "*"
 			}
@@ -5828,9 +5859,9 @@
 			"integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
 		},
 		"@types/uglify-js": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.11.0.tgz",
-			"integrity": "sha512-I0Yd8TUELTbgRHq2K65j8rnDPAzAP+DiaF/syLem7yXwYLsHZhPd+AM2iXsWmf9P2F2NlFCgl5erZPQx9IbM9Q==",
+			"version": "3.11.1",
+			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.11.1.tgz",
+			"integrity": "sha512-7npvPKV+jINLu1SpSYVWG8KvyJBhBa8tmzMMdDoVc2pWUYHN8KIXlPJhjJ4LT97c4dXJA2SHL/q6ADbDriZN+Q==",
 			"requires": {
 				"source-map": "^0.6.1"
 			}
@@ -5841,9 +5872,9 @@
 			"integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ=="
 		},
 		"@types/webpack": {
-			"version": "4.41.23",
-			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.23.tgz",
-			"integrity": "sha512-ojA4CupZg8RCzVJLugWlvqrHpT59GWhqFxbinlsnvk10MjQCWB+ot7XDACctbWhnhtdhYK7+HOH1JxkVLiZhMg==",
+			"version": "4.41.24",
+			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.24.tgz",
+			"integrity": "sha512-1A0MXPwZiMOD3DPMuOKUKcpkdPo8Lq33UGggZ7xio6wJ/jV1dAu5cXDrOfGDnldUroPIRLsr/DT43/GqOA4RFQ==",
 			"requires": {
 				"@types/anymatch": "*",
 				"@types/node": "*",
@@ -6242,38 +6273,38 @@
 			}
 		},
 		"@uifabric/fluent-theme": {
-			"version": "7.3.30",
-			"resolved": "https://registry.npmjs.org/@uifabric/fluent-theme/-/fluent-theme-7.3.30.tgz",
-			"integrity": "sha512-Abk1TBHPoR0J91jBphQlIeRzQFSu+zu/vZC5pHEnUFvPwk0CKW0SHKL3+bllmH26oaT0Y6sQnQNKjrMrn9HxNA==",
+			"version": "7.3.37",
+			"resolved": "https://registry.npmjs.org/@uifabric/fluent-theme/-/fluent-theme-7.3.37.tgz",
+			"integrity": "sha512-iEeHQLV9QqiUmHhFC/jdCyUpyZu0MSX1PW+kgD8h9AIi4De48ZdRauyJWJJEmbB0If+uvb7gZ0lMPrzBNuuC0Q==",
 			"requires": {
-				"@fluentui/theme": "^1.5.1",
+				"@fluentui/theme": "^1.6.0",
 				"@uifabric/merge-styles": "^7.19.1",
 				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/styling": "^7.16.13",
-				"@uifabric/variants": "^7.2.26",
-				"office-ui-fabric-react": "^7.148.0",
+				"@uifabric/styling": "^7.16.17",
+				"@uifabric/variants": "^7.2.30",
+				"office-ui-fabric-react": "^7.149.4",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/foundation": {
-			"version": "7.9.14",
-			"resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.9.14.tgz",
-			"integrity": "sha512-AWsSt28+mid44YPofHB8N1nm4C0QmLJ9WXFps5GyjaBHES6/4bfJ7rKzYioa5bN0TxElyK8rRHzwqKNQhWDBYA==",
+			"version": "7.9.19",
+			"resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.9.19.tgz",
+			"integrity": "sha512-F/kKiFL4uSiosnqdv1BT3aQ3w9bQ3l+F3NiMqDbJpnlBAOMOlH2X7xAxZsNYbS66pgTPKsSP/8/SK3A+0wzMXg==",
 			"requires": {
 				"@uifabric/merge-styles": "^7.19.1",
 				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/styling": "^7.16.13",
-				"@uifabric/utilities": "^7.32.4",
+				"@uifabric/styling": "^7.16.17",
+				"@uifabric/utilities": "^7.33.2",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/icons": {
-			"version": "7.5.12",
-			"resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.5.12.tgz",
-			"integrity": "sha512-VIqj4oMwi4HJPqH3+3RblLoYjPfYzjVyZ8Kk57dmA7tj+vbM38Zn9vObe+Xg/EVEfohD3kD0fyEqPmnEqY17Pg==",
+			"version": "7.5.16",
+			"resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.5.16.tgz",
+			"integrity": "sha512-S+KGDZeN9y5sBJfg7Jgi3/598CxE0hvlMtl1XzzftKPdD2Jw8QCQazgYFqG8iZj6R5ILFjezoDr+yXYj6dMXMQ==",
 			"requires": {
 				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/styling": "^7.16.13",
+				"@uifabric/styling": "^7.16.17",
 				"tslib": "^1.10.0"
 			}
 		},
@@ -6287,13 +6318,13 @@
 			}
 		},
 		"@uifabric/react-hooks": {
-			"version": "7.13.6",
-			"resolved": "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.13.6.tgz",
-			"integrity": "sha512-DvfphxrTsjo3oYioRZ0D8mXdpxWQhhIHeWk1cfdq0MVGqRyKM+cm++9pJpvItFvnTNba38jzKdggqRSUWi+clg==",
+			"version": "7.13.9",
+			"resolved": "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.13.9.tgz",
+			"integrity": "sha512-VtDg2b3ypYXX7MLp1STk1Fj6ZIeZktXnm0hu1Os/pGvq6xkuLRly5XP6ZSHitm8K7ZcMo48CcNL8smmiXprBQg==",
 			"requires": {
-				"@fluentui/react-window-provider": "^0.3.3",
+				"@fluentui/react-window-provider": "^1.0.1",
 				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/utilities": "^7.32.4",
+				"@uifabric/utilities": "^7.33.2",
 				"tslib": "^1.10.0"
 			}
 		},
@@ -6306,22 +6337,22 @@
 			}
 		},
 		"@uifabric/styling": {
-			"version": "7.16.13",
-			"resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.16.13.tgz",
-			"integrity": "sha512-jj5FH7XuQXz8HgRhCXNApeUAynDBv2nfmTpzHawE55x7YR+oliQfsJSY8Ow4YbLAazIR5BuW1n9eKuGxxmIw1w==",
+			"version": "7.16.17",
+			"resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.16.17.tgz",
+			"integrity": "sha512-9TZP5npZopaQUkb7V418bu2OzqjL+4uov9n59Kh/Ll2Bq9WyWg/kngGUMX793gxjOMy9w2IUEd2LN3odM05OlQ==",
 			"requires": {
-				"@fluentui/theme": "^1.5.1",
+				"@fluentui/theme": "^1.6.0",
 				"@microsoft/load-themed-styles": "^1.10.26",
 				"@uifabric/merge-styles": "^7.19.1",
 				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/utilities": "^7.32.4",
+				"@uifabric/utilities": "^7.33.2",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/utilities": {
-			"version": "7.32.4",
-			"resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.32.4.tgz",
-			"integrity": "sha512-IKZc03uyfTrgcCGSPAUWfFl9CyxzpSrxrYwAuO4NgDEySdOlkYBRwsRUh6UwWfM+sJdhg7Y3nupzNU3VSC/arg==",
+			"version": "7.33.2",
+			"resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.33.2.tgz",
+			"integrity": "sha512-v2c3IUJdpru/hoGNOwIW549O5D4XBAc5sLpB7RREGI5ywoWuIJlNyYtBEGOwhAY62J2blj11qi86Ep+oZDM/Kw==",
 			"requires": {
 				"@fluentui/dom-utilities": "^1.1.1",
 				"@uifabric/merge-styles": "^7.19.1",
@@ -6331,11 +6362,11 @@
 			}
 		},
 		"@uifabric/variants": {
-			"version": "7.2.26",
-			"resolved": "https://registry.npmjs.org/@uifabric/variants/-/variants-7.2.26.tgz",
-			"integrity": "sha512-tSLiCP2aVT1Zn3gRBobvzvexJx0kzD/TJ2Il56WlVYLRD0X6wDDO5J+ort0rGUGlJNTvDNZas4v/aNu/96o/mw==",
+			"version": "7.2.30",
+			"resolved": "https://registry.npmjs.org/@uifabric/variants/-/variants-7.2.30.tgz",
+			"integrity": "sha512-9NkFUxlMWCErp+UphQq2+2CBFcrMuJ1WBStWUlvB/WQqazIOZ2dOVcisHxDRdgPHe8MLoaDzy9FWlfCGcVFtAg==",
 			"requires": {
-				"@fluentui/theme": "^1.5.1",
+				"@fluentui/theme": "^1.6.0",
 				"@uifabric/set-version": "^7.0.23",
 				"tslib": "^1.10.0"
 			}
@@ -6564,6 +6595,15 @@
 			"version": "7.4.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
 			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+		},
+		"acorn-globals": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+			"integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+			"requires": {
+				"acorn": "^7.1.1",
+				"acorn-walk": "^7.1.1"
+			}
 		},
 		"acorn-jsx": {
 			"version": "5.3.1",
@@ -7024,9 +7064,9 @@
 			},
 			"dependencies": {
 				"is-buffer": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+					"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
 				}
 			}
 		},
@@ -7117,15 +7157,15 @@
 			}
 		},
 		"babel-jest": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.1.tgz",
-			"integrity": "sha512-duMWEOKrSBYRVTTNpL2SipNIWnZOjP77auOBMPQ3zXAdnDbyZQWU8r/RxNWpUf9N6cgPFecQYelYLytTVXVDtA==",
+			"version": "26.6.3",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.3.tgz",
+			"integrity": "sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==",
 			"requires": {
-				"@jest/transform": "^26.6.1",
-				"@jest/types": "^26.6.1",
+				"@jest/transform": "^26.6.2",
+				"@jest/types": "^26.6.2",
 				"@types/babel__core": "^7.1.7",
 				"babel-plugin-istanbul": "^6.0.0",
-				"babel-preset-jest": "^26.5.0",
+				"babel-preset-jest": "^26.6.2",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
 				"slash": "^3.0.0"
@@ -7237,9 +7277,9 @@
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "26.5.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.5.0.tgz",
-			"integrity": "sha512-ck17uZFD3CDfuwCLATWZxkkuGGFhMij8quP8CNhwj8ek1mqFgbFzRJ30xwC04LLscj/aKsVFfRST+b5PT7rSuw==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.6.2.tgz",
+			"integrity": "sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==",
 			"requires": {
 				"@babel/template": "^7.3.3",
 				"@babel/types": "^7.3.3",
@@ -7248,9 +7288,9 @@
 			}
 		},
 		"babel-preset-current-node-syntax": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.4.tgz",
-			"integrity": "sha512-5/INNCYhUGqw7VbVjT/hb3ucjgkVHKXY7lX3ZjlN4gm565VyFmJUrJ/h+h16ECVB38R/9SF6aACydpKMLZ/c9w==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.0.tgz",
+			"integrity": "sha512-mGkvkpocWJes1CmMKtgGUwCeeq0pOhALyymozzDWYomHTbDLwueDYG6p4TK1YOeYHCzBzYPsWkgTto10JubI1Q==",
 			"requires": {
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
 				"@babel/plugin-syntax-bigint": "^7.8.3",
@@ -7262,16 +7302,17 @@
 				"@babel/plugin-syntax-numeric-separator": "^7.8.3",
 				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-				"@babel/plugin-syntax-optional-chaining": "^7.8.3"
+				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
+				"@babel/plugin-syntax-top-level-await": "^7.8.3"
 			}
 		},
 		"babel-preset-jest": {
-			"version": "26.5.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.5.0.tgz",
-			"integrity": "sha512-F2vTluljhqkiGSJGBg/jOruA8vIIIL11YrxRcO7nviNTMbbofPSHwnm8mgP7d/wS7wRSexRoI6X1A6T74d4LQA==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.6.2.tgz",
+			"integrity": "sha512-YvdtlVm9t3k777c5NPQIv6cxFFFapys25HiUmuSgHwIZhfifweR5c5Sf5nwE3MAbfu327CYSvps8Yx6ANLyleQ==",
 			"requires": {
-				"babel-plugin-jest-hoist": "^26.5.0",
-				"babel-preset-current-node-syntax": "^0.1.3"
+				"babel-plugin-jest-hoist": "^26.6.2",
+				"babel-preset-current-node-syntax": "^1.0.0"
 			}
 		},
 		"babel-runtime": {
@@ -7859,6 +7900,15 @@
 				}
 			}
 		},
+		"call-bind": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
+			"integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.0"
+			}
+		},
 		"call-me-maybe": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
@@ -7989,52 +8039,6 @@
 			"resolved": "https://registry.npmjs.org/check-types/-/check-types-8.0.3.tgz",
 			"integrity": "sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ=="
 		},
-		"chokidar": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-			"integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
-			"requires": {
-				"anymatch": "~3.1.1",
-				"braces": "~3.0.2",
-				"fsevents": "~2.1.2",
-				"glob-parent": "~5.1.0",
-				"is-binary-path": "~2.1.0",
-				"is-glob": "~4.0.1",
-				"normalize-path": "~3.0.0",
-				"readdirp": "~3.5.0"
-			},
-			"dependencies": {
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"requires": {
-						"fill-range": "^7.0.1"
-					}
-				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"requires": {
-						"is-number": "^7.0.0"
-					}
-				}
-			}
-		},
 		"chownr": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -8063,9 +8067,9 @@
 			}
 		},
 		"cjs-module-lexer": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.4.3.tgz",
-			"integrity": "sha512-5RLK0Qfs0PNDpEyBXIr3bIT1Muw3ojSlvpw6dAmkUcO0+uTrsBn7GuEIgx40u+OzbCBLDta7nvmud85P4EmTsQ=="
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz",
+			"integrity": "sha512-uc2Vix1frTfnuzxxu1Hp4ktSvM3QaI4oXl4ZUqL1wjTu/BGki9TrCWoqLTg/drR1KwAEarXuRFCG2Svr1GxPFw=="
 		},
 		"class-utils": {
 			"version": "0.3.6",
@@ -8334,6 +8338,41 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+		},
+		"commoner": {
+			"version": "0.10.8",
+			"resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
+			"integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
+			"requires": {
+				"commander": "^2.5.0",
+				"detective": "^4.3.1",
+				"glob": "^5.0.15",
+				"graceful-fs": "^4.1.2",
+				"iconv-lite": "^0.4.5",
+				"mkdirp": "^0.5.0",
+				"private": "^0.1.6",
+				"q": "^1.1.2",
+				"recast": "^0.11.17"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+				},
+				"glob": {
+					"version": "5.0.15",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"requires": {
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "2 || 3",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				}
+			}
 		},
 		"compare-func": {
 			"version": "2.0.0",
@@ -9781,6 +9820,22 @@
 			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
 			"integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
 		},
+		"detective": {
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+			"integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
+			"requires": {
+				"acorn": "^5.2.1",
+				"defined": "^1.0.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "5.7.4",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+					"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
+				}
+			}
+		},
 		"dezalgo": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
@@ -9797,9 +9852,9 @@
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 		},
 		"diff-sequences": {
-			"version": "26.5.0",
-			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
-			"integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q=="
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
+			"integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q=="
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
@@ -10066,6 +10121,43 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"editorconfig": {
+			"version": "0.15.3",
+			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+			"integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+			"requires": {
+				"commander": "^2.19.0",
+				"lru-cache": "^4.1.5",
+				"semver": "^5.6.0",
+				"sigmund": "^1.0.1"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+				},
+				"lru-cache": {
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+				}
+			}
+		},
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -10215,6 +10307,15 @@
 			"integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
 			"dev": true
 		},
+		"envify": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz",
+			"integrity": "sha1-1xIjKejfFoi6dxsSUBkXyc5cvOg=",
+			"requires": {
+				"jstransform": "^11.0.3",
+				"through": "~2.3.4"
+			}
+		},
 		"envinfo": {
 			"version": "7.5.1",
 			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.5.1.tgz",
@@ -10293,6 +10394,15 @@
 			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
 			"requires": {
 				"es6-promise": "^4.0.3"
+			}
+		},
+		"es6-templates": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz",
+			"integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
+			"requires": {
+				"recast": "~0.11.12",
+				"through": "~2.3.6"
 			}
 		},
 		"escape-html": {
@@ -10424,24 +10534,6 @@
 						"eslint-visitor-keys": "^1.3.0"
 					}
 				},
-				"file-entry-cache": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-					"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
-					"requires": {
-						"flat-cache": "^2.0.1"
-					}
-				},
-				"flat-cache": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-					"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
-					"requires": {
-						"flatted": "^2.0.0",
-						"rimraf": "2.6.3",
-						"write": "1.0.3"
-					}
-				},
 				"globals": {
 					"version": "12.4.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -10456,9 +10548,9 @@
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
 				"import-fresh": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-					"integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
+					"integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
 					"requires": {
 						"parent-module": "^1.0.0",
 						"resolve-from": "^4.0.0"
@@ -10495,14 +10587,6 @@
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 					"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
-				},
-				"rimraf": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
 				},
 				"semver": {
 					"version": "7.3.2",
@@ -10766,14 +10850,6 @@
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
 				"load-json-file": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -10867,17 +10943,6 @@
 					"requires": {
 						"is-core-module": "^2.0.0",
 						"path-parse": "^1.0.6"
-					}
-				},
-				"tsconfig-paths": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
-					"integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
-					"requires": {
-						"@types/json5": "^0.0.29",
-						"json5": "^1.0.1",
-						"minimist": "^1.2.0",
-						"strip-bom": "^3.0.0"
 					}
 				}
 			}
@@ -11283,15 +11348,15 @@
 			}
 		},
 		"expect": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-26.6.1.tgz",
-			"integrity": "sha512-BRfxIBHagghMmr1D2MRY0Qv5d3Nc8HCqgbDwNXw/9izmM5eBb42a2YjLKSbsqle76ozGkAEPELQX4IdNHAKRNA==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-26.6.2.tgz",
+			"integrity": "sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==",
 			"requires": {
-				"@jest/types": "^26.6.1",
+				"@jest/types": "^26.6.2",
 				"ansi-styles": "^4.0.0",
 				"jest-get-type": "^26.3.0",
-				"jest-matcher-utils": "^26.6.1",
-				"jest-message-util": "^26.6.1",
+				"jest-matcher-utils": "^26.6.2",
+				"jest-message-util": "^26.6.2",
 				"jest-regex-util": "^26.0.0"
 			},
 			"dependencies": {
@@ -12221,9 +12286,9 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-			"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.2.1.tgz",
+			"integrity": "sha512-bTLYHSeC0UH/EFXS9KqWnXuOl/wHK5Z/d+ghd5AsFMYN7wIGkUCOJyzy88+wJKkZPGON8u4Z9f6U4FdgURE9qA==",
 			"optional": true
 		},
 		"fstream": {
@@ -12323,6 +12388,16 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
 			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+		},
+		"get-intrinsic": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
+			"integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1"
+			}
 		},
 		"get-pkg-repo": {
 			"version": "1.4.0",
@@ -13403,56 +13478,26 @@
 				"html-minifier": "^3.5.8",
 				"loader-utils": "^1.1.0",
 				"object-assign": "^4.1.1"
+			}
+		},
+		"html-minifier": {
+			"version": "3.5.21",
+			"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
+			"integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
+			"requires": {
+				"camel-case": "3.0.x",
+				"clean-css": "4.2.x",
+				"commander": "2.17.x",
+				"he": "1.2.x",
+				"param-case": "2.1.x",
+				"relateurl": "0.2.x",
+				"uglify-js": "3.4.x"
 			},
 			"dependencies": {
 				"commander": {
 					"version": "2.17.1",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
 					"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
-				},
-				"es6-templates": {
-					"version": "0.2.3",
-					"resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz",
-					"integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
-					"requires": {
-						"recast": "~0.11.12",
-						"through": "~2.3.6"
-					}
-				},
-				"esprima": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-				},
-				"html-minifier": {
-					"version": "3.5.21",
-					"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
-					"integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
-					"requires": {
-						"camel-case": "3.0.x",
-						"clean-css": "4.2.x",
-						"commander": "2.17.x",
-						"he": "1.2.x",
-						"param-case": "2.1.x",
-						"relateurl": "0.2.x",
-						"uglify-js": "3.4.x"
-					}
-				},
-				"recast": {
-					"version": "0.11.23",
-					"resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-					"integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-					"requires": {
-						"ast-types": "0.9.6",
-						"esprima": "~3.1.0",
-						"private": "~0.1.5",
-						"source-map": "~0.5.0"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				},
 				"uglify-js": {
 					"version": "3.4.10",
@@ -13467,11 +13512,6 @@
 							"version": "2.19.0",
 							"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
 							"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
-						},
-						"source-map": {
-							"version": "0.6.1",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 						}
 					}
 				}
@@ -14034,9 +14074,9 @@
 			}
 		},
 		"is-core-module": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.0.0.tgz",
-			"integrity": "sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
+			"integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
 			"requires": {
 				"has": "^1.0.3"
 			}
@@ -14561,90 +14601,15 @@
 			"integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
 		},
 		"jest": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-26.6.1.tgz",
-			"integrity": "sha512-f+ahfqw3Ffy+9vA7sWFGpTmhtKEMsNAZiWBVXDkrpIO73zIz22iimjirnV78kh/eWlylmvLh/0WxHN6fZraZdA==",
+			"version": "26.6.3",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-26.6.3.tgz",
+			"integrity": "sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==",
 			"requires": {
-				"@jest/core": "^26.6.1",
+				"@jest/core": "^26.6.3",
 				"import-local": "^3.0.2",
-				"jest-cli": "^26.6.1"
+				"jest-cli": "^26.6.3"
 			},
 			"dependencies": {
-				"@jest/core": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/@jest/core/-/core-26.6.1.tgz",
-					"integrity": "sha512-p4F0pgK3rKnoS9olXXXOkbus1Bsu6fd8pcvLMPsUy4CVXZ8WSeiwQ1lK5hwkCIqJ+amZOYPd778sbPha/S8Srw==",
-					"requires": {
-						"@jest/console": "^26.6.1",
-						"@jest/reporters": "^26.6.1",
-						"@jest/test-result": "^26.6.1",
-						"@jest/transform": "^26.6.1",
-						"@jest/types": "^26.6.1",
-						"@types/node": "*",
-						"ansi-escapes": "^4.2.1",
-						"chalk": "^4.0.0",
-						"exit": "^0.1.2",
-						"graceful-fs": "^4.2.4",
-						"jest-changed-files": "^26.6.1",
-						"jest-config": "^26.6.1",
-						"jest-haste-map": "^26.6.1",
-						"jest-message-util": "^26.6.1",
-						"jest-regex-util": "^26.0.0",
-						"jest-resolve": "^26.6.1",
-						"jest-resolve-dependencies": "^26.6.1",
-						"jest-runner": "^26.6.1",
-						"jest-runtime": "^26.6.1",
-						"jest-snapshot": "^26.6.1",
-						"jest-util": "^26.6.1",
-						"jest-validate": "^26.6.1",
-						"jest-watcher": "^26.6.1",
-						"micromatch": "^4.0.2",
-						"p-each-series": "^2.1.0",
-						"rimraf": "^3.0.0",
-						"slash": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"@jest/reporters": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.6.1.tgz",
-					"integrity": "sha512-J6OlXVFY3q1SXWJhjme5i7qT/BAZSikdOK2t8Ht5OS32BDo6KfG5CzIzzIFnAVd82/WWbc9Hb7SJ/jwSvVH9YA==",
-					"requires": {
-						"@bcoe/v8-coverage": "^0.2.3",
-						"@jest/console": "^26.6.1",
-						"@jest/test-result": "^26.6.1",
-						"@jest/transform": "^26.6.1",
-						"@jest/types": "^26.6.1",
-						"chalk": "^4.0.0",
-						"collect-v8-coverage": "^1.0.0",
-						"exit": "^0.1.2",
-						"glob": "^7.1.2",
-						"graceful-fs": "^4.2.4",
-						"istanbul-lib-coverage": "^3.0.0",
-						"istanbul-lib-instrument": "^4.0.3",
-						"istanbul-lib-report": "^3.0.0",
-						"istanbul-lib-source-maps": "^4.0.0",
-						"istanbul-reports": "^3.0.2",
-						"jest-haste-map": "^26.6.1",
-						"jest-resolve": "^26.6.1",
-						"jest-util": "^26.6.1",
-						"jest-worker": "^26.6.1",
-						"node-notifier": "^8.0.0",
-						"slash": "^3.0.0",
-						"source-map": "^0.6.0",
-						"string-length": "^4.0.1",
-						"terminal-link": "^2.0.0",
-						"v8-to-istanbul": "^6.0.1"
-					}
-				},
-				"ansi-escapes": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-					"requires": {
-						"type-fest": "^0.11.0"
-					}
-				},
 				"ansi-regex": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -14656,14 +14621,6 @@
 					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
 						"color-convert": "^2.0.1"
-					}
-				},
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"requires": {
-						"fill-range": "^7.0.1"
 					}
 				},
 				"chalk": {
@@ -14698,44 +14655,10 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 				},
-				"cross-spawn": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-					"requires": {
-						"path-key": "^3.1.0",
-						"shebang-command": "^2.0.0",
-						"which": "^2.0.1"
-					}
-				},
 				"emoji-regex": {
 					"version": "8.0.0",
 					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-				},
-				"execa": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
-					"integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
-					"requires": {
-						"cross-spawn": "^7.0.0",
-						"get-stream": "^5.0.0",
-						"human-signals": "^1.1.1",
-						"is-stream": "^2.0.0",
-						"merge-stream": "^2.0.0",
-						"npm-run-path": "^4.0.0",
-						"onetime": "^5.1.0",
-						"signal-exit": "^3.0.2",
-						"strip-final-newline": "^2.0.0"
-					}
-				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
 				},
 				"find-up": {
 					"version": "4.1.0",
@@ -14744,14 +14667,6 @@
 					"requires": {
 						"locate-path": "^5.0.0",
 						"path-exists": "^4.0.0"
-					}
-				},
-				"get-stream": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-					"requires": {
-						"pump": "^3.0.0"
 					}
 				},
 				"has-flag": {
@@ -14773,129 +14688,24 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
 				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-				},
-				"is-stream": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
-				},
-				"istanbul-lib-instrument": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
-					"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
-					"requires": {
-						"@babel/core": "^7.7.5",
-						"@istanbuljs/schema": "^0.1.2",
-						"istanbul-lib-coverage": "^3.0.0",
-						"semver": "^6.3.0"
-					}
-				},
-				"jest-changed-files": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.1.tgz",
-					"integrity": "sha512-NhSdZ5F6b/rIN5V46x1l31vrmukD/bJUXgYAY8VtP1SknYdJwjYDRxuLt7Z8QryIdqCjMIn2C0Cd98EZ4umo8Q==",
-					"requires": {
-						"@jest/types": "^26.6.1",
-						"execa": "^4.0.0",
-						"throat": "^5.0.0"
-					}
-				},
 				"jest-cli": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.1.tgz",
-					"integrity": "sha512-aPLoEjlwFrCWhiPpW5NUxQA1X1kWsAnQcQ0SO/fHsCvczL3W75iVAcH9kP6NN+BNqZcHNEvkhxT5cDmBfEAh+w==",
+					"version": "26.6.3",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
+					"integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
 					"requires": {
-						"@jest/core": "^26.6.1",
-						"@jest/test-result": "^26.6.1",
-						"@jest/types": "^26.6.1",
+						"@jest/core": "^26.6.3",
+						"@jest/test-result": "^26.6.2",
+						"@jest/types": "^26.6.2",
 						"chalk": "^4.0.0",
 						"exit": "^0.1.2",
 						"graceful-fs": "^4.2.4",
 						"import-local": "^3.0.2",
 						"is-ci": "^2.0.0",
-						"jest-config": "^26.6.1",
-						"jest-util": "^26.6.1",
-						"jest-validate": "^26.6.1",
+						"jest-config": "^26.6.3",
+						"jest-util": "^26.6.2",
+						"jest-validate": "^26.6.2",
 						"prompts": "^2.0.1",
 						"yargs": "^15.4.1"
-					}
-				},
-				"jest-resolve-dependencies": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.1.tgz",
-					"integrity": "sha512-MN6lufbZJ3RBfTnJesZtHu3hUCBqPdHRe2+FhIt0yiqJ3fMgzWRqMRQyN/d/QwOE7KXwAG2ekZutbPhuD7s51A==",
-					"requires": {
-						"@jest/types": "^26.6.1",
-						"jest-regex-util": "^26.0.0",
-						"jest-snapshot": "^26.6.1"
-					}
-				},
-				"jest-runtime": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.1.tgz",
-					"integrity": "sha512-7uOCNeezXDWgjEyzYbRN2ViY7xNZzusNVGAMmU0UHRUNXuY4j4GBHKGMqPo/cBPZA9bSYp+lwK2DRRBU5Dv6YQ==",
-					"requires": {
-						"@jest/console": "^26.6.1",
-						"@jest/environment": "^26.6.1",
-						"@jest/fake-timers": "^26.6.1",
-						"@jest/globals": "^26.6.1",
-						"@jest/source-map": "^26.5.0",
-						"@jest/test-result": "^26.6.1",
-						"@jest/transform": "^26.6.1",
-						"@jest/types": "^26.6.1",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0",
-						"cjs-module-lexer": "^0.4.2",
-						"collect-v8-coverage": "^1.0.0",
-						"exit": "^0.1.2",
-						"glob": "^7.1.3",
-						"graceful-fs": "^4.2.4",
-						"jest-config": "^26.6.1",
-						"jest-haste-map": "^26.6.1",
-						"jest-message-util": "^26.6.1",
-						"jest-mock": "^26.6.1",
-						"jest-regex-util": "^26.0.0",
-						"jest-resolve": "^26.6.1",
-						"jest-snapshot": "^26.6.1",
-						"jest-util": "^26.6.1",
-						"jest-validate": "^26.6.1",
-						"slash": "^3.0.0",
-						"strip-bom": "^4.0.0",
-						"yargs": "^15.4.1"
-					}
-				},
-				"jest-snapshot": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.1.tgz",
-					"integrity": "sha512-JA7bZp7HRTIJYAi85pJ/OZ2eur2dqmwIToA5/6d7Mn90isGEfeF9FvuhDLLEczgKP1ihreBzrJ6Vr7zteP5JNA==",
-					"requires": {
-						"@babel/types": "^7.0.0",
-						"@jest/types": "^26.6.1",
-						"@types/babel__traverse": "^7.0.4",
-						"@types/prettier": "^2.0.0",
-						"chalk": "^4.0.0",
-						"expect": "^26.6.1",
-						"graceful-fs": "^4.2.4",
-						"jest-diff": "^26.6.1",
-						"jest-get-type": "^26.3.0",
-						"jest-haste-map": "^26.6.1",
-						"jest-matcher-utils": "^26.6.1",
-						"jest-message-util": "^26.6.1",
-						"jest-resolve": "^26.6.1",
-						"natural-compare": "^1.4.0",
-						"pretty-format": "^26.6.1",
-						"semver": "^7.3.2"
-					},
-					"dependencies": {
-						"semver": {
-							"version": "7.3.2",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-							"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
-						}
 					}
 				},
 				"locate-path": {
@@ -14904,53 +14714,6 @@
 					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 					"requires": {
 						"p-locate": "^4.1.0"
-					}
-				},
-				"micromatch": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-					"requires": {
-						"braces": "^3.0.1",
-						"picomatch": "^2.0.5"
-					}
-				},
-				"node-notifier": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.0.tgz",
-					"integrity": "sha512-46z7DUmcjoYdaWyXouuFNNfUo6eFa94t23c53c+lG/9Cvauk4a98rAUp9672X5dxGdQmLpPzTxzu8f/OeEPaFA==",
-					"optional": true,
-					"requires": {
-						"growly": "^1.3.0",
-						"is-wsl": "^2.2.0",
-						"semver": "^7.3.2",
-						"shellwords": "^0.1.1",
-						"uuid": "^8.3.0",
-						"which": "^2.0.2"
-					},
-					"dependencies": {
-						"semver": {
-							"version": "7.3.2",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-							"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-							"optional": true
-						}
-					}
-				},
-				"npm-run-path": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-					"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-					"requires": {
-						"path-key": "^3.0.0"
-					}
-				},
-				"onetime": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-					"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-					"requires": {
-						"mimic-fn": "^2.1.0"
 					}
 				},
 				"p-locate": {
@@ -14965,11 +14728,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-				},
-				"path-key": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
 				},
 				"pkg-dir": {
 					"version": "4.2.0",
@@ -14992,37 +14750,6 @@
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
 					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
 				},
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				},
-				"shebang-command": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-					"requires": {
-						"shebang-regex": "^3.0.0"
-					}
-				},
-				"shebang-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
-				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
-				},
 				"string-width": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -15041,44 +14768,12 @@
 						"ansi-regex": "^5.0.0"
 					}
 				},
-				"strip-bom": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
-				},
 				"supports-color": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"requires": {
 						"has-flag": "^4.0.0"
-					}
-				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"requires": {
-						"is-number": "^7.0.0"
-					}
-				},
-				"type-fest": {
-					"version": "0.11.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-					"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
-				},
-				"uuid": {
-					"version": "8.3.1",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-					"integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
-					"optional": true
-				},
-				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"requires": {
-						"isexe": "^2.0.0"
 					}
 				},
 				"wrap-ansi": {
@@ -15120,36 +14815,124 @@
 				}
 			}
 		},
+		"jest-changed-files": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.2.tgz",
+			"integrity": "sha512-fDS7szLcY9sCtIip8Fjry9oGf3I2ht/QT21bAHm5Dmf0mD4X3ReNUf17y+bO6fR8WgbIZTlbyG1ak/53cbRzKQ==",
+			"requires": {
+				"@jest/types": "^26.6.2",
+				"execa": "^4.0.0",
+				"throat": "^5.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"execa": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+					"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+					"requires": {
+						"cross-spawn": "^7.0.0",
+						"get-stream": "^5.0.0",
+						"human-signals": "^1.1.1",
+						"is-stream": "^2.0.0",
+						"merge-stream": "^2.0.0",
+						"npm-run-path": "^4.0.0",
+						"onetime": "^5.1.0",
+						"signal-exit": "^3.0.2",
+						"strip-final-newline": "^2.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"is-stream": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+				},
+				"npm-run-path": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+					"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+					"requires": {
+						"path-key": "^3.0.0"
+					}
+				},
+				"onetime": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+					"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+					"requires": {
+						"mimic-fn": "^2.1.0"
+					}
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
 		"jest-config": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.6.1.tgz",
-			"integrity": "sha512-mtJzIynIwW1d1nMlKCNCQiSgWaqFn8cH/fOSNY97xG7Y9tBCZbCSuW2GTX0RPmceSJGO7l27JgwC18LEg0Vg+g==",
+			"version": "26.6.3",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.6.3.tgz",
+			"integrity": "sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==",
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/test-sequencer": "^26.6.1",
-				"@jest/types": "^26.6.1",
-				"babel-jest": "^26.6.1",
+				"@jest/test-sequencer": "^26.6.3",
+				"@jest/types": "^26.6.2",
+				"babel-jest": "^26.6.3",
 				"chalk": "^4.0.0",
 				"deepmerge": "^4.2.2",
 				"glob": "^7.1.1",
 				"graceful-fs": "^4.2.4",
-				"jest-environment-jsdom": "^26.6.1",
-				"jest-environment-node": "^26.6.1",
+				"jest-environment-jsdom": "^26.6.2",
+				"jest-environment-node": "^26.6.2",
 				"jest-get-type": "^26.3.0",
-				"jest-jasmine2": "^26.6.1",
+				"jest-jasmine2": "^26.6.3",
 				"jest-regex-util": "^26.0.0",
-				"jest-resolve": "^26.6.1",
-				"jest-util": "^26.6.1",
-				"jest-validate": "^26.6.1",
+				"jest-resolve": "^26.6.2",
+				"jest-util": "^26.6.2",
+				"jest-validate": "^26.6.2",
 				"micromatch": "^4.0.2",
-				"pretty-format": "^26.6.1"
+				"pretty-format": "^26.6.2"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-				},
 				"ansi-styles": {
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -15175,16 +14958,6 @@
 						"supports-color": "^7.1.0"
 					}
 				},
-				"cliui": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-					"requires": {
-						"string-width": "^4.2.0",
-						"strip-ansi": "^6.0.0",
-						"wrap-ansi": "^6.2.0"
-					}
-				},
 				"color-convert": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -15198,11 +14971,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-				},
 				"fill-range": {
 					"version": "7.0.1",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -15211,119 +14979,15 @@
 						"to-regex-range": "^5.0.1"
 					}
 				},
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-				},
 				"is-number": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-				},
-				"jest-jasmine2": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.6.1.tgz",
-					"integrity": "sha512-2uYdT32o/ZzSxYAPduAgokO8OlAL1YdG/9oxcEY138EDNpIK5XRRJDaGzTZdIBWSxk0aR8XxN44FvfXtHB+Fiw==",
-					"requires": {
-						"@babel/traverse": "^7.1.0",
-						"@jest/environment": "^26.6.1",
-						"@jest/source-map": "^26.5.0",
-						"@jest/test-result": "^26.6.1",
-						"@jest/types": "^26.6.1",
-						"@types/node": "*",
-						"chalk": "^4.0.0",
-						"co": "^4.6.0",
-						"expect": "^26.6.1",
-						"is-generator-fn": "^2.0.0",
-						"jest-each": "^26.6.1",
-						"jest-matcher-utils": "^26.6.1",
-						"jest-message-util": "^26.6.1",
-						"jest-runtime": "^26.6.1",
-						"jest-snapshot": "^26.6.1",
-						"jest-util": "^26.6.1",
-						"pretty-format": "^26.6.1",
-						"throat": "^5.0.0"
-					}
-				},
-				"jest-runtime": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.1.tgz",
-					"integrity": "sha512-7uOCNeezXDWgjEyzYbRN2ViY7xNZzusNVGAMmU0UHRUNXuY4j4GBHKGMqPo/cBPZA9bSYp+lwK2DRRBU5Dv6YQ==",
-					"requires": {
-						"@jest/console": "^26.6.1",
-						"@jest/environment": "^26.6.1",
-						"@jest/fake-timers": "^26.6.1",
-						"@jest/globals": "^26.6.1",
-						"@jest/source-map": "^26.5.0",
-						"@jest/test-result": "^26.6.1",
-						"@jest/transform": "^26.6.1",
-						"@jest/types": "^26.6.1",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0",
-						"cjs-module-lexer": "^0.4.2",
-						"collect-v8-coverage": "^1.0.0",
-						"exit": "^0.1.2",
-						"glob": "^7.1.3",
-						"graceful-fs": "^4.2.4",
-						"jest-config": "^26.6.1",
-						"jest-haste-map": "^26.6.1",
-						"jest-message-util": "^26.6.1",
-						"jest-mock": "^26.6.1",
-						"jest-regex-util": "^26.0.0",
-						"jest-resolve": "^26.6.1",
-						"jest-snapshot": "^26.6.1",
-						"jest-util": "^26.6.1",
-						"jest-validate": "^26.6.1",
-						"slash": "^3.0.0",
-						"strip-bom": "^4.0.0",
-						"yargs": "^15.4.1"
-					}
-				},
-				"jest-snapshot": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.1.tgz",
-					"integrity": "sha512-JA7bZp7HRTIJYAi85pJ/OZ2eur2dqmwIToA5/6d7Mn90isGEfeF9FvuhDLLEczgKP1ihreBzrJ6Vr7zteP5JNA==",
-					"requires": {
-						"@babel/types": "^7.0.0",
-						"@jest/types": "^26.6.1",
-						"@types/babel__traverse": "^7.0.4",
-						"@types/prettier": "^2.0.0",
-						"chalk": "^4.0.0",
-						"expect": "^26.6.1",
-						"graceful-fs": "^4.2.4",
-						"jest-diff": "^26.6.1",
-						"jest-get-type": "^26.3.0",
-						"jest-haste-map": "^26.6.1",
-						"jest-matcher-utils": "^26.6.1",
-						"jest-message-util": "^26.6.1",
-						"jest-resolve": "^26.6.1",
-						"natural-compare": "^1.4.0",
-						"pretty-format": "^26.6.1",
-						"semver": "^7.3.2"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
 				},
 				"micromatch": {
 					"version": "4.0.2",
@@ -15333,52 +14997,6 @@
 						"braces": "^3.0.1",
 						"picomatch": "^2.0.5"
 					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-				},
-				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
-				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
-				},
-				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
 				},
 				"supports-color": {
 					"version": "7.2.0",
@@ -15394,43 +15012,6 @@
 					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 					"requires": {
 						"is-number": "^7.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"yargs": {
-					"version": "15.4.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-					"requires": {
-						"cliui": "^6.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^4.1.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^4.2.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^18.1.2"
-					}
-				},
-				"yargs-parser": {
-					"version": "18.1.3",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
 					}
 				}
 			}
@@ -15495,14 +15076,14 @@
 			}
 		},
 		"jest-diff": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.1.tgz",
-			"integrity": "sha512-BBNy/zin2m4kG5In126O8chOBxLLS/XMTuuM2+YhgyHk87ewPzKTuTJcqj3lOWOi03NNgrl+DkMeV/exdvG9gg==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
+			"integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
 			"requires": {
 				"chalk": "^4.0.0",
-				"diff-sequences": "^26.5.0",
+				"diff-sequences": "^26.6.2",
 				"jest-get-type": "^26.3.0",
-				"pretty-format": "^26.6.1"
+				"pretty-format": "^26.6.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -15559,15 +15140,15 @@
 			}
 		},
 		"jest-each": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.6.1.tgz",
-			"integrity": "sha512-gSn8eB3buchuq45SU7pLB7qmCGax1ZSxfaWuEFblCyNMtyokYaKFh9dRhYPujK6xYL57dLIPhLKatjmB5XWzGA==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.6.2.tgz",
+			"integrity": "sha512-Mer/f0KaATbjl8MCJ+0GEpNdqmnVmDYqCTJYTvoo7rqmRiDllmp2AYN+06F93nXcY3ur9ShIjS+CO/uD+BbH4A==",
 			"requires": {
-				"@jest/types": "^26.6.1",
+				"@jest/types": "^26.6.2",
 				"chalk": "^4.0.0",
 				"jest-get-type": "^26.3.0",
-				"jest-util": "^26.6.1",
-				"pretty-format": "^26.6.1"
+				"jest-util": "^26.6.2",
+				"pretty-format": "^26.6.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -15616,28 +15197,19 @@
 			}
 		},
 		"jest-environment-jsdom": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.6.1.tgz",
-			"integrity": "sha512-A17RiXuHYNVlkM+3QNcQ6n5EZyAc6eld8ra9TW26luounGWpku4tj03uqRgHJCI1d4uHr5rJiuCH5JFRtdmrcA==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.6.2.tgz",
+			"integrity": "sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==",
 			"requires": {
-				"@jest/environment": "^26.6.1",
-				"@jest/fake-timers": "^26.6.1",
-				"@jest/types": "^26.6.1",
+				"@jest/environment": "^26.6.2",
+				"@jest/fake-timers": "^26.6.2",
+				"@jest/types": "^26.6.2",
 				"@types/node": "*",
-				"jest-mock": "^26.6.1",
-				"jest-util": "^26.6.1",
+				"jest-mock": "^26.6.2",
+				"jest-util": "^26.6.2",
 				"jsdom": "^16.4.0"
 			},
 			"dependencies": {
-				"acorn-globals": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
-					"integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
-					"requires": {
-						"acorn": "^7.1.1",
-						"acorn-walk": "^7.1.1"
-					}
-				},
 				"jsdom": {
 					"version": "16.4.0",
 					"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.4.0.tgz",
@@ -15710,23 +15282,23 @@
 					}
 				},
 				"ws": {
-					"version": "7.3.1",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-					"integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
+					"integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
 				}
 			}
 		},
 		"jest-environment-node": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.1.tgz",
-			"integrity": "sha512-YffaCp6h0j1kbcf1NVZ7umC6CPgD67YS+G1BeornfuSkx5s3xdhuwG0DCxSiHPXyT81FfJzA1L7nXvhq50OWIg==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.2.tgz",
+			"integrity": "sha512-zhtMio3Exty18dy8ee8eJ9kjnRyZC1N4C1Nt/VShN1apyXc8rWGtJ9lI7vqiWcyyXS4BVSEn9lxAM2D+07/Tag==",
 			"requires": {
-				"@jest/environment": "^26.6.1",
-				"@jest/fake-timers": "^26.6.1",
-				"@jest/types": "^26.6.1",
+				"@jest/environment": "^26.6.2",
+				"@jest/fake-timers": "^26.6.2",
+				"@jest/types": "^26.6.2",
 				"@types/node": "*",
-				"jest-mock": "^26.6.1",
-				"jest-util": "^26.6.1"
+				"jest-mock": "^26.6.2",
+				"jest-util": "^26.6.2"
 			}
 		},
 		"jest-environment-puppeteer": {
@@ -15791,11 +15363,11 @@
 			"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
 		},
 		"jest-haste-map": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.1.tgz",
-			"integrity": "sha512-9kPafkv0nX6ta1PrshnkiyhhoQoFWncrU/uUBt3/AP1r78WSCU5iLceYRTwDvJl67H3RrXqSlSVDDa/AsUB7OQ==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
+			"integrity": "sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==",
 			"requires": {
-				"@jest/types": "^26.6.1",
+				"@jest/types": "^26.6.2",
 				"@types/graceful-fs": "^4.1.2",
 				"@types/node": "*",
 				"anymatch": "^3.0.3",
@@ -15803,9 +15375,9 @@
 				"fsevents": "^2.1.2",
 				"graceful-fs": "^4.2.4",
 				"jest-regex-util": "^26.0.0",
-				"jest-serializer": "^26.5.0",
-				"jest-util": "^26.6.1",
-				"jest-worker": "^26.6.1",
+				"jest-serializer": "^26.6.2",
+				"jest-util": "^26.6.2",
+				"jest-worker": "^26.6.2",
 				"micromatch": "^4.0.2",
 				"sane": "^4.0.3",
 				"walker": "^1.0.7"
@@ -15847,6 +15419,76 @@
 					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 					"requires": {
 						"is-number": "^7.0.0"
+					}
+				}
+			}
+		},
+		"jest-jasmine2": {
+			"version": "26.6.3",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.6.3.tgz",
+			"integrity": "sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==",
+			"requires": {
+				"@babel/traverse": "^7.1.0",
+				"@jest/environment": "^26.6.2",
+				"@jest/source-map": "^26.6.2",
+				"@jest/test-result": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"co": "^4.6.0",
+				"expect": "^26.6.2",
+				"is-generator-fn": "^2.0.0",
+				"jest-each": "^26.6.2",
+				"jest-matcher-utils": "^26.6.2",
+				"jest-message-util": "^26.6.2",
+				"jest-runtime": "^26.6.3",
+				"jest-snapshot": "^26.6.2",
+				"jest-util": "^26.6.2",
+				"pretty-format": "^26.6.2",
+				"throat": "^5.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
 					}
 				}
 			}
@@ -15935,23 +15577,23 @@
 			}
 		},
 		"jest-leak-detector": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.1.tgz",
-			"integrity": "sha512-j9ZOtJSJKlHjrs4aIxWjiQUjyrffPdiAQn2Iw0916w7qZE5Lk0T2KhIH6E9vfhzP6sw0Q0jtnLLb4vQ71o1HlA==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz",
+			"integrity": "sha512-i4xlXpsVSMeKvg2cEKdfhh0H39qlJlP5Ex1yQxwF9ubahboQYMgTtz5oML35AVA3B4Eu+YsmwaiKVev9KCvLxg==",
 			"requires": {
 				"jest-get-type": "^26.3.0",
-				"pretty-format": "^26.6.1"
+				"pretty-format": "^26.6.2"
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.1.tgz",
-			"integrity": "sha512-9iu3zrsYlUnl8pByhREF9rr5eYoiEb1F7ymNKg6lJr/0qD37LWS5FSW/JcoDl8UdMX2+zAzabDs7sTO+QFKjCg==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz",
+			"integrity": "sha512-llnc8vQgYcNqDrqRDXWwMr9i7rS5XFiCwvh6DTP7Jqa2mqpcCBBlpCbn+trkG0KNhPu/h8rzyBkriOtBstvWhw==",
 			"requires": {
 				"chalk": "^4.0.0",
-				"jest-diff": "^26.6.1",
+				"jest-diff": "^26.6.2",
 				"jest-get-type": "^26.3.0",
-				"pretty-format": "^26.6.1"
+				"pretty-format": "^26.6.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -16000,16 +15642,17 @@
 			}
 		},
 		"jest-message-util": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.1.tgz",
-			"integrity": "sha512-cqM4HnqncIebBNdTKrBoWR/4ufHTll0pK/FWwX0YasK+TlBQEMqw3IEdynuuOTjDPFO3ONlFn37280X48beByw==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.2.tgz",
+			"integrity": "sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@jest/types": "^26.6.1",
+				"@jest/types": "^26.6.2",
 				"@types/stack-utils": "^2.0.0",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
 				"micromatch": "^4.0.2",
+				"pretty-format": "^26.6.2",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.2"
 			},
@@ -16103,11 +15746,11 @@
 			}
 		},
 		"jest-mock": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.1.tgz",
-			"integrity": "sha512-my0lPTBu1awY8iVG62sB2sx9qf8zxNDVX+5aFgoB8Vbqjb6LqIOsfyFA8P1z6H2IsqMbvOX9oCJnK67Y3yUIMA==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.2.tgz",
+			"integrity": "sha512-YyFjePHHp1LzpzYcmgqkJ0nm0gg/lJx2aZFzFy1S6eUqNjXsOqTK10zNRff2dNfssgokjkG65OlWNcIlgd3zew==",
 			"requires": {
-				"@jest/types": "^26.6.1",
+				"@jest/types": "^26.6.2",
 				"@types/node": "*"
 			}
 		},
@@ -16131,15 +15774,15 @@
 			"integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A=="
 		},
 		"jest-resolve": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.1.tgz",
-			"integrity": "sha512-hiHfQH6rrcpAmw9xCQ0vD66SDuU+7ZulOuKwc4jpbmFFsz0bQG/Ib92K+9/489u5rVw0btr/ZhiHqBpmkbCvuQ==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.2.tgz",
+			"integrity": "sha512-sOxsZOq25mT1wRsfHcbtkInS+Ek7Q8jCHUB0ZUTP0tc/c41QHriU/NunqMfCUWsL4H3MHpvQD4QR9kSYhS7UvQ==",
 			"requires": {
-				"@jest/types": "^26.6.1",
+				"@jest/types": "^26.6.2",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
 				"jest-pnp-resolver": "^1.2.2",
-				"jest-util": "^26.6.1",
+				"jest-util": "^26.6.2",
 				"read-pkg-up": "^7.0.1",
 				"resolve": "^1.18.1",
 				"slash": "^3.0.0"
@@ -16278,31 +15921,120 @@
 				}
 			}
 		},
-		"jest-runner": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.1.tgz",
-			"integrity": "sha512-DmpNGdgsbl5s0FGkmsInmqnmqCtliCSnjWA2TFAJS1m1mL5atwfPsf+uoZ8uYQ2X0uDj4NM+nPcDnUpbNTRMBA==",
+		"jest-resolve-dependencies": {
+			"version": "26.6.3",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.3.tgz",
+			"integrity": "sha512-pVwUjJkxbhe4RY8QEWzN3vns2kqyuldKpxlxJlzEYfKSvY6/bMvxoFrYYzUO1Gx28yKWN37qyV7rIoIp2h8fTg==",
 			"requires": {
-				"@jest/console": "^26.6.1",
-				"@jest/environment": "^26.6.1",
-				"@jest/test-result": "^26.6.1",
-				"@jest/types": "^26.6.1",
+				"@jest/types": "^26.6.2",
+				"jest-regex-util": "^26.0.0",
+				"jest-snapshot": "^26.6.2"
+			}
+		},
+		"jest-runner": {
+			"version": "26.6.3",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.3.tgz",
+			"integrity": "sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==",
+			"requires": {
+				"@jest/console": "^26.6.2",
+				"@jest/environment": "^26.6.2",
+				"@jest/test-result": "^26.6.2",
+				"@jest/types": "^26.6.2",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"emittery": "^0.7.1",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.2.4",
-				"jest-config": "^26.6.1",
+				"jest-config": "^26.6.3",
 				"jest-docblock": "^26.0.0",
-				"jest-haste-map": "^26.6.1",
-				"jest-leak-detector": "^26.6.1",
-				"jest-message-util": "^26.6.1",
-				"jest-resolve": "^26.6.1",
-				"jest-runtime": "^26.6.1",
-				"jest-util": "^26.6.1",
-				"jest-worker": "^26.6.1",
+				"jest-haste-map": "^26.6.2",
+				"jest-leak-detector": "^26.6.2",
+				"jest-message-util": "^26.6.2",
+				"jest-resolve": "^26.6.2",
+				"jest-runtime": "^26.6.3",
+				"jest-util": "^26.6.2",
+				"jest-worker": "^26.6.2",
 				"source-map-support": "^0.5.6",
 				"throat": "^5.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"jest-runtime": {
+			"version": "26.6.3",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.3.tgz",
+			"integrity": "sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==",
+			"requires": {
+				"@jest/console": "^26.6.2",
+				"@jest/environment": "^26.6.2",
+				"@jest/fake-timers": "^26.6.2",
+				"@jest/globals": "^26.6.2",
+				"@jest/source-map": "^26.6.2",
+				"@jest/test-result": "^26.6.2",
+				"@jest/transform": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"@types/yargs": "^15.0.0",
+				"chalk": "^4.0.0",
+				"cjs-module-lexer": "^0.6.0",
+				"collect-v8-coverage": "^1.0.0",
+				"exit": "^0.1.2",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.2.4",
+				"jest-config": "^26.6.3",
+				"jest-haste-map": "^26.6.2",
+				"jest-message-util": "^26.6.2",
+				"jest-mock": "^26.6.2",
+				"jest-regex-util": "^26.0.0",
+				"jest-resolve": "^26.6.2",
+				"jest-snapshot": "^26.6.2",
+				"jest-util": "^26.6.2",
+				"jest-validate": "^26.6.2",
+				"slash": "^3.0.0",
+				"strip-bom": "^4.0.0",
+				"yargs": "^15.4.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -16374,63 +16106,6 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
 				},
-				"jest-runtime": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.1.tgz",
-					"integrity": "sha512-7uOCNeezXDWgjEyzYbRN2ViY7xNZzusNVGAMmU0UHRUNXuY4j4GBHKGMqPo/cBPZA9bSYp+lwK2DRRBU5Dv6YQ==",
-					"requires": {
-						"@jest/console": "^26.6.1",
-						"@jest/environment": "^26.6.1",
-						"@jest/fake-timers": "^26.6.1",
-						"@jest/globals": "^26.6.1",
-						"@jest/source-map": "^26.5.0",
-						"@jest/test-result": "^26.6.1",
-						"@jest/transform": "^26.6.1",
-						"@jest/types": "^26.6.1",
-						"@types/yargs": "^15.0.0",
-						"chalk": "^4.0.0",
-						"cjs-module-lexer": "^0.4.2",
-						"collect-v8-coverage": "^1.0.0",
-						"exit": "^0.1.2",
-						"glob": "^7.1.3",
-						"graceful-fs": "^4.2.4",
-						"jest-config": "^26.6.1",
-						"jest-haste-map": "^26.6.1",
-						"jest-message-util": "^26.6.1",
-						"jest-mock": "^26.6.1",
-						"jest-regex-util": "^26.0.0",
-						"jest-resolve": "^26.6.1",
-						"jest-snapshot": "^26.6.1",
-						"jest-util": "^26.6.1",
-						"jest-validate": "^26.6.1",
-						"slash": "^3.0.0",
-						"strip-bom": "^4.0.0",
-						"yargs": "^15.4.1"
-					}
-				},
-				"jest-snapshot": {
-					"version": "26.6.1",
-					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.1.tgz",
-					"integrity": "sha512-JA7bZp7HRTIJYAi85pJ/OZ2eur2dqmwIToA5/6d7Mn90isGEfeF9FvuhDLLEczgKP1ihreBzrJ6Vr7zteP5JNA==",
-					"requires": {
-						"@babel/types": "^7.0.0",
-						"@jest/types": "^26.6.1",
-						"@types/babel__traverse": "^7.0.4",
-						"@types/prettier": "^2.0.0",
-						"chalk": "^4.0.0",
-						"expect": "^26.6.1",
-						"graceful-fs": "^4.2.4",
-						"jest-diff": "^26.6.1",
-						"jest-get-type": "^26.3.0",
-						"jest-haste-map": "^26.6.1",
-						"jest-matcher-utils": "^26.6.1",
-						"jest-message-util": "^26.6.1",
-						"jest-resolve": "^26.6.1",
-						"natural-compare": "^1.4.0",
-						"pretty-format": "^26.6.1",
-						"semver": "^7.3.2"
-					}
-				},
 				"locate-path": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -16451,11 +16126,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-				},
-				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
 				},
 				"slash": {
 					"version": "3.0.0",
@@ -16533,20 +16203,93 @@
 			}
 		},
 		"jest-serializer": {
-			"version": "26.5.0",
-			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.5.0.tgz",
-			"integrity": "sha512-+h3Gf5CDRlSLdgTv7y0vPIAoLgX/SI7T4v6hy+TEXMgYbv+ztzbg5PSN6mUXAT/hXYHvZRWm+MaObVfqkhCGxA==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.6.2.tgz",
+			"integrity": "sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==",
 			"requires": {
 				"@types/node": "*",
 				"graceful-fs": "^4.2.4"
 			}
 		},
-		"jest-util": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.1.tgz",
-			"integrity": "sha512-xCLZUqVoqhquyPLuDXmH7ogceGctbW8SMyQVjD9o+1+NPWI7t0vO08udcFLVPLgKWcvc+zotaUv/RuaR6l8HIA==",
+		"jest-snapshot": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.2.tgz",
+			"integrity": "sha512-OLhxz05EzUtsAmOMzuupt1lHYXCNib0ECyuZ/PZOx9TrZcC8vL0x+DUG3TL+GLX3yHG45e6YGjIm0XwDc3q3og==",
 			"requires": {
-				"@jest/types": "^26.6.1",
+				"@babel/types": "^7.0.0",
+				"@jest/types": "^26.6.2",
+				"@types/babel__traverse": "^7.0.4",
+				"@types/prettier": "^2.0.0",
+				"chalk": "^4.0.0",
+				"expect": "^26.6.2",
+				"graceful-fs": "^4.2.4",
+				"jest-diff": "^26.6.2",
+				"jest-get-type": "^26.3.0",
+				"jest-haste-map": "^26.6.2",
+				"jest-matcher-utils": "^26.6.2",
+				"jest-message-util": "^26.6.2",
+				"jest-resolve": "^26.6.2",
+				"natural-compare": "^1.4.0",
+				"pretty-format": "^26.6.2",
+				"semver": "^7.3.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"jest-util": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+			"integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
+			"requires": {
+				"@jest/types": "^26.6.2",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
@@ -16638,16 +16381,16 @@
 			}
 		},
 		"jest-validate": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.1.tgz",
-			"integrity": "sha512-BEFpGbylKocnNPZULcnk+TGaz1oFZQH/wcaXlaXABbu0zBwkOGczuWgdLucUouuQqn7VadHZZeTvo8VSFDLMOA==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.2.tgz",
+			"integrity": "sha512-NEYZ9Aeyj0i5rQqbq+tpIOom0YS1u2MVu6+euBsvpgIme+FOfRmoC4R5p0JiAUpaFvFy24xgrpMknarR/93XjQ==",
 			"requires": {
-				"@jest/types": "^26.6.1",
+				"@jest/types": "^26.6.2",
 				"camelcase": "^6.0.0",
 				"chalk": "^4.0.0",
 				"jest-get-type": "^26.3.0",
 				"leven": "^3.1.0",
-				"pretty-format": "^26.6.1"
+				"pretty-format": "^26.6.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -16659,9 +16402,9 @@
 					}
 				},
 				"camelcase": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.1.0.tgz",
-					"integrity": "sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ=="
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+					"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
 				},
 				"chalk": {
 					"version": "4.1.0",
@@ -16701,16 +16444,16 @@
 			}
 		},
 		"jest-watcher": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.1.tgz",
-			"integrity": "sha512-0LBIPPncNi9CaLKK15bnxyd2E8OMl4kJg0PTiNOI+MXztXw1zVdtX/x9Pr6pXaQYps+eS/ts43O4+HByZ7yJSw==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.2.tgz",
+			"integrity": "sha512-WKJob0P/Em2csiVthsI68p6aGKTIcsfjH9Gsx1f0A3Italz43e3ho0geSAVsmj09RWOELP1AZ/DXyJgOgDKxXQ==",
 			"requires": {
-				"@jest/test-result": "^26.6.1",
-				"@jest/types": "^26.6.1",
+				"@jest/test-result": "^26.6.2",
+				"@jest/types": "^26.6.2",
 				"@types/node": "*",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^4.0.0",
-				"jest-util": "^26.6.1",
+				"jest-util": "^26.6.2",
 				"string-length": "^4.0.1"
 			},
 			"dependencies": {
@@ -16773,9 +16516,9 @@
 			}
 		},
 		"jest-worker": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.1.tgz",
-			"integrity": "sha512-R5IE3qSGz+QynJx8y+ICEkdI2OJ3RJjRQVEyCcFAd3yVhQSEtquziPO29Mlzgn07LOVE8u8jhJ1FqcwegiXWOw==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+			"integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
 			"requires": {
 				"@types/node": "*",
 				"merge-stream": "^2.0.0",
@@ -17047,9 +16790,41 @@
 			}
 		},
 		"jsrsasign": {
-			"version": "10.0.4",
-			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.0.4.tgz",
-			"integrity": "sha512-G08GDeAwgVkN5PGE9TnJ/4ixV3zkq560RigOoqrRvVc8H4GjfPVTz54/qGPLHK1KGHGP36/2eaLU1HuXmOJgug=="
+			"version": "10.0.5",
+			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.0.5.tgz",
+			"integrity": "sha512-Q9Hu2lvEO02hyIxEoh/GYDnglZEDH6p1vqaOEzPtn0d+ipTrml4lg4golFjEt1TV4upZx3Wag6HQ+xyAtp3qtg=="
+		},
+		"jstransform": {
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
+			"integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
+			"requires": {
+				"base62": "^1.1.0",
+				"commoner": "^0.10.1",
+				"esprima-fb": "^15001.1.0-dev-harmony-fb",
+				"object-assign": "^2.0.0",
+				"source-map": "^0.4.2"
+			},
+			"dependencies": {
+				"esprima-fb": {
+					"version": "15001.1.0-dev-harmony-fb",
+					"resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
+					"integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE="
+				},
+				"object-assign": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+					"integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+				},
+				"source-map": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+					"requires": {
+						"amdefine": ">=0.0.4"
+					}
+				}
+			}
 		},
 		"jsx-ast-utils": {
 			"version": "2.4.1",
@@ -18198,9 +17973,9 @@
 			}
 		},
 		"mocha": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.0.tgz",
-			"integrity": "sha512-lEWEMq2LMfNJMKeuEwb5UELi+OgFDollXaytR5ggQcHpzG3NP/R7rvixAvF+9/lLsTWhWG+4yD2M70GsM06nxw==",
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.1.tgz",
+			"integrity": "sha512-cuLBVfyFfFqbNR0uUKbDGXKGk+UDFe6aR4os78XIrMQpZl/nv7JYHcvP5MFIAb374b2zFXsdgEGwmzMtP0Xg8w==",
 			"requires": {
 				"@ungap/promise-all-settled": "1.1.2",
 				"ansi-colors": "4.1.1",
@@ -18229,6 +18004,29 @@
 				"yargs-unparser": "2.0.0"
 			},
 			"dependencies": {
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"chokidar": {
+					"version": "3.4.3",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+					"integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+					"requires": {
+						"anymatch": "~3.1.1",
+						"braces": "~3.0.2",
+						"fsevents": "~2.1.2",
+						"glob-parent": "~5.1.0",
+						"is-binary-path": "~2.1.0",
+						"is-glob": "~4.0.1",
+						"normalize-path": "~3.0.0",
+						"readdirp": "~3.5.0"
+					}
+				},
 				"diff": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -18239,6 +18037,14 @@
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
 				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
 				"find-up": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -18248,10 +18054,21 @@
 						"path-exists": "^4.0.0"
 					}
 				},
+				"fsevents": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+					"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+					"optional": true
+				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
 				},
 				"js-yaml": {
 					"version": "3.14.0",
@@ -18297,6 +18114,14 @@
 					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"requires": {
 						"has-flag": "^4.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"requires": {
+						"is-number": "^7.0.0"
 					}
 				},
 				"which": {
@@ -18838,6 +18663,43 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
 			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
+		},
+		"node-notifier": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.0.tgz",
+			"integrity": "sha512-46z7DUmcjoYdaWyXouuFNNfUo6eFa94t23c53c+lG/9Cvauk4a98rAUp9672X5dxGdQmLpPzTxzu8f/OeEPaFA==",
+			"optional": true,
+			"requires": {
+				"growly": "^1.3.0",
+				"is-wsl": "^2.2.0",
+				"semver": "^7.3.2",
+				"shellwords": "^0.1.1",
+				"uuid": "^8.3.0",
+				"which": "^2.0.2"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+					"optional": true
+				},
+				"uuid": {
+					"version": "8.3.1",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+					"integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
+					"optional": true
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"optional": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
 		},
 		"node-preload": {
 			"version": "0.2.1",
@@ -19706,21 +19568,21 @@
 			"dev": true
 		},
 		"office-ui-fabric-react": {
-			"version": "7.148.0",
-			"resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.148.0.tgz",
-			"integrity": "sha512-HD7OH9vfBBdxzdXE5Ce6c8m//KOWmkNCKfBmB64YsBaSYDoy+hGhyK8JWjYn/5n9Y9XeP4ee6ALPBcXHw76AQg==",
+			"version": "7.149.4",
+			"resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.149.4.tgz",
+			"integrity": "sha512-9gfzIGlQr9tijkR10S+chRkNhxtyf2bonPFwTvJh/vrJ3R2/CHanHEWh+k4KUjsz2+4bf/+aRY5mjKCpEG65qA==",
 			"requires": {
 				"@fluentui/date-time-utilities": "^7.9.0",
-				"@fluentui/react-focus": "^7.16.13",
-				"@fluentui/react-window-provider": "^0.3.3",
+				"@fluentui/react-focus": "^7.16.17",
+				"@fluentui/react-window-provider": "^1.0.1",
 				"@microsoft/load-themed-styles": "^1.10.26",
-				"@uifabric/foundation": "^7.9.14",
-				"@uifabric/icons": "^7.5.12",
+				"@uifabric/foundation": "^7.9.19",
+				"@uifabric/icons": "^7.5.16",
 				"@uifabric/merge-styles": "^7.19.1",
-				"@uifabric/react-hooks": "^7.13.6",
+				"@uifabric/react-hooks": "^7.13.9",
 				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/styling": "^7.16.13",
-				"@uifabric/utilities": "^7.32.4",
+				"@uifabric/styling": "^7.16.17",
+				"@uifabric/utilities": "^7.33.2",
 				"prop-types": "^15.7.2",
 				"tslib": "^1.10.0"
 			}
@@ -21598,11 +21460,11 @@
 			}
 		},
 		"pretty-format": {
-			"version": "26.6.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.1.tgz",
-			"integrity": "sha512-MeqqsP5PYcRBbGMvwzsyBdmAJ4EFX7pWFyl7x4+dMVg5pE0ZDdBIvEH2ergvIO+Gvwv1wh64YuOY9y5LuyY/GA==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+			"integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
 			"requires": {
-				"@jest/types": "^26.6.1",
+				"@jest/types": "^26.6.2",
 				"ansi-regex": "^5.0.0",
 				"ansi-styles": "^4.0.0",
 				"react-is": "^17.0.1"
@@ -22328,9 +22190,9 @@
 			}
 		},
 		"react-widgets": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/react-widgets/-/react-widgets-4.6.0.tgz",
-			"integrity": "sha512-rfQhu5Eoh2V/qhjkJQy4ZrtGYmldmpyCN6pNFWldGhAUVGTRr8reXfVqD/LDzOycal8XeRVUaW6oABPSgn14FQ==",
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/react-widgets/-/react-widgets-4.6.1.tgz",
+			"integrity": "sha512-x2n4EFQnk1ZG2rWsdekGK3js091k+b06e0CRI4pDEZ0uh/cft3NyGFKS5/x7CV/fN51kHMaM4r5IRGIbPfsLLw==",
 			"requires": {
 				"classnames": "^2.2.6",
 				"date-arithmetic": "^3.1.0",
@@ -22521,6 +22383,29 @@
 			"resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
 			"integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
 			"dev": true
+		},
+		"recast": {
+			"version": "0.11.23",
+			"resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+			"integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
+			"requires": {
+				"ast-types": "0.9.6",
+				"esprima": "~3.1.0",
+				"private": "~0.1.5",
+				"source-map": "~0.5.0"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				}
+			}
 		},
 		"rechoir": {
 			"version": "0.6.2",
@@ -23503,12 +23388,12 @@
 					"integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
 				},
 				"object.assign": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
-					"integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
 					"requires": {
+						"call-bind": "^1.0.0",
 						"define-properties": "^1.1.3",
-						"es-abstract": "^1.18.0-next.0",
 						"has-symbols": "^1.0.1",
 						"object-keys": "^1.1.1"
 					}
@@ -24845,6 +24730,76 @@
 				}
 			}
 		},
+		"terser-webpack-plugin": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+			"integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
+			"requires": {
+				"cacache": "^12.0.2",
+				"find-cache-dir": "^2.1.0",
+				"is-wsl": "^1.1.0",
+				"schema-utils": "^1.0.0",
+				"serialize-javascript": "^4.0.0",
+				"source-map": "^0.6.1",
+				"terser": "^4.1.2",
+				"webpack-sources": "^1.4.0",
+				"worker-farm": "^1.7.0"
+			},
+			"dependencies": {
+				"find-cache-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+					"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^2.0.0",
+						"pkg-dir": "^3.0.0"
+					}
+				},
+				"is-wsl": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+					"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+				},
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
+				},
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+				},
+				"schema-utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"requires": {
+						"ajv": "^6.1.0",
+						"ajv-errors": "^1.0.0",
+						"ajv-keywords": "^3.1.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				},
+				"serialize-javascript": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+					"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+					"requires": {
+						"randombytes": "^2.1.0"
+					}
+				}
+			}
+		},
 		"test-exclude": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -24943,9 +24898,9 @@
 			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
 		},
 		"timers-browserify": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
-			"integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+			"integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
 			"requires": {
 				"setimmediate": "^1.0.4"
 			}
@@ -25080,11 +25035,10 @@
 			"integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
 		},
 		"ts-jest": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.2.tgz",
-			"integrity": "sha512-0+MynTTzzbuy5rGjzsCKjxHJk5gY906c/FSaqQ3081+G7dp2Yygfa9hVlbrtNNcztffh1mC6Rs9jb/yHpcjsoQ==",
+			"version": "26.4.4",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.4.tgz",
+			"integrity": "sha512-3lFWKbLxJm34QxyVNNCgXX1u4o/RV0myvA2y2Bxm46iGIjKlaY0own9gIckbjZJPn+WaJEnfPPJ20HHGpoq4yg==",
 			"requires": {
-				"@jest/create-cache-key-function": "^26.5.0",
 				"@types/jest": "26.x",
 				"bs-logger": "0.x",
 				"buffer-from": "1.x",
@@ -25118,9 +25072,9 @@
 					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
 				},
 				"yargs-parser": {
-					"version": "20.2.3",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.3.tgz",
-					"integrity": "sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww=="
+					"version": "20.2.4",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+					"integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
 				}
 			}
 		},
@@ -25188,29 +25142,6 @@
 			"requires": {
 				"ts-node": "7.0.1",
 				"tsconfig-paths": "^3.5.0"
-			},
-			"dependencies": {
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"optional": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"tsconfig-paths": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
-					"integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
-					"optional": true,
-					"requires": {
-						"@types/json5": "^0.0.29",
-						"json5": "^1.0.1",
-						"minimist": "^1.2.0",
-						"strip-bom": "^3.0.0"
-					}
-				}
 			}
 		},
 		"ts-node": {
@@ -25226,6 +25157,27 @@
 				"mkdirp": "^0.5.1",
 				"source-map-support": "^0.5.6",
 				"yn": "^2.0.0"
+			}
+		},
+		"tsconfig-paths": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+			"integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+			"requires": {
+				"@types/json5": "^0.0.29",
+				"json5": "^1.0.1",
+				"minimist": "^1.2.0",
+				"strip-bom": "^3.0.0"
+			},
+			"dependencies": {
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				}
 			}
 		},
 		"tsd": {
@@ -25256,11 +25208,6 @@
 						"quick-lru": "^1.0.0"
 					}
 				},
-				"ci-info": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-					"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
-				},
 				"find-up": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -25273,14 +25220,6 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
 					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
-				},
-				"is-ci": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-					"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
-					"requires": {
-						"ci-info": "^1.5.0"
-					}
 				},
 				"load-json-file": {
 					"version": "4.0.0",
@@ -25447,23 +25386,6 @@
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
 					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
 				},
-				"update-notifier": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
-					"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
-					"requires": {
-						"boxen": "^1.2.1",
-						"chalk": "^2.0.1",
-						"configstore": "^3.0.0",
-						"import-lazy": "^2.1.0",
-						"is-ci": "^1.0.10",
-						"is-installed-globally": "^0.1.0",
-						"is-npm": "^1.0.0",
-						"latest-version": "^3.0.0",
-						"semver-diff": "^2.0.0",
-						"xdg-basedir": "^3.0.0"
-					}
-				},
 				"yargs-parser": {
 					"version": "10.1.0",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
@@ -25580,43 +25502,6 @@
 			"requires": {
 				"commandpost": "^1.0.0",
 				"editorconfig": "^0.15.0"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-				},
-				"editorconfig": {
-					"version": "0.15.3",
-					"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
-					"integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
-					"requires": {
-						"commander": "^2.19.0",
-						"lru-cache": "^4.1.5",
-						"semver": "^5.6.0",
-						"sigmund": "^1.0.1"
-					}
-				},
-				"lru-cache": {
-					"version": "4.1.5",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
-					}
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-				},
-				"yallist": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-				}
 			}
 		},
 		"typings-for-css-modules-loader": {
@@ -25828,6 +25713,38 @@
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
 			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
 		},
+		"update-notifier": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+			"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+			"requires": {
+				"boxen": "^1.2.1",
+				"chalk": "^2.0.1",
+				"configstore": "^3.0.0",
+				"import-lazy": "^2.1.0",
+				"is-ci": "^1.0.10",
+				"is-installed-globally": "^0.1.0",
+				"is-npm": "^1.0.0",
+				"latest-version": "^3.0.0",
+				"semver-diff": "^2.0.0",
+				"xdg-basedir": "^3.0.0"
+			},
+			"dependencies": {
+				"ci-info": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+					"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
+				},
+				"is-ci": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+					"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+					"requires": {
+						"ci-info": "^1.5.0"
+					}
+				}
+			}
+		},
 		"upper-case": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
@@ -25953,14 +25870,14 @@
 			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 		},
 		"v8-compile-cache": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-			"integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ=="
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+			"integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q=="
 		},
 		"v8-to-istanbul": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-6.0.1.tgz",
-			"integrity": "sha512-PzM1WlqquhBvsV+Gco6WSFeg1AGdD53ccMRkFeyHRE/KRZaVacPOmQYP3EeVgDBtKD2BJ8kgynBQ5OtKiHCH+w==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.0.0.tgz",
+			"integrity": "sha512-fLL2rFuQpMtm9r8hrAV2apXX/WqHJ6+IC4/eQVdMDGBUgH/YMV4Gv3duk3kjmyg6uiQWBAA9nJwue4iJUOkHeA==",
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.1",
 				"convert-source-map": "^1.6.0",
@@ -26085,20 +26002,77 @@
 			}
 		},
 		"watchpack": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
-			"integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
+			"version": "1.7.5",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
+			"integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
 			"requires": {
 				"chokidar": "^3.4.1",
 				"graceful-fs": "^4.1.2",
 				"neo-async": "^2.5.0",
-				"watchpack-chokidar2": "^2.0.0"
+				"watchpack-chokidar2": "^2.0.1"
+			},
+			"dependencies": {
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"optional": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"chokidar": {
+					"version": "3.4.3",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+					"integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+					"optional": true,
+					"requires": {
+						"anymatch": "~3.1.1",
+						"braces": "~3.0.2",
+						"fsevents": "~2.1.2",
+						"glob-parent": "~5.1.0",
+						"is-binary-path": "~2.1.0",
+						"is-glob": "~4.0.1",
+						"normalize-path": "~3.0.0",
+						"readdirp": "~3.5.0"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"optional": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"fsevents": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+					"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+					"optional": true
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"optional": true
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"optional": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				}
 			}
 		},
 		"watchpack-chokidar2": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
-			"integrity": "sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz",
+			"integrity": "sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==",
 			"optional": true,
 			"requires": {
 				"chokidar": "^2.1.8"
@@ -26299,34 +26273,10 @@
 						"estraverse": "^4.1.1"
 					}
 				},
-				"find-cache-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-					"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-					"requires": {
-						"commondir": "^1.0.1",
-						"make-dir": "^2.0.0",
-						"pkg-dir": "^3.0.0"
-					}
-				},
-				"is-wsl": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-					"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
-				},
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				},
-				"make-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-					"requires": {
-						"pify": "^4.0.1",
-						"semver": "^5.6.0"
-					}
 				},
 				"memory-fs": {
 					"version": "0.4.1",
@@ -26336,11 +26286,6 @@
 						"errno": "^0.1.3",
 						"readable-stream": "^2.0.1"
 					}
-				},
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
 				},
 				"readable-stream": {
 					"version": "2.3.7",
@@ -26366,41 +26311,12 @@
 						"ajv-keywords": "^3.1.0"
 					}
 				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-				},
-				"serialize-javascript": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-					"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-					"requires": {
-						"randombytes": "^2.1.0"
-					}
-				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"requires": {
 						"safe-buffer": "~5.1.0"
-					}
-				},
-				"terser-webpack-plugin": {
-					"version": "1.4.5",
-					"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
-					"integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
-					"requires": {
-						"cacache": "^12.0.2",
-						"find-cache-dir": "^2.1.0",
-						"is-wsl": "^1.1.0",
-						"schema-utils": "^1.0.0",
-						"serialize-javascript": "^4.0.0",
-						"source-map": "^0.6.1",
-						"terser": "^4.1.2",
-						"webpack-sources": "^1.4.0",
-						"worker-farm": "^1.7.0"
 					}
 				}
 			}
@@ -26466,6 +26382,61 @@
 						"ini": "^1.3.5",
 						"kind-of": "^6.0.2",
 						"which": "^1.3.1"
+					}
+				}
+			}
+		},
+		"webpack-dev-middleware": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
+			"integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
+			"requires": {
+				"memory-fs": "^0.4.1",
+				"mime": "^2.4.4",
+				"mkdirp": "^0.5.1",
+				"range-parser": "^1.2.1",
+				"webpack-log": "^2.0.0"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"memory-fs": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+					"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+					"requires": {
+						"errno": "^0.1.3",
+						"readable-stream": "^2.0.1"
+					}
+				},
+				"mime": {
+					"version": "2.4.6",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+					"integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+				},
+				"readable-stream": {
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"requires": {
+						"safe-buffer": "~5.1.0"
 					}
 				}
 			}
@@ -26599,20 +26570,6 @@
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
-				"memory-fs": {
-					"version": "0.4.1",
-					"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
-					"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-					"requires": {
-						"errno": "^0.1.3",
-						"readable-stream": "^2.0.1"
-					}
-				},
-				"mime": {
-					"version": "2.4.6",
-					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-					"integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
-				},
 				"readable-stream": {
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -26667,18 +26624,6 @@
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
-				},
-				"webpack-dev-middleware": {
-					"version": "3.7.2",
-					"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
-					"integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
-					"requires": {
-						"memory-fs": "^0.4.1",
-						"mime": "^2.4.4",
-						"mkdirp": "^0.5.1",
-						"range-parser": "^1.2.1",
-						"webpack-log": "^2.0.0"
-					}
 				}
 			}
 		},
@@ -26726,84 +26671,6 @@
 				"react-dom": "^0.14.0"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "5.7.4",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-					"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
-				},
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-				},
-				"commoner": {
-					"version": "0.10.8",
-					"resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
-					"integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
-					"requires": {
-						"commander": "^2.5.0",
-						"detective": "^4.3.1",
-						"glob": "^5.0.15",
-						"graceful-fs": "^4.1.2",
-						"iconv-lite": "^0.4.5",
-						"mkdirp": "^0.5.0",
-						"private": "^0.1.6",
-						"q": "^1.1.2",
-						"recast": "^0.11.17"
-					}
-				},
-				"detective": {
-					"version": "4.7.1",
-					"resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
-					"integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
-					"requires": {
-						"acorn": "^5.2.1",
-						"defined": "^1.0.0"
-					}
-				},
-				"envify": {
-					"version": "3.4.1",
-					"resolved": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz",
-					"integrity": "sha1-1xIjKejfFoi6dxsSUBkXyc5cvOg=",
-					"requires": {
-						"jstransform": "^11.0.3",
-						"through": "~2.3.4"
-					}
-				},
-				"esprima-fb": {
-					"version": "15001.1.0-dev-harmony-fb",
-					"resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
-					"integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE="
-				},
-				"glob": {
-					"version": "5.0.15",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-					"requires": {
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "2 || 3",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"jstransform": {
-					"version": "11.0.3",
-					"resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
-					"integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
-					"requires": {
-						"base62": "^1.1.0",
-						"commoner": "^0.10.1",
-						"esprima-fb": "^15001.1.0-dev-harmony-fb",
-						"object-assign": "^2.0.0",
-						"source-map": "^0.4.2"
-					}
-				},
-				"object-assign": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-					"integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
-				},
 				"react": {
 					"version": "0.14.10",
 					"resolved": "https://registry.npmjs.org/react/-/react-0.14.10.tgz",
@@ -26817,37 +26684,6 @@
 					"version": "0.14.10",
 					"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.10.tgz",
 					"integrity": "sha512-kDs8SWFb8Sry4NAplhpJbZEeAnTPir/m+s9s+lkdqA2a89BzmWGnEgGG/CfmhULjv1ogc4oHrjMfAvFNruT3jQ=="
-				},
-				"recast": {
-					"version": "0.11.23",
-					"resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-					"integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-					"requires": {
-						"ast-types": "0.9.6",
-						"esprima": "~3.1.0",
-						"private": "~0.1.5",
-						"source-map": "~0.5.0"
-					},
-					"dependencies": {
-						"esprima": {
-							"version": "3.1.3",
-							"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-							"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-						},
-						"source-map": {
-							"version": "0.5.7",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-						}
-					}
-				},
-				"source-map": {
-					"version": "0.4.4",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-					"requires": {
-						"amdefine": ">=0.0.4"
-					}
 				}
 			}
 		},
@@ -27304,9 +27140,9 @@
 			},
 			"dependencies": {
 				"camelcase": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.1.0.tgz",
-					"integrity": "sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ=="
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+					"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
 				},
 				"decamelize": {
 					"version": "4.0.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -4538,7 +4538,7 @@
 		},
 		"@microsoft/api-extractor": {
 			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org@microsoft/api-extractor/-/api-extractor-7.8.0.tgz",
+			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.8.0.tgz",
 			"integrity": "sha1-/qaOTyHBvxgCBWD9VyixX+RPCXY=",
 			"dev": true,
 			"requires": {
@@ -4555,7 +4555,7 @@
 		},
 		"@microsoft/api-extractor-model": {
 			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org@microsoft/api-extractor-model/-/api-extractor-model-7.8.0.tgz",
+			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.8.0.tgz",
 			"integrity": "sha1-X1MpmPARCfI9V7QigDu99a1lXYA=",
 			"dev": true,
 			"requires": {

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -73,152 +73,6 @@
 				}
 			}
 		},
-		"@babel/helper-create-class-features-plugin": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz",
-			"integrity": "sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==",
-			"requires": {
-				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-member-expression-to-functions": "^7.12.1",
-				"@babel/helper-optimise-call-expression": "^7.10.4",
-				"@babel/helper-replace-supers": "^7.12.1",
-				"@babel/helper-split-export-declaration": "^7.10.4"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-					"requires": {
-						"@babel/highlight": "^7.10.4"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
-					"integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
-					"requires": {
-						"@babel/types": "^7.12.5",
-						"jsesc": "^2.5.1",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-					"requires": {
-						"@babel/helper-get-function-arity": "^7.10.4",
-						"@babel/template": "^7.10.4",
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-					"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-					"requires": {
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-member-expression-to-functions": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
-					"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
-					"requires": {
-						"@babel/types": "^7.12.1"
-					}
-				},
-				"@babel/helper-optimise-call-expression": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-					"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
-					"requires": {
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/helper-replace-supers": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
-					"integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
-					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.12.1",
-						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/traverse": "^7.12.5",
-						"@babel/types": "^7.12.5"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-					"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
-					"requires": {
-						"@babel/types": "^7.11.0"
-					}
-				},
-				"@babel/helper-validator-identifier": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-				},
-				"@babel/highlight": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
-						"chalk": "^2.0.0",
-						"js-tokens": "^4.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.5.tgz",
-					"integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ=="
-				},
-				"@babel/template": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-					"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
-					"requires": {
-						"@babel/code-frame": "^7.10.4",
-						"@babel/parser": "^7.10.4",
-						"@babel/types": "^7.10.4"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.5.tgz",
-					"integrity": "sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==",
-					"requires": {
-						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.12.5",
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.12.5",
-						"@babel/types": "^7.12.5",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@babel/types": {
-					"version": "7.12.6",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-					"integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
-						"lodash": "^4.17.19",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				}
-			}
-		},
 		"@babel/helper-function-name": {
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
@@ -345,6 +199,152 @@
 			"requires": {
 				"@babel/helper-create-class-features-plugin": "^7.12.1",
 				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"requires": {
+						"@babel/highlight": "^7.10.4"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
+					"integrity": "sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==",
+					"requires": {
+						"@babel/types": "^7.12.1",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-create-class-features-plugin": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz",
+					"integrity": "sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==",
+					"requires": {
+						"@babel/helper-function-name": "^7.10.4",
+						"@babel/helper-member-expression-to-functions": "^7.12.1",
+						"@babel/helper-optimise-call-expression": "^7.10.4",
+						"@babel/helper-replace-supers": "^7.12.1",
+						"@babel/helper-split-export-declaration": "^7.10.4"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+					"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+					"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
+					"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
+					"requires": {
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+					"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+					"requires": {
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.1.tgz",
+					"integrity": "sha512-zJjTvtNJnCFsCXVi5rUInstLd/EIVNmIKA1Q9ynESmMBWPWd+7sdR+G4/wdu+Mppfep0XLyG2m7EBPvjCeFyrw==",
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.12.1",
+						"@babel/helper-optimise-call-expression": "^7.10.4",
+						"@babel/traverse": "^7.12.1",
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.11.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+					"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+					"requires": {
+						"@babel/types": "^7.11.0"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+				},
+				"@babel/highlight": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.12.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.3.tgz",
+					"integrity": "sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw=="
+				},
+				"@babel/template": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+					"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/parser": "^7.10.4",
+						"@babel/types": "^7.10.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.1.tgz",
+					"integrity": "sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==",
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/generator": "^7.12.1",
+						"@babel/helper-function-name": "^7.10.4",
+						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/parser": "^7.12.1",
+						"@babel/types": "^7.12.1",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@babel/types": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+					"integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				}
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
@@ -435,14 +435,6 @@
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
-		"@babel/plugin-syntax-top-level-await": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.1.tgz",
-			"integrity": "sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==",
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
-			}
-		},
 		"@babel/polyfill": {
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
@@ -454,9 +446,9 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-			"integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
+			"integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
@@ -568,9 +560,9 @@
 					}
 				},
 				"import-fresh": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
-					"integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+					"integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
 					"requires": {
 						"parent-module": "^1.0.0",
 						"resolve-from": "^4.0.0"
@@ -728,35 +720,35 @@
 			}
 		},
 		"@fluentui/react-focus": {
-			"version": "7.16.17",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.16.17.tgz",
-			"integrity": "sha512-Uioe+9tZoiXxp5aKam6Y+PyU46UDGMCF4xYctgP3tIpPyi7xfka7Aat6IyIFcTxN53UKea2IcCMzbOhpK0VTLg==",
+			"version": "7.16.13",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.16.13.tgz",
+			"integrity": "sha512-MWyI64GSEZigYe75aCy8VGGIr/tWwk+H8oqPxamoVOHef4kCqYm/70mhrDpBP1oAhJVmdY/Lia6dtkIz3J9wgw==",
 			"requires": {
 				"@fluentui/keyboard-key": "^0.2.12",
 				"@uifabric/merge-styles": "^7.19.1",
 				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/styling": "^7.16.17",
-				"@uifabric/utilities": "^7.33.2",
+				"@uifabric/styling": "^7.16.13",
+				"@uifabric/utilities": "^7.32.4",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@fluentui/react-window-provider": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-1.0.1.tgz",
-			"integrity": "sha512-5hvruDyF0uE8+6YN6Y+d2sEzexBadxUNxUjDcDreTPsmtHPwF5FPBYLhoD7T84L5U4YNvKxKh25tYJm6E0GE2w==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-0.3.3.tgz",
+			"integrity": "sha512-MVPf2hqOQ17LAZsuvGcr3oOHksAskUm+fCYdXFhbVoAgsCDVTIuH6i8XgHFd6YjBtzjZmI4+k/3NTQfDqBX8EQ==",
 			"requires": {
 				"@uifabric/set-version": "^7.0.23",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@fluentui/theme": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-1.6.0.tgz",
-			"integrity": "sha512-X+uJx7+9ChfM0SAq+eDLgL9t65ZA8NAc1Ifrw4eek6cS3c1eY95/tgf1EkX+hOE9+oIuEATujM9THzk+4yd1VQ==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-1.5.1.tgz",
+			"integrity": "sha512-w5986/CN3hWuH44WmlQNxtndBx0khnb1xjISb/4bktRpehYxIlDBmQYRUOUYXr6zwdK7JXJaJPGjOJzSh2DCDg==",
 			"requires": {
 				"@uifabric/merge-styles": "^7.19.1",
 				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/utilities": "^7.33.2",
+				"@uifabric/utilities": "^7.32.4",
 				"tslib": "^1.10.0"
 			}
 		},
@@ -2728,15 +2720,15 @@
 			"integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw=="
 		},
 		"@jest/console": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-26.6.2.tgz",
-			"integrity": "sha512-IY1R2i2aLsLr7Id3S6p2BA82GNWryt4oSvEXLAKc+L2zdi89dSkE8xC1C+0kpATG4JhBJREnQOH7/zmccM2B0g==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-26.6.1.tgz",
+			"integrity": "sha512-cjqcXepwC5M+VeIhwT6Xpi/tT4AiNzlIx8SMJ9IihduHnsSrnWNvTBfKIpmqOOCNOPqtbBx6w2JqfoLOJguo8g==",
 			"requires": {
-				"@jest/types": "^26.6.2",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
-				"jest-message-util": "^26.6.2",
-				"jest-util": "^26.6.2",
+				"jest-message-util": "^26.6.1",
+				"jest-util": "^26.6.1",
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
@@ -2790,299 +2782,49 @@
 				}
 			}
 		},
-		"@jest/core": {
-			"version": "26.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-26.6.3.tgz",
-			"integrity": "sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==",
-			"requires": {
-				"@jest/console": "^26.6.2",
-				"@jest/reporters": "^26.6.2",
-				"@jest/test-result": "^26.6.2",
-				"@jest/transform": "^26.6.2",
-				"@jest/types": "^26.6.2",
-				"@types/node": "*",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.0.0",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.2.4",
-				"jest-changed-files": "^26.6.2",
-				"jest-config": "^26.6.3",
-				"jest-haste-map": "^26.6.2",
-				"jest-message-util": "^26.6.2",
-				"jest-regex-util": "^26.0.0",
-				"jest-resolve": "^26.6.2",
-				"jest-resolve-dependencies": "^26.6.3",
-				"jest-runner": "^26.6.3",
-				"jest-runtime": "^26.6.3",
-				"jest-snapshot": "^26.6.2",
-				"jest-util": "^26.6.2",
-				"jest-validate": "^26.6.2",
-				"jest-watcher": "^26.6.2",
-				"micromatch": "^4.0.2",
-				"p-each-series": "^2.1.0",
-				"rimraf": "^3.0.0",
-				"slash": "^3.0.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"dependencies": {
-				"ansi-escapes": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-					"requires": {
-						"type-fest": "^0.11.0"
-					}
-				},
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-				},
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"requires": {
-						"fill-range": "^7.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-				},
-				"micromatch": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-					"requires": {
-						"braces": "^3.0.1",
-						"picomatch": "^2.0.5"
-					}
-				},
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"requires": {
-						"is-number": "^7.0.0"
-					}
-				},
-				"type-fest": {
-					"version": "0.11.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-					"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
-				}
-			}
+		"@jest/create-cache-key-function": {
+			"version": "26.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-26.5.0.tgz",
+			"integrity": "sha512-DJ+pEBUIqarrbv1W/C39f9YH0rJ4wsXZ/VC6JafJPlHW2HOucKceeaqTOQj9MEDQZjySxMLkOq5mfXZXNZcmWw=="
 		},
 		"@jest/environment": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.2.tgz",
-			"integrity": "sha512-nFy+fHl28zUrRsCeMB61VDThV1pVTtlEokBRgqPrcT1JNq4yRNIyTHfyht6PqtUvY9IsuLGTrbG8kPXjSZIZwA==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.1.tgz",
+			"integrity": "sha512-GNvHwkOFJtNgSwdzH9flUPzF9AYAZhUg124CBoQcwcZCM9s5TLz8Y3fMtiaWt4ffbigoetjGk5PU2Dd8nLrSEw==",
 			"requires": {
-				"@jest/fake-timers": "^26.6.2",
-				"@jest/types": "^26.6.2",
+				"@jest/fake-timers": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
-				"jest-mock": "^26.6.2"
+				"jest-mock": "^26.6.1"
 			}
 		},
 		"@jest/fake-timers": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.6.2.tgz",
-			"integrity": "sha512-14Uleatt7jdzefLPYM3KLcnUl1ZNikaKq34enpb5XG9i81JpppDb5muZvonvKyrl7ftEHkKS5L5/eB/kxJ+bvA==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.6.1.tgz",
+			"integrity": "sha512-T/SkMLgOquenw/nIisBRD6XAYpFir0kNuclYLkse5BpzeDUukyBr+K31xgAo9M0hgjU9ORlekAYPSzc0DKfmKg==",
 			"requires": {
-				"@jest/types": "^26.6.2",
+				"@jest/types": "^26.6.1",
 				"@sinonjs/fake-timers": "^6.0.1",
 				"@types/node": "*",
-				"jest-message-util": "^26.6.2",
-				"jest-mock": "^26.6.2",
-				"jest-util": "^26.6.2"
+				"jest-message-util": "^26.6.1",
+				"jest-mock": "^26.6.1",
+				"jest-util": "^26.6.1"
 			}
 		},
 		"@jest/globals": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.6.2.tgz",
-			"integrity": "sha512-85Ltnm7HlB/KesBUuALwQ68YTU72w9H2xW9FjZ1eL1U3lhtefjjl5c2MiUbpXt/i6LaPRvoOFJ22yCBSfQ0JIA==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.6.1.tgz",
+			"integrity": "sha512-acxXsSguuLV/CeMYmBseefw6apO7NuXqpE+v5r3yD9ye2PY7h1nS20vY7Obk2w6S7eJO4OIAJeDnoGcLC/McEQ==",
 			"requires": {
-				"@jest/environment": "^26.6.2",
-				"@jest/types": "^26.6.2",
-				"expect": "^26.6.2"
-			}
-		},
-		"@jest/reporters": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.6.2.tgz",
-			"integrity": "sha512-h2bW53APG4HvkOnVMo8q3QXa6pcaNt1HkwVsOPMBV6LD/q9oSpxNSYZQYkAnjdMjrJ86UuYeLo+aEZClV6opnw==",
-			"requires": {
-				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "^26.6.2",
-				"@jest/test-result": "^26.6.2",
-				"@jest/transform": "^26.6.2",
-				"@jest/types": "^26.6.2",
-				"chalk": "^4.0.0",
-				"collect-v8-coverage": "^1.0.0",
-				"exit": "^0.1.2",
-				"glob": "^7.1.2",
-				"graceful-fs": "^4.2.4",
-				"istanbul-lib-coverage": "^3.0.0",
-				"istanbul-lib-instrument": "^4.0.3",
-				"istanbul-lib-report": "^3.0.0",
-				"istanbul-lib-source-maps": "^4.0.0",
-				"istanbul-reports": "^3.0.2",
-				"jest-haste-map": "^26.6.2",
-				"jest-resolve": "^26.6.2",
-				"jest-util": "^26.6.2",
-				"jest-worker": "^26.6.2",
-				"node-notifier": "^8.0.0",
-				"slash": "^3.0.0",
-				"source-map": "^0.6.0",
-				"string-length": "^4.0.1",
-				"terminal-link": "^2.0.0",
-				"v8-to-istanbul": "^7.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"istanbul-lib-instrument": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
-					"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
-					"requires": {
-						"@babel/core": "^7.7.5",
-						"@istanbuljs/schema": "^0.1.2",
-						"istanbul-lib-coverage": "^3.0.0",
-						"semver": "^6.3.0"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
+				"@jest/environment": "^26.6.1",
+				"@jest/types": "^26.6.1",
+				"expect": "^26.6.1"
 			}
 		},
 		"@jest/source-map": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.6.2.tgz",
-			"integrity": "sha512-YwYcCwAnNmOVsZ8mr3GfnzdXDAl4LaenZP5z+G0c8bzC9/dugL8zRmxZzdoTl4IaS3CryS1uWnROLPFmb6lVvA==",
+			"version": "26.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.5.0.tgz",
+			"integrity": "sha512-jWAw9ZwYHJMe9eZq/WrsHlwF8E3hM9gynlcDpOyCb9bR8wEd9ZNBZCi7/jZyzHxC7t3thZ10gO2IDhu0bPKS5g==",
 			"requires": {
 				"callsites": "^3.0.0",
 				"graceful-fs": "^4.2.4",
@@ -3097,43 +2839,270 @@
 			}
 		},
 		"@jest/test-result": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.6.2.tgz",
-			"integrity": "sha512-5O7H5c/7YlojphYNrK02LlDIV2GNPYisKwHm2QTKjNZeEzezCbwYs9swJySv2UfPMyZ0VdsmMv7jIlD/IKYQpQ==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.6.1.tgz",
+			"integrity": "sha512-wqAgIerIN2gSdT2A8WeA5+AFh9XQBqYGf8etK143yng3qYd0mF0ie2W5PVmgnjw4VDU6ammI9NdXrKgNhreawg==",
 			"requires": {
-				"@jest/console": "^26.6.2",
-				"@jest/types": "^26.6.2",
+				"@jest/console": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"collect-v8-coverage": "^1.0.0"
 			}
 		},
 		"@jest/test-sequencer": {
-			"version": "26.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.6.3.tgz",
-			"integrity": "sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.6.1.tgz",
+			"integrity": "sha512-0csqA/XApZiNeTIPYh6koIDCACSoR6hi29T61tKJMtCZdEC+tF3PoNt7MS0oK/zKC6daBgCbqXxia5ztr/NyCQ==",
 			"requires": {
-				"@jest/test-result": "^26.6.2",
+				"@jest/test-result": "^26.6.1",
 				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^26.6.2",
-				"jest-runner": "^26.6.3",
-				"jest-runtime": "^26.6.3"
+				"jest-haste-map": "^26.6.1",
+				"jest-runner": "^26.6.1",
+				"jest-runtime": "^26.6.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"cliui": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^6.2.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+				},
+				"jest-runtime": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.1.tgz",
+					"integrity": "sha512-7uOCNeezXDWgjEyzYbRN2ViY7xNZzusNVGAMmU0UHRUNXuY4j4GBHKGMqPo/cBPZA9bSYp+lwK2DRRBU5Dv6YQ==",
+					"requires": {
+						"@jest/console": "^26.6.1",
+						"@jest/environment": "^26.6.1",
+						"@jest/fake-timers": "^26.6.1",
+						"@jest/globals": "^26.6.1",
+						"@jest/source-map": "^26.5.0",
+						"@jest/test-result": "^26.6.1",
+						"@jest/transform": "^26.6.1",
+						"@jest/types": "^26.6.1",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0",
+						"cjs-module-lexer": "^0.4.2",
+						"collect-v8-coverage": "^1.0.0",
+						"exit": "^0.1.2",
+						"glob": "^7.1.3",
+						"graceful-fs": "^4.2.4",
+						"jest-config": "^26.6.1",
+						"jest-haste-map": "^26.6.1",
+						"jest-message-util": "^26.6.1",
+						"jest-mock": "^26.6.1",
+						"jest-regex-util": "^26.0.0",
+						"jest-resolve": "^26.6.1",
+						"jest-snapshot": "^26.6.1",
+						"jest-util": "^26.6.1",
+						"jest-validate": "^26.6.1",
+						"slash": "^3.0.0",
+						"strip-bom": "^4.0.0",
+						"yargs": "^15.4.1"
+					}
+				},
+				"jest-snapshot": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.1.tgz",
+					"integrity": "sha512-JA7bZp7HRTIJYAi85pJ/OZ2eur2dqmwIToA5/6d7Mn90isGEfeF9FvuhDLLEczgKP1ihreBzrJ6Vr7zteP5JNA==",
+					"requires": {
+						"@babel/types": "^7.0.0",
+						"@jest/types": "^26.6.1",
+						"@types/babel__traverse": "^7.0.4",
+						"@types/prettier": "^2.0.0",
+						"chalk": "^4.0.0",
+						"expect": "^26.6.1",
+						"graceful-fs": "^4.2.4",
+						"jest-diff": "^26.6.1",
+						"jest-get-type": "^26.3.0",
+						"jest-haste-map": "^26.6.1",
+						"jest-matcher-utils": "^26.6.1",
+						"jest-message-util": "^26.6.1",
+						"jest-resolve": "^26.6.1",
+						"natural-compare": "^1.4.0",
+						"pretty-format": "^26.6.1",
+						"semver": "^7.3.2"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+				},
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"yargs": {
+					"version": "15.4.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+					"requires": {
+						"cliui": "^6.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^4.1.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^4.2.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^18.1.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
 			}
 		},
 		"@jest/transform": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.2.tgz",
-			"integrity": "sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.1.tgz",
+			"integrity": "sha512-oNFAqVtqRxZRx6vXL3I4bPKUK0BIlEeaalkwxyQGGI8oXDQBtYQBpiMe5F7qPs4QdvvFYB42gPGIMMcxXaBBxQ==",
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/types": "^26.6.2",
+				"@jest/types": "^26.6.1",
 				"babel-plugin-istanbul": "^6.0.0",
 				"chalk": "^4.0.0",
 				"convert-source-map": "^1.4.0",
 				"fast-json-stable-stringify": "^2.0.0",
 				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^26.6.2",
+				"jest-haste-map": "^26.6.1",
 				"jest-regex-util": "^26.0.0",
-				"jest-util": "^26.6.2",
+				"jest-util": "^26.6.1",
 				"micromatch": "^4.0.2",
 				"pirates": "^4.0.1",
 				"slash": "^3.0.0",
@@ -3241,9 +3210,9 @@
 			}
 		},
 		"@jest/types": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-			"integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+			"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"@types/istanbul-reports": "^3.0.0",
@@ -4595,9 +4564,9 @@
 			}
 		},
 		"@microsoft/load-themed-styles": {
-			"version": "1.10.127",
-			"resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.127.tgz",
-			"integrity": "sha512-Uc9+ZhdhrDPG7p3PhBF4ZjeinqECC2zzfE/aDKhUu7oC7XFHH+EhK6SfvMn/JCVVSiWtanaaam4eG3k7lQCmbg=="
+			"version": "1.10.117",
+			"resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.117.tgz",
+			"integrity": "sha512-nEvUltTnpm4FnZ7TFHwQqL1Y5PDqXbAT1WGUXuUAF5RM8dgoRHQ72uIZJ2UBSQNKsY/+IwGWmHBFJVT1e1mzSQ=="
 		},
 		"@microsoft/tsdoc": {
 			"version": "0.12.19",
@@ -5382,9 +5351,9 @@
 			"integrity": "sha512-bWBbC7VG2jdjbgZMX0qpds8U/3h3anfIqE81L8jmVrgFZw/urEDnBA78ymGGKTTK6ciBXmmJ/xlok+Re41S8ww=="
 		},
 		"@types/babel__core": {
-			"version": "7.1.12",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
-			"integrity": "sha512-wMTHiiTiBAAPebqaPiPDLFA4LYPKr6Ph0Xq/6rq1Ur3v66HXyG+clfR9CNETkD7MQS8ZHvpQOtA53DLws5WAEQ==",
+			"version": "7.1.10",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.10.tgz",
+			"integrity": "sha512-x8OM8XzITIMyiwl5Vmo2B1cR1S1Ipkyv4mdlbJjMa1lmuKvKY9FrBbEANIaMlnWn5Rf7uO+rC/VgYabNkE17Hw==",
 			"requires": {
 				"@babel/parser": "^7.1.0",
 				"@babel/types": "^7.0.0",
@@ -5612,9 +5581,9 @@
 			"integrity": "sha512-aWw2YTtAdT7CskFyxEX2K21/zSDStuf/ikI3yBqmwpwJF0pS+/IX5DWv+1UFffZIbruP6cnT9/LAJV1gFwAT1A=="
 		},
 		"@types/lodash": {
-			"version": "4.14.165",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.165.tgz",
-			"integrity": "sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg=="
+			"version": "4.14.162",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.162.tgz",
+			"integrity": "sha512-alvcho1kRUnnD1Gcl4J+hK0eencvzq9rmzvFPRmP5rPHx9VVsJj6bKLTATPVf9ktgv4ujzh7T+XWKp+jhuODig=="
 		},
 		"@types/mime": {
 			"version": "2.0.3",
@@ -5676,9 +5645,9 @@
 			"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
 		},
 		"@types/prosemirror-model": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@types/prosemirror-model/-/prosemirror-model-1.11.1.tgz",
-			"integrity": "sha512-sAue1p9V/JjATX1JzQDFzW2ON8QEGUz3eMSpJX94oCr0CoAQgK4/kSM2funtQKy1GHd+xr7wZ509ykt49b+T1Q==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@types/prosemirror-model/-/prosemirror-model-1.11.0.tgz",
+			"integrity": "sha512-R+vutu3AptoiXGJR0Jdpyr7BkJg24bce9ETUDOrBJZhRcsWeMEFGzidG19GHcY6Yny5zTILxlqXeDEIF3C5b7A==",
 			"requires": {
 				"@types/orderedmap": "*"
 			}
@@ -5746,18 +5715,18 @@
 			"integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
 		},
 		"@types/react": {
-			"version": "16.9.56",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.56.tgz",
-			"integrity": "sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==",
+			"version": "16.9.53",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.53.tgz",
+			"integrity": "sha512-4nW60Sd4L7+WMXH1D6jCdVftuW7j4Za6zdp6tJ33Rqv0nk1ZAmQKML9ZLD4H0dehA3FZxXR/GM8gXplf82oNGw==",
 			"requires": {
 				"@types/prop-types": "*",
 				"csstype": "^3.0.2"
 			}
 		},
 		"@types/react-dom": {
-			"version": "16.9.9",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.9.tgz",
-			"integrity": "sha512-jE16FNWO3Logq/Lf+yvEAjKzhpST/Eac8EMd1i4dgZdMczfgqC8EjpxwNgEe3SExHYLliabXDh9DEhhqnlXJhg==",
+			"version": "16.9.8",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.8.tgz",
+			"integrity": "sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==",
 			"requires": {
 				"@types/react": "*"
 			}
@@ -5859,9 +5828,9 @@
 			"integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
 		},
 		"@types/uglify-js": {
-			"version": "3.11.1",
-			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.11.1.tgz",
-			"integrity": "sha512-7npvPKV+jINLu1SpSYVWG8KvyJBhBa8tmzMMdDoVc2pWUYHN8KIXlPJhjJ4LT97c4dXJA2SHL/q6ADbDriZN+Q==",
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.11.0.tgz",
+			"integrity": "sha512-I0Yd8TUELTbgRHq2K65j8rnDPAzAP+DiaF/syLem7yXwYLsHZhPd+AM2iXsWmf9P2F2NlFCgl5erZPQx9IbM9Q==",
 			"requires": {
 				"source-map": "^0.6.1"
 			}
@@ -5872,9 +5841,9 @@
 			"integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ=="
 		},
 		"@types/webpack": {
-			"version": "4.41.24",
-			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.24.tgz",
-			"integrity": "sha512-1A0MXPwZiMOD3DPMuOKUKcpkdPo8Lq33UGggZ7xio6wJ/jV1dAu5cXDrOfGDnldUroPIRLsr/DT43/GqOA4RFQ==",
+			"version": "4.41.23",
+			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.23.tgz",
+			"integrity": "sha512-ojA4CupZg8RCzVJLugWlvqrHpT59GWhqFxbinlsnvk10MjQCWB+ot7XDACctbWhnhtdhYK7+HOH1JxkVLiZhMg==",
 			"requires": {
 				"@types/anymatch": "*",
 				"@types/node": "*",
@@ -6273,38 +6242,38 @@
 			}
 		},
 		"@uifabric/fluent-theme": {
-			"version": "7.3.37",
-			"resolved": "https://registry.npmjs.org/@uifabric/fluent-theme/-/fluent-theme-7.3.37.tgz",
-			"integrity": "sha512-iEeHQLV9QqiUmHhFC/jdCyUpyZu0MSX1PW+kgD8h9AIi4De48ZdRauyJWJJEmbB0If+uvb7gZ0lMPrzBNuuC0Q==",
+			"version": "7.3.30",
+			"resolved": "https://registry.npmjs.org/@uifabric/fluent-theme/-/fluent-theme-7.3.30.tgz",
+			"integrity": "sha512-Abk1TBHPoR0J91jBphQlIeRzQFSu+zu/vZC5pHEnUFvPwk0CKW0SHKL3+bllmH26oaT0Y6sQnQNKjrMrn9HxNA==",
 			"requires": {
-				"@fluentui/theme": "^1.6.0",
+				"@fluentui/theme": "^1.5.1",
 				"@uifabric/merge-styles": "^7.19.1",
 				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/styling": "^7.16.17",
-				"@uifabric/variants": "^7.2.30",
-				"office-ui-fabric-react": "^7.149.4",
+				"@uifabric/styling": "^7.16.13",
+				"@uifabric/variants": "^7.2.26",
+				"office-ui-fabric-react": "^7.148.0",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/foundation": {
-			"version": "7.9.19",
-			"resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.9.19.tgz",
-			"integrity": "sha512-F/kKiFL4uSiosnqdv1BT3aQ3w9bQ3l+F3NiMqDbJpnlBAOMOlH2X7xAxZsNYbS66pgTPKsSP/8/SK3A+0wzMXg==",
+			"version": "7.9.14",
+			"resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.9.14.tgz",
+			"integrity": "sha512-AWsSt28+mid44YPofHB8N1nm4C0QmLJ9WXFps5GyjaBHES6/4bfJ7rKzYioa5bN0TxElyK8rRHzwqKNQhWDBYA==",
 			"requires": {
 				"@uifabric/merge-styles": "^7.19.1",
 				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/styling": "^7.16.17",
-				"@uifabric/utilities": "^7.33.2",
+				"@uifabric/styling": "^7.16.13",
+				"@uifabric/utilities": "^7.32.4",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/icons": {
-			"version": "7.5.16",
-			"resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.5.16.tgz",
-			"integrity": "sha512-S+KGDZeN9y5sBJfg7Jgi3/598CxE0hvlMtl1XzzftKPdD2Jw8QCQazgYFqG8iZj6R5ILFjezoDr+yXYj6dMXMQ==",
+			"version": "7.5.12",
+			"resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.5.12.tgz",
+			"integrity": "sha512-VIqj4oMwi4HJPqH3+3RblLoYjPfYzjVyZ8Kk57dmA7tj+vbM38Zn9vObe+Xg/EVEfohD3kD0fyEqPmnEqY17Pg==",
 			"requires": {
 				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/styling": "^7.16.17",
+				"@uifabric/styling": "^7.16.13",
 				"tslib": "^1.10.0"
 			}
 		},
@@ -6318,13 +6287,13 @@
 			}
 		},
 		"@uifabric/react-hooks": {
-			"version": "7.13.9",
-			"resolved": "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.13.9.tgz",
-			"integrity": "sha512-VtDg2b3ypYXX7MLp1STk1Fj6ZIeZktXnm0hu1Os/pGvq6xkuLRly5XP6ZSHitm8K7ZcMo48CcNL8smmiXprBQg==",
+			"version": "7.13.6",
+			"resolved": "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.13.6.tgz",
+			"integrity": "sha512-DvfphxrTsjo3oYioRZ0D8mXdpxWQhhIHeWk1cfdq0MVGqRyKM+cm++9pJpvItFvnTNba38jzKdggqRSUWi+clg==",
 			"requires": {
-				"@fluentui/react-window-provider": "^1.0.1",
+				"@fluentui/react-window-provider": "^0.3.3",
 				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/utilities": "^7.33.2",
+				"@uifabric/utilities": "^7.32.4",
 				"tslib": "^1.10.0"
 			}
 		},
@@ -6337,22 +6306,22 @@
 			}
 		},
 		"@uifabric/styling": {
-			"version": "7.16.17",
-			"resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.16.17.tgz",
-			"integrity": "sha512-9TZP5npZopaQUkb7V418bu2OzqjL+4uov9n59Kh/Ll2Bq9WyWg/kngGUMX793gxjOMy9w2IUEd2LN3odM05OlQ==",
+			"version": "7.16.13",
+			"resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.16.13.tgz",
+			"integrity": "sha512-jj5FH7XuQXz8HgRhCXNApeUAynDBv2nfmTpzHawE55x7YR+oliQfsJSY8Ow4YbLAazIR5BuW1n9eKuGxxmIw1w==",
 			"requires": {
-				"@fluentui/theme": "^1.6.0",
+				"@fluentui/theme": "^1.5.1",
 				"@microsoft/load-themed-styles": "^1.10.26",
 				"@uifabric/merge-styles": "^7.19.1",
 				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/utilities": "^7.33.2",
+				"@uifabric/utilities": "^7.32.4",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@uifabric/utilities": {
-			"version": "7.33.2",
-			"resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.33.2.tgz",
-			"integrity": "sha512-v2c3IUJdpru/hoGNOwIW549O5D4XBAc5sLpB7RREGI5ywoWuIJlNyYtBEGOwhAY62J2blj11qi86Ep+oZDM/Kw==",
+			"version": "7.32.4",
+			"resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.32.4.tgz",
+			"integrity": "sha512-IKZc03uyfTrgcCGSPAUWfFl9CyxzpSrxrYwAuO4NgDEySdOlkYBRwsRUh6UwWfM+sJdhg7Y3nupzNU3VSC/arg==",
 			"requires": {
 				"@fluentui/dom-utilities": "^1.1.1",
 				"@uifabric/merge-styles": "^7.19.1",
@@ -6362,11 +6331,11 @@
 			}
 		},
 		"@uifabric/variants": {
-			"version": "7.2.30",
-			"resolved": "https://registry.npmjs.org/@uifabric/variants/-/variants-7.2.30.tgz",
-			"integrity": "sha512-9NkFUxlMWCErp+UphQq2+2CBFcrMuJ1WBStWUlvB/WQqazIOZ2dOVcisHxDRdgPHe8MLoaDzy9FWlfCGcVFtAg==",
+			"version": "7.2.26",
+			"resolved": "https://registry.npmjs.org/@uifabric/variants/-/variants-7.2.26.tgz",
+			"integrity": "sha512-tSLiCP2aVT1Zn3gRBobvzvexJx0kzD/TJ2Il56WlVYLRD0X6wDDO5J+ort0rGUGlJNTvDNZas4v/aNu/96o/mw==",
 			"requires": {
-				"@fluentui/theme": "^1.6.0",
+				"@fluentui/theme": "^1.5.1",
 				"@uifabric/set-version": "^7.0.23",
 				"tslib": "^1.10.0"
 			}
@@ -6595,15 +6564,6 @@
 			"version": "7.4.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
 			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
-		},
-		"acorn-globals": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
-			"integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
-			"requires": {
-				"acorn": "^7.1.1",
-				"acorn-walk": "^7.1.1"
-			}
 		},
 		"acorn-jsx": {
 			"version": "5.3.1",
@@ -7064,9 +7024,9 @@
 			},
 			"dependencies": {
 				"is-buffer": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-					"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
 				}
 			}
 		},
@@ -7157,15 +7117,15 @@
 			}
 		},
 		"babel-jest": {
-			"version": "26.6.3",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.3.tgz",
-			"integrity": "sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.1.tgz",
+			"integrity": "sha512-duMWEOKrSBYRVTTNpL2SipNIWnZOjP77auOBMPQ3zXAdnDbyZQWU8r/RxNWpUf9N6cgPFecQYelYLytTVXVDtA==",
 			"requires": {
-				"@jest/transform": "^26.6.2",
-				"@jest/types": "^26.6.2",
+				"@jest/transform": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/babel__core": "^7.1.7",
 				"babel-plugin-istanbul": "^6.0.0",
-				"babel-preset-jest": "^26.6.2",
+				"babel-preset-jest": "^26.5.0",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
 				"slash": "^3.0.0"
@@ -7277,9 +7237,9 @@
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.6.2.tgz",
-			"integrity": "sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==",
+			"version": "26.5.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.5.0.tgz",
+			"integrity": "sha512-ck17uZFD3CDfuwCLATWZxkkuGGFhMij8quP8CNhwj8ek1mqFgbFzRJ30xwC04LLscj/aKsVFfRST+b5PT7rSuw==",
 			"requires": {
 				"@babel/template": "^7.3.3",
 				"@babel/types": "^7.3.3",
@@ -7288,9 +7248,9 @@
 			}
 		},
 		"babel-preset-current-node-syntax": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.0.tgz",
-			"integrity": "sha512-mGkvkpocWJes1CmMKtgGUwCeeq0pOhALyymozzDWYomHTbDLwueDYG6p4TK1YOeYHCzBzYPsWkgTto10JubI1Q==",
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.4.tgz",
+			"integrity": "sha512-5/INNCYhUGqw7VbVjT/hb3ucjgkVHKXY7lX3ZjlN4gm565VyFmJUrJ/h+h16ECVB38R/9SF6aACydpKMLZ/c9w==",
 			"requires": {
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
 				"@babel/plugin-syntax-bigint": "^7.8.3",
@@ -7302,17 +7262,16 @@
 				"@babel/plugin-syntax-numeric-separator": "^7.8.3",
 				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
-				"@babel/plugin-syntax-top-level-await": "^7.8.3"
+				"@babel/plugin-syntax-optional-chaining": "^7.8.3"
 			}
 		},
 		"babel-preset-jest": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.6.2.tgz",
-			"integrity": "sha512-YvdtlVm9t3k777c5NPQIv6cxFFFapys25HiUmuSgHwIZhfifweR5c5Sf5nwE3MAbfu327CYSvps8Yx6ANLyleQ==",
+			"version": "26.5.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.5.0.tgz",
+			"integrity": "sha512-F2vTluljhqkiGSJGBg/jOruA8vIIIL11YrxRcO7nviNTMbbofPSHwnm8mgP7d/wS7wRSexRoI6X1A6T74d4LQA==",
 			"requires": {
-				"babel-plugin-jest-hoist": "^26.6.2",
-				"babel-preset-current-node-syntax": "^1.0.0"
+				"babel-plugin-jest-hoist": "^26.5.0",
+				"babel-preset-current-node-syntax": "^0.1.3"
 			}
 		},
 		"babel-runtime": {
@@ -7900,15 +7859,6 @@
 				}
 			}
 		},
-		"call-bind": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
-			"integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
-			"requires": {
-				"function-bind": "^1.1.1",
-				"get-intrinsic": "^1.0.0"
-			}
-		},
 		"call-me-maybe": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
@@ -8039,6 +7989,52 @@
 			"resolved": "https://registry.npmjs.org/check-types/-/check-types-8.0.3.tgz",
 			"integrity": "sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ=="
 		},
+		"chokidar": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+			"integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+			"requires": {
+				"anymatch": "~3.1.1",
+				"braces": "~3.0.2",
+				"fsevents": "~2.1.2",
+				"glob-parent": "~5.1.0",
+				"is-binary-path": "~2.1.0",
+				"is-glob": "~4.0.1",
+				"normalize-path": "~3.0.0",
+				"readdirp": "~3.5.0"
+			},
+			"dependencies": {
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				}
+			}
+		},
 		"chownr": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -8067,9 +8063,9 @@
 			}
 		},
 		"cjs-module-lexer": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz",
-			"integrity": "sha512-uc2Vix1frTfnuzxxu1Hp4ktSvM3QaI4oXl4ZUqL1wjTu/BGki9TrCWoqLTg/drR1KwAEarXuRFCG2Svr1GxPFw=="
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.4.3.tgz",
+			"integrity": "sha512-5RLK0Qfs0PNDpEyBXIr3bIT1Muw3ojSlvpw6dAmkUcO0+uTrsBn7GuEIgx40u+OzbCBLDta7nvmud85P4EmTsQ=="
 		},
 		"class-utils": {
 			"version": "0.3.6",
@@ -8338,41 +8334,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
-		},
-		"commoner": {
-			"version": "0.10.8",
-			"resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
-			"integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
-			"requires": {
-				"commander": "^2.5.0",
-				"detective": "^4.3.1",
-				"glob": "^5.0.15",
-				"graceful-fs": "^4.1.2",
-				"iconv-lite": "^0.4.5",
-				"mkdirp": "^0.5.0",
-				"private": "^0.1.6",
-				"q": "^1.1.2",
-				"recast": "^0.11.17"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-				},
-				"glob": {
-					"version": "5.0.15",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-					"requires": {
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "2 || 3",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				}
-			}
 		},
 		"compare-func": {
 			"version": "2.0.0",
@@ -9820,22 +9781,6 @@
 			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
 			"integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
 		},
-		"detective": {
-			"version": "4.7.1",
-			"resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
-			"integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
-			"requires": {
-				"acorn": "^5.2.1",
-				"defined": "^1.0.0"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "5.7.4",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-					"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
-				}
-			}
-		},
 		"dezalgo": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
@@ -9852,9 +9797,9 @@
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 		},
 		"diff-sequences": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
-			"integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q=="
+			"version": "26.5.0",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
+			"integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q=="
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
@@ -10121,43 +10066,6 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"editorconfig": {
-			"version": "0.15.3",
-			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
-			"integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
-			"requires": {
-				"commander": "^2.19.0",
-				"lru-cache": "^4.1.5",
-				"semver": "^5.6.0",
-				"sigmund": "^1.0.1"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-				},
-				"lru-cache": {
-					"version": "4.1.5",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
-					}
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-				},
-				"yallist": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-				}
-			}
-		},
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -10307,15 +10215,6 @@
 			"integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
 			"dev": true
 		},
-		"envify": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz",
-			"integrity": "sha1-1xIjKejfFoi6dxsSUBkXyc5cvOg=",
-			"requires": {
-				"jstransform": "^11.0.3",
-				"through": "~2.3.4"
-			}
-		},
 		"envinfo": {
 			"version": "7.5.1",
 			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.5.1.tgz",
@@ -10394,15 +10293,6 @@
 			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
 			"requires": {
 				"es6-promise": "^4.0.3"
-			}
-		},
-		"es6-templates": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz",
-			"integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
-			"requires": {
-				"recast": "~0.11.12",
-				"through": "~2.3.6"
 			}
 		},
 		"escape-html": {
@@ -10534,6 +10424,24 @@
 						"eslint-visitor-keys": "^1.3.0"
 					}
 				},
+				"file-entry-cache": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+					"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+					"requires": {
+						"flat-cache": "^2.0.1"
+					}
+				},
+				"flat-cache": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+					"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+					"requires": {
+						"flatted": "^2.0.0",
+						"rimraf": "2.6.3",
+						"write": "1.0.3"
+					}
+				},
 				"globals": {
 					"version": "12.4.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -10548,9 +10456,9 @@
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
 				"import-fresh": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
-					"integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+					"integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
 					"requires": {
 						"parent-module": "^1.0.0",
 						"resolve-from": "^4.0.0"
@@ -10587,6 +10495,14 @@
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 					"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
+				},
+				"rimraf": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
 				},
 				"semver": {
 					"version": "7.3.2",
@@ -10850,6 +10766,14 @@
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
 				"load-json-file": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -10943,6 +10867,17 @@
 					"requires": {
 						"is-core-module": "^2.0.0",
 						"path-parse": "^1.0.6"
+					}
+				},
+				"tsconfig-paths": {
+					"version": "3.9.0",
+					"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+					"integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+					"requires": {
+						"@types/json5": "^0.0.29",
+						"json5": "^1.0.1",
+						"minimist": "^1.2.0",
+						"strip-bom": "^3.0.0"
 					}
 				}
 			}
@@ -11348,15 +11283,15 @@
 			}
 		},
 		"expect": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-26.6.2.tgz",
-			"integrity": "sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-26.6.1.tgz",
+			"integrity": "sha512-BRfxIBHagghMmr1D2MRY0Qv5d3Nc8HCqgbDwNXw/9izmM5eBb42a2YjLKSbsqle76ozGkAEPELQX4IdNHAKRNA==",
 			"requires": {
-				"@jest/types": "^26.6.2",
+				"@jest/types": "^26.6.1",
 				"ansi-styles": "^4.0.0",
 				"jest-get-type": "^26.3.0",
-				"jest-matcher-utils": "^26.6.2",
-				"jest-message-util": "^26.6.2",
+				"jest-matcher-utils": "^26.6.1",
+				"jest-message-util": "^26.6.1",
 				"jest-regex-util": "^26.0.0"
 			},
 			"dependencies": {
@@ -12286,9 +12221,9 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.2.1.tgz",
-			"integrity": "sha512-bTLYHSeC0UH/EFXS9KqWnXuOl/wHK5Z/d+ghd5AsFMYN7wIGkUCOJyzy88+wJKkZPGON8u4Z9f6U4FdgURE9qA==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+			"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
 			"optional": true
 		},
 		"fstream": {
@@ -12388,16 +12323,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
 			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
-		},
-		"get-intrinsic": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
-			"integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
-			"requires": {
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
-				"has-symbols": "^1.0.1"
-			}
 		},
 		"get-pkg-repo": {
 			"version": "1.4.0",
@@ -13478,26 +13403,56 @@
 				"html-minifier": "^3.5.8",
 				"loader-utils": "^1.1.0",
 				"object-assign": "^4.1.1"
-			}
-		},
-		"html-minifier": {
-			"version": "3.5.21",
-			"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
-			"integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
-			"requires": {
-				"camel-case": "3.0.x",
-				"clean-css": "4.2.x",
-				"commander": "2.17.x",
-				"he": "1.2.x",
-				"param-case": "2.1.x",
-				"relateurl": "0.2.x",
-				"uglify-js": "3.4.x"
 			},
 			"dependencies": {
 				"commander": {
 					"version": "2.17.1",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
 					"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+				},
+				"es6-templates": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz",
+					"integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
+					"requires": {
+						"recast": "~0.11.12",
+						"through": "~2.3.6"
+					}
+				},
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+				},
+				"html-minifier": {
+					"version": "3.5.21",
+					"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
+					"integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
+					"requires": {
+						"camel-case": "3.0.x",
+						"clean-css": "4.2.x",
+						"commander": "2.17.x",
+						"he": "1.2.x",
+						"param-case": "2.1.x",
+						"relateurl": "0.2.x",
+						"uglify-js": "3.4.x"
+					}
+				},
+				"recast": {
+					"version": "0.11.23",
+					"resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+					"integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
+					"requires": {
+						"ast-types": "0.9.6",
+						"esprima": "~3.1.0",
+						"private": "~0.1.5",
+						"source-map": "~0.5.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				},
 				"uglify-js": {
 					"version": "3.4.10",
@@ -13512,6 +13467,11 @@
 							"version": "2.19.0",
 							"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
 							"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+						},
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 						}
 					}
 				}
@@ -14074,9 +14034,9 @@
 			}
 		},
 		"is-core-module": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
-			"integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.0.0.tgz",
+			"integrity": "sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==",
 			"requires": {
 				"has": "^1.0.3"
 			}
@@ -14601,15 +14561,90 @@
 			"integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
 		},
 		"jest": {
-			"version": "26.6.3",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-26.6.3.tgz",
-			"integrity": "sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-26.6.1.tgz",
+			"integrity": "sha512-f+ahfqw3Ffy+9vA7sWFGpTmhtKEMsNAZiWBVXDkrpIO73zIz22iimjirnV78kh/eWlylmvLh/0WxHN6fZraZdA==",
 			"requires": {
-				"@jest/core": "^26.6.3",
+				"@jest/core": "^26.6.1",
 				"import-local": "^3.0.2",
-				"jest-cli": "^26.6.3"
+				"jest-cli": "^26.6.1"
 			},
 			"dependencies": {
+				"@jest/core": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/core/-/core-26.6.1.tgz",
+					"integrity": "sha512-p4F0pgK3rKnoS9olXXXOkbus1Bsu6fd8pcvLMPsUy4CVXZ8WSeiwQ1lK5hwkCIqJ+amZOYPd778sbPha/S8Srw==",
+					"requires": {
+						"@jest/console": "^26.6.1",
+						"@jest/reporters": "^26.6.1",
+						"@jest/test-result": "^26.6.1",
+						"@jest/transform": "^26.6.1",
+						"@jest/types": "^26.6.1",
+						"@types/node": "*",
+						"ansi-escapes": "^4.2.1",
+						"chalk": "^4.0.0",
+						"exit": "^0.1.2",
+						"graceful-fs": "^4.2.4",
+						"jest-changed-files": "^26.6.1",
+						"jest-config": "^26.6.1",
+						"jest-haste-map": "^26.6.1",
+						"jest-message-util": "^26.6.1",
+						"jest-regex-util": "^26.0.0",
+						"jest-resolve": "^26.6.1",
+						"jest-resolve-dependencies": "^26.6.1",
+						"jest-runner": "^26.6.1",
+						"jest-runtime": "^26.6.1",
+						"jest-snapshot": "^26.6.1",
+						"jest-util": "^26.6.1",
+						"jest-validate": "^26.6.1",
+						"jest-watcher": "^26.6.1",
+						"micromatch": "^4.0.2",
+						"p-each-series": "^2.1.0",
+						"rimraf": "^3.0.0",
+						"slash": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"@jest/reporters": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.6.1.tgz",
+					"integrity": "sha512-J6OlXVFY3q1SXWJhjme5i7qT/BAZSikdOK2t8Ht5OS32BDo6KfG5CzIzzIFnAVd82/WWbc9Hb7SJ/jwSvVH9YA==",
+					"requires": {
+						"@bcoe/v8-coverage": "^0.2.3",
+						"@jest/console": "^26.6.1",
+						"@jest/test-result": "^26.6.1",
+						"@jest/transform": "^26.6.1",
+						"@jest/types": "^26.6.1",
+						"chalk": "^4.0.0",
+						"collect-v8-coverage": "^1.0.0",
+						"exit": "^0.1.2",
+						"glob": "^7.1.2",
+						"graceful-fs": "^4.2.4",
+						"istanbul-lib-coverage": "^3.0.0",
+						"istanbul-lib-instrument": "^4.0.3",
+						"istanbul-lib-report": "^3.0.0",
+						"istanbul-lib-source-maps": "^4.0.0",
+						"istanbul-reports": "^3.0.2",
+						"jest-haste-map": "^26.6.1",
+						"jest-resolve": "^26.6.1",
+						"jest-util": "^26.6.1",
+						"jest-worker": "^26.6.1",
+						"node-notifier": "^8.0.0",
+						"slash": "^3.0.0",
+						"source-map": "^0.6.0",
+						"string-length": "^4.0.1",
+						"terminal-link": "^2.0.0",
+						"v8-to-istanbul": "^6.0.1"
+					}
+				},
+				"ansi-escapes": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+					"requires": {
+						"type-fest": "^0.11.0"
+					}
+				},
 				"ansi-regex": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -14621,6 +14656,14 @@
 					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
 						"color-convert": "^2.0.1"
+					}
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"requires": {
+						"fill-range": "^7.0.1"
 					}
 				},
 				"chalk": {
@@ -14655,10 +14698,44 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 				},
+				"cross-spawn": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
 				"emoji-regex": {
 					"version": "8.0.0",
 					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+				},
+				"execa": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+					"integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+					"requires": {
+						"cross-spawn": "^7.0.0",
+						"get-stream": "^5.0.0",
+						"human-signals": "^1.1.1",
+						"is-stream": "^2.0.0",
+						"merge-stream": "^2.0.0",
+						"npm-run-path": "^4.0.0",
+						"onetime": "^5.1.0",
+						"signal-exit": "^3.0.2",
+						"strip-final-newline": "^2.0.0"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
 				},
 				"find-up": {
 					"version": "4.1.0",
@@ -14667,6 +14744,14 @@
 					"requires": {
 						"locate-path": "^5.0.0",
 						"path-exists": "^4.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"requires": {
+						"pump": "^3.0.0"
 					}
 				},
 				"has-flag": {
@@ -14688,24 +14773,129 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
 				},
-				"jest-cli": {
-					"version": "26.6.3",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
-					"integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+				},
+				"is-stream": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+				},
+				"istanbul-lib-instrument": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+					"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
 					"requires": {
-						"@jest/core": "^26.6.3",
-						"@jest/test-result": "^26.6.2",
-						"@jest/types": "^26.6.2",
+						"@babel/core": "^7.7.5",
+						"@istanbuljs/schema": "^0.1.2",
+						"istanbul-lib-coverage": "^3.0.0",
+						"semver": "^6.3.0"
+					}
+				},
+				"jest-changed-files": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.1.tgz",
+					"integrity": "sha512-NhSdZ5F6b/rIN5V46x1l31vrmukD/bJUXgYAY8VtP1SknYdJwjYDRxuLt7Z8QryIdqCjMIn2C0Cd98EZ4umo8Q==",
+					"requires": {
+						"@jest/types": "^26.6.1",
+						"execa": "^4.0.0",
+						"throat": "^5.0.0"
+					}
+				},
+				"jest-cli": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.1.tgz",
+					"integrity": "sha512-aPLoEjlwFrCWhiPpW5NUxQA1X1kWsAnQcQ0SO/fHsCvczL3W75iVAcH9kP6NN+BNqZcHNEvkhxT5cDmBfEAh+w==",
+					"requires": {
+						"@jest/core": "^26.6.1",
+						"@jest/test-result": "^26.6.1",
+						"@jest/types": "^26.6.1",
 						"chalk": "^4.0.0",
 						"exit": "^0.1.2",
 						"graceful-fs": "^4.2.4",
 						"import-local": "^3.0.2",
 						"is-ci": "^2.0.0",
-						"jest-config": "^26.6.3",
-						"jest-util": "^26.6.2",
-						"jest-validate": "^26.6.2",
+						"jest-config": "^26.6.1",
+						"jest-util": "^26.6.1",
+						"jest-validate": "^26.6.1",
 						"prompts": "^2.0.1",
 						"yargs": "^15.4.1"
+					}
+				},
+				"jest-resolve-dependencies": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.1.tgz",
+					"integrity": "sha512-MN6lufbZJ3RBfTnJesZtHu3hUCBqPdHRe2+FhIt0yiqJ3fMgzWRqMRQyN/d/QwOE7KXwAG2ekZutbPhuD7s51A==",
+					"requires": {
+						"@jest/types": "^26.6.1",
+						"jest-regex-util": "^26.0.0",
+						"jest-snapshot": "^26.6.1"
+					}
+				},
+				"jest-runtime": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.1.tgz",
+					"integrity": "sha512-7uOCNeezXDWgjEyzYbRN2ViY7xNZzusNVGAMmU0UHRUNXuY4j4GBHKGMqPo/cBPZA9bSYp+lwK2DRRBU5Dv6YQ==",
+					"requires": {
+						"@jest/console": "^26.6.1",
+						"@jest/environment": "^26.6.1",
+						"@jest/fake-timers": "^26.6.1",
+						"@jest/globals": "^26.6.1",
+						"@jest/source-map": "^26.5.0",
+						"@jest/test-result": "^26.6.1",
+						"@jest/transform": "^26.6.1",
+						"@jest/types": "^26.6.1",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0",
+						"cjs-module-lexer": "^0.4.2",
+						"collect-v8-coverage": "^1.0.0",
+						"exit": "^0.1.2",
+						"glob": "^7.1.3",
+						"graceful-fs": "^4.2.4",
+						"jest-config": "^26.6.1",
+						"jest-haste-map": "^26.6.1",
+						"jest-message-util": "^26.6.1",
+						"jest-mock": "^26.6.1",
+						"jest-regex-util": "^26.0.0",
+						"jest-resolve": "^26.6.1",
+						"jest-snapshot": "^26.6.1",
+						"jest-util": "^26.6.1",
+						"jest-validate": "^26.6.1",
+						"slash": "^3.0.0",
+						"strip-bom": "^4.0.0",
+						"yargs": "^15.4.1"
+					}
+				},
+				"jest-snapshot": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.1.tgz",
+					"integrity": "sha512-JA7bZp7HRTIJYAi85pJ/OZ2eur2dqmwIToA5/6d7Mn90isGEfeF9FvuhDLLEczgKP1ihreBzrJ6Vr7zteP5JNA==",
+					"requires": {
+						"@babel/types": "^7.0.0",
+						"@jest/types": "^26.6.1",
+						"@types/babel__traverse": "^7.0.4",
+						"@types/prettier": "^2.0.0",
+						"chalk": "^4.0.0",
+						"expect": "^26.6.1",
+						"graceful-fs": "^4.2.4",
+						"jest-diff": "^26.6.1",
+						"jest-get-type": "^26.3.0",
+						"jest-haste-map": "^26.6.1",
+						"jest-matcher-utils": "^26.6.1",
+						"jest-message-util": "^26.6.1",
+						"jest-resolve": "^26.6.1",
+						"natural-compare": "^1.4.0",
+						"pretty-format": "^26.6.1",
+						"semver": "^7.3.2"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "7.3.2",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+							"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+						}
 					}
 				},
 				"locate-path": {
@@ -14714,6 +14904,53 @@
 					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 					"requires": {
 						"p-locate": "^4.1.0"
+					}
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"node-notifier": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.0.tgz",
+					"integrity": "sha512-46z7DUmcjoYdaWyXouuFNNfUo6eFa94t23c53c+lG/9Cvauk4a98rAUp9672X5dxGdQmLpPzTxzu8f/OeEPaFA==",
+					"optional": true,
+					"requires": {
+						"growly": "^1.3.0",
+						"is-wsl": "^2.2.0",
+						"semver": "^7.3.2",
+						"shellwords": "^0.1.1",
+						"uuid": "^8.3.0",
+						"which": "^2.0.2"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "7.3.2",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+							"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+							"optional": true
+						}
+					}
+				},
+				"npm-run-path": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+					"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+					"requires": {
+						"path-key": "^3.0.0"
+					}
+				},
+				"onetime": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+					"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+					"requires": {
+						"mimic-fn": "^2.1.0"
 					}
 				},
 				"p-locate": {
@@ -14728,6 +14965,11 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
 				},
 				"pkg-dir": {
 					"version": "4.2.0",
@@ -14750,6 +14992,37 @@
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
 					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
 				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+				},
 				"string-width": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -14768,12 +15041,44 @@
 						"ansi-regex": "^5.0.0"
 					}
 				},
+				"strip-bom": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
+				},
 				"supports-color": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"requires": {
 						"has-flag": "^4.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				},
+				"type-fest": {
+					"version": "0.11.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+					"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
+				},
+				"uuid": {
+					"version": "8.3.1",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+					"integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
+					"optional": true
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"requires": {
+						"isexe": "^2.0.0"
 					}
 				},
 				"wrap-ansi": {
@@ -14815,124 +15120,36 @@
 				}
 			}
 		},
-		"jest-changed-files": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.2.tgz",
-			"integrity": "sha512-fDS7szLcY9sCtIip8Fjry9oGf3I2ht/QT21bAHm5Dmf0mD4X3ReNUf17y+bO6fR8WgbIZTlbyG1ak/53cbRzKQ==",
-			"requires": {
-				"@jest/types": "^26.6.2",
-				"execa": "^4.0.0",
-				"throat": "^5.0.0"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-					"requires": {
-						"path-key": "^3.1.0",
-						"shebang-command": "^2.0.0",
-						"which": "^2.0.1"
-					}
-				},
-				"execa": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-					"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-					"requires": {
-						"cross-spawn": "^7.0.0",
-						"get-stream": "^5.0.0",
-						"human-signals": "^1.1.1",
-						"is-stream": "^2.0.0",
-						"merge-stream": "^2.0.0",
-						"npm-run-path": "^4.0.0",
-						"onetime": "^5.1.0",
-						"signal-exit": "^3.0.2",
-						"strip-final-newline": "^2.0.0"
-					}
-				},
-				"get-stream": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"is-stream": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
-				},
-				"npm-run-path": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-					"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-					"requires": {
-						"path-key": "^3.0.0"
-					}
-				},
-				"onetime": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-					"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-					"requires": {
-						"mimic-fn": "^2.1.0"
-					}
-				},
-				"path-key": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
-				},
-				"shebang-command": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-					"requires": {
-						"shebang-regex": "^3.0.0"
-					}
-				},
-				"shebang-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
-				},
-				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				}
-			}
-		},
 		"jest-config": {
-			"version": "26.6.3",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.6.3.tgz",
-			"integrity": "sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.6.1.tgz",
+			"integrity": "sha512-mtJzIynIwW1d1nMlKCNCQiSgWaqFn8cH/fOSNY97xG7Y9tBCZbCSuW2GTX0RPmceSJGO7l27JgwC18LEg0Vg+g==",
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/test-sequencer": "^26.6.3",
-				"@jest/types": "^26.6.2",
-				"babel-jest": "^26.6.3",
+				"@jest/test-sequencer": "^26.6.1",
+				"@jest/types": "^26.6.1",
+				"babel-jest": "^26.6.1",
 				"chalk": "^4.0.0",
 				"deepmerge": "^4.2.2",
 				"glob": "^7.1.1",
 				"graceful-fs": "^4.2.4",
-				"jest-environment-jsdom": "^26.6.2",
-				"jest-environment-node": "^26.6.2",
+				"jest-environment-jsdom": "^26.6.1",
+				"jest-environment-node": "^26.6.1",
 				"jest-get-type": "^26.3.0",
-				"jest-jasmine2": "^26.6.3",
+				"jest-jasmine2": "^26.6.1",
 				"jest-regex-util": "^26.0.0",
-				"jest-resolve": "^26.6.2",
-				"jest-util": "^26.6.2",
-				"jest-validate": "^26.6.2",
+				"jest-resolve": "^26.6.1",
+				"jest-util": "^26.6.1",
+				"jest-validate": "^26.6.1",
 				"micromatch": "^4.0.2",
-				"pretty-format": "^26.6.2"
+				"pretty-format": "^26.6.1"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+				},
 				"ansi-styles": {
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -14958,6 +15175,16 @@
 						"supports-color": "^7.1.0"
 					}
 				},
+				"cliui": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^6.2.0"
+					}
+				},
 				"color-convert": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -14971,6 +15198,11 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+				},
 				"fill-range": {
 					"version": "7.0.1",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -14979,15 +15211,119 @@
 						"to-regex-range": "^5.0.1"
 					}
 				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+				},
 				"is-number": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+				},
+				"jest-jasmine2": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.6.1.tgz",
+					"integrity": "sha512-2uYdT32o/ZzSxYAPduAgokO8OlAL1YdG/9oxcEY138EDNpIK5XRRJDaGzTZdIBWSxk0aR8XxN44FvfXtHB+Fiw==",
+					"requires": {
+						"@babel/traverse": "^7.1.0",
+						"@jest/environment": "^26.6.1",
+						"@jest/source-map": "^26.5.0",
+						"@jest/test-result": "^26.6.1",
+						"@jest/types": "^26.6.1",
+						"@types/node": "*",
+						"chalk": "^4.0.0",
+						"co": "^4.6.0",
+						"expect": "^26.6.1",
+						"is-generator-fn": "^2.0.0",
+						"jest-each": "^26.6.1",
+						"jest-matcher-utils": "^26.6.1",
+						"jest-message-util": "^26.6.1",
+						"jest-runtime": "^26.6.1",
+						"jest-snapshot": "^26.6.1",
+						"jest-util": "^26.6.1",
+						"pretty-format": "^26.6.1",
+						"throat": "^5.0.0"
+					}
+				},
+				"jest-runtime": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.1.tgz",
+					"integrity": "sha512-7uOCNeezXDWgjEyzYbRN2ViY7xNZzusNVGAMmU0UHRUNXuY4j4GBHKGMqPo/cBPZA9bSYp+lwK2DRRBU5Dv6YQ==",
+					"requires": {
+						"@jest/console": "^26.6.1",
+						"@jest/environment": "^26.6.1",
+						"@jest/fake-timers": "^26.6.1",
+						"@jest/globals": "^26.6.1",
+						"@jest/source-map": "^26.5.0",
+						"@jest/test-result": "^26.6.1",
+						"@jest/transform": "^26.6.1",
+						"@jest/types": "^26.6.1",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0",
+						"cjs-module-lexer": "^0.4.2",
+						"collect-v8-coverage": "^1.0.0",
+						"exit": "^0.1.2",
+						"glob": "^7.1.3",
+						"graceful-fs": "^4.2.4",
+						"jest-config": "^26.6.1",
+						"jest-haste-map": "^26.6.1",
+						"jest-message-util": "^26.6.1",
+						"jest-mock": "^26.6.1",
+						"jest-regex-util": "^26.0.0",
+						"jest-resolve": "^26.6.1",
+						"jest-snapshot": "^26.6.1",
+						"jest-util": "^26.6.1",
+						"jest-validate": "^26.6.1",
+						"slash": "^3.0.0",
+						"strip-bom": "^4.0.0",
+						"yargs": "^15.4.1"
+					}
+				},
+				"jest-snapshot": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.1.tgz",
+					"integrity": "sha512-JA7bZp7HRTIJYAi85pJ/OZ2eur2dqmwIToA5/6d7Mn90isGEfeF9FvuhDLLEczgKP1ihreBzrJ6Vr7zteP5JNA==",
+					"requires": {
+						"@babel/types": "^7.0.0",
+						"@jest/types": "^26.6.1",
+						"@types/babel__traverse": "^7.0.4",
+						"@types/prettier": "^2.0.0",
+						"chalk": "^4.0.0",
+						"expect": "^26.6.1",
+						"graceful-fs": "^4.2.4",
+						"jest-diff": "^26.6.1",
+						"jest-get-type": "^26.3.0",
+						"jest-haste-map": "^26.6.1",
+						"jest-matcher-utils": "^26.6.1",
+						"jest-message-util": "^26.6.1",
+						"jest-resolve": "^26.6.1",
+						"natural-compare": "^1.4.0",
+						"pretty-format": "^26.6.1",
+						"semver": "^7.3.2"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
 				},
 				"micromatch": {
 					"version": "4.0.2",
@@ -14997,6 +15333,52 @@
 						"braces": "^3.0.1",
 						"picomatch": "^2.0.5"
 					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+				},
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
 				},
 				"supports-color": {
 					"version": "7.2.0",
@@ -15012,6 +15394,43 @@
 					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 					"requires": {
 						"is-number": "^7.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"yargs": {
+					"version": "15.4.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+					"requires": {
+						"cliui": "^6.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^4.1.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^4.2.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^18.1.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
 					}
 				}
 			}
@@ -15076,14 +15495,14 @@
 			}
 		},
 		"jest-diff": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
-			"integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.1.tgz",
+			"integrity": "sha512-BBNy/zin2m4kG5In126O8chOBxLLS/XMTuuM2+YhgyHk87ewPzKTuTJcqj3lOWOi03NNgrl+DkMeV/exdvG9gg==",
 			"requires": {
 				"chalk": "^4.0.0",
-				"diff-sequences": "^26.6.2",
+				"diff-sequences": "^26.5.0",
 				"jest-get-type": "^26.3.0",
-				"pretty-format": "^26.6.2"
+				"pretty-format": "^26.6.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -15140,15 +15559,15 @@
 			}
 		},
 		"jest-each": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.6.2.tgz",
-			"integrity": "sha512-Mer/f0KaATbjl8MCJ+0GEpNdqmnVmDYqCTJYTvoo7rqmRiDllmp2AYN+06F93nXcY3ur9ShIjS+CO/uD+BbH4A==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.6.1.tgz",
+			"integrity": "sha512-gSn8eB3buchuq45SU7pLB7qmCGax1ZSxfaWuEFblCyNMtyokYaKFh9dRhYPujK6xYL57dLIPhLKatjmB5XWzGA==",
 			"requires": {
-				"@jest/types": "^26.6.2",
+				"@jest/types": "^26.6.1",
 				"chalk": "^4.0.0",
 				"jest-get-type": "^26.3.0",
-				"jest-util": "^26.6.2",
-				"pretty-format": "^26.6.2"
+				"jest-util": "^26.6.1",
+				"pretty-format": "^26.6.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -15197,19 +15616,28 @@
 			}
 		},
 		"jest-environment-jsdom": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.6.2.tgz",
-			"integrity": "sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.6.1.tgz",
+			"integrity": "sha512-A17RiXuHYNVlkM+3QNcQ6n5EZyAc6eld8ra9TW26luounGWpku4tj03uqRgHJCI1d4uHr5rJiuCH5JFRtdmrcA==",
 			"requires": {
-				"@jest/environment": "^26.6.2",
-				"@jest/fake-timers": "^26.6.2",
-				"@jest/types": "^26.6.2",
+				"@jest/environment": "^26.6.1",
+				"@jest/fake-timers": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
-				"jest-mock": "^26.6.2",
-				"jest-util": "^26.6.2",
+				"jest-mock": "^26.6.1",
+				"jest-util": "^26.6.1",
 				"jsdom": "^16.4.0"
 			},
 			"dependencies": {
+				"acorn-globals": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+					"integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+					"requires": {
+						"acorn": "^7.1.1",
+						"acorn-walk": "^7.1.1"
+					}
+				},
 				"jsdom": {
 					"version": "16.4.0",
 					"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.4.0.tgz",
@@ -15282,23 +15710,23 @@
 					}
 				},
 				"ws": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-					"integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+					"integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
 				}
 			}
 		},
 		"jest-environment-node": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.2.tgz",
-			"integrity": "sha512-zhtMio3Exty18dy8ee8eJ9kjnRyZC1N4C1Nt/VShN1apyXc8rWGtJ9lI7vqiWcyyXS4BVSEn9lxAM2D+07/Tag==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.1.tgz",
+			"integrity": "sha512-YffaCp6h0j1kbcf1NVZ7umC6CPgD67YS+G1BeornfuSkx5s3xdhuwG0DCxSiHPXyT81FfJzA1L7nXvhq50OWIg==",
 			"requires": {
-				"@jest/environment": "^26.6.2",
-				"@jest/fake-timers": "^26.6.2",
-				"@jest/types": "^26.6.2",
+				"@jest/environment": "^26.6.1",
+				"@jest/fake-timers": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
-				"jest-mock": "^26.6.2",
-				"jest-util": "^26.6.2"
+				"jest-mock": "^26.6.1",
+				"jest-util": "^26.6.1"
 			}
 		},
 		"jest-environment-puppeteer": {
@@ -15363,11 +15791,11 @@
 			"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
 		},
 		"jest-haste-map": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
-			"integrity": "sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.1.tgz",
+			"integrity": "sha512-9kPafkv0nX6ta1PrshnkiyhhoQoFWncrU/uUBt3/AP1r78WSCU5iLceYRTwDvJl67H3RrXqSlSVDDa/AsUB7OQ==",
 			"requires": {
-				"@jest/types": "^26.6.2",
+				"@jest/types": "^26.6.1",
 				"@types/graceful-fs": "^4.1.2",
 				"@types/node": "*",
 				"anymatch": "^3.0.3",
@@ -15375,9 +15803,9 @@
 				"fsevents": "^2.1.2",
 				"graceful-fs": "^4.2.4",
 				"jest-regex-util": "^26.0.0",
-				"jest-serializer": "^26.6.2",
-				"jest-util": "^26.6.2",
-				"jest-worker": "^26.6.2",
+				"jest-serializer": "^26.5.0",
+				"jest-util": "^26.6.1",
+				"jest-worker": "^26.6.1",
 				"micromatch": "^4.0.2",
 				"sane": "^4.0.3",
 				"walker": "^1.0.7"
@@ -15419,76 +15847,6 @@
 					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 					"requires": {
 						"is-number": "^7.0.0"
-					}
-				}
-			}
-		},
-		"jest-jasmine2": {
-			"version": "26.6.3",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.6.3.tgz",
-			"integrity": "sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==",
-			"requires": {
-				"@babel/traverse": "^7.1.0",
-				"@jest/environment": "^26.6.2",
-				"@jest/source-map": "^26.6.2",
-				"@jest/test-result": "^26.6.2",
-				"@jest/types": "^26.6.2",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"co": "^4.6.0",
-				"expect": "^26.6.2",
-				"is-generator-fn": "^2.0.0",
-				"jest-each": "^26.6.2",
-				"jest-matcher-utils": "^26.6.2",
-				"jest-message-util": "^26.6.2",
-				"jest-runtime": "^26.6.3",
-				"jest-snapshot": "^26.6.2",
-				"jest-util": "^26.6.2",
-				"pretty-format": "^26.6.2",
-				"throat": "^5.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
 					}
 				}
 			}
@@ -15577,23 +15935,23 @@
 			}
 		},
 		"jest-leak-detector": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz",
-			"integrity": "sha512-i4xlXpsVSMeKvg2cEKdfhh0H39qlJlP5Ex1yQxwF9ubahboQYMgTtz5oML35AVA3B4Eu+YsmwaiKVev9KCvLxg==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.1.tgz",
+			"integrity": "sha512-j9ZOtJSJKlHjrs4aIxWjiQUjyrffPdiAQn2Iw0916w7qZE5Lk0T2KhIH6E9vfhzP6sw0Q0jtnLLb4vQ71o1HlA==",
 			"requires": {
 				"jest-get-type": "^26.3.0",
-				"pretty-format": "^26.6.2"
+				"pretty-format": "^26.6.1"
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz",
-			"integrity": "sha512-llnc8vQgYcNqDrqRDXWwMr9i7rS5XFiCwvh6DTP7Jqa2mqpcCBBlpCbn+trkG0KNhPu/h8rzyBkriOtBstvWhw==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.1.tgz",
+			"integrity": "sha512-9iu3zrsYlUnl8pByhREF9rr5eYoiEb1F7ymNKg6lJr/0qD37LWS5FSW/JcoDl8UdMX2+zAzabDs7sTO+QFKjCg==",
 			"requires": {
 				"chalk": "^4.0.0",
-				"jest-diff": "^26.6.2",
+				"jest-diff": "^26.6.1",
 				"jest-get-type": "^26.3.0",
-				"pretty-format": "^26.6.2"
+				"pretty-format": "^26.6.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -15642,17 +16000,16 @@
 			}
 		},
 		"jest-message-util": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.2.tgz",
-			"integrity": "sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.1.tgz",
+			"integrity": "sha512-cqM4HnqncIebBNdTKrBoWR/4ufHTll0pK/FWwX0YasK+TlBQEMqw3IEdynuuOTjDPFO3ONlFn37280X48beByw==",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@jest/types": "^26.6.2",
+				"@jest/types": "^26.6.1",
 				"@types/stack-utils": "^2.0.0",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
 				"micromatch": "^4.0.2",
-				"pretty-format": "^26.6.2",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.2"
 			},
@@ -15746,11 +16103,11 @@
 			}
 		},
 		"jest-mock": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.2.tgz",
-			"integrity": "sha512-YyFjePHHp1LzpzYcmgqkJ0nm0gg/lJx2aZFzFy1S6eUqNjXsOqTK10zNRff2dNfssgokjkG65OlWNcIlgd3zew==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.1.tgz",
+			"integrity": "sha512-my0lPTBu1awY8iVG62sB2sx9qf8zxNDVX+5aFgoB8Vbqjb6LqIOsfyFA8P1z6H2IsqMbvOX9oCJnK67Y3yUIMA==",
 			"requires": {
-				"@jest/types": "^26.6.2",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*"
 			}
 		},
@@ -15774,15 +16131,15 @@
 			"integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A=="
 		},
 		"jest-resolve": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.2.tgz",
-			"integrity": "sha512-sOxsZOq25mT1wRsfHcbtkInS+Ek7Q8jCHUB0ZUTP0tc/c41QHriU/NunqMfCUWsL4H3MHpvQD4QR9kSYhS7UvQ==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.1.tgz",
+			"integrity": "sha512-hiHfQH6rrcpAmw9xCQ0vD66SDuU+7ZulOuKwc4jpbmFFsz0bQG/Ib92K+9/489u5rVw0btr/ZhiHqBpmkbCvuQ==",
 			"requires": {
-				"@jest/types": "^26.6.2",
+				"@jest/types": "^26.6.1",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
 				"jest-pnp-resolver": "^1.2.2",
-				"jest-util": "^26.6.2",
+				"jest-util": "^26.6.1",
 				"read-pkg-up": "^7.0.1",
 				"resolve": "^1.18.1",
 				"slash": "^3.0.0"
@@ -15921,120 +16278,31 @@
 				}
 			}
 		},
-		"jest-resolve-dependencies": {
-			"version": "26.6.3",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.3.tgz",
-			"integrity": "sha512-pVwUjJkxbhe4RY8QEWzN3vns2kqyuldKpxlxJlzEYfKSvY6/bMvxoFrYYzUO1Gx28yKWN37qyV7rIoIp2h8fTg==",
-			"requires": {
-				"@jest/types": "^26.6.2",
-				"jest-regex-util": "^26.0.0",
-				"jest-snapshot": "^26.6.2"
-			}
-		},
 		"jest-runner": {
-			"version": "26.6.3",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.3.tgz",
-			"integrity": "sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.1.tgz",
+			"integrity": "sha512-DmpNGdgsbl5s0FGkmsInmqnmqCtliCSnjWA2TFAJS1m1mL5atwfPsf+uoZ8uYQ2X0uDj4NM+nPcDnUpbNTRMBA==",
 			"requires": {
-				"@jest/console": "^26.6.2",
-				"@jest/environment": "^26.6.2",
-				"@jest/test-result": "^26.6.2",
-				"@jest/types": "^26.6.2",
+				"@jest/console": "^26.6.1",
+				"@jest/environment": "^26.6.1",
+				"@jest/test-result": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"emittery": "^0.7.1",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.2.4",
-				"jest-config": "^26.6.3",
+				"jest-config": "^26.6.1",
 				"jest-docblock": "^26.0.0",
-				"jest-haste-map": "^26.6.2",
-				"jest-leak-detector": "^26.6.2",
-				"jest-message-util": "^26.6.2",
-				"jest-resolve": "^26.6.2",
-				"jest-runtime": "^26.6.3",
-				"jest-util": "^26.6.2",
-				"jest-worker": "^26.6.2",
+				"jest-haste-map": "^26.6.1",
+				"jest-leak-detector": "^26.6.1",
+				"jest-message-util": "^26.6.1",
+				"jest-resolve": "^26.6.1",
+				"jest-runtime": "^26.6.1",
+				"jest-util": "^26.6.1",
+				"jest-worker": "^26.6.1",
 				"source-map-support": "^0.5.6",
 				"throat": "^5.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"jest-runtime": {
-			"version": "26.6.3",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.3.tgz",
-			"integrity": "sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==",
-			"requires": {
-				"@jest/console": "^26.6.2",
-				"@jest/environment": "^26.6.2",
-				"@jest/fake-timers": "^26.6.2",
-				"@jest/globals": "^26.6.2",
-				"@jest/source-map": "^26.6.2",
-				"@jest/test-result": "^26.6.2",
-				"@jest/transform": "^26.6.2",
-				"@jest/types": "^26.6.2",
-				"@types/yargs": "^15.0.0",
-				"chalk": "^4.0.0",
-				"cjs-module-lexer": "^0.6.0",
-				"collect-v8-coverage": "^1.0.0",
-				"exit": "^0.1.2",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.4",
-				"jest-config": "^26.6.3",
-				"jest-haste-map": "^26.6.2",
-				"jest-message-util": "^26.6.2",
-				"jest-mock": "^26.6.2",
-				"jest-regex-util": "^26.0.0",
-				"jest-resolve": "^26.6.2",
-				"jest-snapshot": "^26.6.2",
-				"jest-util": "^26.6.2",
-				"jest-validate": "^26.6.2",
-				"slash": "^3.0.0",
-				"strip-bom": "^4.0.0",
-				"yargs": "^15.4.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -16106,6 +16374,63 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
 				},
+				"jest-runtime": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.1.tgz",
+					"integrity": "sha512-7uOCNeezXDWgjEyzYbRN2ViY7xNZzusNVGAMmU0UHRUNXuY4j4GBHKGMqPo/cBPZA9bSYp+lwK2DRRBU5Dv6YQ==",
+					"requires": {
+						"@jest/console": "^26.6.1",
+						"@jest/environment": "^26.6.1",
+						"@jest/fake-timers": "^26.6.1",
+						"@jest/globals": "^26.6.1",
+						"@jest/source-map": "^26.5.0",
+						"@jest/test-result": "^26.6.1",
+						"@jest/transform": "^26.6.1",
+						"@jest/types": "^26.6.1",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0",
+						"cjs-module-lexer": "^0.4.2",
+						"collect-v8-coverage": "^1.0.0",
+						"exit": "^0.1.2",
+						"glob": "^7.1.3",
+						"graceful-fs": "^4.2.4",
+						"jest-config": "^26.6.1",
+						"jest-haste-map": "^26.6.1",
+						"jest-message-util": "^26.6.1",
+						"jest-mock": "^26.6.1",
+						"jest-regex-util": "^26.0.0",
+						"jest-resolve": "^26.6.1",
+						"jest-snapshot": "^26.6.1",
+						"jest-util": "^26.6.1",
+						"jest-validate": "^26.6.1",
+						"slash": "^3.0.0",
+						"strip-bom": "^4.0.0",
+						"yargs": "^15.4.1"
+					}
+				},
+				"jest-snapshot": {
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.1.tgz",
+					"integrity": "sha512-JA7bZp7HRTIJYAi85pJ/OZ2eur2dqmwIToA5/6d7Mn90isGEfeF9FvuhDLLEczgKP1ihreBzrJ6Vr7zteP5JNA==",
+					"requires": {
+						"@babel/types": "^7.0.0",
+						"@jest/types": "^26.6.1",
+						"@types/babel__traverse": "^7.0.4",
+						"@types/prettier": "^2.0.0",
+						"chalk": "^4.0.0",
+						"expect": "^26.6.1",
+						"graceful-fs": "^4.2.4",
+						"jest-diff": "^26.6.1",
+						"jest-get-type": "^26.3.0",
+						"jest-haste-map": "^26.6.1",
+						"jest-matcher-utils": "^26.6.1",
+						"jest-message-util": "^26.6.1",
+						"jest-resolve": "^26.6.1",
+						"natural-compare": "^1.4.0",
+						"pretty-format": "^26.6.1",
+						"semver": "^7.3.2"
+					}
+				},
 				"locate-path": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -16126,6 +16451,11 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+				},
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
 				},
 				"slash": {
 					"version": "3.0.0",
@@ -16203,93 +16533,20 @@
 			}
 		},
 		"jest-serializer": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.6.2.tgz",
-			"integrity": "sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==",
+			"version": "26.5.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.5.0.tgz",
+			"integrity": "sha512-+h3Gf5CDRlSLdgTv7y0vPIAoLgX/SI7T4v6hy+TEXMgYbv+ztzbg5PSN6mUXAT/hXYHvZRWm+MaObVfqkhCGxA==",
 			"requires": {
 				"@types/node": "*",
 				"graceful-fs": "^4.2.4"
 			}
 		},
-		"jest-snapshot": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.2.tgz",
-			"integrity": "sha512-OLhxz05EzUtsAmOMzuupt1lHYXCNib0ECyuZ/PZOx9TrZcC8vL0x+DUG3TL+GLX3yHG45e6YGjIm0XwDc3q3og==",
-			"requires": {
-				"@babel/types": "^7.0.0",
-				"@jest/types": "^26.6.2",
-				"@types/babel__traverse": "^7.0.4",
-				"@types/prettier": "^2.0.0",
-				"chalk": "^4.0.0",
-				"expect": "^26.6.2",
-				"graceful-fs": "^4.2.4",
-				"jest-diff": "^26.6.2",
-				"jest-get-type": "^26.3.0",
-				"jest-haste-map": "^26.6.2",
-				"jest-matcher-utils": "^26.6.2",
-				"jest-message-util": "^26.6.2",
-				"jest-resolve": "^26.6.2",
-				"natural-compare": "^1.4.0",
-				"pretty-format": "^26.6.2",
-				"semver": "^7.3.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
 		"jest-util": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
-			"integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.1.tgz",
+			"integrity": "sha512-xCLZUqVoqhquyPLuDXmH7ogceGctbW8SMyQVjD9o+1+NPWI7t0vO08udcFLVPLgKWcvc+zotaUv/RuaR6l8HIA==",
 			"requires": {
-				"@jest/types": "^26.6.2",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
@@ -16381,16 +16638,16 @@
 			}
 		},
 		"jest-validate": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.2.tgz",
-			"integrity": "sha512-NEYZ9Aeyj0i5rQqbq+tpIOom0YS1u2MVu6+euBsvpgIme+FOfRmoC4R5p0JiAUpaFvFy24xgrpMknarR/93XjQ==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.1.tgz",
+			"integrity": "sha512-BEFpGbylKocnNPZULcnk+TGaz1oFZQH/wcaXlaXABbu0zBwkOGczuWgdLucUouuQqn7VadHZZeTvo8VSFDLMOA==",
 			"requires": {
-				"@jest/types": "^26.6.2",
+				"@jest/types": "^26.6.1",
 				"camelcase": "^6.0.0",
 				"chalk": "^4.0.0",
 				"jest-get-type": "^26.3.0",
 				"leven": "^3.1.0",
-				"pretty-format": "^26.6.2"
+				"pretty-format": "^26.6.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -16402,9 +16659,9 @@
 					}
 				},
 				"camelcase": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-					"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.1.0.tgz",
+					"integrity": "sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ=="
 				},
 				"chalk": {
 					"version": "4.1.0",
@@ -16444,16 +16701,16 @@
 			}
 		},
 		"jest-watcher": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.2.tgz",
-			"integrity": "sha512-WKJob0P/Em2csiVthsI68p6aGKTIcsfjH9Gsx1f0A3Italz43e3ho0geSAVsmj09RWOELP1AZ/DXyJgOgDKxXQ==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.1.tgz",
+			"integrity": "sha512-0LBIPPncNi9CaLKK15bnxyd2E8OMl4kJg0PTiNOI+MXztXw1zVdtX/x9Pr6pXaQYps+eS/ts43O4+HByZ7yJSw==",
 			"requires": {
-				"@jest/test-result": "^26.6.2",
-				"@jest/types": "^26.6.2",
+				"@jest/test-result": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^4.0.0",
-				"jest-util": "^26.6.2",
+				"jest-util": "^26.6.1",
 				"string-length": "^4.0.1"
 			},
 			"dependencies": {
@@ -16516,9 +16773,9 @@
 			}
 		},
 		"jest-worker": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
-			"integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.1.tgz",
+			"integrity": "sha512-R5IE3qSGz+QynJx8y+ICEkdI2OJ3RJjRQVEyCcFAd3yVhQSEtquziPO29Mlzgn07LOVE8u8jhJ1FqcwegiXWOw==",
 			"requires": {
 				"@types/node": "*",
 				"merge-stream": "^2.0.0",
@@ -16790,41 +17047,9 @@
 			}
 		},
 		"jsrsasign": {
-			"version": "10.0.5",
-			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.0.5.tgz",
-			"integrity": "sha512-Q9Hu2lvEO02hyIxEoh/GYDnglZEDH6p1vqaOEzPtn0d+ipTrml4lg4golFjEt1TV4upZx3Wag6HQ+xyAtp3qtg=="
-		},
-		"jstransform": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
-			"integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
-			"requires": {
-				"base62": "^1.1.0",
-				"commoner": "^0.10.1",
-				"esprima-fb": "^15001.1.0-dev-harmony-fb",
-				"object-assign": "^2.0.0",
-				"source-map": "^0.4.2"
-			},
-			"dependencies": {
-				"esprima-fb": {
-					"version": "15001.1.0-dev-harmony-fb",
-					"resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
-					"integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE="
-				},
-				"object-assign": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-					"integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
-				},
-				"source-map": {
-					"version": "0.4.4",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-					"requires": {
-						"amdefine": ">=0.0.4"
-					}
-				}
-			}
+			"version": "10.0.4",
+			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.0.4.tgz",
+			"integrity": "sha512-G08GDeAwgVkN5PGE9TnJ/4ixV3zkq560RigOoqrRvVc8H4GjfPVTz54/qGPLHK1KGHGP36/2eaLU1HuXmOJgug=="
 		},
 		"jsx-ast-utils": {
 			"version": "2.4.1",
@@ -17973,9 +18198,9 @@
 			}
 		},
 		"mocha": {
-			"version": "8.2.1",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.1.tgz",
-			"integrity": "sha512-cuLBVfyFfFqbNR0uUKbDGXKGk+UDFe6aR4os78XIrMQpZl/nv7JYHcvP5MFIAb374b2zFXsdgEGwmzMtP0Xg8w==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.0.tgz",
+			"integrity": "sha512-lEWEMq2LMfNJMKeuEwb5UELi+OgFDollXaytR5ggQcHpzG3NP/R7rvixAvF+9/lLsTWhWG+4yD2M70GsM06nxw==",
 			"requires": {
 				"@ungap/promise-all-settled": "1.1.2",
 				"ansi-colors": "4.1.1",
@@ -18004,29 +18229,6 @@
 				"yargs-unparser": "2.0.0"
 			},
 			"dependencies": {
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"requires": {
-						"fill-range": "^7.0.1"
-					}
-				},
-				"chokidar": {
-					"version": "3.4.3",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-					"integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
-					"requires": {
-						"anymatch": "~3.1.1",
-						"braces": "~3.0.2",
-						"fsevents": "~2.1.2",
-						"glob-parent": "~5.1.0",
-						"is-binary-path": "~2.1.0",
-						"is-glob": "~4.0.1",
-						"normalize-path": "~3.0.0",
-						"readdirp": "~3.5.0"
-					}
-				},
 				"diff": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -18037,14 +18239,6 @@
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
 				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
 				"find-up": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -18054,21 +18248,10 @@
 						"path-exists": "^4.0.0"
 					}
 				},
-				"fsevents": {
-					"version": "2.1.3",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-					"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-					"optional": true
-				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
 				},
 				"js-yaml": {
 					"version": "3.14.0",
@@ -18114,14 +18297,6 @@
 					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"requires": {
 						"has-flag": "^4.0.0"
-					}
-				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"requires": {
-						"is-number": "^7.0.0"
 					}
 				},
 				"which": {
@@ -18663,43 +18838,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
 			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
-		},
-		"node-notifier": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.0.tgz",
-			"integrity": "sha512-46z7DUmcjoYdaWyXouuFNNfUo6eFa94t23c53c+lG/9Cvauk4a98rAUp9672X5dxGdQmLpPzTxzu8f/OeEPaFA==",
-			"optional": true,
-			"requires": {
-				"growly": "^1.3.0",
-				"is-wsl": "^2.2.0",
-				"semver": "^7.3.2",
-				"shellwords": "^0.1.1",
-				"uuid": "^8.3.0",
-				"which": "^2.0.2"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-					"optional": true
-				},
-				"uuid": {
-					"version": "8.3.1",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-					"integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
-					"optional": true
-				},
-				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"optional": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				}
-			}
 		},
 		"node-preload": {
 			"version": "0.2.1",
@@ -19568,21 +19706,21 @@
 			"dev": true
 		},
 		"office-ui-fabric-react": {
-			"version": "7.149.4",
-			"resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.149.4.tgz",
-			"integrity": "sha512-9gfzIGlQr9tijkR10S+chRkNhxtyf2bonPFwTvJh/vrJ3R2/CHanHEWh+k4KUjsz2+4bf/+aRY5mjKCpEG65qA==",
+			"version": "7.148.0",
+			"resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.148.0.tgz",
+			"integrity": "sha512-HD7OH9vfBBdxzdXE5Ce6c8m//KOWmkNCKfBmB64YsBaSYDoy+hGhyK8JWjYn/5n9Y9XeP4ee6ALPBcXHw76AQg==",
 			"requires": {
 				"@fluentui/date-time-utilities": "^7.9.0",
-				"@fluentui/react-focus": "^7.16.17",
-				"@fluentui/react-window-provider": "^1.0.1",
+				"@fluentui/react-focus": "^7.16.13",
+				"@fluentui/react-window-provider": "^0.3.3",
 				"@microsoft/load-themed-styles": "^1.10.26",
-				"@uifabric/foundation": "^7.9.19",
-				"@uifabric/icons": "^7.5.16",
+				"@uifabric/foundation": "^7.9.14",
+				"@uifabric/icons": "^7.5.12",
 				"@uifabric/merge-styles": "^7.19.1",
-				"@uifabric/react-hooks": "^7.13.9",
+				"@uifabric/react-hooks": "^7.13.6",
 				"@uifabric/set-version": "^7.0.23",
-				"@uifabric/styling": "^7.16.17",
-				"@uifabric/utilities": "^7.33.2",
+				"@uifabric/styling": "^7.16.13",
+				"@uifabric/utilities": "^7.32.4",
 				"prop-types": "^15.7.2",
 				"tslib": "^1.10.0"
 			}
@@ -21460,11 +21598,11 @@
 			}
 		},
 		"pretty-format": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-			"integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.1.tgz",
+			"integrity": "sha512-MeqqsP5PYcRBbGMvwzsyBdmAJ4EFX7pWFyl7x4+dMVg5pE0ZDdBIvEH2ergvIO+Gvwv1wh64YuOY9y5LuyY/GA==",
 			"requires": {
-				"@jest/types": "^26.6.2",
+				"@jest/types": "^26.6.1",
 				"ansi-regex": "^5.0.0",
 				"ansi-styles": "^4.0.0",
 				"react-is": "^17.0.1"
@@ -22190,9 +22328,9 @@
 			}
 		},
 		"react-widgets": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/react-widgets/-/react-widgets-4.6.1.tgz",
-			"integrity": "sha512-x2n4EFQnk1ZG2rWsdekGK3js091k+b06e0CRI4pDEZ0uh/cft3NyGFKS5/x7CV/fN51kHMaM4r5IRGIbPfsLLw==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/react-widgets/-/react-widgets-4.6.0.tgz",
+			"integrity": "sha512-rfQhu5Eoh2V/qhjkJQy4ZrtGYmldmpyCN6pNFWldGhAUVGTRr8reXfVqD/LDzOycal8XeRVUaW6oABPSgn14FQ==",
 			"requires": {
 				"classnames": "^2.2.6",
 				"date-arithmetic": "^3.1.0",
@@ -22383,29 +22521,6 @@
 			"resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
 			"integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
 			"dev": true
-		},
-		"recast": {
-			"version": "0.11.23",
-			"resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-			"integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-			"requires": {
-				"ast-types": "0.9.6",
-				"esprima": "~3.1.0",
-				"private": "~0.1.5",
-				"source-map": "~0.5.0"
-			},
-			"dependencies": {
-				"esprima": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				}
-			}
 		},
 		"rechoir": {
 			"version": "0.6.2",
@@ -23388,12 +23503,12 @@
 					"integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
 				},
 				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+					"integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
 					"requires": {
-						"call-bind": "^1.0.0",
 						"define-properties": "^1.1.3",
+						"es-abstract": "^1.18.0-next.0",
 						"has-symbols": "^1.0.1",
 						"object-keys": "^1.1.1"
 					}
@@ -24730,76 +24845,6 @@
 				}
 			}
 		},
-		"terser-webpack-plugin": {
-			"version": "1.4.5",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
-			"integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
-			"requires": {
-				"cacache": "^12.0.2",
-				"find-cache-dir": "^2.1.0",
-				"is-wsl": "^1.1.0",
-				"schema-utils": "^1.0.0",
-				"serialize-javascript": "^4.0.0",
-				"source-map": "^0.6.1",
-				"terser": "^4.1.2",
-				"webpack-sources": "^1.4.0",
-				"worker-farm": "^1.7.0"
-			},
-			"dependencies": {
-				"find-cache-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-					"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-					"requires": {
-						"commondir": "^1.0.1",
-						"make-dir": "^2.0.0",
-						"pkg-dir": "^3.0.0"
-					}
-				},
-				"is-wsl": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-					"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
-				},
-				"make-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-					"requires": {
-						"pify": "^4.0.1",
-						"semver": "^5.6.0"
-					}
-				},
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
-				},
-				"schema-utils": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-errors": "^1.0.0",
-						"ajv-keywords": "^3.1.0"
-					}
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-				},
-				"serialize-javascript": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-					"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-					"requires": {
-						"randombytes": "^2.1.0"
-					}
-				}
-			}
-		},
 		"test-exclude": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -24898,9 +24943,9 @@
 			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
 		},
 		"timers-browserify": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
-			"integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
+			"integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
 			"requires": {
 				"setimmediate": "^1.0.4"
 			}
@@ -25035,10 +25080,11 @@
 			"integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
 		},
 		"ts-jest": {
-			"version": "26.4.4",
-			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.4.tgz",
-			"integrity": "sha512-3lFWKbLxJm34QxyVNNCgXX1u4o/RV0myvA2y2Bxm46iGIjKlaY0own9gIckbjZJPn+WaJEnfPPJ20HHGpoq4yg==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.2.tgz",
+			"integrity": "sha512-0+MynTTzzbuy5rGjzsCKjxHJk5gY906c/FSaqQ3081+G7dp2Yygfa9hVlbrtNNcztffh1mC6Rs9jb/yHpcjsoQ==",
 			"requires": {
+				"@jest/create-cache-key-function": "^26.5.0",
 				"@types/jest": "26.x",
 				"bs-logger": "0.x",
 				"buffer-from": "1.x",
@@ -25072,9 +25118,9 @@
 					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
 				},
 				"yargs-parser": {
-					"version": "20.2.4",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-					"integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
+					"version": "20.2.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.3.tgz",
+					"integrity": "sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww=="
 				}
 			}
 		},
@@ -25142,6 +25188,29 @@
 			"requires": {
 				"ts-node": "7.0.1",
 				"tsconfig-paths": "^3.5.0"
+			},
+			"dependencies": {
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"optional": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"tsconfig-paths": {
+					"version": "3.9.0",
+					"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+					"integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+					"optional": true,
+					"requires": {
+						"@types/json5": "^0.0.29",
+						"json5": "^1.0.1",
+						"minimist": "^1.2.0",
+						"strip-bom": "^3.0.0"
+					}
+				}
 			}
 		},
 		"ts-node": {
@@ -25157,27 +25226,6 @@
 				"mkdirp": "^0.5.1",
 				"source-map-support": "^0.5.6",
 				"yn": "^2.0.0"
-			}
-		},
-		"tsconfig-paths": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
-			"integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
-			"requires": {
-				"@types/json5": "^0.0.29",
-				"json5": "^1.0.1",
-				"minimist": "^1.2.0",
-				"strip-bom": "^3.0.0"
-			},
-			"dependencies": {
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				}
 			}
 		},
 		"tsd": {
@@ -25208,6 +25256,11 @@
 						"quick-lru": "^1.0.0"
 					}
 				},
+				"ci-info": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+					"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
+				},
 				"find-up": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -25220,6 +25273,14 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
 					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+				},
+				"is-ci": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+					"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+					"requires": {
+						"ci-info": "^1.5.0"
+					}
 				},
 				"load-json-file": {
 					"version": "4.0.0",
@@ -25386,6 +25447,23 @@
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
 					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
 				},
+				"update-notifier": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+					"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+					"requires": {
+						"boxen": "^1.2.1",
+						"chalk": "^2.0.1",
+						"configstore": "^3.0.0",
+						"import-lazy": "^2.1.0",
+						"is-ci": "^1.0.10",
+						"is-installed-globally": "^0.1.0",
+						"is-npm": "^1.0.0",
+						"latest-version": "^3.0.0",
+						"semver-diff": "^2.0.0",
+						"xdg-basedir": "^3.0.0"
+					}
+				},
 				"yargs-parser": {
 					"version": "10.1.0",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
@@ -25502,6 +25580,43 @@
 			"requires": {
 				"commandpost": "^1.0.0",
 				"editorconfig": "^0.15.0"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+				},
+				"editorconfig": {
+					"version": "0.15.3",
+					"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+					"integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+					"requires": {
+						"commander": "^2.19.0",
+						"lru-cache": "^4.1.5",
+						"semver": "^5.6.0",
+						"sigmund": "^1.0.1"
+					}
+				},
+				"lru-cache": {
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+				}
 			}
 		},
 		"typings-for-css-modules-loader": {
@@ -25713,38 +25828,6 @@
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
 			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
 		},
-		"update-notifier": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
-			"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
-			"requires": {
-				"boxen": "^1.2.1",
-				"chalk": "^2.0.1",
-				"configstore": "^3.0.0",
-				"import-lazy": "^2.1.0",
-				"is-ci": "^1.0.10",
-				"is-installed-globally": "^0.1.0",
-				"is-npm": "^1.0.0",
-				"latest-version": "^3.0.0",
-				"semver-diff": "^2.0.0",
-				"xdg-basedir": "^3.0.0"
-			},
-			"dependencies": {
-				"ci-info": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-					"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
-				},
-				"is-ci": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-					"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
-					"requires": {
-						"ci-info": "^1.5.0"
-					}
-				}
-			}
-		},
 		"upper-case": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
@@ -25870,14 +25953,14 @@
 			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 		},
 		"v8-compile-cache": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
-			"integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+			"integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ=="
 		},
 		"v8-to-istanbul": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.0.0.tgz",
-			"integrity": "sha512-fLL2rFuQpMtm9r8hrAV2apXX/WqHJ6+IC4/eQVdMDGBUgH/YMV4Gv3duk3kjmyg6uiQWBAA9nJwue4iJUOkHeA==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-6.0.1.tgz",
+			"integrity": "sha512-PzM1WlqquhBvsV+Gco6WSFeg1AGdD53ccMRkFeyHRE/KRZaVacPOmQYP3EeVgDBtKD2BJ8kgynBQ5OtKiHCH+w==",
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.1",
 				"convert-source-map": "^1.6.0",
@@ -26002,77 +26085,20 @@
 			}
 		},
 		"watchpack": {
-			"version": "1.7.5",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
-			"integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
+			"integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
 			"requires": {
 				"chokidar": "^3.4.1",
 				"graceful-fs": "^4.1.2",
 				"neo-async": "^2.5.0",
-				"watchpack-chokidar2": "^2.0.1"
-			},
-			"dependencies": {
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"optional": true,
-					"requires": {
-						"fill-range": "^7.0.1"
-					}
-				},
-				"chokidar": {
-					"version": "3.4.3",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-					"integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
-					"optional": true,
-					"requires": {
-						"anymatch": "~3.1.1",
-						"braces": "~3.0.2",
-						"fsevents": "~2.1.2",
-						"glob-parent": "~5.1.0",
-						"is-binary-path": "~2.1.0",
-						"is-glob": "~4.0.1",
-						"normalize-path": "~3.0.0",
-						"readdirp": "~3.5.0"
-					}
-				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"optional": true,
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
-				"fsevents": {
-					"version": "2.1.3",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-					"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-					"optional": true
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-					"optional": true
-				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"optional": true,
-					"requires": {
-						"is-number": "^7.0.0"
-					}
-				}
+				"watchpack-chokidar2": "^2.0.0"
 			}
 		},
 		"watchpack-chokidar2": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz",
-			"integrity": "sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
+			"integrity": "sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==",
 			"optional": true,
 			"requires": {
 				"chokidar": "^2.1.8"
@@ -26273,10 +26299,34 @@
 						"estraverse": "^4.1.1"
 					}
 				},
+				"find-cache-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+					"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^2.0.0",
+						"pkg-dir": "^3.0.0"
+					}
+				},
+				"is-wsl": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+					"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+				},
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
 				},
 				"memory-fs": {
 					"version": "0.4.1",
@@ -26286,6 +26336,11 @@
 						"errno": "^0.1.3",
 						"readable-stream": "^2.0.1"
 					}
+				},
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
 				},
 				"readable-stream": {
 					"version": "2.3.7",
@@ -26311,12 +26366,41 @@
 						"ajv-keywords": "^3.1.0"
 					}
 				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				},
+				"serialize-javascript": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+					"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+					"requires": {
+						"randombytes": "^2.1.0"
+					}
+				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"requires": {
 						"safe-buffer": "~5.1.0"
+					}
+				},
+				"terser-webpack-plugin": {
+					"version": "1.4.5",
+					"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+					"integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
+					"requires": {
+						"cacache": "^12.0.2",
+						"find-cache-dir": "^2.1.0",
+						"is-wsl": "^1.1.0",
+						"schema-utils": "^1.0.0",
+						"serialize-javascript": "^4.0.0",
+						"source-map": "^0.6.1",
+						"terser": "^4.1.2",
+						"webpack-sources": "^1.4.0",
+						"worker-farm": "^1.7.0"
 					}
 				}
 			}
@@ -26382,61 +26466,6 @@
 						"ini": "^1.3.5",
 						"kind-of": "^6.0.2",
 						"which": "^1.3.1"
-					}
-				}
-			}
-		},
-		"webpack-dev-middleware": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
-			"integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
-			"requires": {
-				"memory-fs": "^0.4.1",
-				"mime": "^2.4.4",
-				"mkdirp": "^0.5.1",
-				"range-parser": "^1.2.1",
-				"webpack-log": "^2.0.0"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				},
-				"memory-fs": {
-					"version": "0.4.1",
-					"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
-					"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-					"requires": {
-						"errno": "^0.1.3",
-						"readable-stream": "^2.0.1"
-					}
-				},
-				"mime": {
-					"version": "2.4.6",
-					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-					"integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
-				},
-				"readable-stream": {
-					"version": "2.3.7",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"requires": {
-						"safe-buffer": "~5.1.0"
 					}
 				}
 			}
@@ -26570,6 +26599,20 @@
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
+				"memory-fs": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+					"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+					"requires": {
+						"errno": "^0.1.3",
+						"readable-stream": "^2.0.1"
+					}
+				},
+				"mime": {
+					"version": "2.4.6",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+					"integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+				},
 				"readable-stream": {
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -26624,6 +26667,18 @@
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
+				},
+				"webpack-dev-middleware": {
+					"version": "3.7.2",
+					"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
+					"integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
+					"requires": {
+						"memory-fs": "^0.4.1",
+						"mime": "^2.4.4",
+						"mkdirp": "^0.5.1",
+						"range-parser": "^1.2.1",
+						"webpack-log": "^2.0.0"
+					}
 				}
 			}
 		},
@@ -26671,6 +26726,84 @@
 				"react-dom": "^0.14.0"
 			},
 			"dependencies": {
+				"acorn": {
+					"version": "5.7.4",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+					"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
+				},
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+				},
+				"commoner": {
+					"version": "0.10.8",
+					"resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
+					"integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
+					"requires": {
+						"commander": "^2.5.0",
+						"detective": "^4.3.1",
+						"glob": "^5.0.15",
+						"graceful-fs": "^4.1.2",
+						"iconv-lite": "^0.4.5",
+						"mkdirp": "^0.5.0",
+						"private": "^0.1.6",
+						"q": "^1.1.2",
+						"recast": "^0.11.17"
+					}
+				},
+				"detective": {
+					"version": "4.7.1",
+					"resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+					"integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
+					"requires": {
+						"acorn": "^5.2.1",
+						"defined": "^1.0.0"
+					}
+				},
+				"envify": {
+					"version": "3.4.1",
+					"resolved": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz",
+					"integrity": "sha1-1xIjKejfFoi6dxsSUBkXyc5cvOg=",
+					"requires": {
+						"jstransform": "^11.0.3",
+						"through": "~2.3.4"
+					}
+				},
+				"esprima-fb": {
+					"version": "15001.1.0-dev-harmony-fb",
+					"resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
+					"integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE="
+				},
+				"glob": {
+					"version": "5.0.15",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"requires": {
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "2 || 3",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"jstransform": {
+					"version": "11.0.3",
+					"resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
+					"integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
+					"requires": {
+						"base62": "^1.1.0",
+						"commoner": "^0.10.1",
+						"esprima-fb": "^15001.1.0-dev-harmony-fb",
+						"object-assign": "^2.0.0",
+						"source-map": "^0.4.2"
+					}
+				},
+				"object-assign": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+					"integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+				},
 				"react": {
 					"version": "0.14.10",
 					"resolved": "https://registry.npmjs.org/react/-/react-0.14.10.tgz",
@@ -26684,6 +26817,37 @@
 					"version": "0.14.10",
 					"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.10.tgz",
 					"integrity": "sha512-kDs8SWFb8Sry4NAplhpJbZEeAnTPir/m+s9s+lkdqA2a89BzmWGnEgGG/CfmhULjv1ogc4oHrjMfAvFNruT3jQ=="
+				},
+				"recast": {
+					"version": "0.11.23",
+					"resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+					"integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
+					"requires": {
+						"ast-types": "0.9.6",
+						"esprima": "~3.1.0",
+						"private": "~0.1.5",
+						"source-map": "~0.5.0"
+					},
+					"dependencies": {
+						"esprima": {
+							"version": "3.1.3",
+							"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+							"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+						}
+					}
+				},
+				"source-map": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+					"requires": {
+						"amdefine": ">=0.0.4"
+					}
 				}
 			}
 		},
@@ -27140,9 +27304,9 @@
 			},
 			"dependencies": {
 				"camelcase": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-					"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.1.0.tgz",
+					"integrity": "sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ=="
 				},
 				"decamelize": {
 					"version": "4.0.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -4538,7 +4538,7 @@
 		},
 		"@microsoft/api-extractor": {
 			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.8.0.tgz",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/api-extractor/-/api-extractor-7.8.0.tgz",
 			"integrity": "sha1-/qaOTyHBvxgCBWD9VyixX+RPCXY=",
 			"dev": true,
 			"requires": {
@@ -4555,7 +4555,7 @@
 		},
 		"@microsoft/api-extractor-model": {
 			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.8.0.tgz",
+			"resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/api-extractor-model/-/api-extractor-model-7.8.0.tgz",
 			"integrity": "sha1-X1MpmPARCfI9V7QigDu99a1lXYA=",
 			"dev": true,
 			"requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1762,7 +1762,7 @@
     },
     "@microsoft/api-extractor": {
       "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.8.0.tgz",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/api-extractor/-/api-extractor-7.8.0.tgz",
       "integrity": "sha1-/qaOTyHBvxgCBWD9VyixX+RPCXY=",
       "dev": true,
       "requires": {
@@ -1779,7 +1779,7 @@
     },
     "@microsoft/api-extractor-model": {
       "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.8.0.tgz",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/api-extractor-model/-/api-extractor-model-7.8.0.tgz",
       "integrity": "sha1-X1MpmPARCfI9V7QigDu99a1lXYA=",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1762,7 +1762,7 @@
     },
     "@microsoft/api-extractor": {
       "version": "7.8.0",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/api-extractor/-/api-extractor-7.8.0.tgz",
+      "resolved": "https://registry.npmjs.org@microsoft/api-extractor/-/api-extractor-7.8.0.tgz",
       "integrity": "sha1-/qaOTyHBvxgCBWD9VyixX+RPCXY=",
       "dev": true,
       "requires": {
@@ -1779,7 +1779,7 @@
     },
     "@microsoft/api-extractor-model": {
       "version": "7.8.0",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@microsoft/api-extractor-model/-/api-extractor-model-7.8.0.tgz",
+      "resolved": "https://registry.npmjs.org@microsoft/api-extractor-model/-/api-extractor-model-7.8.0.tgz",
       "integrity": "sha1-X1MpmPARCfI9V7QigDu99a1lXYA=",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -408,6 +408,12 @@
         "typescript": "^3.7.4"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
         "semver": {
           "version": "7.3.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
@@ -1742,6 +1748,12 @@
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
           }
+        },
+        "import-lazy": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+          "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+          "dev": true
         },
         "resolve": {
           "version": "1.17.0",
@@ -3423,12 +3435,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
-    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -4176,6 +4182,12 @@
         "supports-hyperlinks": "^1.0.1"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
         "get-stdin": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -4845,9 +4857,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
-      "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -6120,9 +6132,9 @@
       }
     },
     "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
       "dev": true
     },
     "iferr": {
@@ -6169,12 +6181,6 @@
           "dev": true
         }
       }
-    },
-    "import-lazy": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
-      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
-      "dev": true
     },
     "import-local": {
       "version": "2.0.0",
@@ -9596,9 +9602,9 @@
       "dev": true
     },
     "run-parallel": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
-      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
       "dev": true
     },
     "run-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1762,7 +1762,7 @@
     },
     "@microsoft/api-extractor": {
       "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org@microsoft/api-extractor/-/api-extractor-7.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.8.0.tgz",
       "integrity": "sha1-/qaOTyHBvxgCBWD9VyixX+RPCXY=",
       "dev": true,
       "requires": {
@@ -1779,7 +1779,7 @@
     },
     "@microsoft/api-extractor-model": {
       "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org@microsoft/api-extractor-model/-/api-extractor-model-7.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.8.0.tgz",
       "integrity": "sha1-X1MpmPARCfI9V7QigDu99a1lXYA=",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -408,12 +408,6 @@
         "typescript": "^3.7.4"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true
-        },
         "semver": {
           "version": "7.3.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
@@ -1748,12 +1742,6 @@
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
           }
-        },
-        "import-lazy": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
-          "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
-          "dev": true
         },
         "resolve": {
           "version": "1.17.0",
@@ -3435,6 +3423,12 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -4182,12 +4176,6 @@
         "supports-hyperlinks": "^1.0.1"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true
-        },
         "get-stdin": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -4857,9 +4845,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
-      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
+      "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -6132,9 +6120,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true
     },
     "iferr": {
@@ -6181,6 +6169,12 @@
           "dev": true
         }
       }
+    },
+    "import-lazy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "dev": true
     },
     "import-local": {
       "version": "2.0.0",
@@ -9602,9 +9596,9 @@
       "dev": true
     },
     "run-parallel": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
       "dev": true
     },
     "run-queue": {

--- a/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
@@ -4,7 +4,7 @@
  */
 
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
-import { NamedFluidDataStoreRegistryEntries } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreFactory, NamedFluidDataStoreRegistryEntries } from "@fluidframework/runtime-definitions";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { DependencyContainerRegistry } from "@fluidframework/synthesize";
 import {
@@ -26,7 +26,7 @@ export class ContainerRuntimeFactoryWithDefaultDataStore extends BaseContainerRu
     public static readonly defaultDataStoreId = defaultDataStoreId;
 
     constructor(
-        private readonly defaultDataStoreName: string,
+        protected readonly defaultFactory: IFluidDataStoreFactory,
         registryEntries: NamedFluidDataStoreRegistryEntries,
         providerEntries: DependencyContainerRegistry = [],
         requestHandlers: RuntimeRequestHandler[] = [],
@@ -48,12 +48,9 @@ export class ContainerRuntimeFactoryWithDefaultDataStore extends BaseContainerRu
      * {@inheritDoc BaseContainerRuntimeFactory.containerInitializingFirstTime}
      */
     protected async containerInitializingFirstTime(runtime: IContainerRuntime) {
-        const router = await runtime.createRootDataStore(
-            this.defaultDataStoreName,
-            ContainerRuntimeFactoryWithDefaultDataStore.defaultDataStoreId,
+        await runtime.createRootDataStore(
+            this.defaultFactory.type,
+            defaultDataStoreId,
         );
-        // We need to request the data store before attaching to ensure it
-        // runs through its entire instantiation flow.
-        await router.request({ url: "/" });
     }
 }

--- a/packages/loader/container-definitions/src/browserPackage.ts
+++ b/packages/loader/container-definitions/src/browserPackage.ts
@@ -34,7 +34,7 @@ export interface IFluidBrowserPackageEnvironment extends IFluidPackageEnvironmen
  */
 export interface IFluidBrowserPackage extends IFluidPackage {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc @fluidframework/core-interfaces#IFluidPackage.fluid}
      */
     fluid: {
         /**
@@ -42,7 +42,7 @@ export interface IFluidBrowserPackage extends IFluidPackage {
          */
         browser: IFluidBrowserPackageEnvironment;
         /**
-         * {@inheritdoc}
+         * {@inheritDoc @fluidframework/core-interfaces#IFluidPackage.fluid.environment}
          */
         [environment: string]: IFluidPackageEnvironment;
     }

--- a/packages/runtime/container-runtime/src/dataStoreRegistry.ts
+++ b/packages/runtime/container-runtime/src/dataStoreRegistry.ts
@@ -9,7 +9,7 @@ import {
 } from "@fluidframework/runtime-definitions";
 
 export class FluidDataStoreRegistry implements IFluidDataStoreRegistry {
-    private readonly map: Map<string, Promise<FluidDataStoreRegistryEntry>>;
+    private readonly map: Map<string, FluidDataStoreRegistryEntry | Promise<FluidDataStoreRegistryEntry>>;
 
     public get IFluidDataStoreRegistry() { return this; }
 

--- a/packages/runtime/runtime-definitions/src/dataStoreRegistry.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreRegistry.ts
@@ -20,8 +20,7 @@ export type FluidDataStoreRegistryEntry =
  * An associated pair of an identifier and registry entry.  Registry entries
  * may be dynamically loaded.
  */
-export type NamedFluidDataStoreRegistryEntry =
-    [string, FluidDataStoreRegistryEntry | Promise<FluidDataStoreRegistryEntry>];
+export type NamedFluidDataStoreRegistryEntry = [string, Promise<FluidDataStoreRegistryEntry>];
 /**
  * An iterable identifier/registry entry pair list
  */

--- a/packages/runtime/runtime-definitions/src/dataStoreRegistry.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreRegistry.ts
@@ -20,7 +20,8 @@ export type FluidDataStoreRegistryEntry =
  * An associated pair of an identifier and registry entry.  Registry entries
  * may be dynamically loaded.
  */
-export type NamedFluidDataStoreRegistryEntry = [string, Promise<FluidDataStoreRegistryEntry>];
+export type NamedFluidDataStoreRegistryEntry =
+    [string, FluidDataStoreRegistryEntry | Promise<FluidDataStoreRegistryEntry>];
 /**
  * An iterable identifier/registry entry pair list
  */

--- a/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
+++ b/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
@@ -9,6 +9,11 @@ import {
     IFluidRouter,
     IRequest,
 } from "@fluidframework/core-interfaces";
+import {
+    IFluidDataStoreFactory,
+    IFluidDataStoreRegistry,
+    IProvideFluidDataStoreRegistry,
+} from "@fluidframework/runtime-definitions";
 
 export async function requestFluidObject<T = IFluidObject>(
     router: IFluidRouter, url: string | IRequest): Promise<T> {
@@ -21,4 +26,20 @@ export async function requestFluidObject<T = IFluidObject>(
 
     assert(response.value);
     return response.value as T;
+}
+
+type Factory = IFluidDataStoreFactory & Partial<IProvideFluidDataStoreRegistry>;
+
+export function createDataStoreFactory(
+    type: string,
+    factory: Factory | Promise<Factory>,
+    ): IFluidDataStoreFactory & IFluidDataStoreRegistry
+{
+    return {
+        type,
+        get IFluidDataStoreFactory() { return this; },
+        get IFluidDataStoreRegistry() { return this; },
+        instantiateDataStore: async (context) => (await factory).instantiateDataStore(context),
+        get: async (name: string) => (await factory).IFluidDataStoreRegistry?.get(name),
+    };
 }

--- a/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
+++ b/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
@@ -28,7 +28,7 @@ export async function requestFluidObject<T = IFluidObject>(
     return response.value as T;
 }
 
-type Factory = IFluidDataStoreFactory & Partial<IProvideFluidDataStoreRegistry>;
+export type Factory = IFluidDataStoreFactory & Partial<IProvideFluidDataStoreRegistry>;
 
 export function createDataStoreFactory(
     type: string,

--- a/packages/test/end-to-end-tests/src/test/contextReload.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/contextReload.spec.ts
@@ -115,9 +115,10 @@ describe("context reload", function() {
 
     const createRuntimeFactory = (dataStore): IRuntimeFactory => {
         const type = TestDataStore.type;
+        const factory = new DataObjectFactory(type, dataStore, [], {});
         return new ContainerRuntimeFactoryWithDefaultDataStore(
-            type,
-            [[type, Promise.resolve(new DataObjectFactory(type, dataStore, [], {}))]],
+            factory,
+            [[type, Promise.resolve(factory)]],
         );
     };
 

--- a/packages/test/end-to-end-tests/src/test/documentDirty.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/documentDirty.spec.ts
@@ -82,13 +82,14 @@ describe("Document Dirty", () => {
             [
                 [mapId, SharedMap.getFactory()],
             ],
+            "default",
         );
 
         const runtimeFactory =
             new ContainerRuntimeFactoryWithDefaultDataStore(
-                "default",
+                factory,
                 [
-                    ["default", Promise.resolve(factory)],
+                    [factory.type, Promise.resolve(factory)],
                 ],
             );
 

--- a/packages/test/end-to-end-tests/src/test/loaderTest.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/loaderTest.spec.ts
@@ -80,10 +80,10 @@ describe("Loader.request", () => {
     async function createContainer(): Promise<IContainer> {
         const runtimeFactory =
             new ContainerRuntimeFactoryWithDefaultDataStore(
-                "default",
+                testSharedDataObjectFactory1,
                 [
-                    ["default", Promise.resolve(testSharedDataObjectFactory1)],
-                    ["TestSharedDataObject2", Promise.resolve(testSharedDataObjectFactory2)],
+                    [testSharedDataObjectFactory1.type, Promise.resolve(testSharedDataObjectFactory1)],
+                    [testSharedDataObjectFactory2.type, Promise.resolve(testSharedDataObjectFactory2)],
                 ],
             );
         loader = createLocalLoader([[codeDetails, runtimeFactory]], deltaConnectionServer, urlResolver);

--- a/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
@@ -20,7 +20,7 @@ import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/loca
 import { SharedMap, SharedDirectory } from "@fluidframework/map";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { IEnvelope, FlushMode } from "@fluidframework/runtime-definitions";
-import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { requestFluidObject, createDataStoreFactory } from "@fluidframework/runtime-utils";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { SharedString } from "@fluidframework/sequence";
 import {
@@ -72,12 +72,14 @@ describe("Ops on Reconnect", () => {
             ],
         );
 
+        const defaultFactory = createDataStoreFactory("default", factory);
+        const dataObject2Factory = createDataStoreFactory("dataObject2", factory);
         const runtimeFactory =
             new ContainerRuntimeFactoryWithDefaultDataStore(
-                "default",
+                defaultFactory,
                 [
-                    ["default", Promise.resolve(factory)],
-                    ["dataObject2", Promise.resolve(factory)],
+                    [defaultFactory.type, Promise.resolve(defaultFactory)],
+                    [dataObject2Factory.type, Promise.resolve(dataObject2Factory)],
                 ],
             );
 

--- a/packages/test/service-load-test/src/loadTestDataStore.ts
+++ b/packages/test/service-load-test/src/loadTestDataStore.ts
@@ -135,6 +135,6 @@ const LoadTestDataStoreInstantiationFactory = new DataObjectFactory(
 );
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    LoadTestDataStore.DataStoreName,
+    LoadTestDataStoreInstantiationFactory,
     new Map([[LoadTestDataStore.DataStoreName, Promise.resolve(LoadTestDataStoreInstantiationFactory)]]),
 );

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -62,6 +62,7 @@
     "@fluidframework/protocol-definitions": "^0.1014.0",
     "@fluidframework/request-handler": "^0.29.0",
     "@fluidframework/runtime-definitions": "^0.29.0",
+    "@fluidframework/runtime-utils": "^0.29.0",
     "@fluidframework/server-local-server": "^0.1014.0",
     "assert": "^2.0.0"
   },

--- a/packages/test/test-utils/src/localCodeLoader.ts
+++ b/packages/test/test-utils/src/localCodeLoader.ts
@@ -12,6 +12,7 @@ import {
 } from "@fluidframework/container-definitions";
 import { IFluidCodeDetails, IProvideFluidCodeDetailsComparer } from "@fluidframework/core-interfaces";
 import { IProvideFluidDataStoreFactory, IProvideFluidDataStoreRegistry } from "@fluidframework/runtime-definitions";
+import { createDataStoreFactory } from "@fluidframework/runtime-utils";
 
 export type SupportedExportInterfaces = Partial<
     IProvideRuntimeFactory &
@@ -49,16 +50,15 @@ export class LocalCodeLoader implements ICodeLoader {
                 if (maybeExport.IRuntimeFactory !== undefined) {
                     fluidModule = { fluidExport: maybeExport };
                 } else {
-                    assert(
-                        maybeExport.IFluidDataStoreFactory !== undefined
-                        || maybeExport.IFluidDataStoreRegistry !== undefined);
+                    assert(maybeExport.IFluidDataStoreFactory !== undefined);
+                    const defaultFactory = createDataStoreFactory("default", maybeExport.IFluidDataStoreFactory);
                     fluidModule = {
                         fluidExport: {
                             ... maybeExport,
                             IRuntimeFactory:
                                 new ContainerRuntimeFactoryWithDefaultDataStore(
-                                    "default",
-                                    [["default", Promise.resolve(maybeExport)]]),
+                                    defaultFactory,
+                                    [[defaultFactory.type, Promise.resolve(defaultFactory)]]),
                         },
                     };
                 }

--- a/packages/test/test-utils/src/testFluidObject.ts
+++ b/packages/test/test-utils/src/testFluidObject.ts
@@ -123,9 +123,6 @@ export type ChannelFactoryRegistry = Iterable<[string | undefined, IChannelFacto
  *      sharedDir = testFluidObject.getSharedObject<SharedDirectory>("sharedDirectory");
  */
 export class TestFluidObjectFactory implements IFluidDataStoreFactory {
-    public static readonly type = "TestFluidObjectFactory";
-    public readonly type = TestFluidObjectFactory.type;
-
     public get IFluidDataStoreFactory() { return this; }
 
     /**
@@ -134,7 +131,8 @@ export class TestFluidObjectFactory implements IFluidDataStoreFactory {
      * IChannelFactory. Entries with string ids are passed to the Fluid object so that it can create a shared object
      * for it.
      */
-    constructor(private readonly factoryEntries: ChannelFactoryRegistry) { }
+    constructor(private readonly factoryEntries: ChannelFactoryRegistry,
+        public readonly type = "TestFluidObjectFactory") { }
 
     public async instantiateDataStore(context: IFluidDataStoreContext) {
         const dataTypes = new Map<string, IChannelFactory>();

--- a/packages/test/version-test-1/@fluid-internal/version-test-2/package.json
+++ b/packages/test/version-test-1/@fluid-internal/version-test-2/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.29.0",
+    "@fluidframework/runtime-utils": "^0.29.0",
     "@fluidframework/view-interfaces": "^0.29.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2"

--- a/packages/test/version-test-1/@fluid-internal/version-test-2/src/index.ts
+++ b/packages/test/version-test-1/@fluid-internal/version-test-2/src/index.ts
@@ -6,17 +6,19 @@
 import {
     ContainerRuntimeFactoryWithDefaultDataStore,
 } from "@fluidframework/aqueduct";
+import { createDataStoreFactory } from "@fluidframework/runtime-utils";
 
 import { VersiontestInstantiationFactory } from "./main";
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
-const pkg = require("../package.json");
-const fluidPackageName = pkg.name as string;
+const fluidPackageName = "@fluid-internal/version-test-2";
+
+const defaultFactory = createDataStoreFactory(fluidPackageName, VersiontestInstantiationFactory);
+const object2Factory = createDataStoreFactory("@fluid-internal/version-test-1", VersiontestInstantiationFactory);
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    fluidPackageName,
+    defaultFactory,
     new Map([
-        [fluidPackageName, Promise.resolve(VersiontestInstantiationFactory)],
-        ["@fluid-internal/version-test-1", Promise.resolve(VersiontestInstantiationFactory)],
+        [defaultFactory.type, Promise.resolve(defaultFactory)],
+        [object2Factory.type, Promise.resolve(object2Factory)],
     ]),
 );

--- a/packages/test/version-test-1/package.json
+++ b/packages/test/version-test-1/package.json
@@ -39,6 +39,7 @@
     "@fluidframework/aqueduct": "^0.29.0",
     "@fluidframework/base-host": "^0.29.0",
     "@fluidframework/common-utils": "^0.25.0",
+    "@fluidframework/runtime-utils": "^0.29.0",
     "@fluidframework/view-interfaces": "^0.29.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2"

--- a/packages/test/version-test-1/src/index.ts
+++ b/packages/test/version-test-1/src/index.ts
@@ -6,16 +6,17 @@
 import {
     ContainerRuntimeFactoryWithDefaultDataStore,
 } from "@fluidframework/aqueduct";
+import { createDataStoreFactory } from "@fluidframework/runtime-utils";
 
 import { VersiontestInstantiationFactory } from "./main";
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-const pkg = require("../package.json");
-const fluidPackageName = pkg.name as string;
+const fluidPackageName = "@fluid-internal/version-test-1";
+
+const defaultFactory = createDataStoreFactory(fluidPackageName, VersiontestInstantiationFactory);
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    fluidPackageName,
+    defaultFactory,
     new Map([
-        [fluidPackageName, Promise.resolve(VersiontestInstantiationFactory)],
+        [defaultFactory.type, Promise.resolve(defaultFactory)],
     ]),
 );

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -26,7 +26,7 @@ import {
 import { IFluidObject, IFluidPackage, IFluidCodeDetails } from "@fluidframework/core-interfaces";
 import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
 import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
-import { RequestParser } from "@fluidframework/runtime-utils";
+import { RequestParser, createDataStoreFactory } from "@fluidframework/runtime-utils";
 import { MultiUrlResolver } from "./multiResolver";
 import { deltaConns, getDocumentServiceFactory } from "./multiDocumentServiceFactory";
 
@@ -89,10 +89,12 @@ function wrapWithRuntimeFactoryIfNeeded(packageJson: IFluidPackage, fluidModule:
     if (fluidModule.fluidExport.IRuntimeFactory === undefined) {
         const dataStoreFactory = fluidModule.fluidExport.IFluidDataStoreFactory;
 
+        const defaultFactory = createDataStoreFactory(packageJson.name, dataStoreFactory);
+
         const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
-            packageJson.name,
+            defaultFactory,
             new Map([
-                [packageJson.name, Promise.resolve(dataStoreFactory)],
+                [defaultFactory.type, Promise.resolve(defaultFactory)],
             ]),
         );
         return {

--- a/tools/generator-fluid/app/templates/src/index.ts
+++ b/tools/generator-fluid/app/templates/src/index.ts
@@ -8,7 +8,7 @@ export { DiceRoller };
  * as a DataObject that can be created in the container.
  */
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    DiceRoller.factory.type,
+    DiceRoller.factory,
     new Map([
         DiceRoller.factory.registryEntry,
         // Add another data store here to create it within the container


### PR DESCRIPTION
Extracting smaller changes from https://github.com/microsoft/FluidFramework/pull/4266

This change is required for future changes, in order to create root data store through Aqueduct's data factory, thus using direct (and detached) creation process of data store, with ability to pass local scope to an object.

Also adding wrappers to create data stores - from async getters, or ability to rename it.

Also removing most of cases where we get data store name from package.json - this is not a good example to follow due to perf considerations (increases package size with all of package.json), as well as backward compatibility considerations (factory names can't change, and changing package name or moving code between packages would cause such change; this also does not compose well, as it assumes single factory per package).
