### PR TITLE
Change logic for throttling limit to time in future in delta manager

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -944,7 +944,7 @@ export class DeltaManager
         }
     }
 
-    public cancelDelayInfo(id: string) {
+    public refreshDelayInfo(id: string) {
         this.throttlingIdSet.delete(id);
         if (this.throttlingIdSet.size === 0) {
             this.timeTillThrottling = 0;
@@ -1056,7 +1056,7 @@ export class DeltaManager
         assert(!readonly || this.connectionMode === "read", "readonly perf with write connection");
         this.set_readonlyPermissions(readonly);
 
-        this.cancelDelayInfo(this.deltaStreamDelayId);
+        this.refreshDelayInfo(this.deltaStreamDelayId);
 
         if (this.closed) {
             // Raise proper events, Log telemetry event and close connection.
@@ -1391,7 +1391,7 @@ export class DeltaManager
         this.fetching = true;
 
         await this.getDeltas(telemetryEventSuffix, from, to, (messages) => {
-            this.cancelDelayInfo(this.deltaStorageDelayId);
+            this.refreshDelayInfo(this.deltaStorageDelayId);
             this.catchUpCore(messages, telemetryEventSuffix);
         });
 

--- a/packages/loader/container-loader/src/retriableDocumentStorageService.ts
+++ b/packages/loader/container-loader/src/retriableDocumentStorageService.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { v4 as uuid } from "uuid";
 import { CreateContainerError } from "@fluidframework/container-utils";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { canRetryOnError, DocumentStorageServiceProxy } from "@fluidframework/driver-utils";
@@ -47,12 +46,11 @@ export class RetriableDocumentStorageService extends DocumentStorageServiceProxy
         let result: T | undefined;
         let success = false;
         let retryAfter = 0;
-        let id: string | undefined;
         do {
             try {
                 result = await api();
-                if (id !== undefined) {
-                    this.deltaManager.cancelDelayInfo(id);
+                if (retryAfter > 0) {
+                    this.deltaManager.cancelDelayInfo();
                 }
                 success = true;
             } catch (err) {
@@ -66,10 +64,7 @@ export class RetriableDocumentStorageService extends DocumentStorageServiceProxy
                 // If the error is throttling error, then wait for the specified time before retrying.
                 // If the waitTime is not specified, then we start with retrying immediately to max of 8s.
                 retryAfter = getRetryDelayFromError(err) ?? Math.min(retryAfter * 2, 8000);
-                if (id === undefined) {
-                    id = uuid();
-                }
-                this.deltaManager.emitDelayInfo(id, retryAfter, CreateContainerError(err));
+                this.deltaManager.emitDelayInfo(retryAfter, CreateContainerError(err));
                 await this.delay(retryAfter);
             }
         } while (!success);

--- a/packages/loader/container-loader/src/retriableDocumentStorageService.ts
+++ b/packages/loader/container-loader/src/retriableDocumentStorageService.ts
@@ -14,7 +14,7 @@ export class RetriableDocumentStorageService extends DocumentStorageServiceProxy
     private disposed = false;
     constructor(
         internalStorageService: IDocumentStorageService,
-        private readonly deltaManager: Pick<DeltaManager, "emitDelayInfo" | "cancelDelayInfo">,
+        private readonly deltaManager: Pick<DeltaManager, "emitDelayInfo" | "refreshDelayInfo">,
     ) {
         super(internalStorageService);
     }
@@ -52,7 +52,7 @@ export class RetriableDocumentStorageService extends DocumentStorageServiceProxy
             try {
                 result = await api();
                 if (id !== undefined) {
-                    this.deltaManager.cancelDelayInfo(id);
+                    this.deltaManager.refreshDelayInfo(id);
                 }
                 success = true;
             } catch (err) {

--- a/packages/loader/container-loader/src/test/retriableDocumentStorageService.spec.ts
+++ b/packages/loader/container-loader/src/test/retriableDocumentStorageService.spec.ts
@@ -14,8 +14,8 @@ describe("RetriableDocumentStorageService Tests", () => {
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         internalService = {} as IDocumentStorageService;
         const deltaManager = {
-            cancelDelayInfo: () => {},
-            refreshDelayInfo: () => "",
+            refreshDelayInfo: () => {},
+            emitDelayInfo: () => {},
         };
         retriableStorageService = new RetriableDocumentStorageService(internalService, deltaManager);
     });

--- a/packages/loader/container-loader/src/test/retriableDocumentStorageService.spec.ts
+++ b/packages/loader/container-loader/src/test/retriableDocumentStorageService.spec.ts
@@ -15,7 +15,7 @@ describe("RetriableDocumentStorageService Tests", () => {
         internalService = {} as IDocumentStorageService;
         const deltaManager = {
             cancelDelayInfo: () => {},
-            emitDelayInfo: () => "",
+            refreshDelayInfo: () => "",
         };
         retriableStorageService = new RetriableDocumentStorageService(internalService, deltaManager);
     });


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/4518

1.) Change logic for throttling limit to time in future in delta manager. Now we don't need to keep track of ids who made the throttling request. While cancelling if the time becomes greater than throttling future time, then we can just cancel the throttling time as we have passed that limit.