### PR TITLE
Update DataContexts API to remove references to Deferred

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContexts.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContexts.ts
@@ -94,12 +94,13 @@ import { FluidDataStoreContext, LocalFluidDataStoreContext } from "./dataStoreCo
     }
 
     /**
-     * Get the context with the given id, once it exists locally and is attached.
+     * Get a Promise that resolves to the requested context once it exists locally and is attached.
      * e.g. If created locally, it must be bound, or if created remotely then it's fine as soon as it's sync'd in.
+     * Can also return undefined if the caller can't wait and the context isn't currently present and ready.
      * @param id The id of the context to get
-     * @param wait If false, return undefined if the context isn't present and ready now. Otherwise, wait for it.
+     * @param wait If false, return undefined if the context isn't present and ready now. Otherwise return the Promise.
      */
-    public async getBoundOrRemoted(id: string, wait: boolean): Promise<FluidDataStoreContext | undefined> {
+    public getBoundOrRemoted(id: string, wait: boolean): Promise<FluidDataStoreContext> | undefined {
         const deferredContext = this.ensureDeferred(id);
 
         if (!wait && !deferredContext.isCompleted) {

--- a/packages/runtime/container-runtime/src/dataStoreContexts.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContexts.ts
@@ -99,7 +99,7 @@ import { FluidDataStoreContext, LocalFluidDataStoreContext } from "./dataStoreCo
      * @param id The id of the context to get
      * @param wait If false, return undefined if the context isn't present and ready now. Otherwise, wait for it.
      */
-    public async getAttached(id: string, wait: boolean): Promise<FluidDataStoreContext | undefined> {
+    public async getBoundOrRemoted(id: string, wait: boolean): Promise<FluidDataStoreContext | undefined> {
         const deferredContext = this.ensureDeferred(id);
 
         if (!wait && !deferredContext.isCompleted) {
@@ -147,7 +147,7 @@ import { FluidDataStoreContext, LocalFluidDataStoreContext } from "./dataStoreCo
      * This could be because it's a local context that's been bound, or because it's a remote context.
      * @param context - The context to add
      */
-    public addBoundOrRemote(context: FluidDataStoreContext) {
+    public addBoundOrRemoted(context: FluidDataStoreContext) {
         const id = context.id;
         assert(!this._contexts.has(id), "Creating store with existing ID");
 

--- a/packages/runtime/container-runtime/src/dataStoreContexts.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContexts.ts
@@ -94,13 +94,12 @@ import { FluidDataStoreContext, LocalFluidDataStoreContext } from "./dataStoreCo
     }
 
     /**
-     * Get a Promise that resolves to the requested context once it exists locally and is attached.
+     * Get the context with the given id, once it exists locally and is attached.
      * e.g. If created locally, it must be bound, or if created remotely then it's fine as soon as it's sync'd in.
-     * Can also return undefined if the caller can't wait and the context isn't currently present and ready.
      * @param id The id of the context to get
-     * @param wait If false, return undefined if the context isn't present and ready now. Otherwise return the Promise.
+     * @param wait If false, return undefined if the context isn't present and ready now. Otherwise, wait for it.
      */
-    public getBoundOrRemoted(id: string, wait: boolean): Promise<FluidDataStoreContext> | undefined {
+    public async getBoundOrRemoted(id: string, wait: boolean): Promise<FluidDataStoreContext | undefined> {
         const deferredContext = this.ensureDeferred(id);
 
         if (!wait && !deferredContext.isCompleted) {

--- a/packages/runtime/container-runtime/src/dataStoreContexts.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContexts.ts
@@ -73,7 +73,7 @@ import { FluidDataStoreContext, LocalFluidDataStoreContext } from "./dataStoreCo
      */
     public getUnbound(id: string): LocalFluidDataStoreContext | undefined {
         const context = this._contexts.get(id);
-        if (!context || !this.notBoundContexts.has(id)) {
+        if (context === undefined || !this.notBoundContexts.has(id)) {
             return undefined;
         }
 

--- a/packages/runtime/container-runtime/src/dataStoreContexts.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContexts.ts
@@ -68,13 +68,12 @@ import { FluidDataStoreContext, LocalFluidDataStoreContext } from "./dataStoreCo
     }
 
     /**
-     * Prepare and return the unbound context with the given id so it can be bound.
+     * Return the unbound local context with the given id.
      */
-    public prepContextForBind(id: string): LocalFluidDataStoreContext {
+    public getUnbound(id: string): LocalFluidDataStoreContext {
         assert(this.notBoundContexts.has(id), "Store being bound should be in not bounded set");
         assert(this._contexts.has(id), "Attempting to bind to a context that hasn't been added yet");
 
-        this.notBoundContexts.delete(id);
         return this._contexts.get(id) as LocalFluidDataStoreContext;
     }
 
@@ -92,8 +91,8 @@ import { FluidDataStoreContext, LocalFluidDataStoreContext } from "./dataStoreCo
     }
 
     /**
-     * This returns a Promise that will resolve when a context with the given id is bound,
-     * or added as remote from another client.
+     * This returns a Promise that will resolve when a context with the given id is
+     * either bound or added as remote from another client.
      * @param id The id of the context to await
      */
     public async waitForContext(id: string): Promise<FluidDataStoreContext> {
@@ -110,9 +109,10 @@ import { FluidDataStoreContext, LocalFluidDataStoreContext } from "./dataStoreCo
     }
 
     /**
-     * Indicates the context has been bound
+     * Update this context as bound
      */
-    public notifyOnBind(id: string) {
+    public bind(id: string) {
+        this.notBoundContexts.delete(id);
         this.resolveDeferred(id);
     }
 

--- a/packages/runtime/container-runtime/src/dataStoreContexts.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContexts.ts
@@ -131,13 +131,12 @@ import { FluidDataStoreContext, LocalFluidDataStoreContext } from "./dataStoreCo
     }
 
     /**
-     * Add the given context, marking it as already bound.
+     * Add the given context, marking it as not local-only.
      * This could be because it's a local context that's been bound, or because it's a remote context.
-     * @param id - id of context to add. Redundant with context.id
      * @param context - The context to add
      */
-    public addBoundOrRemote(id: string, context: FluidDataStoreContext) {
-        assert(id === context.id, "id mismatch for context being added");
+    public addBoundOrRemote(context: FluidDataStoreContext) {
+        const id = context.id;
         assert(!this._contexts.has(id), "Creating store with existing ID");
 
         this._contexts.set(id, context);

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -270,12 +270,16 @@ export class DataStores implements IDisposable {
     }
 
     public async getDataStore(id: string, wait: boolean): Promise<IFluidDataStoreChannel> {
-        const deferredContext = this.contexts.prepDeferredContext(id);
+        const existingContext = this.contexts.get(id);
+        if (existingContext !== undefined && !this.contexts.isNotBound(id)) {
+            return existingContext.realize();
+        }
 
-        if (!wait && !deferredContext.isCompleted) {
+        if (!wait) {
             throw new Error(`DataStore ${id} does not exist`);
         }
 
+        const deferredContext = this.contexts.prepDeferredContext(id);
         const context = await deferredContext.promise;
         return context.realize();
     }

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -271,13 +271,13 @@ export class DataStores implements IDisposable {
     }
 
     public async getDataStore(id: string, wait: boolean): Promise<IFluidDataStoreChannel> {
-        const context = await this.contexts.getBoundOrRemoted(id, wait);
+        const contextP = this.contexts.getBoundOrRemoted(id, wait);
 
-        if (!context) {
+        if (contextP === undefined) {
             throw new Error(`DataStore ${id} does not yet exist or is not yet bound`);
         }
 
-        return context.realize();
+        return (await contextP).realize();
     }
 
     public processSignal(address: string, message: IInboundSignalMessage, local: boolean) {

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -122,7 +122,7 @@ export class DataStores implements IDisposable {
                     snapshotTree,
                     isRootDataStore ?? true);
             }
-            this.contexts.addBoundOrRemote(dataStoreContext);
+            this.contexts.addBoundOrRemoted(dataStoreContext);
         }
     }
 
@@ -180,7 +180,7 @@ export class DataStores implements IDisposable {
             pkg);
 
         // Resolve pending gets and store off any new ones
-       this.contexts.addBoundOrRemote(remotedFluidDataStoreContext);
+       this.contexts.addBoundOrRemoted(remotedFluidDataStoreContext);
 
         // Equivalent of nextTick() - Prefetch once all current ops have completed
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -271,10 +271,10 @@ export class DataStores implements IDisposable {
     }
 
     public async getDataStore(id: string, wait: boolean): Promise<IFluidDataStoreChannel> {
-        const context = await this.contexts.getAttached(id, wait);
+        const context = await this.contexts.getBoundOrRemoted(id, wait);
 
         if (!context) {
-            throw new Error(`DataStore ${id} does not exist yet`);
+            throw new Error(`DataStore ${id} does not yet exist or is not yet bound`);
         }
 
         return context.realize();

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -189,7 +189,7 @@ export class DataStores implements IDisposable {
 
     public  bindFluidDataStore(fluidDataStoreRuntime: IFluidDataStoreChannel): void {
         const id = fluidDataStoreRuntime.id;
-        const localContext = this.contexts.prepContextForBind(id);
+        const localContext = this.contexts.getUnbound(id);
         // If the container is detached, we don't need to send OP or add to pending attach because
         // we will summarize it while uploading the create new summary and make it known to other
         // clients.
@@ -202,7 +202,7 @@ export class DataStores implements IDisposable {
             this.attachOpFiredForDataStore.add(id);
         }
 
-        this.contexts.notifyOnBind(fluidDataStoreRuntime.id);
+        this.contexts.bind(fluidDataStoreRuntime.id);
     }
 
     public createDetachedDataStoreCore(

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -122,7 +122,7 @@ export class DataStores implements IDisposable {
                     snapshotTree,
                     isRootDataStore ?? true);
             }
-            this.contexts.addBoundOrRemote(key, dataStoreContext);
+            this.contexts.addBoundOrRemote(dataStoreContext);
         }
     }
 
@@ -180,7 +180,7 @@ export class DataStores implements IDisposable {
             pkg);
 
         // Resolve pending gets and store off any new ones
-       this.contexts.addBoundOrRemote(attachMessage.id, remotedFluidDataStoreContext);
+       this.contexts.addBoundOrRemote(remotedFluidDataStoreContext);
 
         // Equivalent of nextTick() - Prefetch once all current ops have completed
         // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -271,13 +271,13 @@ export class DataStores implements IDisposable {
     }
 
     public async getDataStore(id: string, wait: boolean): Promise<IFluidDataStoreChannel> {
-        const contextP = this.contexts.getBoundOrRemoted(id, wait);
+        const context = await this.contexts.getBoundOrRemoted(id, wait);
 
-        if (contextP === undefined) {
+        if (context === undefined) {
             throw new Error(`DataStore ${id} does not yet exist or is not yet bound`);
         }
 
-        return (await contextP).realize();
+        return context.realize();
     }
 
     public processSignal(address: string, message: IInboundSignalMessage, local: boolean) {

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -202,8 +202,7 @@ export class DataStores implements IDisposable {
             this.attachOpFiredForDataStore.add(id);
         }
 
-        // Resolve the deferred so other local stores can access it now that the context is bound
-        this.contexts.resolveDeferredBind(fluidDataStoreRuntime.id);
+        this.contexts.notifyOnBind(fluidDataStoreRuntime.id);
     }
 
     public createDetachedDataStoreCore(
@@ -279,8 +278,7 @@ export class DataStores implements IDisposable {
             throw new Error(`DataStore ${id} does not exist`);
         }
 
-        const deferredContext = this.contexts.prepDeferredContext(id);
-        const context = await deferredContext.promise;
+        const context = await this.contexts.waitForContext(id);
         return context.realize();
     }
 

--- a/packages/test/end-to-end-tests/src/test/loaderTest.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/loaderTest.spec.ts
@@ -157,7 +157,8 @@ describe("Loader.request", () => {
             });
             assert(false, "Loader pause flags doesn't pause container op processing");
         } catch (e) {
-            assert.strictEqual(e.message, `DataStore ${newDataStore.id} does not exist`);
+            const topFrame: string | undefined = e?.stack.split("\n")[1].trimLeft();
+            assert(topFrame?.startsWith("at DataStores.getDataStore"), "Expected an error in DataStores.getDataStore");
         }
 
         (container2 as Container).resume();


### PR DESCRIPTION
The use of Deferred is an implementation detail. This also improves the API when binding, with a very minor and I believe inconsequential reordering of some statements.

Next small PR I have in mind (for Monday) is to keep the not bound contexts separate from the all good ones so we can get rid of the `as LocalFluidDataStoreContext` cast.