### PR TITLE
fix Tinylicious build warning 

### DIFF
--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -20,6 +20,7 @@
     "lint": "npm run eslint",
     "start": "node dist/index.js",
     "start:debug": "node --inspect=0.0.0.0:9229 dist/index.js",
+    "test": "npm run test:mocha",
     "test:mocha": "mocha --recursive dist/test -r node_modules/@fluidframework/mocha-test-setup --unhandled-rejections=strict",
     "tsc": "tsc"
   },


### PR DESCRIPTION
When running fluid-build (and probably other things?) there's a warning that tinylicious's package.json doesn't have conforming scripts.  Not anymore!