### PR TITLE
Fix #4730: AgentScheduler doesn't assign the leader on load

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -243,7 +243,7 @@
             "skipFiles": [
                 "<node_internals>/**/*.js"
             ],
-            "preLaunchTask": "fluid-build $cwd"
+            "preLaunchTask": "fluid-build $cwd --nolint"
         }
 
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,7 +23,7 @@
             ]
         },
         {
-            "label": "fluid-build $cwd",
+            "label": "fluid-build $cwd --nolint",
             "type": "process",
             "command": "node",
             "args": [
@@ -31,6 +31,7 @@
                 "--root",
                 "${workspaceRoot}",
                 "--vscode",
+                "--nolint",
                 "${fileDirname}"
             ],
             "group": "build",

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -332,7 +332,7 @@ export class DocumentDeltaConnection
 
     protected closeCore(socketProtocolError: boolean, err: DriverError) {
         if (this.closed) {
-            // We see cases where socket is closed while we have two "disconect" listeners - one from DeltaManager,
+            // We see cases where socket is closed while we have two "disconnect" listeners - one from DeltaManager,
             // one - early handler that should have been removed on establishing connection. This causes asserts in
             // OdspDocumentDeltaConnection.disconnect() due to not expectting two calls.
             this.logger.sendErrorEvent(

--- a/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
+++ b/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
@@ -189,7 +189,7 @@ export class LocalDocumentDeltaConnection
     }
 
     public close() {
-        // Do nothing
+        this.disconnectClient("client close");
     }
 
     /**

--- a/packages/test/end-to-end-tests/src/test/leader.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/leader.spec.ts
@@ -1,0 +1,78 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { Container } from "@fluidframework/container-loader";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { ITestFluidObject } from "@fluidframework/test-utils";
+import {
+    generateLocalNonCompatTest,
+    ITestObjectProvider,
+} from "./compatUtils";
+
+const tests = (args: ITestObjectProvider) => {
+    let container1: Container;
+    let container2: Container;
+    let dataObject1: ITestFluidObject;
+    let dataObject2: ITestFluidObject;
+
+    beforeEach(async () => {
+        container1 = await args.makeTestContainer() as Container;
+        dataObject1 = await requestFluidObject<ITestFluidObject>(container1, "default");
+
+        // write something to get out of view only mode
+        dataObject1.root.set("blah", "blah");
+        await args.opProcessingController.process();
+
+        container2 = await args.loadTestContainer() as Container;
+        dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
+
+        // write something to get out of view only mode
+        dataObject2.root.set("blah", "blah");
+        await args.opProcessingController.process();
+    });
+
+    it("Events on close", async () => {
+        assert(dataObject1.context.leader);
+        assert(!dataObject2.context.leader);
+
+        let leaderEventExpected1 = false;
+        let leaderEventExpected2 = true;
+        let notleaderEventExpected1 = true;
+        let notleaderEventExpected2 = false;
+        dataObject1.runtime.on("leader", () => {
+            assert(leaderEventExpected1, "leader event not expected in data object 1");
+            leaderEventExpected1 = false;
+        });
+
+        dataObject1.runtime.on("notleader", () => {
+            assert(notleaderEventExpected1, "notleader event not expected in data object 1");
+            notleaderEventExpected1 = false;
+        });
+
+        dataObject2.runtime.on("leader", () => {
+            assert(leaderEventExpected2, "leader event not expected in data object 2");
+            leaderEventExpected2 = false;
+        });
+
+        dataObject2.runtime.on("notleader", () => {
+            assert(notleaderEventExpected2, "notleader event not expected in data object 2");
+            notleaderEventExpected2 = false;
+        });
+
+        container1.close();
+
+        await args.opProcessingController.process();
+
+        assert(!notleaderEventExpected1, "Missing notleader event on data object 1");
+        assert(!leaderEventExpected2, "Missing leader event on data object 2");
+        assert(!dataObject1.context.leader);
+        assert(dataObject2.context.leader);
+    });
+};
+
+describe("Leader", () => {
+    generateLocalNonCompatTest(tests, { tinylicious: true });
+});


### PR DESCRIPTION
`AgentScheduler` only clean up values in the consensus collection if there are multiple client. The last client that left would not clear up the task assigned in the `AgentScheduler` and it rely on the next load of to clear it up.

However on load, we try to assign tasks (including leader election) for non assigned task, and that is done before clear up.  It ends up the first client won't assign a leader, and leaving session without a leader. If the session disconnect and reconnect, or there is a second client join, then leader will be assigned then.

The fix is to assign the tasks on load if there is no one assigned to it or the one assigned to it is not in the quorum (already left).  In which case, we will not try to clear it.

This should fix issue #4730.

Also
- added test for the "leader"/"notleader" event on container.close for issue #4297.  
  - For that, the `LocalDocumentDeltaConnection.close` will need to disconnect the client.
- Don't lint for the build task that is run before we launch the debugging session.

