### PR TITLE
Always include timestamp in ticks on debug logs

### DIFF
--- a/packages/utils/telemetry-utils/src/debugLogger.ts
+++ b/packages/utils/telemetry-utils/src/debugLogger.ts
@@ -90,9 +90,7 @@ export class DebugLogger extends TelemetryLogger {
         newEvent.eventName = undefined;
 
         let tick = "";
-        if (event.category === "performance") {
-            tick = `tick=${TelemetryLogger.formatTick(performance.now())}`;
-        }
+        tick = `tick=${TelemetryLogger.formatTick(performance.now())}`;
 
         // Extract stack to put it last, but also to avoid escaping '\n' in it by JSON.stringify below
         const stack = newEvent.stack ? newEvent.stack : "";


### PR DESCRIPTION
Timestamps are always useful on logs, so remove the conditional check and always append `tick` to debug logs sent to console.

e.g. here where 2 logs have the ticks but the other 2 don't:

![image](https://user-images.githubusercontent.com/12305068/99329025-2938db80-2832-11eb-97ff-ca2484d878fb.png)
