### PR TITLE
Rounding expiration time of tokens stored in Redis

### DIFF
--- a/server/historian/packages/historian-base/src/services/riddlerService.ts
+++ b/server/historian/packages/historian-base/src/services/riddlerService.ts
@@ -71,7 +71,7 @@ export class RiddlerService implements ITenantService {
         // in case the service clock is behind, reducing the lifetime of token by 5%
         // to avoid using an expired token.
         if (tokenLifetimeInSec) {
-            tokenLifetimeInSec = tokenLifetimeInSec - ((tokenLifetimeInSec * 5) / 100);
+            tokenLifetimeInSec = Math.round(tokenLifetimeInSec - ((tokenLifetimeInSec * 5) / 100));
         }
         this.cache.set(token, "", tokenLifetimeInSec).catch((error) => {
             winston.error(`Error caching token to redis`, error);

--- a/server/historian/packages/historian-base/src/utils.ts
+++ b/server/historian/packages/historian-base/src/utils.ts
@@ -25,7 +25,7 @@ export function normalizePort(val) {
 export function getTokenLifetimeInSec(token: string): number {
     const claims = jwt.decode(token) as ITokenClaims;
     if (claims && claims.exp) {
-        return (claims.exp - Math.round((new Date()).getTime()) / 1000);
+        return (claims.exp - Math.round((new Date().getTime()) / 1000));
     }
     return undefined;
 }


### PR DESCRIPTION
Redis [EXPIRE](https://redis.io/commands/expire) has the following syntax:

`EXPIRE key seconds`

"seconds" needs to be an integer, and our [redisTenantCache](https://github.com/microsoft/FluidFramework/blob/245baae9f8c08e4bbb712bca3dc7b4bde8a634b1/server/historian/packages/historian-base/src/services/redisTenantCache.ts#L40) is using decimals when calling EXPIRE. That ends up causing the following error in Redis:

`error: Error caching token to redis ERR value is not an integer or out of range {"command":"EXPIRE","args":["tenant:eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkb2N1bWVudElkIjoibGVnZW5kbWFza19zaWdodCIsInNjb3BlcyI6WyJkb2M6cmVhZCIsImRvYzp3cml0ZSIsInN1bW1hcnk6d3JpdGUiXSwidGVuYW50SWQiOiJoZWRhc2lsdi1yZWRpcy10ZXN0IiwidXNlciI6eyJpZCI6IjBlMmMxMWI4LTI3ZGUtNGY4MC1hMGQxLTg0YWQyNTI5YjUyNCIsIm5hbWUiOiJkZW50ZmlnaHRlcl9oZXJvIn0sImlhdCI6MTYwODE3NjM5NCwiZXhwIjoxNjA4MTc5OTk0LCJ2ZXIiOiIxLjAifQ.v_p67Kyn0yf4Hk4aTwqeAn_uwczWXwbWIf99RdiV_H8",3420.1443999528883],"code":"ERR","stack":"ReplyError: ERR value is not an integer or out of range\n    at parseError (/home/node/server/node_modules/redis-parser/lib/parser.js:193:12)\n    at parseType (/home/node/server/node_modules/redis-parser/lib/parser.js:303:14)"}`

The fix is simple and has two parts:

1. Fix the parenthesis order in getTokenLifetimeInSec() in utils.ts, since Math.round() is currently only applied to the Date().getTime() result - before it is divided by 1000.
2. Add Math.round() in ridderService.ts - verifyToken(), since after subtracting 5% of the token lifetime, the result can be a decimal too.