### PR TITLE
Update unreferenced flag in the summary sent to SPO

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -1006,7 +1006,10 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
 
             let id: string | undefined;
             let value: SnapshotTreeValue | undefined;
-            // Tracks if an entry is unreferenced. Currently, only tree entries can be marked as unreferenced.
+
+            // Tracks if an entry is unreferenced. Currently, only tree entries can be marked as unreferenced. If the
+            // property is not present, the tree entry is considered referenced. If the property is present and is
+            // true (which is the only value it can have), the tree entry is considered unreferenced.
             let unreferenced: true | undefined;
 
             switch (summaryObject.type) {
@@ -1085,14 +1088,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                     ...baseEntry,
                     id,
                     value,
+                    unreferenced,
                 };
-
-                // The unreferenced property in a snapshot tree entry indicates whether it is unreferenced. If the
-                // property is not present, the tree entry is considered referenced. If the property is present and is
-                // true (which is the only value it can have), the tree entry is considered unreferenced.
-                if (unreferenced) {
-                    entry.unreferenced = true;
-                }
             } else if (id) {
                 entry = {
                     ...baseEntry,

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -1006,6 +1006,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
 
             let id: string | undefined;
             let value: SnapshotTreeValue | undefined;
+            // Tracks if an entry is unreferenced. Currently, only tree entries can be marked as unreferenced.
+            let unreferenced: true | undefined;
 
             switch (summaryObject.type) {
                 case api.SummaryType.Tree: {
@@ -1016,6 +1018,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                         depth + 1,
                         `${path}/${key}`);
                     value = result.snapshotTree;
+                    unreferenced = summaryObject.unreferenced;
                     reusedBlobs += result.reusedBlobs;
                     blobs += result.blobs;
                     break;
@@ -1083,6 +1086,13 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                     id,
                     value,
                 };
+
+                // The unreferenced property in a snapshot tree entry indicates whether it is unreferenced. If the
+                // property is not present, the tree entry is considered referenced. If the property is present and is
+                // true (which is the only value it can have), the tree entry is considered unreferenced.
+                if (unreferenced) {
+                    entry.unreferenced = true;
+                }
             } else if (id) {
                 entry = {
                     ...baseEntry,


### PR DESCRIPTION
Fixes #4057.

The changes sets the "unreferenced" flag in the summary that is sent to SPO for corresponding entries in the ISummaryTree.