### PR TITLE
Fixed stop in containerRuntime returning unexpected snapshot

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1066,9 +1066,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     public async stop(): Promise<IRuntimeState> {
         this.verifyNotClosed();
 
-        const summaryTree = await this.summarize(true /* fullTree */, false /* trackState */);
-        // back-compat summarize - Remove this once we start return ISummaryTree here.
-        const snapshot = convertSummaryTreeToITree(summaryTree.summary);
+        const snapshot = await this.snapshot();
         const state: IPreviousState = {
             reload: true,
             summaryCollection: this.summarizer.summaryCollection,


### PR DESCRIPTION
PR #4230 updated stop() in containerRuntime to return the result from summarize() instead of snapshot().
summarize() has an extra ".blob" entry which is causing the tests in contextReload.spec.ts to fail. Reverting back to using snapshot() in stop().