### PR TITLE
Make Test createAndAttachContainer UrlResolver Agnostic

### DIFF
--- a/examples/data-objects/table-document/src/test/table.spec.ts
+++ b/examples/data-objects/table-document/src/test/table.spec.ts
@@ -37,7 +37,8 @@ describe("TableDocument", () => {
             [[codeDetails, TableDocument.getFactory()]],
             deltaConnectionServer,
             urlResolver);
-        const container = await createAndAttachContainer(documentId, codeDetails, loader, urlResolver);
+        const container = await createAndAttachContainer(
+            codeDetails, loader, urlResolver.createCreateNewRequest(documentId));
         tableDocument = await requestFluidObject<TableDocument>(container, "default");
 
         opProcessingController = new OpProcessingController(deltaConnectionServer);

--- a/examples/data-objects/table-document/src/test/tableWithInterception.spec.ts
+++ b/examples/data-objects/table-document/src/test/tableWithInterception.spec.ts
@@ -76,7 +76,8 @@ describe("Table Document with Interception", () => {
             const deltaConnectionServer = LocalDeltaConnectionServer.create();
             const urlResolver = new LocalResolver();
             const loader = createLocalLoader([[codeDetails, factory]], deltaConnectionServer, urlResolver);
-            const container = await createAndAttachContainer(documentId, codeDetails, loader, urlResolver);
+            const container = await createAndAttachContainer(
+            codeDetails, loader, urlResolver.createCreateNewRequest(documentId))
             tableDocument = await requestFluidObject<TableDocument>(container, "default");
 
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/examples/data-objects/table-document/src/test/tableWithInterception.spec.ts
+++ b/examples/data-objects/table-document/src/test/tableWithInterception.spec.ts
@@ -77,7 +77,7 @@ describe("Table Document with Interception", () => {
             const urlResolver = new LocalResolver();
             const loader = createLocalLoader([[codeDetails, factory]], deltaConnectionServer, urlResolver);
             const container = await createAndAttachContainer(
-            codeDetails, loader, urlResolver.createCreateNewRequest(documentId))
+                codeDetails, loader, urlResolver.createCreateNewRequest(documentId));
             tableDocument = await requestFluidObject<TableDocument>(container, "default");
 
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -221,7 +221,7 @@ describe("Table Document with Interception", () => {
                     "We should have caught an assert in setCellValue because it detects an infinite recursion");
                 asserted = true;
             }
-            assert.equal(asserted, true, "setCellValue should have asserted because it detects inifinite recursion");
+            assert.equal(asserted, true, "setCellValue should have asserted because it detects infinite recursion");
 
             // Verify that the object is still usable:
             // Set useWrapper to false and call setCellValue on the wrapper again. Verify that we do not get an assert.

--- a/examples/data-objects/webflow/test/flowdocument.spec.ts
+++ b/examples/data-objects/webflow/test/flowdocument.spec.ts
@@ -24,7 +24,7 @@ describe("FlowDocument", () => {
         const deltaConnectionServer = LocalDeltaConnectionServer.create();
         const urlResolver = new LocalResolver();
         const loader = createLocalLoader([[codeDetails, FlowDocument.getFactory()]], deltaConnectionServer, urlResolver);
-        const container = await createAndAttachContainer(documentUrl, codeDetails, loader, urlResolver);
+        const container = await createAndAttachContainer(codeDetails, loader, urlResolver.createCreateNewRequest(documentUrl));
         doc = await requestFluidObject<FlowDocument>(container, "default");
     });
 

--- a/examples/data-objects/webflow/test/layout.spec.ts
+++ b/examples/data-objects/webflow/test/layout.spec.ts
@@ -54,7 +54,7 @@ describe("Layout", () => {
         const deltaConnectionServer = LocalDeltaConnectionServer.create();
         const urlResolver = new LocalResolver();
         const loader = createLocalLoader([[codeDetails, FlowDocument.getFactory()]], deltaConnectionServer, urlResolver);
-        const container = await createAndAttachContainer(documentUrl, codeDetails, loader, urlResolver);
+        const container = await createAndAttachContainer(codeDetails, loader, urlResolver.createCreateNewRequest(documentUrl));
         doc = await requestFluidObject<FlowDocument>(container, "default");
     });
 

--- a/examples/data-objects/webflow/test/segmentspan.spec.ts
+++ b/examples/data-objects/webflow/test/segmentspan.spec.ts
@@ -25,7 +25,7 @@ describe("SegmentSpan", () => {
         const deltaConnectionServer = LocalDeltaConnectionServer.create();
         const urlResolver = new LocalResolver();
         const loader = createLocalLoader([[codeDetails, FlowDocument.getFactory()]], deltaConnectionServer, urlResolver);
-        const container = await createAndAttachContainer(documentUrl, codeDetails, loader, urlResolver);
+        const container = await createAndAttachContainer(codeDetails, loader, urlResolver.createCreateNewRequest(documentUrl));
         doc = await requestFluidObject<FlowDocument>(container, "default");
     });
 

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -5278,7 +5278,7 @@
 		"@microsoft/tsdoc": {
 			"version": "0.12.19",
 			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.19.tgz",
-			"integrity": "sha1-IXPMuSRpqvYgMfqUmdIbFtB/m1c=",
+			"integrity": "sha512-IpgPxHrNxZiMNUSXqR1l/gePKPkfAmIKoDRP9hp7OwjU29ZR8WCJsOJ8iBKgw0Qk+pFwR+8Y1cy8ImLY6e9m4A==",
 			"dev": true
 		},
 		"@mixer/webpack-bundle-compare": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2141,7 +2141,7 @@
     "@microsoft/tsdoc": {
       "version": "0.12.19",
       "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.19.tgz",
-      "integrity": "sha1-IXPMuSRpqvYgMfqUmdIbFtB/m1c=",
+      "integrity": "sha512-IpgPxHrNxZiMNUSXqR1l/gePKPkfAmIKoDRP9hp7OwjU29ZR8WCJsOJ8iBKgw0Qk+pFwR+8Y1cy8ImLY6e9m4A==",
       "dev": true
     },
     "@mrmlnc/readdir-enhanced": {

--- a/packages/test/end-to-end-tests/src/test/codePropsal.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/codePropsal.spec.ts
@@ -92,7 +92,7 @@ describe("CodeProposal.EndToEnd", () => {
     async function createContainer(code: IFluidCodeDetails): Promise<IContainer> {
         const urlResolver = new LocalResolver();
         const loader = createLoader(urlResolver);
-        return createAndAttachContainer(documentId, code, loader, urlResolver);
+        return createAndAttachContainer(code, loader, urlResolver.createCreateNewRequest(documentId));
     }
 
     async function loadContainer(): Promise<IContainer> {

--- a/packages/test/end-to-end-tests/src/test/contextReload.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/contextReload.spec.ts
@@ -97,9 +97,9 @@ describe("context reload (hot-swap)", function() {
                     typeof code.package === "object" && code.package.version === version ? resolve() : reject()))));
     };
 
-    async function createContainer(packageEntries, server, urlResolver): Promise<IContainer> {
+    async function createContainer(packageEntries, server, urlResolver: LocalResolver): Promise<IContainer> {
         const loader: ILoader = createLocalLoader(packageEntries, server, urlResolver, { hotSwapContext: true });
-        return createAndAttachContainer(documentId, defaultCodeDetails, loader, urlResolver);
+        return createAndAttachContainer(defaultCodeDetails, loader, urlResolver.createCreateNewRequest(documentId));
     }
 
     async function loadContainer(packageEntries, server, urlResolver): Promise<IContainer> {

--- a/packages/test/end-to-end-tests/src/test/documentDirty.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/documentDirty.spec.ts
@@ -102,7 +102,8 @@ describe("Document Dirty", () => {
             codeLoader,
         });
 
-        return createAndAttachContainer(documentId, codeDetails, loader, urlResolver);
+        return createAndAttachContainer(
+            codeDetails, loader, urlResolver.createCreateNewRequest(documentId))
     }
 
     beforeEach(async () => {

--- a/packages/test/end-to-end-tests/src/test/documentDirty.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/documentDirty.spec.ts
@@ -103,7 +103,7 @@ describe("Document Dirty", () => {
         });
 
         return createAndAttachContainer(
-            codeDetails, loader, urlResolver.createCreateNewRequest(documentId))
+            codeDetails, loader, urlResolver.createCreateNewRequest(documentId));
     }
 
     beforeEach(async () => {

--- a/packages/test/end-to-end-tests/src/test/loaderTest.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/loaderTest.spec.ts
@@ -12,7 +12,6 @@ import {
 import { IContainer, ILoader, LoaderHeader } from "@fluidframework/container-definitions";
 import { Container } from "@fluidframework/container-loader";
 import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
-import { IUrlResolver } from "@fluidframework/driver-definitions";
 import { LocalResolver } from "@fluidframework/local-driver";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { createAndAttachContainer, createLocalLoader, OpProcessingController } from "@fluidframework/test-utils";
@@ -74,7 +73,7 @@ describe("Loader.request", () => {
     let dataStore1: TestSharedDataObject1;
     let dataStore2: TestSharedDataObject2;
     let loader: ILoader;
-    let urlResolver: IUrlResolver;
+    let urlResolver: LocalResolver;
     let opProcessingController: OpProcessingController;
 
     async function createContainer(): Promise<IContainer> {
@@ -87,7 +86,8 @@ describe("Loader.request", () => {
                 ],
             );
         loader = createLocalLoader([[codeDetails, runtimeFactory]], deltaConnectionServer, urlResolver);
-        return createAndAttachContainer(documentId, codeDetails, loader, urlResolver);
+        return createAndAttachContainer(
+            codeDetails, loader, urlResolver.createCreateNewRequest(documentId));
     }
 
     beforeEach(async () => {

--- a/packages/test/end-to-end-tests/src/test/localLoader.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/localLoader.spec.ts
@@ -9,7 +9,6 @@ import { IContainer, ILoader } from "@fluidframework/container-definitions";
 import { IFluidHandle, IFluidCodeDetails } from "@fluidframework/core-interfaces";
 import { SharedCounter } from "@fluidframework/counter";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
-import { IUrlResolver } from "@fluidframework/driver-definitions";
 import { LocalResolver } from "@fluidframework/local-driver";
 import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
@@ -96,12 +95,13 @@ describe("LocalLoader", () => {
     };
 
     let deltaConnectionServer: ILocalDeltaConnectionServer;
-    let urlResolver: IUrlResolver;
+    let urlResolver: LocalResolver;
     let opProcessingController: OpProcessingController;
 
     async function createContainer(factory: IFluidDataStoreFactory): Promise<IContainer> {
         const loader: ILoader = createLocalLoader([[codeDetails, factory]], deltaConnectionServer, urlResolver);
-        return createAndAttachContainer(documentId, codeDetails, loader, urlResolver);
+        return createAndAttachContainer(
+            codeDetails, loader, urlResolver.createCreateNewRequest(documentId));
     }
 
     async function loadContainer(factory: IFluidDataStoreFactory): Promise<IContainer> {

--- a/packages/test/end-to-end-tests/src/test/localTestServer.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/localTestServer.spec.ts
@@ -6,7 +6,6 @@
 import { strict as assert } from "assert";
 import { IContainer, ILoader } from "@fluidframework/container-definitions";
 import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
-import { IUrlResolver } from "@fluidframework/driver-definitions";
 import { LocalResolver } from "@fluidframework/local-driver";
 import { MessageType } from "@fluidframework/protocol-definitions";
 import { SharedString } from "@fluidframework/sequence";
@@ -31,7 +30,7 @@ describe("LocalTestServer", () => {
     const factory = new TestFluidObjectFactory([[stringId, SharedString.getFactory()]]);
 
     let deltaConnectionServer: ILocalDeltaConnectionServer;
-    let urlResolver: IUrlResolver;
+    let urlResolver: LocalResolver;
     let opProcessingController: OpProcessingController;
     let container1: IContainer;
     let container2: IContainer;
@@ -42,7 +41,8 @@ describe("LocalTestServer", () => {
 
     async function createContainer(): Promise<IContainer> {
         const loader: ILoader = createLocalLoader([[codeDetails, factory]], deltaConnectionServer, urlResolver);
-        return createAndAttachContainer(documentId, codeDetails, loader, urlResolver);
+        return createAndAttachContainer(
+            codeDetails, loader, urlResolver.createCreateNewRequest(documentId));
     }
 
     async function loadContainer(): Promise<IContainer> {

--- a/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/opsOnReconnect.spec.ts
@@ -15,7 +15,6 @@ import {
 } from "@fluidframework/container-runtime";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { IFluidCodeDetails, IFluidHandle, IFluidLoadable } from "@fluidframework/core-interfaces";
-import { IUrlResolver } from "@fluidframework/driver-definitions";
 import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
 import { SharedMap, SharedDirectory } from "@fluidframework/map";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
@@ -43,7 +42,7 @@ describe("Ops on Reconnect", () => {
         config: {},
     };
 
-    let urlResolver: IUrlResolver;
+    let urlResolver: LocalResolver;
     let deltaConnectionServer: ILocalDeltaConnectionServer;
     let documentServiceFactory: LocalDocumentServiceFactory;
     let opProcessingController: OpProcessingController;
@@ -94,7 +93,8 @@ describe("Ops on Reconnect", () => {
 
     async function createContainer(): Promise<IContainer> {
         const loader = await createLoader();
-        return createAndAttachContainer(documentId, codeDetails, loader, urlResolver);
+        return createAndAttachContainer(
+            codeDetails, loader, urlResolver.createCreateNewRequest(documentId));
     }
 
     async function setupSecondContainersDataObject(): Promise<ITestFluidObject> {

--- a/packages/test/end-to-end-tests/src/test/upgradeManager.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/upgradeManager.spec.ts
@@ -13,7 +13,6 @@ import {
 import { Container, Loader } from "@fluidframework/container-loader";
 import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
-import { IUrlResolver } from "@fluidframework/driver-definitions";
 import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
 import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
@@ -48,7 +47,7 @@ describe("UpgradeManager (hot-swap)", () => {
     };
 
     let deltaConnectionServer: ILocalDeltaConnectionServer;
-    let urlResolver: IUrlResolver;
+    let urlResolver: LocalResolver;
     let documentServiceFactory: LocalDocumentServiceFactory;
     let opProcessingController: OpProcessingController;
 
@@ -61,7 +60,8 @@ describe("UpgradeManager (hot-swap)", () => {
             options: { hotSwapContext: true },
         });
 
-        return createAndAttachContainer(documentId, codeDetails, loader, urlResolver);
+        return createAndAttachContainer(
+            codeDetails, loader, urlResolver.createCreateNewRequest(documentId));
     }
 
     async function loadContainer(factory: IFluidDataStoreFactory): Promise<IContainer> {

--- a/packages/test/test-utils/README.md
+++ b/packages/test/test-utils/README.md
@@ -39,14 +39,14 @@ export function createLocalLoader(
 
 ### `createAndAttachContainer`
 
-This method creates and attaches a `Container` with the given `documentId`, `source` and an `IUrlResolver`. An `ILoader` should also be passed in that will be used to load the `Container`:
+This method creates and attaches a `Container` with the given `source` and an `attachRequest`. An `ILoader` should also be passed in that will be used to load the `Container`. The `attachRequest` format varies per url resolver. Most resolvers have helper methods for creating attach requests. You should use the
+helper method on the url resolver passed to the loader to generate the `attachRequest`:
 
 ```typescript
 export async function createAndAttachContainer(
-    documentId: string,
     source: IFluidCodeDetails,
     loader: ILoader,
-    urlResolver: IUrlResolver,
+    attachRequest: IRequest,
 ): Promise<IContainer>
 ```
 

--- a/packages/test/test-utils/README.md
+++ b/packages/test/test-utils/README.md
@@ -117,7 +117,8 @@ The typical usage for testing a Fluid object is as follows:
 5. Create and attach a `Container` by giving it a `documentId` which is used as a URL to resolve the container:
     ```typescript
     const documentId = "testDocument";
-    const container = await createAndAttachContainer(documentId, codeDetails, loader, urlResolver);
+    const container = await createAndAttachContainer(
+            codeDetails, loader, urlResolver.createCreateNewRequest(documentId))
     ```
     > We used the same `IFluidCodeDetails` that was used to create the `Loader` in step 3.
 

--- a/packages/test/test-utils/src/baseTestObjectProvider.ts
+++ b/packages/test/test-utils/src/baseTestObjectProvider.ts
@@ -4,7 +4,7 @@
  */
 
 import { Loader, waitContainerToCatchUp } from "@fluidframework/container-loader";
-import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
+import { IFluidCodeDetails, IRequest } from "@fluidframework/core-interfaces";
 import { IUrlResolver, IDocumentServiceFactory } from "@fluidframework/driver-definitions";
 import { fluidEntryPoint, LocalCodeLoader } from "./localCodeLoader";
 import { createAndAttachContainer } from "./localLoader";
@@ -26,6 +26,7 @@ export abstract class BaseTestObjectProvider<TestContainerConfigType> {
      */
     constructor(
         private readonly createFluidEntryPoint: (testContainerConfig?: TestContainerConfigType) => fluidEntryPoint,
+        private readonly createCreateRequest: (docId: string) => IRequest,
     ) {
 
     }
@@ -67,7 +68,7 @@ export abstract class BaseTestObjectProvider<TestContainerConfigType> {
     public async makeTestContainer(testContainerConfig?: TestContainerConfigType) {
         const loader = this.makeTestLoader(testContainerConfig);
         const container =
-            await createAndAttachContainer(this.documentId, defaultCodeDetails, loader, this.urlResolver);
+            await createAndAttachContainer(defaultCodeDetails, loader, this.createCreateRequest(this.documentId));
         this.opProcessingController.addDeltaManagers(container.deltaManager);
         return container;
     }

--- a/packages/test/test-utils/src/localLoader.ts
+++ b/packages/test/test-utils/src/localLoader.ts
@@ -10,9 +10,9 @@ import {
     ILoaderOptions,
 } from "@fluidframework/container-definitions";
 import { Loader } from "@fluidframework/container-loader";
-import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
+import { IFluidCodeDetails, IRequest } from "@fluidframework/core-interfaces";
 import { IUrlResolver } from "@fluidframework/driver-definitions";
-import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
+import { LocalDocumentServiceFactory } from "@fluidframework/local-driver";
 import { ILocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { fluidEntryPoint, LocalCodeLoader } from "./localCodeLoader";
 
@@ -40,21 +40,18 @@ export function createLocalLoader(
 
 /**
  * Creates a detached Container and attaches it.
- * @param documentId - The documentId for the container.
  * @param source - The code details used to create the Container.
  * @param loader - The loader to use to initialize the container.
- * @param urlresolver - The url resolver to get the create new request from.
+ * @param attachRequest - The request to create new from.
  */
 
 export async function createAndAttachContainer(
-    documentId: string,
     source: IFluidCodeDetails,
     loader: ILoader,
-    urlResolver: IUrlResolver,
+    attachRequest: IRequest,
 ): Promise<IContainer> {
     const container = await loader.createDetachedContainer(source);
-    const attachUrl = (urlResolver as LocalResolver).createCreateNewRequest(documentId);
-    await container.attach(attachUrl);
+    await container.attach(attachRequest);
 
     return container;
 }

--- a/packages/test/test-utils/src/localTestObjectProvider.ts
+++ b/packages/test/test-utils/src/localTestObjectProvider.ts
@@ -4,7 +4,11 @@
  */
 
 import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
-import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
+import {
+    createLocalResolverCreateNewRequest,
+    LocalDocumentServiceFactory,
+    LocalResolver,
+} from "@fluidframework/local-driver";
 import { IClientConfiguration } from "@fluidframework/protocol-definitions";
 import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { BaseTestObjectProvider } from "./baseTestObjectProvider";
@@ -44,7 +48,7 @@ export class LocalTestObjectProvider<TestContainerConfigType>
         private readonly serviceConfiguration?: Partial<IClientConfiguration>,
         private _deltaConnectionServer?: ILocalDeltaConnectionServer | undefined,
     ) {
-        super(createFluidEntryPoint);
+        super(createFluidEntryPoint, (docId)=>createLocalResolverCreateNewRequest(docId));
     }
 
     get deltaConnectionServer() {

--- a/packages/test/test-utils/src/tinyliciousTestObjectProvider.ts
+++ b/packages/test/test-utils/src/tinyliciousTestObjectProvider.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IUrlResolver, IDocumentServiceFactory } from "@fluidframework/driver-definitions";
+import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 
 import { InsecureTokenProvider, InsecureUrlResolver } from "@fluidframework/test-runtime-utils";
@@ -19,13 +19,13 @@ export class TinyliciousTestObjectProvider<TestContainerConfigType>
     extends BaseTestObjectProvider<TestContainerConfigType> {
     private _documentId: string | undefined;
     private _documentServiceFactory: IDocumentServiceFactory | undefined;
-    private _urlResolver: IUrlResolver | undefined;
+    private _urlResolver: InsecureUrlResolver | undefined;
     private _opProcessingController: OpProcessingController | undefined;
 
     constructor(
         createFluidEntryPoint: (testContainerConfig?: TestContainerConfigType) => fluidEntryPoint,
     ) {
-        super(createFluidEntryPoint);
+        super(createFluidEntryPoint, (docId)=>this.urlResolver.createCreateNewRequest(docId));
     }
 
     get documentId() {


### PR DESCRIPTION
Take a IRequest rather than a IUrlResolver that secretly needs to be a LocalResolver. In a later PR we'll remove the dependency of tests on LocalResolver and move them to the test driver interface.