### PR TITLE
Optional constructor parameter causes OdspUrlResolver2 to use PPE MS Graph

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver2.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver2.ts
@@ -34,6 +34,7 @@ export class OdspDriverUrlResolver2 implements IUrlResolver {
         private readonly identityType: IdentityType = "Enterprise",
         logger?: ITelemetryBaseLogger,
         private readonly appName?: string,
+        private readonly usePPE?: boolean,
     ) {
         this.logger = ChildLogger.create(logger, "OdspDriver");
         this.getSharingLinkToken = this.toInstrumentedSharingLinkTokenFetcher(this.logger, tokenFetcher);
@@ -152,6 +153,8 @@ export class OdspDriverUrlResolver2 implements IUrlResolver {
             this.identityType,
             this.logger,
             "existingAccess",
+            undefined,
+            this.usePPE,
         ).then((shareLink) => {
                 if (!shareLink) {
                     throw new Error("Failed to get share link");


### PR DESCRIPTION
OdspUrlResolver2 makes calls to Prod MS Graph.  This URL is hard coded and cannot be changed by package consumers.  The proposal is to add an optional boolean flag that causes it to target PPE Graph instead.