### PR TITLE
doc updates

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,3 +1,9 @@
+## 0.32 Breaking changes
+- [Node version 12.17 required](#Node-version-update)
+
+### Node version updated to 12.17
+Due to changes in server packages and introduction of AsyncLocalStorage module which requires Node version 12.17 or above, you will need to update Node version to 12.17 or above.
+
 ## 0.31 Breaking changes
 - [getAttachSnapshot removed IFluidDataStoreChannel](#getAttachSnapshot-removed-from-IFluidDataStoreChannel)
 

--- a/docs/_includes/node-versions.md
+++ b/docs/_includes/node-versions.md
@@ -1,1 +1,1 @@
-Fluid supports Node.js LTS versions 12.16 and greater.
+Fluid supports Node.js LTS versions 12.17 and greater.

--- a/server/routerlicious/README.md
+++ b/server/routerlicious/README.md
@@ -39,7 +39,7 @@ below steps if you'd like to run a local version of the service or need to make 
 
 #### For Development
 
-* [Node v12.x](https://nodejs.org/en/)
+* [Node v12.x](https://nodejs.org/en/) (v12.17 or above is required)
 * [Node-gyp](https://github.com/nodejs/node-gyp) dependencies
     * If building on Windows, the easiest way to install the dependencies is with windows-build-tools: `npm install --global --production windows-build-tools`
 


### PR DESCRIPTION
Due to some changes in microservices in server packages, AsyncLocalStorage was introduced and it requires Node version 12.17 or greater. Made updates in docs for developers to be aware of.