### PR TITLE
Added unreferenced indicator to summary tree entry in SPO contract

### DIFF
--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -151,6 +151,8 @@ export interface ISnapshotTreeBaseEntry {
 export interface ISnapshotTreeValueEntry extends ISnapshotTreeBaseEntry {
     id?: string;
     value: SnapshotTreeValue;
+    // Indicates that this tree entry is unreferenced. If this is not present, the tree entry is considered referenced.
+    unreferenced?: true;
 }
 
 export interface ISnapshotTreeHandleEntry extends ISnapshotTreeBaseEntry {


### PR DESCRIPTION
Added an unreferenced flag to `ISnapshotTreeValueEntry` in SPO contract in the driver. For trees that are unreferenced, this will be set to true. For referenced trees, this will not be present.
This is 1:1 with the unreferenced flag in runtime's summary tree entry.