### PR TITLE
Fixed back-compat in summarize between 0.31 and 0.32

### DIFF
--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -94,10 +94,7 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
         this.gcDetailsInInitialSummaryP = new LazyPromise(async () => {
             // back-compat: 0.32. getInitialGCSummaryDetailsFn() returns undefined in 0.31. Remove undefined check
             // when N > 34.
-            let gcSummaryDetails: IGarbageCollectionSummaryDetails | undefined;
-            if (getInitialGCSummaryDetailsFn) {
-                gcSummaryDetails = await getInitialGCSummaryDetailsFn();
-            }
+            const gcSummaryDetails = await getInitialGCSummaryDetailsFn?.();
             return gcSummaryDetails ?? { usedRoutes: [] };
         });
     }

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -92,7 +92,13 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
         );
 
         this.gcDetailsInInitialSummaryP = new LazyPromise(async () => {
-            return getInitialGCSummaryDetailsFn ? getInitialGCSummaryDetailsFn() : { usedRoutes: [] };
+            // back-compat: 0.32. getInitialGCSummaryDetailsFn() returns undefined in 0.31. Remove undefined check
+            // when N > 34.
+            let gcSummaryDetails: IGarbageCollectionSummaryDetails | undefined;
+            if (getInitialGCSummaryDetailsFn) {
+                gcSummaryDetails = await getInitialGCSummaryDetailsFn();
+            }
+            return gcSummaryDetails ?? { usedRoutes: [] };
         });
     }
 

--- a/packages/test/end-to-end-tests/src/test/localLoader.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/localLoader.spec.ts
@@ -172,6 +172,8 @@ describe("LocalLoader", () => {
             const container1 = await createContainer(testDataObjectFactory);
             const dataObject1 = await requestFluidObject<TestDataObject>(container1, "default");
 
+            opProcessingController.addDeltaManagers(container1.deltaManager);
+
             dataObject1.increment();
             assert.equal(dataObject1.value, 1, "Local update by 'dataObject1' must be promptly observable");
 
@@ -180,9 +182,7 @@ describe("LocalLoader", () => {
             const dataObject2 = await requestFluidObject<TestDataObject>(container2, "default");
             assert(dataObject1 !== dataObject2, "Each container must return a separate TestDataObject instance.");
 
-            opProcessingController.addDeltaManagers(
-                container1.deltaManager,
-                container2.deltaManager);
+            opProcessingController.addDeltaManagers(container2.deltaManager);
 
             await opProcessingController.process();
             assert.equal(


### PR DESCRIPTION
Fixed summarize broken between 0.31 and 0.32 due to GC changes.

Also fixed local loader tests that was registering delta manager with op processing controller after op was being sent resulting in flaky tests.