### PR TITLE
Better encapsulation of bound state for ContainerRuntime's dataStoreContexts

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1603,6 +1603,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const envelope = message.contents as IEnvelope;
         const transformed = { ...message, contents: envelope.contents };
         const context = this.datastoreContexts.get(envelope.address);
+        assert(!!context, "There should be a store context for the op");
         context.process(transformed, local, localMessageMetadata);
     }
 
@@ -1611,6 +1612,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
 
         this.datastoreContexts.notifyOnBeforeBind(fluidDataStoreRuntime.id);
         const context = this.datastoreContexts.get(fluidDataStoreRuntime.id) as LocalFluidDataStoreContext;
+        assert(!!context, "Attempting to bind to a context that hasn't been added yet");
 
         // If the container is detached, we don't need to send OP or add to pending attach because
         // we will summarize it while uploading the create new summary and make it known to other

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -95,7 +95,6 @@ import {
     ITaskManager,
     ISummarizeResult,
     IChannelSummarizeResult,
-    IContextSummarizeResult,
 } from "@fluidframework/runtime-definitions";
 import {
     FluidSerializer,
@@ -1465,7 +1464,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         // Normalize the child's nodes and prefix the child's id to the ids of GC nodes returned by it.
         // This gradually builds the id of each node to be a path from the root.
         normalizeAndPrefixGCNodeIds(childGCNodes, childId);
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return childGCNodes;
     }
 
@@ -1494,11 +1492,9 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
      * @param trackState - This tells whether we should track state from this summary.
      */
     private async summarize(fullTree: boolean = false, trackState: boolean = true): Promise<IChannelSummarizeResult> {
-        const summarizeResult: IContextSummarizeResult = await this.summarizerNode.summarize(fullTree, trackState);
+        const summarizeResult = await this.summarizerNode.summarize(fullTree, trackState);
         assert(summarizeResult.summary.type === SummaryType.Tree,
             "Container Runtime's summarize should always return a tree");
-            // eslint-disable-next-line max-len
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion, @typescript-eslint/no-unsafe-return
         return summarizeResult as IChannelSummarizeResult;
     }
 

--- a/packages/runtime/container-runtime/src/dataStoreContexts.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContexts.ts
@@ -6,7 +6,7 @@
 import { IDisposable, ITelemetryBaseLogger, ITelemetryLogger } from "@fluidframework/common-definitions";
 import { assert, Deferred, Lazy } from "@fluidframework/common-utils";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
-import { FluidDataStoreContext } from "./dataStoreContext";
+import { FluidDataStoreContext, LocalFluidDataStoreContext } from "./dataStoreContext";
 
  export class DataStoreContexts implements Iterable<[string,FluidDataStoreContext]>, IDisposable {
     private readonly notBoundContexts = new Set<string>();
@@ -17,8 +17,7 @@ import { FluidDataStoreContext } from "./dataStoreContext";
     /**
      * List of pending context needing to be bound, for the case where a client
      * knows a store will exist and is waiting on its creation.
-     * This is a superset of contexts.
-     * Each deferred bind completes when the context exists in _contexts and is bound
+     * This also includes bound contexts, in the completed state, so this is a superset of contexts.
      */
     private readonly deferredContextBinds = new Map<string, Deferred<FluidDataStoreContext>>();
 
@@ -62,6 +61,10 @@ import { FluidDataStoreContext } from "./dataStoreContext";
         return this._contexts.has(id);
     }
 
+    public get(id: string): FluidDataStoreContext | undefined {
+        return this._contexts.get(id);
+    }
+
     /**
      * When a context of the given id is about to be bound/attached, call this to update internal tracking
      */
@@ -73,7 +76,7 @@ import { FluidDataStoreContext } from "./dataStoreContext";
     /**
      * Add the given context, marking it as to-be-bound
      */
-    public addUnboundContext(context: FluidDataStoreContext) {
+    public addUnboundContext(context: LocalFluidDataStoreContext) {
         const id = context.id;
         assert(!this._contexts.has(id), "Creating store with existing ID");
 
@@ -124,14 +127,4 @@ import { FluidDataStoreContext } from "./dataStoreContext";
         const deferredBind = this.prepDeferredBind(id);
         deferredBind.resolve(context);
     }
-
-    public get(id: string): FluidDataStoreContext {
-        const context = this._contexts.get(id);
-        assert(!!context);
-        return context;
-    }
-
-    public tryGet(id: string): FluidDataStoreContext | undefined {
-        return this._contexts.get(id);
-    }
- }
+}

--- a/packages/runtime/container-runtime/src/dataStoreContexts.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContexts.ts
@@ -11,11 +11,15 @@ import { FluidDataStoreContext } from "./dataStoreContext";
  export class DataStoreContexts implements Iterable<[string,FluidDataStoreContext]>, IDisposable {
     private readonly notBoundContexts = new Set<string>();
 
-    // Attached and loaded context proxies
+    /** Attached and loaded context proxies */
     private readonly _contexts = new Map<string, FluidDataStoreContext>();
-    // List of pending contexts (for the case where a client knows a store will exist and is waiting
-    // on its creation). This is a superset of contexts.
-    // The Deferreds complete when the context exists in _contexts and is bound
+
+    /**
+     * List of pending context needing to be bound, for the case where a client
+     * knows a store will exist and is waiting on its creation.
+     * This is a superset of contexts.
+     * Each deferred bind completes when the context exists in _contexts and is bound
+     */
     private readonly deferredContextBinds = new Map<string, Deferred<FluidDataStoreContext>>();
 
     private readonly disposeOnce = new Lazy<void>(()=>{
@@ -80,7 +84,8 @@ import { FluidDataStoreContext } from "./dataStoreContext";
     }
 
     /**
-     * This returns a Deferred that will resolve when a context with the given id is bound
+     * This returns a Deferred that will resolve when a context with the given id is bound.
+     * We may or may not have this context locally already.
      * @param id The id of the context to defer binding on
      */
     public prepDeferredBind(id: string): Deferred<FluidDataStoreContext> {
@@ -98,10 +103,10 @@ import { FluidDataStoreContext } from "./dataStoreContext";
      * @param context - The context (Redundant with existing context that was previously set)
      */
     public resolveDeferredBind(id: string, context: FluidDataStoreContext) {
-        assert(this._contexts.get(id) === context);
-        const deferred = this.deferredContextBinds.get(id);
-        assert(!!deferred);
-        deferred.resolve(context);
+        assert(this._contexts.get(id) === context, "id mismatch for context being bound");
+        const deferredBind = this.deferredContextBinds.get(id);
+        assert(!!deferredBind, "Cannot find deferredBind");
+        deferredBind.resolve(context);
     }
 
     /**

--- a/packages/runtime/container-runtime/src/dataStoreContexts.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContexts.ts
@@ -102,12 +102,13 @@ import { FluidDataStoreContext, LocalFluidDataStoreContext } from "./dataStoreCo
 
     /**
      * Triggers the deferred to resolve, indicating the context has been bound
-     * @param id - The id of the newly-bound context
-     * @param context - The context (Redundant with existing context that was previously added)
+     * @param id - The id of the context to resolve to
      */
-    public resolveDeferredBind(id: string, context: FluidDataStoreContext) {
-        assert(this._contexts.get(id) === context, "context mismatch for context being bound");
+    public resolveDeferredBind(id: string) {
+        const context = this._contexts.get(id);
+        assert(!!context, "Cannot find context we've bound");
         assert(!this.notBoundContexts.has(id), "Expected this id to already be removed from notBoundContexts");
+
         const deferredBind = this.deferredContextBinds.get(id);
         assert(!!deferredBind, "Cannot find deferredBind to resolve");
         deferredBind.resolve(context);

--- a/packages/runtime/container-runtime/src/dataStoreContexts.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContexts.ts
@@ -103,12 +103,13 @@ import { FluidDataStoreContext, LocalFluidDataStoreContext } from "./dataStoreCo
     /**
      * Triggers the deferred to resolve, indicating the context has been bound
      * @param id - The id of the newly-bound context
-     * @param context - The context (Redundant with existing context that was previously set)
+     * @param context - The context (Redundant with existing context that was previously added)
      */
     public resolveDeferredBind(id: string, context: FluidDataStoreContext) {
-        assert(this._contexts.get(id) === context, "id mismatch for context being bound");
+        assert(this._contexts.get(id) === context, "context mismatch for context being bound");
+        assert(!this.notBoundContexts.has(id), "Expected this id to already be removed from notBoundContexts");
         const deferredBind = this.deferredContextBinds.get(id);
-        assert(!!deferredBind, "Cannot find deferredBind");
+        assert(!!deferredBind, "Cannot find deferredBind to resolve");
         deferredBind.resolve(context);
     }
 


### PR DESCRIPTION
The actual semantics of unbound v. bound dataStoreContexts is quite obscured as-is, with the Deferred playing a critical but undersold role, and names lacking clarity.  This change updates naming and includes some very light refactoring to hopefully clarify a bit what the state machine for these is like.