### PR TITLE
Updated request in examples and test fluid object to check for url before returning

### DIFF
--- a/examples/data-objects/codemirror/src/codemirror.ts
+++ b/examples/data-objects/codemirror/src/codemirror.ts
@@ -229,11 +229,11 @@ export class CodeMirrorComponent
     }
 
     public async request(request: IRequest): Promise<IResponse> {
-        return {
-            mimeType: "fluid/object",
-            status: 200,
-            value: this,
-        };
+        if (request.url === "" || request.url === "/") {
+            return { status: 200, mimeType: "fluid/object", value: this };
+        } else {
+            return { status: 404, mimeType: "text/plain", value: `${request.url} not found` };
+        }
     }
 
     private async initialize() {

--- a/examples/data-objects/codemirror/src/codemirror.ts
+++ b/examples/data-objects/codemirror/src/codemirror.ts
@@ -4,6 +4,7 @@
  */
 
 import { EventEmitter } from "events";
+import { defaultFluidObjectRequestHandler } from "@fluidframework/aqueduct";
 import {
     IFluidLoadable,
     IFluidRouter,
@@ -229,11 +230,7 @@ export class CodeMirrorComponent
     }
 
     public async request(request: IRequest): Promise<IResponse> {
-        if (request.url === "" || request.url === "/") {
-            return { status: 200, mimeType: "fluid/object", value: this };
-        } else {
-            return { status: 404, mimeType: "text/plain", value: `${request.url} not found` };
-        }
+        return defaultFluidObjectRequestHandler(this, request);
     }
 
     private async initialize() {

--- a/examples/data-objects/key-value-cache/src/index.ts
+++ b/examples/data-objects/key-value-cache/src/index.ts
@@ -89,11 +89,11 @@ class KeyValue implements IKeyValue, IFluidObject, IFluidRouter {
     }
 
     public async request(request: IRequest): Promise<IResponse> {
-        return {
-            mimeType: "fluid/object",
-            status: 200,
-            value: this,
-        };
+        if (request.url === "" || request.url === "/") {
+            return { status: 200, mimeType: "fluid/object", value: this };
+        } else {
+            return { status: 404, mimeType: "text/plain", value: `${request.url} not found` };
+        }
     }
 
     private async initialize() {

--- a/examples/data-objects/key-value-cache/src/index.ts
+++ b/examples/data-objects/key-value-cache/src/index.ts
@@ -29,7 +29,7 @@ import {
     innerRequestHandler,
     buildRuntimeRequestHandler,
 } from "@fluidframework/request-handler";
-import { defaultRouteRequestHandler } from "@fluidframework/aqueduct";
+import { defaultFluidObjectRequestHandler, defaultRouteRequestHandler } from "@fluidframework/aqueduct";
 import { assert } from "@fluidframework/common-utils";
 
 export const IKeyValue: keyof IProvideKeyValue = "IKeyValue";
@@ -89,11 +89,7 @@ class KeyValue implements IKeyValue, IFluidObject, IFluidRouter {
     }
 
     public async request(request: IRequest): Promise<IResponse> {
-        if (request.url === "" || request.url === "/") {
-            return { status: 200, mimeType: "fluid/object", value: this };
-        } else {
-            return { status: 404, mimeType: "text/plain", value: `${request.url} not found` };
-        }
+        return defaultFluidObjectRequestHandler(this, request);
     }
 
     private async initialize() {

--- a/examples/data-objects/progress-bars/package.json
+++ b/examples/data-objects/progress-bars/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@fluid-example/fluid-object-interfaces": "^0.32.0",
+    "@fluidframework/aqueduct": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.32.0",
     "@fluidframework/datastore": "^0.32.0",
     "@fluidframework/datastore-definitions": "^0.32.0",

--- a/examples/data-objects/progress-bars/src/progressBars.ts
+++ b/examples/data-objects/progress-bars/src/progressBars.ts
@@ -111,11 +111,11 @@ export class ProgressBar extends EventEmitter implements
     }
 
     public async request(request: IRequest): Promise<IResponse> {
-        return {
-            mimeType: "fluid/object",
-            status: 200,
-            value: this,
-        };
+        if (request.url === "" || request.url === "/") {
+            return { status: 200, mimeType: "fluid/object", value: this };
+        } else {
+            return { status: 404, mimeType: "text/plain", value: `${request.url} not found` };
+        }
     }
 }
 

--- a/examples/data-objects/progress-bars/src/progressBars.ts
+++ b/examples/data-objects/progress-bars/src/progressBars.ts
@@ -4,6 +4,7 @@
  */
 
 import { EventEmitter } from "events";
+import { defaultFluidObjectRequestHandler } from "@fluidframework/aqueduct";
 import {
     IFluidObject,
     IFluidHandleContext,
@@ -111,11 +112,7 @@ export class ProgressBar extends EventEmitter implements
     }
 
     public async request(request: IRequest): Promise<IResponse> {
-        if (request.url === "" || request.url === "/") {
-            return { status: 200, mimeType: "fluid/object", value: this };
-        } else {
-            return { status: 404, mimeType: "text/plain", value: `${request.url} not found` };
-        }
+        return defaultFluidObjectRequestHandler(this, request);
     }
 }
 

--- a/examples/data-objects/prosemirror/src/prosemirror.ts
+++ b/examples/data-objects/prosemirror/src/prosemirror.ts
@@ -4,6 +4,7 @@
  */
 
 import { EventEmitter } from "events";
+import { defaultFluidObjectRequestHandler } from "@fluidframework/aqueduct";
 import {
     IFluidLoadable,
     IFluidRouter,
@@ -129,11 +130,7 @@ export class ProseMirror extends EventEmitter
     }
 
     public async request(request: IRequest): Promise<IResponse> {
-        if (request.url === "" || request.url === "/") {
-            return { status: 200, mimeType: "fluid/object", value: this };
-        } else {
-            return { status: 404, mimeType: "text/plain", value: `${request.url} not found` };
-        }
+        return defaultFluidObjectRequestHandler(this, request);
     }
 
     private async initialize() {

--- a/examples/data-objects/prosemirror/src/prosemirror.ts
+++ b/examples/data-objects/prosemirror/src/prosemirror.ts
@@ -129,11 +129,11 @@ export class ProseMirror extends EventEmitter
     }
 
     public async request(request: IRequest): Promise<IResponse> {
-        return {
-            mimeType: "fluid/object",
-            status: 200,
-            value: this,
-        };
+        if (request.url === "" || request.url === "/") {
+            return { status: 200, mimeType: "fluid/object", value: this };
+        } else {
+            return { status: 404, mimeType: "text/plain", value: `${request.url} not found` };
+        }
     }
 
     private async initialize() {

--- a/examples/data-objects/scribe/src/scribe.ts
+++ b/examples/data-objects/scribe/src/scribe.ts
@@ -409,11 +409,11 @@ export class Scribe
     }
 
     public async request(request: IRequest): Promise<IResponse> {
-        return {
-            mimeType: "fluid/object",
-            status: 200,
-            value: this,
-        };
+        if (request.url === "" || request.url === "/") {
+            return { status: 200, mimeType: "fluid/object", value: this };
+        } else {
+            return { status: 404, mimeType: "text/plain", value: `${request.url} not found` };
+        }
     }
 
     public render(elm: HTMLElement, options?: IFluidHTMLOptions): void {

--- a/examples/data-objects/scribe/src/scribe.ts
+++ b/examples/data-objects/scribe/src/scribe.ts
@@ -35,7 +35,7 @@ import {
     innerRequestHandler,
     buildRuntimeRequestHandler,
 } from "@fluidframework/request-handler";
-import { defaultRouteRequestHandler } from "@fluidframework/aqueduct";
+import { defaultFluidObjectRequestHandler, defaultRouteRequestHandler } from "@fluidframework/aqueduct";
 import Axios from "axios";
 
 import * as scribe from "./tools-core";
@@ -409,11 +409,7 @@ export class Scribe
     }
 
     public async request(request: IRequest): Promise<IResponse> {
-        if (request.url === "" || request.url === "/") {
-            return { status: 200, mimeType: "fluid/object", value: this };
-        } else {
-            return { status: 404, mimeType: "text/plain", value: `${request.url} not found` };
-        }
+        return defaultFluidObjectRequestHandler(this, request);
     }
 
     public render(elm: HTMLElement, options?: IFluidHTMLOptions): void {

--- a/examples/data-objects/smde/src/smde.ts
+++ b/examples/data-objects/smde/src/smde.ts
@@ -4,6 +4,7 @@
  */
 
 import { EventEmitter } from "events";
+import { defaultFluidObjectRequestHandler } from "@fluidframework/aqueduct";
 import { assert } from "@fluidframework/common-utils";
 import {
     IFluidObject,
@@ -68,11 +69,7 @@ export class Smde extends EventEmitter implements
     }
 
     public async request(request: IRequest): Promise<IResponse> {
-        if (request.url === "" || request.url === "/") {
-            return { status: 200, mimeType: "fluid/object", value: this };
-        } else {
-            return { status: 404, mimeType: "text/plain", value: `${request.url} not found` };
-        }
+        return defaultFluidObjectRequestHandler(this, request);
     }
 
     private async initialize() {

--- a/examples/data-objects/smde/src/smde.ts
+++ b/examples/data-objects/smde/src/smde.ts
@@ -68,11 +68,11 @@ export class Smde extends EventEmitter implements
     }
 
     public async request(request: IRequest): Promise<IResponse> {
-        return {
-            mimeType: "fluid/object",
-            status: 200,
-            value: this,
-        };
+        if (request.url === "" || request.url === "/") {
+            return { status: 200, mimeType: "fluid/object", value: this };
+        } else {
+            return { status: 404, mimeType: "text/plain", value: `${request.url} not found` };
+        }
     }
 
     private async initialize() {

--- a/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
@@ -19,9 +19,9 @@ import { FluidObjectHandle } from "@fluidframework/datastore";
 import { IDirectory } from "@fluidframework/map";
 import { assert, EventForwarder } from "@fluidframework/common-utils";
 import { IEvent } from "@fluidframework/common-definitions";
-import { RequestParser } from "@fluidframework/runtime-utils";
 import { handleFromLegacyUri } from "@fluidframework/request-handler";
 import { serviceRoutePathRoot } from "../container-services";
+import { defaultFluidObjectRequestHandler } from "../request-handlers";
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export interface IDataObjectProps<O = object, S = undefined> {
@@ -118,26 +118,12 @@ export abstract class PureDataObject<O extends IFluidObject = object, S = undefi
 
     /**
      * Return this object if someone requests it directly
-     * We will return this object in three scenarios
+     * We will return this object in two scenarios:
      *  1. the request url is a "/"
-     *  2. the request url is our url
-     *  3. the request url is empty
+     *  2. the request url is empty
      */
     public async request(req: IRequest): Promise<IResponse> {
-        const pathParts = RequestParser.getPathParts(req.url);
-        const requestUrl = (pathParts.length > 0) ? pathParts[0] : req.url;
-        if (requestUrl === "/" || requestUrl === "") {
-            return {
-                mimeType: "fluid/object",
-                status: 200,
-                value: this,
-            };
-        }
-        return {
-            mimeType: "text/plain",
-            status: 404,
-            value: `unknown request url: ${req.url}`,
-        };
+        return defaultFluidObjectRequestHandler(this, req);
     }
 
     // #endregion IFluidRouter

--- a/packages/framework/aqueduct/src/request-handlers/requestHandlers.ts
+++ b/packages/framework/aqueduct/src/request-handlers/requestHandlers.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IRequest, IRequestHeader } from "@fluidframework/core-interfaces";
+import { IFluidObject, IRequest, IRequestHeader, IResponse } from "@fluidframework/core-interfaces";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { IFluidMountableViewClass } from "@fluidframework/view-interfaces";
 import { RuntimeRequestHandler, buildRuntimeRequestHandler } from "@fluidframework/request-handler";
@@ -65,3 +65,26 @@ export const defaultRouteRequestHandler = (defaultRootId: string) => {
         return undefined; // continue search
     };
 };
+
+/**
+ * Default request handler for a Fluid object that returns the object itself if:
+ *  1. the request url is a "/"
+ *  2. the request url is empty
+ * Returns a 404 error for any other request.
+ */
+export function defaultFluidObjectRequestHandler(fluidObject: IFluidObject, request: IRequest): IResponse {
+    const pathParts = RequestParser.getPathParts(request.url);
+    const requestUrl = (pathParts.length > 0) ? pathParts[0] : request.url;
+    if (requestUrl === "/" || requestUrl === "") {
+        return {
+            mimeType: "fluid/object",
+            status: 200,
+            value: fluidObject,
+        };
+    }
+    return {
+        mimeType: "text/plain",
+        status: 404,
+        value: `unknown request url: ${request.url}`,
+    };
+}

--- a/packages/framework/aqueduct/src/request-handlers/requestHandlers.ts
+++ b/packages/framework/aqueduct/src/request-handlers/requestHandlers.ts
@@ -70,21 +70,12 @@ export const defaultRouteRequestHandler = (defaultRootId: string) => {
  * Default request handler for a Fluid object that returns the object itself if:
  *  1. the request url is a "/"
  *  2. the request url is empty
- * Returns a 404 error for any other request.
+ * Returns a 404 error for any other url.
  */
 export function defaultFluidObjectRequestHandler(fluidObject: IFluidObject, request: IRequest): IResponse {
-    const pathParts = RequestParser.getPathParts(request.url);
-    const requestUrl = (pathParts.length > 0) ? pathParts[0] : request.url;
-    if (requestUrl === "/" || requestUrl === "") {
-        return {
-            mimeType: "fluid/object",
-            status: 200,
-            value: fluidObject,
-        };
+    if (request.url === "/" || request.url === "") {
+        return { mimeType: "fluid/object", status: 200, value: fluidObject };
+    } else {
+        return { mimeType: "text/plain", status: 404, value: `unknown request url: ${request.url}` };
     }
-    return {
-        mimeType: "text/plain",
-        status: 404,
-        value: `unknown request url: ${request.url}`,
-    };
 }

--- a/packages/test/test-utils/src/testFluidObject.ts
+++ b/packages/test/test-utils/src/testFluidObject.ts
@@ -80,11 +80,11 @@ export class TestFluidObject implements ITestFluidObject {
     }
 
     public async request(request: IRequest): Promise<IResponse> {
-        return {
-            mimeType: "fluid/object",
-            status: 200,
-            value: this,
-        };
+        if (request.url === "" || request.url === "/") {
+            return { status: 200, mimeType: "fluid/object", value: this };
+        } else {
+            return { status: 404, mimeType: "text/plain", value: `${request.url} not found` };
+        }
     }
 
     private async initialize() {

--- a/packages/test/test-utils/src/testFluidObject.ts
+++ b/packages/test/test-utils/src/testFluidObject.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { defaultFluidObjectRequestHandler } from "@fluidframework/aqueduct";
 import { IRequest, IResponse, IFluidHandle } from "@fluidframework/core-interfaces";
 import { FluidObjectHandle, mixinRequestHandler } from "@fluidframework/datastore";
 import { SharedMap, ISharedMap } from "@fluidframework/map";
@@ -80,11 +81,7 @@ export class TestFluidObject implements ITestFluidObject {
     }
 
     public async request(request: IRequest): Promise<IResponse> {
-        if (request.url === "" || request.url === "/") {
-            return { status: 200, mimeType: "fluid/object", value: this };
-        } else {
-            return { status: 404, mimeType: "text/plain", value: `${request.url} not found` };
-        }
+        return defaultFluidObjectRequestHandler(this, request);
     }
 
     private async initialize() {


### PR DESCRIPTION
Fixes #4621.

The request handler should not return itself unconditionally. In a scenario where this data object is requested for a DDS that does not exist, the runtime would call into these request handlers which would end up returning the data object instead of an error.