### PR TITLE
Remove logging from processChunk.

### DIFF
--- a/packages/dds/merge-tree/src/snapshotChunks.ts
+++ b/packages/dds/merge-tree/src/snapshotChunks.ts
@@ -135,14 +135,6 @@ export function toLatestVersion(
     chunk: VersionedMergeTreeChunk,
     logger: ITelemetryLogger,
     options: PropertySet | undefined): MergeTreeChunkV1 {
-    if (chunk.version !== "1") {
-        logger.send({
-            eventName: "MergeTreeChunk:toLatestVersion",
-            category: "generic",
-            fromChunkVersion: chunk.version,
-            toChunkVersion: "1",
-        });
-    }
     switch (chunk.version) {
         case undefined: {
             const chunkLegacy = chunk as MergeTreeChunkLegacy;


### PR DESCRIPTION
It seems like most of the logging in https://github.com/microsoft/FluidFramework/issues/4043 is from this line, but I'll do some more poking to see if it comes from elsewhere too.

Should I totally remove the `logger` plumbing back up through `snapshotV1.ts` since it isn't used anywhere else?