### PR TITLE
Add Daily Build For Better Analytics

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -46,6 +46,14 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
 
+schedules:
+- cron: "0 0 * * *"
+  displayName: Daily midnight build
+  always: true
+  branches:
+    include:
+    - main
+
 pr:
   branches:
     include:


### PR DESCRIPTION
Currently our test analytics are dominated by PR build, which introduce a bunch of noise. This should give us a cleaner signal for identifying flaky tests

fixes #4652