### PR TITLE
Use deferral approach for blob cache clearing to reduce timer set/clears

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -102,6 +102,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
     // Save the timeout so we can cancel and reschedule it as needed
     private blobCacheTimeout: ReturnType<typeof setTimeout> | undefined;
     // If the defer flag is set when the timeout fires, we'll reschedule rather than clear immediately
+    // This deferral approach is used (rather than clearing/resetting the timer) as current calling patterns trigger
+    // too many calls to setTimeout/clearTimeout.
     private deferBlobCacheClear: boolean = false;
 
     private readonly attributesBlobHandles: Set<string> = new Set();
@@ -789,23 +791,22 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
      * Schedule a timer for clearing the blob cache or defer the current one.
      */
     private scheduleClearBlobsCache() {
-        const blobCacheTimeoutDuration = 10000;
-        // When the timer runs out, decide whether to proceed with the cache clear or reset the timer
-        const clearCacheOrDefer = () => {
-            this.blobCacheTimeout = undefined;
-            if (this.deferBlobCacheClear) {
-                this.deferBlobCacheClear = false;
-                this.scheduleClearBlobsCache();
-            } else {
-                this.blobCache.clear();
-            }
-        };
-
         if (this.blobCacheTimeout !== undefined) {
             // If we already have an outstanding timer, just signal that we should defer the clear
             this.deferBlobCacheClear = true;
         } else {
-            // If we don't have an outstanding timer, schedule a clear
+            // If we don't have an outstanding timer, set a timer
+            // When the timer runs out, we'll decide whether to proceed with the cache clear or reset the timer
+            const clearCacheOrDefer = () => {
+                this.blobCacheTimeout = undefined;
+                if (this.deferBlobCacheClear) {
+                    this.deferBlobCacheClear = false;
+                    this.scheduleClearBlobsCache();
+                } else {
+                    this.blobCache.clear();
+                }
+            };
+            const blobCacheTimeoutDuration = 10000;
             this.blobCacheTimeout = setTimeout(clearCacheOrDefer, blobCacheTimeoutDuration);
         }
     }


### PR DESCRIPTION
Fixes #4430 

Modifying the approach to blob cache clearing to defer the clear if there are any reads before it fires.  The clear will be delayed a bit, but in exchange we guarantee we won't set/clear too many timers.

In parallel I'm looking into the trace to better understand if it's expected to see so many calls.