### PR TITLE
Remove setimmediate polyfill

### DIFF
--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -80,7 +80,6 @@
     "express": "^4.16.3",
     "moniker": "^0.1.2",
     "nconf": "^0.10.0",
-    "setimmediate": "^1.0.5",
     "uuid": "^3.3.2",
     "webpack-dev-server": "^3.8.0"
   },

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -30,11 +30,6 @@ import { RequestParser, createDataStoreFactory } from "@fluidframework/runtime-u
 import { MultiUrlResolver } from "./multiResolver";
 import { deltaConns, getDocumentServiceFactory } from "./multiDocumentServiceFactory";
 
-// SetImmediate is needed by broadcaster/lambdas, but is not available in the browser.
-// Need a polyfill until this issue is resolved https://github.com/microsoft/FluidFramework/issues/4040
-// eslint-disable-next-line import/no-unassigned-import
-import "setimmediate";
-
 export interface IDevServerUser extends IUser {
     name: string;
 }


### PR DESCRIPTION
We've addressed all the known issues with setImmediate usage in local server scenarios, we can remove the setImmediate polyfill!