### PR TITLE
Fall back to set timeout in broadcast lambdas 

### DIFF
--- a/server/routerlicious/packages/lambdas/src/broadcaster/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/broadcaster/lambda.ts
@@ -105,7 +105,7 @@ export class BroadcasterLambda implements IPartitionLambda {
 
         // Set immediate is not available in all environments, specifically it does not work in a browser.
         // Fallback to set timeout in those cases.
-        if (setImmediate === undefined) {
+        if (typeof setImmediate !== "function") {
             setTimeout(callback, 0);
         } else {
             setImmediate(callback);


### PR DESCRIPTION
Browser's don't support setImmediate, so the broadcast lambda just doesn't work for folks using webpack 5 via local-server. This PR automatically falls back to setTimeout when setImmediate is not available. Resolves #4040

Validated dice roller collab works without the setImmediate polyfill with this change (validated via node modules hackery)