### PR TITLE
Reduce summarizer timeout to 2min for summary ack

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -207,8 +207,8 @@ const DefaultSummaryConfiguration: ISummaryConfiguration = {
     // Snapshot if 1000 ops received since last snapshot.
     maxOps: 1000,
 
-    // Wait 10 minutes for summary ack
-    maxAckWaitTime: 600000,
+    // Wait 2 minutes for summary ack
+    maxAckWaitTime: 120000,
 };
 
 /**

--- a/packages/runtime/container-runtime/src/test/summarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizer.spec.ts
@@ -33,7 +33,7 @@ describe("Runtime", () => {
                     idleTime: 5000, // 5 sec (idle)
                     maxTime: 5000 * 12, // 1 min (active)
                     maxOps: 1000, // 1k ops (active)
-                    maxAckWaitTime: 600000, // 10 min
+                    maxAckWaitTime: 120000, // 2 min
                 };
                 let shouldDeferGenerateSummary: boolean = false;
                 let deferGenerateSummary: Deferred<void>;


### PR DESCRIPTION
Temporary resolution for this IcM incident:
https://portal.microsofticm.com/imp/v3/incidents/details/214040478/home
and for this issue:
https://github.com/microsoft/FluidFramework/issues/4363

By reducing timeout from 10 -> 2min, we reduce the chance of hitting the error where a maximum number of operations has been reached prior to creating a summary