### PR TITLE
Cleanup of summary related interfaces: Server part of changes

### DIFF
--- a/server/routerlicious/packages/protocol-base/src/blobs.ts
+++ b/server/routerlicious/packages/protocol-base/src/blobs.ts
@@ -41,16 +41,15 @@ export function getGitMode(value: SummaryObject): string {
  * @param value - summary object
  * @returns the type of summary object
  */
-export function getGitType(value: SummaryObject): "blob" | "tree" | "attachment" {
+export function getGitType(value: SummaryObject): "blob" | "tree" {
     const type = value.type === SummaryType.Handle ? value.handleType : value.type;
 
     switch (type) {
         case SummaryType.Blob:
+        case SummaryType.Attachment:
             return "blob";
         case SummaryType.Tree:
             return "tree";
-        case SummaryType.Attachment:
-            return "attachment";
         default:
             unreachableCase(type, `Unknown type: ${type}`);
     }

--- a/server/routerlicious/packages/protocol-base/src/blobs.ts
+++ b/server/routerlicious/packages/protocol-base/src/blobs.ts
@@ -15,7 +15,7 @@ import {
     SummaryType,
     SummaryObject,
 } from "@fluidframework/protocol-definitions";
-
+import { unreachableCase } from "@fluidframework/common-utils";
 /**
  * Take a summary object and returns its git mode.
  *
@@ -26,13 +26,12 @@ export function getGitMode(value: SummaryObject): string {
     const type = value.type === SummaryType.Handle ? value.handleType : value.type;
     switch (type) {
         case SummaryType.Blob:
+        case SummaryType.Attachment:
             return FileMode.File;
-        case SummaryType.Commit:
-            return FileMode.Commit;
         case SummaryType.Tree:
             return FileMode.Directory;
         default:
-            throw new Error();
+            unreachableCase(type, `Unknown type: ${type}`);
     }
 }
 
@@ -42,20 +41,18 @@ export function getGitMode(value: SummaryObject): string {
  * @param value - summary object
  * @returns the type of summary object
  */
-export function getGitType(value: SummaryObject): string {
+export function getGitType(value: SummaryObject): "blob" | "tree" | "attachment" {
     const type = value.type === SummaryType.Handle ? value.handleType : value.type;
 
     switch (type) {
         case SummaryType.Blob:
             return "blob";
-        case SummaryType.Commit:
-            return "commit";
         case SummaryType.Tree:
             return "tree";
         case SummaryType.Attachment:
             return "attachment";
         default:
-            throw new Error();
+            unreachableCase(type, `Unknown type: ${type}`);
     }
 }
 

--- a/server/routerlicious/packages/protocol-definitions/src/summary.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/summary.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export type SummaryObject = ISummaryCommit | ISummaryTree | ISummaryBlob | ISummaryHandle | ISummaryAttachment;
+export type SummaryObject = ISummaryTree | ISummaryBlob | ISummaryHandle | ISummaryAttachment;
 
 export type SummaryTree = ISummaryTree | ISummaryHandle;
 
@@ -22,17 +22,19 @@ export interface ISummaryCommitter {
 }
 
 export const enum SummaryType {
-    Commit = 0,
     Tree = 1,
     Blob = 2,
     Handle = 3,
     Attachment = 4,
 }
 
+export type SummaryTypeNoHandle = SummaryType.Tree | SummaryType.Blob | SummaryType.Attachment;
+
 export interface ISummaryHandle {
     type: SummaryType.Handle;
 
-    handleType: SummaryType;
+    // No handles, all other SummaryType are Ok
+    handleType: SummaryTypeNoHandle;
 
     // Stored handle reference
     handle: string;
@@ -56,20 +58,4 @@ export interface ISummaryTree {
 
     // Indicates that this tree entry is unreferenced. If this is not present, the tree entry is considered referenced.
     unreferenced?: true;
-}
-
-export interface ISummaryCommit {
-    type: SummaryType.Commit;
-
-    author: ISummaryAuthor;
-
-    committer: ISummaryAuthor;
-
-    message: string;
-
-    // Tree referenced by the commit
-    tree: SummaryTree;
-
-    // Previous parents to the commit.
-    parents: string[];
 }


### PR DESCRIPTION
Splitting server changes from https://github.com/microsoft/FluidFramework/pull/4682
Need SummaryType.Attachment handling in getGitMode / getGitType in order to remove a copy of those functions on r11s driver.