### PR TITLE
Make ODSP readBlob() correctly work with cache and patch branch info

### DIFF
--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -164,9 +164,8 @@ export interface ISnapshotTree {
 }
 
 export interface ISnapshotBlob {
-    contents?: string;
-    content?: string;
-    encoding: string;
+    content: string;
+    encoding: "base64" | "utf-8";
 }
 
 export interface ISnapshotCommit {
@@ -186,11 +185,13 @@ export interface ITree {
 }
 
 /**
- * Blob content
+ * Blob content, represents blobs in downloaded snapshot.
  */
 export interface IBlob {
     content: string;
-    encoding: string;
+    // SPO only uses "base64" today for download.
+    // We are adding undefined to as temp way to roundtrip strings unchanged.
+    encoding: "base64" | undefined;
     id: string;
     size: number;
 }

--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -190,7 +190,7 @@ export interface ITree {
 export interface IBlob {
     content: string;
     // SPO only uses "base64" today for download.
-    // We are adding undefined to as temp way to roundtrip strings unchanged.
+    // We are adding undefined too, as temp way to roundtrip strings unchanged.
     encoding: "base64" | undefined;
     id: string;
     size: number;

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -503,13 +503,13 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                             const hashP = hashFile(
                                 blob instanceof ArrayBuffer ?
                                 IsoBuffer.from(blob) :
-                                IsoBuffer.from(blob.content, blob.encoding ?? "utf-8"));
-                            const hashP2 = hashP.then((hash: string) => {
+                                IsoBuffer.from(blob.content, blob.encoding ?? "utf-8"))
+                            .then((hash: string) => {
                                 this.blobsShaToPathCache.set(hash, path);
                             }).finally(() => {
-                                this.blobsCachePendingHashes.delete(hashP2);
+                                this.blobsCachePendingHashes.delete(hashP);
                             });
-                            this.blobsCachePendingHashes.add(hashP2);
+                            this.blobsCachePendingHashes.add(hashP);
                         }
                     }
                 }


### PR DESCRIPTION
This is required for the work Si is doing.
Hope to get it in before 0.31 gets in, as lack of this change (and propagation across hosts) will block the rest of the work