### PR TITLE
Emit events from subdirectories when a contained value changes

### DIFF
--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -433,8 +433,8 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
         // Mirror the containedValueChanged op on the SharedDirectory
         this.root.on(
             "containedValueChanged",
-            (changed: IValueChanged, local: boolean, op: ISequencedDocumentMessage) => {
-                this.emit("containedValueChanged", changed, local, op);
+            (changed: IValueChanged, local: boolean) => {
+                this.emit("containedValueChanged", changed, local);
             },
         );
     }
@@ -1570,7 +1570,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
             const event: IDirectoryValueChanged = { key, path: this.absolutePath, previousValue };
             this.directory.emit("valueChanged", event, local, op);
             const containedEvent: IValueChanged = { key, previousValue };
-            this.emit("containedValueChanged", containedEvent, local, op);
+            this.emit("containedValueChanged", containedEvent, local);
         }
         return successfullyRemoved;
     }
@@ -1588,7 +1588,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
         const event: IDirectoryValueChanged = { key, path: this.absolutePath, previousValue };
         this.directory.emit("valueChanged", event, local, op);
         const containedEvent: IValueChanged = { key, previousValue };
-        this.emit("containedValueChanged", containedEvent, local, op);
+        this.emit("containedValueChanged", containedEvent, local);
     }
 
     /**

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -430,6 +430,13 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
         super(id, runtime, attributes);
         this.localValueMaker = new LocalValueMaker(this.serializer);
         this.setMessageHandlers();
+        // Mirror the containedValueChanged op on the SharedDirectory
+        this.root.on(
+            "containedValueChanged",
+            (changed: IValueChanged, local: boolean, op: ISequencedDocumentMessage) => {
+                this.emit("containedValueChanged", changed, local, op);
+            },
+        );
     }
 
     /**

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -394,7 +394,7 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
     public [Symbol.toStringTag]: string = "SharedDirectory";
 
     /**
-     * {@inheritDoc IDirectory.absolutePath}
+     * {@inheritDoc IDirectoryNoEvents.absolutePath}
      */
     public get absolutePath(): string {
         return this.root.absolutePath;
@@ -440,21 +440,21 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
     }
 
     /**
-     * {@inheritDoc IDirectory.get}
+     * {@inheritDoc IDirectoryNoEvents.get}
      */
     public get<T = any>(key: string): T {
         return this.root.get<T>(key);
     }
 
     /**
-     * {@inheritDoc IDirectory.wait}
+     * {@inheritDoc IDirectoryNoEvents.wait}
      */
     public async wait<T = any>(key: string): Promise<T> {
         return this.root.wait<T>(key);
     }
 
     /**
-     * {@inheritDoc IDirectory.set}
+     * {@inheritDoc IDirectoryNoEvents.set}
      */
     public set<T = any>(key: string, value: T): this {
         this.root.set(key, value);
@@ -534,42 +534,42 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
     }
 
     /**
-     * {@inheritDoc IDirectory.createSubDirectory}
+     * {@inheritDoc IDirectoryNoEvents.createSubDirectory}
      */
     public createSubDirectory(subdirName: string): IDirectory {
         return this.root.createSubDirectory(subdirName);
     }
 
     /**
-     * {@inheritDoc IDirectory.getSubDirectory}
+     * {@inheritDoc IDirectoryNoEvents.getSubDirectory}
      */
     public getSubDirectory(subdirName: string): IDirectory {
         return this.root.getSubDirectory(subdirName);
     }
 
     /**
-     * {@inheritDoc IDirectory.hasSubDirectory}
+     * {@inheritDoc IDirectoryNoEvents.hasSubDirectory}
      */
     public hasSubDirectory(subdirName: string): boolean {
         return this.root.hasSubDirectory(subdirName);
     }
 
     /**
-     * {@inheritDoc IDirectory.deleteSubDirectory}
+     * {@inheritDoc IDirectoryNoEvents.deleteSubDirectory}
      */
     public deleteSubDirectory(subdirName: string): boolean {
         return this.root.deleteSubDirectory(subdirName);
     }
 
     /**
-     * {@inheritDoc IDirectory.subdirectories}
+     * {@inheritDoc IDirectoryNoEvents.subdirectories}
      */
     public subdirectories(): IterableIterator<[string, IDirectory]> {
         return this.root.subdirectories();
     }
 
     /**
-     * {@inheritDoc IDirectory.getWorkingDirectory}
+     * {@inheritDoc IDirectoryNoEvents.getWorkingDirectory}
      */
     public getWorkingDirectory(relativePath: string): IDirectory {
         const absolutePath = this.makeAbsolute(relativePath);
@@ -978,7 +978,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
     }
 
     /**
-     * {@inheritDoc IDirectory.get}
+     * {@inheritDoc IDirectoryNoEvents.get}
      */
     public get<T = any>(key: string): T {
         if (!this._storage.has(key)) {
@@ -989,7 +989,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
     }
 
     /**
-     * {@inheritDoc IDirectory.wait}
+     * {@inheritDoc IDirectoryNoEvents.wait}
      */
     public async wait<T = any>(key: string): Promise<T> {
         // Return immediately if the value already exists
@@ -1011,7 +1011,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
     }
 
     /**
-     * {@inheritDoc IDirectory.set}
+     * {@inheritDoc IDirectoryNoEvents.set}
      */
     public set<T = any>(key: string, value: T): this {
         // Undefined/null keys can't be serialized to JSON in the manner we currently snapshot.
@@ -1050,7 +1050,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
     }
 
     /**
-     * {@inheritDoc IDirectory.createSubDirectory}
+     * {@inheritDoc IDirectoryNoEvents.createSubDirectory}
      */
     public createSubDirectory(subdirName: string): IDirectory {
         // Undefined/null subdirectory names can't be serialized to JSON in the manner we currently snapshot.
@@ -1083,21 +1083,21 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
     }
 
     /**
-     * {@inheritDoc IDirectory.getSubDirectory}
+     * {@inheritDoc IDirectoryNoEvents.getSubDirectory}
      */
     public getSubDirectory(subdirName: string): IDirectory {
         return this._subdirectories.get(subdirName);
     }
 
     /**
-     * {@inheritDoc IDirectory.hasSubDirectory}
+     * {@inheritDoc IDirectoryNoEvents.hasSubDirectory}
      */
     public hasSubDirectory(subdirName: string): boolean {
         return this._subdirectories.has(subdirName);
     }
 
     /**
-     * {@inheritDoc IDirectory.deleteSubDirectory}
+     * {@inheritDoc IDirectoryNoEvents.deleteSubDirectory}
      */
     public deleteSubDirectory(subdirName: string): boolean {
         // Delete the sub directory locally first.
@@ -1119,14 +1119,14 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
     }
 
     /**
-     * {@inheritDoc IDirectory.subdirectories}
+     * {@inheritDoc IDirectoryNoEvents.subdirectories}
      */
     public subdirectories(): IterableIterator<[string, IDirectory]> {
         return this._subdirectories.entries();
     }
 
     /**
-     * {@inheritDoc IDirectory.getWorkingDirectory}
+     * {@inheritDoc IDirectoryNoEvents.getWorkingDirectory}
      */
     public getWorkingDirectory(relativePath: string): IDirectory {
         return this.directory.getWorkingDirectory(this.makeAbsolute(relativePath));

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, fromBase64ToUtf8 } from "@fluidframework/common-utils";
+import { assert, fromBase64ToUtf8, TypedEventEmitter } from "@fluidframework/common-utils";
 import { IFluidSerializer } from "@fluidframework/core-interfaces";
 import { addBlobToTree } from "@fluidframework/protocol-base";
 import {
@@ -23,6 +23,7 @@ import * as path from "path-browserify";
 import { debug } from "./debug";
 import {
     IDirectory,
+    IDirectoryEvents,
     IDirectoryValueChanged,
     ISerializableValue,
     ISerializedValue,
@@ -30,6 +31,7 @@ import {
     IValueOpEmitter,
     IValueTypeOperationValue,
     ISharedDirectoryEvents,
+    IValueChanged,
 } from "./interfaces";
 import {
     ILocalValue,
@@ -906,7 +908,7 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
  * Node of the directory tree.
  * @sealed
  */
-class SubDirectory implements IDirectory {
+class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirectory {
     /**
      * String representation for the class.
      */
@@ -954,7 +956,9 @@ class SubDirectory implements IDirectory {
         private readonly directory: SharedDirectory,
         private readonly runtime: IFluidDataStoreRuntime,
         private readonly serializer: IFluidSerializer,
-        public readonly absolutePath: string) {
+        public readonly absolutePath: string,
+    ) {
+        super();
     }
 
     /**
@@ -1558,6 +1562,8 @@ class SubDirectory implements IDirectory {
         if (successfullyRemoved) {
             const event: IDirectoryValueChanged = { key, path: this.absolutePath, previousValue };
             this.directory.emit("valueChanged", event, local, op);
+            const containedEvent: IValueChanged = { key, previousValue };
+            this.emit("containedValueChanged", containedEvent, local, op);
         }
         return successfullyRemoved;
     }
@@ -1574,6 +1580,8 @@ class SubDirectory implements IDirectory {
         this._storage.set(key, value);
         const event: IDirectoryValueChanged = { key, path: this.absolutePath, previousValue };
         this.directory.emit("valueChanged", event, local, op);
+        const containedEvent: IValueChanged = { key, previousValue };
+        this.emit("containedValueChanged", containedEvent, local, op);
     }
 
     /**

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -394,7 +394,7 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
     public [Symbol.toStringTag]: string = "SharedDirectory";
 
     /**
-     * {@inheritDoc IDirectoryNoEvents.absolutePath}
+     * {@inheritDoc IDirectory.absolutePath}
      */
     public get absolutePath(): string {
         return this.root.absolutePath;
@@ -440,21 +440,21 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
     }
 
     /**
-     * {@inheritDoc IDirectoryNoEvents.get}
+     * {@inheritDoc IDirectory.get}
      */
     public get<T = any>(key: string): T {
         return this.root.get<T>(key);
     }
 
     /**
-     * {@inheritDoc IDirectoryNoEvents.wait}
+     * {@inheritDoc IDirectory.wait}
      */
     public async wait<T = any>(key: string): Promise<T> {
         return this.root.wait<T>(key);
     }
 
     /**
-     * {@inheritDoc IDirectoryNoEvents.set}
+     * {@inheritDoc IDirectory.set}
      */
     public set<T = any>(key: string, value: T): this {
         this.root.set(key, value);
@@ -534,42 +534,42 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
     }
 
     /**
-     * {@inheritDoc IDirectoryNoEvents.createSubDirectory}
+     * {@inheritDoc IDirectory.createSubDirectory}
      */
     public createSubDirectory(subdirName: string): IDirectory {
         return this.root.createSubDirectory(subdirName);
     }
 
     /**
-     * {@inheritDoc IDirectoryNoEvents.getSubDirectory}
+     * {@inheritDoc IDirectory.getSubDirectory}
      */
     public getSubDirectory(subdirName: string): IDirectory {
         return this.root.getSubDirectory(subdirName);
     }
 
     /**
-     * {@inheritDoc IDirectoryNoEvents.hasSubDirectory}
+     * {@inheritDoc IDirectory.hasSubDirectory}
      */
     public hasSubDirectory(subdirName: string): boolean {
         return this.root.hasSubDirectory(subdirName);
     }
 
     /**
-     * {@inheritDoc IDirectoryNoEvents.deleteSubDirectory}
+     * {@inheritDoc IDirectory.deleteSubDirectory}
      */
     public deleteSubDirectory(subdirName: string): boolean {
         return this.root.deleteSubDirectory(subdirName);
     }
 
     /**
-     * {@inheritDoc IDirectoryNoEvents.subdirectories}
+     * {@inheritDoc IDirectory.subdirectories}
      */
     public subdirectories(): IterableIterator<[string, IDirectory]> {
         return this.root.subdirectories();
     }
 
     /**
-     * {@inheritDoc IDirectoryNoEvents.getWorkingDirectory}
+     * {@inheritDoc IDirectory.getWorkingDirectory}
      */
     public getWorkingDirectory(relativePath: string): IDirectory {
         const absolutePath = this.makeAbsolute(relativePath);
@@ -978,7 +978,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
     }
 
     /**
-     * {@inheritDoc IDirectoryNoEvents.get}
+     * {@inheritDoc IDirectory.get}
      */
     public get<T = any>(key: string): T {
         if (!this._storage.has(key)) {
@@ -989,7 +989,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
     }
 
     /**
-     * {@inheritDoc IDirectoryNoEvents.wait}
+     * {@inheritDoc IDirectory.wait}
      */
     public async wait<T = any>(key: string): Promise<T> {
         // Return immediately if the value already exists
@@ -1011,7 +1011,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
     }
 
     /**
-     * {@inheritDoc IDirectoryNoEvents.set}
+     * {@inheritDoc IDirectory.set}
      */
     public set<T = any>(key: string, value: T): this {
         // Undefined/null keys can't be serialized to JSON in the manner we currently snapshot.
@@ -1050,7 +1050,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
     }
 
     /**
-     * {@inheritDoc IDirectoryNoEvents.createSubDirectory}
+     * {@inheritDoc IDirectory.createSubDirectory}
      */
     public createSubDirectory(subdirName: string): IDirectory {
         // Undefined/null subdirectory names can't be serialized to JSON in the manner we currently snapshot.
@@ -1083,21 +1083,21 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
     }
 
     /**
-     * {@inheritDoc IDirectoryNoEvents.getSubDirectory}
+     * {@inheritDoc IDirectory.getSubDirectory}
      */
     public getSubDirectory(subdirName: string): IDirectory {
         return this._subdirectories.get(subdirName);
     }
 
     /**
-     * {@inheritDoc IDirectoryNoEvents.hasSubDirectory}
+     * {@inheritDoc IDirectory.hasSubDirectory}
      */
     public hasSubDirectory(subdirName: string): boolean {
         return this._subdirectories.has(subdirName);
     }
 
     /**
-     * {@inheritDoc IDirectoryNoEvents.deleteSubDirectory}
+     * {@inheritDoc IDirectory.deleteSubDirectory}
      */
     public deleteSubDirectory(subdirName: string): boolean {
         // Delete the sub directory locally first.
@@ -1119,14 +1119,14 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
     }
 
     /**
-     * {@inheritDoc IDirectoryNoEvents.subdirectories}
+     * {@inheritDoc IDirectory.subdirectories}
      */
     public subdirectories(): IterableIterator<[string, IDirectory]> {
         return this._subdirectories.entries();
     }
 
     /**
-     * {@inheritDoc IDirectoryNoEvents.getWorkingDirectory}
+     * {@inheritDoc IDirectory.getWorkingDirectory}
      */
     public getWorkingDirectory(relativePath: string): IDirectory {
         return this.directory.getWorkingDirectory(this.makeAbsolute(relativePath));

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -5,7 +5,7 @@
 
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { ISharedObject, ISharedObjectEvents } from "@fluidframework/shared-object-base";
-import { IEventThisPlaceHolder } from "@fluidframework/common-definitions";
+import { IEvent, IEventThisPlaceHolder } from "@fluidframework/common-definitions";
 
 /**
  * Type of "valueChanged" event parameter.
@@ -196,7 +196,17 @@ export interface ISharedDirectoryEvents extends ISharedObjectEvents {
         changed: IDirectoryValueChanged,
         local: boolean,
         op: ISequencedDocumentMessage,
-        target: IEventThisPlaceHolder) => void);
+        target: IEventThisPlaceHolder,
+    ) => void);
+}
+
+export interface IDirectoryEvents extends IEvent {
+    (event: "containedValueChanged", listener: (
+        changed: IValueChanged,
+        local: boolean,
+        op: ISequencedDocumentMessage,
+        target: IEventThisPlaceHolder,
+    ) => void);
 }
 
 /**

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -213,7 +213,7 @@ export interface IDirectoryEvents extends IEvent {
  */
 export interface ISharedDirectory extends
     ISharedObject<ISharedDirectoryEvents & IDirectoryEvents>,
-    Omit<Omit<Omit<IDirectory,"on">,"once">,"off"> {
+    Omit<IDirectory, "on" | "once" | "off"> {
     // The Omit type excludes symbols, which we don't want to exclude.  Adding them back here manually.
     // https://github.com/microsoft/TypeScript/issues/31671
     [Symbol.iterator](): IterableIterator<[string, any]>;

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -116,11 +116,12 @@ export interface IValueTypeCreator {
 }
 
 /**
- * The IDirectoryNoEvents describes the methods of the IDirectory but omits the IEventProvider interface to avoid
- * a Typescript compilation conflict with its definition in ISharedObject.  You should use the IDirectory interface
- * instead.
+ * Interface describing actions on a directory.
+ *
+ * @remarks
+ * When used as a Map, operates on its keys.
  */
-export interface IDirectoryNoEvents extends Map<string, any> {
+export interface IDirectory extends Map<string, any>, IEventProvider<IDirectoryEvents> {
     /**
      * The absolute path of the directory.
      */
@@ -190,14 +191,6 @@ export interface IDirectoryNoEvents extends Map<string, any> {
     getWorkingDirectory(relativePath: string): IDirectory;
 }
 
-/**
- * Interface describing actions on a directory.
- *
- * @remarks
- * When used as a Map, operates on its keys.
- */
-export interface IDirectory extends IDirectoryNoEvents, IEventProvider<IDirectoryEvents> { }
-
 export interface ISharedDirectoryEvents extends ISharedObjectEvents {
     (event: "valueChanged", listener: (
         changed: IDirectoryValueChanged,
@@ -218,8 +211,13 @@ export interface IDirectoryEvents extends IEvent {
 /**
  * Interface describing a shared directory.
  */
-export interface ISharedDirectory extends ISharedObject<ISharedDirectoryEvents>, IDirectoryNoEvents {
-
+export interface ISharedDirectory extends
+    ISharedObject<ISharedDirectoryEvents & IDirectoryEvents>,
+    Omit<Omit<Omit<IDirectory,"on">,"once">,"off"> {
+    // The Omit type excludes symbols, which we don't want to exclude.  Adding them back here manually.
+    // https://github.com/microsoft/TypeScript/issues/31671
+    [Symbol.iterator](): IterableIterator<[string, any]>;
+    readonly [Symbol.toStringTag]: string;
 }
 
 /**

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -117,9 +117,10 @@ export interface IValueTypeCreator {
 
 /**
  * The IDirectoryNoEvents describes the methods of the IDirectory but omits the IEventProvider interface to avoid
- * a Typescript compilation conflict with its definition in ISharedObject.
+ * a Typescript compilation conflict with its definition in ISharedObject.  You should use the IDirectory interface
+ * instead.
  */
-interface IDirectoryNoEvents extends Map<string, any> {
+export interface IDirectoryNoEvents extends Map<string, any> {
     /**
      * The absolute path of the directory.
      */

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -211,7 +211,6 @@ export interface IDirectoryEvents extends IEvent {
     (event: "containedValueChanged", listener: (
         changed: IValueChanged,
         local: boolean,
-        op: ISequencedDocumentMessage,
         target: IEventThisPlaceHolder,
     ) => void);
 }

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -5,7 +5,7 @@
 
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { ISharedObject, ISharedObjectEvents } from "@fluidframework/shared-object-base";
-import { IEvent, IEventThisPlaceHolder } from "@fluidframework/common-definitions";
+import { IEvent, IEventProvider, IEventThisPlaceHolder } from "@fluidframework/common-definitions";
 
 /**
  * Type of "valueChanged" event parameter.
@@ -116,12 +116,10 @@ export interface IValueTypeCreator {
 }
 
 /**
- * Interface describing actions on a directory.
- *
- * @remarks
- * When used as a Map, operates on its keys.
+ * The IDirectoryNoEvents describes the methods of the IDirectory but omits the IEventProvider interface to avoid
+ * a Typescript compilation conflict with its definition in ISharedObject.
  */
-export interface IDirectory extends Map<string, any> {
+interface IDirectoryNoEvents extends Map<string, any> {
     /**
      * The absolute path of the directory.
      */
@@ -191,6 +189,14 @@ export interface IDirectory extends Map<string, any> {
     getWorkingDirectory(relativePath: string): IDirectory;
 }
 
+/**
+ * Interface describing actions on a directory.
+ *
+ * @remarks
+ * When used as a Map, operates on its keys.
+ */
+export interface IDirectory extends IDirectoryNoEvents, IEventProvider<IDirectoryEvents> { }
+
 export interface ISharedDirectoryEvents extends ISharedObjectEvents {
     (event: "valueChanged", listener: (
         changed: IDirectoryValueChanged,
@@ -212,7 +218,7 @@ export interface IDirectoryEvents extends IEvent {
 /**
  * Interface describing a shared directory.
  */
-export interface ISharedDirectory extends ISharedObject<ISharedDirectoryEvents>, IDirectory {
+export interface ISharedDirectory extends ISharedObject<ISharedDirectoryEvents>, IDirectoryNoEvents {
 
 }
 

--- a/packages/dds/map/test/directory.spec.ts
+++ b/packages/dds/map/test/directory.spec.ts
@@ -84,7 +84,7 @@ describe("Directory", () => {
                 let called3: boolean = false;
                 directory.on("op", (arg1, arg2, arg3) => called1 = true);
                 directory.on("valueChanged", (arg1, arg2, arg3, arg4) => called2 = true);
-                directory.on("containedValueChanged", (arg1, arg2, arg3, arg4) => called3 = true);
+                directory.on("containedValueChanged", (arg1, arg2, arg3) => called3 = true);
                 directory.set("dwyane", "johnson");
                 assert.equal(called1, false, "did not receive op event");
                 assert.equal(called2, true, "did not receive valueChanged event");

--- a/packages/dds/map/test/directory.spec.ts
+++ b/packages/dds/map/test/directory.spec.ts
@@ -661,6 +661,31 @@ describe("Directory", () => {
                 assert.equal(directory1.getWorkingDirectory("foo").get("fromSubdir"), "testValue4");
             });
 
+            it("raises the containedValueChanged event when keys are set and deleted from a subdirectory", () => {
+                directory1.createSubDirectory("foo");
+                containerRuntimeFactory.processAllMessages();
+
+                const subdir1 = directory1.getWorkingDirectory("/foo");
+                const subdir2 = directory2.getWorkingDirectory("/foo");
+
+                let called1 = 0;
+                let called2 = 0;
+                subdir1.on("containedValueChanged", () => called1++);
+                subdir2.on("containedValueChanged", () => called2++);
+
+                subdir1.set("testKey", "testValue");
+                containerRuntimeFactory.processAllMessages();
+
+                assert.strictEqual(called1, 1, "containedValueChanged on local subdirectory after set()");
+                assert.strictEqual(called2, 1, "containedValueChanged on remote subdirectory after set()");
+
+                subdir1.delete("testKey");
+                containerRuntimeFactory.processAllMessages();
+
+                assert.strictEqual(called1, 2, "containedValueChanged on local subdirectory after delete()");
+                assert.strictEqual(called2, 2, "containedValueChanged on remote subdirectory after delete()");
+            });
+
             it("Can be cleared from the subdirectory", () => {
                 const fooDirectory = directory1.createSubDirectory("foo");
                 const barDirectory = directory1.createSubDirectory("bar");

--- a/packages/dds/map/test/directory.spec.ts
+++ b/packages/dds/map/test/directory.spec.ts
@@ -663,27 +663,38 @@ describe("Directory", () => {
 
             it("raises the containedValueChanged event when keys are set and deleted from a subdirectory", () => {
                 directory1.createSubDirectory("foo");
+                directory1.createSubDirectory("bar");
                 containerRuntimeFactory.processAllMessages();
 
-                const subdir1 = directory1.getWorkingDirectory("/foo");
-                const subdir2 = directory2.getWorkingDirectory("/foo");
+                const foo1 = directory1.getWorkingDirectory("/foo");
+                const foo2 = directory2.getWorkingDirectory("/foo");
+                const bar1 = directory1.getWorkingDirectory("/bar");
+                const bar2 = directory2.getWorkingDirectory("/bar");
 
                 let called1 = 0;
                 let called2 = 0;
-                subdir1.on("containedValueChanged", () => called1++);
-                subdir2.on("containedValueChanged", () => called2++);
+                let called3 = 0;
+                let called4 = 0;
+                foo1.on("containedValueChanged", () => called1++);
+                foo2.on("containedValueChanged", () => called2++);
+                bar1.on("containedValueChanged", () => called3++);
+                bar2.on("containedValueChanged", () => called4++);
 
-                subdir1.set("testKey", "testValue");
+                foo1.set("testKey", "testValue");
                 containerRuntimeFactory.processAllMessages();
 
-                assert.strictEqual(called1, 1, "containedValueChanged on local subdirectory after set()");
-                assert.strictEqual(called2, 1, "containedValueChanged on remote subdirectory after set()");
+                assert.strictEqual(called1, 1, "containedValueChanged on local foo subdirectory after set()");
+                assert.strictEqual(called2, 1, "containedValueChanged on remote foo subdirectory after set()");
+                assert.strictEqual(called3, 0, "containedValueChanged on local bar subdirectory after set()");
+                assert.strictEqual(called4, 0, "containedValueChanged on remote bar subdirectory after set()");
 
-                subdir1.delete("testKey");
+                foo1.delete("testKey");
                 containerRuntimeFactory.processAllMessages();
 
                 assert.strictEqual(called1, 2, "containedValueChanged on local subdirectory after delete()");
                 assert.strictEqual(called2, 2, "containedValueChanged on remote subdirectory after delete()");
+                assert.strictEqual(called3, 0, "containedValueChanged on local bar subdirectory after delete()");
+                assert.strictEqual(called4, 0, "containedValueChanged on remote bar subdirectory after delete()");
             });
 
             it("Can be cleared from the subdirectory", () => {

--- a/packages/dds/map/test/directory.spec.ts
+++ b/packages/dds/map/test/directory.spec.ts
@@ -79,14 +79,16 @@ describe("Directory", () => {
             });
 
             it("should fire correct directory events", async () => {
-                const dummyDirectory = directory;
                 let called1: boolean = false;
                 let called2: boolean = false;
-                dummyDirectory.on("op", (agr1, arg2, arg3) => called1 = true);
-                dummyDirectory.on("valueChanged", (agr1, arg2, arg3, arg4) => called2 = true);
-                dummyDirectory.set("dwyane", "johnson");
+                let called3: boolean = false;
+                directory.on("op", (arg1, arg2, arg3) => called1 = true);
+                directory.on("valueChanged", (arg1, arg2, arg3, arg4) => called2 = true);
+                directory.on("containedValueChanged", (arg1, arg2, arg3, arg4) => called3 = true);
+                directory.set("dwyane", "johnson");
                 assert.equal(called1, false, "did not receive op event");
                 assert.equal(called2, true, "did not receive valueChanged event");
+                assert.equal(called3, true, "did not receive containedValueChanged event");
             });
 
             it("Rejects a undefined and null key set", () => {


### PR DESCRIPTION
Fixes #4400 

This change adds a "containedValueChanged" event on `IDirectory`s, such that it's no longer necessary to listen to "valueChanged" on the `ISharedDirectory` and inspect the directory path.