### PR TITLE
Added old container runtime / new data store runtime in compat tests

### DIFF
--- a/packages/test/end-to-end-tests/src/test/compat.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/compat.spec.ts
@@ -105,6 +105,9 @@ describe("loader/runtime compatibility", () => {
                 loadContainer( // new loader/container runtime, old data store runtime
                     { fluidExport: createRuntimeFactory(TestDataObject.type, createOldPrimedDataStoreFactory()) },
                     args.deltaConnectionServer),
+                loadContainerWithOldLoader( // old loader/container runtime, new data store runtime
+                    { fluidExport: createOldRuntimeFactory(TestDataObject.type, createPrimedDataStoreFactory()) },
+                    args.deltaConnectionServer),
             ];
 
             const dataObjects = await Promise.all(containersP.map(async (containerP) => containerP.then(

--- a/packages/test/end-to-end-tests/src/test/compatUtils.ts
+++ b/packages/test/end-to-end-tests/src/test/compatUtils.ts
@@ -279,6 +279,26 @@ export const generateCompatTest = (
                 await localTestObjectProvider.reset();
             });
         });
+
+        describe("old ContainerRuntime, new DataStoreRuntime", function() {
+            const runtimeFactory = (containerOptions?: ITestContainerConfig) =>
+                createOldRuntimeFactory(
+                    TestDataObject.type,
+                    getDataStoreFactory(containerOptions),
+                    containerOptions?.runtimeOptions,
+                );
+
+            const localTestObjectProvider = new old.LocalTestObjectProvider(
+                runtimeFactory,
+                options.serviceConfiguration,
+            );
+
+            tests(localTestObjectProvider);
+
+            afterEach(async function() {
+                await localTestObjectProvider.reset();
+            });
+        });
     });
 };
 


### PR DESCRIPTION
Added backwards compat tests to test old container runtime / new data store runtime combination.