### PR TITLE
Remove codeDetails from IContainerRuntime

### DIFF
--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -74,7 +74,6 @@ export interface IContainerRuntime extends
     readonly options: any;
     readonly clientId: string | undefined;
     readonly clientDetails: IClientDetails;
-    readonly codeDetails: IFluidCodeDetails;
     readonly connected: boolean;
     readonly leader: boolean;
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -14,7 +14,6 @@ import {
     IRequest,
     IResponse,
     IFluidHandle,
-    IFluidCodeDetails,
 } from "@fluidframework/core-interfaces";
 import {
     IAudience,
@@ -603,10 +602,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     public readonly IFluidSerializer: IFluidSerializer;
 
     public readonly IFluidHandleContext: IFluidHandleContext;
-
-    public get codeDetails(): IFluidCodeDetails {
-        return this.context.codeDetails ?? this.getQuorum().get("code") as IFluidCodeDetails;
-    }
 
     // internal logger for ContainerRuntime
     private readonly _logger: ITelemetryLogger;


### PR DESCRIPTION
~~This change eliminates the concepts of code details, modules, code loading, etc. from `ContainerContext` and `ContainerRuntime`, leaving them only in `Container` for more separation between the layers and reducing their public exposure.~~

~~My end goal here is to make it so scenarios that don't use traditional code proposal and loading (e.g. our HelloWorld example) can completely drop the code loader, making it an opt-in concept.~~

~~Also some small fixes in the area, like typing on `getCodeDetailsFromQuorum()` to acknowledge it may return `undefined`.~~

After chatting with Tony, going for just a very scoped version of this, just removing `IContainerRuntime.codeDetails` which is enough to experiment with an `IContainerRuntime` implementation that is unaware of code proposals.