### PR TITLE
Added redis for throttling features in R11S and historian config

### DIFF
--- a/server/charts/historian/templates/historian-configmap.yaml
+++ b/server/charts/historian/templates/historian-configmap.yaml
@@ -26,6 +26,12 @@ data:
             "tls": {{ .Values.historian.redis.tls }},
             "pass": "{{ .Values.historian.redis.password }}"
         },
+        "redisForThrottling": {
+            "host": "{{ .Values.historian.redisForThrottling.url }}",
+            "port": "{{ .Values.historian.redisForThrottling.port }}",
+            "tls": {{ .Values.historian.redisForThrottling.tls }},
+            "pass": "{{ .Values.historian.redisForThrottling.password }}"
+        },
         "error": {
             "track": {{ .Values.historian.error.track }},
             "endpoint": "{{ .Values.historian.error.endpoint }}"

--- a/server/charts/historian/values.yaml
+++ b/server/charts/historian/values.yaml
@@ -9,6 +9,10 @@ historian:
     url: redis_url
     port: 6379
     tls: false
+  redisForThrottling:
+    url: redis_url
+    port: 6379
+    tls: false
   host: historian_host
   cert: historian_cert
   ingressClass: ingress_class

--- a/server/historian/packages/historian/config.json
+++ b/server/historian/packages/historian/config.json
@@ -12,6 +12,10 @@
         "host": "redis",
         "port": 6379
     },
+    "redisForThrottling": {
+        "host": "redis",
+        "port": 6379
+    },
     "error": {
         "track": false,
         "endpoint" : ""

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -169,6 +169,12 @@ data:
             "pass": "{{ .Values.redis2.password }}",
             "tls": {{ .Values.redis2.tls }}
         },
+        "redisForThrottling": {
+            "host": "{{ .Values.redisForThrottling.url }}",
+            "port": "{{ .Values.redisForThrottling.port }}",
+            "pass": "{{ .Values.redisForThrottling.password }}",
+            "tls": {{ .Values.redisForThrottling.tls }}
+        },
         "error": {
             "track": {{ .Values.error.track }},
             "endpoint": "{{ .Values.error.endpoint }}"

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -79,6 +79,11 @@ redis2:
   port: 6379
   tls: false
 
+redisForThrottling:
+  url: redis_url
+  port: 6379
+  tls: false
+
 kafka:
   topics:
     rawdeltas: rawdeltas

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -167,6 +167,11 @@
         "port": 6379,
         "tls": false
     },
+    "redisForThrottling": {
+        "host": "redis",
+        "port": 6379,
+        "tls": false
+    },
     "error": {
         "track": false,
         "endpoint" : ""


### PR DESCRIPTION
Throttling feature in Alfred and Historian will use a new Redis instance. A Redis instance config is added in R11S and historian.