### PR TITLE
Fix build:fast error

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -5278,7 +5278,7 @@
 		"@microsoft/tsdoc": {
 			"version": "0.12.19",
 			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.19.tgz",
-			"integrity": "sha1-IXPMuSRpqvYgMfqUmdIbFtB/m1c=",
+			"integrity": "sha512-IpgPxHrNxZiMNUSXqR1l/gePKPkfAmIKoDRP9hp7OwjU29ZR8WCJsOJ8iBKgw0Qk+pFwR+8Y1cy8ImLY6e9m4A==",
 			"dev": true
 		},
 		"@mixer/webpack-bundle-compare": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2141,7 +2141,7 @@
     "@microsoft/tsdoc": {
       "version": "0.12.19",
       "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.19.tgz",
-      "integrity": "sha1-IXPMuSRpqvYgMfqUmdIbFtB/m1c=",
+      "integrity": "sha512-IpgPxHrNxZiMNUSXqR1l/gePKPkfAmIKoDRP9hp7OwjU29ZR8WCJsOJ8iBKgw0Qk+pFwR+8Y1cy8ImLY6e9m4A==",
       "dev": true
     },
     "@mrmlnc/readdir-enhanced": {

--- a/packages/framework/experimental-fluidframework/.eslintrc.js
+++ b/packages/framework/experimental-fluidframework/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
         "@fluidframework/eslint-config-fluid/eslint7"
     ],
     "parserOptions": {
-        "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
+        "project": ["./tsconfig.json"]
     },
     "rules": {
         "@typescript-eslint/strict-boolean-expressions": "off"


### PR DESCRIPTION
The new package `experimental-fluidframework` .eslintrc reference the test tsconfig.json that isn't built, because it doesn't have test yet.
FluidBuild error when it find the associate tsc task for the project reference.  Remove it for now, and will add pack when there are test introduced.