### PR TITLE
[release/0.28] Cherry-pick commit 655c79a AKA PR #4394 into 0.28.

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -10,6 +10,7 @@ import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { assert, performance } from "@fluidframework/common-utils";
 import { ChildLogger, TelemetryLogger } from "@fluidframework/telemetry-utils";
 import {
+    LoaderCachingPolicy,
     IDocumentDeltaConnection,
     IDocumentDeltaStorageService,
     IDocumentService,
@@ -87,6 +88,11 @@ function writeLocalStorage(key: string, value: string) {
  */
 export class OdspDocumentService implements IDocumentService {
     protected updateUsageOpFrequency = startingUpdateUsageOpFrequency;
+
+    readonly policies = {
+        // By default, ODSP tells the container not to prefetch/cache.
+        caching: LoaderCachingPolicy.NoCaching,
+    };
 
     /**
      * @param getStorageToken - function that can provide the storage token. This is is also referred to as

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -32,6 +32,7 @@ import {
 } from "@fluidframework/container-definitions";
 import { CreateContainerError, GenericError } from "@fluidframework/container-utils";
 import {
+    LoaderCachingPolicy,
     IDocumentService,
     IDocumentStorageService,
     IFluidResolvedUrl,
@@ -1150,7 +1151,13 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             throw new Error("Not attached");
         }
         const storageService = await this.service.connectToStorage();
-        return new PrefetchDocumentStorageService(storageService);
+
+        // Enable prefetching for the service unless it has a caching policy set otherwise:
+        const service = new PrefetchDocumentStorageService(storageService);
+        if (this.service.policies?.caching === LoaderCachingPolicy.NoCaching) {
+            service.stopPrefetch();
+        }
+        return service;
     }
 
     private async getDocumentAttributes(

--- a/packages/loader/driver-definitions/src/storage.ts
+++ b/packages/loader/driver-definitions/src/storage.ts
@@ -186,9 +186,30 @@ export interface IDocumentDeltaConnection extends IEventProvider<IDocumentDeltaC
     close();
 }
 
+export enum LoaderCachingPolicy {
+    /**
+     * The loader should not implement any prefetching or caching policy.
+     */
+    NoCaching,
+
+    /**
+     * The loader should implement prefetching policy, i.e. it should prefetch resources from the latest snapshot.
+     */
+    Prefetch,
+}
+
+export interface IDocumentServicePolicies {
+    readonly caching?: LoaderCachingPolicy;
+}
+
 export interface IDocumentService {
 
     resolvedUrl: IResolvedUrl;
+
+    /**
+     * Policies implemented/instructed by driver.
+     */
+    policies?: IDocumentServicePolicies;
 
     /**
      * Access to storage associated with the document...


### PR DESCRIPTION
Per https://github.com/microsoft/FluidFramework/issues/4388#issuecomment-729936477, this ports the prefetch change from main to 0.28.