### PR TITLE
Improve caching in ODSP driver

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -242,14 +242,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                     async () => this.epochTracker.fetchAndParseAsJSON<IBlob>(url, { headers }),
                 );
             });
-            // Verify that we haven't populated the cache in the meantime from a simultaneous read
-            blob = this.blobCache.get(blobid);
-            if (blob === undefined) {
-                blob = response.content;
-                this.blobCache.set(blobid, blob);
-                // Reset the timer on cache write
-                this.scheduleClearBlobsCache();
-            }
+            blob = response.content;
         }
 
         if (this.attributesBlobHandles.has(blobid)) {

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -99,6 +99,9 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
     private readonly blobCache: Map<string, IBlob> = new Map();
     private readonly treesCache: Map<string, ITree> = new Map();
 
+    // Save the timeout so we can cancel and reschedule it as needed
+    private blobCacheTimeout: ReturnType<typeof setTimeout> | undefined;
+
     private readonly attributesBlobHandles: Set<string> = new Set();
 
     private lastSummaryHandle: string | undefined;
@@ -219,6 +222,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
 
     public async read(blobid: string): Promise<string> {
         let blob = this.blobCache.get(blobid);
+        // Reset the timer on attempted cache read
+        this.scheduleClearBlobsCache();
         if (blob === undefined) {
             this.checkSnapshotUrl();
 
@@ -242,6 +247,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
             if (blob === undefined) {
                 blob = response.content;
                 this.blobCache.set(blobid, blob);
+                // Reset the timer on cache write
+                this.scheduleClearBlobsCache();
             }
         }
 
@@ -765,6 +772,18 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
 
     private initBlobsCache(blobs: IBlob[]) {
         blobs.forEach((blob) => this.blobCache.set(blob.id, blob));
+        this.scheduleClearBlobsCache();
+    }
+
+    /**
+     * Stop the current timer for clearing the blob cache (if any) and schedule a new one
+     */
+    private scheduleClearBlobsCache() {
+        const blobCacheTimeoutDuration = 10000;
+        if (this.blobCacheTimeout !== undefined) {
+            clearTimeout(this.blobCacheTimeout);
+        }
+        this.blobCacheTimeout = setTimeout(() => { this.blobCache.clear(); }, blobCacheTimeoutDuration);
     }
 
     private checkSnapshotUrl() {


### PR DESCRIPTION
Fixes #4037 

In particular, adds to the cache on calls to `read()` and clears the cache after 10 seconds without attempted reads or writes as a basic eviction strategy.  Does not attempt to share cache between separate instances of the container, though I expect this duplication should be less consequential if we're clearing the cache regularly.