### PR TITLE
Refactor server configuration interfaces/objects

### DIFF
--- a/server/routerlicious/packages/kafka-orderer/src/kafkaOrderer.ts
+++ b/server/routerlicious/packages/kafka-orderer/src/kafkaOrderer.ts
@@ -10,7 +10,6 @@ import {
     IClientJoin,
     IDocumentMessage,
     IDocumentSystemMessage,
-    IServiceConfiguration,
     MessageType,
 } from "@fluidframework/protocol-definitions";
 import * as core from "@fluidframework/server-services-core";
@@ -24,7 +23,7 @@ export class KafkaOrdererConnection implements core.IOrdererConnection {
         client: IClient,
         maxMessageSize: number,
         clientId: string,
-        serviceConfiguration: IServiceConfiguration,
+        serviceConfiguration: core.IServiceConfiguration,
     ): Promise<KafkaOrdererConnection> {
         // Create the connection
         return new KafkaOrdererConnection(
@@ -51,7 +50,7 @@ export class KafkaOrdererConnection implements core.IOrdererConnection {
         public readonly clientId: string,
         private readonly client: IClient,
         public readonly maxMessageSize: number,
-        public readonly serviceConfiguration: IServiceConfiguration,
+        public readonly serviceConfiguration: core.IServiceConfiguration,
     ) { }
 
     /**
@@ -161,7 +160,7 @@ export class KafkaOrderer implements core.IOrderer {
         tenantId: string,
         documentId: string,
         maxMessageSize: number,
-        serviceConfiguration: IServiceConfiguration,
+        serviceConfiguration: core.IServiceConfiguration,
     ): Promise<KafkaOrderer> {
         return new KafkaOrderer(producer, tenantId, documentId, maxMessageSize, serviceConfiguration);
     }
@@ -173,7 +172,7 @@ export class KafkaOrderer implements core.IOrderer {
         private readonly tenantId: string,
         private readonly documentId: string,
         private readonly maxMessageSize: number,
-        private readonly serviceConfiguration: IServiceConfiguration,
+        private readonly serviceConfiguration: core.IServiceConfiguration,
     ) {
     }
 
@@ -211,7 +210,7 @@ export class KafkaOrdererFactory {
     constructor(
         private readonly producer: core.IProducer,
         private readonly maxMessageSize: number,
-        private readonly serviceConfiguration: IServiceConfiguration,
+        private readonly serviceConfiguration: core.IServiceConfiguration,
     ) {
     }
 

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -13,7 +13,6 @@ import {
     IDocumentMessage,
     IDocumentSystemMessage,
     INack,
-    IServiceConfiguration,
     ISignalMessage,
     MessageType,
     NackErrorType,
@@ -30,28 +29,6 @@ import {
     getRandomInt,
     generateClientId,
 } from "../utils";
-
-export const DefaultServiceConfiguration: IServiceConfiguration = {
-    blockSize: 64436,
-    maxMessageSize: 16 * 1024,
-    enableTraces: true,
-    summary: {
-        idleTime: 5000,
-        maxOps: 1000,
-        maxTime: 5000 * 12,
-        maxAckWaitTime: 600000,
-    },
-    deli: {
-        clientTimeout: 5 * 60 * 1000,
-        activityTimeout: 30 * 1000,
-        noOpConsolidationTimeout: 250,
-    },
-    scribe: {
-        generateServiceSummary: true,
-        clearCacheAfterServiceSummary: false,
-        ignoreStorageException: false,
-    },
-};
 
 interface IRoom {
 
@@ -306,9 +283,9 @@ export function configureWebSocketServices(
                     // Back-compat, removal tracked with issue #4346
                     parentBranch: null, // Does not matter for now.
                     serviceConfiguration: {
-                        blockSize: DefaultServiceConfiguration.blockSize,
-                        maxMessageSize: DefaultServiceConfiguration.maxMessageSize,
-                        summary: DefaultServiceConfiguration.summary,
+                        blockSize: core.DefaultServiceConfiguration.blockSize,
+                        maxMessageSize: core.DefaultServiceConfiguration.maxMessageSize,
+                        summary: core.DefaultServiceConfiguration.summary,
                     },
                     initialClients: clients,
                     initialMessages: [],

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -18,7 +18,6 @@ import {
     ITrace,
     MessageType,
     NackErrorType,
-    IServiceConfiguration,
 } from "@fluidframework/protocol-definitions";
 import { canSummarize } from "@fluidframework/server-services-client";
 import {
@@ -36,6 +35,7 @@ import {
     IProducer,
     IRawOperationMessage,
     ISequencedOperationMessage,
+    IServiceConfiguration,
     ITicketedMessage,
     NackOperationType,
     RawOperationType,

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -15,11 +15,12 @@ import {
     IPartitionLambda,
     IPartitionLambdaFactory,
     IProducer,
+    IServiceConfiguration,
     ITenantManager,
     MongoManager,
 } from "@fluidframework/server-services-core";
 import { generateServiceProtocolEntries } from "@fluidframework/protocol-base";
-import { FileMode, IServiceConfiguration } from "@fluidframework/protocol-definitions";
+import { FileMode } from "@fluidframework/protocol-definitions";
 import { IGitManager } from "@fluidframework/server-services-client";
 import { Provider } from "nconf";
 import { NoOpLambda } from "../utils";

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -16,7 +16,6 @@ import {
     MessageType,
     ISequencedDocumentAugmentedMessage,
     IProtocolState,
-    IServiceConfiguration,
 } from "@fluidframework/protocol-definitions";
 import {
     ControlMessageType,
@@ -27,6 +26,7 @@ import {
     IRawOperationMessage,
     IScribe,
     ISequencedOperationMessage,
+    IServiceConfiguration,
     RawOperationType,
     SequencedOperationType,
     IQueuedMessage,

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -15,10 +15,10 @@ import {
     IProducer,
     IScribe,
     ISequencedOperationMessage,
+    IServiceConfiguration,
     ITenantManager,
     MongoManager,
 } from "@fluidframework/server-services-core";
-import { IServiceConfiguration } from "@fluidframework/protocol-definitions";
 import { Provider } from "nconf";
 import { NoOpLambda } from "../utils";
 import { CheckpointManager } from "./checkpointManager";

--- a/server/routerlicious/packages/lambdas/src/test/deli/lambda.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/deli/lambda.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+    DefaultServiceConfiguration,
     ICollection,
     IPartitionLambda,
     IProducer,
@@ -23,7 +24,6 @@ import {
 import { strict as assert } from "assert";
 import * as _ from "lodash";
 import nconf from "nconf";
-import { DefaultServiceConfiguration } from "../../alfred";
 import { DeliLambdaFactory } from "../../deli/lambdaFactory";
 
 const MinSequenceNumberWindow = 2000;

--- a/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
+++ b/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
@@ -8,7 +8,6 @@ import {
     IConnect,
     IConnected,
     ISequencedDocumentMessage,
-    IServiceConfiguration,
     ISignalMessage,
 } from "@fluidframework/protocol-definitions";
 import { configureWebSocketServices } from "@fluidframework/server-lambdas";
@@ -20,6 +19,7 @@ import {
     IDatabaseManager,
     IDocumentStorage,
     ILogger,
+    IServiceConfiguration,
     IWebSocket,
     IWebSocketServer,
     MongoDatabaseManager,

--- a/server/routerlicious/packages/local-server/src/localOrdererManager.ts
+++ b/server/routerlicious/packages/local-server/src/localOrdererManager.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { IServiceConfiguration } from "@fluidframework/protocol-definitions";
 import { IPubSub, LocalOrderer } from "@fluidframework/server-memory-orderer";
 import { GitManager, IHistorian } from "@fluidframework/server-services-client";
 import {
@@ -12,6 +11,7 @@ import {
     ILogger,
     IOrderer,
     IOrdererManager,
+    IServiceConfiguration,
     ITaskMessageSender,
     ITenantManager,
     TokenGenerator,

--- a/server/routerlicious/packages/memory-orderer/src/interfaces.ts
+++ b/server/routerlicious/packages/memory-orderer/src/interfaces.ts
@@ -4,7 +4,7 @@
  */
 
 import { EventEmitter } from "events";
-import { IClient, IDocumentMessage, IServiceConfiguration } from "@fluidframework/protocol-definitions";
+import { IClient, IDocumentMessage } from "@fluidframework/protocol-definitions";
 import {
     ICollection,
     IContext,
@@ -13,6 +13,7 @@ import {
     IOrderer,
     ISequencedOperationMessage,
     IQueuedMessage,
+    IServiceConfiguration,
 } from "@fluidframework/server-services-core";
 
 export interface IConcreteNode extends EventEmitter {

--- a/server/routerlicious/packages/memory-orderer/src/localNode.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localNode.ts
@@ -5,7 +5,7 @@
 
 import assert from "assert";
 import { EventEmitter } from "events";
-import { IDocumentMessage, IServiceConfiguration } from "@fluidframework/protocol-definitions";
+import { IDocumentMessage } from "@fluidframework/protocol-definitions";
 import {
     IDatabaseManager,
     IDocumentStorage,
@@ -17,6 +17,7 @@ import {
     IWebSocketServer,
     ILogger,
     TokenGenerator,
+    DefaultServiceConfiguration,
 } from "@fluidframework/server-services-core";
 import * as _ from "lodash";
 import * as moniker from "moniker";
@@ -29,28 +30,6 @@ import { Socket } from "./socket";
 
 // Can I treat each Alfred as a mini-Kafka. And consolidate all the deli logic together?
 // Rather than creating one per? I'm in some ways on this path.
-
-const DefaultServiceConfiguration: IServiceConfiguration = {
-    blockSize: 64436,
-    maxMessageSize: 16 * 1024,
-    enableTraces: true,
-    summary: {
-        idleTime: 5000,
-        maxOps: 1000,
-        maxTime: 5000 * 12,
-        maxAckWaitTime: 600000,
-    },
-    deli: {
-        clientTimeout: 5 * 60 * 1000,
-        activityTimeout: 30 * 1000,
-        noOpConsolidationTimeout: 250,
-    },
-    scribe: {
-        generateServiceSummary: true,
-        clearCacheAfterServiceSummary: false,
-        ignoreStorageException: false,
-    },
-};
 
 class RemoteSubscriber implements ISubscriber {
     public id = uuid();

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -5,11 +5,10 @@
 
 import { merge } from "lodash";
 import { ProtocolOpHandler } from "@fluidframework/protocol-base";
-import { IClient, IServiceConfiguration } from "@fluidframework/protocol-definitions";
+import { IClient } from "@fluidframework/protocol-definitions";
 import {
     BroadcasterLambda,
     CheckpointManager,
-    DefaultServiceConfiguration,
     DeliLambda,
     ForemanLambda,
     ScribeLambda,
@@ -19,6 +18,7 @@ import {
 } from "@fluidframework/server-lambdas";
 import { IGitManager } from "@fluidframework/server-services-client";
 import {
+    DefaultServiceConfiguration,
     IContext,
     IDeliState,
     IDatabaseManager,
@@ -29,6 +29,7 @@ import {
     IOrdererConnection,
     IPublisher,
     IScribe,
+    IServiceConfiguration,
     ITaskMessageSender,
     ITenantManager,
     ITopic,

--- a/server/routerlicious/packages/memory-orderer/src/localOrdererConnection.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrdererConnection.ts
@@ -9,7 +9,6 @@ import {
     IClientJoin,
     IDocumentMessage,
     IDocumentSystemMessage,
-    IServiceConfiguration,
     MessageType,
 } from "@fluidframework/protocol-definitions";
 import {
@@ -19,6 +18,7 @@ import {
     IOrdererConnection,
     IProducer,
     IRawOperationMessage,
+    IServiceConfiguration,
     RawOperationType,
 } from "@fluidframework/server-services-core";
 import { ISubscriber } from "./pubsub";

--- a/server/routerlicious/packages/memory-orderer/src/remoteNode.ts
+++ b/server/routerlicious/packages/memory-orderer/src/remoteNode.ts
@@ -6,8 +6,15 @@
 import assert from "assert";
 import { EventEmitter } from "events";
 import { Deferred } from "@fluidframework/common-utils";
-import { IClient, IDocumentMessage, IServiceConfiguration } from "@fluidframework/protocol-definitions";
-import { INode, IOrderer, IOrdererConnection, IWebSocket, MongoManager } from "@fluidframework/server-services-core";
+import { IClient, IDocumentMessage } from "@fluidframework/protocol-definitions";
+import {
+    INode,
+    IOrderer,
+    IOrdererConnection,
+    IServiceConfiguration,
+    IWebSocket,
+    MongoManager,
+} from "@fluidframework/server-services-core";
 import { debug } from "./debug";
 import { IConcreteNode, IConnectedMessage, IConnectMessage, INodeMessage, IOpMessage } from "./interfaces";
 import { IOrdererConnectionFactory, ProxyOrderer } from "./proxyOrderer";

--- a/server/routerlicious/packages/protocol-definitions/src/config.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/config.ts
@@ -18,37 +18,6 @@ export interface ISummaryConfiguration {
     maxAckWaitTime: number;
 }
 
-// Deli lambda configuration
-export interface IDeliServerConfiguration {
-    // Expire clients after this amount of inactivity
-    clientTimeout: number;
-
-    // Timeout for sending no-ops to trigger inactivity checker
-    activityTimeout: number;
-
-    // Timeout for sending consolidated no-ops
-    noOpConsolidationTimeout: number;
-}
-
-// Scribe lambda configuration
-export interface IScribeServerConfiguration {
-    // Enables generating service summaries
-    generateServiceSummary: boolean;
-
-    // Enables clearing the checkpoint cache after a service summary is created
-    clearCacheAfterServiceSummary: boolean;
-
-    // Enables writing a summary nack when an exception occurs during summary creation
-    ignoreStorageException: boolean;
-}
-
-/**
- * Key value store of service configuration properties
- */
-export interface IServiceConfiguration extends IClientConfiguration, IServerConfiguration {
-    [key: string]: any;
-}
-
 /**
  * Key value store of service configuration properties provided to the client as part of connection
  */
@@ -61,18 +30,4 @@ export interface IClientConfiguration {
 
     // Summary algorithm configuration. This is sent to clients when they connect
     summary: ISummaryConfiguration;
-}
-
-/**
- * Key value store of service configuration properties for the server
- */
-export interface IServerConfiguration {
-    // Deli lambda configuration
-    deli: IDeliServerConfiguration;
-
-    // Scribe lambda configuration
-    scribe: IScribeServerConfiguration;
-
-    // Enable adding a traces array to operation messages
-    enableTraces: boolean;
 }

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -20,7 +20,6 @@ import * as redis from "redis";
 import * as winston from "winston";
 import * as ws from "ws";
 import { IAlfredTenant } from "@fluidframework/server-services-client";
-import { DefaultServiceConfiguration } from "@fluidframework/server-lambdas";
 import { AlfredRunner } from "./runner";
 
 class NodeWebSocketServer implements core.IWebSocketServer {
@@ -196,7 +195,7 @@ export class AlfredResourcesFactory implements utils.IResourcesFactory<AlfredRes
         const kafkaOrdererFactory = new KafkaOrdererFactory(
             producer,
             maxSendMessageSize,
-            DefaultServiceConfiguration);
+            core.DefaultServiceConfiguration);
         const serverUrl = config.get("worker:serverUrl");
 
         let eventHubOrdererFactory: KafkaOrdererFactory = null;
@@ -205,7 +204,7 @@ export class AlfredResourcesFactory implements utils.IResourcesFactory<AlfredRes
             eventHubOrdererFactory = new KafkaOrdererFactory(
                 eventHubProducer,
                 maxSendMessageSize,
-                DefaultServiceConfiguration);
+                core.DefaultServiceConfiguration);
         }
 
         const orderManager = new OrdererManager(

--- a/server/routerlicious/packages/routerlicious/src/deli/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/deli/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { BroadcasterLambda, DefaultServiceConfiguration, DeliLambdaFactory } from "@fluidframework/server-lambdas";
+import { BroadcasterLambda, DeliLambdaFactory } from "@fluidframework/server-lambdas";
 import { create as createDocumentRouter } from "@fluidframework/server-lambdas-driver";
 import { LocalKafka, LocalContext, LocalLambdaController } from "@fluidframework/server-memory-orderer";
 import * as services from "@fluidframework/server-services";
@@ -83,7 +83,7 @@ export async function deliCreate(config: Provider): Promise<core.IPartitionLambd
         tenantManager,
         combinedProducer,
         reverseProducer,
-        DefaultServiceConfiguration);
+        core.DefaultServiceConfiguration);
 }
 
 export async function create(config: Provider): Promise<core.IPartitionLambdaFactory> {

--- a/server/routerlicious/packages/routerlicious/src/event-hub/deli/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/event-hub/deli/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { BroadcasterLambda, DefaultServiceConfiguration, DeliLambdaFactory } from "@fluidframework/server-lambdas";
+import { BroadcasterLambda, DeliLambdaFactory } from "@fluidframework/server-lambdas";
 import { create as createDocumentRouter } from "@fluidframework/server-lambdas-driver";
 import { LocalKafka, LocalContext, LocalLambdaController } from "@fluidframework/server-memory-orderer";
 import * as services from "@fluidframework/server-services";
@@ -62,7 +62,7 @@ export async function deliCreate(config: Provider): Promise<core.IPartitionLambd
         tenantManager,
         combinedProducer,
         reverseProducer,
-        DefaultServiceConfiguration);
+        core.DefaultServiceConfiguration);
 }
 
 export async function create(config: Provider): Promise<core.IPartitionLambdaFactory> {

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -3,10 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { DefaultServiceConfiguration, ScribeLambdaFactory } from "@fluidframework/server-lambdas";
+import { ScribeLambdaFactory } from "@fluidframework/server-lambdas";
 import { create as createDocumentRouter } from "@fluidframework/server-lambdas-driver";
 import { createProducer, MongoDbFactory, TenantManager } from "@fluidframework/server-services";
 import {
+    DefaultServiceConfiguration,
     IDocument,
     IPartitionLambdaFactory,
     ISequencedOperationMessage,

--- a/server/routerlicious/packages/routerlicious/src/test/alfred/io.spec.ts
+++ b/server/routerlicious/packages/routerlicious/src/test/alfred/io.spec.ts
@@ -18,12 +18,13 @@ import {
 } from "@fluidframework/protocol-definitions";
 import { KafkaOrdererFactory } from "@fluidframework/server-kafka-orderer";
 import { LocalWebSocket, LocalWebSocketServer } from "@fluidframework/server-local-server";
-import { configureWebSocketServices, DefaultServiceConfiguration } from "@fluidframework/server-lambdas";
+import { configureWebSocketServices } from "@fluidframework/server-lambdas";
 import { PubSub } from "@fluidframework/server-memory-orderer";
 import * as services from "@fluidframework/server-services";
 import { generateToken } from "@fluidframework/server-services-utils";
 import {
     DefaultMetricClient,
+    DefaultServiceConfiguration,
     IClientManager,
     IDeliState,
     IOrdererManager,

--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -1,0 +1,73 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IClientConfiguration } from "@fluidframework/protocol-definitions";
+
+// Deli lambda configuration
+export interface IDeliServerConfiguration {
+    // Expire clients after this amount of inactivity
+    clientTimeout: number;
+
+    // Timeout for sending no-ops to trigger inactivity checker
+    activityTimeout: number;
+
+    // Timeout for sending consolidated no-ops
+    noOpConsolidationTimeout: number;
+}
+
+// Scribe lambda configuration
+export interface IScribeServerConfiguration {
+    // Enables generating service summaries
+    generateServiceSummary: boolean;
+
+    // Enables clearing the checkpoint cache after a service summary is created
+    clearCacheAfterServiceSummary: boolean;
+
+    // Enables writing a summary nack when an exception occurs during summary creation
+    ignoreStorageException: boolean;
+}
+
+/**
+ * Key value store of service configuration properties
+ */
+export interface IServiceConfiguration extends IClientConfiguration, IServerConfiguration {
+    [key: string]: any;
+}
+
+/**
+ * Key value store of service configuration properties for the server
+ */
+export interface IServerConfiguration {
+    // Deli lambda configuration
+    deli: IDeliServerConfiguration;
+
+    // Scribe lambda configuration
+    scribe: IScribeServerConfiguration;
+
+    // Enable adding a traces array to operation messages
+    enableTraces: boolean;
+}
+
+export const DefaultServiceConfiguration: IServiceConfiguration = {
+    blockSize: 64436,
+    maxMessageSize: 16 * 1024,
+    enableTraces: true,
+    summary: {
+        idleTime: 5000,
+        maxOps: 1000,
+        maxTime: 5000 * 12,
+        maxAckWaitTime: 600000,
+    },
+    deli: {
+        clientTimeout: 5 * 60 * 1000,
+        activityTimeout: 30 * 1000,
+        noOpConsolidationTimeout: 250,
+    },
+    scribe: {
+        generateServiceSummary: true,
+        clearCacheAfterServiceSummary: false,
+        ignoreStorageException: false,
+    },
+};

--- a/server/routerlicious/packages/services-core/src/index.ts
+++ b/server/routerlicious/packages/services-core/src/index.ts
@@ -9,6 +9,7 @@ export * from "./clientManager";
 export * from "./combinedContext";
 export * from "./combinedLambda";
 export * from "./combinedProducer";
+export * from "./configuration";
 export * from "./database";
 export * from "./document";
 export * from "./emptyTaskMessageSender";

--- a/server/routerlicious/packages/services-core/src/orderer.ts
+++ b/server/routerlicious/packages/services-core/src/orderer.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { IClient, IDocumentMessage, IServiceConfiguration } from "@fluidframework/protocol-definitions";
+import { IClient, IDocumentMessage } from "@fluidframework/protocol-definitions";
+import { IServiceConfiguration } from "./configuration";
 import { IDocumentDetails } from "./document";
 import { IWebSocket } from "./http";
 


### PR DESCRIPTION
This is a follow up on #4435
- Move `DefaultServiceConfiguration`, `IServiceConfiguration`, and related server config interfaces to `services-core` package
- Remove duplicate `DefaultServiceConfiguration` object from `localNode`.