### PR TITLE
Add instructions for installing windows-build-tools to routerlicious readme

### DIFF
--- a/server/routerlicious/README.md
+++ b/server/routerlicious/README.md
@@ -40,6 +40,7 @@ below steps if you'd like to run a local version of the service or need to make 
 
 * [Node v12.x](https://nodejs.org/en/)
 * [Node-gyp](https://github.com/nodejs/node-gyp) dependencies
+    * If building on Windows, the easiest way to install the dependencies is with windows-build-tools: `npm install --global --production windows-build-tools`
 
 ### Development
 


### PR DESCRIPTION
There are a couple dependencies that don't seem to have or find precompiled binaries, even on latest versions.  Installing the windows-build-tools seems like the easiest path to successful install, confirmed it worked for me on a clean install.