### PR TITLE
Guard against slicing the url when there is no leading slash

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -887,6 +887,9 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
 
             const dataStore = await this.getDataStore(id, wait);
             const subRequest = requestParser.createSubRequest(1);
+            // We always expect createSubRequest to include a leading slash, but asserting here to protect against
+            // unintentionally modifying the url if that changes.
+            assert(subRequest.url.startsWith("/"), "Expected createSubRequest url to include a leading slash");
             subRequest.url = subRequest.url.slice(1);
             return dataStore.IFluidRouter.request(subRequest);
         }

--- a/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
+++ b/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
@@ -46,7 +46,9 @@ export class RemoteFluidObjectHandle implements IFluidHandle {
 
     public async get(): Promise<any> {
         if (this.dataStoreP === undefined) {
-            this.dataStoreP = this.routeContext.resolveHandle({ url: this.absolutePath.slice(1) })
+            // Trim leading slash, if it exists
+            const url = this.absolutePath.startsWith("/") ? this.absolutePath.slice(1) : this.absolutePath;
+            this.dataStoreP = this.routeContext.resolveHandle({ url })
                 .then<IFluidObject>((response) =>
                     response.mimeType === "fluid/object"
                         ? response.value as IFluidObject


### PR DESCRIPTION
Fluid app automated tests are failing on 0.30 (components do not load) because attempts to resolve the handle fail.  This is because during handle resolution, we are trimming the first character off the url because we expect it to be a leading slash.  However, in these cases there is no leading slash.  This change adds a check to make sure we are trimming what we expect.