### PR TITLE
don't add empty .blobs tree to snapshot

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -95,7 +95,10 @@ export class BlobManager {
         }
     }
 
-    public snapshot(): ITree {
+    public snapshot(): ITree | undefined {
+        if (this.blobIds.size === 0) {
+            return;
+        }
         const entries = [...this.blobIds].map((id) => new AttachmentTreeEntry(id, id));
         return { entries, id: null };
     }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1079,8 +1079,10 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             const content = JSON.stringify([...this.chunkMap]);
             summaryTreeBuilder.addBlob(chunksBlobName, content);
         }
-        const blobsTree = convertToSummaryTree(this.blobManager.snapshot(), false);
-        summaryTreeBuilder.addWithStats(".blobs", blobsTree);
+        const blobsTree = this.blobManager.snapshot();
+        if (blobsTree) {
+            summaryTreeBuilder.addWithStats(".blobs", convertToSummaryTree(blobsTree, false));
+        }
     }
 
     public async requestSnapshot(tagMessage: string): Promise<void> {


### PR DESCRIPTION
Only add ".blobs" tree to snapshot when there are blob IDs being tracked by BlobManager.