### PR TITLE
Force ANSI colors for fluid-build when running in the pipeline

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -80,6 +80,11 @@ parameters:
 trigger: none
 
 variables:
+  # We use 'chalk' to colorize output, which auto-detects color support in the
+  # running terminal.  The log output shown in Azure DevOps job runs only has
+  # basic ANSI color support though, so force that in the pipeline
+  - name: FORCE_COLOR
+    value: 1
   - template: include-vars.yml
     parameters:
       publishOverride: ${{ parameters.publishOverride }}


### PR DESCRIPTION
Build logs in Azure DevOps are black and white instead of the colorized output we see locally.  This is because our color library auto-detects color support, and the ADO pipeline environment doesn't work as expected there.  We can set an environment variable to force ANSI colors, which ADO pipelines will show correctly.