### PR TITLE
Added reference flag property to ISummaryTree

### DIFF
--- a/server/routerlicious/packages/protocol-definitions/src/summary.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/summary.ts
@@ -54,8 +54,8 @@ export interface ISummaryTree {
     // TODO type I can infer from SummaryObject. File mode I may want to directly specify so have symlink+exec access
     tree: { [path: string]: SummaryObject };
 
-    // True if this tree entry is unreferenced. If this flag is not present, the tree is considered referenced.
-    unreferenced?: boolean;
+    // Indicates that this tree entry is unreferenced. If this is not present, the tree entry is considered referenced.
+    unreferenced?: true;
 }
 
 export interface ISummaryCommit {

--- a/server/routerlicious/packages/protocol-definitions/src/summary.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/summary.ts
@@ -7,6 +7,10 @@ export type SummaryObject = ISummaryCommit | ISummaryTree | ISummaryBlob | ISumm
 
 export type SummaryTree = ISummaryTree | ISummaryHandle;
 
+export enum ReferenceFlag {
+    Unreferenced = 0,
+}
+
 export interface ISummaryAuthor {
     name: string;
     email: string;
@@ -53,6 +57,9 @@ export interface ISummaryTree {
 
     // TODO type I can infer from SummaryObject. File mode I may want to directly specify so have symlink+exec access
     tree: { [path: string]: SummaryObject };
+
+    // Tells the reference state of this tree. If this flag is not present, the tree is considered referenced.
+    referenceFlag?: ReferenceFlag;
 }
 
 export interface ISummaryCommit {

--- a/server/routerlicious/packages/protocol-definitions/src/summary.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/summary.ts
@@ -7,10 +7,6 @@ export type SummaryObject = ISummaryCommit | ISummaryTree | ISummaryBlob | ISumm
 
 export type SummaryTree = ISummaryTree | ISummaryHandle;
 
-export enum ReferenceFlag {
-    Unreferenced = 0,
-}
-
 export interface ISummaryAuthor {
     name: string;
     email: string;
@@ -58,8 +54,8 @@ export interface ISummaryTree {
     // TODO type I can infer from SummaryObject. File mode I may want to directly specify so have symlink+exec access
     tree: { [path: string]: SummaryObject };
 
-    // Tells the reference state of this tree. If this flag is not present, the tree is considered referenced.
-    referenceFlag?: ReferenceFlag;
+    // True if this tree entry is unreferenced. If this flag is not present, the tree is considered referenced.
+    unreferenced?: boolean;
 }
 
 export interface ISummaryCommit {


### PR DESCRIPTION
Fixes #4687 

Added a property to ISummaryTree to indicate whether the tree is referenced or not. After GC has run, this flag will be set for tree entries that are unreferenced. 