### PR TITLE
Validate package.json schema in policy-check

### DIFF
--- a/tools/build-tools/.vscode/launch.json
+++ b/tools/build-tools/.vscode/launch.json
@@ -12,6 +12,19 @@
             "outFiles": [
                 "${workspaceFolder}/**/*.js"
             ]
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "policy-check",
+            "program": "${workspaceFolder}\\dist\\repoPolicyCheck\\repoPolicyCheck.js",
+            "args": [
+                ""
+            ],
+            "outFiles": [
+                "${workspaceFolder}/**/*.js"
+            ],
+            "cwd": "${workspaceFolder}",
         }
-    ]
+    ],
 }

--- a/tools/build-tools/package-lock.json
+++ b/tools/build-tools/package-lock.json
@@ -2560,6 +2560,22 @@
         "wrappy": "1"
       }
     },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+        }
+      }
+    },
     "os-name": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
@@ -2599,6 +2615,14 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
+    "package-json-validator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/package-json-validator/-/package-json-validator-0.6.3.tgz",
+      "integrity": "sha512-juKiFboV4UKUvWQ+OSxstnyukhuluyuEoFmgZw1Rx21XzmwlgDWLcbl3qzjA3789IRORYhVFs7cmAO0YFGwHCg==",
+      "requires": {
+        "optimist": "~0.6.0"
+      }
     },
     "package-lock-sanitizer": {
       "version": "1.0.1",
@@ -3596,6 +3620,11 @@
       "requires": {
         "execa": "^1.0.0"
       }
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "wrap-ansi": {
       "version": "6.2.0",

--- a/tools/build-tools/package.json
+++ b/tools/build-tools/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluidframework/build-tools",
   "version": "0.2.0",
+  "description": "Fluid Build tool",
   "homepage": "https://fluidframework.com",
   "repository": "https://github.com/microsoft/FluidFramework",
   "license": "MIT",

--- a/tools/build-tools/package.json
+++ b/tools/build-tools/package.json
@@ -1,9 +1,8 @@
 {
   "name": "@fluidframework/build-tools",
   "version": "0.2.0",
-  "description": "Fluid Build tool",
   "homepage": "https://fluidframework.com",
-  "repository": "microsoft/FluidFramework",
+  "repository": "https://github.com/microsoft/FluidFramework",
   "license": "MIT",
   "author": "Microsoft",
   "main": "dist/fluidBuild/fluidBuild.js",
@@ -18,12 +17,12 @@
     "fluid-run-bundle-analyses": "bin/fluid-run-bundle-analyses"
   },
   "scripts": {
-    "build": "tsc -b",
     "debug:layer-check": "node --inspect-brk dist/layerCheck/layerCheck.js --root ../..",
     "layer-check": "node dist/layerCheck/layerCheck.js --root ../..",
     "list-repo-files": "cd ../.. && git ls-files -co --exclude-standard",
     "policy-check": "cd ../.. && git ls-files -co --exclude-standard --full-name | node tools/build-tools/dist/repoPolicyCheck/repoPolicyCheck.js -s",
     "policy-check:fix": "npm run policy-check -- -r",
+    "build": "tsc -b",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
@@ -35,6 +34,7 @@
     "fs-extra": "^9.0.1",
     "glob": "^7.1.3",
     "lodash.isequal": "^4.5.0",
+    "package-json-validator": "^0.6.3",
     "package-lock-sanitizer": "^1.0.1",
     "replace-in-file": "^6.0.0",
     "rimraf": "^2.6.2",

--- a/tools/build-tools/package.json
+++ b/tools/build-tools/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "description": "Fluid Build tool",
   "homepage": "https://fluidframework.com",
-  "repository": "https://github.com/microsoft/FluidFramework",
+  "repository": "microsoft/FluidFramework",
   "license": "MIT",
   "author": "Microsoft",
   "main": "dist/fluidBuild/fluidBuild.js",

--- a/tools/build-tools/package.json
+++ b/tools/build-tools/package.json
@@ -17,12 +17,12 @@
     "fluid-run-bundle-analyses": "bin/fluid-run-bundle-analyses"
   },
   "scripts": {
+    "build": "tsc -b",
     "debug:layer-check": "node --inspect-brk dist/layerCheck/layerCheck.js --root ../..",
     "layer-check": "node dist/layerCheck/layerCheck.js --root ../..",
     "list-repo-files": "cd ../.. && git ls-files -co --exclude-standard",
     "policy-check": "cd ../.. && git ls-files -co --exclude-standard --full-name | node tools/build-tools/dist/repoPolicyCheck/repoPolicyCheck.js -s",
     "policy-check:fix": "npm run policy-check -- -r",
-    "build": "tsc -b",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {

--- a/tools/build-tools/src/repoPolicyCheck/repoPolicyCheck.ts
+++ b/tools/build-tools/src/repoPolicyCheck/repoPolicyCheck.ts
@@ -83,7 +83,7 @@ function routeToHandlers(file: string) {
             } else {
                 process.exitCode = 1;
             }
-            writeOutLine(output);
+            console.log(output);
         }
     });
 }
@@ -116,7 +116,7 @@ lineReader.on('line', line => {
             routeToHandlers(filePath);
             processed++;
         } else {
-            console.log(`Excluded: ${line}`);
+            writeOutLine(`Excluded: ${line}`);
         }
     }
 });


### PR DESCRIPTION
This is a pre-req for #4272.

policy-check now validates package.json schema using [package-json-validator](https://www.npmjs.com/package/package-json-validator).