### PR TITLE
Encapsulate Data Store Summarization and Context

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -88,6 +88,7 @@ import {
     IChannelSummarizeResult,
     CreateChildSummarizerNodeParam,
     SummarizeInternalFn,
+    IGraphNode,
 } from "@fluidframework/runtime-definitions";
 import {
     FluidSerializer,
@@ -1288,9 +1289,10 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     }
 
     private async summarizeInternal(fullTree: boolean, trackState: boolean): Promise<ISummarizeInternalResult> {
+        const gcNodes: IGraphNode[] = [];
         const builder = new SummaryTreeBuilder();
 
-        const gcNodes = await this.dataStores.summarizeInternal(builder, fullTree, trackState);
+        await this.dataStores.summarizeInternal(builder, fullTree, trackState);
 
         this.serializeContainerBlobs(builder);
         const summary = builder.getSummaryTree();

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -53,7 +53,6 @@ import {
 import { CreateContainerError } from "@fluidframework/container-utils";
 import {
     BlobTreeEntry,
-    TreeTreeEntry,
 } from "@fluidframework/protocol-base";
 import {
     IClientDetails,
@@ -74,7 +73,6 @@ import {
 import {
     FlushMode,
     InboundAttachMessage,
-    IGraphNode,
     IFluidDataStoreContext,
     IFluidDataStoreContextDetached,
     IFluidDataStoreRegistry,
@@ -87,7 +85,6 @@ import {
     ISummarizeInternalResult,
     IAgentScheduler,
     ITaskManager,
-    ISummarizeResult,
     IChannelSummarizeResult,
     CreateChildSummarizerNodeParam,
     SummarizeInternalFn,
@@ -97,12 +94,9 @@ import {
     SummaryTracker,
     SummaryTreeBuilder,
     SummarizerNodeWithGC,
-    convertSummaryTreeToITree,
     convertToSummaryTree,
     RequestParser,
     requestFluidObject,
-    convertSnapshotTreeToSummaryTree,
-    normalizeAndPrefixGCNodeIds,
 } from "@fluidframework/runtime-utils";
 import { v4 as uuid } from "uuid";
 import { ContainerFluidHandleContext } from "./containerHandleContext";
@@ -910,36 +904,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
      * @deprecated - Use summarize to get summary of the container runtime.
      */
     public async snapshot(): Promise<ITree> {
-        // Iterate over each store and ask it to snapshot
-        const fluidDataStoreSnapshotsP = Array.from(this.dataStores.contexts).map(async ([fluidDataStoreId, value]) => {
-            const summaryTree = await value.summarize(true /* fullTree */, false /* trackState */);
-            assert(
-                summaryTree.summary.type === SummaryType.Tree,
-                "summarize should always return a tree when fullTree is true");
-            // back-compat summary - Remove this once snapshot is removed.
-            const snapshot = convertSummaryTreeToITree(summaryTree.summary);
-
-            // If ID exists then previous commit is still valid
-            return {
-                fluidDataStoreId,
-                snapshot,
-            };
-        });
-
-        const root: ITree = { entries: [], id: null };
-
-        // Add in module references to the store snapshots
-        const fluidDataStoreSnapshots = await Promise.all(fluidDataStoreSnapshotsP);
-
-        // Sort for better diffing of snapshots (in replay tool, used to find bugs in snapshotting logic)
-        fluidDataStoreSnapshots.sort((a, b) => a?.fluidDataStoreId.localeCompare(b.fluidDataStoreId));
-
-        for (const fluidDataStoreSnapshot of fluidDataStoreSnapshots) {
-            root.entries.push(new TreeTreeEntry(
-                fluidDataStoreSnapshot.fluidDataStoreId,
-                fluidDataStoreSnapshot.snapshot,
-            ));
-        }
+        const root: ITree = { entries: await this.dataStores.snapshot(), id: null };
 
         if (this.chunkMap.size > 0) {
             root.entries.push(new BlobTreeEntry(chunksBlobName, JSON.stringify([...this.chunkMap])));
@@ -1310,39 +1275,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     }
 
     /**
-     * Updates the garbage collection nodes of this node's children:
-     * - Prefixes the child's id to the id of each node returned by the child.
-     * @param childGCNodes - The child's garbage collection nodes.
-     * @param childId - The id of the child node.
-     * @returns the updated GC nodes of the child.
-     */
-    private updateChildGCNodes(childGCNodes: IGraphNode[], childId: string): IGraphNode[] {
-        // Normalize the child's nodes and prefix the child's id to the ids of GC nodes returned by it.
-        // This gradually builds the id of each node to be a path from the root.
-        normalizeAndPrefixGCNodeIds(childGCNodes, childId);
-        return childGCNodes;
-    }
-
-    /**
-     * @returns this channel's garbage collection node.
-     */
-    private getGCNode(): IGraphNode {
-        /**
-         * Get the outbound routes of this channel. This will be updated to only consider root data stores
-         * as referenced and hence outbound.
-         */
-        const outboundRoutes: string[] = [];
-        for (const [contextId] of this.dataStores.contexts) {
-            outboundRoutes.push(`/${contextId}`);
-        }
-
-        return {
-            id: "/",
-            outboundRoutes,
-        };
-    }
-
-    /**
      * Returns a summary of the runtime at the current sequence number.
      * @param fullTree - true to bypass optimizations and force a full summary tree.
      * @param trackState - This tells whether we should track state from this summary.
@@ -1355,29 +1287,9 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     }
 
     private async summarizeInternal(fullTree: boolean, trackState: boolean): Promise<ISummarizeInternalResult> {
-        // A list of this channel's GC nodes. Starts with this channel's GC node and adds the GC nodes all its child
-        // channel contexts.
-        let gcNodes: IGraphNode[] = [ this.getGCNode() ];
         const builder = new SummaryTreeBuilder();
 
-        // Iterate over each store and ask it to snapshot
-        await Promise.all(Array.from(this.dataStores.contexts)
-            .filter(([_, context]) => {
-                // Summarizer works only with clients with no local changes!
-                assert(context.attachState !== AttachState.Attaching);
-                return context.attachState === AttachState.Attached;
-            }).map(async ([contextId, context]) => {
-                const contextSummary = await context.summarize(fullTree, trackState);
-                builder.addWithStats(contextId, contextSummary);
-
-                // back-compat 0.30 - Older versions will not return GC nodes. Set it to empty array.
-                if (contextSummary.gcNodes === undefined) {
-                    contextSummary.gcNodes = [];
-                }
-
-                // Update and add the child context's GC nodes to the main list.
-                gcNodes = gcNodes.concat(this.updateChildGCNodes(contextSummary.gcNodes, contextId));
-            }));
+        const gcNodes = await this.dataStores.summarizeInternal(builder, fullTree, trackState);
 
         this.serializeContainerBlobs(builder);
         const summary = builder.getSummaryTree();
@@ -1401,37 +1313,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     public createSummary(): ISummaryTree {
         const builder = new SummaryTreeBuilder();
 
-        // Attaching graph of some stores can cause other stores to get bound too.
-        // So keep taking summary until no new stores get bound.
-        let notBoundContextsLength: number;
-        do {
-            const builderTree = builder.summary.tree;
-            notBoundContextsLength = this.dataStores.contexts.notBoundLength();
-            // Iterate over each data store and ask it to snapshot
-            Array.from(this.dataStores.contexts)
-                .filter(([key, _]) =>
-                    // Take summary of bounded data stores only, make sure we haven't summarized them already
-                    // and no attach op has been fired for that data store because for loader versions <= 0.24
-                    // we set attach state as "attaching" before taking createNew summary.
-                    !(this.dataStores.contexts.isNotBound(key)
-                        || builderTree[key]
-                        || this.dataStores.attachOpFiredForDataStore.has(key)),
-                )
-                .map(([key, value]) => {
-                    let dataStoreSummary: ISummarizeResult;
-                    if (value.isLoaded) {
-                        const snapshot = value.generateAttachMessage().snapshot;
-                        dataStoreSummary = convertToSummaryTree(snapshot, true);
-                    } else {
-                        // If this data store is not yet loaded, then there should be no changes in the snapshot from
-                        // which it was created as it is detached container. So just use the previous snapshot.
-                        assert(!!this.context.baseSnapshot,
-                            "BaseSnapshot should be there as detached container loaded from snapshot");
-                        dataStoreSummary = convertSnapshotTreeToSummaryTree(this.context.baseSnapshot.trees[key]);
-                    }
-                    builder.addWithStats(key, dataStoreSummary);
-                });
-        } while (notBoundContextsLength !== this.dataStores.contexts.notBoundLength());
+        this.dataStores.createSummary(builder);
 
         this.serializeContainerBlobs(builder);
 

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -378,7 +378,7 @@ export class DataStores implements IDisposable {
     }
 
     public async summarizeInternal(
-        builder: SummaryTreeBuilder, fullTree: boolean, trackState: boolean): Promise<IGraphNode[]> {
+        builder: SummaryTreeBuilder, fullTree: boolean, trackState: boolean): Promise<void> {
         // A list of this channel's GC nodes. Starts with this channel's GC node and adds the GC nodes all its child
         // channel contexts.
         let gcNodes: IGraphNode[] = [ this.getGCNode() ];
@@ -401,7 +401,6 @@ export class DataStores implements IDisposable {
                 // Update and add the child context's GC nodes to the main list.
                 gcNodes = gcNodes.concat(this.updateChildGCNodes(contextSummary.gcNodes, contextId));
             }));
-        return gcNodes;
     }
 
     public createSummary(builder: SummaryTreeBuilder) {

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -339,7 +339,7 @@ export class DataStores implements IDisposable {
         }
     }
 
-        /**
+    /**
      * Notifies this object to take the snapshot of the container.
      * @deprecated - Use summarize to get summary of the container runtime.
      */

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -4,7 +4,12 @@
  */
 
 import { ITelemetryLogger, ITelemetryBaseLogger, IDisposable } from "@fluidframework/common-definitions";
-import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
+import {
+    ISequencedDocumentMessage,
+    ISnapshotTree,
+    ITreeEntry,
+    SummaryType,
+} from "@fluidframework/protocol-definitions";
 import {
     CreateChildSummarizerNodeFn,
     CreateChildSummarizerNodeParam,
@@ -13,15 +18,25 @@ import {
     IEnvelope,
     IFluidDataStoreChannel,
     IFluidDataStoreContextDetached,
+    IGraphNode,
     IInboundSignalMessage,
     InboundAttachMessage,
+    ISummarizeResult,
 } from "@fluidframework/runtime-definitions";
-import { SummaryTracker } from "@fluidframework/runtime-utils";
+import {
+     convertSnapshotTreeToSummaryTree,
+     convertSummaryTreeToITree,
+     convertToSummaryTree,
+     normalizeAndPrefixGCNodeIds,
+     SummaryTracker,
+     SummaryTreeBuilder,
+} from "@fluidframework/runtime-utils";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
 import { AttachState } from "@fluidframework/container-definitions";
 import { BlobCacheStorageService, buildSnapshotTree, readAndParseFromBlobs } from "@fluidframework/driver-utils";
 import { assert, Lazy } from "@fluidframework/common-utils";
 import uuid from "uuid";
+import { TreeTreeEntry } from "@fluidframework/protocol-base";
 import { DataStoreContexts } from "./dataStoreContexts";
 import { ContainerRuntime, nonDataStorePaths } from "./containerRuntime";
 import {
@@ -49,14 +64,14 @@ export class DataStores implements IDisposable {
     private readonly disposeOnce = new Lazy<void>(()=>this.contexts.dispose());
 
     constructor(
-        baseSnapshot: ISnapshotTree | undefined,
+        private readonly baseSnapshot: ISnapshotTree | undefined,
         private readonly runtime: ContainerRuntime,
         private readonly submitAttachFn: (attachContent: any) => void,
         private readonly summaryTracker: SummaryTracker,
         private readonly getCreateChildSummarizerNodeFn:
             (id: string, createParam: CreateChildSummarizerNodeParam)  => CreateChildSummarizerNodeFn,
         baseLogger: ITelemetryBaseLogger,
-        public readonly contexts: DataStoreContexts = new DataStoreContexts(baseLogger),
+        private readonly contexts: DataStoreContexts = new DataStoreContexts(baseLogger),
     ) {
         this.logger = ChildLogger.create(baseLogger);
         // Extract stores stored inside the snapshot
@@ -322,5 +337,137 @@ export class DataStores implements IDisposable {
                 context.emit(eventName);
             }
         }
+    }
+
+        /**
+     * Notifies this object to take the snapshot of the container.
+     * @deprecated - Use summarize to get summary of the container runtime.
+     */
+    public async snapshot(): Promise<ITreeEntry[]> {
+        // Iterate over each store and ask it to snapshot
+        const fluidDataStoreSnapshotsP = Array.from(this.contexts).map(async ([fluidDataStoreId, value]) => {
+            const summaryTree = await value.summarize(true /* fullTree */, false /* trackState */);
+            assert(
+                summaryTree.summary.type === SummaryType.Tree,
+                "summarize should always return a tree when fullTree is true");
+            // back-compat summary - Remove this once snapshot is removed.
+            const snapshot = convertSummaryTreeToITree(summaryTree.summary);
+
+            // If ID exists then previous commit is still valid
+            return {
+                fluidDataStoreId,
+                snapshot,
+            };
+        });
+
+        const entries: ITreeEntry[] = [];
+
+        // Add in module references to the store snapshots
+        const fluidDataStoreSnapshots = await Promise.all(fluidDataStoreSnapshotsP);
+
+        // Sort for better diffing of snapshots (in replay tool, used to find bugs in snapshotting logic)
+        fluidDataStoreSnapshots.sort((a, b) => a?.fluidDataStoreId.localeCompare(b.fluidDataStoreId));
+
+        for (const fluidDataStoreSnapshot of fluidDataStoreSnapshots) {
+            entries.push(new TreeTreeEntry(
+                fluidDataStoreSnapshot.fluidDataStoreId,
+                fluidDataStoreSnapshot.snapshot,
+            ));
+        }
+        return entries;
+    }
+
+    public async summarizeInternal(
+        builder: SummaryTreeBuilder, fullTree: boolean, trackState: boolean): Promise<IGraphNode[]> {
+        // A list of this channel's GC nodes. Starts with this channel's GC node and adds the GC nodes all its child
+        // channel contexts.
+        let gcNodes: IGraphNode[] = [ this.getGCNode() ];
+
+        // Iterate over each store and ask it to snapshot
+        await Promise.all(Array.from(this.contexts)
+            .filter(([_, context]) => {
+                // Summarizer works only with clients with no local changes!
+                assert(context.attachState !== AttachState.Attaching);
+                return context.attachState === AttachState.Attached;
+            }).map(async ([contextId, context]) => {
+                const contextSummary = await context.summarize(fullTree, trackState);
+                builder.addWithStats(contextId, contextSummary);
+
+                // back-compat 0.30 - Older versions will not return GC nodes. Set it to empty array.
+                if (contextSummary.gcNodes === undefined) {
+                    contextSummary.gcNodes = [];
+                }
+
+                // Update and add the child context's GC nodes to the main list.
+                gcNodes = gcNodes.concat(this.updateChildGCNodes(contextSummary.gcNodes, contextId));
+            }));
+        return gcNodes;
+    }
+
+    public createSummary(builder: SummaryTreeBuilder) {
+        // Attaching graph of some stores can cause other stores to get bound too.
+        // So keep taking summary until no new stores get bound.
+        let notBoundContextsLength: number;
+        do {
+            const builderTree = builder.summary.tree;
+            notBoundContextsLength = this.contexts.notBoundLength();
+            // Iterate over each data store and ask it to snapshot
+            Array.from(this.contexts)
+                .filter(([key, _]) =>
+                    // Take summary of bounded data stores only, make sure we haven't summarized them already
+                    // and no attach op has been fired for that data store because for loader versions <= 0.24
+                    // we set attach state as "attaching" before taking createNew summary.
+                    !(this.contexts.isNotBound(key)
+                        || builderTree[key]
+                        || this.attachOpFiredForDataStore.has(key)),
+                )
+                .map(([key, value]) => {
+                    let dataStoreSummary: ISummarizeResult;
+                    if (value.isLoaded) {
+                        const snapshot = value.generateAttachMessage().snapshot;
+                        dataStoreSummary = convertToSummaryTree(snapshot, true);
+                    } else {
+                        // If this data store is not yet loaded, then there should be no changes in the snapshot from
+                        // which it was created as it is detached container. So just use the previous snapshot.
+                        assert(!!this.baseSnapshot,
+                            "BaseSnapshot should be there as detached container loaded from snapshot");
+                        dataStoreSummary = convertSnapshotTreeToSummaryTree(this.baseSnapshot.trees[key]);
+                    }
+                    builder.addWithStats(key, dataStoreSummary);
+                });
+        } while (notBoundContextsLength !== this.contexts.notBoundLength());
+    }
+
+    /**
+     * @returns this channel's garbage collection node.
+     */
+    private getGCNode(): IGraphNode {
+        /**
+         * Get the outbound routes of this channel. This will be updated to only consider root data stores
+         * as referenced and hence outbound.
+         */
+        const outboundRoutes: string[] = [];
+        for (const [contextId] of this.contexts) {
+            outboundRoutes.push(`/${contextId}`);
+        }
+
+        return {
+            id: "/",
+            outboundRoutes,
+        };
+    }
+
+    /**
+     * Updates the garbage collection nodes of this node's children:
+     * - Prefixes the child's id to the id of each node returned by the child.
+     * @param childGCNodes - The child's garbage collection nodes.
+     * @param childId - The id of the child node.
+     * @returns the updated GC nodes of the child.
+     */
+    private updateChildGCNodes(childGCNodes: IGraphNode[], childId: string): IGraphNode[] {
+        // Normalize the child's nodes and prefix the child's id to the ids of GC nodes returned by it.
+        // This gradually builds the id of each node to be a path from the root.
+        normalizeAndPrefixGCNodeIds(childGCNodes, childId);
+        return childGCNodes;
     }
 }


### PR DESCRIPTION
related #4420 , #4448 , #4460 , #4477 

The final PR to encapsulate Data Stores, and not expose contexts to the container runtime. Again this is just copy paste of functionality to encapsulate Data Stores. There is more work necessary on Data Stores to finalize the api. There should be no functional change here, simply moving existing functionality