### PR TITLE
Throttling logging event_type to eventName

### DIFF
--- a/server/routerlicious/packages/services-utils/src/throttlerMiddleware.ts
+++ b/server/routerlicious/packages/services-utils/src/throttlerMiddleware.ts
@@ -75,7 +75,7 @@ export function throttle(
             const messageMetaData = {
                 key: throttleId,
                 weight: throttleOptions.weight,
-                event_type: "throttling",
+                eventName: "throttling",
             };
 
             logger?.info(`Incrementing throttle count: ${throttleId}`, { messageMetaData });


### PR DESCRIPTION
When creating ThrottlingMiddleware, I had a lack of understanding of messageMetaData properties. "throttling" should be the `eventName`, similar to ["http_request"](https://github.com/microsoft/FluidFramework/blob/main/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts#L69)