### PR TITLE
Back compat for future request routing work

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -972,7 +972,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const requestParser = RequestParser.create(request);
         const id = requestParser.pathParts[0];
 
-        if (id === "_channel") {
+        if (id === "_channels") {
             return this.resolveHandle(requestParser.createSubRequest(1));
         }
 

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -284,7 +284,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         const parser = RequestParser.create(request);
         const id = parser.pathParts[0];
 
-        if (id === "_channels" || id === "_objects") {
+        if (id === "_channels" || id === "_custom") {
             return this.request(parser.createSubRequest(1));
         }
 


### PR DESCRIPTION
Reviving request routing work. Prepping back compat - fixing typo (_channel -> _channels), and switching to _objects -> _custom per Curtis feedback.

