### PR TITLE
Remove subcategory and use child logger instead

### DIFF
--- a/packages/drivers/odsp-driver/src/fetchWithRetry.ts
+++ b/packages/drivers/odsp-driver/src/fetchWithRetry.ts
@@ -256,9 +256,9 @@ async function logFetchResponse(
 ) {
     if (logger !== undefined) {
         const additionalProps = getAdditionalProps && (await getAdditionalProps(response, isFinalAttempt));
-        const childLogger = ChildLogger.create(logger, "Request");
-        childLogger.sendTelemetryEvent({
-            eventName: nameForLogging,
+        logger.sendTelemetryEvent({
+            eventName: "odspFetchResponse",
+            requestName: nameForLogging,
             isFinalAttempt,
             status: response.status,
             durationMs: response.durationMs,

--- a/packages/drivers/odsp-driver/src/fetchWithRetry.ts
+++ b/packages/drivers/odsp-driver/src/fetchWithRetry.ts
@@ -5,6 +5,7 @@
 
 import { ITelemetryLogger, ITelemetryProperties } from "@fluidframework/common-definitions";
 import { fetchFailureStatusCode, offlineFetchFailureStatusCode } from "@fluidframework/odsp-doclib-utils";
+import { ChildLogger } from "@fluidframework/telemetry-utils";
 
 /**
  * returns a promise that resolves after timeMs
@@ -255,8 +256,8 @@ async function logFetchResponse(
 ) {
     if (logger !== undefined) {
         const additionalProps = getAdditionalProps && (await getAdditionalProps(response, isFinalAttempt));
-        logger.sendTelemetryEvent({
-            subCategory: "Request",
+        const childLogger = ChildLogger.create(logger, "Request");
+        childLogger.sendTelemetryEvent({
             eventName: nameForLogging,
             isFinalAttempt,
             status: response.status,

--- a/packages/drivers/odsp-driver/src/fetchWithRetry.ts
+++ b/packages/drivers/odsp-driver/src/fetchWithRetry.ts
@@ -5,7 +5,6 @@
 
 import { ITelemetryLogger, ITelemetryProperties } from "@fluidframework/common-definitions";
 import { fetchFailureStatusCode, offlineFetchFailureStatusCode } from "@fluidframework/odsp-doclib-utils";
-import { ChildLogger } from "@fluidframework/telemetry-utils";
 
 /**
  * returns a promise that resolves after timeMs


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/4511
Adding subcategory has implications according to @markfields where it triggers code in the Msft internal Office Fluid repo to create a whole new table when ingesting telemetry events. So use child logger instead.