### PR TITLE
Initial add of external-controller example

### DIFF
--- a/examples/hosts/app-integration/external-controller/.editorconfig
+++ b/examples/hosts/app-integration/external-controller/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[package.json]
+indent_size = 2

--- a/examples/hosts/app-integration/external-controller/.eslintrc.js
+++ b/examples/hosts/app-integration/external-controller/.eslintrc.js
@@ -1,0 +1,11 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+module.exports = {
+    "extends": [
+        "@fluidframework/eslint-config-fluid/eslint7"
+    ],
+    "rules": {}
+}

--- a/examples/hosts/app-integration/external-controller/.gitignore
+++ b/examples/hosts/app-integration/external-controller/.gitignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+lib

--- a/examples/hosts/app-integration/external-controller/.npmignore
+++ b/examples/hosts/app-integration/external-controller/.npmignore
@@ -1,0 +1,3 @@
+nyc
+*.log
+**/*.tsbuildinfo

--- a/examples/hosts/app-integration/external-controller/LICENSE
+++ b/examples/hosts/app-integration/external-controller/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/hosts/app-integration/external-controller/README.md
+++ b/examples/hosts/app-integration/external-controller/README.md
@@ -1,0 +1,44 @@
+# @fluid-example/app-integration-external-controller
+
+**_This demo is a work-in-progress_**
+
+**Dice Roller** is a basic example that has a die and a button. Clicking the button re-rolls the die and persists the value in the root SharedDirectory. The Fluid Container is defined in container/, the data object is defined in dataObject/.
+
+This implementation demonstrates plugging that Container into a standalone application, rather than using the webpack-fluid-loader environment that most of our packages use.  This implementation relies on [Tinylicious](/server/tinylicious), so there are a few extra steps to get started.  We bring our own view that we will bind to the data in the container.
+
+<!-- AUTO-GENERATED-CONTENT:START (GET_STARTED:tinylicious=true) -->
+<!-- The getting started instructions are automatically generated.
+To update them, edit md-magic.config.js in the root of the repo, then run npm run readme:update -->
+
+## Getting Started
+
+You can run this example using the following steps:
+
+1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+   a. For an even faster build, you can add the package name to the build command, like this:
+      `npm run build:fast -- --nolint @fluid-example/app-integration-external-controller`
+1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](../../../server/tinylicious).
+1. Run `npm run start` from this directory (examples/hosts/app-integration/external-controller) and open <http://localhost:8080> in a web browser to see the app running.
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+## Testing
+
+```bash
+    npm run test:jest
+```
+
+For in browser testing update `./jest-puppeteer.config.js` to:
+
+```javascript
+  launch: {
+    dumpio: true, // output browser console to cmd line
+    slowMo: 500,
+    headless: false,
+  },
+```
+
+## Data model
+
+Dice Roller uses the following distributed data structures:
+
+- SharedDirectory - root

--- a/examples/hosts/app-integration/external-controller/jest-puppeteer.config.js
+++ b/examples/hosts/app-integration/external-controller/jest-puppeteer.config.js
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+module.exports = {
+  server: {
+    command: `npm run start:test -- --no-live-reload --port ${process.env["PORT"]}`,
+    port: process.env["PORT"],
+    launchTimeout:10000,
+    usedPortAction: 'error'
+  },
+  launch: {
+    args: ['--no-sandbox', '--disable-setuid-sandbox'], // https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#setting-up-chrome-linux-sandbox
+    dumpio: process.env.FLUID_TEST_VERBOSE !== undefined // output browser console to cmd line
+    // slowMo: 500, // slows down process for easier viewing
+    // headless: false, // run in the browser
+  },
+};

--- a/examples/hosts/app-integration/external-controller/jest.config.js
+++ b/examples/hosts/app-integration/external-controller/jest.config.js
@@ -1,0 +1,23 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Get the test port from the global map and set it in env for this test
+const testTools = require("@fluidframework/test-tools");
+const { name } = require("./package.json");
+
+mappedPort = testTools.getTestPort(name);
+process.env["PORT"] = mappedPort;
+
+module.exports = {
+  preset: "jest-puppeteer",
+  globals: {
+    PATH: `http://localhost:${mappedPort}`
+  },
+  testMatch: ["**/?(*.)+(spec|test).[t]s"],
+  testPathIgnorePatterns: ['/node_modules/', 'dist'],
+  transform: {
+    "^.+\\.ts?$": "ts-jest"
+  },
+};

--- a/examples/hosts/app-integration/external-controller/package.json
+++ b/examples/hosts/app-integration/external-controller/package.json
@@ -1,0 +1,90 @@
+{
+  "name": "@fluid-example/app-integration-external-controller",
+  "version": "0.31.0",
+  "description": "Minimal Fluid Container & Data Object sample to implement a collaborative dice roller as a standalone app.",
+  "homepage": "https://fluidframework.com",
+  "repository": "https://github.com/microsoft/FluidFramework",
+  "license": "MIT",
+  "author": "Microsoft",
+  "main": "dist/index.js",
+  "module": "lib/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "concurrently npm:build:compile npm:lint",
+    "build:compile": "concurrently npm:tsc npm:build:esnext",
+    "build:esnext": "tsc --project ./tsconfig.esnext.json",
+    "build:full": "concurrently npm:build npm:webpack",
+    "build:full:compile": "concurrently npm:build:compile npm:webpack",
+    "clean": "rimraf dist lib *.tsbuildinfo *.build.log",
+    "eslint": "eslint --format stylish src",
+    "eslint:fix": "eslint --ext=ts,tsx --format stylish src --fix",
+    "lint": "npm run eslint",
+    "lint:fix": "npm run eslint:fix",
+    "prepack": "npm run webpack",
+    "start": "webpack-dev-server",
+    "start:test": "webpack-dev-server --config webpack.test.js",
+    "test": "npm run test:jest",
+    "test:jest": "jest",
+    "test:jest:verbose": "cross-env FLUID_TEST_VERBOSE=1 jest",
+    "tsc": "tsc",
+    "tsfmt": "tsfmt --verify",
+    "tsfmt:fix": "tsfmt --replace",
+    "webpack": "webpack --env.production",
+    "webpack:dev": "webpack --env.development"
+  },
+  "dependencies": {
+    "@fluidframework/aqueduct": "^0.31.0",
+    "@fluidframework/get-session-storage-container": "^0.31.0",
+    "@fluidframework/get-tinylicious-container": "^0.31.0"
+  },
+  "devDependencies": {
+    "@fluidframework/build-common": "^0.19.2",
+    "@fluidframework/eslint-config-fluid": "^0.21.0",
+    "@fluidframework/test-tools": "^0.2.3074",
+    "@types/expect-puppeteer": "2.2.1",
+    "@types/jest": "22.2.3",
+    "@types/jest-environment-puppeteer": "2.2.0",
+    "@types/node": "^10.17.24",
+    "@types/puppeteer": "1.3.0",
+    "@typescript-eslint/eslint-plugin": "~4.2.0",
+    "@typescript-eslint/parser": "~4.2.0",
+    "clean-webpack-plugin": "^3.0.0",
+    "concurrently": "^5.2.0",
+    "cross-env": "^7.0.2",
+    "eslint": "~7.9.0",
+    "eslint-plugin-eslint-comments": "~3.2.0",
+    "eslint-plugin-import": "~2.22.0",
+    "eslint-plugin-no-null": "~1.0.2",
+    "eslint-plugin-prefer-arrow": "~1.2.2",
+    "eslint-plugin-react": "~7.21.2",
+    "eslint-plugin-unicorn": "~22.0.0",
+    "html-webpack-plugin": "^4.3.0",
+    "jest": "^26.4.2",
+    "jest-junit": "^10.0.0",
+    "jest-puppeteer": "^4.3.0",
+    "puppeteer": "^1.20.0",
+    "rimraf": "^2.6.2",
+    "ts-jest": "^26.2.0",
+    "ts-loader": "^6.1.2",
+    "typescript": "~3.7.4",
+    "typescript-formatter": "7.1.0",
+    "webpack": "^4.43.0",
+    "webpack-cli": "^3.3.11",
+    "webpack-dev-server": "^3.8.0",
+    "webpack-merge": "^4.1.4"
+  },
+  "fluid": {
+    "browser": {
+      "umd": {
+        "files": [
+          "main.bundle.js"
+        ],
+        "library": "main"
+      }
+    }
+  },
+  "jest-junit": {
+    "outputDirectory": "nyc",
+    "outputName": "jest-junit-report.xml"
+  }
+}

--- a/examples/hosts/app-integration/external-controller/src/app.ts
+++ b/examples/hosts/app-integration/external-controller/src/app.ts
@@ -1,0 +1,54 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { getTinyliciousContainer } from "@fluidframework/get-tinylicious-container";
+
+import { DiceRollerContainerRuntimeFactory } from "./containerCode";
+import { IDiceRoller } from "./dataObject";
+import { renderDiceRoller } from "./view";
+
+// In interacting with the service, we need to be explicit about whether we're creating a new document vs. loading
+// an existing one.  We also need to provide the unique ID for the document we are creating or loading from.
+
+// In this app, we'll choose to create a new document when navigating directly to http://localhost:8080.  For the ID,
+// we'll choose to use the current timestamp.  We'll also choose to interpret the URL hash as an existing document's
+// ID to load from, so the URL for a document load will look something like http://localhost:8080/#1596520748752.
+// These policy choices are arbitrary for demo purposes, and can be changed however you'd like.
+let createNew = false;
+if (location.hash.length === 0) {
+    createNew = true;
+    location.hash = Date.now().toString();
+}
+const documentId = location.hash.substring(1);
+document.title = documentId;
+
+async function start(): Promise<void> {
+    // The getTinyliciousContainer helper function facilitates loading our container code into a Container and
+    // connecting to a locally-running test service called Tinylicious.  This will look different when moving to a
+    // production service, but ultimately we'll still be getting a reference to a Container object.  The helper
+    // function takes the ID of the document we're creating or loading, the container code to load into it, and a
+    // flag to specify whether we're creating a new document or loading an existing one.
+    const container = await getTinyliciousContainer(documentId, DiceRollerContainerRuntimeFactory, createNew);
+
+    // Since we're using a ContainerRuntimeFactoryWithDefaultDataStore, our dice roller is available at the URL "/".
+    const url = "/";
+    const response = await container.request({ url });
+
+    // Verify the response to make sure we got what we expected.
+    if (response.status !== 200 || response.mimeType !== "fluid/object") {
+        throw new Error(`Unable to retrieve data object at URL: "${url}"`);
+    } else if (response.value === undefined) {
+        throw new Error(`Empty response from URL: "${url}"`);
+    }
+
+    // In this app, we know our container code provides a default data object that is an IDiceRoller.
+    const diceRoller: IDiceRoller = response.value;
+
+    // Given an IDiceRoller, we can render the value and provide controls for users to roll it.
+    const div = document.getElementById("content") as HTMLDivElement;
+    renderDiceRoller(diceRoller, div);
+}
+
+start().catch((error) => console.error(error));

--- a/examples/hosts/app-integration/external-controller/src/containerCode.ts
+++ b/examples/hosts/app-integration/external-controller/src/containerCode.ts
@@ -1,0 +1,25 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
+
+import { DiceRollerInstantiationFactory } from "./dataObject";
+
+/**
+ * The DiceRollerContainerRuntimeFactory is the container code for our scenario.
+ *
+ * Since we only need to instantiate and retrieve a single dice roller for our scenario, we can use a
+ * ContainerRuntimeFactoryWithDefaultDataStore. We provide it with the type of the data object we want to create
+ * and retrieve by default, and the registry entry mapping the type to the factory.
+ *
+ * This container code will create the single default data object on our behalf and make it available on the
+ * Container with a URL of "/", so it can be retrieved via container.request("/").
+ */
+export const DiceRollerContainerRuntimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
+    DiceRollerInstantiationFactory,
+    new Map([
+        DiceRollerInstantiationFactory.registryEntry,
+    ]),
+);

--- a/examples/hosts/app-integration/external-controller/src/dataObject.ts
+++ b/examples/hosts/app-integration/external-controller/src/dataObject.ts
@@ -1,0 +1,77 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { EventEmitter } from "events";
+import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
+
+/**
+ * IDiceRoller describes the public API surface for our dice roller data object.
+ */
+export interface IDiceRoller extends EventEmitter {
+    /**
+     * Get the dice value as a number.
+     */
+    readonly value: number;
+
+    /**
+     * Roll the dice.  Will cause a "diceRolled" event to be emitted.
+     */
+    roll: () => void;
+
+    /**
+     * The diceRolled event will fire whenever someone rolls the device, either locally or remotely.
+     */
+    on(event: "diceRolled", listener: () => void): this;
+}
+
+// The root is map-like, so we'll use this key for storing the value.
+const diceValueKey = "diceValue";
+
+/**
+ * The DiceRoller is our data object that implements the IDiceRoller interface.
+ */
+export class DiceRoller extends DataObject implements IDiceRoller {
+    /**
+     * initializingFirstTime is run only once by the first client to create the DataObject.  Here we use it to
+     * initialize the state of the DataObject.
+     */
+    protected async initializingFirstTime() {
+        this.root.set(diceValueKey, 1);
+    }
+
+    /**
+     * hasInitialized is run by each client as they load the DataObject.  Here we use it to set up usage of the
+     * DataObject, by registering an event listener for dice rolls.
+     */
+    protected async hasInitialized() {
+        this.root.on("valueChanged", (changed) => {
+            if (changed.key === diceValueKey) {
+                // When we see the dice value change, we'll emit the diceRolled event we specified in our interface.
+                this.emit("diceRolled");
+            }
+        });
+    }
+
+    public get value() {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return this.root.get(diceValueKey);
+    }
+
+    public readonly roll = () => {
+        const rollValue = Math.floor(Math.random() * 6) + 1;
+        this.root.set(diceValueKey, rollValue);
+    };
+}
+
+/**
+ * The DataObjectFactory is used by Fluid Framework to instantiate our DataObject.  We provide it with a unique name
+ * and the constructor it will call.  In this scenario, the third and fourth arguments are not used.
+ */
+export const DiceRollerInstantiationFactory = new DataObjectFactory(
+    "dice-roller",
+    DiceRoller,
+    [],
+    {},
+);

--- a/examples/hosts/app-integration/external-controller/src/index.html
+++ b/examples/hosts/app-integration/external-controller/src/index.html
@@ -1,0 +1,14 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+<!doctype html>
+<html lang="en" style="height: 100%;">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test application</title>
+</head>
+<body style="margin: 0; height: 100%;">
+    <div id="content" style="min-height: 100%;"></div>
+</body>
+</html>

--- a/examples/hosts/app-integration/external-controller/src/view.ts
+++ b/examples/hosts/app-integration/external-controller/src/view.ts
@@ -1,0 +1,39 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IDiceRoller } from "./dataObject";
+
+/**
+ * Render an IDiceRoller into a given div as a text character, with a button to roll it.
+ * @param diceRoller - The Data Object to be rendered
+ * @param div - The div to render into
+ */
+export function renderDiceRoller(diceRoller: IDiceRoller, div: HTMLDivElement) {
+    const wrapperDiv = document.createElement("div");
+    wrapperDiv.style.textAlign = "center";
+    div.append(wrapperDiv);
+
+    const diceCharDiv = document.createElement("div");
+    diceCharDiv.style.fontSize = "200px";
+
+    const rollButton = document.createElement("button");
+    rollButton.style.fontSize = "50px";
+    rollButton.textContent = "Roll";
+    // Call the roll method to modify the shared data when the button is clicked.
+    rollButton.addEventListener("click", diceRoller.roll);
+
+    wrapperDiv.append(diceCharDiv, rollButton);
+
+    // Get the current value of the shared data to update the view whenever it changes.
+    const updateDiceChar = () => {
+        // Unicode 0x2680-0x2685 are the sides of a dice (⚀⚁⚂⚃⚄⚅)
+        diceCharDiv.textContent = String.fromCodePoint(0x267F + diceRoller.value);
+        diceCharDiv.style.color = `hsl(${diceRoller.value * 60}, 70%, 50%)`;
+    };
+    updateDiceChar();
+
+    // Use the diceRolled event to trigger the rerender whenever the value changes.
+    diceRoller.on("diceRolled", updateDiceChar);
+}

--- a/examples/hosts/app-integration/external-controller/tests/diceRoller.test.ts
+++ b/examples/hosts/app-integration/external-controller/tests/diceRoller.test.ts
@@ -1,0 +1,25 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { globals } from "../jest.config";
+
+// Tests disabled -- requires Tinylicious to be running, which our test environment doesn't do.
+describe("diceRoller", () => {
+    beforeAll(async () => {
+        // Wait for the page to load first before running any tests
+        // so this time isn't attributed to the first test
+        await page.goto(globals.PATH, { waitUntil: "load", timeout: 0 });
+    }, 45000);
+
+    beforeEach(async () => {
+        await page.goto(globals.PATH, { waitUntil: "load" });
+        await page.waitFor(() => window["fluidStarted"]);
+    });
+
+    it("loads and there's a button with Roll", async () => {
+        // Validate there is a button that can be clicked
+        await expect(page).toClick("button", { text: "Roll" });
+    });
+});

--- a/examples/hosts/app-integration/external-controller/tests/index.html
+++ b/examples/hosts/app-integration/external-controller/tests/index.html
@@ -1,0 +1,17 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+<!doctype html>
+<html lang="en" style="height: 100%;">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test - DiceRoller</title>
+</head>
+<body style="margin: 0; height: 100%;">
+    <div id="content" style="min-height: 100%; display: flex;">
+        <div id="sbs-left" style="flex-grow: 1; width: 50%; border: 1px solid lightgray; box-sizing: border-box; position: relative;"></div>
+        <div id="sbs-right" style="flex-grow: 1; width: 50%; border: 1px solid lightgray; box-sizing: border-box; position: relative;"></div>
+    </div>
+</body>
+</html>

--- a/examples/hosts/app-integration/external-controller/tests/index.ts
+++ b/examples/hosts/app-integration/external-controller/tests/index.ts
@@ -1,0 +1,64 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { getSessionStorageContainer } from "@fluidframework/get-session-storage-container";
+import { getDefaultObjectFromContainer } from "@fluidframework/aqueduct";
+
+import { renderDiceRoller } from "../src/view";
+import { DiceRollerContainerRuntimeFactory } from "../src/containerCode";
+import { DiceRoller } from "../src/dataObject";
+
+// Since this is a single page Fluid application we are generating a new document id
+// if one was not provided
+let createNew = false;
+if (window.location.hash.length === 0) {
+    createNew = true;
+    window.location.hash = Date.now().toString();
+}
+const documentId = window.location.hash.substring(1);
+
+/**
+ * This is a helper function for loading the page. It's required because getting the Fluid Container
+ * requires making async calls.
+ */
+export async function createContainerAndRenderInElement(element: HTMLDivElement, createNewFlag: boolean) {
+    // The SessionStorage Container is an in-memory Fluid container that uses the local browser SessionStorage
+    // to store ops.
+    const container = await getSessionStorageContainer(documentId, DiceRollerContainerRuntimeFactory, createNewFlag);
+
+    // Get the Default Object from the Container
+    const defaultObject = await getDefaultObjectFromContainer<DiceRoller>(container);
+
+    // Given an IDiceRoller, we can render its data using the view we've created in our app.
+    renderDiceRoller(defaultObject, element);
+
+    // Setting "fluidStarted" is just for our test automation
+    // eslint-disable-next-line dot-notation
+    window["fluidStarted"] = true;
+}
+
+/**
+ * For local testing we have two div's that we are rendering into independently.
+ */
+async function setup() {
+    const leftElement = document.getElementById("sbs-left") as HTMLDivElement;
+    if (leftElement === null) {
+        throw new Error("sbs-left does not exist");
+    }
+    await createContainerAndRenderInElement(leftElement, createNew);
+    const rightElement = document.getElementById("sbs-right") as HTMLDivElement;
+    if (rightElement === null) {
+        throw new Error("sbs-right does not exist");
+    }
+    // The second time we don't need to createNew because we know a Container exists.
+    await createContainerAndRenderInElement(rightElement, false);
+}
+
+setup().catch((e)=> {
+    console.error(e);
+    console.log(
+        "%cThere were issues setting up and starting the in memory FLuid Server",
+        "font-size:30px");
+});

--- a/examples/hosts/app-integration/external-controller/tsconfig.esnext.json
+++ b/examples/hosts/app-integration/external-controller/tsconfig.esnext.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "./lib",
+        "module": "esnext"
+    },
+}

--- a/examples/hosts/app-integration/external-controller/tsconfig.json
+++ b/examples/hosts/app-integration/external-controller/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "extends": "@fluidframework/build-common/ts-common-config.json",
+    "exclude": [
+        "dist",
+        "node_modules"
+    ],
+    "compilerOptions": {
+        "module": "esnext",
+        "outDir": "dist",
+        "jsx": "react",
+        "types": ["react", "react-dom", "jest", "puppeteer", "jest-environment-puppeteer", "expect-puppeteer"]
+    },
+    "include": [
+        "src/**/*",
+        "tests/**/*"
+    ]
+}

--- a/examples/hosts/app-integration/external-controller/webpack.config.js
+++ b/examples/hosts/app-integration/external-controller/webpack.config.js
@@ -1,0 +1,45 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+const path = require("path");
+const merge = require("webpack-merge");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+// const { CleanWebpackPlugin } = require("clean-webpack-plugin");
+
+module.exports = env => {
+    const isProduction = env && env.production;
+
+    return merge({
+        entry: {
+            app: "./src/app.ts"
+        },
+        resolve: {
+            extensions: [".ts", ".tsx", ".js"],
+        },
+        module: {
+            rules: [{
+                test: /\.tsx?$/,
+                loader: "ts-loader"
+            }]
+        },
+        output: {
+            filename: "[name].bundle.js",
+            path: path.resolve(__dirname, "dist"),
+            library: "[name]",
+            // https://github.com/webpack/webpack/issues/5767
+            // https://github.com/webpack/webpack/issues/7939
+            devtoolNamespace: "fluid-example/dice-roller",
+            libraryTarget: "umd"
+        },
+        plugins: [
+            new HtmlWebpackPlugin({
+                template: "./src/index.html",
+            }),
+            // new CleanWebpackPlugin(),
+        ],
+    }, isProduction
+        ? require("./webpack.prod")
+        : require("./webpack.dev"));
+};

--- a/examples/hosts/app-integration/external-controller/webpack.dev.js
+++ b/examples/hosts/app-integration/external-controller/webpack.dev.js
@@ -1,0 +1,9 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+module.exports = {
+    mode: "development",
+    devtool: "inline-source-map"
+};

--- a/examples/hosts/app-integration/external-controller/webpack.prod.js
+++ b/examples/hosts/app-integration/external-controller/webpack.prod.js
@@ -1,0 +1,9 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+module.exports = {
+    mode: "production",
+    devtool: "source-map"
+};

--- a/examples/hosts/app-integration/external-controller/webpack.test.js
+++ b/examples/hosts/app-integration/external-controller/webpack.test.js
@@ -1,0 +1,48 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+const path = require("path");
+const merge = require("webpack-merge");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+
+module.exports = env => {
+    return ({
+        entry: {
+            app: "./tests/index.ts"
+        },
+        resolve: {
+            extensions: [".ts", ".tsx", ".js"],
+        },
+        module: {
+            rules: [{
+                test: /\.tsx?$/,
+                loader: "ts-loader"
+            },
+            {
+                test: /\.css$/i,
+                use: ['style-loader', 'css-loader'],
+            }]
+        },
+        output: {
+            filename: "[name].bundle.js",
+            path: path.resolve(__dirname, "dist"),
+            library: "[name]",
+            // https://github.com/webpack/webpack/issues/5767
+            // https://github.com/webpack/webpack/issues/7939
+            devtoolNamespace: "fluid-example/draft-js",
+            libraryTarget: "umd"
+        },
+        devServer: {
+            contentBase: path.join(__dirname, 'tests')
+        },
+        plugins: [
+            new HtmlWebpackPlugin({
+                template: "./tests/index.html",
+            }),
+        ],
+        mode: "development",
+        devtool: "inline-source-map"
+    });
+};


### PR DESCRIPTION
Micah, Sam and I will be collaborating on a new app-integration strategy of moving the controller logic outside of the `DataObject`.  This commit starts us off with a duplicate of the external-views sample that we can evolve it from.