### PR TITLE
Remove comments, move DOM creation to html

### DIFF
--- a/examples/hosts/app-integration/external-controller/src/app.ts
+++ b/examples/hosts/app-integration/external-controller/src/app.ts
@@ -8,13 +8,6 @@ import { getTinyliciousContainer } from "@fluidframework/get-tinylicious-contain
 import { IKeyValueDataObject, KeyValueContainerRuntimeFactory } from "./kvpair-dataobject";
 import { renderDiceRoller } from "./view";
 
-// In interacting with the service, we need to be explicit about whether we're creating a new document vs. loading
-// an existing one.  We also need to provide the unique ID for the document we are creating or loading from.
-
-// In this app, we'll choose to create a new document when navigating directly to http://localhost:8080.  For the ID,
-// we'll choose to use the current timestamp.  We'll also choose to interpret the URL hash as an existing document's
-// ID to load from, so the URL for a document load will look something like http://localhost:8080/#1596520748752.
-// These policy choices are arbitrary for demo purposes, and can be changed however you'd like.
 let createNew = false;
 if (location.hash.length === 0) {
     createNew = true;
@@ -24,11 +17,7 @@ const documentId = location.hash.substring(1);
 document.title = documentId;
 
 async function start(): Promise<void> {
-    // The getTinyliciousContainer helper function facilitates loading our container code into a Container and
-    // connecting to a locally-running test service called Tinylicious.  This will look different when moving to a
-    // production service, but ultimately we'll still be getting a reference to a Container object.  The helper
-    // function takes the ID of the document we're creating or loading, the container code to load into it, and a
-    // flag to specify whether we're creating a new document or loading an existing one.
+    // Get Fluid Container (creates if new url)
     const container = await getTinyliciousContainer(documentId, KeyValueContainerRuntimeFactory, createNew);
 
     // Since we're using a ContainerRuntimeFactoryWithDefaultDataStore, our dice roller is available at the URL "/".
@@ -42,12 +31,9 @@ async function start(): Promise<void> {
         throw new Error(`Empty response from URL: "${url}"`);
     }
 
-    // In this app, we know our container code provides a default data object that is an IDiceRoller.
-    const DO: IKeyValueDataObject = response.value;
+    const keyValueDataObject: IKeyValueDataObject = response.value;
 
-    // Given an IDiceRoller, we can render the value and provide controls for users to roll it.
-    const div = document.getElementById("content") as HTMLDivElement;
-    renderDiceRoller(DO, div);
+    renderDiceRoller(keyValueDataObject);
 }
 
 start().catch((error) => console.error(error));

--- a/examples/hosts/app-integration/external-controller/src/index.html
+++ b/examples/hosts/app-integration/external-controller/src/index.html
@@ -9,6 +9,11 @@
     <title>Test application</title>
 </head>
 <body style="margin: 0; height: 100%;">
-    <div id="content" style="min-height: 100%;"></div>
+    <div id="content" style="min-height: 100%;">
+        <div style="text-align: center">
+            <div id="dice" style="font-size: 200px;"></div>
+            <div id="button" style="font-size: 50px;">Roll</div>
+        </div>
+    </div>
 </body>
 </html>

--- a/examples/hosts/app-integration/external-controller/src/kvpair-dataobject/DataObject.ts
+++ b/examples/hosts/app-integration/external-controller/src/kvpair-dataobject/DataObject.ts
@@ -11,17 +11,17 @@ import { IDirectoryValueChanged, IValueChanged } from "@fluidframework/map";
  */
 export interface IKeyValueDataObject {
     /**
-     * Get the dice value as a number.
+     * Get value at Key
      */
     get: (key: string) => any
 
     /**
-     * Roll the dice.  Will cause a "diceRolled" event to be emitted.
+     * Set Value at Key
      */
     set: (key: string, value: any) => void;
 
     /**
-     * The diceRolled event will fire whenever someone rolls the device, either locally or remotely.
+     * Event on value change
      */
     on(event: "changed", listener: (args: IDirectoryValueChanged) => void): this;
 }

--- a/examples/hosts/app-integration/external-controller/src/view.ts
+++ b/examples/hosts/app-integration/external-controller/src/view.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
@@ -6,28 +7,20 @@
 import { IKeyValueDataObject } from "./kvpair-dataobject";
 
 /**
- * Render an IDiceRoller into a given div as a text character, with a button to roll it.
+ * Render Dice into a given HTMLElement as a text character, with a button to roll it.
  * @param dataObject - The Data Object to be rendered
- * @param div - The div to render into
+ * @param div - The HTMLElement to render into
  */
-export function renderDiceRoller(DO: IKeyValueDataObject, div: HTMLDivElement) {
+export function renderDiceRoller(DO: IKeyValueDataObject) {
     const dataKey = "dataKey";
     // Set init value for dataKey
     DO.set(dataKey, 1);
-    const wrapperDiv = document.createElement("div");
-    wrapperDiv.style.textAlign = "center";
-    div.append(wrapperDiv);
 
-    const diceCharDiv = document.createElement("div");
-    diceCharDiv.style.fontSize = "200px";
+    const diceCharDiv = document.getElementById("dice")!;
 
-    const rollButton = document.createElement("button");
-    rollButton.style.fontSize = "50px";
-    rollButton.textContent = "Roll";
+    const rollButton = document.getElementById("button")!;
     // Set the value at our dataKey with a random number between 1 and 6.
     rollButton.addEventListener("click", () => DO.set(dataKey, Math.floor(Math.random() * 6) + 1));
-
-    wrapperDiv.append(diceCharDiv, rollButton);
 
     // Get the current value of the shared data to update the view whenever it changes.
     const updateDiceChar = () => {


### PR DESCRIPTION
I'm mixing 2 concerns with this PR, so feel free to agree with only one part.

1. Remove comments... it was just getting hard to read. Ideally we should be more self explanatory.

2. Move DOM creation to HTML... Shortened fn significantly and improved readability. On the flip, encapsulation into code proposal may be harder with this model, although it could be done through webpack.