### PR TITLE
Hide codeLoader on the ContainerContext

### DIFF
--- a/examples/data-objects/shared-text/src/component.ts
+++ b/examples/data-objects/shared-text/src/component.ts
@@ -165,7 +165,6 @@ export class SharedTextRunner
             // The flowContainerMap MUST be set last
 
             const flowContainerMap = this.collabDoc.createMap();
-            flowContainerMap.set("overlayInk", this.collabDoc.createMap().handle);
             this.rootView.set("flowContainerMap", flowContainerMap.handle);
 
             insights.set(newString.id, this.collabDoc.createMap().handle);

--- a/examples/data-objects/shared-text/src/index.ts
+++ b/examples/data-objects/shared-text/src/index.ts
@@ -7,15 +7,11 @@
 // eslint-disable-next-line import/no-unassigned-import
 import "./publicpath";
 
-import { assert } from "@fluidframework/common-utils";
 import { IContainerContext, IRuntime, IRuntimeFactory } from "@fluidframework/container-definitions";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
 import {
     IFluidDataStoreContext,
     IFluidDataStoreFactory,
-    IFluidDataStoreRegistry,
-    IProvideFluidDataStoreFactory,
-    IProvideFluidDataStoreRegistry,
     NamedFluidDataStoreRegistryEntries,
 } from "@fluidframework/runtime-definitions";
 import {
@@ -61,31 +57,6 @@ const defaultRegistryEntries: NamedFluidDataStoreRegistryEntries = [
     ["@fluid-example/image-collection", images.then((m) => m.fluidExport)],
 ];
 
-class MyRegistry implements IFluidDataStoreRegistry {
-    constructor(
-        private readonly context: IContainerContext,
-        private readonly defaultRegistry: string) {
-    }
-
-    public get IFluidDataStoreRegistry() { return this; }
-
-    public async get(name: string): Promise<IProvideFluidDataStoreFactory | IProvideFluidDataStoreRegistry> {
-        const scope = `${name.split("/")[0]}:cdn`;
-        const config = {};
-        config[scope] = this.defaultRegistry;
-
-        const codeDetails = {
-            package: name,
-            config,
-        };
-        const fluidModule = await this.context.codeLoader.load(codeDetails);
-        const moduleExport = fluidModule.fluidExport;
-        assert(moduleExport.IFluidDataStoreFactory !== undefined ||
-            moduleExport.IFluidDataStoreRegistry  !== undefined);
-        return moduleExport as IProvideFluidDataStoreFactory | IProvideFluidDataStoreRegistry;
-    }
-}
-
 class SharedTextFactoryComponent implements IFluidDataStoreFactory, IRuntimeFactory {
     public static readonly type = "@fluid-example/shared-text";
     public readonly type = SharedTextFactoryComponent.type;
@@ -106,10 +77,6 @@ class SharedTextFactoryComponent implements IFluidDataStoreFactory, IRuntimeFact
             [
                 ...defaultRegistryEntries,
                 [SharedTextFactoryComponent.type, Promise.resolve(this)],
-                [
-                    "verdaccio",
-                    Promise.resolve(new MyRegistry(context, "https://pragueauspkn.azureedge.net")),
-                ],
             ],
             buildRuntimeRequestHandler(
                 defaultRouteRequestHandler(DefaultComponentName),

--- a/packages/loader/container-definitions/src/runtime.ts
+++ b/packages/loader/container-definitions/src/runtime.ts
@@ -27,7 +27,7 @@ import {
 import { IAudience } from "./audience";
 import { IDeltaManager } from "./deltas";
 import { ICriticalContainerError, ContainerWarning } from "./error";
-import { ICodeLoader, ILoader } from "./loader";
+import { ILoader } from "./loader";
 
 // Represents the attachment state of the entity.
 export enum AttachState {
@@ -132,7 +132,6 @@ export interface IContainerContext extends IDisposable {
     readonly quorum: IQuorum;
     readonly audience: IAudience | undefined;
     readonly loader: ILoader;
-    readonly codeLoader: ICodeLoader;
     readonly logger: ITelemetryLogger;
     readonly serviceConfiguration: IServiceConfiguration | undefined;
     readonly version: string;

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -185,7 +185,7 @@ export class ContainerContext implements IContainerContext {
     constructor(
         private readonly container: Container,
         public readonly scope: IFluidObject,
-        public readonly codeLoader: ICodeLoader,
+        private readonly codeLoader: ICodeLoader,
         public readonly codeDetails: IFluidCodeDetails,
         private readonly _baseSnapshot: ISnapshotTree | undefined,
         private readonly attributes: IDocumentAttributes,


### PR DESCRIPTION
Goal is to reduce visibility of the codeLoader to help with layering.

Currently the only scenario trying to use it is verdaccio-based loading in shared-text, which I don't think we've supported for some time.  I'm suspecting it would be better to explicitly pass the codeLoader through container scope if we want to support arbitrary code loading like this, rather than implicitly making it available on the context.