### PR TITLE
Safe summary will only refresh latest from server and not do fullTree

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1336,7 +1336,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     /** Implementation of ISummarizerInternalsProvider.generateSummary */
     public async generateSummary(
         fullTree: boolean = false,
-        safe: boolean = false,
+        refreshLatestAck: boolean = false,
         summaryLogger: ITelemetryLogger,
     ): Promise<GenerateSummaryData | undefined> {
         const summaryRefSeqNum = this.deltaManager.lastSequenceNumber;
@@ -1359,7 +1359,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             }
 
             const trace = Trace.start();
-            const treeWithStats = await this.summarize(fullTree || safe, true /* trackState */);
+            const treeWithStats = await this.summarize(fullTree, true /* trackState */);
 
             const generateData: IGeneratedSummaryData = {
                 summaryStats: treeWithStats.stats,
@@ -1381,8 +1381,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 treeWithStats.summary,
                 this.latestSummaryAck);
 
-            // safe mode refreshes the latest summary ack
-            if (safe) {
+            if (refreshLatestAck) {
                 const version = await this.getVersionFromStorage(this.id);
                 await this.refreshLatestSummaryAck(
                     undefined,

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -57,7 +57,7 @@ export interface ISummarizerInternalsProvider {
     /** Encapsulates the work to walk the internals of the running container to generate a summary */
     generateSummary(
         full: boolean,
-        safe: boolean,
+        refreshLatestAck: boolean,
         summaryLogger: ITelemetryLogger,
     ): Promise<GenerateSummaryData | undefined>;
 


### PR DESCRIPTION
Discovered this would be more clear during #4096 

The API is clearer (fullTree is distinct from refreshLatestAck) and the functionality changes slightly so safe summary does not do fullTree, which is probably better anyway since that can actually induce error scenarios by passing through more code paths.