### PR TITLE
Fix Historian Helm configmap

### DIFF
--- a/server/charts/historian/templates/historian-configmap.yaml
+++ b/server/charts/historian/templates/historian-configmap.yaml
@@ -25,5 +25,9 @@ data:
             "port": "{{ .Values.historian.redis.port }}",
             "tls": {{ .Values.historian.redis.tls }},
             "pass": "{{ .Values.historian.redis.password }}"
+        },
+        "error": {
+            "track": {{ .Values.historian.error.track }},
+            "endpoint": "{{ .Values.historian.error.endpoint }}"
         }
     }

--- a/server/charts/historian/values.yaml
+++ b/server/charts/historian/values.yaml
@@ -13,6 +13,9 @@ historian:
   cert: historian_cert
   ingressClass: ingress_class
   riddler: riddler_url
+  error:
+    track: true
+    endpoint: "error_tracking_endpoint"
 
 gitrest:
   name: gitrest


### PR DESCRIPTION
Historian's Helm configmap is missing the error config that was added to Historian's config.json in #3876. Historian has been verified to deploy correctly following this fix.