### PR TITLE
Fix op processing in fetch tool.

### DIFF
--- a/packages/tools/fetch-tool/src/fluidFetch.ts
+++ b/packages/tools/fetch-tool/src/fluidFetch.ts
@@ -27,8 +27,8 @@ async function fluidFetchOneFile(urlStr: string, name?: string) {
         await writeFile(`${saveDir}/info.json`, JSON.stringify(info, undefined, 2));
     }
 
-    await fluidFetchMessages(documentService, saveDir);
     await fluidFetchSnapshot(documentService, saveDir);
+    await fluidFetchMessages(documentService, saveDir);
 }
 
 async function tryFluidFetchOneSharePointFile(server: string, driveItem: IOdspDriveItem) {


### PR DESCRIPTION
Issue: https://github.com/microsoft/FluidFramework/issues/4635
Bug for hanging while fetching ops is already fixed with this PR:https://github.com/microsoft/FluidFramework/pull/4582
1.) Fix op processing. Unpack the runtime first if it is a runtime message.
2.) Fetch snapshot first as op fetching is slower for large documents. 