### PR TITLE
Remove SHA Computation from Flatten Blob

### DIFF
--- a/packages/drivers/file-driver/src/fileDocumentStorageService.ts
+++ b/packages/drivers/file-driver/src/fileDocumentStorageService.ts
@@ -218,7 +218,7 @@ export function FileSnapshotWriterClassFactory<TBase extends ReaderConstructor>(
 
                 // Prep for the future - refresh latest tree, as it's requests on next snapshot generation.
                 // Do not care about blobs (at least for now), as blobs are not written out (need follow up)
-                this.latestWriterTree = await buildSnapshotTree(tree.entries, this.blobsWriter);
+                this.latestWriterTree = buildSnapshotTree(tree.entries, this.blobsWriter);
 
                 // Do not reset this.commitsWriter - runtime will reference same commits in future snapshots
                 // if data store did not change in between two snapshots.

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -836,7 +836,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         let snapshot: ISnapshotTree | undefined;
         const blobs = new Map();
         if (previousContextState.snapshot !== undefined) {
-            snapshot = await buildSnapshotTree(previousContextState.snapshot.entries, blobs);
+            snapshot = buildSnapshotTree(previousContextState.snapshot.entries, blobs);
 
             /**
              * Should be removed / updated after issue #2914 is fixed.
@@ -854,7 +854,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         if (blobs.size > 0) {
             this.blobsCacheStorageService =
-                new BlobCacheStorageService(this.storageService, Promise.resolve(blobs));
+                new BlobCacheStorageService(this.storageService, blobs);
         }
         const attributes: IDocumentAttributes = {
             branch: this.id,

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -55,8 +55,8 @@
     "@fluidframework/protocol-base": "^0.1015.0",
     "@fluidframework/protocol-definitions": "^0.1015.0",
     "@fluidframework/telemetry-utils": "^0.31.0",
-    "uuid": "^8.3.1",
-    "assert": "^2.0.0"
+    "assert": "^2.0.0",
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -55,6 +55,7 @@
     "@fluidframework/protocol-base": "^0.1015.0",
     "@fluidframework/protocol-definitions": "^0.1015.0",
     "@fluidframework/telemetry-utils": "^0.31.0",
+    "uuid": "^8.3.1",
     "assert": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/loader/driver-utils/src/blobCacheStorageService.ts
+++ b/packages/loader/driver-utils/src/blobCacheStorageService.ts
@@ -12,13 +12,13 @@ import { DocumentStorageServiceProxy } from "./documentStorageServiceProxy";
 export class BlobCacheStorageService extends DocumentStorageServiceProxy {
     constructor(
         internalStorageService: IDocumentStorageService,
-        private readonly blobs: Promise<Map<string, string>>,
+        private readonly blobs: Map<string, string>,
     ) {
         super(internalStorageService);
     }
 
     public async read(id: string): Promise<string> {
-        const blob = (await this.blobs).get(id);
+        const blob = this.blobs.get(id);
         if (blob !== undefined) {
             return blob;
         }

--- a/packages/loader/driver-utils/src/buildSnapshotTree.ts
+++ b/packages/loader/driver-utils/src/buildSnapshotTree.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, gitHashFile, IsoBuffer } from "@fluidframework/common-utils";
+import { assert, IsoBuffer } from "@fluidframework/common-utils";
 import * as git from "@fluidframework/gitresources";
 import {
     FileMode,
@@ -14,12 +14,13 @@ import {
     TreeEntry,
 } from "@fluidframework/protocol-definitions";
 import { buildHierarchy } from "@fluidframework/protocol-base";
+import { v4 as uuid } from "uuid";
 
-async function flattenCore(
+function flattenCore(
     path: string,
     treeEntries: ITreeEntry[],
     blobMap: Map<string, string>,
-): Promise<git.ITreeEntry[]> {
+): git.ITreeEntry[] {
     const entries: git.ITreeEntry[] = [];
     for (const treeEntry of treeEntries) {
         const subPath = `${path}${treeEntry.path}`;
@@ -27,13 +28,13 @@ async function flattenCore(
         if (treeEntry.type === TreeEntry.Blob) {
             const blob = treeEntry.value as IBlob;
             const buffer = IsoBuffer.from(blob.contents, blob.encoding);
-            const sha = await gitHashFile(buffer);
-            blobMap.set(sha, buffer.toString("base64"));
+            const id = uuid();
+            blobMap.set(id, buffer.toString("base64"));
 
             const entry: git.ITreeEntry = {
                 mode: FileMode[treeEntry.mode],
                 path: subPath,
-                sha,
+                sha: id,
                 size: buffer.length,
                 type: "blob",
                 url: "",
@@ -62,7 +63,7 @@ async function flattenCore(
             };
             entries.push(entry);
 
-            const subTreeEntries = await flattenCore(`${subPath}/`, t.entries, blobMap);
+            const subTreeEntries = flattenCore(`${subPath}/`, t.entries, blobMap);
             entries.push(...subTreeEntries);
         }
     }
@@ -77,8 +78,8 @@ async function flattenCore(
  * @param blobMap - a map of blob's sha1 to content
  * @returns A flatten with of the ITreeEntry
  */
-async function flatten(tree: ITreeEntry[], blobMap: Map<string, string>): Promise<git.ITree> {
-    const entries = await flattenCore("", tree, blobMap);
+function flatten(tree: ITreeEntry[], blobMap: Map<string, string>): git.ITree {
+    const entries = flattenCore("", tree, blobMap);
     return {
         sha: "",
         tree: entries,
@@ -94,10 +95,10 @@ async function flatten(tree: ITreeEntry[], blobMap: Map<string, string>): Promis
  * NOTE: blobMap's validity is contingent on the returned promise's resolution
  * @returns the hierarchical tree
  */
-export async function buildSnapshotTree(
+export function buildSnapshotTree(
     entries: ITreeEntry[],
     blobMap: Map<string, string>,
-): Promise<ISnapshotTree> {
-    const flattened = await flatten(entries, blobMap);
+): ISnapshotTree {
+    const flattened = flatten(entries, blobMap);
     return buildHierarchy(flattened);
 }

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -549,7 +549,7 @@ export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
 
     constructor(
         id: string,
-        private readonly initSnapshotValue: Promise<ISnapshotTree> | string | null,
+        private readonly initSnapshotValue: ISnapshotTree | string | null,
         runtime: ContainerRuntime,
         storage: IDocumentStorageService,
         scope: IFluidObject,
@@ -588,7 +588,7 @@ export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
                 const commit = (await this.storage.getVersions(this.initSnapshotValue, 1))[0];
                 tree = await this.storage.getSnapshotTree(commit);
             } else {
-                tree = await this.initSnapshotValue;
+                tree = this.initSnapshotValue;
             }
 
             const localReadAndParse = async <T>(id: string) => readAndParse<T>(this.storage, id);

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -71,17 +71,23 @@ export class DataStores implements IDisposable {
         baseLogger: ITelemetryBaseLogger,
         private readonly contexts: DataStoreContexts = new DataStoreContexts(baseLogger),
     ) {
-        this.logger = ChildLogger.create(baseLogger);
+        this.logger = ChildLogger.create(baseLogger,"DataStores");
         // Extract stores stored inside the snapshot
         const fluidDataStores = new Map<string, ISnapshotTree | string>();
 
         if (typeof baseSnapshot === "object") {
-            Object.keys(baseSnapshot.trees).forEach((value) => {
+            for (const value of Object.keys(baseSnapshot.trees)) {
                 if (!nonDataStorePaths.includes(value)) {
+                    if (value.startsWith(".")) {
+                        this.logger.sendErrorEvent({
+                            eventName: "UnknownDotTree",
+                        });
+                        continue;
+                    }
                     const tree = baseSnapshot.trees[value];
                     fluidDataStores.set(value, tree);
                 }
-            });
+            }
         }
 
         // Create a context for each of them
@@ -160,12 +166,9 @@ export class DataStores implements IDisposable {
         }
 
         const flatBlobs = new Map<string, string>();
-        let flatBlobsP = Promise.resolve(flatBlobs);
-        let snapshotTreeP: Promise<ISnapshotTree> | null = null;
+        let snapshotTree: ISnapshotTree | null = null;
         if (attachMessage.snapshot) {
-            snapshotTreeP = buildSnapshotTree(attachMessage.snapshot.entries, flatBlobs);
-            // flatBlobs' validity is contingent on snapshotTreeP's resolution
-            flatBlobsP = snapshotTreeP.then(() => { return flatBlobs; });
+            snapshotTree = buildSnapshotTree(attachMessage.snapshot.entries, flatBlobs);
         }
 
         // Include the type of attach message which is the pkg of the store to be
@@ -173,9 +176,9 @@ export class DataStores implements IDisposable {
         const pkg = [attachMessage.type];
         const remotedFluidDataStoreContext = new RemotedFluidDataStoreContext(
             attachMessage.id,
-            snapshotTreeP,
+            snapshotTree === null ? null : Promise.resolve(snapshotTree),
             this.runtime,
-            new BlobCacheStorageService(this.runtime.storage, flatBlobsP),
+            new BlobCacheStorageService(this.runtime.storage, flatBlobs),
             this.runtime.scope,
             this.getCreateChildSummarizerNodeFn(
                 attachMessage.id,
@@ -222,6 +225,8 @@ export class DataStores implements IDisposable {
         isRoot: boolean,
         id = uuid()): IFluidDataStoreContextDetached
     {
+        assert(!id.startsWith("."), "Datastore id's must not start with '.'");
+
         const context = new LocalDetachedFluidDataStoreContext(
             id,
             pkg,
@@ -238,6 +243,8 @@ export class DataStores implements IDisposable {
     }
 
     public _createFluidDataStoreContext(pkg: string[], id: string, isRoot: boolean, props?: any) {
+        assert(!id.startsWith("."), "Datastore id's must not start with '.'");
+
         const context = new LocalFluidDataStoreContext(
             id,
             pkg,

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -91,7 +91,7 @@ export class DataStores implements IDisposable {
             if (this.runtime.attachState !== AttachState.Detached) {
                 dataStoreContext = new RemotedFluidDataStoreContext(
                     key,
-                    typeof value === "string" ? value : Promise.resolve(value),
+                    value,
                     this.runtime,
                     this.runtime.storage,
                     this.runtime.scope,
@@ -170,7 +170,7 @@ export class DataStores implements IDisposable {
         const pkg = [attachMessage.type];
         const remotedFluidDataStoreContext = new RemotedFluidDataStoreContext(
             attachMessage.id,
-            snapshotTree === null ? null : Promise.resolve(snapshotTree),
+            snapshotTree,
             this.runtime,
             new BlobCacheStorageService(this.runtime.storage, flatBlobs),
             this.runtime.scope,

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -71,23 +71,17 @@ export class DataStores implements IDisposable {
         baseLogger: ITelemetryBaseLogger,
         private readonly contexts: DataStoreContexts = new DataStoreContexts(baseLogger),
     ) {
-        this.logger = ChildLogger.create(baseLogger,"DataStores");
+        this.logger = ChildLogger.create(baseLogger);
         // Extract stores stored inside the snapshot
         const fluidDataStores = new Map<string, ISnapshotTree | string>();
 
         if (typeof baseSnapshot === "object") {
-            for (const value of Object.keys(baseSnapshot.trees)) {
+            Object.keys(baseSnapshot.trees).forEach((value) => {
                 if (!nonDataStorePaths.includes(value)) {
-                    if (value.startsWith(".")) {
-                        this.logger.sendErrorEvent({
-                            eventName: "UnknownDotTree",
-                        });
-                        continue;
-                    }
                     const tree = baseSnapshot.trees[value];
                     fluidDataStores.set(value, tree);
                 }
-            }
+            });
         }
 
         // Create a context for each of them
@@ -225,8 +219,6 @@ export class DataStores implements IDisposable {
         isRoot: boolean,
         id = uuid()): IFluidDataStoreContextDetached
     {
-        assert(!id.startsWith("."), "Datastore id's must not start with '.'");
-
         const context = new LocalDetachedFluidDataStoreContext(
             id,
             pkg,
@@ -243,8 +235,6 @@ export class DataStores implements IDisposable {
     }
 
     public _createFluidDataStoreContext(pkg: string[], id: string, isRoot: boolean, props?: any) {
-        assert(!id.startsWith("."), "Datastore id's must not start with '.'");
-
         const context = new LocalFluidDataStoreContext(
             id,
             pkg,

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -225,7 +225,7 @@ describe("Data Store Context Tests", () => {
 
             remotedDataStoreContext = new RemotedFluidDataStoreContext(
                 dataStoreId,
-                Promise.resolve(snapshotTree),
+                snapshotTree,
                 containerRuntime,
                 new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
                 scope,
@@ -263,7 +263,7 @@ describe("Data Store Context Tests", () => {
 
             remotedDataStoreContext = new RemotedFluidDataStoreContext(
                 dataStoreId,
-                Promise.resolve(snapshotTree),
+                snapshotTree,
                 containerRuntime,
                 new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
                 scope,
@@ -303,7 +303,7 @@ describe("Data Store Context Tests", () => {
 
             remotedDataStoreContext = new RemotedFluidDataStoreContext(
                 dataStoreId,
-                Promise.resolve(snapshotTree),
+                snapshotTree,
                 containerRuntime,
                 new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
                 scope,

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -227,7 +227,7 @@ describe("Data Store Context Tests", () => {
                 dataStoreId,
                 Promise.resolve(snapshotTree),
                 containerRuntime,
-                new BlobCacheStorageService(storage as IDocumentStorageService, Promise.resolve(blobCache)),
+                new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
                 scope,
                 createSummarizerNodeFn,
             );
@@ -265,7 +265,7 @@ describe("Data Store Context Tests", () => {
                 dataStoreId,
                 Promise.resolve(snapshotTree),
                 containerRuntime,
-                new BlobCacheStorageService(storage as IDocumentStorageService, Promise.resolve(blobCache)),
+                new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
                 scope,
                 createSummarizerNodeFn,
             );
@@ -305,7 +305,7 @@ describe("Data Store Context Tests", () => {
                 dataStoreId,
                 Promise.resolve(snapshotTree),
                 containerRuntime,
-                new BlobCacheStorageService(storage as IDocumentStorageService, Promise.resolve(blobCache)),
+                new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
                 scope,
                 createSummarizerNodeFn,
             );

--- a/packages/runtime/datastore/src/channelContext.ts
+++ b/packages/runtime/datastore/src/channelContext.ts
@@ -31,8 +31,8 @@ export function createServiceEndpoints(
     submitFn: (content: any, localOpMetadata: unknown) => void,
     dirtyFn: () => void,
     storageService: IDocumentStorageService,
-    tree?: Promise<ISnapshotTree>,
-    extraBlobs?: Promise<Map<string, string>>,
+    tree?: ISnapshotTree,
+    extraBlobs?: Map<string, string>,
 ) {
     const deltaConnection = new ChannelDeltaConnection(
         id,

--- a/packages/runtime/datastore/src/channelStorageService.ts
+++ b/packages/runtime/datastore/src/channelStorageService.ts
@@ -21,40 +21,35 @@ export class ChannelStorageService implements IChannelStorageService {
         }
     }
 
-    private readonly flattenedTreeP: Promise<{ [path: string]: string }>;
+    private readonly flattenedTree: { [path: string]: string };
 
     constructor(
-        private readonly tree: Promise<ISnapshotTree> | undefined,
+        private readonly tree: ISnapshotTree | undefined,
         private readonly storage: Pick<IDocumentStorageService, "read">,
-        private readonly extraBlobs?: Promise<Map<string, string>>,
+        private readonly extraBlobs?: Map<string, string>,
     ) {
+        this.flattenedTree = {};
         // Create a map from paths to blobs
         if (tree !== undefined) {
-            this.flattenedTreeP = tree.then((snapshotTree) => {
-                const flattenedTree: { [path: string]: string } = {};
-                ChannelStorageService.flattenTree("", snapshotTree, flattenedTree);
-                return flattenedTree;
-            });
-        } else {
-            this.flattenedTreeP = Promise.resolve({});
+             ChannelStorageService.flattenTree("", tree, this.flattenedTree);
         }
     }
 
     public async contains(path: string): Promise<boolean> {
-        return (await this.flattenedTreeP)[path] !== undefined;
+        return this.flattenedTree[path] !== undefined;
     }
 
     public async read(path: string): Promise<string> {
         const id = await this.getIdForPath(path);
         const blob = this.extraBlobs !== undefined
-            ? (await this.extraBlobs).get(id)
+            ? this.extraBlobs.get(id)
             : undefined;
 
         return blob ?? this.storage.read(id);
     }
 
     public async list(path: string): Promise<string[]> {
-        let tree = await this.tree;
+        let tree = this.tree;
         const pathParts = getNormalizedObjectStoragePathParts(path);
         while (tree !== undefined && pathParts.length > 0) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -69,6 +64,6 @@ export class ChannelStorageService implements IChannelStorageService {
     }
 
     private async getIdForPath(path: string): Promise<string> {
-        return (await this.flattenedTreeP)[path];
+        return this.flattenedTree[path];
     }
 }

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -488,9 +488,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
                         is local channel contexts: ${this.contexts.get(id) instanceof LocalChannelContext}`);
 
                     const flatBlobs = new Map<string, string>();
-                    const snapshotTreeP = buildSnapshotTree(attachMessage.snapshot.entries, flatBlobs);
-                    // flatBlobsP's validity is contingent on snapshotTreeP's resolution
-                    const flatBlobsP = snapshotTreeP.then((snapshotTree) => { return flatBlobs; });
+                    const snapshotTree = buildSnapshotTree(attachMessage.snapshot.entries, flatBlobs);
 
                     const remoteChannelContext = new RemoteChannelContext(
                         this,
@@ -499,9 +497,9 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
                         (content, localContentMetadata) => this.submitChannelOp(id, content, localContentMetadata),
                         (address: string) => this.setChannelDirty(address),
                         id,
-                        snapshotTreeP,
+                        snapshotTree,
                         this.sharedObjectRegistry,
-                        flatBlobsP,
+                        flatBlobs,
                         this.dataStoreContext.getCreateChildSummarizerNodeFn(
                             id,
                             {

--- a/packages/runtime/datastore/src/localChannelContext.ts
+++ b/packages/runtime/datastore/src/localChannelContext.ts
@@ -67,9 +67,8 @@ export class LocalChannelContext implements IChannelContext {
                 this.submitFn,
                 this.dirtyFn,
                 this.storageService,
-                clonedSnapshotTree !== undefined ? Promise.resolve(clonedSnapshotTree) : undefined,
-                blobMap !== undefined ?
-                    Promise.resolve(blobMap) : undefined,
+                clonedSnapshotTree,
+                blobMap,
             );
         });
         this.factory = registry.get(type);

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -47,9 +47,9 @@ export class RemoteChannelContext implements IChannelContext {
         submitFn: (content: any, localOpMetadata: unknown) => void,
         dirtyFn: (address: string) => void,
         private readonly id: string,
-        baseSnapshot: Promise<ISnapshotTree> | ISnapshotTree,
+        baseSnapshot:  ISnapshotTree,
         private readonly registry: ISharedObjectRegistry,
-        extraBlobs: Promise<Map<string, string>> | undefined,
+        extraBlobs: Map<string, string> | undefined,
         createSummarizerNode: CreateChildSummarizerNodeFn,
         private readonly attachMessageType?: string,
     ) {
@@ -59,7 +59,7 @@ export class RemoteChannelContext implements IChannelContext {
             submitFn,
             () => dirtyFn(this.id),
             storageService,
-            Promise.resolve(baseSnapshot),
+            baseSnapshot,
             extraBlobs);
 
         const thisSummarizeInternal =

--- a/packages/runtime/datastore/src/test/channelStorageService.spec.ts
+++ b/packages/runtime/datastore/src/test/channelStorageService.spec.ts
@@ -22,7 +22,7 @@ describe("ChannelStorageService", () => {
                 assert.fail();
             },
         };
-        const ss = new ChannelStorageService(Promise.resolve(tree), storage);
+        const ss = new ChannelStorageService(tree, storage);
 
         assert.equal(await ss.contains("/"), false);
         assert.deepEqual(await ss.list(""), []);
@@ -43,7 +43,7 @@ describe("ChannelStorageService", () => {
                 return id;
             },
         };
-        const ss = new ChannelStorageService(Promise.resolve(tree), storage);
+        const ss = new ChannelStorageService(tree, storage);
 
         assert.equal(await ss.contains("foo"), true);
         assert.deepStrictEqual(await ss.list(""), ["foo"]);
@@ -73,7 +73,7 @@ describe("ChannelStorageService", () => {
                 return id;
             },
         };
-        const ss = new ChannelStorageService(Promise.resolve(tree), storage);
+        const ss = new ChannelStorageService(tree, storage);
 
         assert.equal(await ss.contains("nested/foo"), true);
         assert.deepStrictEqual(await ss.list("nested/"), ["foo"]);


### PR DESCRIPTION
This is related to #4310 as to validate data store attributes and fail fast we need synchronous access to the attributes blob. The only thing blocking that is the sha calculation in flattenCore.

It seems safe to replace the SHA with a uuid, as the SHA is only used as an in memory id when creating the snapshotTree. Once buildSnapshotTree is synchronous, it allows the unwinding of a bunch of async code that existed simply to all the async SHA calculation. 