### PR TITLE
Update data stores' used routes after GC has run

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1355,9 +1355,13 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             }
 
             if (this.runtimeOptions.runGC) {
-                // Get the container's GC data and run GC on the reference graph in the GC data.
+                // Get the container's GC data and run GC on the reference graph in it.
                 const gcData = await this.dataStores.getGCData();
-                runGarbageCollection(gcData.gcNodes, [ "/" ], this.logger);
+                const { referencedNodeIds } = runGarbageCollection(gcData.gcNodes, [ "/" ], this.logger);
+
+                // Remove this node's route ("/") and notify data stores of routes that are used in it.
+                const usedRoutes = referencedNodeIds.filter((id: string) => { return id !== "/"; });
+                this.dataStores.updateUsedRoutes(usedRoutes);
             }
 
             const trace = Trace.start();

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -439,6 +439,18 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
     }
 
     /**
+     * After GC has run, called to notify this data store of routes that are used in it.
+     * @param usedRoutes - The routes that are used in this data store.
+     */
+    public updateUsedRoutes(usedRoutes: string[]) {
+        // Currently, only data stores can be collected. Once we have GC at DDS layer, the DDS' in the data store will
+        // also be notified of their used routes. See - https://github.com/microsoft/FluidFramework/issues/4611
+
+        // Update the used state of this data store in the summarizer node.
+        this.summarizerNode.used = usedRoutes.includes("/") || usedRoutes.includes("") ? true : false;
+    }
+
+    /**
      * @deprecated 0.18.Should call request on the runtime directly
      */
     public async request(request: IRequest): Promise<IResponse> {

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -447,7 +447,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
         // also be notified of their used routes. See - https://github.com/microsoft/FluidFramework/issues/4611
 
         // Update the used state of this data store in the summarizer node.
-        this.summarizerNode.used = usedRoutes.includes("/") || usedRoutes.includes("") ? true : false;
+        this.summarizerNode.used = usedRoutes.includes("/") || usedRoutes.includes("");
     }
 
     /**

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -464,8 +464,9 @@ export class DataStores implements IDisposable {
         for (const route of usedRoutes) {
             const dataStoreId = route.split("/")[1];
             const dataStoreRoute = route.slice(dataStoreId.length + 1);
-            if (usedRoutesMap.has(dataStoreId)) {
-                usedRoutesMap.get(dataStoreId)?.push(dataStoreRoute);
+            const routes = usedRoutesMap.get(dataStoreId);
+            if (routes !== undefined) {
+                routes.push(dataStoreRoute);
             } else {
                 usedRoutesMap.set(dataStoreId, [dataStoreRoute]);
             }

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -455,6 +455,29 @@ export class DataStores implements IDisposable {
     }
 
     /**
+     * After GC has run, called to notify this Container's data stores of routes that are used in it.
+     * @param usedRoutes - The routes that are used in all data stores in this Container.
+     */
+    public updateUsedRoutes(usedRoutes: string[]) {
+        // Build a map of data store ids to routes used in it.
+        const usedRoutesMap: Map<string, string[]> = new Map();
+        for (const route of usedRoutes) {
+            const dataStoreId = route.split("/")[1];
+            const dataStoreRoute = route.slice(dataStoreId.length + 1);
+            if (usedRoutesMap.has(dataStoreId)) {
+                usedRoutesMap.get(dataStoreId)?.push(dataStoreRoute);
+            } else {
+                usedRoutesMap.set(dataStoreId, [dataStoreRoute]);
+            }
+        }
+
+        // Update the used routes in each data store. Used routes is empty for unused data stores.
+        for (const [contextId, context] of this.contexts) {
+            context.updateUsedRoutes(usedRoutesMap.get(contextId) ?? []);
+        }
+    }
+
+    /**
      * Returns the outbound routes of this channel. Only root data stores are considered referenced and their paths are
      * part of outbound routes.
      */

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -252,31 +252,31 @@ describe("Data Store Context Tests", () => {
                 const contents = JSON.parse((gcEntry.value as IBlob).contents) as IGCDetails;
                 assert.deepStrictEqual(contents.gcData, emptyGCData, "GC data from summary should be empty.");
             });
-        });
 
-        it("can successfully update used state", () => {
-            localDataStoreContext = new LocalFluidDataStoreContext(
-                dataStoreId,
-                ["TestComp", "SubComp"],
-                containerRuntime,
-                storage,
-                scope,
-                createSummarizerNodeFn,
-                attachCb,
-                undefined,
-                false /* isRootDataStore */);
+            it("can successfully update used state", () => {
+                localDataStoreContext = new LocalFluidDataStoreContext(
+                    dataStoreId,
+                    ["TestComp", "SubComp"],
+                    containerRuntime,
+                    storage,
+                    scope,
+                    createSummarizerNodeFn,
+                    attachCb,
+                    undefined,
+                    false /* isRootDataStore */);
 
-            // Get the summarizer node for this data store which tracks its used state.
-            const dataStoreSummarizerNode = summarizerNode.getChild(dataStoreId);
-            assert.strictEqual(dataStoreSummarizerNode?.used, true, "Data store is used by default");
+                // Get the summarizer node for this data store which tracks its used state.
+                const dataStoreSummarizerNode = summarizerNode.getChild(dataStoreId);
+                assert.strictEqual(dataStoreSummarizerNode?.used, false, "Data store is unused by default");
 
-            // Update the data store to not have any used routes.
-            localDataStoreContext.updateUsedRoutes([]);
-            assert.strictEqual(dataStoreSummarizerNode?.used, false, "Data store should be unused without used routes");
+                // Update the data store to be used.
+                localDataStoreContext.updateUsedRoutes([""]);
+                assert.strictEqual(dataStoreSummarizerNode?.used, true, "Data store should now be used");
 
-            // Update the data store to be used.
-            localDataStoreContext.updateUsedRoutes([""]);
-            assert.strictEqual(dataStoreSummarizerNode?.used, true, "Data store should now be used");
+                // Update the data store to not have any used routes.
+                localDataStoreContext.updateUsedRoutes([]);
+                assert.strictEqual(dataStoreSummarizerNode?.used, false, "Data store should now be unused");
+            });
         });
     });
 
@@ -537,41 +537,41 @@ describe("Data Store Context Tests", () => {
                 const gcData = await remotedDataStoreContext.getGCData();
                 assert.deepStrictEqual(gcData, gcDetails.gcData, "GC data from getGCData is incorrect.");
             });
-        });
 
-        it("can successfully update used state", () => {
-            dataStoreAttributes = {
-                pkg: "TestDataStore1",
-            };
-            const buffer = IsoBuffer.from(JSON.stringify(dataStoreAttributes), "utf-8");
-            const blobCache = new Map<string, string>([["fluidDataStoreAttributes", buffer.toString("base64")]]);
-            const snapshotTree: ISnapshotTree = {
-                id: "dummy",
-                blobs: { [".component"]: "fluidDataStoreAttributes" },
-                commits: {},
-                trees: {},
-            };
+            it("can successfully update used state", () => {
+                dataStoreAttributes = {
+                    pkg: "TestDataStore1",
+                };
+                const buffer = IsoBuffer.from(JSON.stringify(dataStoreAttributes), "utf-8");
+                const blobCache = new Map<string, string>([["fluidDataStoreAttributes", buffer.toString("base64")]]);
+                const snapshotTree: ISnapshotTree = {
+                    id: "dummy",
+                    blobs: { [".component"]: "fluidDataStoreAttributes" },
+                    commits: {},
+                    trees: {},
+                };
 
-            remotedDataStoreContext = new RemotedFluidDataStoreContext(
-                dataStoreId,
-                snapshotTree,
-                containerRuntime,
-                new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
-                scope,
-                createSummarizerNodeFn,
-            );
+                remotedDataStoreContext = new RemotedFluidDataStoreContext(
+                    dataStoreId,
+                    snapshotTree,
+                    containerRuntime,
+                    new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
+                    scope,
+                    createSummarizerNodeFn,
+                );
 
-            // Get the summarizer node for this data store which tracks its used state.
-            const dataStoreSummarizerNode = summarizerNode.getChild(dataStoreId);
-            assert.strictEqual(dataStoreSummarizerNode?.used, true, "Data store is used by default");
+                // Get the summarizer node for this data store which tracks its used state.
+                const dataStoreSummarizerNode = summarizerNode.getChild(dataStoreId);
+                assert.strictEqual(dataStoreSummarizerNode?.used, false, "Data store is unused by default");
 
-            // Update the data store to not have any used routes.
-            remotedDataStoreContext.updateUsedRoutes([]);
-            assert.strictEqual(dataStoreSummarizerNode?.used, false, "Data store should be unused without used routes");
+                // Update the data store to be used.
+                remotedDataStoreContext.updateUsedRoutes([""]);
+                assert.strictEqual(dataStoreSummarizerNode?.used, true, "Data store should now be used");
 
-            // Update the data store to be used.
-            remotedDataStoreContext.updateUsedRoutes([""]);
-            assert.strictEqual(dataStoreSummarizerNode?.used, true, "Data store should now be used");
+                // Update the data store to not have any used routes.
+                remotedDataStoreContext.updateUsedRoutes([]);
+                assert.strictEqual(dataStoreSummarizerNode?.used, false, "Data store should now be unused");
+            });
         });
     });
 });

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -138,8 +138,9 @@ export interface ISummarizerNode {
 }
 
 /**
- * Extends the functionality of ISummarizerNode to support garbage collection. It adds / udpates the following APIs:
+ * Extends the functionality of ISummarizerNode to support garbage collection. It adds / udpates the following:
  * - getGCData - A new API that can be used to get the garbage collection data for this node.
+ * - used - Returns whether this node is in use or not.
  * - summarize - Added a trackState flag which indicates whether the summarizer node should track the state of the
  *   summary or not.
  * - createChild - Added the following params:
@@ -147,6 +148,9 @@ export interface ISummarizerNode {
  *   - getInitialGCDataFn - This gets the initial GC data for this node from the caller.
  */
 export interface ISummarizerNodeWithGC extends ISummarizerNode {
+    // This tells whether this node is in use or not. Unused node can be garbage collected and reclaimed.
+    used: boolean;
+
     summarize(fullTree: boolean, trackState?: boolean): Promise<IContextSummarizeResult>;
     createChild(
         /** Summarize function */

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -27,11 +27,11 @@ export interface IRootSummarizerNodeWithGC extends ISummarizerNodeWithGC, ISumma
  * - Adds GC data to the result of summarize.
  * - Adds trackState param to summarize. If trackState is false, it bypasses the SummarizerNode and calls
  *   directly into summarizeInternal method.
- * - Adds used property that tracks whether this node is in use or not.
+ * - Tracks the used state of this node.
  */
 export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummarizerNodeWithGC {
     private gcData: IGCData | undefined;
-    public used: boolean = true;
+    public used: boolean = false;
 
     /**
      * Do not call constructor directly.

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -27,9 +27,11 @@ export interface IRootSummarizerNodeWithGC extends ISummarizerNodeWithGC, ISumma
  * - Adds GC data to the result of summarize.
  * - Adds trackState param to summarize. If trackState is false, it bypasses the SummarizerNode and calls
  *   directly into summarizeInternal method.
+ * - Adds used property that tracks whether this node is in use or not.
  */
 export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummarizerNodeWithGC {
     private gcData: IGCData | undefined;
+    public used: boolean = true;
 
     /**
      * Do not call constructor directly.


### PR DESCRIPTION
Fixes #4493.

Added used state tracking to SummarizerNodeWithGC. After GC has run, it generates a list of used routes for each data store and notifies it. The data store then updates the used state in SummarizerNodeWithGC.
This used state will be sent in the node's summary tree in a follow up PR.