### PR TITLE
Add utility api to convert snapshot tree to app and protocol summary tree.

### DIFF
--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -253,6 +253,32 @@ export function convertSnapshotTreeToSummaryTree(
 }
 
 /**
+ * Utility to convert serialized snapshot taken in detached container to format where we can use it to
+ * attach the container.
+ * @param serializedSnapshotTree - serialized snapshot tree to be converted to summary tree for attach.
+ */
+export function convertSnapshotTreeToProtocolAndAppSummaryTree(
+    serializedSnapshotTree: string,
+): ISummaryTree {
+    const snapshotTree = JSON.parse(serializedSnapshotTree);
+    const summaryTree = convertSnapshotTreeToSummaryTree(snapshotTree).summary;
+    const appSummaryTree: ISummaryTree = {
+        type: SummaryType.Tree,
+        tree: {},
+    };
+    const entries = Object.entries(summaryTree.tree);
+    for (const [key, subTree] of entries) {
+        if (key !== ".protocol") {
+            appSummaryTree.tree[key] = subTree;
+            // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+            delete summaryTree.tree[key];
+        }
+    }
+    summaryTree.tree[".app"] = appSummaryTree;
+    return summaryTree;
+}
+
+/**
  * Converts ISummaryTree to ITree format. This is needed for back-compat while we get rid of snapshot.
  * @param summaryTree - summary tree in ISummaryTree format
  */

--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -260,7 +260,7 @@ export function convertSnapshotTreeToSummaryTree(
 export function convertSnapshotTreeToProtocolAndAppSummaryTree(
     serializedSnapshotTree: string,
 ): ISummaryTree {
-    const snapshotTree = JSON.parse(serializedSnapshotTree);
+    const snapshotTree: ISnapshotTree = JSON.parse(serializedSnapshotTree);
     const summaryTree = convertSnapshotTreeToSummaryTree(snapshotTree).summary;
     const appSummaryTree: ISummaryTree = {
         type: SummaryType.Tree,

--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -257,7 +257,7 @@ export function convertSnapshotTreeToSummaryTree(
  * attach the container.
  * @param serializedSnapshotTree - serialized snapshot tree to be converted to summary tree for attach.
  */
-export function convertSnapshotTreeToProtocolAndAppSummaryTree(
+export function convertContainerToDriverSerializedFormat(
     serializedSnapshotTree: string,
 ): ISummaryTree {
     const snapshotTree: ISnapshotTree = JSON.parse(serializedSnapshotTree);

--- a/packages/test/end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -24,7 +24,7 @@ import { MergeTreeDeltaType } from "@fluidframework/merge-tree";
 import { MessageType, ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { DataStoreMessageType } from "@fluidframework/datastore";
 import { ContainerMessageType } from "@fluidframework/container-runtime";
-import { convertSnapshotTreeToProtocolAndAppSummaryTree, requestFluidObject } from "@fluidframework/runtime-utils";
+import { convertContainerToDriverSerializedFormat, requestFluidObject } from "@fluidframework/runtime-utils";
 import {
     ILocalTestObjectProvider,
     generateLocalTest,
@@ -253,7 +253,7 @@ const tests = (args: ILocalTestObjectProvider) => {
         dataStore.root.set("attachKey", subDataStore1.handle);
 
         const snapshotTree = container.serialize();
-        const summaryForAttach = convertSnapshotTreeToProtocolAndAppSummaryTree(snapshotTree);
+        const summaryForAttach = convertContainerToDriverSerializedFormat(snapshotTree);
         const resolvedUrl = await args.urlResolver.resolve(request);
         const service = await args.documentServiceFactory.createContainer(summaryForAttach as any, resolvedUrl);
         const absoluteUrl = await args.urlResolver.getAbsoluteUrl(service.resolvedUrl, "/");


### PR DESCRIPTION
Add utility api to convert serialized snapshot taken by container.serialize() api to app and protocol tree format so that it can be used to create container directly through service factory.
This will be used if app has the snapshot taken by serialize() api and then it uses that to create container on server.
Example is shown in test case also.