### PR TITLE
Config historian logger

### DIFF
--- a/server/historian/README.md
+++ b/server/historian/README.md
@@ -9,7 +9,7 @@ For consistency we recommend building and developing within a container
 
 You can build the production container by running.
 
-`docker build -t historian . --build-arg NPM_TOKEN=${NPM_TOKEN}`
+`docker build -t historian .`
 
 And then mount it for development by running.
 

--- a/server/historian/README.md
+++ b/server/historian/README.md
@@ -9,7 +9,7 @@ For consistency we recommend building and developing within a container
 
 You can build the production container by running.
 
-`docker build -t historian .`
+`docker build -t historian . --build-arg NPM_TOKEN=${NPM_TOKEN}`
 
 And then mount it for development by running.
 

--- a/server/historian/packages/historian-base/package.json
+++ b/server/historian/packages/historian-base/package.json
@@ -22,7 +22,7 @@
     "tslint": "tslint 'src/**/*.ts'"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.24.0-0",
+    "@fluidframework/common-utils": "^0.24.0",
     "@fluidframework/gitresources": "^0.1012.0",
     "@fluidframework/server-services": "^0.1012.2",
     "@fluidframework/server-services-core": "^0.1012.2",

--- a/server/historian/packages/historian-base/package.json
+++ b/server/historian/packages/historian-base/package.json
@@ -39,7 +39,7 @@
     "request": "^2.88.0",
     "request-promise-native": "^1.0.5",
     "split": "^1.0.0",
-    "winston": "^2.4.4"
+    "winston": "^3.1.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",

--- a/server/historian/packages/historian-base/src/logger.ts
+++ b/server/historian/packages/historian-base/src/logger.ts
@@ -1,0 +1,64 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as debug from "debug";
+import * as winston from "winston";
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import Transport = require("winston-transport");
+
+export interface IWinstonConfig {
+    colorize: boolean;
+    json: boolean;
+    label: string;
+    level: string;
+    timestamp: boolean;
+    additionalTransportList: Transport[];
+}
+
+/**
+ * Configures the default behavior of the Winston logger based on the provided config
+ */
+export function configureLogging(config: IWinstonConfig) {
+    const formatters = [winston.format.label({ label: config.label })];
+
+    if (config.colorize) {
+        formatters.push(winston.format.colorize());
+    }
+
+    if (config.timestamp) {
+        formatters.push(winston.format.timestamp());
+    }
+
+    if (config.json) {
+        formatters.push(winston.format.json());
+    } else {
+        formatters.push(winston.format.simple());
+    }
+
+    winston.configure({
+        format: winston.format.combine(...formatters),
+        transports: [
+            new winston.transports.Console({
+                handleExceptions: true,
+                level: config.level,
+            }),
+        ],
+    });
+
+    if (config.additionalTransportList) {
+        for (const transport of config.additionalTransportList) {
+            winston.add(transport);
+        }
+    }
+
+    // Forward all debug library logs through winston
+    (debug as any).log = (msg, ...args) => winston.info(msg, ...args);
+    // Override the default log format to not include the timestamp since winston will do this for us
+    // eslint-disable-next-line space-before-function-paren
+    (debug as any).formatArgs = function (args) {
+        const name = this.namespace;
+        args[0] = `${name} ${args[0]}`;
+    };
+}

--- a/server/historian/packages/historian-base/src/runner.ts
+++ b/server/historian/packages/historian-base/src/runner.ts
@@ -9,6 +9,7 @@ import * as utils from "@fluidframework/server-services-utils";
 import { Provider } from "nconf";
 import * as winston from "winston";
 import { ICache, ITenantService } from "./services";
+import { configureLogging } from "./logger";
 import * as app from "./app";
 
 export class HistorianRunner implements utils.IRunner {
@@ -26,7 +27,7 @@ export class HistorianRunner implements utils.IRunner {
     // eslint-disable-next-line @typescript-eslint/promise-function-async
     public start(): Promise<void> {
         this.runningDeferred = new Deferred<void>();
-
+        configureLogging(this.config.get("logger"));
         // Create the historian app
         const historian = app.create(this.config, this.riddler, this.cache);
         historian.set("port", this.port);

--- a/server/historian/packages/historian/package.json
+++ b/server/historian/packages/historian/package.json
@@ -34,7 +34,7 @@
     "request": "^2.88.0",
     "request-promise-native": "^1.0.5",
     "split": "^1.0.0",
-    "winston": "^2.4.4"
+    "winston": "^3.1.0"
   },
   "devDependencies": {
     "@fluidframework/eslint-config-fluid": "^0.19.1",

--- a/server/historian/packages/historian/src/www.ts
+++ b/server/historian/packages/historian/src/www.ts
@@ -4,42 +4,14 @@
  */
 
 import * as path from "path";
-import * as debug from "debug";
 import * as nconf from "nconf";
-import * as winston from "winston";
 import { runService } from "@fluidframework/server-services-utils";
 import { HistorianResourcesFactory, HistorianRunnerFactory } from "@fluidframework/historian-base";
 
-const provider = nconf.argv().env("__" as any).file(path.join(__dirname, "../config.json")).use("memory");
-
-/**
- * Default logger setup
- */
-const loggerConfig = provider.get("logger");
-winston.configure({
-    transports: [
-        new winston.transports.Console({
-            colorize: loggerConfig.colorize,
-            handleExceptions: true,
-            json: loggerConfig.json,
-            level: loggerConfig.level,
-            stringify: (obj) => JSON.stringify(obj),
-            timestamp: loggerConfig.timestamp,
-        }),
-    ],
-});
-
-// Update debug library to output to winston
-(debug as any).log = (msg, ...args) => winston.info(msg, ...args);
-// override the default log format to not include the timestamp since winston will do this for us
-// tslint:disable-next-line:only-arrow-functions
-(debug as any).formatArgs = function(args) {
-    const name = this.namespace;
-    args[0] = `${name  } ${  args[0]}`;
-};
-
+const configFile = path.join(__dirname, "../config.json");
+const config = nconf.argv().env({ separator: "__", parseValues: true }).file(configFile).use("memory");
 runService(
     new HistorianResourcesFactory(),
     new HistorianRunnerFactory(),
     "historian",
-    provider);
+    config);


### PR DESCRIPTION
With historian refactored to aligned with the pattern of r11s, configureLogging method is actually configuring the winston instance under @fluidframework/server-services-utils/node_modules/winston/lib/winston.js. However, historian is using the winston instance provide by historian/node_modules/winston/lib/winston.js. This left the instance that historian uses unconfigured. This change fix this issue by creating historian's own configureLogging method and configure it's own logger upon runner starting.