### PR TITLE
FetchTool: change the patched tree file to tree.json 

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,7 @@
             "type": "process",
             "command": "node",
             "args": [
-                "${workspaceRoot}/node_modules/@fluid-internal/build-tools/dist/fluidBuild.js",
+                "${workspaceRoot}/node_modules/@fluidframework/build-tools/dist/fluidBuild/fluidBuild.js",
                 "--root",
                 "${workspaceRoot}",
                 "--vscode"

--- a/packages/tools/fetch-tool/src/fluidFetchSnapshot.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchSnapshot.ts
@@ -102,7 +102,7 @@ function fetchBlobs(prefix: string,
 function createTreeBlob(tree: ISnapshotTree, prefix: string, patched: boolean): IFetchedTree {
     assert(!!tree.id);
     const content = JSON.stringify(tree);
-    const filename = `tree-${tree.id}${patched ? "-patched" : ""}`;
+    const filename = patched ? "tree" : `tree-${tree.id}`;
     const treePath = `${prefix}${filename}`;
     return { treePath, blobId: tree.id, filename, blob: content, patched, reused: false };
 }


### PR DESCRIPTION
Fix #4476, so that other tools will work.

Also fix vscode build task to the right build-tool path.