### PR TITLE
Clear socket connection timeout in odsp driver on fail

### DIFF
--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -126,6 +126,8 @@ export class DocumentDeltaConnection
      */
     private earlyOpHandlerAttached: boolean = false;
 
+    private socketConnectionTimeout: ReturnType<typeof setTimeout> | undefined;
+
     private readonly submitManager: BatchManager<IDocumentMessage[]>;
 
     private _details: IConnected | undefined;
@@ -423,7 +425,7 @@ export class DocumentDeltaConnection
             this.socket.emit("connect_document", connectMessage);
 
             // Give extra 2 seconds for handshake on top of socket connection timeout
-            setTimeout(() => {
+            this.socketConnectionTimeout = setTimeout(() => {
                 if (!success) {
                     fail(false, createErrorObject("Timeout waiting for handshake from ordering service"));
                 }
@@ -466,6 +468,8 @@ export class DocumentDeltaConnection
         }
         // removeTrackedListeners removes all listeners, including connection listeners
         this.removeConnectionListeners();
+
+        clearTimeout(this.socketConnectionTimeout);
 
         this.removeEarlyOpHandler();
         this.removeEarlySignalHandler();


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/4337
When the delta connection failed for some reason, we should clear the listeners, timeout etc so that they stop listening to further events. If they keep listening, then any failure in future would cause the disconnect again, which can cause problems like the assert that we hit in disconnect() in odspdeltaconnection.