### PR TITLE
Add version to test drivers interfaces

### DIFF
--- a/packages/test/test-drivers/src/interfaces.ts
+++ b/packages/test/test-drivers/src/interfaces.ts
@@ -11,7 +11,14 @@ export interface ITestDriver{
     /**
      * The type of server the test driver executes against
      */
-    type: TestDriverTypes;
+    readonly type: TestDriverTypes;
+
+    /**
+     * The semantic version of the test drivers package.
+     * In general this version will match that of the  client
+     * interfaces and implementation exposed and used by the test driver.
+     */
+    readonly version: string;
 
     /**
      * Creates a document service factory targetting the server

--- a/packages/test/test-drivers/src/localServerTestDriver.ts
+++ b/packages/test/test-drivers/src/localServerTestDriver.ts
@@ -11,11 +11,23 @@ import {
 import { ISummaryConfiguration } from "@fluidframework/protocol-definitions";
 import { LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { ITestDriver } from "./interfaces";
+import { pkgVersion } from "./packageVersion";
 
 export class LocalServerTestDriver implements ITestDriver {
+    /**
+     * @deprecated - We only need this for some back-compat cases. Once we have a release with
+     * all the test driver changes, this will be removed in 0.33
+     */
+    public static createWithOptions(options?: {serviceConfiguration?: {summary?: Partial<ISummaryConfiguration>}}) {
+        const localDriver =  new LocalServerTestDriver();
+        localDriver.reset(options);
+        return localDriver;
+    }
+
     private _server = LocalDeltaConnectionServer.create();
 
     public readonly type = "local";
+    public readonly version = pkgVersion;
     public get server() {return this._server;}
 
     createDocumentServiceFactory(): LocalDocumentServiceFactory {
@@ -36,8 +48,8 @@ export class LocalServerTestDriver implements ITestDriver {
      * @deprecated - We only need this for some back-compat cases. Once we have a release with
      * all the test driver changes, this will be removed in 0.33
      */
-    public async reset(options?: {serviceConfiguration?: {summary?: Partial<ISummaryConfiguration>}}) {
-        await this._server?.webSocketServer.close();
+    public reset(options?: {serviceConfiguration?: {summary?: Partial<ISummaryConfiguration>}}) {
+        this._server?.webSocketServer.close().catch(()=>{});
         this._server = LocalDeltaConnectionServer.create(undefined, options?.serviceConfiguration as any);
     }
 }

--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -20,6 +20,7 @@ import {
 } from "@fluidframework/tool-utils";
 import { IClientConfig } from "@fluidframework/odsp-doclib-utils";
 import { ITestDriver } from "./interfaces";
+import { pkgVersion } from "./packageVersion";
 
 const passwordTokenConfig = (username, password): OdspTokenConfig => ({
     type: "password",
@@ -54,6 +55,7 @@ export class OdspTestDriver implements ITestDriver {
     }
 
     public readonly type = "odsp";
+    public readonly version = pkgVersion;
     private readonly odspTokenManager = new OdspTokenManager(odspTokensCache);
     constructor(
         private readonly config: Readonly<IOdspConfig>,

--- a/packages/test/test-drivers/src/routerliciousTestDriver.ts
+++ b/packages/test/test-drivers/src/routerliciousTestDriver.ts
@@ -9,6 +9,7 @@ import { RouterliciousDocumentServiceFactory, DefaultErrorTracking } from "@flui
 import { InsecureTokenProvider, InsecureUrlResolver } from "@fluidframework/test-runtime-utils";
 import { v4 as uuid } from "uuid";
 import { ITestDriver } from "./interfaces";
+import { pkgVersion } from "./packageVersion";
 
 export class RouterliciousTestDriver implements ITestDriver {
     public static createFromEnv() {
@@ -31,6 +32,7 @@ export class RouterliciousTestDriver implements ITestDriver {
     }
 
     public readonly type = "routerlicious";
+    public readonly version = pkgVersion;
     private readonly testIdPrefix: string;
     constructor(
         private readonly bearerSecret: string,

--- a/packages/test/test-drivers/src/tinyliciousTestDriver.ts
+++ b/packages/test/test-drivers/src/tinyliciousTestDriver.ts
@@ -11,9 +11,11 @@ import {
     InsecureTinyliciousUrlResolver,
 } from "@fluidframework/tinylicious-driver";
 import { ITestDriver } from "./interfaces";
+import { pkgVersion } from "./packageVersion";
 
 export class TinyliciousTestDriver implements ITestDriver {
     public readonly type = "tinylicious";
+    public readonly version = pkgVersion;
 
     createDocumentServiceFactory(): RouterliciousDocumentServiceFactory {
         return new RouterliciousDocumentServiceFactory(


### PR DESCRIPTION
In addition to type tests may want to include or exclude drivers based on their version. this will allow that by exposing the version of the test driver