### PR TITLE
normalize data corruption error category labels

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,6 +1,10 @@
 ## 0.33 Breaking changes
+- [Normalizing enum ContainerErrorType](#normalizing-enum-containererrortype)
 - [Map and Directory typing changes from enabling strictNullCheck](#map-and-directory-typing-changes-from-enabling-strictNullCheck)
 - [MergeTree's ReferencePosition.getTileLabels and ReferencePosition.getRangeLabels() return undefined if it doesn't exist](#mergetree-referenceposition-gettilelabels-getrangelabels-changes)
+
+## Normalizing enum ContainerErrorType
+In an effort to clarify error categorization, a name and value in this enumeration were changed.
 
 ## Map and Directory typing changes from enabling strictNullCheck
 Typescript compile options `strictNullCheck` is enabled for the `@fluidframework/map` package. Some of the API signature is updated to include possibility of `undefined` and `null`, which can cause new typescript compile error when upgrading.  Existing code may need to update to handle the possiblity of `undefined` or `null.

--- a/packages/loader/container-definitions/src/error.ts
+++ b/packages/loader/container-definitions/src/error.ts
@@ -20,7 +20,7 @@ export enum ContainerErrorType {
     /**
      * Data loss error detected by Container / DeltaManager. Likely points to storage issue.
      */
-    dataCorruption = "dataCorruption",
+    dataCorruptionError = "dataCorruptionError",
 }
 
 /**

--- a/packages/loader/container-utils/src/error.ts
+++ b/packages/loader/container-utils/src/error.ts
@@ -36,7 +36,7 @@ export class GenericError extends LoggingError implements IGenericError {
 }
 
 export class DataCorruptionError extends LoggingError implements IErrorBase {
-    readonly errorType = "dataCorruptionError";
+    readonly errorType = ContainerErrorType.dataCorruptionError;
     readonly canRetry = false;
 
     constructor(


### PR DESCRIPTION
This change is a first step towards normalizing how errors are categorized generally -- especially for the purposes of log filtration downstream (see #4663 )

@anthony-murphy , just want to point out specifically that although we had discussed it might not be appropriate to import the `ContainerErrorType` enum directly into the `loader/container-utils` package because there was an intent to keep the latter from comingling with the `loader/container-definitions`, it is actually already getting imported there today.  Perhaps any according reorganization can be deferred to a later PR if necessary(?)