### PR TITLE
Allow adding server metadata to the client join message

### DIFF
--- a/server/routerlicious/packages/kafka-orderer/src/kafkaOrderer.ts
+++ b/server/routerlicious/packages/kafka-orderer/src/kafkaOrderer.ts
@@ -56,7 +56,7 @@ export class KafkaOrdererConnection implements core.IOrdererConnection {
     /**
      * Sends the client join op for this connection
      */
-    public async connect() {
+    public async connect(clientJoinMessageServerMetadata?: any) {
         const clientDetail: IClientJoin = {
             clientId: this.clientId,
             detail: this.client,
@@ -69,6 +69,7 @@ export class KafkaOrdererConnection implements core.IOrdererConnection {
             referenceSequenceNumber: -1,
             traces: this.serviceConfiguration.enableTraces ? [] : undefined,
             type: MessageType.ClientJoin,
+            serverMetadata: clientJoinMessageServerMetadata,
         };
 
         const message: core.IRawOperationMessage = {

--- a/server/routerlicious/packages/memory-orderer/src/localOrdererConnection.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrdererConnection.ts
@@ -43,7 +43,7 @@ export class LocalOrdererConnection implements IOrdererConnection {
         this.maxMessageSize = serviceConfiguration.maxMessageSize;
     }
 
-    public async connect() {
+    public async connect(clientJoinMessageServerMetadata?: any) {
         // Send the connect message
         const clientDetail: IClientJoin = {
             clientId: this.clientId,
@@ -57,6 +57,7 @@ export class LocalOrdererConnection implements IOrdererConnection {
             referenceSequenceNumber: -1,
             traces: this.serviceConfiguration.enableTraces ? [] : undefined,
             type: MessageType.ClientJoin,
+            serverMetadata: clientJoinMessageServerMetadata,
         };
 
         const message: IRawOperationMessage = {

--- a/server/routerlicious/packages/services-core/src/orderer.ts
+++ b/server/routerlicious/packages/services-core/src/orderer.ts
@@ -47,7 +47,7 @@ export interface IOrdererConnection {
     /**
      * Sends the client join op for this connection
      */
-    connect(): Promise<void>;
+    connect(clientJoinMessageServerMetadata?: any): Promise<void>;
 
     /**
      * Orders the provided list of messages. The messages in the array are guaranteed to be ordered sequentially


### PR DESCRIPTION
Allow adding server metadata to the client join message.
This allows the frontend to pass additional information to deli / other lambdas when clients are joining