### PR TITLE
added correlation id in RestWrapper in case of no getCorrelationId passed

### DIFF
--- a/server/routerlicious/packages/services-client/src/restWrapper.ts
+++ b/server/routerlicious/packages/services-client/src/restWrapper.ts
@@ -5,6 +5,7 @@
 
 import * as querystring from "querystring";
 import { AxiosError, AxiosInstance, AxiosRequestConfig, default as Axios } from "axios";
+import * as uuid from "uuid";
 import { debug } from "./debug";
 
 export class RestWrapper {
@@ -72,6 +73,9 @@ export class RestWrapper {
     private async request<T>(options: AxiosRequestConfig, statusCode: number): Promise<T> {
         if (this.defaultHeaders) {
             options.headers = { ...this.defaultHeaders, ...options.headers };
+        }
+        if (options.headers["x-correlation-id"] === undefined) {
+            options.headers["x-correlation-id"] = uuid.v4();
         }
 
         const response = await this.axios.request<T>(options)

--- a/server/routerlicious/packages/services-client/src/restWrapper.ts
+++ b/server/routerlicious/packages/services-client/src/restWrapper.ts
@@ -74,7 +74,7 @@ export class RestWrapper {
         if (this.defaultHeaders) {
             options.headers = { ...this.defaultHeaders, ...options.headers };
         }
-        if (options.headers === undefined || options.headers["x-correlation-id"] === undefined) {
+        if (!options.headers?.["x-correlation-id"]) {
             options.headers = { ...{ "x-correlation-id": uuid.v4() }, ...options.headers };
         }
 

--- a/server/routerlicious/packages/services-client/src/restWrapper.ts
+++ b/server/routerlicious/packages/services-client/src/restWrapper.ts
@@ -74,8 +74,8 @@ export class RestWrapper {
         if (this.defaultHeaders) {
             options.headers = { ...this.defaultHeaders, ...options.headers };
         }
-        if (options.headers["x-correlation-id"] === undefined) {
-            options.headers["x-correlation-id"] = uuid.v4();
+        if (options.headers === undefined || options.headers["x-correlation-id"] === undefined) {
+            options.headers = { ...{ "x-correlation-id": uuid.v4() }, ...options.headers };
         }
 
         const response = await this.axios.request<T>(options)

--- a/server/routerlicious/packages/services-client/src/test/restwrapper.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/restwrapper.spec.ts
@@ -10,6 +10,8 @@ import { RestWrapper } from "../restWrapper";
 describe("RestWrapper", () => {
     const baseurl = "https://fake.microsoft.com";
     const requestUrl = "/fakerequesturl/";
+    const correlationIdHeader = "x-correlation-id";
+    const headerCount = 1;
     const maxContentLength = 1000 * 1024 * 1024;
     let axiosMock: Partial<AxiosInstance>;
     let axiosErrorMock: Partial<AxiosInstance>;
@@ -90,7 +92,8 @@ describe("RestWrapper", () => {
             // assert
             assert.equal(baseurl, requestOptions.baseURL, "baseURL should be the same");
             assert.equal(requestUrl, requestOptions.url, "requestUrl should be the same");
-            assert.equal(undefined, requestOptions.headers as {}, "Headers should be empty");
+            assert.equal(headerCount, Object.keys(requestOptions.headers).length, "Headers should only have 1 header");
+            assert.equal(correlationIdHeader, Object.keys(requestOptions.headers)[0], "Headers should only have x-correlation-id");
         });
 
         it("Default QueryString and Default Headers", async () => {
@@ -169,7 +172,8 @@ describe("RestWrapper", () => {
             // assert
             assert.equal(baseurl, requestOptions.baseURL, "baseURL should be the same");
             assert.equal(requestUrl, requestOptions.url, "requestUrl should be the same");
-            assert.equal(undefined, requestOptions.headers as {}, "Headers should be empty");
+            assert.equal(headerCount, Object.keys(requestOptions.headers).length, "Headers should only have 1 header");
+            assert.equal(correlationIdHeader, Object.keys(requestOptions.headers)[0], "Headers should only have x-correlation-id");
         });
 
         it("Default QueryString and Default Headers", async () => {
@@ -249,7 +253,8 @@ describe("RestWrapper", () => {
             // assert
             assert.equal(baseurl, requestOptions.baseURL, "baseURL should be the same");
             assert.equal(requestUrl, requestOptions.url, "requestUrl should be the same");
-            assert.equal(undefined, requestOptions.headers as {}, "Headers should be empty");
+            assert.equal(headerCount, Object.keys(requestOptions.headers).length, "Headers should only have 1 header");
+            assert.equal(correlationIdHeader, Object.keys(requestOptions.headers)[0], "Headers should only have x-correlation-id");
         });
 
         it("Default QueryString and Default Headers", async () => {
@@ -329,7 +334,8 @@ describe("RestWrapper", () => {
             // assert
             assert.equal(baseurl, requestOptions.baseURL, "baseURL should be the same");
             assert.equal(requestUrl, requestOptions.url, "requestUrl should be the same");
-            assert.equal(undefined, requestOptions.headers as {}, "Headers should be empty");
+            assert.equal(headerCount, Object.keys(requestOptions.headers).length, "Headers should only have 1 header");
+            assert.equal(correlationIdHeader, Object.keys(requestOptions.headers)[0], "Headers should only have x-correlation-id");
         });
 
         it("Default QueryString and Default Headers", async () => {


### PR DESCRIPTION
This is a follow up of [last PR](https://github.com/microsoft/FluidFramework/pull/4693). This PR adds correlation id in RestWrapper in case somewhere getCorrelationId function is not passed. As I noticed in routerlicious-driver, there are some places where [historian client](https://github.com/PingZhu2232/FluidFramework/blob/dbe8475f11186492eb1cd8f611caa936994a2d2d/server/routerlicious/packages/services-client/src/historian.ts) are used but getCorrelationId function is not passed as a parameter to the historian client, so want to add it here to add correlation id in the header in routerlicious-driver.