### PR TITLE
Throttle Alfred socket connections per tenant and submitOps per client

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -53,18 +53,24 @@ data:
             "maxMessageSize": "16KB",
             "maxNumberOfClientsPerDocument": {{ .Values.alfred.maxNumberOfClientsPerDocument }},
             "throttling": {
-                "maxRequestsPerMs": {{ .Values.alfred.throttling.maxRequestsPerMs }},
-                "maxRequestBurst": {{ .Values.alfred.throttling.maxRequestBurst }},
-                "minRequestCooldownIntervalInMs": {{ .Values.alfred.throttling.minRequestCooldownIntervalInMs }},
-                "minRequestThrottleIntervalInMs": {{ .Values.alfred.throttling.minRequestThrottleIntervalInMs }},
-                "maxSocketConnectionsPerMs": {{ .Values.alfred.throttling.maxSocketConnectionsPerMs }},
-                "maxSocketConnectionBurst": {{ .Values.alfred.throttling.maxSocketConnectionBurst }},
-                "minSocketConnectionCooldownIntervalInMs": {{ .Values.alfred.throttling.minSocketConnectionCooldownIntervalInMs }},
-                "minSocketConnectionThrottleIntervalInMs": {{ .Values.alfred.throttling.minSocketConnectionThrottleIntervalInMs }},
-                "maxSubmitOpsPerMs": {{ .Values.alfred.throttling.maxSubmitOpsPerMs }},
-                "maxSubmitOpBurst": {{ .Values.alfred.throttling.maxSubmitOpBurst }},
-                "minSubmitOpCooldownIntervalInMs": {{ .Values.alfred.throttling.minSubmitOpCooldownIntervalInMs }},
-                "minSubmitOpThrottleIntervalInMs": {{ .Values.alfred.throttling.minSubmitOpThrottleIntervalInMs }}
+                "requests": {
+                    "maxPerMs": {{ .Values.alfred.throttling.requests.maxPerMs }},
+                    "maxBurst": {{ .Values.alfred.throttling.requests.maxBurst }},
+                    "minCooldownIntervalInMs": {{ .Values.alfred.throttling.requests.minCooldownIntervalInMs }},
+                    "minThrottleIntervalInMs": {{ .Values.alfred.throttling.requests.minThrottleIntervalInMs }}
+                },
+                "socketConnections": {
+                    "maxPerMs": {{ .Values.alfred.throttling.socketConnections.maxPerMs }},
+                    "maxBurst": {{ .Values.alfred.throttling.socketConnections.maxBurst }},
+                    "minCooldownIntervalInMs": {{ .Values.alfred.throttling.socketConnections.minCooldownIntervalInMs }},
+                    "minThrottleIntervalInMs": {{ .Values.alfred.throttling.socketConnections.minThrottleIntervalInMs }}
+                },
+                "submitOps": {
+                    "maxPerMs": {{ .Values.alfred.throttling.submitOps.maxPerMs }},
+                    "maxBurst": {{ .Values.alfred.throttling.submitOps.maxBurst }},
+                    "minCooldownIntervalInMs": {{ .Values.alfred.throttling.submitOps.minCooldownIntervalInMs }},
+                    "minThrottleIntervalInMs": {{ .Values.alfred.throttling.submitOps.minThrottleIntervalInMs }}
+                }
             },
             "topic": "{{ .Values.kafka.topics.rawdeltas }}",
             "bucket": "snapshots",

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -56,7 +56,10 @@ data:
                 "maxRequestsPerMs": {{ .Values.alfred.throttling.maxRequestsPerMs }},
                 "maxRequestBurst": {{ .Values.alfred.throttling.maxRequestBurst }},
                 "minCooldownIntervalInMs": {{ .Values.alfred.throttling.minCooldownIntervalInMs }},
-                "minThrottleIntervalInMs": {{ .Values.alfred.throttling.minThrottleIntervalInMs }}
+                "minThrottleIntervalInMs": {{ .Values.alfred.throttling.minThrottleIntervalInMs }},
+                "maxOpenSocketConnections": {{ .Values.alfred.throttling.maxOpenSocketConnections }},
+                "maxSubmitOpsPerMs": {{ .Values.alfred.throttling.maxSubmitOpsPerMs }},
+                "maxSubmitOpsBurst": {{ .Values.alfred.throttling.maxSubmitOpsBurst }}
             },
             "topic": "{{ .Values.kafka.topics.rawdeltas }}",
             "bucket": "snapshots",

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -55,11 +55,16 @@ data:
             "throttling": {
                 "maxRequestsPerMs": {{ .Values.alfred.throttling.maxRequestsPerMs }},
                 "maxRequestBurst": {{ .Values.alfred.throttling.maxRequestBurst }},
-                "minCooldownIntervalInMs": {{ .Values.alfred.throttling.minCooldownIntervalInMs }},
-                "minThrottleIntervalInMs": {{ .Values.alfred.throttling.minThrottleIntervalInMs }},
-                "maxOpenSocketConnections": {{ .Values.alfred.throttling.maxOpenSocketConnections }},
+                "minRequestCooldownIntervalInMs": {{ .Values.alfred.throttling.minRequestCooldownIntervalInMs }},
+                "minRequestThrottleIntervalInMs": {{ .Values.alfred.throttling.minRequestThrottleIntervalInMs }},
+                "maxSocketConnectionsPerMs": {{ .Values.alfred.throttling.maxSocketConnectionsPerMs }},
+                "maxSocketConnectionBurst": {{ .Values.alfred.throttling.maxSocketConnectionBurst }},
+                "minSocketConnectionCooldownIntervalInMs": {{ .Values.alfred.throttling.minSocketConnectionCooldownIntervalInMs }},
+                "minSocketConnectionThrottleIntervalInMs": {{ .Values.alfred.throttling.minSocketConnectionThrottleIntervalInMs }},
                 "maxSubmitOpsPerMs": {{ .Values.alfred.throttling.maxSubmitOpsPerMs }},
-                "maxSubmitOpsBurst": {{ .Values.alfred.throttling.maxSubmitOpsBurst }}
+                "maxSubmitOpBurst": {{ .Values.alfred.throttling.maxSubmitOpBurst }},
+                "minSubmitOpCooldownIntervalInMs": {{ .Values.alfred.throttling.minSubmitOpCooldownIntervalInMs }},
+                "minSubmitOpThrottleIntervalInMs": {{ .Values.alfred.throttling.minSubmitOpThrottleIntervalInMs }}
             },
             "topic": "{{ .Values.kafka.topics.rawdeltas }}",
             "bucket": "snapshots",

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -53,11 +53,11 @@ data:
             "maxMessageSize": "16KB",
             "maxNumberOfClientsPerDocument": {{ .Values.alfred.maxNumberOfClientsPerDocument }},
             "throttling": {
-                "requests": {
-                    "maxPerMs": {{ .Values.alfred.throttling.requests.maxPerMs }},
-                    "maxBurst": {{ .Values.alfred.throttling.requests.maxBurst }},
-                    "minCooldownIntervalInMs": {{ .Values.alfred.throttling.requests.minCooldownIntervalInMs }},
-                    "minThrottleIntervalInMs": {{ .Values.alfred.throttling.requests.minThrottleIntervalInMs }}
+                "restCalls": {
+                    "maxPerMs": {{ .Values.alfred.throttling.restCalls.maxPerMs }},
+                    "maxBurst": {{ .Values.alfred.throttling.restCalls.maxBurst }},
+                    "minCooldownIntervalInMs": {{ .Values.alfred.throttling.restCalls.minCooldownIntervalInMs }},
+                    "minThrottleIntervalInMs": {{ .Values.alfred.throttling.restCalls.minThrottleIntervalInMs }}
                 },
                 "socketConnections": {
                     "maxPerMs": {{ .Values.alfred.throttling.socketConnections.maxPerMs }},

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -17,7 +17,7 @@ alfred:
   key: jwt_key
   maxNumberOfClientsPerDocument: 1000000
   throttling:
-    requests:
+    restCalls:
         maxPerMs: 1000000
         maxBurst: 1000000
         minCooldownIntervalInMs: 1000000

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -17,18 +17,21 @@ alfred:
   key: jwt_key
   maxNumberOfClientsPerDocument: 1000000
   throttling:
-    maxRequestsPerMs: 1000000
-    maxRequestBurst: 1000000
-    minRequestCooldownIntervalInMs: 1000000
-    minRequestThrottleIntervalInMs: 1000000
-    maxSocketConnectionsPerMs: 1000000
-    maxSocketConnectionBurst: 1000000
-    minSocketConnectionCooldownIntervalInMs: 1000000
-    minSocketConnectionThrottleIntervalInMs: 1000000
-    maxSubmitOpsPerMs: 1000000
-    maxSubmitOpBurst: 1000000
-    minSubmitOpCooldownIntervalInMs: 1000000
-    minSubmitOpThrottleIntervalInMs: 1000000
+    requests:
+        maxPerMs: 1000000
+        maxBurst: 1000000
+        minCooldownIntervalInMs: 1000000
+        minThrottleIntervalInMs: 1000000
+    socketConnections:
+        maxPerMs: 1000000
+        maxBurst: 1000000
+        minCooldownIntervalInMs: 1000000
+        minThrottleIntervalInMs: 1000000
+    submitOps:
+        maxPerMs: 1000000
+        maxBurst: 1000000
+        minCooldownIntervalInMs: 1000000
+        minThrottleIntervalInMs: 1000000
 
 deli:
   name: deli

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -19,11 +19,16 @@ alfred:
   throttling:
     maxRequestsPerMs: 1000000
     maxRequestBurst: 1000000
-    minCooldownIntervalInMs: 1000000
-    minThrottleIntervalInMs: 1000000
-    maxOpenSocketConnections: 1000000
+    minRequestCooldownIntervalInMs: 1000000
+    minRequestThrottleIntervalInMs: 1000000
+    maxSocketConnectionsPerMs: 1000000
+    maxSocketConnectionBurst: 1000000
+    minSocketConnectionCooldownIntervalInMs: 1000000
+    minSocketConnectionThrottleIntervalInMs: 1000000
     maxSubmitOpsPerMs: 1000000
-    maxSubmitOpsBurst: 1000000
+    maxSubmitOpBurst: 1000000
+    minSubmitOpCooldownIntervalInMs: 1000000
+    minSubmitOpThrottleIntervalInMs: 1000000
 
 deli:
   name: deli

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -21,6 +21,9 @@ alfred:
     maxRequestBurst: 1000000
     minCooldownIntervalInMs: 1000000
     minThrottleIntervalInMs: 1000000
+    maxOpenSocketConnections: 1000000
+    maxSubmitOpsPerMs: 1000000
+    maxSubmitOpsBurst: 1000000
 
 deli:
   name: deli

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -99,7 +99,9 @@ function selectProtocolVersion(connectVersions: string[]): string {
 }
 
 /**
- * @returns true if throttled and sent nack; false if not throttled or no throttler provided.
+ * When throttled, sends nack before returning.
+ *
+ * @returns true if throttled; false if not throttled or no throttler provided.
  */
 function checkThrottle(
     throttler: core.IThrottler | undefined,

--- a/server/routerlicious/packages/lambdas/src/utils/messageGenerator.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/messageGenerator.ts
@@ -11,13 +11,14 @@ import {
     NackErrorType,
 } from "@fluidframework/protocol-definitions";
 
-export const createNackMessage = (code: number, type: NackErrorType, message: string): INack => ({
+export const createNackMessage = (code: number, type: NackErrorType, message: string, retryAfter?: number): INack => ({
     operation: undefined,
     sequenceNumber: -1,
     content: {
         code,
         type,
         message,
+        retryAfter,
     },
 });
 

--- a/server/routerlicious/packages/lambdas/src/utils/messageGenerator.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/messageGenerator.ts
@@ -11,14 +11,19 @@ import {
     NackErrorType,
 } from "@fluidframework/protocol-definitions";
 
-export const createNackMessage = (code: number, type: NackErrorType, message: string, retryAfter?: number): INack => ({
+export const createNackMessage = (
+    code: number,
+    type: NackErrorType,
+    message: string,
+    retryAfterInSec?: number,
+): INack => ({
     operation: undefined,
     sequenceNumber: -1,
     content: {
         code,
         type,
         message,
-        retryAfter,
+        retryAfter: retryAfterInSec,
     },
 });
 

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
@@ -35,7 +35,7 @@ export class AlfredRunner implements utils.IRunner {
         private readonly tenantManager: ITenantManager,
         private readonly restThrottler: IThrottler,
         private readonly socketConnectThrottler: IThrottler,
-        private readonly socketOpThrottler: IThrottler,
+        private readonly socketSubmitOpThrottler: IThrottler,
         private readonly storage: IDocumentStorage,
         private readonly clientManager: IClientManager,
         private readonly appTenants: IAlfredTenant[],
@@ -79,7 +79,7 @@ export class AlfredRunner implements utils.IRunner {
             maxTokenLifetimeSec,
             isTokenExpiryEnabled,
             this.socketConnectThrottler,
-            this.socketOpThrottler);
+            this.socketSubmitOpThrottler);
 
         // Listen on provided port, on all network interfaces.
         httpServer.listen(this.port);

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
@@ -34,6 +34,8 @@ export class AlfredRunner implements utils.IRunner {
         private readonly orderManager: IOrdererManager,
         private readonly tenantManager: ITenantManager,
         private readonly restThrottler: IThrottler,
+        private readonly socketConnectThrottler: IThrottler,
+        private readonly socketOpThrottler: IThrottler,
         private readonly storage: IDocumentStorage,
         private readonly clientManager: IClientManager,
         private readonly appTenants: IAlfredTenant[],
@@ -75,7 +77,9 @@ export class AlfredRunner implements utils.IRunner {
             winston,
             maxNumberOfClientsPerDocument,
             maxTokenLifetimeSec,
-            isTokenExpiryEnabled);
+            isTokenExpiryEnabled,
+            this.socketConnectThrottler,
+            this.socketOpThrottler);
 
         // Listen on provided port, on all network interfaces.
         httpServer.listen(this.port);

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -171,13 +171,13 @@ export class AlfredResourcesFactory implements utils.IResourcesFactory<AlfredRes
 
         // Rest API Throttler
         const throttleMaxRequestsPerMs =
-            config.get("alfred:throttling:requests:maxPerMs") as number | undefined;
+            config.get("alfred:throttling:restCalls:maxPerMs") as number | undefined;
         const throttleMaxRequestBurst =
-            config.get("alfred:throttling:requests:maxBurst") as number | undefined;
+            config.get("alfred:throttling:restCalls:maxBurst") as number | undefined;
         const throttleMinRequestCooldownIntervalInMs =
-            config.get("alfred:throttling:requests:minCooldownIntervalInMs") as number | undefined;
+            config.get("alfred:throttling:restCalls:minCooldownIntervalInMs") as number | undefined;
         const throttleMinRequestThrottleIntervalInMs =
-            config.get("alfred:throttling:requests:minThrottleIntervalInMs") as number | undefined;
+            config.get("alfred:throttling:restCalls:minThrottleIntervalInMs") as number | undefined;
         const throttleStorageManager = new services.RedisThrottleStorageManager(redisClient);
         const restThrottlerHelper = new services.ThrottlerHelper(
             throttleStorageManager,

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -171,13 +171,13 @@ export class AlfredResourcesFactory implements utils.IResourcesFactory<AlfredRes
 
         // Rest API Throttler
         const throttleMaxRequestsPerMs =
-            config.get("alfred:throttling:maxRequestsPerMs") as number | undefined;
+            config.get("alfred:throttling:requests:maxPerMs") as number | undefined;
         const throttleMaxRequestBurst =
-            config.get("alfred:throttling:maxRequestBurst") as number | undefined;
+            config.get("alfred:throttling:requests:maxBurst") as number | undefined;
         const throttleMinRequestCooldownIntervalInMs =
-            config.get("alfred:throttling:minRequestCooldownIntervalInMs") as number | undefined;
+            config.get("alfred:throttling:requests:minCooldownIntervalInMs") as number | undefined;
         const throttleMinRequestThrottleIntervalInMs =
-            config.get("alfred:throttling:minRequestThrottleIntervalInMs") as number | undefined;
+            config.get("alfred:throttling:requests:minThrottleIntervalInMs") as number | undefined;
         const throttleStorageManager = new services.RedisThrottleStorageManager(redisClient);
         const restThrottlerHelper = new services.ThrottlerHelper(
             throttleStorageManager,
@@ -191,13 +191,13 @@ export class AlfredResourcesFactory implements utils.IResourcesFactory<AlfredRes
 
         // Socket Connection Throttler
         const throttleMaxSocketConnectionsPerMs =
-            config.get("alfred:throttling:maxSocketConnectionsPerMs") as number | undefined;
+            config.get("alfred:throttling:socketConnections:maxPerMs") as number | undefined;
         const throttleMaxSocketConnectionBurst =
-            config.get("alfred:throttling:maxSocketConnectionBurst") as number | undefined;
+            config.get("alfred:throttling:socketConnections:maxBurst") as number | undefined;
         const throttleMinSocketConnectionCooldownIntervalInMs =
-            config.get("alfred:throttling:minSocketConnectionCooldownIntervalInMs") as number | undefined;
+            config.get("alfred:throttling:socketConnections:minCooldownIntervalInMs") as number | undefined;
         const throttleMinSocketConnectionThrottleIntervalInMs =
-            config.get("alfred:throttling:minSocketConnectionThrottleIntervalInMs") as number | undefined;
+            config.get("alfred:throttling:socketConnections:minThrottleIntervalInMs") as number | undefined;
         const socketConnectThrottlerHelper = new services.ThrottlerHelper(
             throttleStorageManager,
             throttleMaxSocketConnectionsPerMs,
@@ -211,13 +211,13 @@ export class AlfredResourcesFactory implements utils.IResourcesFactory<AlfredRes
 
         // Socket SubmitOp Throttler
         const throttleMaxSubmitOpsPerMs =
-            config.get("alfred:throttling:maxSubmitOpsPerMs") as number | undefined;
+            config.get("alfred:throttling:submitOps:maxPerMs") as number | undefined;
         const throttleMaxSubmitOpBurst =
-            config.get("alfred:throttling:maxSubmitOpBurst") as number | undefined;
+            config.get("alfred:throttling:submitOps:maxBurst") as number | undefined;
         const throttleMinSubmitOpCooldownIntervalInMs =
-            config.get("alfred:throttling:minSubmitOpCooldownIntervalInMs") as number | undefined;
+            config.get("alfred:throttling:submitOps:minCooldownIntervalInMs") as number | undefined;
         const throttleMinSubmitOpThrottleIntervalInMs =
-            config.get("alfred:throttling:minSubmitOpThrottleIntervalInMs") as number | undefined;
+            config.get("alfred:throttling:submitOps:minThrottleIntervalInMs") as number | undefined;
         const socketSubmitOpThrottlerHelper = new services.ThrottlerHelper(
             throttleStorageManager,
             throttleMaxSubmitOpsPerMs,

--- a/server/routerlicious/packages/routerlicious-base/src/test/alfred/io.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/alfred/io.spec.ts
@@ -15,6 +15,9 @@ import {
     ISummaryTree,
     SummaryType,
     ICommittedProposal,
+    INack,
+    INackContent,
+    NackErrorType,
 } from "@fluidframework/protocol-definitions";
 import { KafkaOrdererFactory } from "@fluidframework/server-kafka-orderer";
 import { LocalWebSocket, LocalWebSocketServer } from "@fluidframework/server-local-server";
@@ -40,6 +43,7 @@ import {
     TestKafka,
     TestTenantManager,
     DebugLogger,
+    TestThrottler,
 } from "@fluidframework/server-test-utils";
 import { OrdererManager } from "../../alfred";
 
@@ -57,6 +61,8 @@ describe("Routerlicious", () => {
                 let testOrderer: IOrdererManager;
                 let testTenantManager: TestTenantManager;
                 let testClientManager: IClientManager;
+
+                const throttleLimit = 5;
 
                 beforeEach(() => {
                     const collectionNames = "test";
@@ -87,6 +93,9 @@ describe("Routerlicious", () => {
                     const pubsub = new PubSub();
                     webSocketServer = new LocalWebSocketServer(pubsub);
 
+                    const testConnectionThrottler = new TestThrottler(throttleLimit);
+                    const testSubmitOpThrottler = new TestThrottler(throttleLimit);
+
                     configureWebSocketServices(
                         webSocketServer,
                         testOrderer,
@@ -94,7 +103,12 @@ describe("Routerlicious", () => {
                         testStorage,
                         testClientManager,
                         new DefaultMetricClient(),
-                        DebugLogger.create("fluid-server:TestAlfredIO"));
+                        DebugLogger.create("fluid-server:TestAlfredIO"),
+                        undefined,
+                        undefined,
+                        false,
+                        testConnectionThrottler,
+                        testSubmitOpThrottler);
                 });
 
                 function connectToServer(
@@ -124,6 +138,10 @@ describe("Routerlicious", () => {
                         deferred.reject(error);
                     });
 
+                    socket.on("nack", (reason: string, nackMessages: INack[]) => {
+                        deferred.reject(nackMessages);
+                    });
+
                     socket.send(
                         "connect_document",
                         connectMessage,
@@ -134,6 +152,7 @@ describe("Routerlicious", () => {
                                 deferred.resolve(connectedMessage);
                             }
                         });
+
 
                     return deferred.promise;
                 }
@@ -168,6 +187,43 @@ describe("Routerlicious", () => {
                                 testId, testTenantId, testSecret, secondSocket);
                             assert.equal(secondConnectMessage.existing, true);
                         });
+
+
+                    it("Should throttle excess connections for tenant", async () => {
+                        for (let i = 0; i < throttleLimit; i++) {
+                            const id = `${testId}-${i}`;
+                            const socket = webSocketServer.createConnection();
+                            const connectMessage = await connectToServer(id, testTenantId, testSecret, socket);
+                            assert.ok(connectMessage.clientId);
+                            assert.equal(connectMessage.existing, false);
+
+                            // Verify a connection message was sent
+                            const message = deliKafka.getLastMessage();
+                            const systemJoinMessage = message.operation as ISequencedDocumentSystemMessage;
+                            assert.equal(message.documentId, id);
+                            assert.equal(systemJoinMessage.clientId, undefined);
+                            assert.equal(systemJoinMessage.type, MessageType.ClientJoin);
+                            const JoinMessage = JSON.parse(systemJoinMessage.data) as IClientJoin;
+                            assert.equal(JoinMessage.clientId, connectMessage.clientId);
+                        }
+
+                        const failedConnectMessage = await connectToServer(`${testId}-${throttleLimit + 1}`, testTenantId, testSecret, webSocketServer.createConnection())
+                            .then(() => {
+                                assert.fail("Connection should have failed");
+                            })
+                            .catch((err) => {
+                                if (err instanceof Array && err[0]?.content) {
+                                    return err[0].content;
+                                }
+                                assert.fail("Connection failed for other reason(s) than a nack");
+                            }) as INackContent;
+                        assert.strictEqual(failedConnectMessage.code, 429);
+                        assert.strictEqual(failedConnectMessage.type, NackErrorType.ThrottlingError);
+                        assert.strictEqual(failedConnectMessage.retryAfter, 1);
+
+                        // A separate tenant should not be throttled
+                        await connectToServer(testId, `${testTenantId}-2`, testSecret, webSocketServer.createConnection());
+                    });
                 });
 
                 describe("#disconnect", () => {
@@ -206,6 +262,43 @@ describe("Routerlicious", () => {
                         assert.equal(lastMessage.documentId, testId);
                         assert.equal(lastMessage.type, RawOperationType);
                         assert.deepEqual(lastMessage.operation, message);
+                    });
+
+                    it("Should throttle excess submitOps for tenant", async () => {
+                        const socket = webSocketServer.createConnection();
+                        const connectMessage = await connectToServer(testId, testTenantId, testSecret, socket);
+
+                        const messageFactory = new MessageFactory(testId, connectMessage.clientId);
+
+                        let i = 0;
+                        const deferredNack = new Deferred<INack[]>();
+                        socket.on("nack", (reason: string, nackMessages: INack[]) => {
+                            if (i < throttleLimit) {
+                                deferredNack.reject(`Submit op NACK before reaching throttle limit: ${nackMessages}`);
+                            } else {
+                                deferredNack.resolve(nackMessages);
+                            }
+                        });
+                        for (; i < throttleLimit; i++) {
+                            const message = messageFactory.createDocumentMessage();
+
+                            const beforeCount = deliKafka.getRawMessages().length;
+                            socket.send("submitOp", connectMessage.clientId, [message]);
+                            assert.equal(deliKafka.getRawMessages().length, beforeCount + 1);
+                            const lastMessage = deliKafka.getLastMessage();
+                            assert.equal(lastMessage.documentId, testId);
+                            assert.equal(lastMessage.type, RawOperationType);
+                            assert.deepEqual(lastMessage.operation, message);
+                        }
+
+                        const blockedMessage = messageFactory.createDocumentMessage();
+                        socket.send("submitOp", connectMessage.clientId, [blockedMessage]);
+                        const nackMessages = await deferredNack.promise;
+
+                        const nackContent = nackMessages[0]?.content as INackContent;
+                        assert.strictEqual(nackContent.code, 429);
+                        assert.strictEqual(nackContent.type, NackErrorType.ThrottlingError);
+                        assert.strictEqual(nackContent.retryAfter, 1);
                     });
                 });
             });

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -38,11 +38,16 @@
         "throttling": {
             "maxRequestsPerMs": 1000000,
             "maxRequestBurst": 1000000,
-            "minCooldownIntervalInMs": 1000000,
-            "minThrottleIntervalInMs": 1000000,
-            "maxOpenSocketConnections": 1000000,
+            "minRequestCooldownIntervalInMs": 1000000,
+            "minRequestThrottleIntervalInMs": 1000000,
+            "maxSocketConnectionsPerMs": 1000000,
+            "maxSocketConnectionBurst": 1000000,
+            "minSocketConnectionCooldownIntervalInMs": 1000000,
+            "minSocketConnectionThrottleIntervalInMs": 1000000,
             "maxSubmitOpsPerMs": 1000000,
-            "maxSubmitOpsBurst": 1000000
+            "maxSubmitOpBurst": 1000000,
+            "minSubmitOpCooldownIntervalInMs": 1000000,
+            "minSubmitOpThrottleIntervalInMs": 1000000
         },
         "topic": "rawdeltas",
         "bucket": "snapshots",

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -36,7 +36,7 @@
         "maxMessageSize": "16KB",
         "maxNumberOfClientsPerDocument": 1000000,
         "throttling": {
-            "requests": {
+            "restCalls": {
                 "maxPerMs": 1000000,
                 "maxBurst": 1000000,
                 "minCooldownIntervalInMs": 1000000,

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -39,7 +39,10 @@
             "maxRequestsPerMs": 1000000,
             "maxRequestBurst": 1000000,
             "minCooldownIntervalInMs": 1000000,
-            "minThrottleIntervalInMs": 1000000
+            "minThrottleIntervalInMs": 1000000,
+            "maxOpenSocketConnections": 1000000,
+            "maxSubmitOpsPerMs": 1000000,
+            "maxSubmitOpsBurst": 1000000
         },
         "topic": "rawdeltas",
         "bucket": "snapshots",

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -36,18 +36,24 @@
         "maxMessageSize": "16KB",
         "maxNumberOfClientsPerDocument": 1000000,
         "throttling": {
-            "maxRequestsPerMs": 1000000,
-            "maxRequestBurst": 1000000,
-            "minRequestCooldownIntervalInMs": 1000000,
-            "minRequestThrottleIntervalInMs": 1000000,
-            "maxSocketConnectionsPerMs": 1000000,
-            "maxSocketConnectionBurst": 1000000,
-            "minSocketConnectionCooldownIntervalInMs": 1000000,
-            "minSocketConnectionThrottleIntervalInMs": 1000000,
-            "maxSubmitOpsPerMs": 1000000,
-            "maxSubmitOpBurst": 1000000,
-            "minSubmitOpCooldownIntervalInMs": 1000000,
-            "minSubmitOpThrottleIntervalInMs": 1000000
+            "requests": {
+                "maxPerMs": 1000000,
+                "maxBurst": 1000000,
+                "minCooldownIntervalInMs": 1000000,
+                "minThrottleIntervalInMs": 1000000
+            },
+            "socketConnections": {
+                "maxPerMs": 1000000,
+                "maxBurst": 1000000,
+                "minCooldownIntervalInMs": 1000000,
+                "minThrottleIntervalInMs": 1000000
+            },
+            "submitOps": {
+                "maxPerMs": 1000000,
+                "maxBurst": 1000000,
+                "minCooldownIntervalInMs": 1000000,
+                "minThrottleIntervalInMs": 1000000
+            }
         },
         "topic": "rawdeltas",
         "bucket": "snapshots",


### PR DESCRIPTION
Use the Throttler class library to add optional throttling to Alfred's `configureWebSocketServices` lambda.