### PR TITLE
Providing tenant info for InsecureTokenProvider to support Tinylicious

### DIFF
--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -66,8 +66,6 @@ export interface IRouterliciousRouteOptions extends IBaseRouteOptions {
 
 export interface ITinyliciousRouteOptions extends IBaseRouteOptions {
     mode: "tinylicious";
-    tenantId?: string;
-    tenantSecret?: string;
     bearerSecret?: string;
 }
 

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -66,6 +66,8 @@ export interface IRouterliciousRouteOptions extends IBaseRouteOptions {
 
 export interface ITinyliciousRouteOptions extends IBaseRouteOptions {
     mode: "tinylicious";
+    tenantId?: string;
+    tenantSecret?: string;
     bearerSecret?: string;
 }
 

--- a/packages/tools/webpack-fluid-loader/src/multiDocumentServiceFactory.ts
+++ b/packages/tools/webpack-fluid-loader/src/multiDocumentServiceFactory.ts
@@ -13,7 +13,6 @@ import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
 // eslint-disable-next-line import/no-internal-modules
 import uuid from "uuid/v4";
 import { IDevServerUser, IRouterliciousRouteOptions, RouteOptions } from "./loader";
-import { getuid } from "process";
 
 export const deltaConns = new Map<string, ILocalDeltaConnectionServer>();
 
@@ -34,7 +33,11 @@ export function getDocumentServiceFactory(documentId: string, options: RouteOpti
         getUser());
 
         if (options.mode === "tinylicious") {
-            routerliciousTokenProvider = new InsecureTokenProvider("tinylicious", documentId, "12345", getUser());
+            routerliciousTokenProvider = new InsecureTokenProvider(
+                "tinylicious",
+                documentId,
+                "12345",
+                getUser());
         }
     return MultiDocumentServiceFactory.create([
         new LocalDocumentServiceFactory(deltaConn),

--- a/packages/tools/webpack-fluid-loader/src/multiDocumentServiceFactory.ts
+++ b/packages/tools/webpack-fluid-loader/src/multiDocumentServiceFactory.ts
@@ -13,6 +13,7 @@ import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
 // eslint-disable-next-line import/no-internal-modules
 import uuid from "uuid/v4";
 import { IDevServerUser, IRouterliciousRouteOptions, RouteOptions } from "./loader";
+import { getuid } from "process";
 
 export const deltaConns = new Map<string, ILocalDeltaConnectionServer>();
 
@@ -26,16 +27,15 @@ export function getDocumentServiceFactory(documentId: string, options: RouteOpti
         name: getRandomName(),
     });
 
-    if (options.mode === "tinylicious") {
-        options.tenantId = "tinylicious";
-        options.tenantSecret = "12345";
-    }
-    const routerliciousTokenProvider = new InsecureTokenProvider(
+    let routerliciousTokenProvider = new InsecureTokenProvider(
         (options as IRouterliciousRouteOptions).tenantId ,
         documentId,
         (options as IRouterliciousRouteOptions).tenantSecret,
         getUser());
 
+        if (options.mode === "tinylicious") {
+            routerliciousTokenProvider = new InsecureTokenProvider("tinylicious", documentId, "12345", getUser());
+        }
     return MultiDocumentServiceFactory.create([
         new LocalDocumentServiceFactory(deltaConn),
         // TODO: web socket token

--- a/packages/tools/webpack-fluid-loader/src/multiDocumentServiceFactory.ts
+++ b/packages/tools/webpack-fluid-loader/src/multiDocumentServiceFactory.ts
@@ -26,19 +26,23 @@ export function getDocumentServiceFactory(documentId: string, options: RouteOpti
         name: getRandomName(),
     });
 
-    let routerliciousTokenProvider = new InsecureTokenProvider(
-        (options as IRouterliciousRouteOptions).tenantId ,
-        documentId,
-        (options as IRouterliciousRouteOptions).tenantSecret,
-        getUser());
+    let routerliciousTokenProvider: InsecureTokenProvider;
+    // tokenprovider and routerlicious document service will not be called for local and spo server.
+    if (options.mode === "tinylicious") {
+        routerliciousTokenProvider = new InsecureTokenProvider(
+            "tinylicious",
+            documentId,
+            "12345",
+            getUser());
+    }
+    else {
+        routerliciousTokenProvider = new InsecureTokenProvider(
+            (options as IRouterliciousRouteOptions).tenantId ,
+            documentId,
+            (options as IRouterliciousRouteOptions).tenantSecret,
+            getUser());
+    }
 
-        if (options.mode === "tinylicious") {
-            routerliciousTokenProvider = new InsecureTokenProvider(
-                "tinylicious",
-                documentId,
-                "12345",
-                getUser());
-        }
     return MultiDocumentServiceFactory.create([
         new LocalDocumentServiceFactory(deltaConn),
         // TODO: web socket token

--- a/packages/tools/webpack-fluid-loader/src/multiDocumentServiceFactory.ts
+++ b/packages/tools/webpack-fluid-loader/src/multiDocumentServiceFactory.ts
@@ -26,6 +26,10 @@ export function getDocumentServiceFactory(documentId: string, options: RouteOpti
         name: getRandomName(),
     });
 
+    if (options.mode === "tinylicious") {
+        options.tenantId = "tinylicious";
+        options.tenantSecret = "12345";
+    }
     const routerliciousTokenProvider = new InsecureTokenProvider(
         (options as IRouterliciousRouteOptions).tenantId ,
         documentId,


### PR DESCRIPTION
Fixed #4299 
Provided tenant info of Tinylicious to InsecureTokenProvider.
Curtis suggested this quick fix which is adding tenant info in options. The other solution would be creating multiTokenProvider file and handle different cases there, which I can do later. Thanks to Navin who quickly found the solution.