### PR TITLE
Add logs pausing and resuming delta queue to verify our counts

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -355,9 +355,11 @@ export class DeltaManager
         this._reconnectMode = reconnectAllowed ? ReconnectMode.Enabled : ReconnectMode.Never;
 
         this._inbound = new DeltaQueue<ISequencedDocumentMessage>(
-            (op) => {
-                this.processInboundMessage(op);
-            });
+                (op) => {
+                    this.processInboundMessage(op);
+                },
+                logger,
+            );
 
         this._inbound.on("error", (error) => {
             this.close(CreateContainerError(error));

--- a/packages/loader/container-loader/src/deltaQueue.ts
+++ b/packages/loader/container-loader/src/deltaQueue.ts
@@ -95,7 +95,7 @@ export class DeltaQueue<T> extends TypedEventEmitter<IDeltaQueueEvents<T>> imple
         if (this.logger) {
             this.logger.sendTelemetryEvent({
                 eventName: "DeltaQueuePause",
-            },  `${this.userPause}`);
+            },  this.userPause);
         }
     }
 
@@ -108,7 +108,7 @@ export class DeltaQueue<T> extends TypedEventEmitter<IDeltaQueueEvents<T>> imple
         if (this.logger) {
             this.logger.sendTelemetryEvent({
                 eventName: "DeltaQueueResume",
-            },  `${this.userPause}`);
+            },  this.userPause);
         }
     }
 
@@ -122,7 +122,7 @@ export class DeltaQueue<T> extends TypedEventEmitter<IDeltaQueueEvents<T>> imple
         if (this.logger) {
             this.logger.sendTelemetryEvent({
                 eventName: "DeltaQueueSystemPause",
-            },  `${this.sysPause}`);
+            },  this.sysPause);
         }
     }
 
@@ -135,7 +135,7 @@ export class DeltaQueue<T> extends TypedEventEmitter<IDeltaQueueEvents<T>> imple
         if (this.logger) {
             this.logger.sendTelemetryEvent({
                 eventName: "DeltaQueueSystemResume",
-            },  `${this.sysPause}`);
+            },  this.sysPause);
         }
     }
 


### PR DESCRIPTION
This is being added in to 0.28 so that we can debug why the summarizer is timing out and not continuing to create summaries even after the service acks the op for this ICM issue:
https://portal.microsofticm.com/imp/v3/incidents/details/214040478/home