### PR TITLE
Improve document partition cleanup

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/lambdaFactory.ts
@@ -11,7 +11,8 @@ import { DocumentLambda } from "./documentLambda";
 export class DocumentLambdaFactory extends EventEmitter implements IPartitionLambdaFactory {
     constructor(
         private readonly documentLambdaFactory: IPartitionLambdaFactory,
-        private readonly activityTimeout?: number,
+        private readonly partitionActivityTimeout?: number,
+        private readonly partitionActivityCheckInterval?: number,
     ) {
         super();
 
@@ -22,8 +23,12 @@ export class DocumentLambdaFactory extends EventEmitter implements IPartitionLam
     }
 
     public async create(config: Provider, context: IContext): Promise<IPartitionLambda> {
-        const lambda = new DocumentLambda(this.documentLambdaFactory, config, context, this.activityTimeout);
-        return lambda;
+        return new DocumentLambda(
+            this.documentLambdaFactory,
+            config,
+            context,
+            this.partitionActivityTimeout,
+            this.partitionActivityCheckInterval);
     }
 
     public async dispose(): Promise<void> {

--- a/server/routerlicious/packages/lambdas-driver/src/test/document-router/index.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/document-router/index.spec.ts
@@ -24,11 +24,16 @@ describe("document-router", () => {
             factory = await plugin.create(config);
         });
 
+        afterEach(async () => {
+           await factory.dispose();
+        });
+
         describe(".create", () => {
             it("Should be able to create a new lambda", async () => {
                 const context = new TestContext();
                 const lambda = await factory.create(config, context);
                 assert.ok(lambda);
+                lambda.close();
             });
         });
     });

--- a/server/routerlicious/packages/lambdas-driver/src/test/document-router/lambdaFactory.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/document-router/lambdaFactory.spec.ts
@@ -28,6 +28,7 @@ describe("document-router", () => {
             it("Should create a new IPartitionLambda", async () => {
                 const lambda = await factory.create(config, testContext);
                 assert.ok(lambda);
+                lambda.close();
             });
         });
 


### PR DESCRIPTION
Fixes #863
Introduces a GC-like pass through all the partitions to close inactive ones. This will greatly reduce the amount of active node timers on busy servers.

I also think the `partitionActivityTimeout` & `partitionActivityCheckInterval` params should come from the service configuration object. We can do that after #4435 is completed.