### PR TITLE
Set ISummaryTree's unreferenced flag for data stores that are unreferenced

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -423,6 +423,11 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
         };
         addBlobToSummary(summarizeResult, gcBlobKey, JSON.stringify(gcDetails));
 
+        // If we are not referenced, update the summary tree to indicate that.
+        if (!this.summarizerNode.isReferenced()) {
+            summarizeResult.summary.unreferenced = true;
+        }
+
         return { ...summarizeResult, id: this.id };
     }
 
@@ -452,7 +457,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
         // also be notified of their used routes. See - https://github.com/microsoft/FluidFramework/issues/4611
 
         // Update the used routes in this data store's summarizer node.
-        this.summarizerNode.usedRoutes = usedRoutes;
+        this.summarizerNode.updateUsedRoutes(usedRoutes);
     }
 
     /**

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -591,9 +591,7 @@ describe("Data Store Context Tests", () => {
                     "summarize should return a handle since nothing changed");
 
                 // Update the used routes of the data store.
-                const dataStoreSummarizerNode = summarizerNode.getChild(dataStoreId);
-                assert(dataStoreSummarizerNode !== undefined, "Data store's summarizer node is missing");
-                dataStoreSummarizerNode.usedRoutes = [""];
+                remotedDataStoreContext.updateUsedRoutes([""]);
 
                 // Since the used state has changed, it should generate a full summary tree.
                 summarizeResult = await remotedDataStoreContext.summarize(false /* fullTree */);

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -142,7 +142,7 @@ export interface ISummarizerNode {
  */
 export interface ISummarizerNodeWithGC extends ISummarizerNode {
     // This tells whether this node is in use or not. Unused node can be garbage collected and reclaimed.
-    usedRoutes: string[];
+    readonly usedRoutes: string[];
 
     summarize(fullTree: boolean, trackState?: boolean): Promise<IContextSummarizeResult>;
     createChild(
@@ -169,6 +169,7 @@ export interface ISummarizerNodeWithGC extends ISummarizerNode {
     getChild(id: string): ISummarizerNodeWithGC | undefined;
     getGCData(): Promise<IGarbageCollectionData>;
     isReferenced(): boolean;
+    updateUsedRoutes(usedRoutes: string[]): void;
 }
 
 export const channelsTreeName = ".channels";

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -64,6 +64,10 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
     // The GC details of this node in the initial summary.
     private readonly gcDetailsInInitialSummaryP: LazyPromise<IGarbageCollectionSummaryDetails>;
 
+    public get usedRoutes(): string[] {
+        return this._usedRoutes;
+    }
+
     /**
      * Do not call constructor directly.
      * Use createRootSummarizerNodeWithGC to create root node, or createChild to create child nodes.
@@ -79,7 +83,7 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
         wipSummaryLogger?: ITelemetryLogger,
         private readonly getGCDataFn?: () => Promise<IGarbageCollectionData>,
         getInitialGCSummaryDetailsFn?: () => Promise<IGarbageCollectionSummaryDetails>,
-        public usedRoutes: string[] = [],
+        private _usedRoutes: string[] = [],
     ) {
         super(
             logger,
@@ -299,6 +303,12 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 
     public isReferenced(): boolean {
         return this.usedRoutes.includes("") || this.usedRoutes.includes("/");
+    }
+
+    public updateUsedRoutes(usedRoutes: string[]) {
+        // Sort the given routes before updating. This will ensure that the routes compared in hasUsedStateChanged()
+        // are in the same order.
+        this._usedRoutes = usedRoutes.sort();
     }
 
     /**


### PR DESCRIPTION
Fixes #4729 

Updates the unreferenced flag for data stores that are not referenced. Currently, DDSs / channel context's are always considered referenced, so not updating them. This will happen later when DDSs can be GC'd as well.

Also, fixed a bug where the comparison between usedRoutes and referenceUsedRoutes was returning false due to different ordering of routes in them.