### PR TITLE
Depend on Data Store Context Interfaces Not Classes

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -4093,7 +4093,7 @@
 		"@microsoft/tsdoc": {
 			"version": "0.12.19",
 			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.19.tgz",
-			"integrity": "sha1-IXPMuSRpqvYgMfqUmdIbFtB/m1c=",
+			"integrity": "sha512-IpgPxHrNxZiMNUSXqR1l/gePKPkfAmIKoDRP9hp7OwjU29ZR8WCJsOJ8iBKgw0Qk+pFwR+8Y1cy8ImLY6e9m4A==",
 			"dev": true
 		},
 		"@mixer/webpack-bundle-compare": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2047,7 +2047,7 @@
     "@microsoft/tsdoc": {
       "version": "0.12.19",
       "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.19.tgz",
-      "integrity": "sha1-IXPMuSRpqvYgMfqUmdIbFtB/m1c=",
+      "integrity": "sha512-IpgPxHrNxZiMNUSXqR1l/gePKPkfAmIKoDRP9hp7OwjU29ZR8WCJsOJ8iBKgw0Qk+pFwR+8Y1cy8ImLY6e9m4A==",
       "dev": true
     },
     "@mrmlnc/readdir-enhanced": {


### PR DESCRIPTION
This is just staging some work to make it possible to write tests for DataStores:
https://github.com/anthony-murphy/FluidFramework-1/blob/2989da88994ddd81d2113b0cd4a79a516ef2b7f6/packages/runtime/container-runtime/src/test/datastores.spec.ts

This change removes coupling to classes, which are hard to test, and move those to interfaces, which are much easier to test. The next phase will decouple DataStores from the ContainerRuntime class, and add the tests above