### PR TITLE
Allow retry for NACKs with code 429

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -67,7 +67,8 @@ export const getRetryDelayFromError = (error: any): number | undefined => error?
 
 function getNackReconnectInfo(nackContent: INackContent) {
     const reason = `Nack: ${nackContent.message}`;
-    const canRetry = ![403, 429].includes(nackContent.code);
+    const canRetry = (nackContent.code === 429 && nackContent.retryAfter !== undefined)
+        || ![403, 429].includes(nackContent.code);
     return createGenericNetworkError(reason, canRetry, nackContent.retryAfter, nackContent.code);
 }
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -67,8 +67,7 @@ export const getRetryDelayFromError = (error: any): number | undefined => error?
 
 function getNackReconnectInfo(nackContent: INackContent) {
     const reason = `Nack: ${nackContent.message}`;
-    const canRetry = (nackContent.code === 429 && nackContent.retryAfter !== undefined)
-        || ![403, 429].includes(nackContent.code);
+    const canRetry = nackContent.code !== 403;
     return createGenericNetworkError(reason, canRetry, nackContent.retryAfter, nackContent.code);
 }
 


### PR DESCRIPTION
Currently, container-loader's deltaManager doesn't allow NACKs with code 429 to be retried. However, if retryAfter is present on a 429 (too many requests), retry should be allowed.