### PR TITLE
Update uuid package

### DIFF
--- a/examples/apps/spaces/package.json
+++ b/examples/apps/spaces/package.json
@@ -54,7 +54,7 @@
     "react-collapsible": "^2.7.0",
     "react-dom": "^16.10.2",
     "react-grid-layout": "^0.18.3",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -57,7 +57,7 @@
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
     "react-tabs": "^3.1.0",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
@@ -67,7 +67,7 @@
     "@types/node": "^10.17.24",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",
-    "@types/uuid": "^3.4.4",
+    "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
     "concurrently": "^5.2.0",

--- a/examples/hosts/node-host/package.json
+++ b/examples/hosts/node-host/package.json
@@ -33,7 +33,7 @@
     "@fluidframework/routerlicious-host": "^0.31.0",
     "@fluidframework/test-runtime-utils": "^0.31.0",
     "jsonwebtoken": "^8.4.0",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",

--- a/examples/utils/get-tinylicious-container/package.json
+++ b/examples/utils/get-tinylicious-container/package.json
@@ -33,7 +33,7 @@
     "@fluidframework/protocol-definitions": "^0.1015.0",
     "@fluidframework/routerlicious-driver": "^0.31.0",
     "jsrsasign": "^10.0.2",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -59,7 +59,7 @@
     "@fluidframework/shared-object-base": "^0.31.0",
     "assert": "^2.0.0",
     "debug": "^4.1.1",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -98,6 +98,6 @@
     "ts-node": "^7.0.1",
     "typescript": "~3.7.4",
     "typescript-formatter": "7.1.0",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.1"
   }
 }

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/protocol-definitions": "^0.1015.0",
     "@fluidframework/shared-object-base": "^0.31.0",
     "assert": "^2.0.0",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.31.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -40,7 +40,7 @@
     "@fluidframework/telemetry-utils": "^0.31.0",
     "assert": "^2.0.0",
     "debug": "^4.1.1",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -65,7 +65,7 @@
     "assert": "^2.0.0",
     "debug": "^4.1.1",
     "jsrsasign": "^10.0.2",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",

--- a/packages/drivers/local-driver/src/localSessionStorageDb.ts
+++ b/packages/drivers/local-driver/src/localSessionStorageDb.ts
@@ -5,7 +5,7 @@
 import { EventEmitter } from "events";
 import { ICollection, IDb } from "@fluidframework/server-services-core";
 import { ITestDbFactory } from "@fluidframework/server-test-utils";
-import uuid from "uuid";
+import { v4 as uuid } from "uuid";
 
 /**
  * A collection for testing that stores data in the browsers session storage

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -71,7 +71,7 @@
     "sha.js": "^2.4.11",
     "sinon": "^7.4.2",
     "socket.io-client": "^2.1.1",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -15,7 +15,7 @@ import {
     ISignalMessage,
 } from "@fluidframework/protocol-definitions";
 // eslint-disable-next-line import/no-internal-modules
-import uuid from "uuid/v4";
+import { v4 as uuid } from "uuid";
 import { IOdspSocketError } from "./contracts";
 import { errorObjectFromSocketError } from "./odspError";
 

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -14,7 +14,6 @@ import {
     ISequencedDocumentMessage,
     ISignalMessage,
 } from "@fluidframework/protocol-definitions";
-// eslint-disable-next-line import/no-internal-modules
 import { v4 as uuid } from "uuid";
 import { IOdspSocketError } from "./contracts";
 import { errorObjectFromSocketError } from "./odspError";

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -71,7 +71,7 @@
     "@fluidframework/synthesize": "^0.31.0",
     "@fluidframework/view-interfaces": "^0.31.0",
     "assert": "^2.0.0",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -67,7 +67,7 @@
     "debug": "^4.1.1",
     "double-ended-queue": "^2.1.0-0",
     "lodash": "^4.17.19",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluid-internal/test-loader-utils": "^0.31.0",

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -5,7 +5,7 @@
 
 // eslint-disable-next-line import/no-internal-modules
 import merge from "lodash/merge";
-import uuid from "uuid";
+import { v4 as uuid } from "uuid";
 import {
     ITelemetryLogger,
 } from "@fluidframework/common-definitions";

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -4,7 +4,7 @@
  */
 
 import { EventEmitter } from "events";
-import uuid from "uuid";
+import { v4 as uuid } from "uuid";
 import { ITelemetryBaseLogger, ITelemetryLogger } from "@fluidframework/common-definitions";
 import {
     IFluidObject,

--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -6,7 +6,7 @@
 import { parse } from "url";
 import { fromUtf8ToBase64, Uint8ArrayToString } from "@fluidframework/common-utils";
 import { ISummaryTree, ISnapshotTree, SummaryType } from "@fluidframework/protocol-definitions";
-import uuid from "uuid";
+import { v4 as uuid } from "uuid";
 
 export interface IParsedUrl {
     id: string;

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -56,7 +56,7 @@
     "@fluidframework/runtime-definitions": "^0.31.0",
     "assert": "^2.0.0",
     "debug": "^4.1.1",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -71,7 +71,7 @@
     "assert": "^2.0.0",
     "debug": "^4.1.1",
     "double-ended-queue": "^2.1.0-0",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
@@ -85,7 +85,7 @@
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.17.24",
     "@types/sinon": "^7.0.13",
-    "@types/uuid": "^3.4.4",
+    "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
     "concurrently": "^5.2.0",

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -35,7 +35,7 @@ import { ChildLogger } from "@fluidframework/telemetry-utils";
 import { AttachState } from "@fluidframework/container-definitions";
 import { BlobCacheStorageService, buildSnapshotTree, readAndParseFromBlobs } from "@fluidframework/driver-utils";
 import { assert, Lazy } from "@fluidframework/common-utils";
-import uuid from "uuid";
+import { v4 as uuid } from "uuid";
 import { TreeTreeEntry } from "@fluidframework/protocol-base";
 import { DataStoreContexts } from "./dataStoreContexts";
 import { ContainerRuntime, nonDataStorePaths } from "./containerRuntime";

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -69,7 +69,7 @@
     "assert": "^2.0.0",
     "debug": "^4.1.1",
     "lodash": "^4.17.19",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
@@ -80,7 +80,7 @@
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.17.24",
-    "@types/uuid": "^3.4.4",
+    "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
     "concurrently": "^5.2.0",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -64,7 +64,7 @@
     "assert": "^2.0.0",
     "axios": "^0.18.0",
     "jsrsasign": "^10.0.2",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
@@ -74,7 +74,7 @@
     "@types/jsrsasign": "^8.0.8",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.17.24",
-    "@types/uuid": "^3.4.4",
+    "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
     "concurrently": "^5.2.0",

--- a/packages/test/end-to-end-tests/package.json
+++ b/packages/test/end-to-end-tests/package.json
@@ -99,7 +99,7 @@
     "@types/mocha": "^5.2.5",
     "@types/nock": "^9.3.0",
     "@types/node": "^10.17.24",
-    "@types/uuid": "^3.4.4",
+    "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
     "assert": "^2.0.0",
@@ -140,7 +140,7 @@
     "ts-loader": "^6.1.2",
     "typescript": "~3.7.4",
     "typescript-formatter": "7.1.0",
-    "uuid": "^3.3.2",
+    "uuid": "^8.3.1",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11"
   }

--- a/packages/test/end-to-end-tests/src/real-service-tests/r11sEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/real-service-tests/r11sEndToEndTests.spec.ts
@@ -5,7 +5,7 @@
 
 import assert from "assert";
 import * as moniker from "moniker";
-import uuid from "uuid";
+import { v4 as uuid } from "uuid";
 import { IRequest, IFluidCodeDetails } from "@fluidframework/core-interfaces";
 import { AttachState } from "@fluidframework/container-definitions";
 import { Loader } from "@fluidframework/container-loader";

--- a/packages/test/end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/blobs.spec.ts
@@ -10,7 +10,7 @@ import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { ISummaryConfiguration } from "@fluidframework/protocol-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { SharedString } from "@fluidframework/sequence";
-import uuid from "uuid";
+import { v4 as uuid } from "uuid";
 import { ReferenceType } from "@fluidframework/merge-tree";
 import { generateLocalNonCompatTest, ITestObjectProvider, ITestContainerConfig, TestDataObject } from "./compatUtils";
 

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -68,7 +68,7 @@
     "@fluidframework/test-runtime-utils": "^0.31.0",
     "assert": "^2.0.0",
     "debug": "^4.1.1",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -80,7 +80,7 @@
     "express": "^4.16.3",
     "moniker": "^0.1.2",
     "nconf": "^0.10.0",
-    "uuid": "^3.3.2",
+    "uuid": "^8.3.1",
     "webpack-dev-server": "^3.8.0"
   },
   "devDependencies": {

--- a/packages/tools/webpack-fluid-loader/src/multiDocumentServiceFactory.ts
+++ b/packages/tools/webpack-fluid-loader/src/multiDocumentServiceFactory.ts
@@ -11,7 +11,7 @@ import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicio
 import { getRandomName } from "@fluidframework/server-services-client";
 import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
 // eslint-disable-next-line import/no-internal-modules
-import uuid from "uuid/v4";
+import { v4 as uuid } from "uuid";
 import { IDevServerUser, IRouterliciousRouteOptions, RouteOptions } from "./loader";
 
 export const deltaConns = new Map<string, ILocalDeltaConnectionServer>();

--- a/packages/tools/webpack-fluid-loader/src/multiDocumentServiceFactory.ts
+++ b/packages/tools/webpack-fluid-loader/src/multiDocumentServiceFactory.ts
@@ -10,7 +10,6 @@ import { OdspDocumentServiceFactory } from "@fluidframework/odsp-driver";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 import { getRandomName } from "@fluidframework/server-services-client";
 import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
-// eslint-disable-next-line import/no-internal-modules
 import { v4 as uuid } from "uuid";
 import { IDevServerUser, IRouterliciousRouteOptions, RouteOptions } from "./loader";
 

--- a/server/gateway/package.json
+++ b/server/gateway/package.json
@@ -116,7 +116,7 @@
     "serve-favicon": "^2.5.0",
     "split": "^1.0.0",
     "static-expiry": "0.0.11",
-    "uuid": "^3.3.2",
+    "uuid": "^8.3.1",
     "winston": "^3.1.0"
   },
   "devDependencies": {
@@ -147,7 +147,7 @@
     "@types/serve-favicon": "^2.2.28",
     "@types/socket.io-client": "^1.4.32",
     "@types/split": "^0.3.28",
-    "@types/uuid": "^3.4.4",
+    "@types/uuid": "^8.3.0",
     "@types/ws": "^6.0.1",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/eslint-plugin-tslint": "~2.16.0",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -63,7 +63,7 @@
     "lodash": "^4.17.19",
     "nconf": "^0.10.0",
     "semver": "^6.3.0",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/server-services-core": "^0.1016.0",
     "@fluidframework/server-test-utils": "^0.1016.0",
     "jsrsasign": "^10.0.2",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -42,13 +42,13 @@
     "double-ended-queue": "^2.1.0-0",
     "lodash": "^4.17.19",
     "moniker": "^0.1.2",
-    "uuid": "^3.3.2",
+    "uuid": "^8.3.1",
     "ws": "^6.1.2"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
     "@fluidframework/eslint-config-fluid": "^0.21.0",
-    "@types/uuid": "^3.4.4",
+    "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
     "concurrently": "^5.2.0",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -59,7 +59,7 @@
     "jsrsasign": "^10.0.2",
     "jwt-decode": "^3.0.0",
     "sillyname": "0.1.0",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -31,7 +31,7 @@
     "jsonwebtoken": "^8.4.0",
     "nconf": "^0.10.0",
     "sillyname": "0.1.0",
-    "uuid": "^3.3.2",
+    "uuid": "^8.3.1",
     "winston": "^3.1.0"
   },
   "devDependencies": {

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -54,7 +54,7 @@
     "debug": "^4.1.1",
     "lodash": "^4.17.19",
     "string-hash": "^1.1.3",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",

--- a/server/routerlicious/packages/test-utils/src/testHistorian.ts
+++ b/server/routerlicious/packages/test-utils/src/testHistorian.ts
@@ -7,7 +7,7 @@ import { gitHashFile, IsoBuffer } from "@fluidframework/common-utils";
 import * as git from "@fluidframework/gitresources";
 import { IHistorian } from "@fluidframework/server-services-client";
 import { ICollection, IDb } from "@fluidframework/server-services-core";
-import uuid from "uuid";
+import { v4 as uuid } from "uuid";
 import { TestDb } from "./testCollection";
 
 export class TestHistorian implements IHistorian {

--- a/server/service-monitor/package.json
+++ b/server/service-monitor/package.json
@@ -36,7 +36,7 @@
     "debug": "^4.1.1",
     "jsonwebtoken": "^8.5.1",
     "nconf": "^0.10.0",
-    "uuid": "^3.3.2",
+    "uuid": "^8.3.1",
     "winston": "3.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Update uuid package to the latest version. The new version supports tree shaking which is nice.

I'm updating this because Push is unable to upgrade to the latest client packages. We use the latest version of uuid, which is not compatible with uuid v3 (> v3 removes the default export), so it's causing issues in my webpack build. I could downgrade my package but I would rather upgrade it in this repo.
