### PR TITLE
Move r11s Alfred tests to r11s-base

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -78,6 +78,8 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.19.2",
     "@fluidframework/eslint-config-fluid": "^0.21.0",
+    "@fluidframework/server-local-server": "^0.1016.1",
+    "@fluidframework/server-test-utils": "^0.1016.1",
     "@types/bytes": "^3.0.0",
     "@types/compression": "0.0.33",
     "@types/cookie-parser": "^1.4.1",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -19,9 +19,31 @@
     "eslint:fix": "eslint --format stylish src --fix",
     "lint": "npm run eslint",
     "lint:fix": "npm run eslint:fix",
+    "test": "mocha --recursive dist/test --unhandled-rejections=strict",
+    "test:coverage": "nyc npm test -- --reporter mocha-junit-reporter --reporter-options mochaFile=nyc/junit-report.xml",
     "tsc": "tsc",
     "tsfmt": "tsfmt --verify",
     "tsfmt:fix": "tsfmt --replace"
+  },
+  "nyc": {
+    "all": true,
+    "cache-dir": "nyc/.cache",
+    "exclude": [
+      "src/test/**/*.ts",
+      "dist/test/**/*.js"
+    ],
+    "exclude-after-remap": false,
+    "include": [
+      "src/**/*.ts",
+      "dist/**/*.js"
+    ],
+    "report-dir": "nyc/report",
+    "reporter": [
+      "cobertura",
+      "html",
+      "text"
+    ],
+    "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.26.0",
@@ -69,6 +91,7 @@
     "@types/redis": "^2.8.8",
     "@types/request": "^2.47.1",
     "@types/split": "^0.3.28",
+    "@types/supertest": "^2.0.5",
     "@types/ws": "^6.0.1",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
@@ -80,7 +103,11 @@
     "eslint-plugin-prefer-arrow": "~1.2.2",
     "eslint-plugin-react": "~7.21.2",
     "eslint-plugin-unicorn": "~22.0.0",
+    "mocha": "^8.1.1",
+    "mocha-junit-reporter": "^1.18.0",
+    "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
+    "supertest": "^3.1.0",
     "typescript": "~3.8.2",
     "typescript-formatter": "7.1.0"
   }

--- a/server/routerlicious/packages/routerlicious-base/src/test/alfred/io.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/alfred/io.spec.ts
@@ -41,7 +41,7 @@ import {
     TestTenantManager,
     DebugLogger,
 } from "@fluidframework/server-test-utils";
-import { OrdererManager } from "@fluidframework/server-routerlicious-base";
+import { OrdererManager } from "../../alfred";
 
 describe("Routerlicious", () => {
     describe("Alfred", () => {

--- a/server/routerlicious/packages/routerlicious-base/tsconfig.json
+++ b/server/routerlicious/packages/routerlicious-base/tsconfig.json
@@ -7,7 +7,10 @@
     "compilerOptions": {
         "strictNullChecks": false,
         "rootDir": "./src",
-        "outDir": "./dist"
+        "outDir": "./dist",
+        "types": [
+            "mocha"
+        ]
     },
     "include": [
         "src/**/*"

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -34,31 +34,9 @@
     "lint:fix": "npm run eslint:fix",
     "scriptorium": "node dist/scriptorium/index.js",
     "scriptorium:debug": "node --inspect=0.0.0.0:5858 dist/scriptorium/index.js",
-    "test": "mocha --recursive dist/test --unhandled-rejections=strict",
-    "test:coverage": "nyc npm test -- --reporter mocha-junit-reporter --reporter-options mochaFile=nyc/junit-report.xml",
     "tsc": "tsc",
     "tsfmt": "tsfmt --verify",
     "tsfmt:fix": "tsfmt --replace"
-  },
-  "nyc": {
-    "all": true,
-    "cache-dir": "nyc/.cache",
-    "exclude": [
-      "src/test/**/*.ts",
-      "dist/test/**/*.js"
-    ],
-    "exclude-after-remap": false,
-    "include": [
-      "src/**/*.ts",
-      "dist/**/*.js"
-    ],
-    "report-dir": "nyc/report",
-    "reporter": [
-      "cobertura",
-      "html",
-      "text"
-    ],
-    "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.26.0",
@@ -114,7 +92,6 @@
     "@types/redis": "^2.8.8",
     "@types/request": "^2.47.1",
     "@types/split": "^0.3.28",
-    "@types/supertest": "^2.0.5",
     "@types/ws": "^6.0.1",
     "@typescript-eslint/eslint-plugin": "~4.2.0",
     "@typescript-eslint/parser": "~4.2.0",
@@ -130,17 +107,13 @@
     "eslint-plugin-react": "~7.21.2",
     "eslint-plugin-unicorn": "~22.0.0",
     "html-loader": "^0.5.5",
-    "mocha": "^8.1.1",
-    "mocha-junit-reporter": "^1.18.0",
     "node-sass": "^4.9.3",
-    "nyc": "^15.0.0",
     "random-js": "^1.0.8",
     "rimraf": "^2.6.2",
     "sass-loader": "^7.1.0",
     "source-map-loader": "^0.2.4",
     "string-hash": "^1.1.3",
     "style-loader": "^1.0.0",
-    "supertest": "^3.1.0",
     "thread-loader": "^1.2.0",
     "ts-loader": "^6.1.2",
     "typescript": "~3.8.2",


### PR DESCRIPTION
Alfred's main source code lives in `routerlicious-base`, but its socket unit tests reside in `routerlicious`.

This should have been done as part of #3592, but better late than never!