### PR TITLE
Hook our azure dev ops pipeline to our azure key vault

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -23,10 +23,6 @@ parameters:
     - skip
     - force
 
-variables:
-- group: prague-key-vault
-
-
 trigger:
   branches:
     include:
@@ -72,6 +68,8 @@ pr:
 
 extends:
   template: templates/build-npm-package.yml
+  variables:
+  - group: prague-key-vault
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -68,8 +68,6 @@ pr:
 
 extends:
   template: templates/build-npm-package.yml
-  variables:
-  - group: prague-key-vault
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -23,6 +23,10 @@ parameters:
     - skip
     - force
 
+variables:
+- group: prague-key-vault
+
+
 trigger:
   branches:
     include:
@@ -45,9 +49,6 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
-
-variables:
-- group: prague-key-vault
 
 pr:
   branches:

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -46,6 +46,9 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
 
+variables:
+- group: prague-key-vault
+
 pr:
   branches:
     include:
@@ -104,10 +107,10 @@ extends:
         - task: Npm@1
           displayName: '[end-to-end tests] npm run ci:test:realsvc'
           env:
-            fluid__webpack__bearerSecret: $(fluid__webpack__bearerSecret)
-            fluid__webpack__fluidHost: $(fluid__webpack__fluidHost)
-            fluid__webpack__tenantId: $(fluid__webpack__tenantId)
-            fluid__webpack__tenantSecret: $(fluid__webpack__tenantSecret)
+            fluid__webpack__bearerSecret: $(fluid-webpack-bearerSecret)
+            fluid__webpack__fluidHost: $(fluid-webpack-fluidHost)
+            fluid__webpack__tenantId: $(fluid-webpack-tenantId)
+            fluid__webpack__tenantSecret: $(fluid-webpack-tenantSecret)
           inputs:
             command: 'custom'
             workingDir: packages/test/end-to-end-tests

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -20,6 +20,7 @@ parameters:
   type: string
 
 variables:
+- group: prague-key-vault
 - name: skipComponentGovernanceDetection
   value: true
 - name: shouldPublish


### PR DESCRIPTION
In this change we take a dependency on the existence of a variable group, prague-key-vault. In our internal environment we hook this up to pull from key vault to pull real secrets for running real service tests. In our public environments this variable group must exist, but can be empty