### PR TITLE
Remove nextTick as it causes performance degradation.

### DIFF
--- a/packages/drivers/odsp-driver/src/rateLimiter.ts
+++ b/packages/drivers/odsp-driver/src/rateLimiter.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import process from "process";
 import { assert } from "@fluidframework/common-utils";
 
 export class RateLimiter {
@@ -40,7 +39,8 @@ export class RateLimiter {
                 });
             };
             this.tasks.push(task);
-            process.nextTick(this.sched.bind(this));
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            Promise.resolve().then(async () => this.sched());
         });
     }
 


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/4433
The timers can be throttled by browser. So don't use nextTick, just use Promise.resolve().then() which is equivalent of nextTick.