### PR TITLE
Enable strictNullCheck for the map package (and fixes)

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,3 +1,9 @@
+## 0.33 Breaking changes
+- [Map and Directory typing changes from enabling strictNullCheck](#map-and-directory-typing-changes-from-enabling-strictNullCheck)
+
+## Map and Directory typing changes from enabling strictNullCheck
+Typescript compile options `strictNullCheck` is enabled for the `@fluidframework/map` package. Some of the API signature is updated to include possibility of `undefined` and `null`, which can cause new typescript compile error when upgrading.  Existing code may need to update to handle the possiblity of `undefined` or `null.
+
 ## 0.32 Breaking changes
 - [Node version 12.17 required](#Node-version-update)
 
@@ -20,7 +26,7 @@ Due to changes in server packages and introduction of AsyncLocalStorage module w
 The branching feature has been removed. This includes all related members, methods, etc. such as `parentBranch`, `branchId`, `branch()`, etc.
 
 ### removeAllEntriesForDocId api name and signature change
-`removeAllEntriesForDocId` api renamed to `removeEntries`. Now it takes `IFileEntry` as argument instead of just docId. 
+`removeAllEntriesForDocId` api renamed to `removeEntries`. Now it takes `IFileEntry` as argument instead of just docId.
 
 ### snapshot removed from IChannel and ISharedObject
 `snapshot` has been removed from `IChannel` and `ISharedObject`. It is replaced by `summarize` which should be used to get a summary of the channel / shared object.

--- a/examples/apps/collaborative-textarea/src/fluid-object/index.tsx
+++ b/examples/apps/collaborative-textarea/src/fluid-object/index.tsx
@@ -43,7 +43,7 @@ export class CollaborativeText extends DataObject implements IFluidHTMLView {
 
     protected async hasInitialized() {
         // Store the text if we are loading the first time or loading from existing
-        this.text = await this.root.get<IFluidHandle<SharedString>>(this.textKey).get();
+        this.text = await this.root.get<IFluidHandle<SharedString>>(this.textKey)?.get();
     }
 
     /**

--- a/examples/apps/spaces/src/fluid-object/storage/spacesStorage.ts
+++ b/examples/apps/spaces/src/fluid-object/storage/spacesStorage.ts
@@ -87,7 +87,8 @@ export class SpacesStorage extends DataObject implements ISpacesStorage<ISpacesI
     }
 
     public updateLayout(key: string, newLayout: Layout): void {
-        const currentEntry = this.root.get<ISpacesStoredItem<ISpacesItem>>(key);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const currentEntry = this.root.get<ISpacesStoredItem<ISpacesItem>>(key)!;
         const model = {
             serializableItemData: currentEntry.serializableItemData,
             layout: { x: newLayout.x, y: newLayout.y, w: newLayout.w, h: newLayout.h },

--- a/examples/data-objects/clicker/src/index.tsx
+++ b/examples/data-objects/clicker/src/index.tsx
@@ -34,7 +34,7 @@ export class Clicker extends DataObject implements IFluidHTMLView {
 
     protected async hasInitialized() {
         const counterHandle = this.root.get<IFluidHandle<SharedCounter>>(counterKey);
-        this._counter = await counterHandle.get();
+        this._counter = await counterHandle?.get();
         this.setupAgent();
     }
 

--- a/examples/data-objects/codemirror/src/codemirror.ts
+++ b/examples/data-objects/codemirror/src/codemirror.ts
@@ -249,7 +249,7 @@ export class CodeMirrorComponent
         }
 
         this.root = await this.runtime.getChannel("root") as ISharedMap;
-        this.text = await this.root.get<IFluidHandle<SharedString>>("text").get();
+        this.text = await this.root.get<IFluidHandle<SharedString>>("text")?.get();
     }
 
     public render(elm: HTMLElement): void {

--- a/examples/data-objects/image-gallery/src/index.tsx
+++ b/examples/data-objects/image-gallery/src/index.tsx
@@ -81,20 +81,24 @@ export class ImageGalleryObject extends DataObject implements IFluidHTMLView {
 
         this.reactRender(div);
         if (this.imageGallery !== undefined) {
-            this.imageGallery.slideToIndex(this.root.get("position"));
+            this.imageGallery.slideToIndex(this.getPosition());
         }
 
         this.root.on("valueChanged", (_, local) => {
             if (local) {
                 return;
             }
-            const position = this.root.get<number>("position");
+
             if (this.imageGallery !== undefined) {
                 // This is a result of a remote slide, don't trigger onSlide for this slide
                 this.reactRender(div, () => this.reactRender(div));
-                this.imageGallery.slideToIndex(position);
+                this.imageGallery.slideToIndex(this.getPosition());
             }
         });
+    }
+
+    private getPosition() {
+        return this.root.get<number>("position") ?? 0;
     }
 }
 

--- a/examples/data-objects/multiview/constellation-model/src/model.ts
+++ b/examples/data-objects/multiview/constellation-model/src/model.ts
@@ -57,12 +57,14 @@ export class Constellation extends DataObject implements IConstellation {
     }
 
     private async updateStarsFromRoot() {
-        const starHandles = this.root.get<IFluidHandle<ICoordinate>[]>(starListKey);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const starHandles = this.root.get<IFluidHandle<ICoordinate>[]>(starListKey)!;
         this._stars = await Promise.all(starHandles.map(async (starHandle) => starHandle.get()));
     }
 
     public async addStar(x: number, y: number): Promise<void> {
-        const starHandles = this.root.get<IFluidHandle<ICoordinate>[]>(starListKey);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const starHandles = this.root.get<IFluidHandle<ICoordinate>[]>(starListKey)!;
         const newStar = await Coordinate.getFactory().createChildInstance(this.context);
         newStar.x = x;
         newStar.y = y;

--- a/examples/data-objects/multiview/coordinate-model/src/model.ts
+++ b/examples/data-objects/multiview/coordinate-model/src/model.ts
@@ -45,7 +45,7 @@ export class Coordinate extends DataObject implements ICoordinate {
     }
 
     public get x() {
-        return this.root.get(xKey);
+        return this.root.get(xKey) ?? 0;
     }
 
     public set x(newX: number) {
@@ -53,7 +53,7 @@ export class Coordinate extends DataObject implements ICoordinate {
     }
 
     public get y() {
-        return this.root.get(yKey);
+        return this.root.get(yKey) ?? 0;
     }
 
     public set y(newY: number) {

--- a/examples/data-objects/pond/src/data-objects/clicker.tsx
+++ b/examples/data-objects/pond/src/data-objects/clicker.tsx
@@ -45,11 +45,11 @@ export class Clicker extends DataObject implements IFluidHTMLView {
 
     protected async hasInitialized() {
         const counter1Handle = this.root.get<IFluidHandle<SharedCounter>>(counter1Key);
-        this.counter1 = await counter1Handle.get();
+        this.counter1 = await counter1Handle?.get();
 
-        const storedMap = await this.root.get<IFluidHandle<ISharedMap>>(storedMapKey).get();
-        const counter2Handle = storedMap.get<IFluidHandle<SharedCounter>>(counter2Key);
-        this.counter2 = await counter2Handle.get();
+        const storedMap = await this.root.get<IFluidHandle<ISharedMap>>(storedMapKey)?.get();
+        const counter2Handle = storedMap?.get<IFluidHandle<SharedCounter>>(counter2Key);
+        this.counter2 = await counter2Handle?.get();
     }
 
     // start IFluidHTMLView

--- a/examples/data-objects/pond/src/index.tsx
+++ b/examples/data-objects/pond/src/index.tsx
@@ -49,11 +49,18 @@ export class Pond extends DataObject implements IFluidHTMLView {
     }
 
     protected async hasInitialized() {
-        const clicker = await this.root.get<IFluidHandle>(Clicker.ComponentName).get();
+        const clickerHandle = this.root.get<IFluidHandle>(Clicker.ComponentName);
+        if (!clickerHandle) {
+            throw new Error("Pond not intialized correctly");
+        }
+        const clicker = await clickerHandle.get();
         this.clickerView = new HTMLViewAdapter(clicker);
 
-        const clickerUsingProviders
-            = await this.root.get<IFluidHandle>(ExampleUsingProviders.ComponentName).get();
+        const clickerUserProvidersHandle = this.root.get<IFluidHandle>(ExampleUsingProviders.ComponentName);
+        if (!clickerUserProvidersHandle) {
+            throw new Error("Pond not intialized correctly");
+        }
+        const clickerUsingProviders = await clickerUserProvidersHandle.get();
         this.clickerUsingProvidersView = new HTMLViewAdapter(clickerUsingProviders);
     }
 

--- a/examples/data-objects/primitives/src/map.tsx
+++ b/examples/data-objects/primitives/src/map.tsx
@@ -88,12 +88,12 @@ export class MapEntryComponent extends React.Component<IMapEntryProps, IMapEntry
         super(props);
 
         this.state = {
-            mapValue: this.props.map.get(this.props.mapKey),
+            mapValue: this.props.map.get(this.props.mapKey) ?? "",
         };
 
         this.props.map.on("valueChanged", (changed) => {
             if (changed.key === this.props.mapKey) {
-                this.setState({ mapValue: this.props.map.get(this.props.mapKey) });
+                this.setState({ mapValue: this.props.map.get(this.props.mapKey) ?? "" });
             }
         });
     }

--- a/examples/data-objects/smde/src/smde.ts
+++ b/examples/data-objects/smde/src/smde.ts
@@ -88,7 +88,7 @@ export class Smde extends EventEmitter implements
         }
 
         this.root = await this.runtime.getChannel("root") as ISharedMap;
-        this._text = await this.root.get<IFluidHandle<SharedString>>("text").get();
+        this._text = await this.root.get<IFluidHandle<SharedString>>("text")?.get();
     }
 
     public render(elm: HTMLElement, options?: IFluidHTMLOptions): void {

--- a/examples/data-objects/table-view/src/tableview.ts
+++ b/examples/data-objects/table-view/src/tableview.ts
@@ -52,8 +52,11 @@ export class TableView extends DataObject implements IFluidHTMLView {
     public render(elm: HTMLElement, options?: IFluidHTMLOptions): void {
         elm.append(this.templateRoot);
 
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const tableDocumentHandle = this.root.get<IFluidHandle<TableDocument>>(innerDocKey)!;
+
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.root.get<IFluidHandle<TableDocument>>(innerDocKey).get().then((doc) => {
+        tableDocumentHandle.get().then((doc) => {
             const grid = template.get(this.templateRoot, "grid");
             const gridView = new GridView(doc, this);
             grid.appendChild(gridView.root);

--- a/examples/data-objects/vltava/src/fluidObjects/anchor/anchor.ts
+++ b/examples/data-objects/vltava/src/fluidObjects/anchor/anchor.ts
@@ -65,11 +65,11 @@ export class Anchor extends DataObject implements IProvideFluidHTMLView, IProvid
 
     protected async hasInitialized() {
         this.defaultFluidObjectInternal =
-            (await this.root.get<IFluidHandle>(this.defaultFluidObjectId).get())
-                .IFluidHTMLView;
+            (await this.root.get<IFluidHandle>(this.defaultFluidObjectId)?.get())
+                ?.IFluidHTMLView;
 
         this.lastEditedFluidObject =
-            (await this.root.get<IFluidHandle>(this.lastEditedFluidObjectId).get())
-                .IFluidLastEditedTracker;
+            (await this.root.get<IFluidHandle>(this.lastEditedFluidObjectId)?.get())
+                ?.IFluidLastEditedTracker;
     }
 }

--- a/examples/data-objects/vltava/src/fluidObjects/tabs/dataModel.ts
+++ b/examples/data-objects/vltava/src/fluidObjects/tabs/dataModel.ts
@@ -59,7 +59,8 @@ export class TabsDataModel extends EventEmitter implements ITabsDataModel {
         if (!root.hasSubDirectory(tabs)) {
             root.createSubDirectory(tabs);
         }
-        this.tabs = root.getSubDirectory(tabs);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        this.tabs = root.getSubDirectory(tabs)!;
 
         root.on(
             "valueChanged",

--- a/examples/data-objects/vltava/src/fluidObjects/vltava/dataModel.ts
+++ b/examples/data-objects/vltava/src/fluidObjects/vltava/dataModel.ts
@@ -59,7 +59,8 @@ export class VltavaDataModel extends EventEmitter implements IVltavaDataModel {
     }
 
     public async getDefaultFluidObject(): Promise<IFluidObject> {
-        return this.defaultFluidObject.get();
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return this.defaultFluidObject.get()!;
     }
 
     public getTitle(): string {

--- a/examples/data-objects/vltava/src/fluidObjects/vltava/vltava.tsx
+++ b/examples/data-objects/vltava/src/fluidObjects/vltava/vltava.tsx
@@ -46,7 +46,8 @@ export class Vltava extends DataObject implements IFluidHTMLView {
     protected async hasInitialized() {
         this.dataModelInternal =
             new VltavaDataModel(
-                this.root.get<IFluidHandle>(defaultObjectId),
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                this.root.get<IFluidHandle>(defaultObjectId)!,
                 this.context,
                 this.runtime);
     }

--- a/packages/agents/intelligence-runner-agent/src/serviceManager.ts
+++ b/packages/agents/intelligence-runner-agent/src/serviceManager.ts
@@ -33,9 +33,9 @@ export class IntelligentServicesManager {
                 // And then run plugin insights rate limited
                 this.rateLimiter = new RateLimiter(
                     async () => {
-                        const output = await this.documentInsights
-                            .get<IFluidHandle<ISharedMap>>(this.sharedString.id)
-                            .get();
+                        const handle = this.documentInsights.get<IFluidHandle<ISharedMap>>(this.sharedString.id);
+                        if (!handle) { return; }
+                        const output = await handle.get();
 
                         // Run the shared services
                         const text = this.sharedString.getText();

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -775,9 +775,9 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
         serializable: ISerializableValue,
     ): ILocalValue {
         if (serializable.type === ValueType[ValueType.Plain] || serializable.type === ValueType[ValueType.Shared]) {
-            return this.localValueMaker.fromSerializablePlainOrShared(serializable);
+            return this.localValueMaker.fromSerializable(serializable);
         } else {
-            return this.localValueMaker.fromSerializableValueEmitter(
+            return this.localValueMaker.fromSerializableValueType(
                 serializable,
                 this.makeDirectoryValueOpEmitter(key, absolutePath),
             );

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -1283,7 +1283,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
             return;
         }
         this.clearExceptPendingKeys();
-        this.directory.emit("clear", local, op, this);
+        this.directory.emit("clear", local, op, this.directory);
     }
 
     /**
@@ -1564,7 +1564,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
      */
     private clearCore(local: boolean, op: ISequencedDocumentMessage | null) {
         this._storage.clear();
-        this.directory.emit("clear", local, op, this);
+        this.directory.emit("clear", local, op, this.directory);
     }
 
     /**
@@ -1579,7 +1579,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
         const successfullyRemoved = this._storage.delete(key);
         if (successfullyRemoved) {
             const event: IDirectoryValueChanged = { key, path: this.absolutePath, previousValue };
-            this.directory.emit("valueChanged", event, local, op, this);
+            this.directory.emit("valueChanged", event, local, op, this.directory);
             const containedEvent: IValueChanged = { key, previousValue };
             this.emit("containedValueChanged", containedEvent, local, this);
         }
@@ -1597,7 +1597,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
         const previousValue = this.get(key);
         this._storage.set(key, value);
         const event: IDirectoryValueChanged = { key, path: this.absolutePath, previousValue };
-        this.directory.emit("valueChanged", event, local, op, this);
+        this.directory.emit("valueChanged", event, local, op, this.directory);
         const containedEvent: IValueChanged = { key, previousValue };
         this.emit("containedValueChanged", containedEvent, local, this);
     }

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -246,7 +246,8 @@ function serializeDirectory(root: SubDirectory, serializer: IFluidSerializer): I
     stack.push([root, content]);
 
     while (stack.length > 0) {
-        const [currentSubDir, currentSubDirObject] = stack.pop();
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const [currentSubDir, currentSubDirObject] = stack.pop()!;
         for (const [key, value] of currentSubDir.getSerializedStorage(serializer)) {
             if (!currentSubDirObject.storage) {
                 currentSubDirObject.storage = {};
@@ -434,7 +435,7 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
         this.root.on(
             "containedValueChanged",
             (changed: IValueChanged, local: boolean) => {
-                this.emit("containedValueChanged", changed, local);
+                this.emit("containedValueChanged", changed, local, this);
             },
         );
     }
@@ -442,14 +443,14 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
     /**
      * {@inheritDoc IDirectory.get}
      */
-    public get<T = any>(key: string): T {
+    public get<T = any>(key: string): T | undefined {
         return this.root.get<T>(key);
     }
 
     /**
      * {@inheritDoc IDirectory.wait}
      */
-    public async wait<T = any>(key: string): Promise<T> {
+    public async wait<T = any>(key: string): Promise<T | undefined> {
         return this.root.wait<T>(key);
     }
 
@@ -543,7 +544,7 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
     /**
      * {@inheritDoc IDirectory.getSubDirectory}
      */
-    public getSubDirectory(subdirName: string): IDirectory {
+    public getSubDirectory(subdirName: string): IDirectory | undefined {
         return this.root.getSubDirectory(subdirName);
     }
 
@@ -571,7 +572,7 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
     /**
      * {@inheritDoc IDirectory.getWorkingDirectory}
      */
-    public getWorkingDirectory(relativePath: string): IDirectory {
+    public getWorkingDirectory(relativePath: string): IDirectory | undefined {
         const absolutePath = this.makeAbsolute(relativePath);
         if (absolutePath === posix.sep) {
             return this.root;
@@ -631,7 +632,7 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
             // Send the localOpMetadata as undefined because we don't care about the ack.
             this.submitDirectoryMessage(op, undefined /* localOpMetadata */);
             const event: IDirectoryValueChanged = { key, path: absolutePath, previousValue };
-            this.emit("valueChanged", event, true, null);
+            this.emit("valueChanged", event, true, null, this);
         };
         return { emit };
     }
@@ -649,7 +650,10 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
     protected reSubmitCore(content: any, localOpMetadata: unknown) {
         const message = content as IDirectoryOperation;
         const handler = this.messageHandlers.get(message.type);
-        handler.submit(message, localOpMetadata);
+
+        // eslint-disable-next-line max-len
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion
+        handler!.submit(message, localOpMetadata);
     }
 
     /**
@@ -682,7 +686,8 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
         const stack: [SubDirectory, IDirectoryDataObject][] = [];
         stack.push([this.root, data]);
         while (stack.length > 0) {
-            const [currentSubDir, currentSubDirObject] = stack.pop();
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const [currentSubDir, currentSubDirObject] = stack.pop()!;
             if (currentSubDirObject.subdirectories) {
                 for (const [subdirName, subdirObject] of Object.entries(currentSubDirObject.subdirectories)) {
                     let newSubDir = currentSubDir.getSubDirectory(subdirName) as SubDirectory;
@@ -739,7 +744,8 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
         if (message.type === MessageType.Operation) {
             const op: IDirectoryOperation = message.contents as IDirectoryOperation;
             if (this.messageHandlers.has(op.type)) {
-                this.messageHandlers.get(op.type)
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                this.messageHandlers.get(op.type)!
                     .process(op, local, message, localOpMetadata);
             }
         }
@@ -769,9 +775,9 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
         serializable: ISerializableValue,
     ): ILocalValue {
         if (serializable.type === ValueType[ValueType.Plain] || serializable.type === ValueType[ValueType.Shared]) {
-            return this.localValueMaker.fromSerializable(serializable);
+            return this.localValueMaker.fromSerializablePlainOrShared(serializable);
         } else {
-            return this.localValueMaker.fromSerializable(
+            return this.localValueMaker.fromSerializableValueEmitter(
                 serializable,
                 this.makeDirectoryValueOpEmitter(key, absolutePath),
             );
@@ -786,13 +792,13 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
             "clear",
             {
                 process: (op: IDirectoryClearOperation, local, message, localOpMetadata) => {
-                    const subdir = this.getWorkingDirectory(op.path) as SubDirectory;
+                    const subdir = this.getWorkingDirectory(op.path) as SubDirectory | undefined;
                     if (subdir) {
                         subdir.processClearMessage(op, local, message, localOpMetadata);
                     }
                 },
                 submit: (op: IDirectoryClearOperation, localOpMetadata: unknown) => {
-                    const subdir = this.getWorkingDirectory(op.path) as SubDirectory;
+                    const subdir = this.getWorkingDirectory(op.path) as SubDirectory | undefined;
                     if (subdir) {
                         // We don't reuse the metadata but send a new one on each submit.
                         subdir.submitClearMessage(op);
@@ -804,13 +810,13 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
             "delete",
             {
                 process: (op: IDirectoryDeleteOperation, local, message, localOpMetadata) => {
-                    const subdir = this.getWorkingDirectory(op.path) as SubDirectory;
+                    const subdir = this.getWorkingDirectory(op.path) as SubDirectory | undefined;
                     if (subdir) {
                         subdir.processDeleteMessage(op, local, message, localOpMetadata);
                     }
                 },
                 submit: (op: IDirectoryDeleteOperation, localOpMetadata: unknown) => {
-                    const subdir = this.getWorkingDirectory(op.path) as SubDirectory;
+                    const subdir = this.getWorkingDirectory(op.path) as SubDirectory | undefined;
                     if (subdir) {
                         // We don't reuse the metadata but send a new one on each submit.
                         subdir.submitKeyMessage(op);
@@ -822,14 +828,14 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
             "set",
             {
                 process: (op: IDirectorySetOperation, local, message, localOpMetadata) => {
-                    const subdir = this.getWorkingDirectory(op.path) as SubDirectory;
+                    const subdir = this.getWorkingDirectory(op.path) as SubDirectory | undefined;
                     if (subdir) {
                         const context = local ? undefined : this.makeLocal(op.key, op.path, op.value);
                         subdir.processSetMessage(op, context, local, message, localOpMetadata);
                     }
                 },
                 submit: (op: IDirectorySetOperation, localOpMetadata: unknown) => {
-                    const subdir = this.getWorkingDirectory(op.path) as SubDirectory;
+                    const subdir = this.getWorkingDirectory(op.path) as SubDirectory | undefined;
                     if (subdir) {
                         // We don't reuse the metadata but send a new one on each submit.
                         subdir.submitKeyMessage(op);
@@ -842,13 +848,13 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
             "createSubDirectory",
             {
                 process: (op: IDirectoryCreateSubDirectoryOperation, local, message, localOpMetadata) => {
-                    const parentSubdir = this.getWorkingDirectory(op.path) as SubDirectory;
+                    const parentSubdir = this.getWorkingDirectory(op.path) as SubDirectory | undefined;
                     if (parentSubdir) {
                         parentSubdir.processCreateSubDirectoryMessage(op, local, message, localOpMetadata);
                     }
                 },
                 submit: (op: IDirectoryCreateSubDirectoryOperation, localOpMetadata: unknown) => {
-                    const parentSubdir = this.getWorkingDirectory(op.path) as SubDirectory;
+                    const parentSubdir = this.getWorkingDirectory(op.path) as SubDirectory | undefined;
                     if (parentSubdir) {
                         // We don't reuse the metadata but send a new one on each submit.
                         parentSubdir.submitSubDirectoryMessage(op);
@@ -861,13 +867,13 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
             "deleteSubDirectory",
             {
                 process: (op: IDirectoryDeleteSubDirectoryOperation, local, message, localOpMetadata) => {
-                    const parentSubdir = this.getWorkingDirectory(op.path) as SubDirectory;
+                    const parentSubdir = this.getWorkingDirectory(op.path) as SubDirectory | undefined;
                     if (parentSubdir) {
                         parentSubdir.processDeleteSubDirectoryMessage(op, local, message, localOpMetadata);
                     }
                 },
                 submit: (op: IDirectoryDeleteSubDirectoryOperation, localOpMetadata: unknown) => {
-                    const parentSubdir = this.getWorkingDirectory(op.path) as SubDirectory;
+                    const parentSubdir = this.getWorkingDirectory(op.path) as SubDirectory | undefined;
                     if (parentSubdir) {
                         // We don't reuse the metadata but send a new one on each submit.
                         parentSubdir.submitSubDirectoryMessage(op);
@@ -884,7 +890,7 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
             "act",
             {
                 process: (op: IDirectoryValueTypeOperation, local, message, localOpMetadata) => {
-                    const subdir = this.getWorkingDirectory(op.path) as SubDirectory;
+                    const subdir = this.getWorkingDirectory(op.path) as SubDirectory | undefined;
                     // Subdir might not exist if we deleted it
                     if (!subdir) {
                         return;
@@ -901,7 +907,7 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
                     const translatedValue = this.serializer.parse(JSON.stringify(op.value.value));
                     handler.process(previousValue, translatedValue, local, message);
                     const event: IDirectoryValueChanged = { key: op.key, path: op.path, previousValue };
-                    this.emit("valueChanged", event, local, message);
+                    this.emit("valueChanged", event, local, message, this);
                 },
                 submit: (op, localOpMetadata: unknown) => {
                     this.submitDirectoryMessage(op, localOpMetadata);
@@ -980,21 +986,18 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
     /**
      * {@inheritDoc IDirectory.get}
      */
-    public get<T = any>(key: string): T {
-        if (!this._storage.has(key)) {
-            return undefined;
-        }
-
-        return this._storage.get(key).value as T;
+    public get<T = any>(key: string): T | undefined {
+        return this._storage.get(key)?.value as T | undefined;
     }
 
     /**
      * {@inheritDoc IDirectory.wait}
      */
-    public async wait<T = any>(key: string): Promise<T> {
+    public async wait<T = any>(key: string): Promise<T | undefined> {
         // Return immediately if the value already exists
         if (this._storage.has(key)) {
-            return this._storage.get(key).value as T;
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            return this._storage.get(key)!.value as T;
         }
 
         // Otherwise subscribe to changes
@@ -1065,7 +1068,8 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
         // Create the sub directory locally first.
         this.createSubDirectoryCore(subdirName, true, null);
 
-        const subDir: IDirectory = this._subdirectories.get(subdirName);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const subDir: IDirectory = this._subdirectories.get(subdirName)!;
 
         // If we are not attached, don't submit the op.
         if (!this.directory.isAttached()) {
@@ -1085,7 +1089,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
     /**
      * {@inheritDoc IDirectory.getSubDirectory}
      */
-    public getSubDirectory(subdirName: string): IDirectory {
+    public getSubDirectory(subdirName: string): IDirectory | undefined {
         return this._subdirectories.get(subdirName);
     }
 
@@ -1128,7 +1132,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
     /**
      * {@inheritDoc IDirectory.getWorkingDirectory}
      */
-    public getWorkingDirectory(relativePath: string): IDirectory {
+    public getWorkingDirectory(relativePath: string): IDirectory | undefined {
         return this.directory.getWorkingDirectory(this.makeAbsolute(relativePath));
     }
 
@@ -1279,7 +1283,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
             return;
         }
         this.clearExceptPendingKeys();
-        this.directory.emit("clear", local, op);
+        this.directory.emit("clear", local, op, this);
     }
 
     /**
@@ -1314,7 +1318,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
      */
     public processSetMessage(
         op: IDirectorySetOperation,
-        context: ILocalValue,
+        context: ILocalValue | undefined,
         local: boolean,
         message: ISequencedDocumentMessage,
         localOpMetadata: unknown,
@@ -1322,7 +1326,13 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
         if (!this.needProcessStorageOperation(op, local, message, localOpMetadata)) {
             return;
         }
-        this.setCore(op.key, context, local, message);
+
+        // needProcessStorageOperation should have returned false if local is true
+        // so we can assume context is not undefined
+
+        // eslint-disable-next-line max-len
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion
+        this.setCore(op.key, context!, local, message);
     }
 
     /**
@@ -1538,7 +1548,8 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
         // we will get the value for the pendingKeys and clear the map
         const temp = new Map<string, ILocalValue>();
         this.pendingKeys.forEach((value, key, map) => {
-            temp.set(key, this._storage.get(key));
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            temp.set(key, this._storage.get(key)!);
         });
         this._storage.clear();
         temp.forEach((value, key, map) => {
@@ -1551,9 +1562,9 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
      * @param local - Whether the message originated from the local client
      * @param op - The message if from a remote clear, or null if from a local clear
      */
-    private clearCore(local: boolean, op: ISequencedDocumentMessage) {
+    private clearCore(local: boolean, op: ISequencedDocumentMessage | null) {
         this._storage.clear();
-        this.directory.emit("clear", local, op);
+        this.directory.emit("clear", local, op, this);
     }
 
     /**
@@ -1563,14 +1574,14 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
      * @param op - The message if from a remote delete, or null if from a local delete
      * @returns True if the key existed and was deleted, false if it did not exist
      */
-    private deleteCore(key: string, local: boolean, op: ISequencedDocumentMessage) {
+    private deleteCore(key: string, local: boolean, op: ISequencedDocumentMessage | null) {
         const previousValue = this.get(key);
         const successfullyRemoved = this._storage.delete(key);
         if (successfullyRemoved) {
             const event: IDirectoryValueChanged = { key, path: this.absolutePath, previousValue };
-            this.directory.emit("valueChanged", event, local, op);
+            this.directory.emit("valueChanged", event, local, op, this);
             const containedEvent: IValueChanged = { key, previousValue };
-            this.emit("containedValueChanged", containedEvent, local);
+            this.emit("containedValueChanged", containedEvent, local, this);
         }
         return successfullyRemoved;
     }
@@ -1582,13 +1593,13 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
      * @param local - Whether the message originated from the local client
      * @param op - The message if from a remote set, or null if from a local set
      */
-    private setCore(key: string, value: ILocalValue, local: boolean, op: ISequencedDocumentMessage) {
+    private setCore(key: string, value: ILocalValue, local: boolean, op: ISequencedDocumentMessage | null) {
         const previousValue = this.get(key);
         this._storage.set(key, value);
         const event: IDirectoryValueChanged = { key, path: this.absolutePath, previousValue };
-        this.directory.emit("valueChanged", event, local, op);
+        this.directory.emit("valueChanged", event, local, op, this);
         const containedEvent: IValueChanged = { key, previousValue };
-        this.emit("containedValueChanged", containedEvent, local);
+        this.emit("containedValueChanged", containedEvent, local, this);
     }
 
     /**
@@ -1597,7 +1608,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
      * @param local - Whether the message originated from the local client
      * @param op - The message if from a remote create, or null if from a local create
      */
-    private createSubDirectoryCore(subdirName: string, local: boolean, op: ISequencedDocumentMessage) {
+    private createSubDirectoryCore(subdirName: string, local: boolean, op: ISequencedDocumentMessage | null) {
         if (!this._subdirectories.has(subdirName)) {
             this._subdirectories.set(
                 subdirName,
@@ -1616,7 +1627,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
      * @param local - Whether the message originated from the local client
      * @param op - The message if from a remote delete, or null if from a local delete
      */
-    private deleteSubDirectoryCore(subdirName: string, local: boolean, op: ISequencedDocumentMessage) {
+    private deleteSubDirectoryCore(subdirName: string, local: boolean, op: ISequencedDocumentMessage | null) {
         // This should make the subdirectory structure unreachable so it can be GC'd and won't appear in snapshots
         // Might want to consider cleaning out the structure more exhaustively though?
         return this._subdirectories.delete(subdirName);

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -139,7 +139,7 @@ export interface IDirectory extends Map<string, any>, IEventProvider<IDirectoryE
      * @param key - Key to retrieve from
      * @returns The stored value once available
      */
-    wait<T = any>(key: string): Promise<T | undefined>;
+    wait<T = any>(key: string): Promise<T>;
 
     /**
      * Sets the value stored at key to the provided value.
@@ -264,7 +264,7 @@ export interface ISharedMap extends ISharedObject<ISharedMapEvents>, Map<string,
      * @param key - Key to retrieve from
      * @returns The stored value once available
      */
-    wait<T = any>(key: string): Promise<T | undefined>;
+    wait<T = any>(key: string): Promise<T>;
 
     /**
      * Sets the value stored at key to the provided value.

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -132,14 +132,14 @@ export interface IDirectory extends Map<string, any>, IEventProvider<IDirectoryE
      * @param key - Key to retrieve from
      * @returns The stored value, or undefined if the key is not set
      */
-    get<T = any>(key: string): T;
+    get<T = any>(key: string): T | undefined;
 
     /**
      * A form of get except it will only resolve the promise once the key exists in the directory.
      * @param key - Key to retrieve from
      * @returns The stored value once available
      */
-    wait<T = any>(key: string): Promise<T>;
+    wait<T = any>(key: string): Promise<T | undefined>;
 
     /**
      * Sets the value stored at key to the provided value.
@@ -161,7 +161,7 @@ export interface IDirectory extends Map<string, any>, IEventProvider<IDirectoryE
      * @param subdirName - Name of the child directory to get
      * @returns The requested IDirectory
      */
-    getSubDirectory(subdirName: string): IDirectory;
+    getSubDirectory(subdirName: string): IDirectory | undefined;
 
     /**
      * Checks whether this directory has a child directory with the given name.
@@ -188,14 +188,19 @@ export interface IDirectory extends Map<string, any>, IEventProvider<IDirectoryE
      * @param relativePath - Path of the IDirectory to get, relative to this IDirectory
      * @returns The requested IDirectory
      */
-    getWorkingDirectory(relativePath: string): IDirectory;
+    getWorkingDirectory(relativePath: string): IDirectory | undefined;
 }
 
 export interface ISharedDirectoryEvents extends ISharedObjectEvents {
     (event: "valueChanged", listener: (
         changed: IDirectoryValueChanged,
         local: boolean,
-        op: ISequencedDocumentMessage,
+        op: ISequencedDocumentMessage | null,
+        target: IEventThisPlaceHolder,
+    ) => void);
+    (event: "clear", listener: (
+        local: boolean,
+        op: ISequencedDocumentMessage | null,
         target: IEventThisPlaceHolder,
     ) => void);
 }
@@ -234,8 +239,13 @@ export interface ISharedMapEvents extends ISharedObjectEvents {
     (event: "valueChanged", listener: (
         changed: IDirectoryValueChanged,
         local: boolean,
-        op: ISequencedDocumentMessage,
+        op: ISequencedDocumentMessage | null,
         target: IEventThisPlaceHolder) => void);
+    (event: "clear", listener: (
+        local: boolean,
+        op: ISequencedDocumentMessage | null,
+        target: IEventThisPlaceHolder
+    ) => void);
 }
 
 /**
@@ -247,14 +257,14 @@ export interface ISharedMap extends ISharedObject<ISharedMapEvents>, Map<string,
      * @param key - Key to retrieve from
      * @returns The stored value, or undefined if the key is not set
      */
-    get<T = any>(key: string): T;
+    get<T = any>(key: string): T | undefined;
 
     /**
      * A form of get except it will only resolve the promise once the key exists in the map.
      * @param key - Key to retrieve from
      * @returns The stored value once available
      */
-    wait<T = any>(key: string): Promise<T>;
+    wait<T = any>(key: string): Promise<T | undefined>;
 
     /**
      * Sets the value stored at key to the provided value.
@@ -302,7 +312,7 @@ export interface ISerializedValue {
     /**
      * String representation of the value.
      */
-    value: string;
+    value: string | undefined;
 }
 
 /**

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -312,7 +312,7 @@ export interface ISerializedValue {
     /**
      * String representation of the value.
      */
-    value: string | undefined;
+    value: string;
 }
 
 /**

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -312,7 +312,7 @@ export interface ISerializedValue {
     /**
      * String representation of the value.
      */
-    value: string;
+    value: string | undefined;
 }
 
 /**

--- a/packages/dds/map/src/localValues.ts
+++ b/packages/dds/map/src/localValues.ts
@@ -179,9 +179,8 @@ export class LocalValueMaker {
     /**
      * Create a new local value from an incoming serialized value.
      * @param serializable - The serializable value to make local
-     * @param emitter - The value op emitter, if the serializable is a value type
      */
-    public fromSerializablePlainOrShared(serializable: ISerializableValue, emitter?: IValueOpEmitter): ILocalValue {
+    public fromSerializable(serializable: ISerializableValue): ILocalValue {
         // Migrate from old shared value to handles
         if (serializable.type === ValueType[ValueType.Shared]) {
             serializable.type = ValueType[ValueType.Plain];
@@ -197,7 +196,12 @@ export class LocalValueMaker {
         return new PlainLocalValue(translatedValue);
     }
 
-    public fromSerializableValueEmitter(serializable: ISerializableValue, emitter: IValueOpEmitter): ILocalValue {
+    /**
+     * Create a new local value from an incoming serialized value for value type
+     * @param serializable - The serializable value to make local
+     * @param emitter - The value op emitter, if the serializable is a value type
+     */
+    public fromSerializableValueType(serializable: ISerializableValue, emitter: IValueOpEmitter): ILocalValue {
         if (this.valueTypes.has(serializable.type)) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const valueType = this.valueTypes.get(serializable.type)!;

--- a/packages/dds/map/src/localValues.ts
+++ b/packages/dds/map/src/localValues.ts
@@ -181,23 +181,26 @@ export class LocalValueMaker {
      * @param serializable - The serializable value to make local
      * @param emitter - The value op emitter, if the serializable is a value type
      */
-    public fromSerializable(serializable: ISerializableValue, emitter?: IValueOpEmitter): ILocalValue {
-        if (serializable.type === ValueType[ValueType.Plain] || serializable.type === ValueType[ValueType.Shared]) {
-            // Migrate from old shared value to handles
-            if (serializable.type === ValueType[ValueType.Shared]) {
-                serializable.type = ValueType[ValueType.Plain];
-                const handle: ISerializedHandle = {
-                    type: "__fluid_handle__",
-                    url: serializable.value as string,
-                };
-                serializable.value = handle;
-            }
+    public fromSerializablePlainOrShared(serializable: ISerializableValue, emitter?: IValueOpEmitter): ILocalValue {
+        // Migrate from old shared value to handles
+        if (serializable.type === ValueType[ValueType.Shared]) {
+            serializable.type = ValueType[ValueType.Plain];
+            const handle: ISerializedHandle = {
+                type: "__fluid_handle__",
+                url: serializable.value as string,
+            };
+            serializable.value = handle;
+        }
 
-            const translatedValue = parseHandles(serializable.value, this.serializer);
+        const translatedValue = parseHandles(serializable.value, this.serializer);
 
-            return new PlainLocalValue(translatedValue);
-        } else if (this.valueTypes.has(serializable.type)) {
-            const valueType = this.valueTypes.get(serializable.type);
+        return new PlainLocalValue(translatedValue);
+    }
+
+    public fromSerializableValueEmitter(serializable: ISerializableValue, emitter: IValueOpEmitter): ILocalValue {
+        if (this.valueTypes.has(serializable.type)) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const valueType = this.valueTypes.get(serializable.type)!;
 
             serializable.value = parseHandles(serializable.value, this.serializer);
 
@@ -231,7 +234,8 @@ export class LocalValueMaker {
      */
     public makeValueType(type: string, emitter: IValueOpEmitter, params: any): ILocalValue {
         const valueType = this.loadValueType(params, type, emitter);
-        return new ValueTypeLocalValue(valueType, this.valueTypes.get(type));
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return new ValueTypeLocalValue(valueType, this.valueTypes.get(type)!);
     }
 
     /**

--- a/packages/dds/map/src/map.ts
+++ b/packages/dds/map/src/map.ts
@@ -206,14 +206,14 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
     /**
     * {@inheritDoc ISharedMap.get}
     */
-    public get<T = any>(key: string): T {
+    public get<T = any>(key: string): T | undefined {
         return this.kernel.get<T>(key);
     }
 
     /**
     * {@inheritDoc ISharedMap.wait}
     */
-    public async wait<T = any>(key: string): Promise<T> {
+    public async wait<T = any>(key: string): Promise<T | undefined> {
         return this.kernel.wait<T>(key);
     }
 

--- a/packages/dds/map/src/map.ts
+++ b/packages/dds/map/src/map.ts
@@ -213,7 +213,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
     /**
     * {@inheritDoc ISharedMap.wait}
     */
-    public async wait<T = any>(key: string): Promise<T | undefined> {
+    public async wait<T = any>(key: string): Promise<T> {
         return this.kernel.wait<T>(key);
     }
 

--- a/packages/dds/map/src/mapKernel.ts
+++ b/packages/dds/map/src/mapKernel.ts
@@ -527,7 +527,7 @@ export class MapKernel implements IValueTypeCreator {
         const previousValue = this.get(key);
         this.data.set(key, value);
         const event: IValueChanged = { key, previousValue };
-        this.eventEmitter.emit("valueChanged", event, local, op, this);
+        this.eventEmitter.emit("valueChanged", event, local, op, this.eventEmitter);
     }
 
     /**
@@ -537,7 +537,7 @@ export class MapKernel implements IValueTypeCreator {
      */
     private clearCore(local: boolean, op: ISequencedDocumentMessage | null): void {
         this.data.clear();
-        this.eventEmitter.emit("clear", local, op, this);
+        this.eventEmitter.emit("clear", local, op, this.eventEmitter);
     }
 
     /**
@@ -552,7 +552,7 @@ export class MapKernel implements IValueTypeCreator {
         const successfullyRemoved = this.data.delete(key);
         if (successfullyRemoved) {
             const event: IValueChanged = { key, previousValue };
-            this.eventEmitter.emit("valueChanged", event, local, op, this);
+            this.eventEmitter.emit("valueChanged", event, local, op, this.eventEmitter);
         }
         return successfullyRemoved;
     }
@@ -722,7 +722,7 @@ export class MapKernel implements IValueTypeCreator {
                         this.serializer);
                     handler.process(previousValue, translatedValue, local, message);
                     const event: IValueChanged = { key: op.key, previousValue };
-                    this.eventEmitter.emit("valueChanged", event, local, message, this);
+                    this.eventEmitter.emit("valueChanged", event, local, message, this.eventEmitter);
                 },
                 submit: (op: IMapValueTypeOperation, localOpMetadata: unknown) => {
                     this.submitMessage(op, localOpMetadata);
@@ -777,7 +777,7 @@ export class MapKernel implements IValueTypeCreator {
             this.submitMessage(op, undefined /* localOpMetadata */);
 
             const event: IValueChanged = { key, previousValue };
-            this.eventEmitter.emit("valueChanged", event, true, null, this);
+            this.eventEmitter.emit("valueChanged", event, true, null, this.eventEmitter);
         };
 
         return { emit };

--- a/packages/dds/map/src/mapKernel.ts
+++ b/packages/dds/map/src/mapKernel.ts
@@ -274,12 +274,13 @@ export class MapKernel implements IValueTypeCreator {
     /**
      * {@inheritDoc ISharedMap.get}
      */
-    public get<T = any>(key: string): T {
+    public get<T = any>(key: string): T | undefined {
         if (!this.data.has(key)) {
             return undefined;
         }
 
-        const localValue = this.data.get(key);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const localValue = this.data.get(key)!;
 
         return localValue.value as T;
     }
@@ -287,7 +288,7 @@ export class MapKernel implements IValueTypeCreator {
     /**
      * {@inheritDoc ISharedMap.wait}
      */
-    public async wait<T = any>(key: string): Promise<T> {
+    public async wait<T = any>(key: string): Promise<T | undefined> {
         // Return immediately if the value already exists
         if (this.has(key)) {
             return this.get<T>(key);
@@ -377,7 +378,7 @@ export class MapKernel implements IValueTypeCreator {
 
         // If we are not attached, don't submit the op.
         if (!this.isAttached()) {
-            return;
+            return this;
         }
 
         // This is a special form of serialized valuetype only used for set, containing info for initialization.
@@ -488,7 +489,8 @@ export class MapKernel implements IValueTypeCreator {
     public trySubmitMessage(op: any, localOpMetadata: unknown): boolean {
         const type: string = op.type;
         if (this.messageHandlers.has(type)) {
-            this.messageHandlers.get(type).submit(op as IMapOperation, localOpMetadata);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            this.messageHandlers.get(type)!.submit(op as IMapOperation, localOpMetadata);
             return true;
         }
         return false;
@@ -505,8 +507,9 @@ export class MapKernel implements IValueTypeCreator {
     public tryProcessMessage(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): boolean {
         const op = message.contents as IMapOperation;
         if (this.messageHandlers.has(op.type)) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             this.messageHandlers
-                .get(op.type)
+                .get(op.type)!
                 .process(op, local, message, localOpMetadata);
             return true;
         }
@@ -520,7 +523,7 @@ export class MapKernel implements IValueTypeCreator {
      * @param local - Whether the message originated from the local client
      * @param op - The message if from a remote set, or null if from a local set
      */
-    private setCore(key: string, value: ILocalValue, local: boolean, op: ISequencedDocumentMessage): void {
+    private setCore(key: string, value: ILocalValue, local: boolean, op: ISequencedDocumentMessage | null): void {
         const previousValue = this.get(key);
         this.data.set(key, value);
         const event: IValueChanged = { key, previousValue };
@@ -532,7 +535,7 @@ export class MapKernel implements IValueTypeCreator {
      * @param local - Whether the message originated from the local client
      * @param op - The message if from a remote clear, or null if from a local clear
      */
-    private clearCore(local: boolean, op: ISequencedDocumentMessage): void {
+    private clearCore(local: boolean, op: ISequencedDocumentMessage | null): void {
         this.data.clear();
         this.eventEmitter.emit("clear", local, op, this);
     }
@@ -544,7 +547,7 @@ export class MapKernel implements IValueTypeCreator {
      * @param op - The message if from a remote delete, or null if from a local delete
      * @returns True if the key existed and was deleted, false if it did not exist
      */
-    private deleteCore(key: string, local: boolean, op: ISequencedDocumentMessage): boolean {
+    private deleteCore(key: string, local: boolean, op: ISequencedDocumentMessage | null): boolean {
         const previousValue = this.get(key);
         const successfullyRemoved = this.data.delete(key);
         if (successfullyRemoved) {
@@ -562,7 +565,8 @@ export class MapKernel implements IValueTypeCreator {
         // we will get the value for the pendingKeys and clear the map
         const temp = new Map<string, ILocalValue>();
         this.pendingKeys.forEach((value, key) => {
-            temp.set(key, this.data.get(key));
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            temp.set(key, this.data.get(key)!);
         });
         this.data.clear();
         temp.forEach((value, key) => {
@@ -582,9 +586,9 @@ export class MapKernel implements IValueTypeCreator {
      */
     private makeLocal(key: string, serializable: ISerializableValue): ILocalValue {
         if (serializable.type === ValueType[ValueType.Plain] || serializable.type === ValueType[ValueType.Shared]) {
-            return this.localValueMaker.fromSerializable(serializable);
+            return this.localValueMaker.fromSerializablePlainOrShared(serializable);
         } else {
-            return this.localValueMaker.fromSerializable(
+            return this.localValueMaker.fromSerializableValueEmitter(
                 serializable,
                 this.makeMapValueOpEmitter(key),
             );
@@ -687,8 +691,8 @@ export class MapKernel implements IValueTypeCreator {
                         return;
                     }
 
-                    const context = local ? undefined : this.makeLocal(op.key, op.value);
-
+                    // needProcessKeyOperation should have returned false if local is true
+                    const context = this.makeLocal(op.key, op.value);
                     this.setCore(op.key, context, local, message);
                 },
                 submit: (op: IMapSetOperation, localOpMetadata: unknown) => {

--- a/packages/dds/map/src/mapKernel.ts
+++ b/packages/dds/map/src/mapKernel.ts
@@ -586,9 +586,9 @@ export class MapKernel implements IValueTypeCreator {
      */
     private makeLocal(key: string, serializable: ISerializableValue): ILocalValue {
         if (serializable.type === ValueType[ValueType.Plain] || serializable.type === ValueType[ValueType.Shared]) {
-            return this.localValueMaker.fromSerializablePlainOrShared(serializable);
+            return this.localValueMaker.fromSerializable(serializable);
         } else {
-            return this.localValueMaker.fromSerializableValueEmitter(
+            return this.localValueMaker.fromSerializableValueType(
                 serializable,
                 this.makeMapValueOpEmitter(key),
             );

--- a/packages/dds/map/src/mapKernel.ts
+++ b/packages/dds/map/src/mapKernel.ts
@@ -288,17 +288,19 @@ export class MapKernel implements IValueTypeCreator {
     /**
      * {@inheritDoc ISharedMap.wait}
      */
-    public async wait<T = any>(key: string): Promise<T | undefined> {
+    public async wait<T = any>(key: string): Promise<T> {
         // Return immediately if the value already exists
         if (this.has(key)) {
-            return this.get<T>(key);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            return this.get<T>(key)!;
         }
 
         // Otherwise subscribe to changes
         return new Promise<T>((resolve) => {
             const callback = (changed: IValueChanged) => {
                 if (key === changed.key) {
-                    resolve(this.get<T>(changed.key));
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    resolve(this.get<T>(changed.key)!);
                     this.eventEmitter.removeListener("valueChanged", callback);
                 }
             };

--- a/packages/dds/map/src/test/directory.spec.ts
+++ b/packages/dds/map/src/test/directory.spec.ts
@@ -92,7 +92,7 @@ describe("Directory", () => {
                     assert.equal(valueChangedExpected, true, "valueChange event not expected");
                     valueChangedExpected = false;
 
-                    assert.equal(changed.key, "dwyane");
+                    assert.equal(changed.key, "dwayne");
                     assert.equal(changed.previousValue, previousValue);
                     assert.equal(changed.path, directory.absolutePath);
 
@@ -105,7 +105,7 @@ describe("Directory", () => {
                         "containedValueChanged event not expected for containedValueChanged event");
                     containedValueChangedExpected = false;
 
-                    assert.equal(changed.key, "dwyane");
+                    assert.equal(changed.key, "dwayne");
                     assert.equal(changed.previousValue, previousValue);
 
                     assert.equal(local, true, "local should be true for local action for containedValueChanged event");
@@ -126,7 +126,7 @@ describe("Directory", () => {
 
                 // Test set
                 previousValue = undefined;
-                directory.set("dwyane", "johnson");
+                directory.set("dwayne", "johnson");
                 assert.equal(valueChangedExpected, false, "missing valueChangedExpected event");
                 assert.equal(containedValueChangedExpected, false, "missing containedValueChanged event");
 
@@ -134,7 +134,7 @@ describe("Directory", () => {
                 previousValue = "johnson";
                 valueChangedExpected = true;
                 containedValueChangedExpected = true;
-                directory.delete("dwyane");
+                directory.delete("dwayne");
                 assert.equal(valueChangedExpected, false, "missing valueChangedExpected event");
                 assert.equal(containedValueChangedExpected, false, "missing containedValueChanged event");
 

--- a/packages/dds/map/src/test/directory.spec.ts
+++ b/packages/dds/map/src/test/directory.spec.ts
@@ -181,11 +181,9 @@ describe("Directory", () => {
                 directory.set("testKey", "testValue");
                 assert.equal(directory.get("testKey"), "testValue", "Failed to set testKey");
                 directory.createSubDirectory("testSubDir").set("testSubKey", "testSubValue");
-                assert.equal(
-                    directory.getWorkingDirectory("testSubDir").get("testSubKey"),
-                    "testSubValue",
-                    "Failed to set testSubKey",
-                );
+                const subdir = directory.getWorkingDirectory("testSubDir");
+                assert(subdir);
+                assert.equal(subdir.get("testSubKey"), "testSubValue", "Failed to set testSubKey");
             });
 
             it("Should populate the directory from a basic JSON object (old format)", async () => {
@@ -224,16 +222,16 @@ describe("Directory", () => {
                     },
                 });
                 assert.equal(directory.size, 2, "Failed to initialize directory storage correctly");
-                assert.equal(directory.getWorkingDirectory("/foo").get("testKey"), "testValue");
-                assert.equal(directory.getWorkingDirectory("foo").get("testKey2"), "testValue2");
-                assert.equal(directory.getWorkingDirectory("/bar").get("testKey3"), "testValue3");
-                assert.equal(directory.getWorkingDirectory("").get("testKey"), "testValue4");
-                assert.equal(directory.getWorkingDirectory("/").get("testKey2"), "testValue5");
+                assert.equal(directory.getWorkingDirectory("/foo")?.get("testKey"), "testValue");
+                assert.equal(directory.getWorkingDirectory("foo")?.get("testKey2"), "testValue2");
+                assert.equal(directory.getWorkingDirectory("/bar")?.get("testKey3"), "testValue3");
+                assert.equal(directory.getWorkingDirectory("")?.get("testKey"), "testValue4");
+                assert.equal(directory.getWorkingDirectory("/")?.get("testKey2"), "testValue5");
                 directory.set("testKey", "newValue");
                 assert.equal(directory.get("testKey"), "newValue", "Failed to set testKey");
                 directory.createSubDirectory("testSubDir").set("testSubKey", "newSubValue");
                 assert.equal(
-                    directory.getWorkingDirectory("testSubDir").get("testSubKey"),
+                    directory.getWorkingDirectory("testSubDir")?.get("testSubKey"),
                     "newSubValue",
                     "Failed to set testSubKey",
                 );
@@ -273,18 +271,18 @@ describe("Directory", () => {
                     },
                 });
                 assert.equal(directory.size, 2, "Failed to initialize directory storage correctly");
-                assert.equal(directory.getWorkingDirectory("/foo").get("testKey"), "testValue");
-                assert.equal(directory.getWorkingDirectory("foo").get("testKey2"), undefined);
-                assert.equal(directory.getWorkingDirectory("/bar").get("testKey3"), "testValue3");
-                assert.equal(directory.getWorkingDirectory("").get("testKey"), "testValue4");
-                assert.equal(directory.getWorkingDirectory("/").get("testKey2"), undefined);
+                assert.equal(directory.getWorkingDirectory("/foo")?.get("testKey"), "testValue");
+                assert.equal(directory.getWorkingDirectory("foo")?.get("testKey2"), undefined);
+                assert.equal(directory.getWorkingDirectory("/bar")?.get("testKey3"), "testValue3");
+                assert.equal(directory.getWorkingDirectory("")?.get("testKey"), "testValue4");
+                assert.equal(directory.getWorkingDirectory("/")?.get("testKey2"), undefined);
                 assert.ok(directory.has("testKey2"));
-                assert.ok(directory.getWorkingDirectory("/foo").has("testKey2"));
+                assert.ok(directory.getWorkingDirectory("/foo")?.has("testKey2"));
                 directory.set("testKey", "newValue");
                 assert.equal(directory.get("testKey"), "newValue", "Failed to set testKey");
                 directory.createSubDirectory("testSubDir").set("testSubKey", "newSubValue");
                 assert.equal(
-                    directory.getWorkingDirectory("testSubDir").get("testSubKey"),
+                    directory.getWorkingDirectory("testSubDir")?.get("testSubKey"),
                     "newSubValue",
                     "Failed to set testSubKey",
                 );
@@ -331,8 +329,10 @@ describe("Directory", () => {
 
                 assert.equal(directory2.get("first"), "second");
                 assert.equal(directory2.get("long1"), longWord);
-                assert.equal(directory2.getWorkingDirectory("/nested").get("deepKey1"), "deepValue1");
-                assert.equal(directory2.getWorkingDirectory("/nested").get("long2"), logWord2);
+                const nestedSubDir = directory2.getWorkingDirectory("/nested");
+                assert(nestedSubDir);
+                assert.equal(nestedSubDir.get("deepKey1"), "deepValue1");
+                assert.equal(nestedSubDir.get("long2"), logWord2);
             });
         });
 
@@ -472,14 +472,14 @@ describe("Directory", () => {
                 containerRuntimeFactory.processAllMessages();
 
                 // Verify the local SharedDirectory
-                assert.equal(directory1.getWorkingDirectory("foo").get("testKey"), "testValue");
-                assert.equal(directory1.getWorkingDirectory("foo/").get("testKey2"), "testValue2");
-                assert.equal(directory1.getWorkingDirectory("bar").get("testKey3"), "testValue3");
+                assert.equal(directory1.getWorkingDirectory("foo")?.get("testKey"), "testValue");
+                assert.equal(directory1.getWorkingDirectory("foo/")?.get("testKey2"), "testValue2");
+                assert.equal(directory1.getWorkingDirectory("bar")?.get("testKey3"), "testValue3");
 
                 // Verify the remote SharedDirectory
-                assert.equal(directory2.getWorkingDirectory("foo").get("testKey"), "testValue");
-                assert.equal(directory2.getWorkingDirectory("foo/").get("testKey2"), "testValue2");
-                assert.equal(directory2.getWorkingDirectory("bar").get("testKey3"), "testValue3");
+                assert.equal(directory2.getWorkingDirectory("foo")?.get("testKey"), "testValue");
+                assert.equal(directory2.getWorkingDirectory("foo/")?.get("testKey2"), "testValue2");
+                assert.equal(directory2.getWorkingDirectory("bar")?.get("testKey3"), "testValue3");
             });
 
             it("Can clear keys stored directly under the root", () => {
@@ -495,16 +495,16 @@ describe("Directory", () => {
                 containerRuntimeFactory.processAllMessages();
 
                 // Verify the local SharedDirectory
-                assert.equal(directory1.getWorkingDirectory("/foo/").get("testKey"), "testValue");
-                assert.equal(directory1.getWorkingDirectory("./foo").get("testKey2"), "testValue2");
-                assert.equal(directory1.getWorkingDirectory("bar").get("testKey3"), "testValue3");
+                assert.equal(directory1.getWorkingDirectory("/foo/")?.get("testKey"), "testValue");
+                assert.equal(directory1.getWorkingDirectory("./foo")?.get("testKey2"), "testValue2");
+                assert.equal(directory1.getWorkingDirectory("bar")?.get("testKey3"), "testValue3");
                 assert.equal(directory1.get("testKey"), undefined);
                 assert.equal(directory1.get("testKey2"), undefined);
 
                 // Verify the remote SharedDirectory
-                assert.equal(directory2.getWorkingDirectory("/foo/").get("testKey"), "testValue");
-                assert.equal(directory2.getWorkingDirectory("./foo").get("testKey2"), "testValue2");
-                assert.equal(directory2.getWorkingDirectory("bar").get("testKey3"), "testValue3");
+                assert.equal(directory2.getWorkingDirectory("/foo/")?.get("testKey"), "testValue");
+                assert.equal(directory2.getWorkingDirectory("./foo")?.get("testKey2"), "testValue2");
+                assert.equal(directory2.getWorkingDirectory("bar")?.get("testKey3"), "testValue3");
                 assert.equal(directory2.get("testKey"), undefined);
                 assert.equal(directory2.get("testKey2"), undefined);
             });
@@ -522,16 +522,16 @@ describe("Directory", () => {
                 containerRuntimeFactory.processAllMessages();
 
                 // Verify the local SharedDirectory
-                assert.equal(directory1.getWorkingDirectory("foo").get("testKey"), "testValue");
-                assert.equal(directory1.getWorkingDirectory("foo").get("testKey2"), "testValue2");
-                assert.equal(directory1.getWorkingDirectory("bar").get("testKey3"), "testValue3");
+                assert.equal(directory1.getWorkingDirectory("foo")?.get("testKey"), "testValue");
+                assert.equal(directory1.getWorkingDirectory("foo")?.get("testKey2"), "testValue2");
+                assert.equal(directory1.getWorkingDirectory("bar")?.get("testKey3"), "testValue3");
                 assert.equal(directory1.get("testKey"), "testValue4");
                 assert.equal(directory1.get("testKey2"), undefined);
 
                 // Verify the remote SharedDirectory
-                assert.equal(directory2.getWorkingDirectory("foo").get("testKey"), "testValue");
-                assert.equal(directory2.getWorkingDirectory("foo").get("testKey2"), "testValue2");
-                assert.equal(directory2.getWorkingDirectory("bar").get("testKey3"), "testValue3");
+                assert.equal(directory2.getWorkingDirectory("foo")?.get("testKey"), "testValue");
+                assert.equal(directory2.getWorkingDirectory("foo")?.get("testKey2"), "testValue2");
+                assert.equal(directory2.getWorkingDirectory("bar")?.get("testKey3"), "testValue3");
                 assert.equal(directory2.get("testKey"), "testValue4");
                 assert.equal(directory2.get("testKey2"), undefined);
             });
@@ -620,7 +620,9 @@ describe("Directory", () => {
 
                 // Verify the remote SharedDirectory
                 const fooDirectory2 = directory2.getSubDirectory("foo");
+                assert(fooDirectory2);
                 const barDirectory2 = fooDirectory2.getSubDirectory("bar");
+                assert(barDirectory2);
                 assert.equal(fooDirectory2.absolutePath, "/foo");
                 assert.equal(barDirectory2.absolutePath, "/foo/bar");
             });
@@ -636,6 +638,7 @@ describe("Directory", () => {
 
                 // Verify the local SharedDirectory
                 const testSubdir = directory1.getWorkingDirectory("/foo");
+                assert(testSubdir);
                 assert.equal(testSubdir.has("testKey"), true);
                 assert.equal(testSubdir.has("garbage"), false);
                 assert.equal(testSubdir.get("testKey"), "testValue");
@@ -644,6 +647,7 @@ describe("Directory", () => {
 
                 // Verify the remote SharedDirectory
                 const barSubDir = directory2.getWorkingDirectory("/foo");
+                assert(barSubDir);
                 assert.equal(barSubDir.has("testKey"), true);
                 assert.equal(barSubDir.has("garbage"), false);
                 assert.equal(barSubDir.get("testKey"), "testValue");
@@ -656,10 +660,10 @@ describe("Directory", () => {
                 containerRuntimeFactory.processAllMessages();
 
                 // Verify the local sub directory1
-                assert.equal(directory1.getWorkingDirectory("foo").get("fromSubdir"), "testValue4");
+                assert.equal(directory1.getWorkingDirectory("foo")?.get("fromSubdir"), "testValue4");
 
                 // Verify the remote sub directory1
-                assert.equal(directory1.getWorkingDirectory("foo").get("fromSubdir"), "testValue4");
+                assert.equal(directory2.getWorkingDirectory("foo")?.get("fromSubdir"), "testValue4");
             });
 
             it("raises the containedValueChanged event when keys are set and deleted from a subdirectory", () => {
@@ -668,9 +672,13 @@ describe("Directory", () => {
                 containerRuntimeFactory.processAllMessages();
 
                 const foo1 = directory1.getWorkingDirectory("/foo");
+                assert(foo1);
                 const foo2 = directory2.getWorkingDirectory("/foo");
+                assert(foo2);
                 const bar1 = directory1.getWorkingDirectory("/bar");
+                assert(bar1);
                 const bar2 = directory2.getWorkingDirectory("/bar");
+                assert(bar2);
 
                 let called1 = 0;
                 let called2 = 0;
@@ -707,23 +715,28 @@ describe("Directory", () => {
                 directory1.set("testKey", "testValue4");
                 directory1.set("testKey2", "testValue5");
                 const testSubdir = directory1.getWorkingDirectory("/foo");
+                assert(testSubdir);
                 testSubdir.clear();
 
                 containerRuntimeFactory.processAllMessages();
 
                 // Verify the local SharedDirectory
-                assert.equal(directory1.getWorkingDirectory("foo").get("testKey"), undefined);
-                assert.equal(directory1.getWorkingDirectory("foo").get("testKey2"), undefined);
-                assert.equal(directory1.getWorkingDirectory("bar").get("testKey3"), "testValue3");
-                assert.equal(directory1.getWorkingDirectory("..").get("testKey"), "testValue4");
-                assert.equal(directory1.getWorkingDirectory(".").get("testKey2"), "testValue5");
+                const fooSubDirectory1 = directory1.getWorkingDirectory("foo");
+                assert(fooSubDirectory1);
+                assert.equal(fooSubDirectory1.get("testKey"), undefined);
+                assert.equal(fooSubDirectory1.get("testKey2"), undefined);
+                assert.equal(directory1.getWorkingDirectory("bar")?.get("testKey3"), "testValue3");
+                assert.equal(directory1.getWorkingDirectory("..")?.get("testKey"), "testValue4");
+                assert.equal(directory1.getWorkingDirectory(".")?.get("testKey2"), "testValue5");
 
                 // Verify the remote SharedDirectory
-                assert.equal(directory2.getWorkingDirectory("foo").get("testKey"), undefined);
-                assert.equal(directory2.getWorkingDirectory("foo").get("testKey2"), undefined);
-                assert.equal(directory2.getWorkingDirectory("bar").get("testKey3"), "testValue3");
-                assert.equal(directory2.getWorkingDirectory("..").get("testKey"), "testValue4");
-                assert.equal(directory2.getWorkingDirectory(".").get("testKey2"), "testValue5");
+                const fooSubDirectory2 = directory2.getWorkingDirectory("foo");
+                assert(fooSubDirectory2);
+                assert.equal(fooSubDirectory2.get("testKey"), undefined);
+                assert.equal(fooSubDirectory2.get("testKey2"), undefined);
+                assert.equal(directory2.getWorkingDirectory("bar")?.get("testKey3"), "testValue3");
+                assert.equal(directory2.getWorkingDirectory("..")?.get("testKey"), "testValue4");
+                assert.equal(directory2.getWorkingDirectory(".")?.get("testKey2"), "testValue5");
             });
 
             it("Can delete keys from the subdirectory", () => {
@@ -735,23 +748,33 @@ describe("Directory", () => {
                 directory1.set("testKey", "testValue4");
                 directory1.set("testKey2", "testValue5");
                 const testSubdirFoo = directory1.getWorkingDirectory("/foo");
+                assert(testSubdirFoo);
                 testSubdirFoo.delete("testKey2");
                 const testSubdirBar = directory1.getWorkingDirectory("/bar");
+                assert(testSubdirBar);
                 testSubdirBar.delete("testKey3");
 
                 containerRuntimeFactory.processAllMessages();
 
                 // Verify the local SharedDirectory
-                assert.equal(directory1.getWorkingDirectory("foo").get("testKey"), "testValue");
-                assert.equal(directory1.getWorkingDirectory("foo").get("testKey2"), undefined);
-                assert.equal(directory1.getWorkingDirectory("bar").get("testKey3"), undefined);
+                const fooSubDirectory1 = directory1.getWorkingDirectory("foo");
+                assert(fooSubDirectory1);
+                const barSubDirectory1 = directory1.getWorkingDirectory("bar");
+                assert(barSubDirectory1);
+                assert.equal(fooSubDirectory1.get("testKey"), "testValue");
+                assert.equal(fooSubDirectory1.get("testKey2"), undefined);
+                assert.equal(barSubDirectory1.get("testKey3"), undefined);
                 assert.equal(directory1.get("testKey"), "testValue4");
                 assert.equal(directory1.get("testKey2"), "testValue5");
 
                 // Verify the remote SharedDirectory
-                assert.equal(directory2.getWorkingDirectory("foo").get("testKey"), "testValue");
-                assert.equal(directory2.getWorkingDirectory("foo").get("testKey2"), undefined);
-                assert.equal(directory2.getWorkingDirectory("bar").get("testKey3"), undefined);
+                const fooSubDirectory2 = directory2.getWorkingDirectory("foo");
+                assert(fooSubDirectory2);
+                const barSubDirectory2 = directory2.getWorkingDirectory("bar");
+                assert(barSubDirectory2);
+                assert.equal(fooSubDirectory2.get("testKey"), "testValue");
+                assert.equal(fooSubDirectory2.get("testKey2"), undefined);
+                assert.equal(barSubDirectory2.get("testKey3"), undefined);
                 assert.equal(directory2.get("testKey"), "testValue4");
                 assert.equal(directory2.get("testKey2"), "testValue5");
             });
@@ -769,9 +792,11 @@ describe("Directory", () => {
 
                 // Verify the local SharedDirectory
                 const testSubdirFoo = directory1.getWorkingDirectory("/foo");
+                assert(testSubdirFoo);
                 assert.equal(testSubdirFoo.size, 2);
                 // Verify the remote SharedDirectory
                 const testSubdirFoo2 = directory2.getWorkingDirectory("/foo");
+                assert(testSubdirFoo2);
                 assert.equal(testSubdirFoo2.size, 2);
 
                 testSubdirFoo.delete("testKey2");
@@ -793,6 +818,7 @@ describe("Directory", () => {
                 assert.equal(testSubdirFoo2.size, 1);
 
                 const testSubdirBar = directory1.getWorkingDirectory("/bar");
+                assert(testSubdirBar);
                 testSubdirBar.delete("testKey3");
 
                 // Verify the local SharedDirectory
@@ -862,6 +888,7 @@ describe("Directory", () => {
 
                 // Verify the remote SharedDirectory
                 const barDirectory2 = directory2.getSubDirectory("bar");
+                assert(barDirectory2);
                 assert.equal(barDirectory2.getWorkingDirectory("baz"), undefined);
             });
 
@@ -897,6 +924,7 @@ describe("Directory", () => {
 
                 // Verify the local SharedDirectory
                 const fooSubDir = directory1.getWorkingDirectory("/foo");
+                assert(fooSubDir);
                 const fooSubDirIterator = fooSubDir.keys();
                 const fooSubDirResult1 = fooSubDirIterator.next();
                 assert.equal(fooSubDirResult1.value, "testKey");
@@ -909,6 +937,7 @@ describe("Directory", () => {
                 assert.equal(fooSubDirResult3.done, true);
 
                 const barSubDir = directory1.getWorkingDirectory("/bar");
+                assert(barSubDir);
                 const barSubDirIterator = barSubDir.keys();
                 const barSubDirResult1 = barSubDirIterator.next();
                 assert.equal(barSubDirResult1.value, "testKey3");
@@ -919,6 +948,7 @@ describe("Directory", () => {
 
                 // Verify the remote SharedDirectory
                 const fooSubDir2 = directory2.getWorkingDirectory("/foo");
+                assert(fooSubDir2);
                 const fooSubDir2Iterator = fooSubDir2.keys();
                 const fooSubDir2Result1 = fooSubDir2Iterator.next();
                 assert.equal(fooSubDir2Result1.value, "testKey");
@@ -931,6 +961,7 @@ describe("Directory", () => {
                 assert.equal(fooSubDir2Result3.done, true);
 
                 const barSubDir2 = directory2.getWorkingDirectory("/bar");
+                assert(barSubDir2);
                 const barSubDir2Iterator = barSubDir2.keys();
                 const barSubDir2Result1 = barSubDir2Iterator.next();
                 assert.equal(barSubDir2Result1.value, "testKey3");
@@ -953,6 +984,7 @@ describe("Directory", () => {
 
                 // Verify the local SharedDirectory
                 const fooSubDir = directory1.getWorkingDirectory("/foo");
+                assert(fooSubDir);
                 const fooSubDirIterator = fooSubDir.values();
                 const fooSubDirResult1 = fooSubDirIterator.next();
                 assert.equal(fooSubDirResult1.value, "testValue");
@@ -965,6 +997,7 @@ describe("Directory", () => {
                 assert.equal(fooSubDirResult3.done, true);
 
                 const barSubDir = directory1.getWorkingDirectory("/bar");
+                assert(barSubDir);
                 const barSubDirIterator = barSubDir.values();
                 const barSubDirResult1 = barSubDirIterator.next();
                 assert.equal(barSubDirResult1.value, "testValue3");
@@ -975,6 +1008,7 @@ describe("Directory", () => {
 
                 // Verify the remote SharedDirectory
                 const fooSubDir2 = directory2.getWorkingDirectory("/foo");
+                assert(fooSubDir2);
                 const fooSubDir2Iterator = fooSubDir2.values();
                 const fooSubDir2Result1 = fooSubDir2Iterator.next();
                 assert.equal(fooSubDir2Result1.value, "testValue");
@@ -987,6 +1021,7 @@ describe("Directory", () => {
                 assert.equal(fooSubDir2Result3.done, true);
 
                 const barSubDir2 = directory2.getWorkingDirectory("/bar");
+                assert(barSubDir2);
                 const barSubDir2Iterator = barSubDir2.values();
                 const barSubDir2Result1 = barSubDir2Iterator.next();
                 assert.equal(barSubDir2Result1.value, "testValue3");
@@ -1009,6 +1044,7 @@ describe("Directory", () => {
 
                 // Verify the local SharedDirectory
                 const fooSubDir = directory1.getWorkingDirectory("/foo");
+                assert(fooSubDir);
                 const fooSubDirIterator = fooSubDir.entries();
                 const fooSubDirResult1 = fooSubDirIterator.next();
                 assert.equal(fooSubDirResult1.value[0], "testKey");
@@ -1023,6 +1059,7 @@ describe("Directory", () => {
                 assert.equal(fooSubDirResult3.done, true);
 
                 const barSubDir = directory1.getWorkingDirectory("/bar");
+                assert(barSubDir);
 
                 const expectedEntries = new Set(["testKey3"]);
                 for (const entry of barSubDir) {
@@ -1033,6 +1070,7 @@ describe("Directory", () => {
 
                 // Verify the remote SharedDirectory
                 const fooSubDir2 = directory2.getWorkingDirectory("/foo");
+                assert(fooSubDir2);
                 const fooSubDir2Iterator = fooSubDir2.entries();
                 const fooSubDir2Result1 = fooSubDir2Iterator.next();
                 assert.equal(fooSubDir2Result1.value[0], "testKey");
@@ -1047,6 +1085,7 @@ describe("Directory", () => {
                 assert.equal(fooSubDir2Result3.done, true);
 
                 const barSubDir2 = directory2.getWorkingDirectory("/bar");
+                assert(barSubDir2);
 
                 const expectedEntries2 = new Set(["testKey3"]);
                 for (const entry of barSubDir2) {
@@ -1073,6 +1112,7 @@ describe("Directory", () => {
 
                 // Verify the remote SharedDirectory
                 const fooDirectory2 = directory2.getSubDirectory("foo");
+                assert(fooDirectory2);
                 const expectedDirectories2 = new Set(["bar", "baz"]);
                 for (const [subDirName] of fooDirectory2.subdirectories()) {
                     assert.ok(expectedDirectories2.has(subDirName));

--- a/packages/dds/map/src/test/map.spec.ts
+++ b/packages/dds/map/src/test/map.spec.ts
@@ -54,13 +54,52 @@ describe("Map", () => {
 
             it("should fire correct map events", async () => {
                 const dummyMap = map;
-                let called1: boolean = false;
-                let called2: boolean = false;
-                dummyMap.on("op", (agr1, arg2, arg3) => called1 = true);
-                dummyMap.on("valueChanged", (agr1, arg2, arg3, arg4) => called2 = true);
+                let valueChangedExpected = true;
+                let clearExpected = false;
+                let previousValue: any;
+
+                dummyMap.on("op", (arg1, arg2, arg3) => {
+                    assert.fail("shouldn't receive an op event");
+                });
+                dummyMap.on("valueChanged", (changed, local, op, target) => {
+                    assert.equal(valueChangedExpected, true, "valueChange event not expected");
+                    valueChangedExpected = false;
+
+                    assert.equal(changed.key, "marco");
+                    assert.equal(changed.previousValue, previousValue);
+
+                    assert.equal(local, true, "local should be true for local action for valueChanged event");
+                    assert.equal(op, null, "op should be null for local actions for valueChanged event");
+                    assert.equal(target, dummyMap, "target should be the map for valueChanged event");
+                });
+                dummyMap.on("clear", (local, op, target) => {
+                    assert.equal(clearExpected, true, "clear event not expected");
+                    clearExpected = false;
+
+                    assert.equal(local, true, "local should be true for local action  for clear event");
+                    assert.equal(op, null, "op should be null for local actions for clear event");
+                    assert.equal(target, dummyMap, "target should be the map for clear event");
+                });
+                dummyMap.on("error", (error) => {
+                    // propagate error in the event handlers
+                    throw error;
+                });
+
+                // Test set
+                previousValue = undefined;
                 dummyMap.set("marco", "polo");
-                assert.equal(called1, false, "did not receive op event");
-                assert.equal(called2, true, "did not receive valueChanged event");
+                assert.equal(valueChangedExpected, false, "missing valueChanged event");
+
+                // Test delete
+                previousValue = "polo";
+                valueChangedExpected = true;
+                dummyMap.delete("marco");
+                assert.equal(valueChangedExpected, false, "missing valueChanged event");
+
+                // Test clear
+                clearExpected = true;
+                dummyMap.clear();
+                assert.equal(clearExpected, false, "missing clear event");
             });
 
             it("Should return undefined when a key does not exist in the map", () => {

--- a/packages/dds/map/src/test/map.spec.ts
+++ b/packages/dds/map/src/test/map.spec.ts
@@ -363,11 +363,13 @@ describe("Map", () => {
 
                     // Verify the local SharedMap
                     const localSubMap = map1.get<IFluidHandle>("test");
+                    assert(localSubMap);
                     assert.equal(
                         localSubMap.absolutePath, subMap.handle.absolutePath, "could not get the handle's path");
 
                     // Verify the remote SharedMap
                     const remoteSubMap = map2.get<IFluidHandle>("test");
+                    assert(remoteSubMap);
                     assert.equal(
                         remoteSubMap.absolutePath,
                         subMap.handle.absolutePath,

--- a/packages/dds/matrix/test/matrix.stress.spec.ts
+++ b/packages/dds/matrix/test/matrix.stress.spec.ts
@@ -266,7 +266,7 @@ describe("Matrix", () => {
             it(`Stress (numClients=${numClients} numOps=${numOps} syncProbability=${syncProbability} disconnectProbability=${disconnectProbability} seed=0x${seed.toString(16).padStart(8, "0")})`,
                 // Note: Must use 'function' rather than arrow '() => { .. }' in order to set 'this.timeout(..)'
                 async function () {
-                    this.timeout(10000);
+                    this.timeout(15000);
 
                     await stress(numClients, numOps, syncProbability, disconnectProbability, seed);
                 }

--- a/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
@@ -62,7 +62,7 @@ function createSubDirectoryWithInterception<T extends IDirectory>(
         return createSubDirectoryWithInterception(baseDirectory, subSubDirectory, context, setInterceptionCallback);
     };
 
-    subDirectoryWithInterception.getSubDirectory = (subdirName: string): IDirectory => {
+    subDirectoryWithInterception.getSubDirectory = (subdirName: string): IDirectory | undefined => {
         const subSubDirectory = subDirectory.getSubDirectory(subdirName);
         return subSubDirectory === undefined ?
             subSubDirectory :
@@ -94,8 +94,9 @@ function createSubDirectoryWithInterception<T extends IDirectory>(
         return iterator;
     };
 
-    subDirectoryWithInterception.getWorkingDirectory = (relativePath: string): IDirectory => {
+    subDirectoryWithInterception.getWorkingDirectory = (relativePath: string): IDirectory | undefined => {
         const subSubDirectory = subDirectory.getWorkingDirectory(relativePath);
+        if (!subSubDirectory) { return undefined; }
         return createSubDirectoryWithInterception(baseDirectory, subSubDirectory, context, setInterceptionCallback);
     };
 

--- a/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
@@ -96,8 +96,9 @@ function createSubDirectoryWithInterception<T extends IDirectory>(
 
     subDirectoryWithInterception.getWorkingDirectory = (relativePath: string): IDirectory | undefined => {
         const subSubDirectory = subDirectory.getWorkingDirectory(relativePath);
-        if (!subSubDirectory) { return undefined; }
-        return createSubDirectoryWithInterception(baseDirectory, subSubDirectory, context, setInterceptionCallback);
+        return subSubDirectory === undefined ?
+            subSubDirectory :
+            createSubDirectoryWithInterception(baseDirectory, subSubDirectory, context, setInterceptionCallback);
     };
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return

--- a/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
@@ -225,7 +225,7 @@ describe("Shared Directory with Interception", () => {
             verifySubDirectoryArrtibution(bar, key, value, userAttributes);
         });
 
-        it("should be able to get a wrapped subDirectory via getSubDirectory and getWorkingDirectory", async () => {
+        it("should be able to get a wrapped subDirectory via getSubDirectory/getWorkingDirectory", async () => {
             const root = createDirectoryWithInterception(sharedDirectory, dataStoreContext, subDirectoryinterceptionCb);
 
             // Create a sub directory and get it via getSubDirectory.
@@ -249,6 +249,16 @@ describe("Shared Directory with Interception", () => {
             value = "read";
             bar.set(key, value);
             verifySubDirectoryArrtibution(bar, key, value, userAttributes);
+        });
+
+        it("should get undefined for non-existent subDirectory via getSubDirectory/getWorkingDirectory", async () => {
+            const root = createDirectoryWithInterception(sharedDirectory, dataStoreContext, subDirectoryinterceptionCb);
+
+            const foo = root.getSubDirectory("foo");
+            assert.strictEqual(foo, undefined);
+
+            const bar = root.getWorkingDirectory("bar");
+            assert.strictEqual(bar, undefined);
         });
 
         /**

--- a/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
@@ -25,6 +25,7 @@ describe("Shared Directory with Interception", () => {
             }
 
             let currentSubDir = root.getSubDirectory(attributionDirectoryName);
+            assert(currentSubDir);
             if (path === "/") {
                 return currentSubDir;
             }
@@ -58,7 +59,7 @@ describe("Shared Directory with Interception", () => {
 
         /**
          * This callback creates / gets an attribution directory that is a subdirectory of the given directory. It sets
-         * the user attribute in the attribution directory againist the same key used in the original set.
+         * the user attribute in the attribution directory against the same key used in the original set.
          * For example - For directory /foo, it sets the attribute in /foo/attribute
          */
         function subDirectoryinterceptionCb(
@@ -69,7 +70,8 @@ describe("Shared Directory with Interception", () => {
             if (!subDirectory.hasSubDirectory(attributionDirectoryName)) {
                 subDirectory.createSubDirectory(attributionDirectoryName);
             }
-            const attributionDirectory: IDirectory = subDirectory.getSubDirectory(attributionDirectoryName);
+            const attributionDirectory = subDirectory.getSubDirectory(attributionDirectoryName);
+            assert(attributionDirectory);
             attributionDirectory.set(key, userAttributes);
         }
 
@@ -100,6 +102,7 @@ describe("Shared Directory with Interception", () => {
             assert.equal(directory.get(key), value, "The retrieved value should match the value that was set");
 
             const attributionDir = directory.getSubDirectory(attributionDirectoryName);
+            assert(attributionDir);
             if (props === undefined) {
                 assert.equal(
                     attributionDir,
@@ -158,6 +161,7 @@ describe("Shared Directory with Interception", () => {
             // Verify that attribution directory `/attribution` was created for root and the user attribute
             // set on it.
             const rootAttribution = root.getSubDirectory(attributionDirectoryName);
+            assert(rootAttribution);
             assert.equal(
                 rootAttribution.get(key), userAttributes, "The user attrributes set via callback should exist");
 
@@ -170,6 +174,7 @@ describe("Shared Directory with Interception", () => {
             // Verify that attribution directory `/attribution/foo` was created for /foo and the user attribute
             // set on it.
             const fooAttribution = rootAttribution.getSubDirectory("foo");
+            assert(fooAttribution);
             assert.equal(
                 fooAttribution.get(key), userAttributes, "The user attributes set via callback should exist");
 
@@ -182,6 +187,7 @@ describe("Shared Directory with Interception", () => {
             // Verify that attribution directory `/attribution/foo/bar` was created for /foo/bar and the user
             // attribute set on it.
             const barAttribution = fooAttribution.getSubDirectory("bar");
+            assert(barAttribution);
             assert.equal(
                 barAttribution.get(key), userAttributes, "The user attributes set via callback should exist");
         });
@@ -225,6 +231,8 @@ describe("Shared Directory with Interception", () => {
             // Create a sub directory and get it via getSubDirectory.
             root.createSubDirectory("foo");
             const foo = root.getSubDirectory("foo");
+            assert(foo);
+
             // Set a key and verify that user attribute is set via the interception callback.
             let key: string = "color";
             let value: string = "green";
@@ -234,6 +242,8 @@ describe("Shared Directory with Interception", () => {
             // Create a sub directory via the unwrapped object and get its working directory via the wrapper.
             sharedDirectory.createSubDirectory("bar");
             const bar = root.getWorkingDirectory("bar");
+            assert(bar);
+
             // Set a key and verify that user attribute is set via the interception callback.
             key = "permission";
             value = "read";

--- a/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
@@ -98,7 +98,7 @@ describe("Shared Directory with Interception", () => {
 
         // Verifies that the props are stored correctly in the attribution sub directory - a sub directory
         // of the given directory with name `attributionDirectoryName`.
-        function verifySubDirectoryArrtibution(directory: IDirectory, key: string, value: string, props?: any) {
+        function verifySubDirectoryAttribution(directory: IDirectory, key: string, value: string, props?: any) {
             assert.equal(directory.get(key), value, "The retrieved value should match the value that was set");
 
             const attributionDir = directory.getSubDirectory(attributionDirectoryName);
@@ -210,19 +210,19 @@ describe("Shared Directory with Interception", () => {
             const key: string = "level";
             let value: string = "root";
             root.set(key, value);
-            verifySubDirectoryArrtibution(root, key, value, userAttributes);
+            verifySubDirectoryAttribution(root, key, value, userAttributes);
 
             // Create the level 1 directory `/foo`.
             const foo = root.createSubDirectory("foo");
             value = "level1";
             foo.set(key, value);
-            verifySubDirectoryArrtibution(foo, key, value, userAttributes);
+            verifySubDirectoryAttribution(foo, key, value, userAttributes);
 
             // Create the level 2 directory `/foo/bar`.
             const bar = foo.createSubDirectory("bar");
             value = "level2";
             bar.set(key, value);
-            verifySubDirectoryArrtibution(bar, key, value, userAttributes);
+            verifySubDirectoryAttribution(bar, key, value, userAttributes);
         });
 
         it("should be able to get a wrapped subDirectory via getSubDirectory/getWorkingDirectory", async () => {
@@ -237,7 +237,7 @@ describe("Shared Directory with Interception", () => {
             let key: string = "color";
             let value: string = "green";
             foo.set(key, value);
-            verifySubDirectoryArrtibution(foo, key, value, userAttributes);
+            verifySubDirectoryAttribution(foo, key, value, userAttributes);
 
             // Create a sub directory via the unwrapped object and get its working directory via the wrapper.
             sharedDirectory.createSubDirectory("bar");
@@ -248,7 +248,7 @@ describe("Shared Directory with Interception", () => {
             key = "permission";
             value = "read";
             bar.set(key, value);
-            verifySubDirectoryArrtibution(bar, key, value, userAttributes);
+            verifySubDirectoryAttribution(bar, key, value, userAttributes);
         });
 
         it("should get undefined for non-existent subDirectory via getSubDirectory/getWorkingDirectory", async () => {

--- a/packages/framework/last-edited-experimental/src/lastEditedTrackerDataObject.ts
+++ b/packages/framework/last-edited-experimental/src/lastEditedTrackerDataObject.ts
@@ -46,7 +46,8 @@ export class LastEditedTrackerDataObject extends DataObject
 
     protected async hasInitialized() { // hasInitialized
         const sharedSummaryBlock =
-            await this.root.get<IFluidHandle<SharedSummaryBlock>>(this.sharedSummaryBlockId).get();
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            await this.root.get<IFluidHandle<SharedSummaryBlock>>(this.sharedSummaryBlockId)!.get();
         this._lastEditedTracker = new LastEditedTracker(sharedSummaryBlock);
     }
 }

--- a/packages/framework/react/src/helpers/setFluidState.ts
+++ b/packages/framework/react/src/helpers/setFluidState.ts
@@ -37,8 +37,11 @@ export function setFluidState<SV, SF>(
     const storedStateHandle = syncedState.get<IFluidHandle>(
         `syncedState-${syncedStateId}`,
     );
-    let storedState = fluidObjectMap.get(storedStateHandle?.absolutePath)
-        ?.fluidObject as ISharedMap;
+    let storedState: ISharedMap | undefined;
+    if (storedStateHandle) {
+        storedState = fluidObjectMap.get(storedStateHandle.absolutePath)
+            ?.fluidObject as ISharedMap;
+    }
     if (storedStateHandle === undefined || storedState === undefined) {
         const newState = SharedMap.create(runtime);
         fluidObjectMap.set(newState.handle.absolutePath, {

--- a/packages/framework/react/src/interface.ts
+++ b/packages/framework/react/src/interface.ts
@@ -608,7 +608,7 @@ export interface ISyncedState {
     /**
      * Get values from the synced state for a syncedStateId as key
      */
-    get: <T, >(key: string) => T;
+    get: <T, >(key: string) => T | undefined;
     /**
      * Add a listener to the synced state using a provided callback
      */

--- a/packages/runtime/agent-scheduler/src/scheduler.ts
+++ b/packages/runtime/agent-scheduler/src/scheduler.ts
@@ -44,6 +44,7 @@ class AgentScheduler extends EventEmitter implements IAgentScheduler {
         } else {
             root = await runtime.getChannel("root") as ISharedMap;
             const handle = await root.wait<IFluidHandle<ConsensusRegisterCollection<string | null>>>("scheduler");
+            assert(handle !== undefined);
             scheduler = await handle.get();
         }
         const agentScheduler = new AgentScheduler(runtime, context, scheduler);

--- a/packages/test/end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/blobs.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import { IsoBuffer } from "@fluidframework/common-utils";
 import { ContainerMessageType } from "@fluidframework/container-runtime";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
@@ -51,6 +51,7 @@ const tests = (args: ITestObjectProvider) => {
         const dataStore2 = await requestFluidObject<TestDataObject>(container2, "default");
 
         const blobHandle = await dataStore2._root.wait<IFluidHandle<ArrayBufferLike>>(testKey);
+        assert(blobHandle);
         assert.strictEqual(IsoBuffer.from(await blobHandle.get()).toString("utf-8"), testString);
     });
 
@@ -125,8 +126,8 @@ const tests = (args: ITestObjectProvider) => {
         // validate on remote container, local container, and container loaded from summary
         for (const container of [container1, container2, await args.loadTestContainer(testContainerConfig)]) {
             const dataStore2 = await requestFluidObject<TestDataObject>(container, "default");
-            const handle: IFluidHandle<SharedString> =
-                await dataStore2._root.wait("sharedString");
+            const handle = await dataStore2._root.wait<IFluidHandle<SharedString>>("sharedString");
+            assert(handle);
             const sharedString2 = await handle.get();
 
             const props = sharedString2.getPropertiesAtPosition(0);

--- a/packages/test/end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
@@ -81,6 +81,8 @@ function generate(
                 sharedMap2.wait<IFluidHandle<IConsensusOrderedCollection>>("collection"),
                 sharedMap3.wait<IFluidHandle<IConsensusOrderedCollection>>("collection"),
             ]);
+            assert(collection2Handle);
+            assert(collection3Handle);
             const collection2 = await collection2Handle.get();
             const collection3 = await collection3Handle.get();
 
@@ -111,6 +113,8 @@ function generate(
                 sharedMap2.wait<IFluidHandle<IConsensusOrderedCollection>>("collection"),
                 sharedMap3.wait<IFluidHandle<IConsensusOrderedCollection>>("collection"),
             ]);
+            assert(collection2Handle);
+            assert(collection3Handle);
             const collection2 = await collection2Handle.get();
             const collection3 = await collection3Handle.get();
 
@@ -151,6 +155,8 @@ function generate(
                 sharedMap2.wait<IFluidHandle<IConsensusOrderedCollection>>("collection"),
                 sharedMap3.wait<IFluidHandle<IConsensusOrderedCollection>>("collection"),
             ]);
+            assert(collection2Handle);
+            assert(collection3Handle);
             const collection2 = await collection2Handle.get();
             const collection3 = await collection3Handle.get();
 
@@ -208,6 +214,7 @@ function generate(
             // Pull the collection off of the 2nd container
             const collection2Handle =
                 await sharedMap2.wait<IFluidHandle<IConsensusOrderedCollection>>("collection");
+            assert(collection2Handle);
             const collection2 = await collection2Handle.get();
 
             // acquire one handle in each container
@@ -226,6 +233,7 @@ function generate(
 
             const collection2Handle =
                 await sharedMap2.wait<IFluidHandle<IConsensusOrderedCollection>>("collection");
+            assert(collection2Handle);
             const collection2 = await collection2Handle.get();
 
             await collection1.add("testValue");
@@ -247,6 +255,7 @@ function generate(
 
             const collection2Handle =
                 await sharedMap2.wait<IFluidHandle<IConsensusOrderedCollection>>("collection");
+            assert(collection2Handle);
             const collection2 = await collection2Handle.get();
 
             let waitRejected = false;
@@ -269,6 +278,8 @@ function generate(
                 sharedMap2.wait<IFluidHandle<IConsensusOrderedCollection>>("collection"),
                 sharedMap3.wait<IFluidHandle<IConsensusOrderedCollection>>("collection"),
             ]);
+            assert(collection2Handle);
+            assert(collection3Handle);
             const collection2 = await collection2Handle.get();
             const collection3 = await collection3Handle.get();
             await args.opProcessingController.pauseProcessing();

--- a/packages/test/end-to-end-tests/src/test/consensusRegisterCollectionEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/consensusRegisterCollectionEndToEndTests.spec.ts
@@ -72,6 +72,8 @@ function generate(name: string, ctor: ISharedObjectConstructor<IConsensusRegiste
                 sharedMap2.wait<IFluidHandle<IConsensusRegisterCollection>>("collection"),
                 sharedMap3.wait<IFluidHandle<IConsensusRegisterCollection>>("collection"),
             ]);
+            assert(collection2Handle);
+            assert(collection3Handle);
             const collection2 = await collection2Handle.get();
             const collection3 = await collection3Handle.get();
 
@@ -95,6 +97,8 @@ function generate(name: string, ctor: ISharedObjectConstructor<IConsensusRegiste
                 sharedMap2.wait<IFluidHandle<IConsensusRegisterCollection>>("collection"),
                 sharedMap3.wait<IFluidHandle<IConsensusRegisterCollection>>("collection"),
             ]);
+            assert(collection2Handle);
+            assert(collection3Handle);
             const collection2 = await collection2Handle.get();
             const collection3 = await collection3Handle.get();
 
@@ -122,6 +126,8 @@ function generate(name: string, ctor: ISharedObjectConstructor<IConsensusRegiste
                 sharedMap2.wait<IFluidHandle<IConsensusRegisterCollection>>("collection"),
                 sharedMap3.wait<IFluidHandle<IConsensusRegisterCollection>>("collection"),
             ]);
+            assert(collection2Handle);
+            assert(collection3Handle);
             const collection2 = await collection2Handle.get();
             const collection3 = await collection3Handle.get();
 
@@ -180,6 +186,7 @@ function generate(name: string, ctor: ISharedObjectConstructor<IConsensusRegiste
             // Pull the collection off of the 2nd container
             const collection2Handle =
                 await sharedMap2.wait<IFluidHandle<IConsensusRegisterCollection>>("collection");
+            assert(collection2Handle);
             const collection2 = await collection2Handle.get();
 
             // acquire one handle in each container

--- a/packages/test/end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -498,7 +498,6 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         assert.strictEqual(dataStore2FromRC.runtime.id, dataStore2.runtime.id, "DataStore2 id should match");
     });
 
-    // eslint-disable-next-line max-len
     it("Container rehydration with not bounded data store handle stored in root of bound dataStore. The not bounded" +
         "data store also stores handle not bounded dds",
     async () => {

--- a/packages/test/end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
@@ -52,11 +52,11 @@ const tests = (args: ITestObjectProvider) => {
     });
 
     function expectAllValues(msg, key, path, value1, value2, value3) {
-        const user1Value = sharedDirectory1.getWorkingDirectory(path).get(key);
+        const user1Value = sharedDirectory1.getWorkingDirectory(path)?.get(key);
         assert.equal(user1Value, value1, `Incorrect value for ${key} in container 1 ${msg}`);
-        const user2Value = sharedDirectory2.getWorkingDirectory(path).get(key);
+        const user2Value = sharedDirectory2.getWorkingDirectory(path)?.get(key);
         assert.equal(user2Value, value2, `Incorrect value for ${key} in container 2 ${msg}`);
-        const user3Value = sharedDirectory3.getWorkingDirectory(path).get(key);
+        const user3Value = sharedDirectory3.getWorkingDirectory(path)?.get(key);
         assert.equal(user3Value, value3, `Incorrect value for ${key} in container 3 ${msg}`);
     }
 
@@ -72,6 +72,10 @@ const tests = (args: ITestObjectProvider) => {
         const dir1 = path ? sharedDirectory1.getWorkingDirectory(path) : sharedDirectory1;
         const dir2 = path ? sharedDirectory2.getWorkingDirectory(path) : sharedDirectory2;
         const dir3 = path ? sharedDirectory3.getWorkingDirectory(path) : sharedDirectory3;
+
+        assert(dir1);
+        assert(dir2);
+        assert(dir3);
 
         const keys1 = Array.from(dir1.keys());
         assert.equal(keys1.length, size, "Incorrect number of Keys in container 1");
@@ -146,6 +150,7 @@ const tests = (args: ITestObjectProvider) => {
             let user3ValueChangedCount: number = 0;
             sharedDirectory1.on("valueChanged", (changed, local, msg) => {
                 if (!local) {
+                    assert(msg);
                     if (msg.type === MessageType.Operation) {
                         assert.equal(changed.key, "testKey1", "Incorrect value for testKey1 in container 1");
                         user1ValueChangedCount = user1ValueChangedCount + 1;
@@ -154,6 +159,7 @@ const tests = (args: ITestObjectProvider) => {
             });
             sharedDirectory2.on("valueChanged", (changed, local, msg) => {
                 if (!local) {
+                    assert(msg);
                     if (msg.type === MessageType.Operation) {
                         assert.equal(changed.key, "testKey1", "Incorrect value for testKey1 in container 2");
                         user2ValueChangedCount = user2ValueChangedCount + 1;
@@ -162,6 +168,7 @@ const tests = (args: ITestObjectProvider) => {
             });
             sharedDirectory3.on("valueChanged", (changed, local, msg) => {
                 if (!local) {
+                    assert(msg);
                     if (msg.type === MessageType.Operation) {
                         assert.equal(changed.key, "testKey1", "Incorrect value for testKey1 in container 3");
                         user3ValueChangedCount = user3ValueChangedCount + 1;
@@ -294,9 +301,9 @@ const tests = (args: ITestObjectProvider) => {
                 await args.opProcessingController.process();
 
                 const [map1, map2, map3] = await Promise.all([
-                    sharedDirectory1.get<IFluidHandle<ISharedMap>>("mapKey").get(),
-                    sharedDirectory2.get<IFluidHandle<ISharedMap>>("mapKey").get(),
-                    sharedDirectory3.get<IFluidHandle<ISharedMap>>("mapKey").get(),
+                    sharedDirectory1.get<IFluidHandle<ISharedMap>>("mapKey")?.get(),
+                    sharedDirectory2.get<IFluidHandle<ISharedMap>>("mapKey")?.get(),
+                    sharedDirectory3.get<IFluidHandle<ISharedMap>>("mapKey")?.get(),
                 ]);
 
                 assert.ok(map1, "Map did not correctly set as value in container 1");
@@ -328,6 +335,7 @@ const tests = (args: ITestObjectProvider) => {
 
             expectAllAfterValues("testKey1", "testSubDir1", "testValue1");
             const subDir1 = sharedDirectory3.getWorkingDirectory("testSubDir1");
+            assert(subDir1);
             subDir1.delete("testKey1");
 
             await args.opProcessingController.process();
@@ -367,7 +375,7 @@ const tests = (args: ITestObjectProvider) => {
             await args.opProcessingController.process();
 
             expectAllSize(2, "testSubDir1");
-            sharedDirectory3.getWorkingDirectory("testSubDir1").clear();
+            sharedDirectory3.getWorkingDirectory("testSubDir1")?.clear();
 
             await args.opProcessingController.process();
 
@@ -380,6 +388,7 @@ const tests = (args: ITestObjectProvider) => {
             let user3ValueChangedCount: number = 0;
             sharedDirectory1.on("valueChanged", (changed, local, msg) => {
                 if (!local) {
+                    assert(msg);
                     if (msg.type === MessageType.Operation) {
                         assert.equal(changed.key, "testKey1", "Incorrect value for key in container 1");
                         assert.equal(changed.path, "/testSubDir1", "Incorrect value for path in container 1");
@@ -389,6 +398,7 @@ const tests = (args: ITestObjectProvider) => {
             });
             sharedDirectory2.on("valueChanged", (changed, local, msg) => {
                 if (!local) {
+                    assert(msg);
                     if (msg.type === MessageType.Operation) {
                         assert.equal(changed.key, "testKey1", "Incorrect value for key in container 2");
                         assert.equal(changed.path, "/testSubDir1", "Incorrect value for path in container 2");
@@ -398,6 +408,7 @@ const tests = (args: ITestObjectProvider) => {
             });
             sharedDirectory3.on("valueChanged", (changed, local, msg) => {
                 if (!local) {
+                    assert(msg);
                     if (msg.type === MessageType.Operation) {
                         assert.equal(changed.key, "testKey1", "Incorrect value for key in container 3");
                         assert.equal(changed.path, "/testSubDir1", "Incorrect value for path in container 3");
@@ -561,10 +572,11 @@ const tests = (args: ITestObjectProvider) => {
 
                 await args.opProcessingController.process();
 
-                // The new directory should be availble in the remote client and it should contain that key that was
+                // The new directory should be available in the remote client and it should contain that key that was
                 // set in local state.
-                const newDirectory2
-                    = await sharedDirectory2.get<IFluidHandle<SharedDirectory>>("newSharedDirectory").get();
+                const newDirectory2Handle = sharedDirectory2.get<IFluidHandle<SharedDirectory>>("newSharedDirectory");
+                assert(newDirectory2Handle);
+                const newDirectory2 = await newDirectory2Handle.get();
                 assert.equal(
                     newDirectory2.get("newKey"),
                     "newValue",
@@ -599,10 +611,11 @@ const tests = (args: ITestObjectProvider) => {
 
                 await args.opProcessingController.process();
 
-                // The new directory should be availble in the remote client and it should contain that key that was
+                // The new directory should be available in the remote client and it should contain that key that was
                 // set in local state.
-                const newDirectory2
-                    = await sharedDirectory2.get<IFluidHandle<SharedDirectory>>("newSharedDirectory").get();
+                const newDirectory2Handle = sharedDirectory2.get<IFluidHandle<SharedDirectory>>("newSharedDirectory");
+                assert(newDirectory2Handle);
+                const newDirectory2 = await newDirectory2Handle.get();
                 assert.ok(
                     newDirectory2.getSubDirectory(subDirName),
                     "The subdirectory created in local state is not available in directory 2");

--- a/packages/test/end-to-end-tests/src/test/fluidObjectHandle.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/fluidObjectHandle.spec.ts
@@ -91,6 +91,7 @@ const tests = (args: ITestObjectProvider) => {
 
         // Get the handle in the remote client.
         const remoteSharedMapHandle = secondContainerObject1._root.get<IFluidHandle<SharedMap>>("sharedMap");
+        assert(remoteSharedMapHandle);
 
         // Verify that the remote client's handle has the correct absolute path.
         assert.equal(remoteSharedMapHandle.absolutePath, absolutePath, "The remote handle's path is incorrect");
@@ -121,6 +122,7 @@ const tests = (args: ITestObjectProvider) => {
 
         // Get the handle in the remote client.
         const remoteSharedMapHandle = secondContainerObject1._root.get<IFluidHandle<SharedMap>>("sharedMap");
+        assert(remoteSharedMapHandle);
 
         // Verify that the remote client's handle has the correct absolute path.
         assert.equal(remoteSharedMapHandle.absolutePath, absolutePath, "The remote handle's path is incorrect");
@@ -149,6 +151,7 @@ const tests = (args: ITestObjectProvider) => {
         // Get the handle in the remote client.
         const remoteDataObjectHandle =
             secondContainerObject1._root.get<IFluidHandle<TestFluidObject>>("dataObject2");
+        assert(remoteDataObjectHandle);
 
         // Verify that the remote client's handle has the correct absolute path.
         assert.equal(remoteDataObjectHandle.absolutePath, absolutePath, "The remote handle's path is incorrect");

--- a/packages/test/end-to-end-tests/src/test/localLoader.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/localLoader.spec.ts
@@ -72,6 +72,7 @@ export class TestDataObject extends DataObject {
 
     protected async hasInitialized() {
         const counterHandle = await this.root.wait<IFluidHandle<SharedCounter>>(counterKey);
+        assert(counterHandle);
         this.counter = await counterHandle.get();
     }
 }

--- a/packages/test/end-to-end-tests/src/test/mapEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/mapEndToEndTests.spec.ts
@@ -124,6 +124,7 @@ const tests = (args: ITestObjectProvider) => {
         let user3ValueChangedCount: number = 0;
         sharedMap1.on("valueChanged", (changed, local, msg) => {
             if (!local) {
+                assert(msg);
                 if (msg.type === MessageType.Operation) {
                     assert.equal(changed.key, "testKey1", "Incorrect value for testKey1 in container 1");
                     user1ValueChangedCount = user1ValueChangedCount + 1;
@@ -132,6 +133,7 @@ const tests = (args: ITestObjectProvider) => {
         });
         sharedMap2.on("valueChanged", (changed, local, msg) => {
             if (!local) {
+                assert(msg);
                 if (msg.type === MessageType.Operation) {
                     assert.equal(changed.key, "testKey1", "Incorrect value for testKey1 in container 2");
                     user2ValueChangedCount = user2ValueChangedCount + 1;
@@ -140,6 +142,7 @@ const tests = (args: ITestObjectProvider) => {
         });
         sharedMap3.on("valueChanged", (changed, local, msg) => {
             if (!local) {
+                assert(msg);
                 if (msg.type === MessageType.Operation) {
                     assert.equal(changed.key, "testKey1", "Incorrect value for testKey1 in container 3");
                     user3ValueChangedCount = user3ValueChangedCount + 1;
@@ -283,9 +286,10 @@ const tests = (args: ITestObjectProvider) => {
 
         await args.opProcessingController.process();
 
-        // The new map should be availble in the remote client and it should contain that key that was
+        // The new map should be available in the remote client and it should contain that key that was
         // set in local state.
-        const newSharedMap2 = await sharedMap2.get<IFluidHandle<SharedMap>>("newSharedMap").get();
+        const newSharedMap2 = await sharedMap2.get<IFluidHandle<SharedMap>>("newSharedMap")?.get();
+        assert(newSharedMap2);
         assert.equal(newSharedMap2.get("newKey"), "newValue", "The data set in local state is not available in map 2");
 
         // Set a new value for the same key in the remote map.

--- a/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
@@ -286,9 +286,11 @@ describe("Ops on Reconnect", () => {
 
             // Get dataObject2 in the second container.
             const container2Object1Map1 = await container2Object1.getSharedObject<SharedMap>(map1Id);
-            const container2Object2 =
-                await container2Object1Map1.get<
-                    IFluidHandle<ITestFluidObject & IFluidLoadable>>("dataStore2Key").get();
+            assert(container2Object1Map1);
+            const container2Object2Handle =
+                container2Object1Map1.get<IFluidHandle<ITestFluidObject & IFluidLoadable>>("dataStore2Key");
+            assert(container2Object2Handle);
+            const container2Object2 = await container2Object2Handle.get();
             assert.ok(container2Object2, "Could not get dataStore2 in the second container");
 
             // Disconnect the client.
@@ -388,9 +390,10 @@ describe("Ops on Reconnect", () => {
 
             // Get dataObject2 in the second container.
             const container2Object1Map1 = await container2Object1.getSharedObject<SharedMap>(map1Id);
-            const container2Object2 =
-                await container2Object1Map1.get<
-                    IFluidHandle<ITestFluidObject & IFluidLoadable>>("dataStore2Key").get();
+            const container2Object2Handle =
+                container2Object1Map1.get<IFluidHandle<ITestFluidObject & IFluidLoadable>>("dataStore2Key");
+            assert(container2Object2Handle);
+            const container2Object2 = await container2Object2Handle.get();
             assert.ok(container2Object2, "Could not get dataStore2 in the second container");
 
             // Set values in the DDSes across the two dataStores interleaved with each other.

--- a/packages/test/end-to-end-tests/src/test/primedComponent.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/primedComponent.spec.ts
@@ -37,12 +37,14 @@ const tests = (args: ITestObjectProvider) => {
         dataObject.root.set("key", handle);
 
         const handle2 = dataObject.root.get<IFluidHandle<string>>("key");
+        assert(handle2, "blob Handle not found");
         const value2 = await handle2.get();
         assert(value2 === "aaaa", "Could not get blob from shared object in the dataObject");
 
         const container2 = await args.loadTestContainer() as Container;
         const dataObject2 = await requestFluidObject<TestDataObject>(container2, "default");
         const blobHandle = await dataObject2.root.wait<IFluidHandle<string>>("key");
+        assert(blobHandle, "blob Handle not found");
         const value = await blobHandle.get();
         assert(value === "aaaa", "Blob value not synced across containers");
     });

--- a/packages/test/end-to-end-tests/src/test/sharedInterval.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/sharedInterval.spec.ts
@@ -255,9 +255,9 @@ const tests = (args: ITestObjectProvider) => {
             sharedMap1.set("outerString", SharedString.create(dataObject1.runtime).handle);
             await args.opProcessingController.process();
 
-            const outerString1 = await sharedMap1.get<IFluidHandle<SharedString>>("outerString").get();
-            const outerString2 = await sharedMap2.get<IFluidHandle<SharedString>>("outerString").get();
-            const outerString3 = await sharedMap3.get<IFluidHandle<SharedString>>("outerString").get();
+            const outerString1 = await sharedMap1.get<IFluidHandle<SharedString>>("outerString")?.get();
+            const outerString2 = await sharedMap2.get<IFluidHandle<SharedString>>("outerString")?.get();
+            const outerString3 = await sharedMap3.get<IFluidHandle<SharedString>>("outerString")?.get();
             assert.ok(outerString1, "String did not correctly set as value in container 1's map");
             assert.ok(outerString2, "String did not correctly set as value in container 2's map");
             assert.ok(outerString3, "String did not correctly set as value in container 3's map");

--- a/packages/test/end-to-end-tests/src/test/sharedStringLoading.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/sharedStringLoading.spec.ts
@@ -51,7 +51,8 @@ describe("SharedString", () => {
 
             const container = await loader.createDetachedContainer(codeDetails);
             const dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
-            const sharedString  = await dataObject.root.get<IFluidHandle<SharedString>>(stringId).get();
+            const sharedString  = await dataObject.root.get<IFluidHandle<SharedString>>(stringId)?.get();
+            assert(sharedString);
             sharedString.insertText(0, text);
 
             await container.attach(urlResolver.createCreateNewRequest(documentId));
@@ -72,7 +73,8 @@ describe("SharedString", () => {
 
             const container = await loader.resolve(urlResolver.createCreateNewRequest(documentId));
             const dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
-            const sharedString  = await dataObject.root.get<IFluidHandle<SharedString>>(stringId).get();
+            const sharedString  = await dataObject.root.get<IFluidHandle<SharedString>>(stringId)?.get();
+            assert(sharedString);
             assert.strictEqual(sharedString.getText(0), text);
         }
         { // failure load client
@@ -124,7 +126,7 @@ describe("SharedString", () => {
             const dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
 
             try {
-                await dataObject.root.get<IFluidHandle<SharedString>>(stringId).get();
+                await dataObject.root.get<IFluidHandle<SharedString>>(stringId)?.get();
                 assert.fail("expected failure");
             } catch {}
         }

--- a/packages/test/version-test-1/@fluid-internal/version-test-2/src/main.tsx
+++ b/packages/test/version-test-1/@fluid-internal/version-test-2/src/main.tsx
@@ -33,7 +33,8 @@ export class VersionTest extends DataObject implements IFluidHTMLView {
         const rerender = () => {
             const title = this.root.get("title");
             const title2 = this.root.get("title2");
-            const diceValue = this.root.get<number>("diceValue");
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const diceValue = this.root.get<number>("diceValue")!;
 
             ReactDOM.render(
                 <div>
@@ -71,7 +72,8 @@ export class VersionTest extends DataObject implements IFluidHTMLView {
         return div;
     }
     private rollDice() {
-        const dice: number = this.root.get("diceValue");
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const dice: number = this.root.get("diceValue")!;
         this.root.set("diceValue", dice + 1);
     }
 


### PR DESCRIPTION
Fix #4761 
Also
- Fix a bug in the dds-interceptor where getWorkingDirectory of a non-existent subdirectory throw instead of returning undefined. Test added.
- Add missing `clear` event signature for directory and map. (Related to #4594)
- Directory events are missing the "target" argument returning `this`
- Map events `target` should be the map itself, instead of the `MapKernel`
- Expanded local action events testing for map and dictionary