### PR TITLE
Fix UX tests for 0.1015 package bump

### DIFF
--- a/examples/apps/collaborative-textarea/tests/collaborativetext.test.ts
+++ b/examples/apps/collaborative-textarea/tests/collaborativetext.test.ts
@@ -64,8 +64,16 @@ describe("collaborativetext", () => {
 
         setText(0, "hello");
 
-        await page.waitFor(100);
-        
+        await page.waitForFunction( async () => {
+                const divs = document.getElementsByClassName("text-area");
+                const textAreaElements = divs[0].getElementsByTagName("textarea");
+                const textarea = textAreaElements[0] as HTMLTextAreaElement;
+                if (textarea) {
+                    return textarea.value.includes("hello");
+                }
+            }, { timeout: 1000 }
+        );
+
         const ta12 = await getValue(0);
         expect(ta12).toEqual("hello");
 

--- a/examples/apps/collaborative-textarea/tests/collaborativetext.test.ts
+++ b/examples/apps/collaborative-textarea/tests/collaborativetext.test.ts
@@ -64,6 +64,8 @@ describe("collaborativetext", () => {
 
         setText(0, "hello");
 
+        await page.waitFor(100);
+        
         const ta12 = await getValue(0);
         expect(ta12).toEqual("hello");
 

--- a/examples/data-objects/clicker-react/clicker-react/tests/clicker.test.ts
+++ b/examples/data-objects/clicker-react/clicker-react/tests/clicker.test.ts
@@ -42,7 +42,10 @@ describe("clicker", () => {
 
         // Click the button
         await expect(page).toClick("button", { text: "+" });
-        await page.waitFor(100);
+        await page.waitForFunction(() => 
+            (document.querySelector(".value") as HTMLDivElement).innerText.includes("1"),
+            { timeout: 1000 }
+        );
         // Validate both users have 1 as their value
         const postValue = await getValue(0);
         expect(postValue).toEqual("1");
@@ -62,7 +65,10 @@ describe("clicker", () => {
 
         // Click the button
         await expect(page).toClick("button", { text: "+" });
-        await page.waitFor(100);
+        await page.waitForFunction(() => 
+            (document.querySelector(".value") as HTMLDivElement).innerText.includes("1"),
+            { timeout: 1000 }
+        );
         // Validate both users have 1 as their value
         const postValue = await getValue(0);
         expect(postValue).toEqual("1");

--- a/examples/data-objects/clicker-react/clicker-react/tests/clicker.test.ts
+++ b/examples/data-objects/clicker-react/clicker-react/tests/clicker.test.ts
@@ -42,7 +42,7 @@ describe("clicker", () => {
 
         // Click the button
         await expect(page).toClick("button", { text: "+" });
-
+        await page.waitFor(100);
         // Validate both users have 1 as their value
         const postValue = await getValue(0);
         expect(postValue).toEqual("1");
@@ -62,7 +62,7 @@ describe("clicker", () => {
 
         // Click the button
         await expect(page).toClick("button", { text: "+" });
-
+        await page.waitFor(100);
         // Validate both users have 1 as their value
         const postValue = await getValue(0);
         expect(postValue).toEqual("1");

--- a/examples/data-objects/clicker-react/clicker-reducer/tests/clicker.test.ts
+++ b/examples/data-objects/clicker-react/clicker-reducer/tests/clicker.test.ts
@@ -43,8 +43,11 @@ describe("clicker", () => {
         // Click the button
         await expect(page).toClick("button", { text: "+" });
 
-        await page.waitFor(100);
-        
+        await page.waitForFunction(() => 
+            (document.querySelector(".value") as HTMLDivElement).innerText.includes("1"),
+            { timeout: 1000 }
+        );
+
         // Validate both users have 1 as their value
         const postValue = await getValue(0);
         expect(postValue).toEqual("1");
@@ -64,6 +67,11 @@ describe("clicker", () => {
 
         // Click the button
         await expect(page).toClick("button", { text: "+" });
+
+        await page.waitForFunction(() => 
+            (document.querySelector(".value") as HTMLDivElement).innerText.includes("1"),
+            { timeout: 1000 }
+        );
 
         // Validate both users have 1 as their value
         const postValue = await getValue(0);

--- a/examples/data-objects/clicker-react/clicker-reducer/tests/clicker.test.ts
+++ b/examples/data-objects/clicker-react/clicker-reducer/tests/clicker.test.ts
@@ -43,6 +43,8 @@ describe("clicker", () => {
         // Click the button
         await expect(page).toClick("button", { text: "+" });
 
+        await page.waitFor(100);
+        
         // Validate both users have 1 as their value
         const postValue = await getValue(0);
         expect(postValue).toEqual("1");

--- a/examples/data-objects/clicker-react/clicker-with-hook/tests/clicker.test.ts
+++ b/examples/data-objects/clicker-react/clicker-with-hook/tests/clicker.test.ts
@@ -42,6 +42,7 @@ describe("clicker", () => {
 
         // Click the button
         await expect(page).toClick("button", { text: "+" });
+        await page.waitFor(100);
 
         // Validate both users have 1 as their value
         const postValue = await getValue(0);

--- a/examples/data-objects/clicker-react/clicker-with-hook/tests/clicker.test.ts
+++ b/examples/data-objects/clicker-react/clicker-with-hook/tests/clicker.test.ts
@@ -42,7 +42,10 @@ describe("clicker", () => {
 
         // Click the button
         await expect(page).toClick("button", { text: "+" });
-        await page.waitFor(100);
+        await page.waitForFunction(() => 
+            (document.querySelector(".value") as HTMLDivElement).innerText.includes("1"),
+            { timeout: 1000 }
+        );
 
         // Validate both users have 1 as their value
         const postValue = await getValue(0);
@@ -63,6 +66,10 @@ describe("clicker", () => {
 
         // Click the button
         await expect(page).toClick("button", { text: "+" });
+        await page.waitForFunction(() => 
+            (document.querySelector(".value") as HTMLDivElement).innerText.includes("1"),
+            { timeout: 1000 }
+        );
 
         // Validate both users have 1 as their value
         const postValue = await getValue(0);

--- a/examples/data-objects/clicker/tests/clicker.test.ts
+++ b/examples/data-objects/clicker/tests/clicker.test.ts
@@ -42,7 +42,11 @@ describe("clicker", () => {
 
         // Click the button
         await expect(page).toClick("button", { text: "+" });
-        await page.waitFor(100);
+        await page.waitForFunction( () => 
+            (document.querySelector(".clicker-value-class") as HTMLDivElement).innerText.includes("1"),
+            { timeout: 1000 }
+        );
+
 
         // Validate both users have 1 as their value
         const postValue = await getValue(0);
@@ -63,6 +67,10 @@ describe("clicker", () => {
 
         // Click the button
         await expect(page).toClick("button", { text: "+" });
+        await page.waitForFunction( () => 
+            (document.querySelector(".clicker-value-class") as HTMLDivElement).innerText.includes("1"),
+            { timeout: 1000 }
+        );
 
         // Validate both users have 1 as their value
         const postValue = await getValue(0);

--- a/examples/data-objects/clicker/tests/clicker.test.ts
+++ b/examples/data-objects/clicker/tests/clicker.test.ts
@@ -42,6 +42,7 @@ describe("clicker", () => {
 
         // Click the button
         await expect(page).toClick("button", { text: "+" });
+        await page.waitFor(100);
 
         // Validate both users have 1 as their value
         const postValue = await getValue(0);

--- a/examples/data-objects/pond/src/data-objects/clicker.tsx
+++ b/examples/data-objects/pond/src/data-objects/clicker.tsx
@@ -120,12 +120,12 @@ class CounterReactView extends React.Component<CounterProps, CounterState> {
                 <h3>Clicker</h3>
                 <h5>Clicker on the root directory increments 1</h5>
                 <div>
-                    <span className="clicker-value-class-5+1">{this.state.value1}</span>
+                    <span className="clicker-value-class-5">{this.state.value1}</span>
                     <button onClick={() => { this.props.counter1.increment(1); }}>+1</button>
                 </div>
                 <h5>Clicker on a map on the root directory increments 10</h5>
                 <div>
-                    <span className="clicker-value-class-0+10">{this.state.value2}</span>
+                    <span className="clicker-value-class-10">{this.state.value2}</span>
                     <button onClick={() => { this.props.counter2.increment(10); }}>+10</button>
                 </div>
             </div>

--- a/examples/data-objects/pond/tests/pond.test.ts
+++ b/examples/data-objects/pond/tests/pond.test.ts
@@ -30,41 +30,47 @@ describe("pond", () => {
                 if (clicker) {
                     return clicker.innerText;
                 }
-
+        
                 return "";
             }, index, classId);
         };
+        
 
         // Validate both users have 5 as their value
-        const preValue_51 = await getValue(0, "clicker-value-class-5+1");
+        const preValue_51 = await getValue(0, "clicker-value-class-5");
         expect(preValue_51).toEqual("5");
-        const preValue2_51 = await getValue(1, "clicker-value-class-5+1");
+        const preValue2_51 = await getValue(1, "clicker-value-class-5");
         expect(preValue2_51).toEqual("5");
 
         // Click the +1 button
         await expect(page).toClick("button", { text: "+1" });
-        await page.waitFor(100);
-
+        await page.waitForFunction( () => 
+            (document.querySelector(".clicker-value-class-5") as HTMLDivElement).innerText.includes("6"),
+            { timeout: 1000 }
+        );
         // Validate both users have 6 as their value
-        const postValue_51 = await getValue(0, "clicker-value-class-5+1");
+        const postValue_51 = await getValue(0, "clicker-value-class-5");
         expect(postValue_51).toEqual("6");
-        const postValue2_51 = await getValue(1, "clicker-value-class-5+1");
+        const postValue2_51 = await getValue(1, "clicker-value-class-5");
         expect(postValue2_51).toEqual("6");
 
         // Validate both users have 0 as their value
-        const preValue_010 = await getValue(0, "clicker-value-class-0+10");
+        const preValue_010 = await getValue(0, "clicker-value-class-10");
         expect(preValue_010).toEqual("0");
-        const preValue2_010 = await getValue(1, "clicker-value-class-0+10");
+        const preValue2_010 = await getValue(1, "clicker-value-class-10");
         expect(preValue2_010).toEqual("0");
 
         // Click the +10 button
         await expect(page).toClick("button", { text: "+10" });
-        await page.waitFor(100);
+        await page.waitForFunction( () => 
+            (document.querySelector(".clicker-value-class-10") as HTMLDivElement).innerText.includes("10"),
+            { timeout: 1000 }
+        );
 
         // Validate both users have 10 as their value
-        const postValue_010 = await getValue(0, "clicker-value-class-0+10");
+        const postValue_010 = await getValue(0, "clicker-value-class-10");
         expect(postValue_010).toEqual("10");
-        const postValue2_010 = await getValue(1, "clicker-value-class-0+10");
+        const postValue2_010 = await getValue(1, "clicker-value-class-10");
         expect(postValue2_010).toEqual("10");
     });
 });

--- a/examples/data-objects/pond/tests/pond.test.ts
+++ b/examples/data-objects/pond/tests/pond.test.ts
@@ -43,6 +43,7 @@ describe("pond", () => {
 
         // Click the +1 button
         await expect(page).toClick("button", { text: "+1" });
+        await page.waitFor(100);
 
         // Validate both users have 6 as their value
         const postValue_51 = await getValue(0, "clicker-value-class-5+1");
@@ -58,6 +59,7 @@ describe("pond", () => {
 
         // Click the +10 button
         await expect(page).toClick("button", { text: "+10" });
+        await page.waitFor(100);
 
         // Validate both users have 10 as their value
         const postValue_010 = await getValue(0, "clicker-value-class-0+10");


### PR DESCRIPTION
- Adds a page.waitForFunction that delays checking for updated UI values in tests that trigger an async call from user actions. This delays the check until the change has actually reflected in the UI using selectors to verify if the checked value has changed.
- This fixes the tests in pond, collaborative-text, clicker-reducer, and clicker-react packages as they were checking the value immediately and failing with 0.1015 server bump (https://dev.azure.com/fluidframework/public/_build/results?buildId=9644&view=logs&j=7e6a3fb7-dbfe-5169-4db8-92b72295ba6c&t=79e8be69-8a79-5815-3f51-23227749607b)