### PR TITLE
Emit connect_document_error on throttle instead of nack

### DIFF
--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -106,39 +106,35 @@ function selectProtocolVersion(connectVersions: string[]): string {
 function checkThrottle(
     throttler: core.IThrottler | undefined,
     throttleId: string,
-    socket: core.IWebSocket,
-    logger: core.ILogger): boolean {
+    logger?: core.ILogger): core.ThrottlingError | undefined {
     if (!throttler) {
-        return false;
+        return;
     }
+
     const messageMetaData = {
         key: throttleId,
         weight: 1,
         event_type: "throttling",
     };
+
     try {
         throttler.incrementCount(throttleId);
     } catch (e) {
         if (e instanceof core.ThrottlingError) {
-            logger.info(`Throttled: ${throttleId}`, { messageMetaData: {
-                ...messageMetaData,
-                reason: e.message,
-                retryAfterInSeconds: e.retryAfter,
-            } });
-            const nackMessage = createNackMessage(
-                e.code,
-                NackErrorType.ThrottlingError,
-                e.message,
-                e.retryAfter);
-            socket.emit("nack", "", [nackMessage]);
-            return true;
+            logger?.info(`Throttled: ${throttleId}`, {
+                messageMetaData: {
+                    ...messageMetaData,
+                    reason: e.message,
+                    retryAfterInSeconds: e.retryAfter,
+                },
+            });
+            return e;
         } else {
-            logger.error(
+            logger?.error(
                 `Throttle increment failed: ${safeStringify(e, undefined, 2)}`,
                 { messageMetaData });
         }
     }
-    return false;
 }
 
 export function configureWebSocketServices(
@@ -195,6 +191,13 @@ export function configureWebSocketServices(
         }
 
         async function connectDocument(message: IConnect): Promise<IConnectedClient> {
+            const throttleError = checkThrottle(
+                connectThrottler,
+                getSocketConnectThrottleId(message.tenantId),
+                logger);
+            if (throttleError) {
+                return Promise.reject(throttleError);
+            }
             if (!message.token) {
                 // eslint-disable-next-line prefer-promise-reject-errors
                 return Promise.reject("Must provide an authorization token");
@@ -354,15 +357,6 @@ export function configureWebSocketServices(
         // Note connect is a reserved socket.io word so we use connect_document to represent the connect request
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         socket.on("connect_document", async (connectionMessage: IConnect) => {
-            const isThrottled = checkThrottle(
-                connectThrottler,
-                getSocketConnectThrottleId(connectionMessage.tenantId),
-                socket,
-                logger);
-            if (isThrottled) {
-                return;
-            }
-
             connectDocument(connectionMessage).then(
                 (message) => {
                     socket.emit("connect_document_success", message.connection);
@@ -385,12 +379,17 @@ export function configureWebSocketServices(
         socket.on(
             "submitOp",
             (clientId: string, messageBatches: (IDocumentMessage | IDocumentMessage[])[]) => {
-                const isThrottled = checkThrottle(
+                const throttleError = checkThrottle(
                     submitOpThrottler,
                     getSubmitOpThrottleId(clientId),
-                    socket,
                     logger);
-                if (isThrottled) {
+                if (throttleError) {
+                    const nackMessage = createNackMessage(
+                        throttleError.code,
+                        NackErrorType.ThrottlingError,
+                        throttleError.message,
+                        throttleError.retryAfter);
+                    socket.emit("nack", "", [nackMessage]);
                     return;
                 }
 

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -99,9 +99,7 @@ function selectProtocolVersion(connectVersions: string[]): string {
 }
 
 /**
- * When throttled, sends nack before returning.
- *
- * @returns true if throttled; false if not throttled or no throttler provided.
+ * @returns ThrottlingError if throttled; undefined if not throttled or no throttler provided.
  */
 function checkThrottle(
     throttler: core.IThrottler | undefined,

--- a/server/routerlicious/packages/routerlicious-base/src/test/alfred/io.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/alfred/io.spec.ts
@@ -212,10 +212,7 @@ describe("Routerlicious", () => {
                                 assert.fail("Connection should have failed");
                             })
                             .catch((err) => {
-                                if (err instanceof Array && err[0]?.content) {
-                                    return err[0].content;
-                                }
-                                assert.fail("Connection failed for other reason(s) than a nack");
+                                return err;
                             }) as INackContent;
                         assert.strictEqual(failedConnectMessage.code, 429);
                         assert.strictEqual(failedConnectMessage.type, NackErrorType.ThrottlingError);


### PR DESCRIPTION
Emitting a `nack` of type ThrottlingWarning when throttling a document connection has the unintended consequence of causing all connected clients for a tenant to receive a handshake timeout. Emitting a `connect_document_error` with the ThrottlingError, instead, has the desired effect of preventing additional document connections for a tenant for `retryAfter` seconds.