### PR TITLE
Fixed flaky document dirty test with force readonly

### DIFF
--- a/packages/test/end-to-end-tests/src/test/documentDirty.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/documentDirty.spec.ts
@@ -311,7 +311,7 @@ describe("Document Dirty", () => {
             checkDirtyState("after value set while force readonly", true, 0);
 
             container.forceReadonly(false);
-            await ensureContainerConnected(container);
+            assert(container.connected, "Setting readonly to false should not cause disconnection");
 
             // Document should still be dirty right after turning off force readonly
             checkDirtyState("after clear readonly and replayed ops", true, 0);

--- a/packages/test/end-to-end-tests/src/test/documentDirty.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/documentDirty.spec.ts
@@ -339,7 +339,7 @@ describe("Document Dirty", () => {
                 checkDirtyState("after value set while force readonly", true, 0);
 
                 container.forceReadonly(false);
-                await ensureContainerConnected(container);
+                assert(container.connected, "Setting readonly to false should not cause disconnection");
 
                 // Document should still be dirty right after turning off force readonly
                 checkDirtyState("after reconnect and replayed ops", true, 0);


### PR DESCRIPTION
One of the document dirty tests with force readonly was flaky. It was asynchronously waiting for container to be connected after setting readonly to false. This was causing pending ops to be processed and set the document to clean which it was not expecting.

Removed the async wait for container reconnection and added an assert that the container is connected when forcing readonly.