### PR TITLE
Make Vltava work again / remove extra layer in PureDataObjectFactory

### DIFF
--- a/examples/apps/spaces/src/fluid-object/index.tsx
+++ b/examples/apps/spaces/src/fluid-object/index.tsx
@@ -9,7 +9,6 @@ import { Layout } from "react-grid-layout";
 import {
     DataObject,
     DataObjectFactory,
-    getFluidObjectFactoryFromInstance,
 } from "@fluidframework/aqueduct";
 import {
     IFluidHandle,
@@ -184,7 +183,7 @@ export class Spaces extends DataObject implements IFluidHTMLView {
             throw new Error("Unknown item, can't add");
         }
 
-        const serializableObject = await itemMapEntry.create(getFluidObjectFactoryFromInstance(this.context));
+        const serializableObject = await itemMapEntry.create(this.context);
         return this.storageComponent.addItem(
             {
                 serializableObject,

--- a/examples/apps/spaces/src/fluid-object/spacesItemMap.ts
+++ b/examples/apps/spaces/src/fluid-object/spacesItemMap.ts
@@ -5,7 +5,11 @@
 
 import { IFluidHandle, IFluidLoadable } from "@fluidframework/core-interfaces";
 import { AsSerializable, Serializable } from "@fluidframework/datastore-definitions";
-import { NamedFluidDataStoreRegistryEntries, IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
+import {
+    NamedFluidDataStoreRegistryEntries,
+    IFluidDataStoreFactory,
+    IFluidDataStoreContext,
+} from "@fluidframework/runtime-definitions";
 import { ReactViewAdapter } from "@fluidframework/view-adapters";
 import { fluidExport as cmfe } from "@fluid-example/codemirror/dist/codemirror";
 import { CollaborativeText } from "@fluid-example/collaborative-textarea";
@@ -13,7 +17,7 @@ import { Coordinate } from "@fluid-example/multiview-coordinate-model";
 import { SliderCoordinateView } from "@fluid-example/multiview-slider-coordinate-view";
 import { fluidExport as pmfe } from "@fluid-example/prosemirror/dist/prosemirror";
 import { ClickerInstantiationFactory } from "@fluid-example/clicker";
-import { IFluidDataObjectFactory } from "@fluidframework/aqueduct";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
 
 import * as React from "react";
 import { Layout } from "react-grid-layout";
@@ -24,8 +28,10 @@ interface ISingleHandleItem {
 
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 function createSingleHandleItem(subFactory: IFluidDataStoreFactory) {
-    return async (dataObjectFactory: IFluidDataObjectFactory): Promise<ISingleHandleItem> => {
-        const object = await dataObjectFactory.createAnonymousChildInstance<IFluidLoadable>(subFactory);
+    return async (context: IFluidDataStoreContext): Promise<ISingleHandleItem> => {
+        const packagePath = [...context.packagePath, subFactory.type];
+        const router = await context.containerRuntime.createDataStore(packagePath);
+        const object = await requestFluidObject<IFluidLoadable>(router, "/");
         return {
             handle: object.handle,
         };
@@ -50,7 +56,7 @@ const getSliderCoordinateView = async (serializableObject: ISingleHandleItem) =>
 export interface ISpacesItemEntry<T extends Serializable = AsSerializable<any>> {
     // Would be better if items to bring their own subregistries, and their own ability to create components
     // This might be done by integrating these items with the Spaces subcomponent registry?
-    create: (createSubObject: IFluidDataObjectFactory) => Promise<T>;
+    create: (context: IFluidDataStoreContext) => Promise<T>;
     getView: (serializableObject: T) => Promise<JSX.Element>;
     friendlyName: string;
     fabricIconName: string;

--- a/examples/data-objects/vltava/src/fluidObjects/anchor/anchor.ts
+++ b/examples/data-objects/vltava/src/fluidObjects/anchor/anchor.ts
@@ -30,7 +30,16 @@ export class Anchor extends DataObject implements IProvideFluidHTMLView, IProvid
         return this.defaultFluidObjectInternal;
     }
 
-    private static readonly factory = new DataObjectFactory("anchor", Anchor, [], {});
+    private static readonly factory = new DataObjectFactory(
+        "anchor",
+        Anchor,
+        [],
+        {},
+        [
+            LastEditedTrackerDataObject.getFactory().registryEntry,
+            Vltava.getFactory().registryEntry,
+        ],
+        );
 
     public static getFactory() {
         return Anchor.factory;
@@ -47,7 +56,7 @@ export class Anchor extends DataObject implements IProvideFluidHTMLView, IProvid
     }
 
     protected async initializingFirstTime() {
-        const defaultFluidObject = await Vltava.getFactory().createInstance(this.context.containerRuntime);
+        const defaultFluidObject = await Vltava.getFactory().createChildInstance(this.context);
         this.root.set(this.defaultFluidObjectId, defaultFluidObject.handle);
 
         const lastEditedFluidObject = await LastEditedTrackerDataObject.getFactory().createChildInstance(this.context);

--- a/examples/data-objects/vltava/src/fluidObjects/tabs/dataModel.ts
+++ b/examples/data-objects/vltava/src/fluidObjects/tabs/dataModel.ts
@@ -18,8 +18,6 @@ import {
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 
-import { IFluidDataObjectFactory } from "@fluidframework/aqueduct";
-
 import { v4 as uuid } from "uuid";
 
 import { IFluidObjectInternalRegistry } from "../../interfaces";
@@ -43,12 +41,12 @@ export interface ITabsDataModel extends EventEmitter {
 }
 
 export class TabsDataModel extends EventEmitter implements ITabsDataModel {
-    private tabs: IDirectory;
+    private readonly tabs: IDirectory;
 
     constructor(
         public root: ISharedDirectory,
         private readonly internalRegistry: IFluidObjectInternalRegistry,
-        private readonly createSubObject: IFluidDataObjectFactory,
+        private readonly createSubObject: (factory: IFluidDataStoreFactory) => Promise<IFluidLoadable>,
         private readonly getFluidObjectFromDirectory: <T extends IFluidObject & IFluidLoadable>(
             id: string,
             directory: IDirectory,
@@ -57,7 +55,11 @@ export class TabsDataModel extends EventEmitter implements ITabsDataModel {
     ) {
         super();
 
-        this.tabs = root.getSubDirectory("tab-ids");
+        const tabs = "tab-ids";
+        if (!root.hasSubDirectory(tabs)) {
+            root.createSubDirectory(tabs);
+        }
+        this.tabs = root.getSubDirectory(tabs);
 
         root.on(
             "valueChanged",
@@ -67,7 +69,7 @@ export class TabsDataModel extends EventEmitter implements ITabsDataModel {
                 op: ISequencedDocumentMessage,
                 target: ISharedDirectory,
             ) => {
-                if (changed.path === this.tabs.absolutePath && !local) {
+                if (changed.path === this.tabs.absolutePath) {
                     this.emit("newTab", local);
                 }
             });
@@ -79,13 +81,12 @@ export class TabsDataModel extends EventEmitter implements ITabsDataModel {
 
     public async createTab(factory: IFluidDataStoreFactory): Promise<string> {
         const newKey = uuid();
-        const fluidObject = await this.createSubObject.createAnonymousChildInstance<IFluidLoadable>(factory);
+        const fluidObject = await this.createSubObject(factory);
         this.tabs.set(newKey, {
             type: factory.type,
             handleOrId: fluidObject.handle,
         });
 
-        this.emit("newTab", true);
         return newKey;
     }
 
@@ -95,7 +96,6 @@ export class TabsDataModel extends EventEmitter implements ITabsDataModel {
     }
 
     public async getFluidObjectTab(id: string): Promise<IFluidObject | undefined> {
-        this.tabs = this.root.getSubDirectory("tab-ids");
         return this.getFluidObjectFromDirectory(id, this.tabs, this.getObjectFromDirectory);
     }
 

--- a/examples/data-objects/vltava/src/fluidObjects/vltava/dataModel.ts
+++ b/examples/data-objects/vltava/src/fluidObjects/vltava/dataModel.ts
@@ -9,7 +9,6 @@ import { IFluidObject, IFluidHandle } from "@fluidframework/core-interfaces";
 import { IFluidLastEditedTracker } from "@fluidframework/last-edited-experimental";
 import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
-import { ISharedDirectory } from "@fluidframework/map";
 import { IQuorum, ISequencedClient } from "@fluidframework/protocol-definitions";
 import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
 import { handleFromLegacyUri } from "@fluidframework/request-handler";
@@ -42,7 +41,7 @@ export class VltavaDataModel extends EventEmitter implements IVltavaDataModel {
     }
 
     constructor(
-        private readonly root: ISharedDirectory,
+        private readonly defaultFluidObject: IFluidHandle,
         private readonly context: IFluidDataStoreContext,
         runtime: IFluidDataStoreRuntime,
     ) {
@@ -60,7 +59,7 @@ export class VltavaDataModel extends EventEmitter implements IVltavaDataModel {
     }
 
     public async getDefaultFluidObject(): Promise<IFluidObject> {
-        return this.root.get<IFluidHandle>("tabs-id").get();
+        return this.defaultFluidObject.get();
     }
 
     public getTitle(): string {

--- a/examples/data-objects/vltava/src/fluidObjects/vltava/vltava.tsx
+++ b/examples/data-objects/vltava/src/fluidObjects/vltava/vltava.tsx
@@ -5,6 +5,7 @@
 
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
 
 import React from "react";
 import ReactDOM from "react-dom";
@@ -12,6 +13,8 @@ import ReactDOM from "react-dom";
 import { TabsFluidObject } from "../tabs";
 import { IVltavaDataModel, VltavaDataModel } from "./dataModel";
 import { VltavaView } from "./view";
+
+const defaultObjectId = "tabs-id";
 
 /**
  * Vltava is an application experience
@@ -36,14 +39,14 @@ export class Vltava extends DataObject implements IFluidHTMLView {
     public get IFluidHTMLView() { return this; }
 
     protected async initializingFirstTime() {
-        const tabsFluidObject = await TabsFluidObject.getFactory().createChildInstance(this.context);
-        this.root.set("tabs-component-id", tabsFluidObject.handle);
+        const tabsFluidObject = await TabsFluidObject.getFactory().createInstance(this.context.containerRuntime);
+        this.root.set(defaultObjectId, tabsFluidObject.handle);
     }
 
     protected async hasInitialized() {
         this.dataModelInternal =
             new VltavaDataModel(
-                this.root,
+                this.root.get<IFluidHandle>(defaultObjectId),
                 this.context,
                 this.runtime);
     }

--- a/examples/data-objects/vltava/src/index.ts
+++ b/examples/data-objects/vltava/src/index.ts
@@ -11,7 +11,6 @@ import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqu
 import { IFluidObject } from "@fluidframework/core-interfaces";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import {
-    LastEditedTrackerDataObject,
     setupLastEditedTrackerForContainer,
     IFluidLastEditedTracker,
 } from "@fluidframework/last-edited-experimental";
@@ -26,7 +25,6 @@ import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
     Anchor,
     TabsFluidObject,
-    Vltava,
 } from "./fluidObjects";
 import {
     IFluidObjectInternalRegistry,
@@ -133,10 +131,8 @@ const generateFactory = () => {
         Anchor.getFactory(),
         [
             ...containerFluidObjects,
-            LastEditedTrackerDataObject.getFactory().registryEntry,
             // We don't want to include the default wrapper fluidObject in our list of available fluidObjects
             Anchor.getFactory().registryEntry,
-            Vltava.getFactory().registryEntry,
             ["internalRegistry", Promise.resolve(new InternalRegistry(containerFluidObjectsDefinition))],
         ],
     );

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/common-utils";
-import { IRequest, IFluidObject, IFluidRouter } from "@fluidframework/core-interfaces";
+import { IRequest, IFluidRouter } from "@fluidframework/core-interfaces";
 import {
     FluidDataStoreRuntime,
     ISharedObjectRegistry,
@@ -24,7 +23,6 @@ import {
 } from "@fluidframework/runtime-definitions";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { IChannelFactory } from "@fluidframework/datastore-definitions";
-import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
     FluidObjectSymbolProvider,
     DependencyContainer,
@@ -43,76 +41,6 @@ export interface IRootDataObjectFactory extends IFluidDataStoreFactory {
         rootDataStoreId: string,
         runtime: IContainerRuntime): Promise<IFluidRouter>;
 }
-
-function buildRegistryPath(
-    context: IFluidDataStoreContext,
-    factory: IFluidDataStoreFactory)
-{
-    const parentPath = context.packagePath;
-    assert(parentPath.length > 0);
-    // A factory should  not contain the registry for itself.
-    assert(parentPath[parentPath.length - 1] !== factory.type);
-    return [...parentPath, factory.type];
-}
-
-/*
- * This interface is exposed by data store objects to create sub-objects.
- * It assumes that factories passed in to methods of this interface are present in registry of object's context
- * that is represented by this interface.
- */
-export interface IFluidDataObjectFactory {
-    /**
-     * Creates a new child instance of the object. Uses PureDataObjectFactory for that, and thus we
-     * have type information about object created and can pass in initia state.
-     * @param initialState - The initial state to provide to the created component.
-     * @returns an object created by this factory. Data store and objects created are not attached to container.
-     * They get attached only when a handle to one of them is attached to already attached objects.
-     */
-    createChildInstance<
-        TObject extends PureDataObject<O, S, E>,
-        TFactory extends PureDataObjectFactory<TObject, O, S, E>,
-        O, S, E extends IEvent = IEvent>
-    (subFactory: TFactory, initialState?: S): Promise<TObject>;
-
-    /**
-     * Similar to above, but uses any data store factory. Given that there is no type information about such factory
-     * (or objects it creates, hanse "Anonymous" in name), IFluidObject (by default) is returned by doing a request
-     * to created data store.
-     */
-    createAnonymousChildInstance<T = IFluidObject>(
-        subFactory: IFluidDataStoreFactory,
-        request?: string | IRequest): Promise<T>;
-}
-
-/**
- * An implementation of IFluidDataObjectFactory for PureDataObjectFactory's objects (i.e. PureDataObject).
- */
-class FluidDataObjectFactory {
-    constructor(private readonly context: IFluidDataStoreContext) {
-    }
-
-    public async createChildInstance<
-        TObject extends PureDataObject<O, S, E>,
-        TFactory extends PureDataObjectFactory<TObject, O, S, E>,
-        O, S, E extends IEvent = IEvent>(subFactory: TFactory, initialState?: S)
-    {
-        return subFactory.createChildInstance(this.context, initialState);
-    }
-
-    public async createAnonymousChildInstance<T = IFluidObject>(
-        subFactory: IFluidDataStoreFactory,
-        request: string | IRequest = "/")
-    {
-        const packagePath = buildRegistryPath(this.context, subFactory);
-        const factory2 = await this.context.IFluidDataStoreRegistry?.get(subFactory.type);
-        assert(factory2 === subFactory);
-            const router = await this.context.containerRuntime.createDataStore(packagePath);
-        return requestFluidObject<T>(router, request);
-    }
-}
-
-export const getFluidObjectFactoryFromInstance = (context: IFluidDataStoreContext) =>
-    new FluidDataObjectFactory(context) as IFluidDataObjectFactory;
 
 /**
  * Proxy over PureDataObject
@@ -248,10 +176,9 @@ export class PureDataObjectFactory<TObj extends PureDataObject<O, S, E>, O, S, E
         parentContext: IFluidDataStoreContext,
         initialState?: S,
     ): Promise<TObj> {
-        const packagePath = buildRegistryPath(parentContext, this);
         return this.createNonRootInstanceCore(
             parentContext.containerRuntime,
-            packagePath,
+            [...parentContext.packagePath, this.type],
             initialState);
     }
 


### PR DESCRIPTION
When refactoring PureDataObjectFactory, I've added helper class / interface to assist in creation of child objects.
This layer makes code less readable, but also code today incorrectly creates objects, using wrong context (i.e. creates root object for context where actually it has to be "rooty", i.e. its factory is in root registry on container).
Also Vltava is broken for other reasons, and we use patterns that spread knowledge across multiple modules, thus allowing code to diverge (renames break it).
As a general rule, we should stop using root DDS as an API (i.e. passing around), as that does not provide type safety / protect against changes in structure.
