### PR TITLE
bug fix for correlation id middleware

### DIFF
--- a/server/routerlicious/packages/services-utils/src/asyncLocalStorage.ts
+++ b/server/routerlicious/packages/services-utils/src/asyncLocalStorage.ts
@@ -19,4 +19,4 @@ export const bindCorrelationId = (headerName: string = "x-correlation-id") =>
         const id: string = req.header(headerName) || uuid.v4();
         res.setHeader(headerName, id);
         asyncLocalStorage.run(id, () => next());
-    })
+    });

--- a/server/routerlicious/packages/services-utils/src/asyncLocalStorage.ts
+++ b/server/routerlicious/packages/services-utils/src/asyncLocalStorage.ts
@@ -14,12 +14,9 @@ export function getCorrelationId(): string | undefined {
     return id;
 }
 
-export function bindCorrelationId(headerName: string = "x-correlation-id"):
-    (req: Request, res: Response, next: NextFunction) => void {
-    const randId = uuid.v4();
-    return (req, res, next) => {
-        const id: string = req.header(headerName) || randId;
+export const bindCorrelationId = (headerName: string = "x-correlation-id") =>
+    ((req: Request, res: Response, next: NextFunction): void => {
+        const id: string = req.header(headerName) || uuid.v4();
         res.setHeader(headerName, id);
         asyncLocalStorage.run(id, () => next());
-    };
-}
+    })


### PR DESCRIPTION
**Overview**
In the last commit, random uuid was generated by uuid.v4() outside of the Express middleware, which causes the stored correlation id remains the same among different http calls. Moving it inside of the middleware to generate new random ones every time it gets a new http request.

**To Do**
Will need to update services-utils versions in Historian and Gitrest after the next release where this PR is merged onto main branch.