### PR TITLE
Set hotSwapContext to true in old loader in tests

### DIFF
--- a/packages/test/end-to-end-tests/src/test/contextReload.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/contextReload.spec.ts
@@ -108,7 +108,7 @@ describe("context reload (hot-swap)", function() {
     }
 
     async function createContainerWithOldLoader(packageEntries, server, urlResolver): Promise<old.IContainer> {
-        const loader = old.createLocalLoader(packageEntries, server, urlResolver);
+        const loader = old.createLocalLoader(packageEntries, server, urlResolver, { hotSwapContext: true });
         return old.createAndAttachContainer(documentId, defaultCodeDetails, loader, urlResolver);
     }
 

--- a/packages/test/end-to-end-tests/src/test/contextReload.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/contextReload.spec.ts
@@ -108,7 +108,8 @@ describe("context reload (hot-swap)", function() {
     }
 
     async function createContainerWithOldLoader(packageEntries, server, urlResolver): Promise<old.IContainer> {
-        const loader = old.createLocalLoader(packageEntries, server, urlResolver, { hotSwapContext: true });
+        // back-compat remove in 0.34: cast of function
+        const loader = (old.createLocalLoader as any)(packageEntries, server, urlResolver, { hotSwapContext: true });
         return old.createAndAttachContainer(documentId, defaultCodeDetails, loader, urlResolver);
     }
 


### PR DESCRIPTION
Our compat tests check N/N-2 currently. This was actually an N/N+1 bug at the time of introducing the hot-swap PR.

This test failure wouldn't show up until the version _after_ the hot-swap PR went in.

The fix is to just consume the new loader API in the tests for _old_ loader as well as new loader.