### PR TITLE
Fix rehyrdate tests

### DIFF
--- a/packages/test/end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -51,7 +51,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
     let testDeltaConnectionServer: ILocalDeltaConnectionServer;
     let loader: Loader;
     let request: IRequest;
-
+    let opProcessingController: OpProcessingController;
     async function createDetachedContainerAndGetRootDataStore() {
         const container = await loader.createDetachedContainer(codeDetails);
         // Get the root dataStore from the detached container.
@@ -102,6 +102,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         const urlResolver = new LocalResolver();
         request = urlResolver.createCreateNewRequest(documentId);
         loader = createTestLoader(urlResolver);
+        opProcessingController = new OpProcessingController(testDeltaConnectionServer);
     });
 
     it("Dehydrated container snapshot", async () => {
@@ -346,6 +347,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         const snapshotTree = container.serialize();
 
         const rehydratedContainer = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree);
+        opProcessingController.addDeltaManagers(rehydratedContainer.deltaManager);
         await rehydratedContainer.attach(request);
 
         // Now load the container from another loader.
@@ -354,6 +356,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         assert(rehydratedContainer.resolvedUrl);
         const requestUrl2 = await urlResolver2.getAbsoluteUrl(rehydratedContainer.resolvedUrl, "");
         const container2 = await loader2.resolve({ url: requestUrl2 });
+        opProcessingController.addDeltaManagers(rehydratedContainer.deltaManager);
 
         // Get the sharedString1 from dataStore2 in rehydrated container.
         const responseBefore = await rehydratedContainer.request({ url: `/${dataStore2.context.id}` });
@@ -364,9 +367,6 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         const responseAfter = await container2.request({ url: `/${dataStore2.context.id}` });
         const dataStore3 = responseAfter.value as TestFluidObject;
         const sharedMap3 = await dataStore3.getSharedObject<SharedMap>(sharedMapId);
-
-        const opProcessingController = new OpProcessingController();
-        opProcessingController.addDeltaManagers(container2.deltaManager, rehydratedContainer.deltaManager);
 
         await opProcessingController.process();
         assert.strictEqual(sharedMap3.get("1"), "B", "Contents should be as required");
@@ -392,6 +392,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         const snapshotTree = container.serialize();
 
         const rehydratedContainer = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree);
+        opProcessingController.addDeltaManagers(rehydratedContainer.deltaManager);
         await rehydratedContainer.attach(request);
 
         // Now load the container from another loader.
@@ -400,6 +401,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         assert(rehydratedContainer.resolvedUrl);
         const requestUrl2 = await urlResolver2.getAbsoluteUrl(rehydratedContainer.resolvedUrl, "");
         const container2 = await loader2.resolve({ url: requestUrl2 });
+        opProcessingController.addDeltaManagers(container2.deltaManager);
 
         // Get the sharedString1 from dataStore2 in container2.
         const responseBefore = await container2.request({ url: `/${dataStore2.context.id}` });
@@ -411,9 +413,6 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         const responseAfter = await rehydratedContainer.request({ url: `/${dataStore2.context.id}` });
         const dataStore2FromRC = responseAfter.value as TestFluidObject;
         const sharedMapFromRC = await dataStore2FromRC.getSharedObject<SharedMap>(sharedMapId);
-
-        const opProcessingController = new OpProcessingController();
-        opProcessingController.addDeltaManagers(container2.deltaManager, rehydratedContainer.deltaManager);
 
         await opProcessingController.process();
         assert.strictEqual(sharedMapFromRC.get("1"), "B", "Changes should be reflected in other map");
@@ -486,7 +485,8 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         const snapshotTree = container.serialize();
         const rehydratedContainer = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree);
 
-        const responseForDDS = await rehydratedContainer.request({ url: `/${defaultDataStore.runtime.id}/${ddsId}` });
+        const responseForDDS =
+            await rehydratedContainer.request({ url: `/${defaultDataStore.runtime.id}/${ddsId}` });
         const ddd2FromRC = responseForDDS.value as SharedString;
         assert(ddd2FromRC, "ddd2 should have been serialized properly");
         assert.strictEqual(ddd2FromRC.id, ddsId, "DDS id should match");
@@ -498,6 +498,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         assert.strictEqual(dataStore2FromRC.runtime.id, dataStore2.runtime.id, "DataStore2 id should match");
     });
 
+    // eslint-disable-next-line max-len
     it("Container rehydration with not bounded data store handle stored in root of bound dataStore. The not bounded" +
         "data store also stores handle not bounded dds",
     async () => {


### PR DESCRIPTION
These tests weren't registering deltamangers with the op processing controller before the ops were sent, so the controller didn't know about them. 

related to #4718 