### PR TITLE
Bump tinylicious version since it depends on newer common-utils

### DIFF
--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinylicious",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Tiny, test implementation of the routerlicious reference service",
   "homepage": "https://fluidframework.com",
   "repository": "https://github.com/microsoft/FluidFramework",


### PR DESCRIPTION
I think this is right?

Next need to bump the dependencies in Client to 0.4.x afterwards.