### PR TITLE
Bump axios v0.18.x -> 0.21.1 in R11s

### DIFF
--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -5022,19 +5022,11 @@
 			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
 		},
 		"axios": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-			"integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+			"version": "0.21.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+			"integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
 			"requires": {
-				"follow-redirects": "1.5.10",
-				"is-buffer": "^2.0.2"
-			},
-			"dependencies": {
-				"is-buffer": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
-				}
+				"follow-redirects": "^1.10.0"
 			}
 		},
 		"azure-devops-node-api": {
@@ -9269,27 +9261,9 @@
 			}
 		},
 		"follow-redirects": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-			"requires": {
-				"debug": "=3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				}
-			}
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+			"integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
 		},
 		"for-in": {
 			"version": "1.0.2",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -56,7 +56,7 @@
     "@fluidframework/protocol-base": "^0.1016.1",
     "@fluidframework/protocol-definitions": "^0.1016.1",
     "@types/node": "^12.19.0",
-    "axios": "^0.18.0",
+    "axios": "^0.21.1",
     "debug": "^4.1.1",
     "jsrsasign": "^10.0.2",
     "jwt-decode": "^3.0.0",

--- a/server/routerlicious/packages/services-client/src/test/restwrapper.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/restwrapper.spec.ts
@@ -17,7 +17,7 @@ describe("RestWrapper", () => {
 
     before(() => {
         axiosMock = {
-            request: async (options?) => new Promise<AxiosResponse>(
+            request: async (options?) => new Promise<any>(
                 (resolve, reject) => {
                     requestOptions = options;
                     const response: AxiosResponse = {
@@ -35,7 +35,7 @@ describe("RestWrapper", () => {
         };
 
         axiosErrorMock = {
-            request: async (options?) => new Promise<AxiosResponse>(
+            request: async (options?) => new Promise<any>(
                 (resolve, reject) => {
                     requestOptions = options;
 
@@ -55,6 +55,8 @@ describe("RestWrapper", () => {
                         name: "ServerError",
                         request: {},
                         response,
+                        isAxiosError: true,
+                        toJSON: () => ({}),
                     };
 
                     throw err;

--- a/server/routerlicious/packages/services-client/src/test/restwrapper.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/restwrapper.spec.ts
@@ -17,25 +17,25 @@ describe("RestWrapper", () => {
 
     before(() => {
         axiosMock = {
-            request: async (options?) => new Promise<any>(
+            request: async <T = any, R = AxiosResponse<T>>(options?) => new Promise<R>(
                 (resolve, reject) => {
                     requestOptions = options;
-                    const response: AxiosResponse = {
+                    const response: AxiosResponse<T> = {
                         config: {},
-                        data: {},
+                        data: {} as T,
                         headers: {},
                         request: options.responseType,
                         status: 200,
                         statusText: "OK",
                     };
 
-                    resolve(response);
+                    resolve(response as any);
                 },
             ),
         };
 
         axiosErrorMock = {
-            request: async (options?) => new Promise<any>(
+            request: async <T = any, R = AxiosResponse<T>>(options?) => new Promise<R>(
                 (resolve, reject) => {
                     requestOptions = options;
 

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -55,7 +55,7 @@
     "@fluidframework/server-services-shared": "^0.1016.1",
     "@fluidframework/server-services-utils": "^0.1016.1",
     "amqplib": "^0.5.5",
-    "axios": "^0.18.0",
+    "axios": "^0.21.1",
     "debug": "^4.1.1",
     "kafka-node": "^5.0.0",
     "lru-cache": "^6.0.0",


### PR DESCRIPTION
Versions of Axios earlier than 0.21.1 are deprecated (see [snyk.io axios](https://snyk.io/vuln/npm:axios)), and there are no breaking changes between 0.18.1 and 0.21.1 (see [axios changelog](https://github.com/axios/axios/blob/master/CHANGELOG.md)).

This PR simply bumps Axios to a non-deprecated version in R11s