### PR TITLE
Remove deprecated debug statement

### DIFF
--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { debug } from "util";
 import { ITokenClaims, IUser, ScopeType } from "@fluidframework/protocol-definitions";
 import * as jwt from "jsonwebtoken";
 import { v4 as uuid } from "uuid";
@@ -23,7 +22,7 @@ export function generateToken(
     // eslint-disable-next-line @typescript-eslint/no-use-before-define, no-param-reassign
     user = (user) ? user : generateUser();
     if (user.id === "" || user.id === undefined) {
-        debug("User with no id");
+        console.error("User with no id");
         // eslint-disable-next-line @typescript-eslint/no-use-before-define, no-param-reassign
         user = generateUser();
     }


### PR DESCRIPTION
Use console.error instead of debug here since debug has been deprecated and causes errors when we generate a r11s token for Gateway, with no user passed in

https://node.readthedocs.io/en/latest/api/util/#utildebugstring
![image](https://user-images.githubusercontent.com/7992711/98885274-94f00280-2446-11eb-919f-f2a314ebdbb5.png)
