### PR TITLE
Update image paths for multiple microservices

### DIFF
--- a/server/routerlicious/docker-compose.yml
+++ b/server/routerlicious/docker-compose.yml
@@ -1,5 +1,14 @@
 version: '3.4'
 services:
+    gateway:
+        image: prague.azurecr.io/gateway:latest
+        ports:
+            - "3000:3000"
+        command: node dist/www.js
+        environment:
+            - DEBUG=fluid:*
+            - NODE_ENV=development
+        restart: always
     alfred:
         build:
             context: .
@@ -112,6 +121,19 @@ services:
         image: "mongo:3.4.3"
     rabbitmq:
         image: "rabbitmq:alpine"
+    auspkn:
+        image: prague.azurecr.io/auspkn:4149
+        command: node dist/www.js
+        ports:
+            - "3002:3000"
+        environment:
+            - npm__url=http://verdaccio:4873
+    verdaccio:
+        image: verdaccio/verdaccio:3.8.1
+        ports:
+            - "4873:4873"
+        volumes:
+            - ./verdaccio/conf:/verdaccio/conf
 volumes:
   git:
     driver: local

--- a/server/routerlicious/docker-compose.yml
+++ b/server/routerlicious/docker-compose.yml
@@ -1,14 +1,5 @@
 version: '3.4'
 services:
-    gateway:
-        image: prague.azurecr.io/gateway:latest
-        ports:
-            - "3000:3000"
-        command: node dist/www.js
-        environment:
-            - DEBUG=fluid:*
-            - NODE_ENV=development
-        restart: always
     alfred:
         build:
             context: .
@@ -77,7 +68,7 @@ services:
             - NODE_ENV=development
         restart: always
     historian:
-        image: prague.azurecr.io/historian:30824
+        image: mcr.microsoft.com/fluidframework/routerlicious/historian:latest
         ports:
             - "3001:3000"
         environment:
@@ -85,7 +76,7 @@ services:
             - NODE_ENV=development
         restart: always
     gitrest:
-        image: prague.azurecr.io/gitrest:30825
+        image: mcr.microsoft.com/fluidframework/routerlicious/gitrest:latest
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development
@@ -93,7 +84,7 @@ services:
             - git:/home/node/documents
         restart: always
     git:
-        image: prague.azurecr.io/gitssh:654
+        image: mcr.microsoft.com/fluidframework/routerlicious/gitssh:latest
         ports:
             - "3022:22"
         volumes:
@@ -121,19 +112,6 @@ services:
         image: "mongo:3.4.3"
     rabbitmq:
         image: "rabbitmq:alpine"
-    auspkn:
-        image: prague.azurecr.io/auspkn:4149
-        command: node dist/www.js
-        ports:
-            - "3002:3000"
-        environment:
-            - npm__url=http://verdaccio:4873
-    verdaccio:
-        image: verdaccio/verdaccio:3.8.1
-        ports:
-            - "4873:4873"
-        volumes:
-            - ./verdaccio/conf:/verdaccio/conf
 volumes:
   git:
     driver: local


### PR DESCRIPTION
While testing my other changes, I noticed that for historian endpoints, running routerlicious would result 404 returned on these requests, turns out that the historian image used is an old one from Prague ACR. After talking with Tanvir, we decided to replace the image to the latest one we have been using in https://github.com/microsoft/FluidFramework/blob/main/server/docker-compose.yml.
However, not just historian uses the old image from prague, also other microservices, gitrest and git, are also updated here. For components we no longer use, gateway, verdaccio and auspkn, they are also removed as part of this PR.