### PR TITLE
Add telemetry to remote channel context errors

### DIFF
--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -51,6 +51,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
+    "@fluidframework/common-definitions": "^0.19.1",
     "@fluidframework/common-utils": "^0.25.0",
     "@fluidframework/container-definitions": "^0.30.0",
     "@fluidframework/telemetry-utils": "^0.30.0",

--- a/packages/loader/container-utils/src/error.ts
+++ b/packages/loader/container-utils/src/error.ts
@@ -4,8 +4,14 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { ContainerErrorType, IGenericError, ICriticalContainerError } from "@fluidframework/container-definitions";
+import {
+    ContainerErrorType,
+    IGenericError,
+    ICriticalContainerError,
+    IErrorBase,
+} from "@fluidframework/container-definitions";
 import { CustomErrorWithProps } from "@fluidframework/telemetry-utils";
+import { ITelemetryProperties } from "@fluidframework/common-definitions";
 
 function messageFromError(error: any) {
     if (typeof error?.message === "string") {
@@ -26,6 +32,18 @@ export class GenericError extends CustomErrorWithProps implements IGenericError 
         readonly error: any,
     ) {
         super(errorMessage);
+    }
+}
+
+export class DataCorruptionError extends CustomErrorWithProps implements IErrorBase {
+    readonly errorType = "dataCorruptionError";
+    readonly canRetry = false;
+
+    constructor(
+        errorMessage: string,
+        props: ITelemetryProperties,
+    ) {
+        super(errorMessage, props);
     }
 }
 

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -4,27 +4,13 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { IErrorBase } from "@fluidframework/container-definitions";
-import { CustomErrorWithProps } from "@fluidframework/telemetry-utils";
-import { ITelemetryProperties } from "@fluidframework/common-definitions";
+import { DataCorruptionError } from "@fluidframework/container-utils";
 import {
     ISequencedDocumentMessage,
 } from "@fluidframework/protocol-definitions";
 import { FlushMode } from "@fluidframework/runtime-definitions";
 import Deque from "double-ended-queue";
 import { ContainerRuntime, ContainerMessageType } from "./containerRuntime";
-
-export class DataCorruptionError extends CustomErrorWithProps implements IErrorBase {
-    readonly errorType = "dataCorruptionError";
-    readonly canRetry = false;
-
-    constructor(
-        errorMessage: string,
-        props: ITelemetryProperties,
-    ) {
-        super(errorMessage, props);
-    }
-}
 
 /**
  * This represents a message that has been submitted and is added to the pending queue when `submit` is called on the

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -151,7 +151,7 @@ export class RemoteChannelContext implements IChannelContext {
                     channelId: this.id,
                     dataStoreId: this.dataStoreContext.id,
                     dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
-                    dataStoreFactoryType: this.attachMessageType
+                    channelFactoryType: this.attachMessageType
                 });
             }
             attributes = factory.attributes;
@@ -162,7 +162,7 @@ export class RemoteChannelContext implements IChannelContext {
                     channelId: this.id,
                     dataStoreId: this.dataStoreContext.id,
                     dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
-                    dataStoreFactoryType: attributes.type,
+                    channelFactoryType: attributes.type,
                 });
             }
         }

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -137,7 +137,7 @@ export class RemoteChannelContext implements IChannelContext {
         // the attributes. Since old attach messages
         // will not have attributes we need to keep
         // this as long as we support old attach messages
-        if (attributes) {
+        if (attributes == undefined) {
             if (this.attachMessageType === undefined) {
                 // TODO: Strip out potential PII content #1920
                 throw new DataCorruptionError("Channel type not available", {

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -137,8 +137,9 @@ export class RemoteChannelContext implements IChannelContext {
         // the attributes. Since old attach messages
         // will not have attributes we need to keep
         // this as long as we support old attach messages
-        if (attributes === undefined) {
+        if (attributes) {
             if (this.attachMessageType === undefined) {
+                // TODO: Strip out potential PII content #1920
                 throw new DataCorruptionError("Channel type not available", {
                     channelId: this.id,
                     dataStoreId: this.dataStoreContext.id,
@@ -147,6 +148,7 @@ export class RemoteChannelContext implements IChannelContext {
             }
             factory = this.registry.get(this.attachMessageType);
             if (factory === undefined) {
+                // TODO: Strip out potential PII content #1920
                 throw new DataCorruptionError(`Channel Factory ${this.attachMessageType} for attach not registered`, {
                     channelId: this.id,
                     dataStoreId: this.dataStoreContext.id,
@@ -158,6 +160,7 @@ export class RemoteChannelContext implements IChannelContext {
         } else {
             factory = this.registry.get(attributes.type);
             if (factory === undefined) {
+                // TODO: Strip out potential PII content #1920
                 throw new DataCorruptionError(`Channel Factory ${attributes.type} not registered`, {
                     channelId: this.id,
                     dataStoreId: this.dataStoreContext.id,

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -151,6 +151,7 @@ export class RemoteChannelContext implements IChannelContext {
                     channelId: this.id,
                     dataStoreId: this.dataStoreContext.id,
                     dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
+                    dataStoreFactoryType: this.attachMessageType
                 });
             }
             attributes = factory.attributes;
@@ -161,6 +162,7 @@ export class RemoteChannelContext implements IChannelContext {
                     channelId: this.id,
                     dataStoreId: this.dataStoreContext.id,
                     dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
+                    dataStoreFactoryType: attributes.type,
                 });
             }
         }

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -137,7 +137,7 @@ export class RemoteChannelContext implements IChannelContext {
         // the attributes. Since old attach messages
         // will not have attributes we need to keep
         // this as long as we support old attach messages
-        if (attributes == undefined) {
+        if (attributes === undefined) {
             if (this.attachMessageType === undefined) {
                 // TODO: Strip out potential PII content #1920
                 throw new DataCorruptionError("Channel type not available", {

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -151,7 +151,7 @@ export class RemoteChannelContext implements IChannelContext {
                     channelId: this.id,
                     dataStoreId: this.dataStoreContext.id,
                     dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
-                    channelFactoryType: this.attachMessageType
+                    channelFactoryType: this.attachMessageType,
                 });
             }
             attributes = factory.attributes;

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { CreateContainerError } from "@fluidframework/container-utils";
+import { CreateContainerError, DataCorruptionError } from "@fluidframework/container-utils";
 import {
     IChannel,
     IChannelAttributes,
@@ -139,17 +139,29 @@ export class RemoteChannelContext implements IChannelContext {
         // this as long as we support old attach messages
         if (attributes === undefined) {
             if (this.attachMessageType === undefined) {
-                throw new Error("Channel type not available");
+                throw new DataCorruptionError("Channel type not available", {
+                    channelId: this.id,
+                    dataStoreId: this.dataStoreContext.id,
+                    dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
+                });
             }
             factory = this.registry.get(this.attachMessageType);
             if (factory === undefined) {
-                throw new Error(`Channel Factory ${this.attachMessageType} for attach not registered`);
+                throw new DataCorruptionError(`Channel Factory ${this.attachMessageType} for attach not registered`, {
+                    channelId: this.id,
+                    dataStoreId: this.dataStoreContext.id,
+                    dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
+                });
             }
             attributes = factory.attributes;
         } else {
             factory = this.registry.get(attributes.type);
             if (factory === undefined) {
-                throw new Error(`Channel Factory ${attributes.type} not registered`);
+                throw new DataCorruptionError(`Channel Factory ${attributes.type} not registered`, {
+                    channelId: this.id,
+                    dataStoreId: this.dataStoreContext.id,
+                    dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
+                });
             }
         }
 


### PR DESCRIPTION
- Add channel id, data store id, and the data store package path (as a proxy for data store type) to the telemetry returned from errors in remote channel context for investigating #4414 
- Reuses the DataCorruptionError class by moving it to a more general location in "container-utils" so the whole "container-runtime" package isn't imported to use the error class

However, @vladsud I'm not sure if we should reuse this class since the only other place it is being used is when pendingStateManager sees a pending state with a different clientSequenceNumber than the one in the message, which is an explicit data corruption case

Two alternatives:
- Create a separate ChannelError class similar to DataCorruptionError but with its own error type that is specific to the datastore package and throw that error instead with the above details
- Access the logger and explicitly log the error from within RemoteChannelContext using this.runtime.logger.sendErrorEvent with a new eventName and the parameters above. This will give two total message in the log, however, one for the event that was added and the existing one for the error itself