### PR TITLE
FluidBuild: fix eslint dependent tsc tasks and add building a specific directory support

### DIFF
--- a/tools/build-tools/package-lock.json
+++ b/tools/build-tools/package-lock.json
@@ -528,6 +528,12 @@
         "@types/node": "*"
       }
     },
+    "@types/json5": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.30.tgz",
+      "integrity": "sha512-sqm9g7mHlPY/43fcSNrCYfOeX9zkTTK+euO5E6+CVijSMm5tTjkVdwdqRkY3ljjIAf8679vps5jKUoJBCLsMDA==",
+      "dev": true
+    },
     "@types/lodash": {
       "version": "4.14.137",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.137.tgz",
@@ -1867,9 +1873,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
+      "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ=="
     },
     "int64-buffer": {
       "version": "0.1.10",

--- a/tools/build-tools/package.json
+++ b/tools/build-tools/package.json
@@ -34,6 +34,7 @@
     "danger": "^10.4.1",
     "fs-extra": "^9.0.1",
     "glob": "^7.1.3",
+    "json5": "^2.1.3",
     "lodash.isequal": "^4.5.0",
     "package-json-validator": "^0.6.3",
     "package-lock-sanitizer": "^1.0.1",

--- a/tools/build-tools/package.json
+++ b/tools/build-tools/package.json
@@ -49,6 +49,7 @@
     "@types/async": "^2.4.1",
     "@types/fs-extra": "^8.1.0",
     "@types/glob": "^7.1.1",
+    "@types/json5": "^0.0.30",
     "@types/lodash.isequal": "^4.5.5",
     "@types/node": "^11.9.4",
     "@types/rimraf": "^2.0.3",

--- a/tools/build-tools/src/common/fluidUtils.ts
+++ b/tools/build-tools/src/common/fluidUtils.ts
@@ -5,7 +5,7 @@
 
 import * as fs from "fs";
 import { commonOptions } from "./commonOptions";
-import { existsSync, realpathAsync, readJsonAsync, lookUpDir } from "./utils";
+import { existsSync, realpathAsync, readJsonAsync, lookUpDirAsync } from "./utils";
 import * as path from "path";
 import { logVerbose } from "./logging";
 import { IPackageManifest } from "./fluidRepo";
@@ -46,7 +46,7 @@ async function isFluidRoot(dir: string) {
 }
 
 async function inferRoot() {
-    return lookUpDir(process.cwd(), async (curr) => {
+    return lookUpDirAsync(process.cwd(), async (curr) => {
         logVerbose(`InferRoot: probing ${curr}`);
         try {
             if (await isFluidRoot(curr)) {

--- a/tools/build-tools/src/common/npmPackage.ts
+++ b/tools/build-tools/src/common/npmPackage.ts
@@ -18,7 +18,7 @@ import {
     ExecAsyncResult,
     readJsonSync,
     existsSync,
-    lookUpDirAsync,
+    lookUpDirSync,
 } from "./utils"
 import { MonoRepo } from "./monoRepo";
 import { options } from "../fluidBuild/options";
@@ -193,7 +193,7 @@ export class Package {
         }
         let succeeded = true;
         for (const dep of this.combinedDependencies) {
-            if (!await lookUpDirAsync(this.directory, (currentDir) => {
+            if (!lookUpDirSync(this.directory, (currentDir) => {
                 // TODO: check semver as well
                 return existsSync(path.join(currentDir, "node_modules", dep.name));
             })) {

--- a/tools/build-tools/src/common/npmPackage.ts
+++ b/tools/build-tools/src/common/npmPackage.ts
@@ -18,7 +18,7 @@ import {
     ExecAsyncResult,
     readJsonSync,
     existsSync,
-    lookUpDir,
+    lookUpDirAsync,
 } from "./utils"
 import { MonoRepo } from "./monoRepo";
 import { options } from "../fluidBuild/options";
@@ -193,7 +193,7 @@ export class Package {
         }
         let succeeded = true;
         for (const dep of this.combinedDependencies) {
-            if (!await lookUpDir(this.directory, (currentDir) => {
+            if (!await lookUpDirAsync(this.directory, (currentDir) => {
                 // TODO: check semver as well
                 return existsSync(path.join(currentDir, "node_modules", dep.name));
             })) {

--- a/tools/build-tools/src/common/utils.ts
+++ b/tools/build-tools/src/common/utils.ts
@@ -122,8 +122,8 @@ export function readJsonSync(filename: string) {
     return JSON.parse(content);
 }
 
-export async function lookUpDir(dir: string, callback: (currentDir: string) => boolean | Promise<boolean>) {
-    let curr = dir;
+export async function lookUpDirAsync(dir: string, callback: (currentDir: string) => boolean | Promise<boolean>) {
+    let curr = path.resolve(dir);
     while (true) {
         if (await callback(curr)) {
             return curr;
@@ -139,7 +139,24 @@ export async function lookUpDir(dir: string, callback: (currentDir: string) => b
     return undefined;
 }
 
-export async function isSameFileOrDir(f1: string, f2: string) {
+export function lookUpDirSync(dir: string, callback: (currentDir: string) => boolean) {
+    let curr = path.resolve(dir);
+    while (true) {
+        if (callback(curr)) {
+            return curr;
+        }
+
+        const up = path.resolve(curr, "..");
+        if (up === curr) {
+            break;
+        }
+        curr = up;
+    }
+
+    return undefined;
+}
+
+export function isSameFileOrDir(f1: string, f2: string) {
     if (f1 === f2) { return true; }
     const n1 = path.normalize(f1);
     const n2 = path.normalize(f2);

--- a/tools/build-tools/src/common/utils.ts
+++ b/tools/build-tools/src/common/utils.ts
@@ -122,7 +122,7 @@ export function readJsonSync(filename: string) {
     return JSON.parse(content);
 }
 
-export async function lookUpDirAsync(dir: string, callback: (currentDir: string) => boolean | Promise<boolean>) {
+export async function lookUpDirAsync(dir: string, callback: (currentDir: string) => Promise<boolean>) {
     let curr = path.resolve(dir);
     while (true) {
         if (await callback(curr)) {

--- a/tools/build-tools/src/fluidBuild/buildGraph.ts
+++ b/tools/build-tools/src/fluidBuild/buildGraph.ts
@@ -66,10 +66,10 @@ export class BuildPackage {
         return this.buildTask;
     }
 
-    public findTask(command: string): Task | undefined {
+    public findTask(command: string, options?: any): Task | undefined {
         const task = this.task;
         if (!task) { return undefined; }
-        return task.matchTask(command);
+        return task.matchTask(command, options);
     }
 
     public async isUpToDate(): Promise<boolean> {

--- a/tools/build-tools/src/fluidBuild/fluidBuild.ts
+++ b/tools/build-tools/src/fluidBuild/fluidBuild.ts
@@ -20,7 +20,7 @@ async function main() {
     const timer = new Timer(commonOptions.timer);
     const resolvedRoot = await getResolvedFluidRoot();
 
-    logStatus(`Processing ${resolvedRoot}`);
+    logStatus(`Fluid Repo Root: ${resolvedRoot}`);
 
     // Detect nohoist state mismatch and infer uninstall switch
     if (options.install) {
@@ -35,14 +35,14 @@ async function main() {
     const repo = new FluidRepoBuild(resolvedRoot, options.services);
     timer.time("Package scan completed");
 
-    // Set matched package based on options filter
-    const matched = repo.setMatched(options);
-    if (!matched) {
-        console.error("ERROR: No package matched");
-        process.exit(-4)
-    }
-
     try {
+        // Set matched package based on options filter
+        const matched = repo.setMatched(options);
+        if (!matched) {
+            console.error("ERROR: No package matched");
+            process.exit(-4)
+        }
+
         // Dependency checks
         if (options.depcheck) {
             repo.depcheck();

--- a/tools/build-tools/src/fluidBuild/fluidPackageCheck.ts
+++ b/tools/build-tools/src/fluidBuild/fluidPackageCheck.ts
@@ -228,10 +228,12 @@ export class FluidPackageCheck {
             if (pkg.getScript("tsc")) {
                 if (pkg.getScript("build:test")) {
                     if (pkg.getScript("build:esnext")) {
+                        // If we have build:esnext, that means that we are building it two ways (commonjs and esm)
                         buildCommonJs.push("tsc");
                         buildCommonJs.push("build:test");
                         buildCompile.push("build:commonjs");
                     } else {
+                        // Only building it one way, so just we only need to to build with tsc and test
                         buildCompile.push("tsc");
                         buildCompile.push("build:test");
                         concurrentBuildCompile = false;

--- a/tools/build-tools/src/fluidBuild/fluidPackageCheck.ts
+++ b/tools/build-tools/src/fluidBuild/fluidPackageCheck.ts
@@ -222,12 +222,21 @@ export class FluidPackageCheck {
             // prepack scripts
             const prepack: string[] = [];
 
+            let concurrentBuildCompile = true;
+
             const buildPrefix = pkg.getScript("build:genver") ? "npm run build:genver && " : "";
             if (pkg.getScript("tsc")) {
                 if (pkg.getScript("build:test")) {
-                    buildCommonJs.push("tsc");
-                    buildCommonJs.push("build:test");
-                    buildCompile.push("build:commonjs");
+                    if (pkg.getScript("build:esnext")) {
+                        buildCommonJs.push("tsc");
+                        buildCommonJs.push("build:test");
+                        buildCompile.push("build:commonjs");
+                    } else {
+                        buildCompile.push("tsc");
+                        buildCompile.push("build:test");
+                        concurrentBuildCompile = false;
+                    }
+
                 } else {
                     buildCompile.push("tsc");
                 }
@@ -292,7 +301,7 @@ export class FluidPackageCheck {
                 }
             }
             check("build", build, true, buildPrefix);
-            check("build:compile", buildCompile);
+            check("build:compile", buildCompile, concurrentBuildCompile);
             check("build:commonjs", buildCommonJs, false);
             check("build:full", buildFull);
             check("build:full:compile", buildFullCompile);

--- a/tools/build-tools/src/fluidBuild/fluidRepoBuild.ts
+++ b/tools/build-tools/src/fluidBuild/fluidRepoBuild.ts
@@ -4,7 +4,7 @@
  */
 
 import { Package, Packages } from "../common/npmPackage";
-import { globFn } from "../common/utils";
+import { existsSync, globFn, lookUpDirSync, isSameFileOrDir } from "../common/utils";
 import { FluidPackageCheck } from "./fluidPackageCheck";
 import { FluidRepo } from "../common/fluidRepo";
 import { MonoRepoKind } from "../common/monoRepo";
@@ -13,11 +13,13 @@ import { ISymlinkOptions, symlinkPackage } from "./symlinkUtils";
 import { BuildGraph } from "./buildGraph";
 import { logVerbose } from "../common/logging";
 import { MonoRepo } from "../common/monoRepo";
+import * as path from "path";
 
 export interface IPackageMatchedOptions {
     match: string[];
     all: boolean;
     server: boolean;
+    dirs: string[];
 };
 
 export class FluidRepoBuild extends FluidRepo {
@@ -40,7 +42,7 @@ export class FluidRepoBuild extends FluidRepo {
     };
 
     public setMatched(options: IPackageMatchedOptions) {
-        const hasMatchArgs = options.match.length;
+        const hasMatchArgs = options.match.length || options.dirs.length;
 
         if (hasMatchArgs) {
             let matched = false;
@@ -49,6 +51,19 @@ export class FluidRepoBuild extends FluidRepo {
                 if (this.matchWithFilter(pkg => regExp.test(pkg.name))) {
                     matched = true;
                 }
+            });
+
+            options.dirs.forEach((arg) => {
+                const pkgDir = lookUpDirSync(arg, (currentDir) => {
+                    return existsSync(path.join(currentDir, "package.json"));
+                });
+                if (!pkgDir) {
+                    throw new Error("Directory specified in --dir is not a package. package.json not found.");
+                }
+                if (!this.matchWithFilter(pkg => isSameFileOrDir(pkg.directory, pkgDir))) {
+                    throw new Error(`Directory specified in --dir is not in a Fluid repo. ${arg} -> ${path.join(pkgDir, "package.json")}`);
+                }
+                matched = true;
             });
             return matched;
         }

--- a/tools/build-tools/src/fluidBuild/options.ts
+++ b/tools/build-tools/src/fluidBuild/options.ts
@@ -3,8 +3,10 @@
  * Licensed under the MIT License.
  */
 
+import * as path from "path";
 import * as os from "os";
 import { commonOptionString, parseOption } from "../common/commonOptions"
+import { existsSync } from "../common/utils";
 import { IPackageMatchedOptions } from "./fluidRepoBuild";
 import { ISymlinkOptions } from "./symlinkUtils";
 
@@ -37,6 +39,7 @@ export const options: FastBuildOptions = {
     showExec: false,
     clean: false,
     match: [],
+    dirs: [],
     matchedOnly: true,
     buildScriptNames: [],
     vscode: false,
@@ -58,12 +61,13 @@ export const options: FastBuildOptions = {
 function printUsage() {
     console.log(
         `
-Usage: fluid-build <options> [<package regexp> ...]
+Usage: fluid-build <options> [(<package regexp>|<path>) ...]
   [<package regexp> ...] Regexp to match the package name (default: all packages)
 Options:
      --all            Operate on all packages/monorepo (default: client monorepo)
   -c --clean          Same as running build script 'clean' on matched packages (all if package regexp is not specified)
   -d --dep            Apply actions (clean/force/rebuild) to matched packages and their dependent packages
+     --dir <path>     Directory to build
      --fix            Auto fix warning from package check if possible
   -f --force          Force build and ignore dependency check on matched packages (all if package regexp is not specified)
   -? --help           Print this message
@@ -254,9 +258,14 @@ export function parseOptions(argv: string[]) {
             continue;
         }
 
-        // Package regexp
+        // Package regexp or paths
         if (!arg.startsWith("-")) {
-            options.match.push(arg);
+            const resolvedPath = path.resolve(arg);
+            if (existsSync(resolvedPath)) {
+                options.dirs.push(arg);
+            } else {
+                options.match.push(arg);
+            }
             continue;
         }
 

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
@@ -42,7 +42,7 @@ export abstract class LeafTask extends Task {
         this.addDependentTasks(this.dependentTasks);
     }
 
-    public matchTask(command: string): LeafTask | undefined {
+    public matchTask(command: string, options?: any): LeafTask | undefined {
         return (this.command === command) ? this : undefined;
     }
 
@@ -149,8 +149,8 @@ export abstract class LeafTask extends Task {
         return leafIsUpToDate;
     }
 
-    protected addChildTask(dependentTasks: LeafTask[], node: BuildPackage, command: string) {
-        const task = node.findTask(command);
+    protected addChildTask(dependentTasks: LeafTask[], node: BuildPackage, command: string, options?: any) {
+        const task = node.findTask(command, options);
         if (task) {
             task.collectLeafTasks(dependentTasks);
             return task;

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/lintTasks.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/lintTasks.ts
@@ -4,8 +4,10 @@
  */
 
 import { LeafTask } from "./leafTask";
-import { TscDependentTask } from "./tscTask";
-import { existsSync } from "fs";
+import { TscTask, TscDependentTask } from "./tscTask";
+import { existsSync, readFileSync } from "fs";
+import * as path from "path";
+import * as JSON5 from "json5";
 
 abstract class LintBaseTask extends TscDependentTask {
     protected addDependentTasks(dependentTasks: LeafTask[]) {
@@ -33,20 +35,50 @@ export class TsLintTask extends LintBaseTask {
 export class EsLintTask extends LintBaseTask {
     private _configFileFullPath: string | undefined
     protected get doneFile() {
-        // TODO: This assume there is only one tslint task per package
+        // TODO: This assume there is only one eslint task per package
         return "eslint.done.build.log";
     }
 
     protected get configFileFullPath() {
         if (!this._configFileFullPath) {
-            const jsonConfig = this.getPackageFileFullPath(".eslintrc.json");
-            if (existsSync(jsonConfig)) {
-                this._configFileFullPath = jsonConfig;
-            } else {
-                this._configFileFullPath = this.getPackageFileFullPath(".eslintrc.js");
+            // TODO: we currently don't support .cjs, .yaml and .yml, or config in package.json
+            const possibleConfig = [".eslintrc.js", ".eslintrc.json", ".eslintrc"];
+            for (const configFile of possibleConfig) {
+                const configFileFullPath = this.getPackageFileFullPath(configFile);
+                if (existsSync(configFileFullPath)) {
+                    this._configFileFullPath = configFileFullPath;
+                    break;
+                }
+            }
+            if (!this._configFileFullPath) {
+                throw new Error(`Unable to find config file for eslint ${this.command}`);
             }
         }
         return this._configFileFullPath;
+    }
+
+    protected addDependentTasks(dependentTasks: LeafTask[]) {
+        let config: any;
+        try {
+            if (path.parse(this.configFileFullPath).ext !== ".js") {
+                // TODO: optimize double read for TscDependentTask.getDoneFileContent and there.
+                const configFile = readFileSync(this.configFileFullPath, "utf8");
+                config = JSON5.parse(configFile);
+            } else {
+                config = require(this.configFileFullPath);
+                if (config === undefined) {
+                    throw new Error("Exports not found");
+                }
+            }
+        } catch (e) {
+            throw new Error(`Unable to parse options from ${this.configFileFullPath}. ${e}`)
+        }
+        if (config.parserOptions?.project) {
+            for (const tsConfigPath of config.parserOptions?.project) {
+                this.addTscTask(dependentTasks, { tsConfig: this.getPackageFileFullPath(tsConfigPath) });
+            }
+        }
+        super.addDependentTasks(dependentTasks);
     }
 }
 

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -22,7 +22,7 @@ interface ITsBuildInfo {
 }
 
 interface TscTaskMatchOptions {
-    tsConfig: string;
+    tsConfig?: string;
 };
 
 export class TscTask extends LeafTask {

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -21,6 +21,10 @@ interface ITsBuildInfo {
     }
 }
 
+interface TscTaskMatchOptions {
+    tsConfig: string;
+};
+
 export class TscTask extends LeafTask {
     private _tsBuildInfoFullPath: string | undefined;
     private _tsBuildInfo: ITsBuildInfo | undefined;
@@ -29,7 +33,7 @@ export class TscTask extends LeafTask {
     private _projectReference: TscTask | undefined;
     private _sourceStats: fs.Stats[] | undefined;
 
-    public matchTask(command: string, options?: any): LeafTask | undefined {
+    public matchTask(command: string, options?: TscTaskMatchOptions): LeafTask | undefined {
         if (!options?.tsConfig) { return super.matchTask(command); }
         if (command !== "tsc") { return undefined; }
         const configFile = this.configFileFullPath;

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -29,6 +29,14 @@ export class TscTask extends LeafTask {
     private _projectReference: TscTask | undefined;
     private _sourceStats: fs.Stats[] | undefined;
 
+    public matchTask(command: string, options?: any): LeafTask | undefined {
+        if (!options?.tsConfig) { return super.matchTask(command); }
+        if (command !== "tsc") { return undefined; }
+        const configFile = this.configFileFullPath;
+        if (!configFile) { return undefined; }
+        return isSameFileOrDir(configFile, options.tsConfig)? this : undefined;
+    }
+
     protected addDependentTasks(dependentTasks: LeafTask[]) {
         if (this.addChildTask(dependentTasks, this.node, "npm run build:genver")) {
             this.logVerboseDependency(this.node, "build:genver");
@@ -106,7 +114,7 @@ export class TscTask extends LeafTask {
     private remapSrcDeclFile(fullPath: string) {
         if (!this._sourceStats) {
             const config = this.readTsConfig();
-            this._sourceStats = config? config.fileNames.map(fs.lstatSync) : [];
+            this._sourceStats = config ? config.fileNames.map(fs.lstatSync) : [];
         }
 
         const parsed = path.parse(fullPath);
@@ -119,7 +127,7 @@ export class TscTask extends LeafTask {
     }
 
     private patchOptionPaths(object: any, dir: string) {
-        for (const key of  ["configFilePath", "declarationDir", "outDir", "rootDir", "project"]) {
+        for (const key of ["configFilePath", "declarationDir", "outDir", "rootDir", "project"]) {
             const value = object[key];
             if (value !== undefined) {
                 object[key] = path.resolve(dir, value);
@@ -168,7 +176,7 @@ export class TscTask extends LeafTask {
             }
 
             // Fix up relative path from the command line based on the package directory
-            const commandOptions = { ... parsedCommand.options };
+            const commandOptions = { ...parsedCommand.options };
             this.patchOptionPaths(commandOptions, this.node.pkg.directory);
 
             // Parse the config file relative to the config file directory
@@ -301,27 +309,31 @@ export class TscTask extends LeafTask {
 
 // Base class for tasks that are dependent on a tsc compile
 export abstract class TscDependentTask extends LeafWithDoneFileTask {
-    private tscTask: TscTask | undefined;
+    protected tscTasks: TscTask[] = [];
     protected get recheckLeafIsUpToDate() {
         return true;
     }
 
     protected async getDoneFileContent() {
         try {
-            const doneFileContent = { tsBuildInfoFile: {}, config: "" };
-            if (this.tscTask) {
-                const tsBuildInfo = await this.tscTask.readTsBuildInfo();
+            const tsBuildInfoFiles: ITsBuildInfo[] = [];
+            for (const tscTask of this.tscTasks) {
+                const tsBuildInfo = await tscTask.readTsBuildInfo();
                 if (tsBuildInfo === undefined) {
+                    // If any of the tsc task don't have build info, we can't track
                     return undefined;
                 }
-                doneFileContent.tsBuildInfoFile = tsBuildInfo;
-                const configFile = this.configFileFullPath;
-                if (existsSync(configFile)) {
-                    // Include the config file if it exists so that we can detect changes
-                    doneFileContent.config = await readFileAsync(this.configFileFullPath, "utf8");
-                }
+                tsBuildInfoFiles.push(tsBuildInfo);
             }
-            return JSON.stringify(doneFileContent);
+
+            const configFile = this.configFileFullPath;
+            let config = "";
+            if (existsSync(configFile)) {
+                // Include the config file if it exists so that we can detect changes
+                config = await readFileAsync(this.configFileFullPath, "utf8");
+            }
+
+            return JSON.stringify({ tsBuildInfoFiles, config });
         } catch (e) {
             this.logVerboseTask(`error generating done file content ${e}`);
             return undefined;
@@ -329,11 +341,22 @@ export abstract class TscDependentTask extends LeafWithDoneFileTask {
     }
 
     protected addDependentTasks(dependentTasks: LeafTask[]) {
-        const tscTask = this.addChildTask(dependentTasks, this.node, "tsc");
-        if (tscTask) {
-            this.tscTask = tscTask as TscTask;
-            this.logVerboseDependency(this.node, "tsc");
+        if (this.tscTasks.length === 0) {
+            // derived class didn't populate it.
+           this.addTscTask(dependentTasks);
         }
+    }
+    protected addTscTask(dependentTasks: LeafTask[], options?: any) {
+        const tscTask = this.addChildTask(dependentTasks, this.node, "tsc", options);
+        if (!tscTask) {
+            if (options) {
+                throw new Error(`Unable to find tsc task matching ${options.tsConfig} for dependent task ${this.command}`);
+            } else {
+                throw new Error(`Unable to find tsc task for dependent task ${this.command}`);
+            }
+        }
+        this.tscTasks.push(tscTask as TscTask);
+        this.logVerboseDependency(this.node, tscTask.command);
     }
 
     protected abstract get configFileFullPath(): string;

--- a/tools/build-tools/src/fluidBuild/tasks/npmTask.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/npmTask.ts
@@ -21,10 +21,10 @@ export class NPMTask extends Task {
 
     public get isLeaf() { return false; }
 
-    public matchTask(command: string): Task | undefined {
+    public matchTask(command: string, options?: any): Task | undefined {
         if (command === this.command) { return this; }
         for (const task of this.subTasks) {
-            const t = task.matchTask(command);
+            const t = task.matchTask(command, options);
             if (t) { return t; }
         }
         return undefined;

--- a/tools/build-tools/src/fluidBuild/tasks/task.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/task.ts
@@ -60,7 +60,7 @@ export abstract class Task {
 
     public abstract initializeDependentTask(): void;
     public abstract get isLeaf(): boolean;
-    public abstract matchTask(command: string): Task | undefined;
+    public abstract matchTask(command: string, options?: any): Task | undefined;
     public abstract collectLeafTasks(leafTasks: LeafTask[]): void;
     protected abstract async checkIsUpToDate(): Promise<boolean>;
     protected abstract async runTask(q: AsyncPriorityQueue<TaskExec>): Promise<BuildResult>;


### PR DESCRIPTION
To support separating build for test, eslint now need to track multiple *.tsbuildinfo for incremental build
Allow specifying a path to build the package (and dependencies) that contains the path

