### PR TITLE
Fix: summarizer container got stuck in pause when inbound op pushed to queue during summary generation

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -268,8 +268,6 @@ export class ScheduleManager {
     private readonly deltaScheduler: DeltaScheduler;
     private pauseSequenceNumber: number | undefined;
     private pauseClientId: string | undefined;
-
-    private paused = false;
     private localPaused = false;
     private batchClientId: string | undefined;
 
@@ -372,19 +370,6 @@ export class ScheduleManager {
         }
     }
 
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
-    public pause(): Promise<void> {
-        this.paused = true;
-        return this.deltaManager.inbound.systemPause();
-    }
-
-    public resume() {
-        this.paused = false;
-        if (!this.localPaused) {
-            this.deltaManager.inbound.systemResume();
-        }
-    }
-
     private setPaused(localPaused: boolean) {
         // Return early if no change in value
         if (this.localPaused === localPaused) {
@@ -392,7 +377,7 @@ export class ScheduleManager {
         }
 
         this.localPaused = localPaused;
-        if (localPaused || this.paused) {
+        if (localPaused) {
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
             this.deltaManager.inbound.systemPause();
         } else {
@@ -1712,7 +1697,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         this.summarizerNode.startSummary(summaryRefSeqNum);
 
         try {
-            await this.scheduleManager.pause();
+            await this.deltaManager.inbound.pause();
 
             const attemptData: Omit<IUnsubmittedSummaryData, "reason"> = {
                 referenceSequenceNumber: summaryRefSeqNum,
@@ -1800,7 +1785,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             // Cleanup wip summary in case of failure
             this.summarizerNode.clearSummary();
             // Restart the delta manager
-            this.scheduleManager.resume();
+            this.deltaManager.inbound.resume();
         }
     }
 


### PR DESCRIPTION
This should fix #4377 

ScheduleManager has multiple way to tracking pause/resume state for patched op.  Summary also use it pause the delta inbound during summarization.  Since we switch to counting pause/resume, the schedulemanager could cause the pause/resume out of balance with this sequence:
- Summary start which calls ScheduleManager.pause() -> (this.pause === true)  -> inbound.pause()
- op got pushed to the inbound queue -> ScheduleManager.updatePauseState -> ScheduleManager.localPause = false, but instead we call pause again because this.pause === true)
- Summary stops -> ScheduleManager.resume() is called, and inbound.resume() is called

The middle step is what cause the extra inbound.pause() to be called.

The fix is to separate the summarizer pause/resume call and the schedule manager's tracking of batch ops, and have the summarizer directly call deltamanager's inbound queue for pause/resume