### PR TITLE
[bump] package version for eslint-config-fluid

### DIFF
--- a/common/build/eslint-config-fluid/package-lock.json
+++ b/common/build/eslint-config-fluid/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/eslint-config-fluid",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/eslint-config-fluid",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Shareable ESLint config for the Fluid Framework",
   "homepage": "https://fluidframework.com",
   "repository": "https://github.com/microsoft/FluidFramework",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/get-session-storage-container": "^0.29.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",

--- a/examples/apps/spaces/package.json
+++ b/examples/apps/spaces/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/get-session-storage-container": "^0.29.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/node": "^10.17.24",

--- a/examples/data-objects/badge/package.json
+++ b/examples/data-objects/badge/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/node": "^10.17.24",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker-react/clicker-context/package.json
+++ b/examples/data-objects/clicker-react/clicker-context/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",

--- a/examples/data-objects/clicker-react/clicker-function/package.json
+++ b/examples/data-objects/clicker-react/clicker-function/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",

--- a/examples/data-objects/clicker-react/clicker-react/package.json
+++ b/examples/data-objects/clicker-react/clicker-react/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker-react/clicker-reducer/package.json
+++ b/examples/data-objects/clicker-react/clicker-reducer/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",

--- a/examples/data-objects/clicker-react/clicker-with-hook/package.json
+++ b/examples/data-objects/clicker-react/clicker-with-hook/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -72,7 +72,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@types/assert": "^1.5.1",
     "@types/debug": "^4.1.5",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/flow-util-lib/package.json
+++ b/examples/data-objects/flow-util-lib/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@types/benchmark": "^1.0.31",
     "@types/mocha": "^5.2.5",

--- a/examples/data-objects/image-collection/package.json
+++ b/examples/data-objects/image-collection/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/image-gallery/package.json
+++ b/examples/data-objects/image-gallery/package.json
@@ -40,7 +40,7 @@
     "react-image-gallery": "^0.9.1"
   },
   "devDependencies": {
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/node": "^10.17.24",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/examples/data-objects/math/package.json
+++ b/examples/data-objects/math/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/node": "^10.17.24",
     "@types/puppeteer": "1.3.0",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/musica/package.json
+++ b/examples/data-objects/musica/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.4.4",
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/node": "^10.17.24",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/pond/package.json
+++ b/examples/data-objects/pond/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/primitives/package.json
+++ b/examples/data-objects/primitives/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/node": "^10.17.24",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/progress-bars/package.json
+++ b/examples/data-objects/progress-bars/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/examples/data-objects/react-inputs/package.json
+++ b/examples/data-objects/react-inputs/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/scribe/package.json
+++ b/examples/data-objects/scribe/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/async": "^2.0.50",
     "@types/lodash": "^4.14.118",

--- a/examples/data-objects/search-menu/package.json
+++ b/examples/data-objects/search-menu/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/simple-fluidobject-embed/package.json
+++ b/examples/data-objects/simple-fluidobject-embed/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/view-interfaces": "^0.29.0"
   },
   "devDependencies": {
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/local-driver": "^0.29.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@fluidframework/runtime-utils": "^0.29.0",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/node": "^10.17.24",

--- a/examples/data-objects/video-players/package.json
+++ b/examples/data-objects/video-players/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/node": "^10.17.24",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -81,7 +81,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/local-driver": "^0.29.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@fluidframework/runtime-utils": "^0.29.0",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",

--- a/examples/hosts/app-integration/external-views/package.json
+++ b/examples/hosts/app-integration/external-views/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",

--- a/examples/hosts/host-service-interfaces/package.json
+++ b/examples/hosts/host-service-interfaces/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/examples/hosts/hosts-sample/package.json
+++ b/examples/hosts/hosts-sample/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
     "concurrently": "^5.2.0",

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/examples/hosts/node-host/package.json
+++ b/examples/hosts/node-host/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
     "concurrently": "^5.2.0",

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
     "@fluidframework/bundle-size-tools": "^0.0.8505",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@mixer/webpack-bundle-compare": "^0.1.0",
     "@types/node": "^10.17.24",
     "@types/puppeteer": "1.3.0",

--- a/examples/utils/fluid-object-interfaces/package.json
+++ b/examples/utils/fluid-object-interfaces/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",

--- a/examples/utils/get-session-storage-container/package.json
+++ b/examples/utils/get-session-storage-container/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/examples/utils/get-tinylicious-container/package.json
+++ b/examples/utils/get-tinylicious-container/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/jsrsasign": "^8.0.8",
     "@types/mocha": "^5.2.5",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1300,9 +1300,9 @@
 			}
 		},
 		"@fluidframework/eslint-config-fluid": {
-			"version": "0.21.0-9126",
-			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.21.0-9126.tgz",
-			"integrity": "sha512-ybEHhIU832ju0c/77g9xNXrebXySlSafgidv2s5LTsXf1xO0I2w6m/cCfW6Osfjb8WgvFC3eCjrOUgIGJ+uXIQ==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.21.0.tgz",
+			"integrity": "sha512-dP67WN/8PzhlckybrCctNq3KVaGF1j/Q7N5d5ywNLyuPG5TntSLtOmwwsHEKzhWtLKZxXLYK6nljq3FwB9r1Gw==",
 			"requires": {
 				"@typescript-eslint/eslint-plugin": "~2.17.0",
 				"@typescript-eslint/parser": "~2.17.0",
@@ -1328,16 +1328,6 @@
 						"tsutils": "^3.17.1"
 					}
 				},
-				"@typescript-eslint/experimental-utils": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.17.0.tgz",
-					"integrity": "sha512-2bNf+mZ/3mj5/3CP56v+ldRK3vFy9jOvmCPs/Gr2DeSJh+asPZrhFniv4QmQsHWQFPJFWhFHgkGgJeRmK4m8iQ==",
-					"requires": {
-						"@types/json-schema": "^7.0.3",
-						"@typescript-eslint/typescript-estree": "2.17.0",
-						"eslint-scope": "^5.0.0"
-					}
-				},
 				"@typescript-eslint/parser": {
 					"version": "2.17.0",
 					"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.17.0.tgz",
@@ -1347,20 +1337,6 @@
 						"@typescript-eslint/experimental-utils": "2.17.0",
 						"@typescript-eslint/typescript-estree": "2.17.0",
 						"eslint-visitor-keys": "^1.1.0"
-					}
-				},
-				"@typescript-eslint/typescript-estree": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.17.0.tgz",
-					"integrity": "sha512-g0eVRULGnEEUakxRfJO0s0Hr1LLQqsI6OrkiCLpdHtdJJek+wyd8mb00vedqAoWldeDcOcP8plqw8/jx9Gr3Lw==",
-					"requires": {
-						"debug": "^4.1.1",
-						"eslint-visitor-keys": "^1.1.0",
-						"glob": "^7.1.6",
-						"is-glob": "^4.0.1",
-						"lodash": "^4.17.15",
-						"semver": "^6.3.0",
-						"tsutils": "^3.17.1"
 					}
 				},
 				"ansi-escapes": {
@@ -1674,30 +1650,12 @@
 						"escape-string-regexp": "^1.0.5"
 					}
 				},
-				"file-entry-cache": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-					"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
-					"requires": {
-						"flat-cache": "^2.0.1"
-					}
-				},
 				"find-up": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"requires": {
 						"locate-path": "^2.0.0"
-					}
-				},
-				"flat-cache": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-					"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
-					"requires": {
-						"flatted": "^2.0.0",
-						"rimraf": "2.6.3",
-						"write": "1.0.3"
 					}
 				},
 				"globals": {
@@ -1893,14 +1851,6 @@
 						"signal-exit": "^3.0.2"
 					}
 				},
-				"rimraf": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
 				"rxjs": {
 					"version": "6.6.3",
 					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
@@ -1973,9 +1923,185 @@
 			}
 		},
 		"@fluidframework/gitresources": {
-			"version": "0.1015.0-9629",
-			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1015.0-9629.tgz",
-			"integrity": "sha512-HIF23QOizA+WqOAyOelHfb9AKTVtyUfuLx7Q106MNERGEhS6eUBytmIeLDaeJb/sVzjPRmjDFkaVFC62wawFeQ=="
+			"version": "0.1015.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1015.0.tgz",
+			"integrity": "sha512-AQv0WPBEHW/WhNNj1TbELIZmLp7ZuxEA5tmIVCgF0tr7Nq791BOUCafjQh89uNBmCGFTeKDDvZVX6VYvOEJQvw=="
+		},
+		"@fluidframework/local-driver": {
+			"version": "0.27.15",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.27.15.tgz",
+			"integrity": "sha512-jFvvI27RK7JOLnvdMFaS9q0MaYSrYDYu/K1zObkYUBFbycM4id7kD7U99hBR8SJJ9UxaAqy9Kkni2tM14s2ivw==",
+			"requires": {
+				"@fluidframework/common-definitions": "^0.19.1",
+				"@fluidframework/common-utils": "^0.24.0",
+				"@fluidframework/core-interfaces": "^0.27.15",
+				"@fluidframework/driver-definitions": "^0.27.15",
+				"@fluidframework/driver-utils": "^0.27.15",
+				"@fluidframework/protocol-definitions": "^0.1013.0",
+				"@fluidframework/routerlicious-driver": "^0.27.15",
+				"@fluidframework/server-local-server": "^0.1013.0",
+				"@fluidframework/server-services-client": "^0.1013.0",
+				"@fluidframework/server-services-core": "^0.1013.0",
+				"@fluidframework/server-test-utils": "^0.1013.0",
+				"debug": "^4.1.1",
+				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"@fluidframework/common-utils": {
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.24.0.tgz",
+					"integrity": "sha512-JDtSIg+3hN1PRswebmdr3KROV7ywyzcCfKISkouvLFyKw7RLP7unmC3QWBhbesEw/jb5WbA8ji9LUwPIPJ3bxw==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.19.1",
+						"@types/events": "^3.0.0",
+						"assert": "^2.0.0",
+						"base64-js": "^1.3.1",
+						"events": "^3.1.0",
+						"lodash": "^4.17.19",
+						"sha.js": "^2.4.11"
+					}
+				},
+				"@fluidframework/gitresources": {
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1013.0.tgz",
+					"integrity": "sha512-X1j5sUNcpWnmyXCQjPx0C2d5jed3OgHnq3vRVzPwVmvGhu7B+tofsbJEMExMHX/J+ambDHq40ipEA55sTuXdwQ=="
+				},
+				"@fluidframework/protocol-base": {
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1013.0.tgz",
+					"integrity": "sha512-2Y6Iu3rQut21aFS+oTYeIKAyyRkYeqMYJ+xAP8wSW0R6eiZPz3q1EhcXpJkEW9f5y84FNjbNsfV9jqI29URMHg==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
+						"assert": "^2.0.0",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@fluidframework/protocol-definitions": {
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1013.0.tgz",
+					"integrity": "sha512-lFuBYRSQGHAfcUlgb4JitCIJMQ7e4o9+Yd7jVmM5KFh9xuunndC/D8n1JC087wNgLJ5nNavvv7cubYsD9a8FEg==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.19.1"
+					}
+				},
+				"@fluidframework/server-lambdas": {
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1013.0.tgz",
+					"integrity": "sha512-x125RhVhxc5iu1ijFOWBEiO8V59au2/ZH5eQtTXTqDmD8mm7XDlErIxCN7V/AucACX89ROnEtdD5CVuid4Poqg==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-base": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
+						"@fluidframework/server-services-client": "^0.1013.0",
+						"@fluidframework/server-services-core": "^0.1013.0",
+						"@types/semver": "^6.0.1",
+						"async": "^2.6.1",
+						"double-ended-queue": "^2.1.0-0",
+						"json-stringify-safe": "^5.0.1",
+						"jsonwebtoken": "^8.4.0",
+						"lodash": "^4.17.19",
+						"nconf": "^0.10.0",
+						"semver": "^6.3.0",
+						"uuid": "^3.3.2"
+					}
+				},
+				"@fluidframework/server-local-server": {
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1013.0.tgz",
+					"integrity": "sha512-ibzSUPia8pfOcgY4HAQFtBAWnAqR2nQ2wqvIGo5cILeCjrCOzKOQt5Pdbp4lS2Ll641uBFj4Ytl+ZGiQm9ooKg==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
+						"@fluidframework/server-lambdas": "^0.1013.0",
+						"@fluidframework/server-memory-orderer": "^0.1013.0",
+						"@fluidframework/server-services-client": "^0.1013.0",
+						"@fluidframework/server-services-core": "^0.1013.0",
+						"@fluidframework/server-test-utils": "^0.1013.0",
+						"uuid": "^3.3.2"
+					}
+				},
+				"@fluidframework/server-memory-orderer": {
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1013.0.tgz",
+					"integrity": "sha512-KqwwYGEChWF7KNRRSCJY/fyWANdenWM6ljtqn+iLIAEdlkQT1wjgUYCAQk0mD2PgjaybtKYpVx3nSwRz6DvRTA==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/protocol-base": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
+						"@fluidframework/server-lambdas": "^0.1013.0",
+						"@fluidframework/server-services-client": "^0.1013.0",
+						"@fluidframework/server-services-core": "^0.1013.0",
+						"@types/debug": "^4.1.5",
+						"@types/double-ended-queue": "^2.1.0",
+						"@types/lodash": "^4.14.118",
+						"@types/node": "^10.17.24",
+						"@types/ws": "^6.0.1",
+						"debug": "^4.1.1",
+						"double-ended-queue": "^2.1.0-0",
+						"lodash": "^4.17.19",
+						"moniker": "^0.1.2",
+						"uuid": "^3.3.2",
+						"ws": "^6.1.2"
+					}
+				},
+				"@fluidframework/server-services-client": {
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1013.0.tgz",
+					"integrity": "sha512-OotVg4R8w5jZ/pQT+xAy6JkrCNAegN+3DDZTLZKhRv/zSL2f5l2cMTiUg0kOVJpYhBUNNQ7oRadD0FlwtA837g==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-base": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
+						"@types/node": "^10.17.24",
+						"axios": "^0.18.0",
+						"debug": "^4.1.1",
+						"jsonwebtoken": "^8.4.0",
+						"sillyname": "0.1.0",
+						"uuid": "^3.3.2"
+					}
+				},
+				"@fluidframework/server-services-core": {
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1013.0.tgz",
+					"integrity": "sha512-LNV1Fvczjj/sT9ZN3g201oyBLL+m8p8zYkRrhRzcPoH6hVv6q1xiYmEbfAjpM7aAjQlVho7bHDu3a45tttdamQ==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
+						"@fluidframework/server-services-client": "^0.1013.0",
+						"@types/nconf": "^0.0.37",
+						"@types/node": "^10.17.24",
+						"debug": "^4.1.1",
+						"nconf": "^0.10.0"
+					}
+				},
+				"@fluidframework/server-test-utils": {
+					"version": "0.1013.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1013.0.tgz",
+					"integrity": "sha512-qxGIfLg050c/4zjcB3D/LfwHRPqwvx7djqVW7KppQ/QIu3uK1SrrT9jehC8SFkOuaIULG1tYMwEf/CeFbkEWnA==",
+					"requires": {
+						"@fluidframework/common-utils": "^0.24.0",
+						"@fluidframework/gitresources": "^0.1013.0",
+						"@fluidframework/protocol-base": "^0.1013.0",
+						"@fluidframework/protocol-definitions": "^0.1013.0",
+						"@fluidframework/server-services-client": "^0.1013.0",
+						"@fluidframework/server-services-core": "^0.1013.0",
+						"debug": "^4.1.1",
+						"lodash": "^4.17.19",
+						"string-hash": "^1.1.3",
+						"uuid": "^3.3.2"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				}
+			}
 		},
 		"@fluidframework/map": {
 			"version": "0.27.15",
@@ -2073,21 +2199,21 @@
 			}
 		},
 		"@fluidframework/protocol-base": {
-			"version": "0.1015.0-9629",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1015.0-9629.tgz",
-			"integrity": "sha512-/EAt+MXXmFkG/O6GKdOu+udvs4ccsG4halzN0+iZCVxmWhie8kBXch7nEMyidToI/Jt47IF/Bz8dSmPw6nyqGQ==",
+			"version": "0.1015.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1015.0.tgz",
+			"integrity": "sha512-QnuAt6nVI245vHtY9VrvDM3Vhu6HpC6h9omLxOaLWGFtogLeiqF2daXgrDta1UC8hacVdDgVr/A5T0kf3Ib38w==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.25.0",
-				"@fluidframework/gitresources": "0.1015.0-9629",
-				"@fluidframework/protocol-definitions": "0.1015.0-9629",
+				"@fluidframework/gitresources": "^0.1015.0",
+				"@fluidframework/protocol-definitions": "^0.1015.0",
 				"assert": "^2.0.0",
 				"lodash": "^4.17.19"
 			}
 		},
 		"@fluidframework/protocol-definitions": {
-			"version": "0.1015.0-9629",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1015.0-9629.tgz",
-			"integrity": "sha512-6gnXF/IiIEurFTp/D3UgF1/2wmXVBo1ngPCTJrE8XMnL+1LTDjrM7vGoy6KzfhwQ1AKr0lJMqSvngZ0FeGQXuA==",
+			"version": "0.1015.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1015.0.tgz",
+			"integrity": "sha512-o5fZDZp+Zn17cAtMgrxZmL/5iFkIcoRt2XkwdROgqidNfWzss2waiH4iQhncY6h2ajfilMLbUqD2vXWXV3i9RA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1"
 			}
@@ -2312,68 +2438,28 @@
 				}
 			}
 		},
-		"@fluidframework/server-local-server": {
-			"version": "0.1015.0-9629",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1015.0-9629.tgz",
-			"integrity": "sha512-qrIg4Uy7Eb/rT1Eu1Aomhg2HlmYUmpctleDEwKxB0NUIHV++mXIT/ZPqeowB2aT2u49hslvGpVBHFVah/ediYQ==",
+		"@fluidframework/server-lambdas": {
+			"version": "0.1015.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1015.0.tgz",
+			"integrity": "sha512-hXDBoT3pqwGgVmkZeE9r7ZBoN9C9wT1JGX7xzqwTL98Sr3IkUoZ9UPppyiwuIpVojYqU4L0k+zGOMHdRhD2JxQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.25.0",
-				"@fluidframework/protocol-definitions": "0.1015.0-9629",
-				"@fluidframework/server-lambdas": "0.1015.0-9629",
-				"@fluidframework/server-memory-orderer": "0.1015.0-9629",
-				"@fluidframework/server-services-client": "0.1015.0-9629",
-				"@fluidframework/server-services-core": "0.1015.0-9629",
-				"@fluidframework/server-test-utils": "0.1015.0-9629",
-				"jsrsasign": "^10.0.2",
+				"@fluidframework/gitresources": "^0.1015.0",
+				"@fluidframework/protocol-base": "^0.1015.0",
+				"@fluidframework/protocol-definitions": "^0.1015.0",
+				"@fluidframework/server-services-client": "^0.1015.0",
+				"@fluidframework/server-services-core": "^0.1015.0",
+				"@types/semver": "^6.0.1",
+				"async": "^2.6.1",
+				"double-ended-queue": "^2.1.0-0",
+				"json-stringify-safe": "^5.0.1",
+				"jsonwebtoken": "^8.4.0",
+				"lodash": "^4.17.19",
+				"nconf": "^0.10.0",
+				"semver": "^6.3.0",
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
-				"@fluidframework/server-lambdas": {
-					"version": "0.1015.0-9629",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1015.0-9629.tgz",
-					"integrity": "sha512-X3cVzTLC2Px91rgEXPaxb0c9PHH05aTzbq/N42K63sM3l9GtFweU3WwPFxD9k58oPrldNipdKYbBqhaYjh+5kw==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.25.0",
-						"@fluidframework/gitresources": "0.1015.0-9629",
-						"@fluidframework/protocol-base": "0.1015.0-9629",
-						"@fluidframework/protocol-definitions": "0.1015.0-9629",
-						"@fluidframework/server-services-client": "0.1015.0-9629",
-						"@fluidframework/server-services-core": "0.1015.0-9629",
-						"@types/semver": "^6.0.1",
-						"async": "^2.6.1",
-						"double-ended-queue": "^2.1.0-0",
-						"json-stringify-safe": "^5.0.1",
-						"jsonwebtoken": "^8.4.0",
-						"lodash": "^4.17.19",
-						"nconf": "^0.10.0",
-						"semver": "^6.3.0",
-						"uuid": "^3.3.2"
-					}
-				},
-				"@fluidframework/server-memory-orderer": {
-					"version": "0.1015.0-9629",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1015.0-9629.tgz",
-					"integrity": "sha512-X7TcjdAB4KonC4uAtfVABvME/yGFdueJIqGGMVLcq2Z+f1Sj7o0zk3fEbzcCE5b6zRj//H7+qNVT/Yj4HaacPw==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.25.0",
-						"@fluidframework/protocol-base": "0.1015.0-9629",
-						"@fluidframework/protocol-definitions": "0.1015.0-9629",
-						"@fluidframework/server-lambdas": "0.1015.0-9629",
-						"@fluidframework/server-services-client": "0.1015.0-9629",
-						"@fluidframework/server-services-core": "0.1015.0-9629",
-						"@types/debug": "^4.1.5",
-						"@types/double-ended-queue": "^2.1.0",
-						"@types/lodash": "^4.14.118",
-						"@types/node": "^10.17.24",
-						"@types/ws": "^6.0.1",
-						"debug": "^4.1.1",
-						"double-ended-queue": "^2.1.0-0",
-						"lodash": "^4.17.19",
-						"moniker": "^0.1.2",
-						"uuid": "^3.3.2",
-						"ws": "^6.1.2"
-					}
-				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -2381,15 +2467,55 @@
 				}
 			}
 		},
-		"@fluidframework/server-services-client": {
-			"version": "0.1015.0-9629",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1015.0-9629.tgz",
-			"integrity": "sha512-+VoPYcgl784RYPgNpBQdciAQ/M4c/RUuliTPGOyDT7R907BFlHUeJoubcRRHoAWhqCkJyi7xxzo30wESoZp0rA==",
+		"@fluidframework/server-local-server": {
+			"version": "0.1015.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1015.0.tgz",
+			"integrity": "sha512-on8husLzQt1h5RX75Lc3Q5+Y+wE8qlU336JOiOOFao+KBH2Fy4y9WFNEagp0hsp4qvW0L8S59bOrCAOaDXC5YA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.25.0",
-				"@fluidframework/gitresources": "0.1015.0-9629",
-				"@fluidframework/protocol-base": "0.1015.0-9629",
-				"@fluidframework/protocol-definitions": "0.1015.0-9629",
+				"@fluidframework/protocol-definitions": "^0.1015.0",
+				"@fluidframework/server-lambdas": "^0.1015.0",
+				"@fluidframework/server-memory-orderer": "^0.1015.0",
+				"@fluidframework/server-services-client": "^0.1015.0",
+				"@fluidframework/server-services-core": "^0.1015.0",
+				"@fluidframework/server-test-utils": "^0.1015.0",
+				"jsrsasign": "^10.0.2",
+				"uuid": "^3.3.2"
+			}
+		},
+		"@fluidframework/server-memory-orderer": {
+			"version": "0.1015.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1015.0.tgz",
+			"integrity": "sha512-FKxdnS92qMqsgMo4Wq6cAoZlVOkxecxAaoGqp7oWJypXSKb7dHEhRUwVbRa9uyilbwAFF7JxhV2BHyN9XNrDRA==",
+			"requires": {
+				"@fluidframework/common-utils": "^0.25.0",
+				"@fluidframework/protocol-base": "^0.1015.0",
+				"@fluidframework/protocol-definitions": "^0.1015.0",
+				"@fluidframework/server-lambdas": "^0.1015.0",
+				"@fluidframework/server-services-client": "^0.1015.0",
+				"@fluidframework/server-services-core": "^0.1015.0",
+				"@types/debug": "^4.1.5",
+				"@types/double-ended-queue": "^2.1.0",
+				"@types/lodash": "^4.14.118",
+				"@types/node": "^10.17.24",
+				"@types/ws": "^6.0.1",
+				"debug": "^4.1.1",
+				"double-ended-queue": "^2.1.0-0",
+				"lodash": "^4.17.19",
+				"moniker": "^0.1.2",
+				"uuid": "^3.3.2",
+				"ws": "^6.1.2"
+			}
+		},
+		"@fluidframework/server-services-client": {
+			"version": "0.1015.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1015.0.tgz",
+			"integrity": "sha512-kfovt9y7Zlb1jc7wyqnpc34mrscxHaqkBpWn+s95NYco8NyCw7kG2qlOhlGTt4MKhdH+jtQRbx1PCIEEsP+2FQ==",
+			"requires": {
+				"@fluidframework/common-utils": "^0.25.0",
+				"@fluidframework/gitresources": "^0.1015.0",
+				"@fluidframework/protocol-base": "^0.1015.0",
+				"@fluidframework/protocol-definitions": "^0.1015.0",
 				"@types/node": "^10.17.24",
 				"axios": "^0.18.0",
 				"debug": "^4.1.1",
@@ -2400,21 +2526,21 @@
 			},
 			"dependencies": {
 				"jwt-decode": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.1.tgz",
-					"integrity": "sha512-EaH9dTD9ogCmxZRdiTsIUIJslqjoFfk8nEAi+Bq8u/aUjrVuhZ6eZjhWRH6SC9NBA0Lwr3K35H2zDnWvK/n4vQ=="
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+					"integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
 				}
 			}
 		},
 		"@fluidframework/server-services-core": {
-			"version": "0.1015.0-9629",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1015.0-9629.tgz",
-			"integrity": "sha512-F2Lj5ZTrjIZI2sH6PedQTWAJCo3DiVpxGh/hXSYJorI3VpyQ3QtRytckFC5Yk5hrtnQDGzUIO1a50XQlZGaAfA==",
+			"version": "0.1015.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1015.0.tgz",
+			"integrity": "sha512-kPj+rpHwec8nWc9p6Y8jFYO2meFj7QJDySY8pr6JzIpY4mpuPk6QRQUxmCbtiKlhnwKWkzN1e4CAdVkDPGKpug==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.25.0",
-				"@fluidframework/gitresources": "0.1015.0-9629",
-				"@fluidframework/protocol-definitions": "0.1015.0-9629",
-				"@fluidframework/server-services-client": "0.1015.0-9629",
+				"@fluidframework/gitresources": "^0.1015.0",
+				"@fluidframework/protocol-definitions": "^0.1015.0",
+				"@fluidframework/server-services-client": "^0.1015.0",
 				"@types/nconf": "^0.0.37",
 				"@types/node": "^10.17.24",
 				"debug": "^4.1.1",
@@ -2422,16 +2548,16 @@
 			}
 		},
 		"@fluidframework/server-test-utils": {
-			"version": "0.1015.0-9629",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1015.0-9629.tgz",
-			"integrity": "sha512-utqTsh4ogc+Fe40oUttmrTqshLBwcFCXCRoO7kC+/rRV5HaUWqJJAbv0LD7i2Fg9taAy5rwYXIhv7J6qsQyO2Q==",
+			"version": "0.1015.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1015.0.tgz",
+			"integrity": "sha512-tESHPhY9ysOFNVEjLreoAbgUYpVuxP9GTx+eFC3SBjpMU8OTGFCA2NOK1OxE4sWcz5ekz7qVSKC1gccAf0GZKg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.25.0",
-				"@fluidframework/gitresources": "0.1015.0-9629",
-				"@fluidframework/protocol-base": "0.1015.0-9629",
-				"@fluidframework/protocol-definitions": "0.1015.0-9629",
-				"@fluidframework/server-services-client": "0.1015.0-9629",
-				"@fluidframework/server-services-core": "0.1015.0-9629",
+				"@fluidframework/gitresources": "^0.1015.0",
+				"@fluidframework/protocol-base": "^0.1015.0",
+				"@fluidframework/protocol-definitions": "^0.1015.0",
+				"@fluidframework/server-services-client": "^0.1015.0",
+				"@fluidframework/server-services-core": "^0.1015.0",
 				"debug": "^4.1.1",
 				"lodash": "^4.17.19",
 				"string-hash": "^1.1.3",
@@ -5683,6 +5809,16 @@
 				}
 			}
 		},
+		"@typescript-eslint/experimental-utils": {
+			"version": "2.17.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.17.0.tgz",
+			"integrity": "sha512-2bNf+mZ/3mj5/3CP56v+ldRK3vFy9jOvmCPs/Gr2DeSJh+asPZrhFniv4QmQsHWQFPJFWhFHgkGgJeRmK4m8iQ==",
+			"requires": {
+				"@types/json-schema": "^7.0.3",
+				"@typescript-eslint/typescript-estree": "2.17.0",
+				"eslint-scope": "^5.0.0"
+			}
+		},
 		"@typescript-eslint/parser": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.2.0.tgz",
@@ -5826,6 +5962,27 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.2.0.tgz",
 			"integrity": "sha512-xkv5nIsxfI/Di9eVwN+G9reWl7Me9R5jpzmZUch58uQ7g0/hHVuGUbbn4NcxcM5y/R4wuJIIEPKPDb5l4Fdmwg=="
+		},
+		"@typescript-eslint/typescript-estree": {
+			"version": "2.17.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.17.0.tgz",
+			"integrity": "sha512-g0eVRULGnEEUakxRfJO0s0Hr1LLQqsI6OrkiCLpdHtdJJek+wyd8mb00vedqAoWldeDcOcP8plqw8/jx9Gr3Lw==",
+			"requires": {
+				"debug": "^4.1.1",
+				"eslint-visitor-keys": "^1.1.0",
+				"glob": "^7.1.6",
+				"is-glob": "^4.0.1",
+				"lodash": "^4.17.15",
+				"semver": "^6.3.0",
+				"tsutils": "^3.17.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				}
+			}
 		},
 		"@typescript-eslint/visitor-keys": {
 			"version": "4.2.0",
@@ -11230,6 +11387,14 @@
 				"escape-string-regexp": "^1.0.5"
 			}
 		},
+		"file-entry-cache": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+			"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+			"requires": {
+				"flat-cache": "^2.0.1"
+			}
+		},
 		"file-loader": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-3.0.1.tgz",
@@ -11510,6 +11675,26 @@
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
 			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
+		},
+		"flat-cache": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+			"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+			"requires": {
+				"flatted": "^2.0.0",
+				"rimraf": "2.6.3",
+				"write": "1.0.3"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
+			}
 		},
 		"flatted": {
 			"version": "2.0.2",
@@ -19664,26 +19849,6 @@
 					"version": "0.1013.0",
 					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1013.0.tgz",
 					"integrity": "sha512-X1j5sUNcpWnmyXCQjPx0C2d5jed3OgHnq3vRVzPwVmvGhu7B+tofsbJEMExMHX/J+ambDHq40ipEA55sTuXdwQ=="
-				},
-				"@fluidframework/local-driver": {
-					"version": "0.27.15",
-					"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.27.15.tgz",
-					"integrity": "sha512-jFvvI27RK7JOLnvdMFaS9q0MaYSrYDYu/K1zObkYUBFbycM4id7kD7U99hBR8SJJ9UxaAqy9Kkni2tM14s2ivw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/common-utils": "^0.24.0",
-						"@fluidframework/core-interfaces": "^0.27.15",
-						"@fluidframework/driver-definitions": "^0.27.15",
-						"@fluidframework/driver-utils": "^0.27.15",
-						"@fluidframework/protocol-definitions": "^0.1013.0",
-						"@fluidframework/routerlicious-driver": "^0.27.15",
-						"@fluidframework/server-local-server": "^0.1013.0",
-						"@fluidframework/server-services-client": "^0.1013.0",
-						"@fluidframework/server-services-core": "^0.1013.0",
-						"@fluidframework/server-test-utils": "^0.1013.0",
-						"debug": "^4.1.1",
-						"uuid": "^3.3.2"
-					}
 				},
 				"@fluidframework/protocol-base": {
 					"version": "0.1013.0",

--- a/packages/agents/intelligence-runner-agent/package.json
+++ b/packages/agents/intelligence-runner-agent/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@types/node": "^10.17.24",
     "@types/request": "^2.47.1",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@fluidframework/test-runtime-utils": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@fluidframework/test-runtime-utils": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@fluidframework/test-runtime-utils": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@fluidframework/test-runtime-utils": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@fluidframework/test-runtime-utils": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@fluidframework/test-runtime-utils": "^0.29.0",
     "@types/assert": "^1.5.1",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@fluidframework/test-runtime-utils": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@fluidframework/test-runtime-utils": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/gitresources": "^0.1015.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@fluidframework/server-services-client": "^0.1015.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/debug": "^4.1.5",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@fluidframework/test-runtime-utils": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/mocha": "^5.2.5",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/debug": "^4.1.5",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/debug": "^4.1.5",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@types/assert": "^1.5.1",
     "@types/mocha": "^5.2.5",

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@types/assert": "^1.5.1",
     "@types/jsrsasign": "^8.0.8",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@types/assert": "^1.5.1",
     "@types/mocha": "^5.2.5",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/debug": "^4.1.5",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/debug": "^4.1.5",

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@types/assert": "^1.5.1",
     "@types/mocha": "^5.2.5",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@types/assert": "^1.5.1",
     "@types/mocha": "^5.2.5",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/mocha": "^5.2.5",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@fluidframework/test-runtime-utils": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/framework/last-edited-experimental/package.json
+++ b/packages/framework/last-edited-experimental/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/mocha": "^5.2.5",

--- a/packages/framework/react/package.json
+++ b/packages/framework/react/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",
     "@types/react": "^16.9.15",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@fluidframework/test-runtime-utils": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
     "@fluidframework/datastore": "^0.29.0",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/mocha": "^5.2.5",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@fluidframework/test-runtime-utils": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/react": "^16.9.15",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",

--- a/packages/hosts/base-host/package.json
+++ b/packages/hosts/base-host/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@fluidframework/test-runtime-utils": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/loader/container-definitions/package.json
+++ b/packages/loader/container-definitions/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -72,7 +72,7 @@
   "devDependencies": {
     "@fluid-internal/test-loader-utils": "^0.29.0",
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",

--- a/packages/loader/core-interfaces/package.json
+++ b/packages/loader/core-interfaces/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/packages/loader/driver-definitions/package.json
+++ b/packages/loader/driver-definitions/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/mocha": "^5.2.5",

--- a/packages/loader/execution-context-loader/package.json
+++ b/packages/loader/execution-context-loader/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/debug": "^4.1.5",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
     "concurrently": "^5.2.0",

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/isomorphic-fetch": "^0.0.35",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@types/assert": "^1.5.1",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",

--- a/packages/runtime/client-api/package.json
+++ b/packages/runtime/client-api/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/debug": "^4.1.5",
     "@types/jwt-decode": "^2.2.1",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@fluidframework/test-runtime-utils": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@types/assert": "^1.5.1",
     "@types/jsrsasign": "^8.0.8",

--- a/packages/test/end-to-end-tests/package.json
+++ b/packages/test/end-to-end-tests/package.json
@@ -74,7 +74,7 @@
     "@fluidframework/driver-base": "^0.29.0",
     "@fluidframework/driver-definitions": "^0.29.0",
     "@fluidframework/driver-utils": "^0.29.0",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/ink": "^0.29.0",
     "@fluidframework/local-driver": "^0.29.0",
     "@fluidframework/map": "^0.29.0",

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -57,7 +57,7 @@
     "@fluidframework/common-utils": "^0.25.0",
     "@fluidframework/container-loader": "^0.29.0",
     "@fluidframework/container-runtime": "^0.29.0",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@fluidframework/protocol-definitions": "^0.1015.0",
     "@fluidframework/sequence": "^0.29.0",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/mocha": "^5.2.5",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/packages/test/service-load-test/package.json
+++ b/packages/test/service-load-test/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.17.24",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@types/assert": "^1.5.1",
     "@types/mocha": "^5.2.5",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/diff": "^3.5.1",

--- a/packages/test/version-test-1/package.json
+++ b/packages/test/version-test-1/package.json
@@ -45,7 +45,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.29.0",
     "@types/jest": "22.2.3",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@types/assert": "^1.5.1",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",

--- a/packages/tools/merge-tree-client-replay/package.json
+++ b/packages/tools/merge-tree-client-replay/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/node": "^10.17.24",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/node": "^10.17.24",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -85,7 +85,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@types/assert": "^1.5.1",
     "@types/express": "^4.11.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
     "concurrently": "^5.2.0",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@fluidframework/mocha-test-setup": "^0.29.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/debug": "^4.1.5",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
-    "@fluidframework/eslint-config-fluid": "^0.21.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",


### PR DESCRIPTION
            @fluidframework/build-common:     0.20.0 (unchanged)
     @fluidframework/eslint-config-fluid:     0.21.0 -> 0.21.1
      @fluidframework/common-definitions:     0.20.0 (unchanged)
            @fluidframework/common-utils:     0.26.0 (unchanged)
                                  Server:   0.1015.0 (unchanged)
                                  Client:     0.29.0 (unchanged)
                         generator-fluid:      0.3.0 (unchanged)
                             tinylicious:      0.2.0 (unchanged)
                             dice-roller:      0.0.1 (unchanged)

Also remove pre-release dependencies for eslint-config-fluid
     @fluidframework/eslint-config-fluid -> ^0.21.0