### PR TITLE
ISnapshotTree: type safety (ids, values): server part only

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -222,7 +222,7 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
 
         const [serviceProtocolTree, lastSummaryTree] = await Promise.all([
             // eslint-disable-next-line no-null/no-null
-            gitManager.createTree({ entries: serviceProtocolEntries, id: null }),
+            gitManager.createTree({ entries: serviceProtocolEntries }),
             gitManager.getTree(lastCommit.tree.sha, false),
         ]);
 

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -156,9 +156,9 @@ export class SummaryWriter implements ISummaryWriter {
             JSON.stringify(checkpoint));
 
         const [logTailTree, protocolTree, serviceProtocolTree, appSummaryTree] = await Promise.all([
-            this.summaryStorage.createTree({ entries: logTailEntries, id: null }),
-            this.summaryStorage.createTree({ entries: protocolEntries, id: null }),
-            this.summaryStorage.createTree({ entries: serviceProtocolEntries, id: null }),
+            this.summaryStorage.createTree({ entries: logTailEntries }),
+            this.summaryStorage.createTree({ entries: protocolEntries }),
+            this.summaryStorage.createTree({ entries: serviceProtocolEntries }),
             this.summaryStorage.getTree(content.handle, false),
         ]);
 
@@ -251,8 +251,8 @@ export class SummaryWriter implements ISummaryWriter {
         // Fetch the last commit and summary tree. Create new trees with logTail and serviceProtocol.
         const lastCommit = await this.summaryStorage.getCommit(existingRef.object.sha);
         const [logTailTree, serviceProtocolTree, lastSummaryTree] = await Promise.all([
-            this.summaryStorage.createTree({ entries: logTailEntries, id: null }),
-            this.summaryStorage.createTree({ entries: serviceProtocolEntries, id: null }),
+            this.summaryStorage.createTree({ entries: logTailEntries }),
+            this.summaryStorage.createTree({ entries: serviceProtocolEntries }),
             this.summaryStorage.getTree(lastCommit.tree.sha, false),
         ]);
 

--- a/server/routerlicious/packages/protocol-base/src/blobs.ts
+++ b/server/routerlicious/packages/protocol-base/src/blobs.ts
@@ -8,7 +8,7 @@ import {
     FileMode,
     IBlob,
     IAttachment,
-    ISnapshotTree,
+    ISnapshotTreeEx,
     ITree,
     ITreeEntry,
     TreeEntry,
@@ -68,9 +68,9 @@ export function getGitType(value: SummaryObject): string {
  */
 export function buildHierarchy(
     flatTree: git.ITree,
-    blobsShaToPathCache: Map<string, string> = new Map<string, string>()): ISnapshotTree {
-    const lookup: { [path: string]: ISnapshotTree } = {};
-    const root: ISnapshotTree = { id: flatTree.sha, blobs: {}, commits: {}, trees: {} };
+    blobsShaToPathCache: Map<string, string> = new Map<string, string>()): ISnapshotTreeEx {
+    const lookup: { [path: string]: ISnapshotTreeEx } = {};
+    const root: ISnapshotTreeEx = { id: flatTree.sha, blobs: {}, commits: {}, trees: {} };
     lookup[""] = root;
 
     for (const entry of flatTree.tree) {

--- a/server/routerlicious/packages/protocol-base/src/blobs.ts
+++ b/server/routerlicious/packages/protocol-base/src/blobs.ts
@@ -10,7 +10,6 @@ import {
     IAttachment,
     ISnapshotTreeEx,
     ITree,
-    ITreeEntry,
     TreeEntry,
     SummaryType,
     SummaryObject,
@@ -100,7 +99,7 @@ export function buildHierarchy(
 /**
  * Basic implementation of a blob ITreeEntry
  */
-export class BlobTreeEntry implements ITreeEntry {
+export class BlobTreeEntry {
     public readonly mode = FileMode.File;
     public readonly type = TreeEntry.Blob;
     public readonly value: IBlob;
@@ -119,7 +118,7 @@ export class BlobTreeEntry implements ITreeEntry {
 /**
  * Basic implementation of a commit ITreeEntry
  */
-export class CommitTreeEntry implements ITreeEntry {
+export class CommitTreeEntry {
     public readonly mode = FileMode.Commit;
     public readonly type = TreeEntry.Commit;
 
@@ -134,7 +133,7 @@ export class CommitTreeEntry implements ITreeEntry {
 /**
  * Basic implementation of a tree ITreeEntry
  */
-export class TreeTreeEntry implements ITreeEntry {
+export class TreeTreeEntry {
     public readonly mode = FileMode.Directory;
     public readonly type = TreeEntry.Tree;
 
@@ -149,7 +148,7 @@ export class TreeTreeEntry implements ITreeEntry {
 /**
  * Basic implementation of an attachment ITreeEntry
  */
-export class AttachmentTreeEntry implements ITreeEntry {
+export class AttachmentTreeEntry {
     public readonly mode = FileMode.File;
     public readonly type = TreeEntry.Attachment;
     public readonly value: IAttachment;

--- a/server/routerlicious/packages/protocol-definitions/src/storage.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/storage.ts
@@ -56,20 +56,26 @@ export interface ICreateBlobResponse {
 /**
  * A tree entry wraps a path with a type of node
  */
-export interface ITreeEntry {
+export type ITreeEntry = {
     // Path to the object
     path: string;
-
-    // One of the below enum string values
-    type: TreeEntry.Blob | TreeEntry.Commit | TreeEntry.Tree | TreeEntry.Attachment;
-
-    // The value of the entry - either a tree or a blob
-    value: IBlob | IAttachment | ITree | string;
-
     // The file mode; one of 100644 for file (blob), 100755 for executable (blob), 040000 for subdirectory (tree),
     // 160000 for submodule (commit), or 120000 for a blob that specifies the path of a symlink
     mode: FileMode;
-}
+} & (
+{
+    type: TreeEntry.Blob;
+    value: IBlob;
+} | {
+    type: TreeEntry.Commit;
+    value: string;
+} | {
+    type: TreeEntry.Tree;
+    value: ITree;
+} | {
+    type: TreeEntry.Attachment;
+    value: IAttachment;
+});
 
 /**
  * Type of entries that can be stored in a tree

--- a/server/routerlicious/packages/protocol-definitions/src/storage.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/storage.ts
@@ -61,7 +61,7 @@ export interface ITreeEntry {
     path: string;
 
     // One of the below enum string values
-    type: string;
+    type: TreeEntry.Blob | TreeEntry.Commit | TreeEntry.Tree | TreeEntry.Attachment;
 
     // The value of the entry - either a tree or a blob
     value: IBlob | IAttachment | ITree | string;
@@ -86,14 +86,20 @@ export interface ITree {
 
     // Unique ID representing all entries in the tree. Can be used to optimize snapshotting in the case
     // it is known that the ITree has already been created and stored
-    id: string | null;
+    id?: string;
 }
 
 export interface ISnapshotTree {
-    id: string | null;
+    id? : string;
     blobs: { [path: string]: string };
+    // TODO: Commits should be removed from here to ISnapshotTreeEx once ODSP snapshots move away from commits
     commits: { [path: string]: string };
     trees: { [path: string]: ISnapshotTree };
+}
+
+export interface ISnapshotTreeEx extends ISnapshotTree {
+    id: string;
+    trees: { [path: string]: ISnapshotTreeEx };
 }
 
 /**

--- a/server/routerlicious/packages/test-utils/src/testDocumentStorage.ts
+++ b/server/routerlicious/packages/test-utils/src/testDocumentStorage.ts
@@ -18,7 +18,7 @@ import {
     ICommittedProposal,
     ITreeEntry,
     SummaryType,
-    ISnapshotTree,
+    ISnapshotTreeEx,
     SummaryObject,
 } from "@fluidframework/protocol-definitions";
 import {
@@ -75,7 +75,7 @@ export class TestDocumentStorage implements IDocumentStorage {
             getQuorumTreeEntries(documentId, sequenceNumber, sequenceNumber, term, quorumSnapshot);
 
         const [protocolTree, appSummaryTree] = await Promise.all([
-            gitManager.createTree({ entries, id: null }),
+            gitManager.createTree({ entries }),
             gitManager.getTree(handle, false),
         ]);
 
@@ -206,7 +206,7 @@ export async function writeSummaryTree(
     manager: IGitManager,
     summaryTree: ISummaryTree,
     blobsShaCache: Set<string>,
-    snapshot: ISnapshotTree | undefined,
+    snapshot: ISnapshotTreeEx | undefined,
 ): Promise<string> {
     const entries = await Promise.all(Object.keys(summaryTree.tree).map(async (key) => {
         const entry = summaryTree.tree[key];
@@ -229,7 +229,7 @@ async function writeSummaryTreeObject(
     blobsShaCache: Set<string>,
     key: string,
     object: SummaryObject,
-    snapshot: ISnapshotTree | undefined,
+    snapshot: ISnapshotTreeEx | undefined,
     currentPath = "",
 ): Promise<string> {
     switch (object.type) {
@@ -254,7 +254,7 @@ async function writeSummaryTreeObject(
 function getIdFromPath(
     handleType: SummaryType,
     handlePath: string,
-    fullSnapshot: ISnapshotTree,
+    fullSnapshot: ISnapshotTreeEx,
 ): string {
     const path = handlePath.split("/").map((part) => decodeURIComponent(part));
     if (path[0] === "") {
@@ -268,24 +268,16 @@ function getIdFromPath(
 function getIdFromPathCore(
     handleType: SummaryType,
     path: string[],
-    snapshot: ISnapshotTree,
+    snapshot: ISnapshotTreeEx,
 ): string {
     const key = path[0];
     if (path.length === 1) {
         switch (handleType) {
             case SummaryType.Blob: {
-                const tryId = snapshot.blobs[key];
-                if (!tryId) {
-                    throw Error("Parent summary does not have blob handle for specified path.");
-                }
-                return tryId;
+                return snapshot.blobs[key];
             }
             case SummaryType.Tree: {
-                const tryId = snapshot.trees[key]?.id;
-                if (!tryId) {
-                    throw Error("Parent summary does not have tree handle for specified path.");
-                }
-                return tryId;
+                return snapshot.trees[key]?.id;
             }
             default:
                 throw Error(`Unexpected handle summary object type: "${handleType}".`);


### PR DESCRIPTION
Server changes for https://github.com/microsoft/FluidFramework/pull/4838
Please see full PR for benefits and changes in client code.

1. ISnapshotTree.id : change default value from null to undefined and remove all the dummy IDs / nulls across code base.
Note that today runtime have no usage for these IDs, as driver does not provide any way to ask for sub-tree (only commit tree by version), and currently there is no support for partial trees or ability for summarizer to leverage tree IDs (it uses indirect references by summary handle + path not to read back trees after each summary).
   - ISnapshotTreeEx is created for r11s server who needs to have IDs in place for internal usage.
   - In future, I'd love to move commits property from ISnapshotTree to ISnapshotTreeEx as nowhere in the code we leverage commits (with exception of ODSP driver - that usage is going away).

2. ITreeEntry has much stronger type definition, that allows us to remove all casting of value property and get help of compiler in catching mismatches (like type = Tree, but value being IBlob).

