### PR TITLE
Update gateway paths to restore spo support

### DIFF
--- a/server/gateway/src/controllers/loader.ts
+++ b/server/gateway/src/controllers/loader.ts
@@ -56,7 +56,12 @@ export async function initialize(
         async () => Promise.resolve(resolved.tokens.storageToken),
         async () => Promise.resolve(resolved.tokens.socketToken)));
 
-    const tokenProvider = new GatewayTokenProvider(document.location.origin, resolved.url, hostToken, accessToken);
+    const tokenProvider = new GatewayTokenProvider(
+        document.location.origin,
+        resolved.url,
+        hostToken,
+        resolved.tokens.storageToken,
+    );
     documentServiceFactories.push(new RouterliciousDocumentServiceFactory(
         tokenProvider,
         false,

--- a/server/gateway/src/controllers/loader.ts
+++ b/server/gateway/src/controllers/loader.ts
@@ -18,6 +18,7 @@ import { IGitCache } from "@fluidframework/server-services-client";
 import { HTMLViewAdapter } from "@fluidframework/view-adapters";
 import { SemVerCdnCodeResolver } from "@fluidframework/web-code-loader";
 import { GatewayTokenProvider } from "../shared";
+import { isSpoTenant } from "../odspUtils";
 import { DocumentFactory } from "./documentFactory";
 import { IHostServices } from "./services";
 import { seedFromScriptIds } from "./helpers";
@@ -60,7 +61,7 @@ export async function initialize(
         document.location.origin,
         resolved.url,
         hostToken,
-        resolved.tokens.storageToken,
+        isSpoTenant(config.tenantId) ? resolved.tokens.storageToken : accessToken,
     );
     documentServiceFactories.push(new RouterliciousDocumentServiceFactory(
         tokenProvider,

--- a/server/gateway/src/controllers/loaderHost.ts
+++ b/server/gateway/src/controllers/loaderHost.ts
@@ -34,23 +34,26 @@ export async function initialize(
     accessToken: string,
     config: any,
     clientId: string,
+    isSpoTenantPath: boolean,
 ) {
     debug(`Loading ${url}`);
 
     const documentServiceFactories: IDocumentServiceFactory[] = [];
-    // TODO: need to be support refresh token
-    documentServiceFactories.push(new OdspDocumentServiceFactory(
-        async () => Promise.resolve(resolved.tokens.storageToken),
-        async () => Promise.resolve(resolved.tokens.socketToken)));
-
-    const tokenProvider = new GatewayTokenProvider(document.location.origin, resolved.url, hostToken, accessToken);
-    documentServiceFactories.push(new RouterliciousDocumentServiceFactory(
-        tokenProvider,
-        false,
-        new DefaultErrorTracking(),
-        false,
-        true,
-        cache));
+    if (isSpoTenantPath) {
+        // TODO: need to be support refresh token
+        documentServiceFactories.push(new OdspDocumentServiceFactory(
+            async () => Promise.resolve(resolved.tokens.storageToken),
+            async () => Promise.resolve(resolved.tokens.socketToken)));
+    } else {
+        const tokenProvider = new GatewayTokenProvider(document.location.origin, resolved.url, hostToken, accessToken);
+        documentServiceFactories.push(new RouterliciousDocumentServiceFactory(
+            tokenProvider,
+            false,
+            new DefaultErrorTracking(),
+            false,
+            true,
+            cache));
+    }
 
     config.moniker = (await Axios.get("/api/v1/moniker")).data;
     config.url = url;

--- a/server/gateway/src/gatewayUrlResolver.ts
+++ b/server/gateway/src/gatewayUrlResolver.ts
@@ -23,28 +23,6 @@ export interface FullTree {
     code: IFluidCodeDetails | null,
 }
 
-export function resolveR11sUrl(
-    config: Provider,
-    alfred: IAlfred,
-    tenantId: string,
-    documentId: string,
-    accessToken: string,
-    request: Request,
-): [Promise<IFluidResolvedUrl>, Promise<undefined | FullTree>] {
-    const endPointConfig: { provider: Provider, tenantId: string, documentId: string } = {
-        provider: config,
-        tenantId,
-        documentId,
-    };
-
-    const resolverList = [
-        new RouterliciousUrlResolver(endPointConfig, async () => Promise.resolve(accessToken))];
-    const resolvedP = configurableUrlResolver(resolverList, request);
-    const fullTreeP = alfred.getFullTree(tenantId, documentId);
-    // RouterliciousUrlResolver only resolves as IFluidResolvedUrl
-    return [resolvedP as Promise<IFluidResolvedUrl>, fullTreeP];
-}
-
 export function resolveSpoUrl(
     config: Provider,
     tenantId: string,
@@ -69,4 +47,26 @@ export function resolveSpoUrl(
     } else {
         throw new Error("Failed to find client ID and secret values");
     }
+}
+
+export function resolveR11sUrl(
+    config: Provider,
+    alfred: IAlfred,
+    tenantId: string,
+    documentId: string,
+    accessToken: string,
+    request: Request,
+): [Promise<IFluidResolvedUrl>, Promise<undefined | FullTree>] {
+    const endPointConfig: { provider: Provider, tenantId: string, documentId: string } = {
+        provider: config,
+        tenantId,
+        documentId,
+    };
+
+    const resolverList = [
+        new RouterliciousUrlResolver(endPointConfig, async () => Promise.resolve(accessToken))];
+    const resolvedP = configurableUrlResolver(resolverList, request);
+    const fullTreeP = alfred.getFullTree(tenantId, documentId);
+    // RouterliciousUrlResolver only resolves as IFluidResolvedUrl
+    return [resolvedP as Promise<IFluidResolvedUrl>, fullTreeP];
 }

--- a/server/gateway/src/gatewayUrlResolver.ts
+++ b/server/gateway/src/gatewayUrlResolver.ts
@@ -13,57 +13,60 @@ import { IGitCache } from "@fluidframework/server-services-client";
 import { Request } from "express";
 import { Provider } from "nconf";
 import dotenv from "dotenv";
-import winston from "winston";
 import { IAlfred } from "./interfaces";
-import { isSpoTenant, spoGetResolvedUrl } from "./odspUtils";
+import { spoGetResolvedUrl } from "./odspUtils";
 
 dotenv.config();
 
-interface FullTree {
+export interface FullTree {
     cache: IGitCache,
     code: IFluidCodeDetails | null,
 }
 
-export function resolveUrl(
+export function resolveR11sUrl(
     config: Provider,
     alfred: IAlfred,
     tenantId: string,
     documentId: string,
+    accessToken: string,
     request: Request,
-    accessToken?: string,
+): [Promise<IFluidResolvedUrl>, Promise<undefined | FullTree>] {
+    const endPointConfig: { provider: Provider, tenantId: string, documentId: string } = {
+        provider: config,
+        tenantId,
+        documentId,
+    };
+
+    const resolverList = [
+        new RouterliciousUrlResolver(endPointConfig, async () => Promise.resolve(accessToken))];
+    const resolvedP = configurableUrlResolver(resolverList, request);
+    const fullTreeP = alfred.getFullTree(tenantId, documentId);
+    // RouterliciousUrlResolver only resolves as IFluidResolvedUrl
+    return [resolvedP as Promise<IFluidResolvedUrl>, fullTreeP];
+}
+
+export function resolveSpoUrl(
+    config: Provider,
+    tenantId: string,
+    documentId: string,
+    request: Request,
     driveId?: string,
 ): [Promise<IFluidResolvedUrl>, Promise<undefined | FullTree>] {
-    if (isSpoTenant(tenantId)) {
-        winston.info("hi");
-        const microsoftConfiguration = config.get("login:microsoft");
-        const clientId = _.isEmpty(microsoftConfiguration.clientId)
-            ? process.env.MICROSOFT_CONFIGURATION_CLIENT_ID : microsoftConfiguration.clientId;
-        const clientSecret = _.isEmpty(microsoftConfiguration.clientSecret)
-            ? process.env.MICROSOFT_CONFIGURATION_CLIENT_SECRET : microsoftConfiguration.clientSecret;
-        if (clientId !== undefined && clientSecret !== undefined) {
-            const clientConfig: IClientConfig = {
-                clientId,
-                clientSecret,
-            };
-            const resolvedP = spoGetResolvedUrl(tenantId, documentId,
-                request.session?.tokens, clientConfig, driveId);
-            const fullTreeP = Promise.resolve(undefined);
-            return [resolvedP, fullTreeP];
-        } else {
-            throw new Error("Failed to find client ID and secret values");
-        }
-    } else {
-        const endPointConfig: { provider: Provider, tenantId: string, documentId: string } = {
-            provider: config,
-            tenantId,
-            documentId,
+    const microsoftConfiguration = config.get("login:microsoft");
+    const clientId = _.isEmpty(microsoftConfiguration.clientId)
+        ? process.env.MICROSOFT_CONFIGURATION_CLIENT_ID : microsoftConfiguration.clientId;
+    const clientSecret = _.isEmpty(microsoftConfiguration.clientSecret)
+        ? process.env.MICROSOFT_CONFIGURATION_CLIENT_SECRET : microsoftConfiguration.clientSecret;
+    if (clientId !== undefined && clientSecret !== undefined) {
+        const clientConfig: IClientConfig = {
+            clientId,
+            clientSecret,
         };
-
-        const resolverList = [
-            new RouterliciousUrlResolver(endPointConfig, async () => Promise.resolve(accessToken ?? ""))];
-        const resolvedP = configurableUrlResolver(resolverList, request);
-        const fullTreeP = alfred.getFullTree(tenantId, documentId);
-        // RouterliciousUrlResolver only resolves as IFluidResolvedUrl
-        return [resolvedP as Promise<IFluidResolvedUrl>, fullTreeP];
+        const resolvedP = spoGetResolvedUrl(tenantId, documentId,
+            request.session?.tokens, clientConfig, driveId);
+        const fullTreeP = Promise.resolve(undefined);
+        return [resolvedP, fullTreeP];
+    } else {
+        throw new Error("Failed to find client ID and secret values");
     }
 }

--- a/server/gateway/src/gatewayUrlResolver.ts
+++ b/server/gateway/src/gatewayUrlResolver.ts
@@ -13,6 +13,7 @@ import { IGitCache } from "@fluidframework/server-services-client";
 import { Request } from "express";
 import { Provider } from "nconf";
 import dotenv from "dotenv";
+import winston from "winston";
 import { IAlfred } from "./interfaces";
 import { isSpoTenant, spoGetResolvedUrl } from "./odspUtils";
 
@@ -28,11 +29,12 @@ export function resolveUrl(
     alfred: IAlfred,
     tenantId: string,
     documentId: string,
-    accessToken: string,
     request: Request,
+    accessToken?: string,
     driveId?: string,
 ): [Promise<IFluidResolvedUrl>, Promise<undefined | FullTree>] {
     if (isSpoTenant(tenantId)) {
+        winston.info("hi");
         const microsoftConfiguration = config.get("login:microsoft");
         const clientId = _.isEmpty(microsoftConfiguration.clientId)
             ? process.env.MICROSOFT_CONFIGURATION_CLIENT_ID : microsoftConfiguration.clientId;
@@ -57,7 +59,8 @@ export function resolveUrl(
             documentId,
         };
 
-        const resolverList = [new RouterliciousUrlResolver(endPointConfig, async () => Promise.resolve(accessToken))];
+        const resolverList = [
+            new RouterliciousUrlResolver(endPointConfig, async () => Promise.resolve(accessToken ?? ""))];
         const resolvedP = configurableUrlResolver(resolverList, request);
         const fullTreeP = alfred.getFullTree(tenantId, documentId);
         // RouterliciousUrlResolver only resolves as IFluidResolvedUrl

--- a/server/gateway/src/routes/loader.ts
+++ b/server/gateway/src/routes/loader.ts
@@ -82,10 +82,11 @@ export function create(
                 const search = parse(request.url).search;
                 const scopes = [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite];
                 const user = getUser(request);
+                const isSpoTenantPath = isSpoTenant(tenantId);
                 let fullTreeP: Promise<undefined | FullTree>;
                 let resolvedP: Promise<IFluidResolvedUrl>;
                 let r11sAccessToken = "";
-                if (isSpoTenant(tenantId)) {
+                if (isSpoTenantPath) {
                     [resolvedP, fullTreeP] =
                         resolveSpoUrl(config, tenantId, documentId, request, driveId);
                 } else {
@@ -190,6 +191,7 @@ export function create(
                                 clientId: _.isEmpty(configClientId)
                                 ? process.env.MICROSOFT_CONFIGURATION_CLIENT_ID : configClientId,
                                 config: workerConfig,
+                                isSpoTenantPath,
                                 hostToken,
                                 accessToken: r11sAccessToken,
                                 partials: defaultPartials,

--- a/server/gateway/src/routes/loader.ts
+++ b/server/gateway/src/routes/loader.ts
@@ -80,9 +80,10 @@ export function create(
                 const search = parse(request.url).search;
                 const scopes = [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite];
                 const user = getUser(request);
-                const accessToken = getR11sToken(tenantId, documentId, appTenants, scopes, user as IExtendedUser);
+                const accessToken = getR11sToken(
+                    tenantId, documentId, appTenants, scopes, user as IExtendedUser);
                 const [resolvedP, fullTreeP] =
-                    resolveUrl(config, alfred, tenantId, documentId, accessToken, request, driveId);
+                    resolveUrl(config, alfred, tenantId, documentId, request, accessToken, driveId);
 
                 const workerConfig = getConfig(
                     config.get("worker"),

--- a/server/gateway/src/routes/loader.ts
+++ b/server/gateway/src/routes/loader.ts
@@ -9,6 +9,7 @@ import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
 import { ScopeType } from "@fluidframework/protocol-definitions";
 import { IAlfredTenant } from "@fluidframework/server-services-client";
 import { extractPackageIdentifierDetails, SemVerCdnCodeResolver } from "@fluidframework/web-code-loader";
+import { IFluidResolvedUrl } from "@fluidframework/driver-definitions";
 import { Router } from "express";
 import safeStringify from "json-stringify-safe";
 import jwt from "jsonwebtoken";
@@ -17,9 +18,10 @@ import { v4 as uuid } from "uuid";
 import winston from "winston";
 import dotenv from "dotenv";
 import { spoEnsureLoggedIn } from "../gatewayOdspUtils";
-import { resolveUrl } from "../gatewayUrlResolver";
+import { FullTree, resolveR11sUrl, resolveSpoUrl } from "../gatewayUrlResolver";
 import { IAlfred, IKeyValueWrapper } from "../interfaces";
 import { getConfig, getJWTClaims, getR11sToken, getUserDetails, queryParamAsString } from "../utils";
+import { isSpoTenant } from "../odspUtils";
 import { defaultPartials } from "./partials";
 import { getUser, IExtendedUser } from "./utils";
 
@@ -80,11 +82,18 @@ export function create(
                 const search = parse(request.url).search;
                 const scopes = [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite];
                 const user = getUser(request);
-                const accessToken = getR11sToken(
-                    tenantId, documentId, appTenants, scopes, user as IExtendedUser);
-                const [resolvedP, fullTreeP] =
-                    resolveUrl(config, alfred, tenantId, documentId, request, accessToken, driveId);
-
+                let fullTreeP: Promise<undefined | FullTree>;
+                let resolvedP: Promise<IFluidResolvedUrl>;
+                let r11sAccessToken = "";
+                if (isSpoTenant(tenantId)) {
+                    [resolvedP, fullTreeP] =
+                        resolveSpoUrl(config, tenantId, documentId, request, driveId);
+                } else {
+                    r11sAccessToken = getR11sToken(
+                        tenantId, documentId, appTenants, scopes, user as IExtendedUser);
+                    [resolvedP, fullTreeP] =
+                        resolveR11sUrl(config, alfred, tenantId, documentId, r11sAccessToken, request);
+                }
                 const workerConfig = getConfig(
                     config.get("worker"),
                     tenantId,
@@ -182,7 +191,7 @@ export function create(
                                 ? process.env.MICROSOFT_CONFIGURATION_CLIENT_ID : configClientId,
                                 config: workerConfig,
                                 hostToken,
-                                accessToken,
+                                accessToken: r11sAccessToken,
                                 partials: defaultPartials,
                                 resolved: JSON.stringify(resolved),
                                 scripts,

--- a/server/gateway/src/routes/loaderFramed.ts
+++ b/server/gateway/src/routes/loaderFramed.ts
@@ -83,10 +83,11 @@ export function create(
                 const search = parse(request.url).search;
                 const scopes = [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite];
                 const user = getUser(request);
+                const isSpoTenantPath = isSpoTenant(tenantId);
                 let fullTreeP: Promise<undefined | FullTree>;
                 let resolvedP: Promise<IFluidResolvedUrl>;
                 let r11sAccessToken = "";
-                if (isSpoTenant(tenantId)) {
+                if (isSpoTenantPath) {
                     [resolvedP, fullTreeP] =
                         resolveSpoUrl(config, tenantId, documentId, request);
                 } else {
@@ -193,6 +194,7 @@ export function create(
                                 clientId: _.isEmpty(configClientId)
                                     ? process.env.MICROSOFT_CONFIGURATION_CLIENT_ID : configClientId,
                                 config: workerConfig,
+                                isSpoTenantPath,
                                 hostToken,
                                 accessToken: r11sAccessToken,
                                 npm: config.get("worker:npm"),

--- a/server/gateway/src/routes/loaderFramed.ts
+++ b/server/gateway/src/routes/loaderFramed.ts
@@ -83,7 +83,7 @@ export function create(
                 const user = getUser(request);
                 const accessToken = getR11sToken(tenantId, documentId, appTenants, scopes, user as IExtendedUser);
                 const [resolvedP, fullTreeP] =
-                    resolveUrl(config, alfred, tenantId, documentId, accessToken, request);
+                    resolveUrl(config, alfred, tenantId, documentId, request, accessToken);
 
                 const workerConfig = getConfig(
                     config.get("worker"),

--- a/server/gateway/src/routes/loaderFramed.ts
+++ b/server/gateway/src/routes/loaderFramed.ts
@@ -16,9 +16,11 @@ import { Provider } from "nconf";
 import { v4 } from "uuid";
 import winston from "winston";
 import dotenv from "dotenv";
+import { IFluidResolvedUrl } from "@fluidframework/driver-definitions";
 import { spoEnsureLoggedIn } from "../gatewayOdspUtils";
-import { resolveUrl } from "../gatewayUrlResolver";
+import { FullTree, resolveR11sUrl, resolveSpoUrl } from "../gatewayUrlResolver";
 import { IAlfred, IKeyValueWrapper } from "../interfaces";
+import { isSpoTenant } from "../odspUtils";
 import { getConfig, getUserDetails, queryParamAsString, getR11sToken } from "../utils";
 import { getUser, IExtendedUser } from "./utils";
 
@@ -81,9 +83,18 @@ export function create(
                 const search = parse(request.url).search;
                 const scopes = [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite];
                 const user = getUser(request);
-                const accessToken = getR11sToken(tenantId, documentId, appTenants, scopes, user as IExtendedUser);
-                const [resolvedP, fullTreeP] =
-                    resolveUrl(config, alfred, tenantId, documentId, request, accessToken);
+                let fullTreeP: Promise<undefined | FullTree>;
+                let resolvedP: Promise<IFluidResolvedUrl>;
+                let r11sAccessToken = "";
+                if (isSpoTenant(tenantId)) {
+                    [resolvedP, fullTreeP] =
+                        resolveSpoUrl(config, tenantId, documentId, request);
+                } else {
+                    r11sAccessToken = getR11sToken(
+                        tenantId, documentId, appTenants, scopes, user as IExtendedUser);
+                    [resolvedP, fullTreeP] =
+                        resolveR11sUrl(config, alfred, tenantId, documentId, r11sAccessToken, request);
+                }
 
                 const workerConfig = getConfig(
                     config.get("worker"),
@@ -183,7 +194,7 @@ export function create(
                                     ? process.env.MICROSOFT_CONFIGURATION_CLIENT_ID : configClientId,
                                 config: workerConfig,
                                 hostToken,
-                                accessToken,
+                                accessToken: r11sAccessToken,
                                 npm: config.get("worker:npm"),
                                 partials: {
                                     layoutFramed: "layoutFramed",

--- a/server/gateway/src/routes/loaderFrs.ts
+++ b/server/gateway/src/routes/loaderFrs.ts
@@ -9,6 +9,7 @@ import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
 import { ScopeType } from "@fluidframework/protocol-definitions";
 import { IAlfredTenant } from "@fluidframework/server-services-client";
 import { extractPackageIdentifierDetails, SemVerCdnCodeResolver } from "@fluidframework/web-code-loader";
+import { IFluidResolvedUrl } from "@fluidframework/driver-definitions";
 import { Router } from "express";
 import safeStringify from "json-stringify-safe";
 import jwt from "jsonwebtoken";
@@ -17,9 +18,10 @@ import { v4 } from "uuid";
 import winston from "winston";
 import dotenv from "dotenv";
 import { spoEnsureLoggedIn } from "../gatewayOdspUtils";
-import { resolveUrl } from "../gatewayUrlResolver";
+import { FullTree, resolveR11sUrl, resolveSpoUrl } from "../gatewayUrlResolver";
 import { IAlfred, IKeyValueWrapper } from "../interfaces";
 import { getConfig, getJWTClaims, getUserDetails, queryParamAsString, getR11sToken } from "../utils";
+import { isSpoTenant } from "../odspUtils";
 import { defaultPartials } from "./partials";
 import { getUser, IExtendedUser } from "./utils";
 
@@ -62,9 +64,17 @@ export function create(
         const search = parse(request.url).search;
         const scopes = [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite];
         const user = getUser(request);
-        const accessToken = getR11sToken(tenantId, documentId, appTenants, scopes, user as IExtendedUser);
-        const [resolvedP, fullTreeP] =
-            resolveUrl(config, alfred, tenantId, documentId, request, accessToken);
+        let fullTreeP: Promise<undefined | FullTree>;
+        let resolvedP: Promise<IFluidResolvedUrl>;
+        if (isSpoTenant(tenantId)) {
+            [resolvedP, fullTreeP] =
+                resolveSpoUrl(config, tenantId, documentId, request);
+        } else {
+            const r11sAccessToken = getR11sToken(
+                tenantId, documentId, appTenants, scopes, user as IExtendedUser);
+            [resolvedP, fullTreeP] =
+                resolveR11sUrl(config, alfred, tenantId, documentId, r11sAccessToken, request);
+        }
 
         const workerConfig = getConfig(
             config.get("worker"),

--- a/server/gateway/src/routes/loaderFrs.ts
+++ b/server/gateway/src/routes/loaderFrs.ts
@@ -66,7 +66,8 @@ export function create(
         const user = getUser(request);
         let fullTreeP: Promise<undefined | FullTree>;
         let resolvedP: Promise<IFluidResolvedUrl>;
-        if (isSpoTenant(tenantId)) {
+        const isSpoTenantPath = isSpoTenant(tenantId);
+        if (isSpoTenantPath) {
             [resolvedP, fullTreeP] =
                 resolveSpoUrl(config, tenantId, documentId, request);
         } else {
@@ -172,6 +173,7 @@ export function create(
                         clientId: _.isEmpty(configClientId)
                             ? process.env.MICROSOFT_CONFIGURATION_CLIENT_ID : configClientId,
                         config: workerConfig,
+                        isSpoTenantPath,
                         jwt: jwtToken,
                         partials: defaultPartials,
                         resolved: JSON.stringify(resolved),

--- a/server/gateway/src/routes/loaderFrs.ts
+++ b/server/gateway/src/routes/loaderFrs.ts
@@ -64,7 +64,7 @@ export function create(
         const user = getUser(request);
         const accessToken = getR11sToken(tenantId, documentId, appTenants, scopes, user as IExtendedUser);
         const [resolvedP, fullTreeP] =
-            resolveUrl(config, alfred, tenantId, documentId, accessToken, request);
+            resolveUrl(config, alfred, tenantId, documentId, request, accessToken);
 
         const workerConfig = getConfig(
             config.get("worker"),

--- a/server/gateway/src/utils.ts
+++ b/server/gateway/src/utils.ts
@@ -32,14 +32,15 @@ export function getR11sToken(
     tenants: IAlfredTenant[],
     scopes: ScopeType[],
     user: IAlfredUser,
-    lifetimeSec: number = 60 * 60): string {
+    lifetimeSec: number = 60 * 60,
+    hostToken: string = ""): string {
+    let token = hostToken;
     for (const tenant of tenants) {
         if (tenantId === tenant.id) {
-            return generateToken(tenantId, documentId, tenant.key, scopes, user, lifetimeSec);
+            token = generateToken(tenantId, documentId, tenant.key, scopes, user, lifetimeSec);
         }
     }
-
-    throw new Error("Invalid tenant");
+    return token;
 }
 
 /**

--- a/server/gateway/src/utils.ts
+++ b/server/gateway/src/utils.ts
@@ -32,15 +32,14 @@ export function getR11sToken(
     tenants: IAlfredTenant[],
     scopes: ScopeType[],
     user: IAlfredUser,
-    lifetimeSec: number = 60 * 60,
-    hostToken: string = ""): string {
-    let token = hostToken;
+    lifetimeSec: number = 60 * 60): string {
     for (const tenant of tenants) {
         if (tenantId === tenant.id) {
-            token = generateToken(tenantId, documentId, tenant.key, scopes, user, lifetimeSec);
+            return generateToken(tenantId, documentId, tenant.key, scopes, user, lifetimeSec);
         }
     }
-    return token;
+
+    throw new Error("Invalid tenant");
 }
 
 /**

--- a/server/gateway/views/loader.hjs
+++ b/server/gateway/views/loader.hjs
@@ -26,6 +26,7 @@
         var accessToken = "{{ accessToken }}";
         var config = {{{ config }}};
         var clientId = "{{ clientId }}";
+        var isSpoTenantPath = {{{ isSpoTenantPath }}};
 
         {{#scripts}}
         var scriptIds = [
@@ -47,6 +48,7 @@
             hostToken,
             accessToken,
             config,
+            isSpoTenantPath,
         );
 
         const connectionDiv = document.getElementById("connection-state");

--- a/server/gateway/views/loaderHost.hjs
+++ b/server/gateway/views/loaderHost.hjs
@@ -27,6 +27,7 @@
         var npm = "{{ npm }}";
         var config = {{{ config }}};
         var clientId = "{{ clientId }}";
+        var isSpoTenantPath = {{{ isSpoTenantPath }}};
 
         var scriptIds = [];
 
@@ -37,7 +38,8 @@
             hostToken,
             accessToken,
             config,
-            clientId);
+            clientId,
+            isSpoTenantPath);
     </script>
 {{/scripts}}
 


### PR DESCRIPTION
- Adds two separate resolveSpoUrl and resolveR11sUrl functions as Sharepoint uses its own access token whereas Routerlicious uses locally generated one
- getR11sToken is no longer called on the spo/spo-df loader code paths. This was causing those paths to break as the appTenants available from config did not have the spo/spo-df tenant keys available
- Loader routes now pass an isSpoTenantPath boolean to indicate which service factory to use in the controllers
-- loader and loaderFramed routes select on this boolean to pick between the r11s/odsp document service factory in the loader and loaderHost controllers respectively
-- loaderFrs route reuses the loader controller, as before, but now also passes the additional isSpoTenantPath variable to it