### PR TITLE
Add service config option for controlling message traces

### DIFF
--- a/server/routerlicious/packages/kafka-orderer/src/kafkaOrderer.ts
+++ b/server/routerlicious/packages/kafka-orderer/src/kafkaOrderer.ts
@@ -68,7 +68,7 @@ export class KafkaOrdererConnection implements core.IOrdererConnection {
             contents: null,
             data: JSON.stringify(clientDetail),
             referenceSequenceNumber: -1,
-            traces: [],
+            traces: this.serviceConfiguration.enableTraces ? [] : undefined,
             type: MessageType.ClientJoin,
         };
 
@@ -114,7 +114,7 @@ export class KafkaOrdererConnection implements core.IOrdererConnection {
             contents: null,
             data: JSON.stringify(this.clientId),
             referenceSequenceNumber: -1,
-            traces: [],
+            traces: this.serviceConfiguration.enableTraces ? [] : undefined,
             type: MessageType.ClientLeave,
         };
         const message: core.IRawOperationMessage = {
@@ -134,20 +134,22 @@ export class KafkaOrdererConnection implements core.IOrdererConnection {
     }
 
     private async submitRawOperation(messages: core.IRawOperationMessage[]): Promise<void> {
-        // Add trace
-        messages.forEach((message) => {
-            const operation = message.operation;
-            if (operation && operation.traces === undefined) {
-                operation.traces = [];
-            } else if (operation && operation.traces && operation.traces.length > 1) {
-                operation.traces.push(
-                    {
-                        action: "end",
-                        service: "alfred",
-                        timestamp: Date.now(),
-                    });
-            }
-        });
+        if (this.serviceConfiguration.enableTraces) {
+            // Add trace
+            messages.forEach((message) => {
+                const operation = message.operation;
+                if (operation && operation.traces === undefined) {
+                    operation.traces = [];
+                } else if (operation && operation.traces && operation.traces.length > 1) {
+                    operation.traces.push(
+                        {
+                            action: "end",
+                            service: "alfred",
+                            timestamp: Date.now(),
+                        });
+                }
+            });
+        }
 
         return this.producer.send(messages, this.tenantId, this.documentId);
     }

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -40,6 +40,7 @@ export const DefaultServiceConfiguration: IServiceConfiguration = {
         maxTime: 5000 * 12,
         maxAckWaitTime: 600000,
     },
+    enableTraces: true,
 };
 
 interface IRoom {
@@ -66,7 +67,7 @@ function getRoomId(room: IRoom) {
 // Sanitize the received op before sending.
 function sanitizeMessage(message: any): IDocumentMessage {
     // Trace sampling.
-    if (getRandomInt(100) === 0 && message.operation && message.operation.traces) {
+    if (message.operation && message.operation.traces && getRandomInt(100) === 0) {
         message.operation.traces.push(
             {
                 action: "start",

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -18,6 +18,7 @@ import {
     ITrace,
     MessageType,
     NackErrorType,
+    IServiceConfiguration,
 } from "@fluidframework/protocol-definitions";
 import { canSummarize } from "@fluidframework/server-services-client";
 import {
@@ -113,7 +114,8 @@ export class DeliLambda implements IPartitionLambda {
         private readonly reverseProducer: IProducer,
         private readonly clientTimeout: number,
         private readonly activityTimeout: number,
-        private readonly noOpConsolidationTimeout: number) {
+        private readonly noOpConsolidationTimeout: number,
+        private readonly serviceConfiguration: IServiceConfiguration) {
         // Instantiate existing clients
         if (lastCheckpoint.clients) {
             for (const client of lastCheckpoint.clients) {
@@ -556,7 +558,7 @@ export class DeliLambda implements IPartitionLambda {
             contents: null,
             data: JSON.stringify(clientId),
             referenceSequenceNumber: -1,
-            traces: [],
+            traces: this.serviceConfiguration.enableTraces ? [] : undefined,
             type: MessageType.ClientLeave,
         };
         const leaveMessage: IRawOperationMessage = {
@@ -612,7 +614,7 @@ export class DeliLambda implements IPartitionLambda {
                 clientSequenceNumber: -1,
                 contents: null,
                 referenceSequenceNumber: -1,
-                traces: [],
+                traces: this.serviceConfiguration.enableTraces ? [] : undefined,
                 type,
             },
             tenantId: this.tenantId,

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -19,7 +19,7 @@ import {
     MongoManager,
 } from "@fluidframework/server-services-core";
 import { generateServiceProtocolEntries } from "@fluidframework/protocol-base";
-import { FileMode } from "@fluidframework/protocol-definitions";
+import { FileMode, IServiceConfiguration } from "@fluidframework/protocol-definitions";
 import { IGitManager } from "@fluidframework/server-services-client";
 import { Provider } from "nconf";
 import { NoOpLambda } from "../utils";
@@ -56,7 +56,8 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
         private readonly collection: ICollection<IDocument>,
         private readonly tenantManager: ITenantManager,
         private readonly forwardProducer: IProducer,
-        private readonly reverseProducer: IProducer) {
+        private readonly reverseProducer: IProducer,
+        private readonly serviceConfiguration: IServiceConfiguration) {
         super();
     }
 
@@ -143,7 +144,8 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
             this.reverseProducer,
             ClientSequenceTimeout,
             ActivityCheckingTimeout,
-            NoopConsolidationTimeout);
+            NoopConsolidationTimeout,
+            this.serviceConfiguration);
     }
 
     public async dispose(): Promise<void> {

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -16,6 +16,7 @@ import {
     MessageType,
     ISequencedDocumentAugmentedMessage,
     IProtocolState,
+    IServiceConfiguration,
 } from "@fluidframework/protocol-definitions";
 import {
     ControlMessageType,
@@ -67,6 +68,7 @@ export class ScribeLambda extends SequencedLambda {
         private readonly summaryReader: ISummaryReader,
         private readonly checkpointManager: ICheckpointManager,
         scribe: IScribe,
+        private readonly serviceConfiguration: IServiceConfiguration,
         private readonly producer: IProducer | undefined,
         private protocolHandler: ProtocolOpHandler,
         private term: number,
@@ -377,7 +379,7 @@ export class ScribeLambda extends SequencedLambda {
             clientSequenceNumber: -1,
             contents,
             referenceSequenceNumber: -1,
-            traces: [],
+            traces: this.serviceConfiguration.enableTraces ? [] : undefined,
             type: MessageType.SummaryAck,
         };
 
@@ -389,7 +391,7 @@ export class ScribeLambda extends SequencedLambda {
             clientSequenceNumber: -1,
             contents,
             referenceSequenceNumber: -1,
-            traces: [],
+            traces: this.serviceConfiguration.enableTraces ? [] : undefined,
             type: MessageType.SummaryNack,
         };
 
@@ -414,7 +416,7 @@ export class ScribeLambda extends SequencedLambda {
             contents: null,
             data: JSON.stringify(controlMessage),
             referenceSequenceNumber: -1,
-            traces: [],
+            traces: this.serviceConfiguration.enableTraces ? [] : undefined,
             type: MessageType.Control,
         };
 

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -18,6 +18,7 @@ import {
     ITenantManager,
     MongoManager,
 } from "@fluidframework/server-services-core";
+import { IServiceConfiguration } from "@fluidframework/protocol-definitions";
 import { Provider } from "nconf";
 import { NoOpLambda } from "../utils";
 import { CheckpointManager } from "./checkpointManager";
@@ -47,6 +48,7 @@ export class ScribeLambdaFactory extends EventEmitter implements IPartitionLambd
         private readonly messageCollection: ICollection<ISequencedOperationMessage>,
         private readonly producer: IProducer,
         private readonly tenantManager: ITenantManager,
+        private readonly serviceConfiguration: IServiceConfiguration,
     ) {
         super();
     }
@@ -126,6 +128,7 @@ export class ScribeLambdaFactory extends EventEmitter implements IPartitionLambd
             summaryReader,
             checkpointManager,
             lastCheckpoint,
+            this.serviceConfiguration,
             this.producer,
             protocolHandler,
             latestSummary.term,

--- a/server/routerlicious/packages/lambdas/src/test/deli/lambda.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/deli/lambda.spec.ts
@@ -23,6 +23,7 @@ import {
 import { strict as assert } from "assert";
 import * as _ from "lodash";
 import nconf from "nconf";
+import { DefaultServiceConfiguration } from "../../alfred";
 import { ClientSequenceTimeout, DeliLambdaFactory } from "../../deli/lambdaFactory";
 
 const MinSequenceNumberWindow = 2000;
@@ -85,7 +86,8 @@ describe("Routerlicious", () => {
                     testCollection,
                     testTenantManager,
                     testForwardProducer,
-                    testReverseProducer);
+                    testReverseProducer,
+                    DefaultServiceConfiguration);
 
                 testContext = new TestContext();
                 const config = (new nconf.Provider({})).defaults({ documentId: testId, tenantId: testTenantId })

--- a/server/routerlicious/packages/memory-orderer/src/localNode.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localNode.ts
@@ -39,6 +39,7 @@ const DefaultServiceConfiguration: IServiceConfiguration = {
         maxTime: 5000 * 12,
         maxAckWaitTime: 600000,
     },
+    enableTraces: true,
 };
 
 class RemoteSubscriber implements ISubscriber {

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -290,7 +290,8 @@ export class LocalOrderer implements IOrderer {
                     this.rawDeltasKafka,
                     this.clientTimeout,
                     ActivityCheckingTimeout,
-                    NoopConsolidationTimeout);
+                    NoopConsolidationTimeout,
+                    this.serviceConfiguration);
             });
     }
 
@@ -343,6 +344,7 @@ export class LocalOrderer implements IOrderer {
             summaryReader,
             checkpointManager,
             scribe,
+            this.serviceConfiguration,
             this.rawDeltasKafka,
             protocolHandler,
             1, // TODO (Change when local orderer also ticks epoch)

--- a/server/routerlicious/packages/memory-orderer/src/localOrdererConnection.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrdererConnection.ts
@@ -52,7 +52,7 @@ export class LocalOrdererConnection implements IOrdererConnection {
             contents: null,
             data: JSON.stringify(clientDetail),
             referenceSequenceNumber: -1,
-            traces: [],
+            traces: this.serviceConfiguration.enableTraces ? [] : undefined,
             type: MessageType.ClientJoin,
         };
 
@@ -92,7 +92,7 @@ export class LocalOrdererConnection implements IOrdererConnection {
             contents: null,
             data: JSON.stringify(this.clientId),
             referenceSequenceNumber: -1,
-            traces: [],
+            traces: this.serviceConfiguration.enableTraces ? [] : undefined,
             type: MessageType.ClientLeave,
         };
         const message: IRawOperationMessage = {
@@ -111,18 +111,20 @@ export class LocalOrdererConnection implements IOrdererConnection {
     }
 
     private submitRawOperation(messages: IRawOperationMessage[]) {
-        // Add trace
-        messages.forEach((message) => {
-            const operation = message.operation;
-            if (operation && operation.traces) {
-                operation.traces.push(
-                    {
-                        action: "start",
-                        service: "alfred",
-                        timestamp: performance.now(),
-                    });
-            }
-        });
+        if (this.serviceConfiguration.enableTraces) {
+            // Add trace
+            messages.forEach((message) => {
+                const operation = message.operation;
+                if (operation && operation.traces) {
+                    operation.traces.push(
+                        {
+                            action: "start",
+                            service: "alfred",
+                            timestamp: performance.now(),
+                        });
+                }
+            });
+        }
 
         const boxcar: IBoxcarMessage = {
             contents: messages,

--- a/server/routerlicious/packages/protocol-definitions/src/config.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/config.ts
@@ -30,5 +30,9 @@ export interface IServiceConfiguration {
     // Server defined ideal block size for storing snapshots
     blockSize: number;
 
+    // Summary algorithm configuration. This is sent to clients when they connect
     summary: ISummaryConfiguration;
+
+    // Enable adding a traces array to operation messages
+    enableTraces: boolean;
 }

--- a/server/routerlicious/packages/routerlicious/src/deli/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/deli/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { BroadcasterLambda, DeliLambdaFactory } from "@fluidframework/server-lambdas";
+import { BroadcasterLambda, DefaultServiceConfiguration, DeliLambdaFactory } from "@fluidframework/server-lambdas";
 import { create as createDocumentRouter } from "@fluidframework/server-lambdas-driver";
 import { LocalKafka, LocalContext, LocalLambdaController } from "@fluidframework/server-memory-orderer";
 import * as services from "@fluidframework/server-services";
@@ -77,7 +77,13 @@ export async function deliCreate(config: Provider): Promise<core.IPartitionLambd
 
     await broadcasterLambda.start();
 
-    return new DeliLambdaFactory(mongoManager, collection, tenantManager, combinedProducer, reverseProducer);
+    return new DeliLambdaFactory(
+        mongoManager,
+        collection,
+        tenantManager,
+        combinedProducer,
+        reverseProducer,
+        DefaultServiceConfiguration);
 }
 
 export async function create(config: Provider): Promise<core.IPartitionLambdaFactory> {

--- a/server/routerlicious/packages/routerlicious/src/event-hub/deli/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/event-hub/deli/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { BroadcasterLambda, DeliLambdaFactory } from "@fluidframework/server-lambdas";
+import { BroadcasterLambda, DefaultServiceConfiguration, DeliLambdaFactory } from "@fluidframework/server-lambdas";
 import { create as createDocumentRouter } from "@fluidframework/server-lambdas-driver";
 import { LocalKafka, LocalContext, LocalLambdaController } from "@fluidframework/server-memory-orderer";
 import * as services from "@fluidframework/server-services";
@@ -56,7 +56,13 @@ export async function deliCreate(config: Provider): Promise<core.IPartitionLambd
 
     await broadcasterLambda.start();
 
-    return new DeliLambdaFactory(mongoManager, collection, tenantManager, combinedProducer, reverseProducer);
+    return new DeliLambdaFactory(
+        mongoManager,
+        collection,
+        tenantManager,
+        combinedProducer,
+        reverseProducer,
+        DefaultServiceConfiguration);
 }
 
 export async function create(config: Provider): Promise<core.IPartitionLambdaFactory> {

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ScribeLambdaFactory } from "@fluidframework/server-lambdas";
+import { DefaultServiceConfiguration, ScribeLambdaFactory } from "@fluidframework/server-lambdas";
 import { create as createDocumentRouter } from "@fluidframework/server-lambdas-driver";
 import { createProducer, MongoDbFactory, TenantManager } from "@fluidframework/server-services";
 import {
@@ -62,7 +62,8 @@ export async function scribeCreate(config: Provider): Promise<IPartitionLambdaFa
         collection,
         scribeDeltas,
         producer,
-        tenantManager);
+        tenantManager,
+        DefaultServiceConfiguration);
 }
 
 export async function create(config: Provider): Promise<IPartitionLambdaFactory> {


### PR DESCRIPTION
Allows enabling / disabling the "traces" feature. 

Also in the future we could use `IServiceConfiguration` for some per lambda configs now that it's passed to each one. For example the deli timeouts and scribe options could come from that object instead of the constructor args.