### PR TITLE
Fix historian config mount path in Helm chart

### DIFF
--- a/server/charts/historian/templates/historian-deployment.yaml
+++ b/server/charts/historian/templates/historian-deployment.yaml
@@ -36,7 +36,7 @@ spec:
           value: production
         volumeMounts:
         - name: config
-          mountPath: /home/node/server/config.json
+          mountPath: /home/node/server/packages/historian/config.json
           subPath: config.json
       dnsConfig:
         options:


### PR DESCRIPTION
Currently helm deployments of the latest historian images (after 8599) don't work because the config is not being updated by historian-configmap.yml. The location of the config.json moved in #3876 but it was not updated in historian-deployment.yml, so the config was always local values instead of deployment values