### PR TITLE
Small interface cleanup

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,9 +1,14 @@
 ## 0.29 Breaking Changes
 
 - [removeAllEntriesForDocId api in host storage changed](#removeAllEntriesForDocId-api-in-host-storage-changed)
+- [IContainerRuntimeBase.IProvideFluidDataStoreRegistry](#IContainerRuntimeBase.IProvideFluidDataStoreRegistry)
 
 ### removeAllEntriesForDocId api in host storage changed
 `removeAllEntriesForDocId` api in host storage is now an async api.
+
+### IContainerRuntimeBase.IProvideFluidDataStoreRegistry
+`IProvideFluidDataStoreRegistry` implementation moved from IContainerRuntimeBase to IContainerRuntime. Data stores and objects should not have access to global state in container.
+`IProvideFluidDataStoreRegistry` is removed from IFluidDataStoreChannel - it has not been implemented there for a while (it moved to context).
 
 ## 0.28 Breaking Changes
 

--- a/examples/data-objects/vltava/src/fluidObjects/tabs/tabs.tsx
+++ b/examples/data-objects/vltava/src/fluidObjects/tabs/tabs.tsx
@@ -10,6 +10,7 @@ import {
 } from "@fluidframework/aqueduct";
 import { IFluidObject } from "@fluidframework/core-interfaces";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
+import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 
 import React from "react";
 import ReactDOM from "react-dom";
@@ -44,7 +45,11 @@ export class TabsFluidObject extends DataObject implements IFluidHTMLView {
     }
 
     protected async hasInitialized() {
-        const registry = await this.context.containerRuntime.IFluidDataStoreRegistry.get("internalRegistry");
+        // TODO: This code should not rely on container globals (i.e. IContainerRuntime)
+        // It should be refactored to pass dependencies in.
+        const runtime = this.context.containerRuntime as IContainerRuntime;
+
+        const registry = await runtime.IFluidDataStoreRegistry.get("internalRegistry");
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const registryDetails = (registry as IFluidObject).IFluidObjectInternalRegistry!;
         this.dataModelInternal =

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -7,7 +7,6 @@ import { IEventProvider } from "@fluidframework/common-definitions";
 import {
     AttachState,
     ContainerWarning,
-    IAudience,
     IDeltaManager,
     ILoader,
 } from "@fluidframework/container-definitions";
@@ -24,13 +23,13 @@ import {
     IDocumentMessage,
     IHelpMessage,
     IPendingProposal,
-    IQuorum,
     ISequencedDocumentMessage,
 } from "@fluidframework/protocol-definitions";
 import {
     FlushMode,
     IContainerRuntimeBase,
     IContainerRuntimeBaseEvents,
+    IProvideFluidDataStoreRegistry,
  } from "@fluidframework/runtime-definitions";
 import { IProvideContainerRuntimeDirtyable } from "./containerRuntimeDirtyable";
 
@@ -67,6 +66,7 @@ export type IContainerRuntimeBaseWithCombinedEvents =
 export interface IContainerRuntime extends
     IProvideContainerRuntime,
     Partial<IProvideContainerRuntimeDirtyable>,
+    IProvideFluidDataStoreRegistry,
     IContainerRuntimeBaseWithCombinedEvents {
     readonly id: string;
     readonly existing: boolean;
@@ -107,16 +107,6 @@ export interface IContainerRuntime extends
      * it results in container corruption - loading this file after that will always result in error.
      */
     createRootDataStore(pkg: string | string[], rootDataStoreId: string): Promise<IFluidRouter>;
-
-    /**
-     * Returns the current quorum.
-     */
-    getQuorum(): IQuorum;
-
-    /**
-     * Returns the current audience.
-     */
-    getAudience(): IAudience;
 
     /**
      * Used to raise an unrecoverable error on the runtime.

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -64,9 +64,8 @@ export interface IContainerRuntimeBaseEvents extends IEvent{
  */
 export interface IContainerRuntimeBase extends
     IEventProvider<IContainerRuntimeBaseEvents>,
-    IProvideFluidHandleContext,
-    /* TODO: Used by spaces. we should switch to IoC to provide the global registry */
-    IProvideFluidDataStoreRegistry {
+    IProvideFluidHandleContext
+{
 
     readonly logger: ITelemetryLogger;
     readonly clientDetails: IClientDetails;
@@ -125,6 +124,16 @@ export interface IContainerRuntimeBase extends
     getTaskManager(): Promise<ITaskManager>;
 
     uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
+
+    /**
+     * Returns the current quorum.
+     */
+    getQuorum(): IQuorum;
+
+    /**
+     * Returns the current audience.
+     */
+    getAudience(): IAudience;
 }
 
 /**
@@ -135,7 +144,6 @@ export interface IContainerRuntimeBase extends
  */
 export interface IFluidDataStoreChannel extends
     IFluidRouter,
-    Partial<IProvideFluidDataStoreRegistry>,
     IDisposable {
 
     readonly id: string;


### PR DESCRIPTION
Splitting pieces from https://github.com/microsoft/FluidFramework/pull/4266

1. Move **getQuorum** & **getAudience** from IContainerRuntime to IContainerRuntimeBase.  All data stores have access to it, so there is not much reason to make them available only at container root level. In future we might want to re-evaluate where this info shows up. Things like quorum, deltaManager, leader - these are not data store specific, and likely should be all on some global object that is available to all entities in container in one single place. That said, it's possible we want to allow data stores control access to this data when creating child data stores (no decisions made here).
2. Move **IProvideFluidDataStoreRegistry** implementation from IContainerRuntimeBase to IContainerRuntime. Global container registry should not be visible random objects in container. Data stores can examine their own registries only.
   - inspecting code in Bohemia says it's not a problem - code that reaches to it uses IContainerRuntime (though it's questionable if it should be exposed even on IContainerRuntime).
3. Remove **IProvideFluidDataStoreRegistry** from IFluidDataStoreChannel 0 it is not on implementation.