### PR TITLE
Fix latent bug with getIdForPath with root path

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentStorageService.ts
@@ -173,6 +173,11 @@ export class DocumentStorageService implements IDocumentStorageService {
             // root of tree should be unnamed
             path.shift();
         }
+        if (path.length === 0) {
+            const tryId = previousFullSnapshot.id;
+            assert(!!tryId && tryId.length > 0, "Parent summary does not have handle for specified path.");
+            return tryId;
+        }
 
         return this.getIdFromPathCore(handleType, path, previousFullSnapshot);
     }
@@ -183,21 +188,18 @@ export class DocumentStorageService implements IDocumentStorageService {
         /** Previous snapshot, subtree relative to this path part */
         previousSnapshot: ISnapshotTree,
     ): string {
+        assert(path.length > 0, "Expected at least 1 path part");
         const key = path[0];
         if (path.length === 1) {
             switch (handleType) {
                 case SummaryType.Blob: {
                     const tryId = previousSnapshot.blobs[key];
-                    if (!tryId) {
-                        throw Error("Parent summary does not have blob handle for specified path.");
-                    }
+                    assert(!!tryId, "Parent summary does not have blob handle for specified path.");
                     return tryId;
                 }
                 case SummaryType.Tree: {
                     const tryId = previousSnapshot.trees[key]?.id;
-                    if (!tryId) {
-                        throw Error("Parent summary does not have tree handle for specified path.");
-                    }
+                    assert(!!tryId, "Parent summary does not have tree handle for specified path.");
                     return tryId;
                 }
                 default:

--- a/packages/drivers/routerlicious-driver/src/documentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentStorageService.ts
@@ -175,7 +175,7 @@ export class DocumentStorageService implements IDocumentStorageService {
         }
         if (path.length === 0) {
             const tryId = previousFullSnapshot.id;
-            assert(!!tryId && tryId.length > 0, "Parent summary does not have handle for specified path.");
+            assert(!!tryId, "Parent summary does not have handle for specified path.");
             return tryId;
         }
 


### PR DESCRIPTION
It isn't possible to hit this bug currently, but discovered when testing changes for differential summary at the root in #4096.

From driver perspective, this is still incorrect behavior.