### PR TITLE
Improve out of order op processing

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -1407,6 +1407,7 @@ export class DeltaManager
         this.fetching = true;
 
         await this.getDeltas(telemetryEventSuffix, from, to, (messages) => {
+            this.refreshDelayInfo(this.deltaStorageDelayId);
             this.enqueueMessages(messages, telemetryEventSuffix);
         });
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -731,7 +731,7 @@ export class DeltaManager
         telemetryEventSuffix: string,
         fromInitial: number,
         to: number | undefined,
-        callback: (messages: ISequencedDocumentMessage[]) => void) {
+        callback: (messages?: ISequencedDocumentMessage[]) => void) {
         let retry: number = 0;
         let from: number = fromInitial;
         let deltas: ISequencedDocumentMessage[] = [];
@@ -838,8 +838,12 @@ export class DeltaManager
             if (to !== undefined && this.lastQueuedSequenceNumber >= to) {
                 // the client caught up while we were trying to fetch ops from storage
                 // bail out since we no longer need to request these ops
-                callback([]);
-                telemetryEvent.end({ deltasRetrievedTotal, requests });
+                callback();
+                telemetryEvent.end({
+                    deltasRetrievedTotal,
+                    requests,
+                    lastQueuedSequenceNumber: this.lastQueuedSequenceNumber,
+                });
                 return;
             }
 
@@ -1405,7 +1409,9 @@ export class DeltaManager
 
         await this.getDeltas(telemetryEventSuffix, from, to, (messages) => {
             this.refreshDelayInfo(this.deltaStorageDelayId);
-            this.enqueueMessages(messages, telemetryEventSuffix);
+            if (messages) {
+                this.enqueueMessages(messages, telemetryEventSuffix);
+            }
         });
 
         this.fetching = false;

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -731,7 +731,7 @@ export class DeltaManager
         telemetryEventSuffix: string,
         fromInitial: number,
         to: number | undefined,
-        callback: (messages?: ISequencedDocumentMessage[]) => void) {
+        callback: (messages: ISequencedDocumentMessage[]) => void) {
         let retry: number = 0;
         let from: number = fromInitial;
         let deltas: ISequencedDocumentMessage[] = [];
@@ -838,7 +838,6 @@ export class DeltaManager
             if (to !== undefined && this.lastQueuedSequenceNumber >= to) {
                 // the client caught up while we were trying to fetch ops from storage
                 // bail out since we no longer need to request these ops
-                callback();
                 telemetryEvent.end({
                     deltasRetrievedTotal,
                     requests,
@@ -1408,11 +1407,10 @@ export class DeltaManager
         this.fetching = true;
 
         await this.getDeltas(telemetryEventSuffix, from, to, (messages) => {
-            this.refreshDelayInfo(this.deltaStorageDelayId);
-            if (messages) {
-                this.enqueueMessages(messages, telemetryEventSuffix);
-            }
+            this.enqueueMessages(messages, telemetryEventSuffix);
         });
+
+        this.refreshDelayInfo(this.deltaStorageDelayId);
 
         this.fetching = false;
     }


### PR DESCRIPTION
Consider the following scenario:

1. Client loads a summary @ seq 150 and connects to the document
2. Server sends the client their join op @ seq 160
    - This causes the client to add that op into `pending` and call `fetchMissingDeltas` to ask for ops 151 - 159
    - Lets say the storage api is not returning any deltas. At this point the client keeps retrying that call until it gets them
3. Server sends the client ops 151 - 159 through the WebSocket
4. Client processes ops 151 - 159

At this point the client has all the ops it needs to be fully connected. However `deltaManager` did not process op 160, which remains in `pending`. So the client is stuck waiting for `fetchMissingDeltas` to complete. This PR makes the client process that pending op so it won't get stuck.

Changes:
- Process pending ops after successfully processing an inbound op
- Stop trying to fetch deltas from storage if the delta manager already caught up
- Replace `catchUpCore` method with `processPendingOps` method that only processes pending ops