### PR TITLE
add read params to getCommits

### DIFF
--- a/server/gitrest/src/routes/git/refs.ts
+++ b/server/gitrest/src/routes/git/refs.ts
@@ -149,14 +149,6 @@ function getRefId(id): string {
     return `refs/${id}`;
 }
 
-function getReadParams(params): IGetRefParamsExternal | undefined {
-    if (params) {
-        const getRefParams: IGetRefParamsExternal = JSON.parse(decodeURIComponent(params));
-        return getRefParams;
-    }
-    return undefined;
-}
-
 export function create(
     store: nconf.Provider,
     repoManager: utils.RepositoryManager,
@@ -177,7 +169,7 @@ export function create(
             request.params.owner,
             request.params.repo,
             getRefId(request.params[0]),
-            getReadParams(request.query?.config),
+            utils.getReadParams(request.query?.config),
             externalStorageManager);
         handleResponse(resultP, response);
     });

--- a/server/gitrest/src/routes/repository/commits.ts
+++ b/server/gitrest/src/routes/repository/commits.ts
@@ -4,6 +4,7 @@
  */
 
 import * as resources from "@fluidframework/gitresources";
+import { IGetRefParamsExternal } from "@fluidframework/server-services-client";
 import { Router } from "express";
 import * as nconf from "nconf";
 import git from "nodegit";
@@ -17,6 +18,7 @@ export async function getCommits(
     repo: string,
     ref: string,
     count: number,
+    readParams: IGetRefParamsExternal,
     externalStorageManager: IExternalStorageManager): Promise<resources.ICommitDetails[]> {
     const repository = await repoManager.open(owner, repo);
     try {
@@ -52,17 +54,20 @@ export async function getCommits(
         return Promise.all(detailedCommits);
     } catch (err) {
         winston.info(`getCommits error: ${err}`);
-        try {
-            const result = await externalStorageManager.read(repo, ref);
-            if (!result) {
+        if (readParams?.config?.enabled) {
+            try {
+                const result = await externalStorageManager.read(repo, ref);
+                if (!result) {
+                    return Promise.reject(err);
+                }
+                return getCommits(repoManager, owner, repo, ref, count, readParams, externalStorageManager);
+            } catch (bridgeError) {
+                // If file does not exist or error trying to look up commit, return the original error.
+                winston.error(`BridgeError: ${bridgeError}`);
                 return Promise.reject(err);
             }
-            return getCommits(repoManager, owner, repo, ref, count, externalStorageManager);
-        } catch (bridgeError) {
-            // If file does not exist or error trying to look up commit, return the original error.
-            winston.error(`BridgeError: ${bridgeError}`);
-            return Promise.reject(err);
         }
+        return Promise.reject(err);
     }
 }
 
@@ -84,6 +89,7 @@ export function create(store: nconf.Provider, repoManager: utils.RepositoryManag
             request.params.repo,
             request.query.sha as string,
             Number(request.query.count as string),
+            utils.getReadParams(request.query?.config),
             externalStorageManager);
         return resultP.then(
             (result) => {

--- a/server/gitrest/src/routes/repository/commits.ts
+++ b/server/gitrest/src/routes/repository/commits.ts
@@ -18,7 +18,7 @@ export async function getCommits(
     repo: string,
     ref: string,
     count: number,
-    readParams: IGetRefParamsExternal,
+    readParams: IGetRefParamsExternal | undefined,
     externalStorageManager: IExternalStorageManager): Promise<resources.ICommitDetails[]> {
     const repository = await repoManager.open(owner, repo);
     try {

--- a/server/gitrest/src/test/routes.spec.ts
+++ b/server/gitrest/src/test/routes.spec.ts
@@ -13,6 +13,7 @@ import {
 } from "@fluidframework/gitresources";
 import {
     ICreateRefParamsExternal,
+    IGetRefParamsExternal,
 } from "@fluidframework/server-services-client";
 import * as async from "async";
 import lorem from "lorem-ipsum";
@@ -140,6 +141,10 @@ describe("GitRest", () => {
         const testRef: ICreateRefParamsExternal = {
             ref: "refs/heads/main",
             sha: "cf0b592907d683143b28edd64d274ca70f68998e",
+            config: { enabled: true },
+        };
+
+        const testReadParams: IGetRefParamsExternal = {
             config: { enabled: true },
         };
 
@@ -459,6 +464,7 @@ describe("GitRest", () => {
                             testRepoName,
                             lastCommit,
                             1,
+                            testReadParams,
                             externalStorageManager);
                         const parentCommit = commits[0];
                         assert.ok(parentCommit.commit);

--- a/server/gitrest/src/utils.ts
+++ b/server/gitrest/src/utils.ts
@@ -8,6 +8,7 @@ import * as path from "path";
 import * as util from "util";
 import git from "nodegit";
 import * as resources from "@fluidframework/gitresources";
+import { IGetRefParamsExternal } from "@fluidframework/server-services-client";
 import * as winston from "winston";
 
 const exists = util.promisify(fs.exists);
@@ -50,6 +51,17 @@ function committerToICommitter(committer: git.Signature, time: Date): resources.
 
 function oidToCommitHash(oid: git.Oid): resources.ICommitHash {
     return { sha: oid.tostrS(), url: "" };
+}
+
+/**
+ * Helper function to decode externalstorage read params
+ */
+export function getReadParams(params): IGetRefParamsExternal | undefined {
+    if (params) {
+        const getRefParams: IGetRefParamsExternal = JSON.parse(decodeURIComponent(params));
+        return getRefParams;
+    }
+    return undefined;
 }
 
 /**

--- a/server/historian/packages/historian-base/src/services/restGitService.ts
+++ b/server/historian/packages/historian-base/src/services/restGitService.ts
@@ -76,9 +76,17 @@ export class RestGitService {
     }
 
     public async getCommits(sha: string, count: number): Promise<git.ICommitDetails[]> {
+        let config;
+        if (this.writeToExternalStorage) {
+            const getRefParams: IGetRefParamsExternal = {
+                config: { enabled: true },
+            };
+            config = encodeURIComponent(JSON.stringify(getRefParams));
+        }
         const query = querystring.stringify({
             count,
             sha,
+            config,
         });
         return this.get(`/repos/${this.getRepoPath()}/commits?${query}`);
     }


### PR DESCRIPTION
Adding read params to getCommits in historian and parse them in gitrest to decide whether to read from external storage or not.