### PR TITLE
Remove outFiles from 'Debug Current Test' option in vscode launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -234,7 +234,6 @@
             "request": "launch",
             "name": "Debug Current Test",
             "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-            "outFiles": [ "${workspaceFolder}/dist/**/*.js" ],
             "stopOnEntry": false,
             "env": {
                 "TS_NODE_PROJECT": "${fileDirname}/../../tsconfig.json",


### PR DESCRIPTION
outFiles was added to "Debug Current Test" via PR #4306.
However, with we can't add breakpoints while debugging tests locally in vs code. This makes debugging locally a lot harder. So, removing the outFiles.