### PR TITLE
Remove slice call from RemoteFluidObjectHandle

### DIFF
--- a/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
+++ b/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
@@ -46,9 +46,7 @@ export class RemoteFluidObjectHandle implements IFluidHandle {
 
     public async get(): Promise<any> {
         if (this.dataStoreP === undefined) {
-            // Trim leading slash, if it exists
-            const url = this.absolutePath.startsWith("/") ? this.absolutePath.slice(1) : this.absolutePath;
-            this.dataStoreP = this.routeContext.resolveHandle({ url })
+            this.dataStoreP = this.routeContext.resolveHandle({ url: this.absolutePath })
                 .then<IFluidObject>((response) =>
                     response.mimeType === "fluid/object"
                         ? response.value as IFluidObject


### PR DESCRIPTION
It looks like the slice should not be necessary even with the new absolute url format.