### PR TITLE
[release/0.29] Cherry-pick commit f7b6b5c AKA PR #4424 into 0.29

### DIFF
--- a/packages/dds/merge-tree/src/snapshotChunks.ts
+++ b/packages/dds/merge-tree/src/snapshotChunks.ts
@@ -135,14 +135,6 @@ export function toLatestVersion(
     chunk: VersionedMergeTreeChunk,
     logger: ITelemetryLogger,
     options: PropertySet | undefined): MergeTreeChunkV1 {
-    if (chunk.version !== "1") {
-        logger.send({
-            eventName: "MergeTreeChunk:toLatestVersion",
-            category: "generic",
-            fromChunkVersion: chunk.version,
-            toChunkVersion: "1",
-        });
-    }
     switch (chunk.version) {
         case undefined: {
             const chunkLegacy = chunk as MergeTreeChunkLegacy;


### PR DESCRIPTION
Removes logging from processChunk in 0.29 as was done in main in #4424.