### PR TITLE
Handle errors when resolving handles

### DIFF
--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -297,7 +297,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
                 this.logger.sendErrorEvent({ eventName: "GetChannelFailedInRequest" }, error);
 
                 return {
-                    status: 404,
+                    status: 500,
                     mimeType: "text/plain",
                     value: `Failed to get Channel with id:[${id}] error:{${error}}`,
                 };

--- a/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
+++ b/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
@@ -50,7 +50,7 @@ export class RemoteFluidObjectHandle implements IFluidHandle {
                 .then<IFluidObject>((response) =>
                     response.mimeType === "fluid/object"
                         ? response.value as IFluidObject
-                        : Promise.reject(new Error("Not found")));
+                        : Promise.reject(new Error(response.value)));
         }
 
         return this.dataStoreP;

--- a/packages/test/end-to-end-tests/src/test/sharedStringLoading.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/sharedStringLoading.spec.ts
@@ -122,11 +122,11 @@ describe("SharedString", () => {
 
             const container = await loader.resolve(urlResolver.createCreateNewRequest(documentId));
             const dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
-            // TODO: this should probably throw, but currently returns the dataObject due to #4613
-            // this test should be updated when that issue is fix
-            const sharedString  = await dataObject.root.get<IFluidHandle<SharedString>>(stringId).get();
-            // eslint-disable-next-line dot-notation
-            assert.strictEqual(sharedString["getText"], undefined);
+
+            try {
+                await dataObject.root.get<IFluidHandle<SharedString>>(stringId).get();
+                assert.fail("expected failure");
+            } catch {}
         }
     });
 });


### PR DESCRIPTION
Return 500 on channel load failure, rather than 404 which is handled differently throughout the stack

related #4613
