### PR TITLE
Encapsulate Data Store Methods Not Related to Summarization

### DIFF
--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -284,7 +284,7 @@ export class DataStores implements IDisposable {
         const context = this.contexts.get(address);
         if (!context) {
             // Attach message may not have been processed yet
-            assert(!local);
+            assert(!local, "Missing datastore for local signal");
             this.logger.sendTelemetryEvent({
                 eventName: "SignalFluidDataStoreNotFound",
                 fluidDataStoreId: address,


### PR DESCRIPTION
Decided it was best to break apart #4420 as i don't want to introduce unintentional errors while merging. The end goal is still the same, fully encapsulate data stores with eventual goal of hosting on a channel.

Related #4448 , #4460 

This PR encapsulates all remaining methods that are not related to summarization. After we encapsulate summarization, we make contexts private on data stores, and remove the dependecy of the the container runtime on data store contexts