### PR TITLE
aria hide browser chrome on fluid examples in docs pages

### DIFF
--- a/docs/themes/thxvscode/layouts/shortcodes/fluid_bundle_loader.html
+++ b/docs/themes/thxvscode/layouts/shortcodes/fluid_bundle_loader.html
@@ -3,7 +3,7 @@
 
 <div id="content" style="min-height: 200px; display: flex;">
     <div class="browser-window-wrapper">
-        <div class="browser-window">
+        <div aria-hidden="true" class="browser-window">
             <div class="browser-window-nav">
                 <div class="browser-window-nav-url">
                     http://localhost:8080
@@ -18,7 +18,7 @@
         <div id="{{ $idPrefix }}-left"></div>
     </div>
     <div class="browser-window-wrapper">
-        <div class="browser-window">
+        <div aria-hidden="true" class="browser-window">
             <div class="browser-window-nav">
                 <div class="browser-window-nav-url">
                     http://localhost:8080


### PR DESCRIPTION
browser chrome is distracting for screen reader users and doesn't serve much of a purpose. Hiding this section so that screen readers pass right over


![image](https://user-images.githubusercontent.com/1434956/101101416-61a01f80-357d-11eb-8a87-3e46083f9e98.png)
