### PR TITLE
[main > 29]: Replace nextTick with Promise.resolve (#4441)

### DIFF
--- a/packages/drivers/odsp-driver/src/rateLimiter.ts
+++ b/packages/drivers/odsp-driver/src/rateLimiter.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import process from "process";
 import { assert } from "@fluidframework/common-utils";
 
 export class RateLimiter {
@@ -40,7 +39,8 @@ export class RateLimiter {
                 });
             };
             this.tasks.push(task);
-            process.nextTick(this.sched.bind(this));
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            Promise.resolve().then(async () => this.sched());
         });
     }
 


### PR DESCRIPTION
The timers can be throttled by browser. So don't use nextTick, just use Promise.resolve().then() which is equivalent of nextTick.