### PR TITLE
Move deli and scribe lambda configuration into the service configuration object

### DIFF
--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -34,13 +34,23 @@ import {
 export const DefaultServiceConfiguration: IServiceConfiguration = {
     blockSize: 64436,
     maxMessageSize: 16 * 1024,
+    enableTraces: true,
     summary: {
         idleTime: 5000,
         maxOps: 1000,
         maxTime: 5000 * 12,
         maxAckWaitTime: 600000,
     },
-    enableTraces: true,
+    deli: {
+        clientTimeout: 5 * 60 * 1000,
+        activityTimeout: 30 * 1000,
+        noOpConsolidationTimeout: 250,
+    },
+    scribe: {
+        generateServiceSummary: true,
+        clearCacheAfterServiceSummary: false,
+        ignoreStorageException: false,
+    },
 };
 
 interface IRoom {

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -279,7 +279,11 @@ export function configureWebSocketServices(
                     mode: "write",
                     // Back-compat, removal tracked with issue #4346
                     parentBranch: null,
-                    serviceConfiguration: connection.serviceConfiguration,
+                    serviceConfiguration: {
+                        blockSize: connection.serviceConfiguration.blockSize,
+                        maxMessageSize: connection.serviceConfiguration.maxMessageSize,
+                        summary: connection.serviceConfiguration.summary,
+                    },
                     initialClients: clients,
                     initialMessages: [],
                     initialSignals: [],
@@ -295,7 +299,11 @@ export function configureWebSocketServices(
                     mode: "read",
                     // Back-compat, removal tracked with issue #4346
                     parentBranch: null, // Does not matter for now.
-                    serviceConfiguration: DefaultServiceConfiguration,
+                    serviceConfiguration: {
+                        blockSize: DefaultServiceConfiguration.blockSize,
+                        maxMessageSize: DefaultServiceConfiguration.maxMessageSize,
+                        summary: DefaultServiceConfiguration.summary,
+                    },
                     initialClients: clients,
                     initialMessages: [],
                     initialSignals: [],

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -112,9 +112,6 @@ export class DeliLambda implements IPartitionLambda {
         collection: ICollection<IDocument>,
         private readonly forwardProducer: IProducer,
         private readonly reverseProducer: IProducer,
-        private readonly clientTimeout: number,
-        private readonly activityTimeout: number,
-        private readonly noOpConsolidationTimeout: number,
         private readonly serviceConfiguration: IServiceConfiguration) {
         // Instantiate existing clients
         if (lastCheckpoint.clients) {
@@ -671,7 +668,7 @@ export class DeliLambda implements IPartitionLambda {
     private getIdleClient(timestamp: number): IClientSequenceNumber {
         if (this.clientSeqManager.count() > 0) {
             const client = this.clientSeqManager.peek();
-            if (client.canEvict && (timestamp - client.lastUpdate > this.clientTimeout)) {
+            if (client.canEvict && (timestamp - client.lastUpdate > this.serviceConfiguration.deli.clientTimeout)) {
                 return client;
             }
         }
@@ -686,7 +683,7 @@ export class DeliLambda implements IPartitionLambda {
                 const noOpMessage = this.createOpMessage(MessageType.NoOp);
                 this.sendToAlfred(noOpMessage);
             }
-        }, this.activityTimeout);
+        }, this.serviceConfiguration.deli.activityTimeout);
     }
 
     private clearIdleTimer() {
@@ -705,7 +702,7 @@ export class DeliLambda implements IPartitionLambda {
                 const noOpMessage = this.createOpMessage(MessageType.NoOp);
                 this.sendToAlfred(noOpMessage);
             }
-        }, this.noOpConsolidationTimeout);
+        }, this.serviceConfiguration.deli.noOpConsolidationTimeout);
     }
 
     private clearNoopConsolidationTimer() {

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -25,15 +25,6 @@ import { Provider } from "nconf";
 import { NoOpLambda } from "../utils";
 import { DeliLambda } from "./lambda";
 
-// We expire clients after 5 minutes of no activity
-export const ClientSequenceTimeout = 5 * 60 * 1000;
-
-// Timeout for sending no-ops to trigger inactivity checker.
-export const ActivityCheckingTimeout = 30 * 1000;
-
-// Timeout for sending consolidated no-ops.
-export const NoopConsolidationTimeout = 250;
-
 // Epoch should never tick in our current setting. This flag is just for being extra cautious.
 // TODO: Remove when everything is up to date.
 const FlipTerm = false;
@@ -142,9 +133,6 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
             // The producer as well it shouldn't take. Maybe it just gives an output stream?
             this.forwardProducer,
             this.reverseProducer,
-            ClientSequenceTimeout,
-            ActivityCheckingTimeout,
-            NoopConsolidationTimeout,
             this.serviceConfiguration);
     }
 

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -133,9 +133,7 @@ export class ScribeLambdaFactory extends EventEmitter implements IPartitionLambd
             protocolHandler,
             latestSummary.term,
             latestSummary.protocolHead,
-            opMessages,
-            true,
-            false);
+            opMessages);
     }
 
     public async dispose(): Promise<void> {

--- a/server/routerlicious/packages/lambdas/src/test/deli/lambda.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/deli/lambda.spec.ts
@@ -24,7 +24,7 @@ import { strict as assert } from "assert";
 import * as _ from "lodash";
 import nconf from "nconf";
 import { DefaultServiceConfiguration } from "../../alfred";
-import { ClientSequenceTimeout, DeliLambdaFactory } from "../../deli/lambdaFactory";
+import { DeliLambdaFactory } from "../../deli/lambdaFactory";
 
 const MinSequenceNumberWindow = 2000;
 
@@ -181,12 +181,12 @@ describe("Routerlicious", () => {
                     assert.equal(testKafka.getLastMessage().operation.minimumSequenceNumber, 10);
 
                     await lambda.handler(
-                        kafkaMessageFactory.sequenceMessage(secondMessageFactory.create(20, 1 + ClientSequenceTimeout),
+                        kafkaMessageFactory.sequenceMessage(secondMessageFactory.create(20, 1 + DefaultServiceConfiguration.deli.clientTimeout),
                             testId));
                     await lambda.handler(kafkaMessageFactory.sequenceMessage(
                         secondMessageFactory.create(
                             20,
-                            ClientSequenceTimeout + 2 * MinSequenceNumberWindow),
+                            DefaultServiceConfiguration.deli.clientTimeout + 2 * MinSequenceNumberWindow),
                         testId));
                     await quiesce();
                     // assert.equal(testKafka.getLastMessage().operation.minimumSequenceNumber, 20);

--- a/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
+++ b/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
@@ -93,7 +93,6 @@ export class LocalDeltaConnectionServer implements ILocalDeltaConnectionServer {
             testTenantManager,
             new EmptyTaskMessageSender(),
             {},
-            16 * 1024,
             generateToken,
             async () => new TestHistorian(testDbFactory.testDatabase),
             logger,

--- a/server/routerlicious/packages/local-server/src/localOrdererManager.ts
+++ b/server/routerlicious/packages/local-server/src/localOrdererManager.ts
@@ -84,7 +84,6 @@ export class LocalOrdererManager implements IOrdererManager {
             undefined /* foremanContext */,
             undefined /* scribeContext */,
             undefined /* deliContext */,
-            undefined /* clientTimeout */,
             this.serviceConfiguration);
 
         const lambdas = [

--- a/server/routerlicious/packages/local-server/src/localOrdererManager.ts
+++ b/server/routerlicious/packages/local-server/src/localOrdererManager.ts
@@ -26,7 +26,6 @@ export class LocalOrdererManager implements IOrdererManager {
         private readonly tenantManager: ITenantManager,
         private readonly taskMessageSender: ITaskMessageSender,
         private readonly permission: any, // Can probably remove
-        private readonly maxMessageSize: number,
         private readonly tokenGenerator: TokenGenerator,
         private readonly createHistorian: (tenant: string) => Promise<IHistorian>,
         private readonly logger: ILogger,
@@ -73,7 +72,6 @@ export class LocalOrdererManager implements IOrdererManager {
             this.taskMessageSender,
             this.tenantManager,
             this.permission,
-            this.maxMessageSize,
             this.tokenGenerator,
             this.logger,
             gitManager,

--- a/server/routerlicious/packages/memory-orderer/src/localNode.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localNode.ts
@@ -33,13 +33,23 @@ import { Socket } from "./socket";
 const DefaultServiceConfiguration: IServiceConfiguration = {
     blockSize: 64436,
     maxMessageSize: 16 * 1024,
+    enableTraces: true,
     summary: {
         idleTime: 5000,
         maxOps: 1000,
         maxTime: 5000 * 12,
         maxAckWaitTime: 600000,
     },
-    enableTraces: true,
+    deli: {
+        clientTimeout: 5 * 60 * 1000,
+        activityTimeout: 30 * 1000,
+        noOpConsolidationTimeout: 250,
+    },
+    scribe: {
+        generateServiceSummary: true,
+        clearCacheAfterServiceSummary: false,
+        ignoreStorageException: false,
+    },
 };
 
 class RemoteSubscriber implements ISubscriber {

--- a/server/routerlicious/packages/memory-orderer/src/localNode.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localNode.ts
@@ -269,7 +269,6 @@ export class LocalNode extends EventEmitter implements IConcreteNode {
             this.taskMessageSender,
             this.tenantManager,
             this.permission,
-            this.maxMessageSize,
             this.tokenGenerator,
             this.logger);
         assert(!this.orderMap.has(fullId));

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -7,14 +7,11 @@ import { merge } from "lodash";
 import { ProtocolOpHandler } from "@fluidframework/protocol-base";
 import { IClient, IServiceConfiguration } from "@fluidframework/protocol-definitions";
 import {
-    ActivityCheckingTimeout,
     BroadcasterLambda,
     CheckpointManager,
-    ClientSequenceTimeout,
     DefaultServiceConfiguration,
     DeliLambda,
     ForemanLambda,
-    NoopConsolidationTimeout,
     ScribeLambda,
     ScriptoriumLambda,
     SummaryReader,
@@ -111,9 +108,7 @@ export class LocalOrderer implements IOrderer {
         foremanContext: IContext = new LocalContext(logger),
         scribeContext: IContext = new LocalContext(logger),
         deliContext: IContext = new LocalContext(logger),
-        clientTimeout: number = ClientSequenceTimeout,
         serviceConfiguration: Partial<IServiceConfiguration> = {},
-        scribeNackOnSummarizeException = false,
     ) {
         const documentDetails = await setup.documentP();
 
@@ -134,9 +129,7 @@ export class LocalOrderer implements IOrderer {
             foremanContext,
             scribeContext,
             deliContext,
-            clientTimeout,
-            merge({}, DefaultServiceConfiguration, serviceConfiguration),
-            scribeNackOnSummarizeException);
+            merge({}, DefaultServiceConfiguration, serviceConfiguration));
     }
 
     public rawDeltasKafka: LocalKafka;
@@ -169,9 +162,7 @@ export class LocalOrderer implements IOrderer {
         private readonly foremanContext: IContext,
         private readonly scribeContext: IContext,
         private readonly deliContext: IContext,
-        private readonly clientTimeout: number,
         private readonly serviceConfiguration: IServiceConfiguration,
-        private readonly scribeNackOnSummarizeException: boolean,
     ) {
         this.existing = details.existing;
         this.dbObject = this.getDeliState();
@@ -288,9 +279,6 @@ export class LocalOrderer implements IOrderer {
                     documentCollection,
                     this.deltasKafka,
                     this.rawDeltasKafka,
-                    this.clientTimeout,
-                    ActivityCheckingTimeout,
-                    NoopConsolidationTimeout,
                     this.serviceConfiguration);
             });
     }
@@ -349,10 +337,7 @@ export class LocalOrderer implements IOrderer {
             protocolHandler,
             1, // TODO (Change when local orderer also ticks epoch)
             protocolHead,
-            scribeMessages.map((message) => message.operation),
-            false,
-            false,
-            this.scribeNackOnSummarizeException);
+            scribeMessages.map((message) => message.operation));
     }
 
     private startLambdas() {

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -92,7 +92,6 @@ export class LocalOrderer implements IOrderer {
         taskMessageSender: ITaskMessageSender,
         tenantManager: ITenantManager,
         permission: any,
-        maxMessageSize: number,
         tokenGenerator: TokenGenerator,
         logger: ILogger,
         gitManager?: IGitManager,
@@ -121,7 +120,6 @@ export class LocalOrderer implements IOrderer {
             tenantManager,
             gitManager,
             permission,
-            maxMessageSize,
             tokenGenerator,
             pubSub,
             broadcasterContext,
@@ -154,7 +152,6 @@ export class LocalOrderer implements IOrderer {
         private readonly tenantManager: ITenantManager,
         private readonly gitManager: IGitManager | undefined,
         private readonly permission: any,
-        private readonly maxMessageSize: number,
         private readonly foremanTokenGenrator: TokenGenerator,
         private readonly pubSub: IPubSub,
         private readonly broadcasterContext: IContext,
@@ -198,7 +195,6 @@ export class LocalOrderer implements IOrderer {
             this.documentId,
             clientId,
             client,
-            this.maxMessageSize,
             this.serviceConfiguration);
 
         // Document is now existing regardless of the original value

--- a/server/routerlicious/packages/memory-orderer/src/localOrdererConnection.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrdererConnection.ts
@@ -27,6 +27,8 @@ export class LocalOrdererConnection implements IOrdererConnection {
     // Back-compat, removal tracked with issue #4346
     public readonly parentBranch = null;
 
+    public readonly maxMessageSize: number;
+
     constructor(
         public socket: ISubscriber,
         public readonly existing: boolean,
@@ -36,9 +38,10 @@ export class LocalOrdererConnection implements IOrdererConnection {
         public readonly documentId: string,
         public readonly clientId: string,
         private readonly client: IClient,
-        public readonly maxMessageSize: number,
         public readonly serviceConfiguration: IServiceConfiguration,
-    ) { }
+    ) {
+        this.maxMessageSize = serviceConfiguration.maxMessageSize;
+    }
 
     public async connect() {
         // Send the connect message

--- a/server/routerlicious/packages/protocol-definitions/src/config.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/config.ts
@@ -19,7 +19,7 @@ export interface ISummaryConfiguration {
 }
 
 // Deli lambda configuration
-export interface IDeliConfiguration {
+export interface IDeliServerConfiguration {
     // Expire clients after this amount of inactivity
     clientTimeout: number;
 
@@ -31,7 +31,7 @@ export interface IDeliConfiguration {
 }
 
 // Scribe lambda configuration
-export interface IScribeConfiguration {
+export interface IScribeServerConfiguration {
     // Enables generating service summaries
     generateServiceSummary: boolean;
 
@@ -43,11 +43,16 @@ export interface IScribeConfiguration {
 }
 
 /**
- * Key value store of service configuration properties provided as part of connection
+ * Key value store of service configuration properties
  */
-export interface IServiceConfiguration {
+export interface IServiceConfiguration extends IClientConfiguration, IServerConfiguration {
     [key: string]: any;
+}
 
+/**
+ * Key value store of service configuration properties provided to the client as part of connection
+ */
+export interface IClientConfiguration {
     // Max message size the server will accept before requiring chunking
     maxMessageSize: number;
 
@@ -56,12 +61,17 @@ export interface IServiceConfiguration {
 
     // Summary algorithm configuration. This is sent to clients when they connect
     summary: ISummaryConfiguration;
+}
 
+/**
+ * Key value store of service configuration properties for the server
+ */
+export interface IServerConfiguration {
     // Deli lambda configuration
-    deli: IDeliConfiguration;
+    deli: IDeliServerConfiguration;
 
     // Scribe lambda configuration
-    scribe: IScribeConfiguration;
+    scribe: IScribeServerConfiguration;
 
     // Enable adding a traces array to operation messages
     enableTraces: boolean;

--- a/server/routerlicious/packages/protocol-definitions/src/config.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/config.ts
@@ -32,7 +32,6 @@ export interface IDeliConfiguration {
 
 // Scribe lambda configuration
 export interface IScribeConfiguration {
-
     // Enables generating service summaries
     generateServiceSummary: boolean;
 

--- a/server/routerlicious/packages/protocol-definitions/src/config.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/config.ts
@@ -18,6 +18,31 @@ export interface ISummaryConfiguration {
     maxAckWaitTime: number;
 }
 
+// Deli lambda configuration
+export interface IDeliConfiguration {
+    // Expire clients after this amount of inactivity
+    clientTimeout: number;
+
+    // Timeout for sending no-ops to trigger inactivity checker
+    activityTimeout: number;
+
+    // Timeout for sending consolidated no-ops
+    noOpConsolidationTimeout: number;
+}
+
+// Scribe lambda configuration
+export interface IScribeConfiguration {
+
+    // Enables generating service summaries
+    generateServiceSummary: boolean;
+
+    // Enables clearing the checkpoint cache after a service summary is created
+    clearCacheAfterServiceSummary: boolean;
+
+    // Enables writing a summary nack when an exception occurs during summary creation
+    ignoreStorageException: boolean;
+}
+
 /**
  * Key value store of service configuration properties provided as part of connection
  */
@@ -32,6 +57,12 @@ export interface IServiceConfiguration {
 
     // Summary algorithm configuration. This is sent to clients when they connect
     summary: ISummaryConfiguration;
+
+    // Deli lambda configuration
+    deli: IDeliConfiguration;
+
+    // Scribe lambda configuration
+    scribe: IScribeConfiguration;
 
     // Enable adding a traces array to operation messages
     enableTraces: boolean;

--- a/server/routerlicious/packages/protocol-definitions/src/sockets.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/sockets.ts
@@ -4,7 +4,7 @@
  */
 
 import { ConnectionMode, IClient, ISignalClient } from "./clients";
-import { IServiceConfiguration } from "./config";
+import { IClientConfiguration } from "./config";
 import { ISequencedDocumentMessage, ISignalMessage } from "./protocol";
 import { ITokenClaims } from "./tokens";
 
@@ -106,7 +106,7 @@ export interface IConnected {
     /**
      * Configuration details provided by the service
      */
-    serviceConfiguration: IServiceConfiguration;
+    serviceConfiguration: IClientConfiguration;
 
     /**
      * Connection mode of client.


### PR DESCRIPTION
Also split up the server and client configuration. We'll only send the client what they care about in the `connect_document_response` message.