### PR TITLE
Fixed some data corruption not logging needed information

### DIFF
--- a/packages/drivers/odsp-driver/src/test/odspError.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspError.spec.ts
@@ -65,13 +65,13 @@ describe("Odsp Error", () => {
 
     it("throwOdspNetworkError sprequestguid exists", async () => {
         const error1: any = createOdspNetworkErrorWithResponse("Error", 400);
-        const errorBag = { ...error1.getProperties() };
+        const errorBag = { ...error1.getTelemetryProperties() };
         assert.equal("xxx-xxx", errorBag.sprequestguid, "sprequestguid should be 'xxx-xxx'");
     });
 
     it("throwOdspNetworkError sprequestguid undefined", async () => {
         const error1: any = createOdspNetworkError("Error", 400);
-        const errorBag = { ...error1.getProperties() };
+        const errorBag = { ...error1.getTelemetryProperties() };
         assert.equal(undefined, errorBag.sprequestguid, "sprequestguid should not be defined");
     });
 
@@ -220,7 +220,7 @@ describe("Odsp Error", () => {
     it("Check Epoch Mismatch error props", async () => {
         const error: any = createOdspNetworkErrorWithResponse("Epoch Mismatch", 409);
         assert.strictEqual(error.errorType, OdspErrorType.epochVersionMismatch, "Error type should be epoch mismatch");
-        const errorBag = { ...error.getProperties() };
+        const errorBag = { ...error.getTelemetryProperties() };
         assert.strictEqual(errorBag.errorType, OdspErrorType.epochVersionMismatch, "Error type should exist in prop bag");
     });
 });

--- a/packages/drivers/odsp-driver/src/test/odspError.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspError.spec.ts
@@ -65,13 +65,13 @@ describe("Odsp Error", () => {
 
     it("throwOdspNetworkError sprequestguid exists", async () => {
         const error1: any = createOdspNetworkErrorWithResponse("Error", 400);
-        const errorBag = { ...error1.getCustomProperties() };
+        const errorBag = { ...error1.getProperties() };
         assert.equal("xxx-xxx", errorBag.sprequestguid, "sprequestguid should be 'xxx-xxx'");
     });
 
     it("throwOdspNetworkError sprequestguid undefined", async () => {
         const error1: any = createOdspNetworkError("Error", 400);
-        const errorBag = { ...error1.getCustomProperties() };
+        const errorBag = { ...error1.getProperties() };
         assert.equal(undefined, errorBag.sprequestguid, "sprequestguid should not be defined");
     });
 
@@ -220,7 +220,7 @@ describe("Odsp Error", () => {
     it("Check Epoch Mismatch error props", async () => {
         const error: any = createOdspNetworkErrorWithResponse("Epoch Mismatch", 409);
         assert.strictEqual(error.errorType, OdspErrorType.epochVersionMismatch, "Error type should be epoch mismatch");
-        const errorBag = { ...error.getCustomProperties() };
+        const errorBag = { ...error.getProperties() };
         assert.strictEqual(errorBag.errorType, OdspErrorType.epochVersionMismatch, "Error type should exist in prop bag");
     });
 });

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -45,7 +45,7 @@ import {
     createWriteError,
     createGenericNetworkError,
 } from "@fluidframework/driver-utils";
-import { CreateContainerError } from "@fluidframework/container-utils";
+import { CreateContainerError, DataCorruptionError } from "@fluidframework/container-utils";
 import { debug } from "./debug";
 import { DeltaQueue } from "./deltaQueue";
 import { logNetworkFailure, waitForConnectedState } from "./networkUtils";
@@ -1265,14 +1265,15 @@ export class DeltaManager
                     const message1 = this.comparableMessagePayload(this.previouslyProcessedMessage);
                     const message2 = this.comparableMessagePayload(message);
                     if (message1 !== message2) {
-                        const error = {
-                            errorType: ContainerErrorType.dataCorruption,
-                            message: "Two messages with same seq# and different payload!",
-                            clientId: this.connection?.clientId,
-                            sequenceNumber: message.sequenceNumber,
-                            message1,
-                            message2,
-                        };
+                        const error = new DataCorruptionError(
+                            "Two messages with same seq# and different payload!",
+                            {
+                                clientId: this.connection?.clientId,
+                                sequenceNumber: message.sequenceNumber,
+                                message1,
+                                message2,
+                            },
+                        );
                         this.close(error);
                     }
                 }

--- a/packages/loader/container-utils/src/error.ts
+++ b/packages/loader/container-utils/src/error.ts
@@ -10,7 +10,7 @@ import {
     ICriticalContainerError,
     IErrorBase,
 } from "@fluidframework/container-definitions";
-import { CustomErrorWithProps } from "@fluidframework/telemetry-utils";
+import { LoggingError } from "@fluidframework/telemetry-utils";
 import { ITelemetryProperties } from "@fluidframework/common-definitions";
 
 function messageFromError(error: any) {
@@ -24,7 +24,7 @@ function messageFromError(error: any) {
 /**
  * Generic error
  */
-export class GenericError extends CustomErrorWithProps implements IGenericError {
+export class GenericError extends LoggingError implements IGenericError {
     readonly errorType = ContainerErrorType.genericError;
 
     constructor(
@@ -35,7 +35,7 @@ export class GenericError extends CustomErrorWithProps implements IGenericError 
     }
 }
 
-export class DataCorruptionError extends CustomErrorWithProps implements IErrorBase {
+export class DataCorruptionError extends LoggingError implements IErrorBase {
     readonly errorType = "dataCorruptionError";
     readonly canRetry = false;
 
@@ -56,14 +56,14 @@ export function CreateContainerError(error: any): ICriticalContainerError {
 
     if (typeof error === "object" && error !== null) {
         const err = error;
-        if (error.errorType !== undefined && error instanceof CustomErrorWithProps) {
+        if (error.errorType !== undefined && error instanceof LoggingError) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-return
             return err;
         }
 
         // Only get properties we know about.
         // Grabbing all properties will expose PII in telemetry!
-        return new CustomErrorWithProps(
+        return new LoggingError(
             messageFromError(error),
             {
                 errorType: error.errorType ?? ContainerErrorType.genericError,

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -9,7 +9,7 @@ import {
     IAuthorizationError,
     DriverErrorType,
 } from "@fluidframework/driver-definitions";
-import { CustomErrorWithProps } from "@fluidframework/telemetry-utils";
+import { LoggingError } from "@fluidframework/telemetry-utils";
 
 export enum OnlineStatus {
     Offline,
@@ -31,7 +31,7 @@ export function isOnline(): OnlineStatus {
 /**
  * Generic network error class.
  */
-export class GenericNetworkError extends CustomErrorWithProps implements IDriverErrorBase {
+export class GenericNetworkError extends LoggingError implements IDriverErrorBase {
     readonly errorType = DriverErrorType.genericNetworkError;
 
     constructor(
@@ -43,7 +43,7 @@ export class GenericNetworkError extends CustomErrorWithProps implements IDriver
     }
 }
 
-export class AuthorizationError extends CustomErrorWithProps implements IAuthorizationError {
+export class AuthorizationError extends LoggingError implements IAuthorizationError {
     readonly errorType = DriverErrorType.authorizationError;
     readonly canRetry = false;
 
@@ -56,7 +56,7 @@ export class AuthorizationError extends CustomErrorWithProps implements IAuthori
     }
 }
 
-export class NetworkErrorBasic<T> extends CustomErrorWithProps {
+export class NetworkErrorBasic<T> extends LoggingError {
     constructor(
         errorMessage: string,
         readonly errorType: T,
@@ -80,7 +80,7 @@ export class NonRetryableError<T> extends NetworkErrorBasic<T> {
 /**
  * Throttling error class - used to communicate all throttling errors
  */
-export class ThrottlingError extends CustomErrorWithProps implements IThrottlingWarning {
+export class ThrottlingError extends LoggingError implements IThrottlingWarning {
     readonly errorType = DriverErrorType.throttlingError;
     readonly canRetry = true;
 

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -11,7 +11,7 @@ import {
     Timer,
     IPromiseTimerResult,
 } from "@fluidframework/common-utils";
-import { ChildLogger, CustomErrorWithProps, PerformanceEvent } from "@fluidframework/telemetry-utils";
+import { ChildLogger, LoggingError, PerformanceEvent } from "@fluidframework/telemetry-utils";
 import {
     IFluidRouter,
     IFluidRunnable,
@@ -79,7 +79,7 @@ export interface ISummarizingWarning extends IErrorBase {
     readonly logged: boolean;
 }
 
-export class SummarizingWarning extends CustomErrorWithProps implements ISummarizingWarning {
+export class SummarizingWarning extends LoggingError implements ISummarizingWarning {
     readonly errorType = summarizingError;
     readonly canRetry = true;
 

--- a/packages/test/end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/error.spec.ts
@@ -82,18 +82,18 @@ describe("Errors Types", () => {
             message: "Some message",
         };
         const iError = (CreateContainerError(err) as any) as LoggingError;
-        const props = iError.getProperties();
+        const props = iError.getTelemetryProperties();
         assert.equal(props.userData, undefined, "We shouldn't expose the properties of the inner/original error");
         assert.equal(props.message, err.message, "But name is copied over!");
     });
 
     function assertCustomPropertySupport(err: any) {
         err.asdf = "asdf";
-        if (err.getProperties !== undefined) {
-            assert.equal(err.getProperties().asdf, "asdf", "Error should have property asdf");
+        if (err.getTelemetryProperties !== undefined) {
+            assert.equal(err.getTelemetryProperties().asdf, "asdf", "Error should have property asdf");
         }
         else {
-            assert.fail("Error should support getProperties()");
+            assert.fail("Error should support getTelemetryProperties()");
         }
     }
 

--- a/packages/test/end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/error.spec.ts
@@ -23,7 +23,7 @@ import {
     invalidFileNameStatusCode,
     OdspErrorType,
 } from "@fluidframework/odsp-doclib-utils";
-import { CustomErrorWithProps } from "@fluidframework/telemetry-utils";
+import { LoggingError } from "@fluidframework/telemetry-utils";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { LocalCodeLoader } from "@fluidframework/test-utils";
 
@@ -81,19 +81,19 @@ describe("Errors Types", () => {
             userData: "My name is Mark",
             message: "Some message",
         };
-        const iError = (CreateContainerError(err) as any) as CustomErrorWithProps;
-        const props = iError.getCustomProperties();
+        const iError = (CreateContainerError(err) as any) as LoggingError;
+        const props = iError.getProperties();
         assert.equal(props.userData, undefined, "We shouldn't expose the properties of the inner/original error");
         assert.equal(props.message, err.message, "But name is copied over!");
     });
 
     function assertCustomPropertySupport(err: any) {
         err.asdf = "asdf";
-        if (err.getCustomProperties !== undefined) {
-            assert.equal(err.getCustomProperties().asdf, "asdf", "Error should have property asdf");
+        if (err.getProperties !== undefined) {
+            assert.equal(err.getProperties().asdf, "asdf", "Error should have property asdf");
         }
         else {
-            assert.fail("Error should support getCustomProperties()");
+            assert.fail("Error should support getProperties()");
         }
     }
 

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -70,11 +70,11 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
             // If we know for sure it does, we have to not log it.
             if (error.containsPII) {
                 event.error = "Error message was removed as it contained PII";
-            } else if (error.getProperties) {
-                const customProps: ITelemetryProperties = error.getProperties();
-                for (const key of Object.keys(customProps)) {
+            } else if (error.getTelemetryProperties) {
+                const telemetryProps: ITelemetryProperties = error.getTelemetryProperties();
+                for (const key of Object.keys(telemetryProps)) {
                     if (event[key] === undefined) {
-                        event[key] = customProps[key];
+                        event[key] = telemetryProps[key];
                     }
                 }
             }
@@ -479,7 +479,7 @@ export class LoggingError extends Error {
     }
 
     // Return all properties
-    public getProperties(): ITelemetryProperties {
+    public getTelemetryProperties(): ITelemetryProperties {
         const props: ITelemetryProperties = {};
         // Could not use {...this} because it does not return properties of base class.
         for (const key of Object.getOwnPropertyNames(this)) {


### PR DESCRIPTION
Fixes #4669.

Renamed CustomErrorWithProps -> LoggingError. It indicates that this error should be used when logging it to telemetry.
Updated couple of errors in delta manager and data stores to DataCorruptionError so that the additional properties are logged.