### PR TITLE
Split controller out, add lifecycle handling

### DIFF
--- a/examples/hosts/app-integration/external-controller/src/app.ts
+++ b/examples/hosts/app-integration/external-controller/src/app.ts
@@ -5,6 +5,7 @@
 
 import { getTinyliciousContainer } from "@fluidframework/get-tinylicious-container";
 
+import { DiceRollerController } from "./controller";
 import { IKeyValueDataObject, KeyValueContainerRuntimeFactory } from "./kvpair-dataobject";
 import { renderDiceRoller } from "./view";
 // import { renderDiceRoller } from "./reactView";
@@ -34,10 +35,12 @@ async function start(): Promise<void> {
 
     // In this app, we know our container code provides a default data object that is an IDiceRoller.
     const keyValueDataObject: IKeyValueDataObject = response.value;
+    const diceRollerController = new DiceRollerController(keyValueDataObject);
+    await diceRollerController.initialize(createNew);
 
     // Given an IDiceRoller, we can render the value and provide controls for users to roll it.
     const div = document.getElementById("content") as HTMLDivElement;
-    renderDiceRoller(keyValueDataObject, div);
+    renderDiceRoller(diceRollerController, div);
 }
 
 start().catch((error) => console.error(error));

--- a/examples/hosts/app-integration/external-controller/src/controller.ts
+++ b/examples/hosts/app-integration/external-controller/src/controller.ts
@@ -1,0 +1,90 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { EventEmitter } from "events";
+import { IKeyValueDataObject } from "./kvpair-dataobject";
+
+/**
+ * IDiceRoller describes the public API surface for our dice roller data object.
+ */
+export interface IDiceRollerController extends EventEmitter {
+    /**
+     * Get the dice value as a number.
+     */
+    readonly value: number;
+
+    /**
+     * Roll the dice.  Will cause a "diceRolled" event to be emitted.
+     */
+    roll: () => void;
+
+    /**
+     * The diceRolled event will fire whenever someone rolls the device, either locally or remotely.
+     */
+    on(event: "diceRolled", listener: () => void): this;
+}
+
+// The data is stored in a key-value pair data object, so we'll use this key for storing the value.
+const diceValueKey = "diceValue";
+
+/**
+ * The DiceRoller is our data object that implements the IDiceRoller interface.
+ */
+export class DiceRollerController extends EventEmitter implements IDiceRollerController {
+    constructor(private readonly kvPairDataObject: IKeyValueDataObject) {
+        super();
+        this.kvPairDataObject.on("changed", (changed) => {
+            if (changed.key === diceValueKey) {
+                // When we see the dice value change, we'll emit the diceRolled event we specified in our interface.
+                this.emit("diceRolled");
+            }
+        });
+    }
+
+    /**
+     * When we create the dice roller for the first time (with respect to the document's lifetime), we need to
+     * initialize its value.  This should only be called once over the document's lifetime.
+     */
+    private initializeFirstTime(): void {
+        this.kvPairDataObject.set(diceValueKey, 1);
+    }
+
+    private async initializeFromExisting(): Promise<void> {
+        // If the value is already there, we are initialized enough.
+        if (this.kvPairDataObject.get(diceValueKey) !== undefined) {
+            return;
+        }
+
+        // Otherwise, we expect the value will be set by the client that is creating the dice roller.
+        // The set should be on the way, in the pending ops.
+        return new Promise((resolve) => {
+            const resolveIfKeySet = () => {
+                if (this.kvPairDataObject.get(diceValueKey) !== undefined) {
+                    resolve();
+                    this.kvPairDataObject.off("changed", resolveIfKeySet);
+                }
+            };
+            this.kvPairDataObject.on("changed", resolveIfKeySet);
+        });
+    }
+
+    public async initialize(firstTime: boolean): Promise<void> {
+        if (firstTime) {
+            this.initializeFirstTime();
+        } else {
+            return this.initializeFromExisting();
+        }
+    }
+
+    public get value() {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return this.kvPairDataObject.get(diceValueKey);
+    }
+
+    public readonly roll = () => {
+        const rollValue = Math.floor(Math.random() * 6) + 1;
+        this.kvPairDataObject.set(diceValueKey, rollValue);
+    };
+}

--- a/examples/hosts/app-integration/external-controller/src/reactView.tsx
+++ b/examples/hosts/app-integration/external-controller/src/reactView.tsx
@@ -5,41 +5,46 @@
 
 import React from "react";
 import ReactDOM from "react-dom";
-import { IKeyValueDataObject } from "./kvpair-dataobject";
+import { IDiceRollerController } from "./controller";
 
 /**
  * Render Dice into a given HTMLElement as a text character, with a button to roll it.
  * @param dataObject - The Data Object to be rendered
  * @param div - The HTMLElement to render into
  */
-export function renderDiceRoller(dataObject: IKeyValueDataObject, div: HTMLDivElement) {
-    ReactDOM.render(<ReactView dataObject={dataObject} />, div);
+export function renderDiceRoller(diceRoller: IDiceRollerController, div: HTMLDivElement) {
+    ReactDOM.render(<ReactView diceRoller={diceRoller} />, div);
 }
 
 interface IReactViewProps {
-    dataObject: IKeyValueDataObject
+    diceRoller: IDiceRollerController;
 }
 
 const ReactView = (props: IReactViewProps) => {
-    const { dataObject } = props;
-    const [diceValue, setDiceValue] = React.useState(1);
+    const { diceRoller } = props;
+    const [diceValue, setDiceValue] = React.useState(diceRoller.value);
 
     const diceCharacter = String.fromCodePoint(0x267F + diceValue);
-    const rollDice = () => dataObject.set("dice", Math.floor(Math.random() * 6) + 1);
-    const syncLocalAndFluidState = () => setDiceValue(dataObject.get("dice"));
 
     React.useEffect(() => {
-        dataObject.on("changed", syncLocalAndFluidState);
-        return () => {
-            dataObject.off("changed", syncLocalAndFluidState);
+        // useEffect runs async after render, so it's possible for the dice value to update after render but
+        // before we get our event listener registered.  We refresh our dice value in case that happened.
+        setDiceValue(diceRoller.value);
+        const onDiceRolled = () => {
+            setDiceValue(diceRoller.value);
         };
-    });
+        diceRoller.on("diceRolled", onDiceRolled);
+        return () => {
+            diceRoller.off("diceRolled", onDiceRolled);
+        };
+    }, [diceRoller]);
+
     return (
         <div style={{ textAlign: "center" }}>
             <div style={{ fontSize: 200, color: `hsl(${diceValue * 60}, 70%, 50%)` }}>
                 {diceCharacter}
             </div>
-            <button style={{ fontSize: 50 }} onClick={rollDice}>
+            <button style={{ fontSize: 50 }} onClick={diceRoller.roll}>
                 Roll
             </button>
         </div>

--- a/examples/hosts/app-integration/external-controller/src/view.ts
+++ b/examples/hosts/app-integration/external-controller/src/view.ts
@@ -3,17 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import { IKeyValueDataObject } from "./kvpair-dataobject";
+import { IDiceRollerController } from "./controller";
 
 /**
- * Render Dice into a given HTMLElement as a text character, with a button to roll it.
- * @param dataObject - The Data Object to be rendered
- * @param div - The HTMLElement to render into
+ * Render an IDiceRollerController into a given div as a text character, with a button to roll it.
+ * @param diceRoller - The dice roller to be rendered
+ * @param div - The div to render into
  */
-export function renderDiceRoller(dataObject: IKeyValueDataObject, div: HTMLDivElement) {
-    const dataKey = "dataKey";
-    // Set init value for dataKey
-    dataObject.set(dataKey, 1);
+export function renderDiceRoller(diceRoller: IDiceRollerController, div: HTMLDivElement) {
     const wrapperDiv = document.createElement("div");
     wrapperDiv.style.textAlign = "center";
     div.append(wrapperDiv);
@@ -24,19 +21,19 @@ export function renderDiceRoller(dataObject: IKeyValueDataObject, div: HTMLDivEl
     const rollButton = document.createElement("button");
     rollButton.style.fontSize = "50px";
     rollButton.textContent = "Roll";
-    // Set the value at our dataKey with a random number between 1 and 6.
-    rollButton.addEventListener("click", () => dataObject.set(dataKey, Math.floor(Math.random() * 6) + 1));
+    // Call the roll method to modify the shared data when the button is clicked.
+    rollButton.addEventListener("click", diceRoller.roll);
 
     wrapperDiv.append(diceCharDiv, rollButton);
 
     // Get the current value of the shared data to update the view whenever it changes.
     const updateDiceChar = () => {
         // Unicode 0x2680-0x2685 are the sides of a dice (⚀⚁⚂⚃⚄⚅)
-        diceCharDiv.textContent = String.fromCodePoint(0x267F + (dataObject.get(dataKey) as number));
-        diceCharDiv.style.color = `hsl(${dataObject.get(dataKey) * 60}, 70%, 50%)`;
+        diceCharDiv.textContent = String.fromCodePoint(0x267F + diceRoller.value);
+        diceCharDiv.style.color = `hsl(${diceRoller.value * 60}, 70%, 50%)`;
     };
     updateDiceChar();
 
-    // Use the changed event to trigger the rerender whenever the value changes.
-    dataObject.on("changed", updateDiceChar);
+    // Use the diceRolled event to trigger the rerender whenever the value changes.
+    diceRoller.on("diceRolled", updateDiceChar);
 }

--- a/examples/hosts/app-integration/external-controller/tests/index.ts
+++ b/examples/hosts/app-integration/external-controller/tests/index.ts
@@ -7,8 +7,9 @@
 import { getSessionStorageContainer } from "@fluidframework/get-session-storage-container";
 import { getDefaultObjectFromContainer } from "@fluidframework/aqueduct";
 
-import { renderDiceRoller } from "../src/view";
+import { DiceRollerController } from "../src/controller";
 import { KeyValueContainerRuntimeFactory, KeyValueDataObject } from "../src/kvpair-dataobject";
+import { renderDiceRoller } from "../src/view";
 
 // Since this is a single page Fluid application we are generating a new document id
 // if one was not provided
@@ -29,10 +30,12 @@ export async function createContainerAndRenderInElement(element: HTMLDivElement,
     const container = await getSessionStorageContainer(documentId, KeyValueContainerRuntimeFactory, createNewFlag);
 
     // Get the Default Object from the Container
-    const defaultObject = await getDefaultObjectFromContainer<KeyValueDataObject>(container);
+    const kvPairDataObject = await getDefaultObjectFromContainer<KeyValueDataObject>(container);
+    const diceRollerController = new DiceRollerController(kvPairDataObject);
+    await diceRollerController.initialize(createNewFlag);
 
     // Given an IDiceRoller, we can render its data using the view we've created in our app.
-    renderDiceRoller(defaultObject, element);
+    renderDiceRoller(diceRollerController, element);
 
     // Setting "fluidStarted" is just for our test automation
     // eslint-disable-next-line dot-notation


### PR DESCRIPTION
This change does two things:

1. Current example resets the dice value to 1 on each load, which defeats collaborative scenarios.  This change adds lifecycle handling (not pretty, but functionally correct) to support persisting the dice value across loads.
2. Splits the controller logic into its own file/class.  This enables the View to avoid those concerns about lifecycle (instead these can be a function of the App which already knows if we're in a create-new flow), and also makes it easier to directly compare against the external-views/container-views samples.