### PR TITLE
Enable strictNullCheck in merge-tree

### DIFF
--- a/packages/dds/matrix/src/handlecache.ts
+++ b/packages/dds/matrix/src/handlecache.ts
@@ -76,7 +76,8 @@ export class HandleCache implements IVectorConsumer<Handle> {
         for (let pos = start; pos < end; pos++) {
             const { segment, offset } = vector.getContainingSegment(pos);
             const asPerm = segment as PermutationSegment;
-            handles.push(asPerm.start + offset);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            handles.push(asPerm.start + offset!);
         }
 
         return handles;

--- a/packages/dds/matrix/src/permutationvector.ts
+++ b/packages/dds/matrix/src/permutationvector.ts
@@ -205,7 +205,8 @@ export class PermutationVector extends Client {
             return undefined;
         }
 
-        return this.getPosition(segment) + offset;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return this.getPosition(segment) + offset!;
     }
 
     public handleToPosition(handle: Handle, localSeq = this.mergeTree.collabWindow.localSeq) {

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -829,7 +829,7 @@ export class Client {
                 op: msg.contents as ops.IMergeTreeOp,
                 sequencedMessage: msg,
             };
-            if (opArgs.sequencedMessage!.clientId === this.longClientId) {
+            if (opArgs.sequencedMessage?.clientId === this.longClientId) {
                 this.ackPendingSegment(opArgs);
             }
             else {

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -731,7 +731,7 @@ export class Client {
         resetOp: ops.IMergeTreeDeltaOp,
         segmentGroup: SegmentGroup): ops.IMergeTreeDeltaOp[] {
         assert(!!segmentGroup, "Segment group undefined");
-        const NACKedSegmentGroup = this.mergeTree.pendingSegments!.dequeue();
+        const NACKedSegmentGroup = this.mergeTree.pendingSegments?.dequeue();
         assert(segmentGroup === NACKedSegmentGroup, "Segment group not at head of merge tree pending queue");
 
         const opList: ops.IMergeTreeDeltaOp[] = [];

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -629,7 +629,7 @@ export class Client {
 
             if (this.verboseOps) {
                 console.log(`@cli ${this.getLongClientId(this.getCollabWindow().clientId)} ` +
-                    `ack seq # ${deltaOpArgs.sequencedMessage!.sequenceNumber}`);
+                    `ack seq # ${deltaOpArgs.sequencedMessage?.sequenceNumber}`);
             }
         };
 

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -247,7 +247,7 @@ export class Client {
         this.completeAndLogOp(
             opArgs,
             this.getClientSequenceArgs(opArgs),
-            { start: op.pos1!, end: -1 },
+            { start: op.pos1 },
             traceStart);
 
         return op;
@@ -471,7 +471,7 @@ export class Client {
     private completeAndLogOp(
         opArgs: IMergeTreeDeltaOpArgs,
         clientArgs: IMergeTreeClientSequenceArgs,
-        range: IIntegerRange,
+        range: Partial<IIntegerRange>,
         traceStart?: Trace) {
         if (!opArgs.sequencedMessage) {
             if (traceStart) {

--- a/packages/dds/merge-tree/src/collections.ts
+++ b/packages/dds/merge-tree/src/collections.ts
@@ -7,7 +7,6 @@
 /* eslint-disable no-bitwise, no-param-reassign */
 
 /* Remove once strictNullCheck is enabled */
-/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 
 import { Trace } from "@fluidframework/common-utils";
 import * as Base from "./base";

--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -106,7 +106,8 @@ export class LocalReference implements ReferencePosition {
     }
 
     public getOffset() {
-        if (this.segment.removedSeq) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        if (this.segment!.removedSeq) {
             return 0;
         }
         return this.offset;
@@ -216,7 +217,8 @@ export class LocalReferenceCollection {
                 at: [lref],
             };
         } else {
-            refsAtOffset.at.push(lref);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            refsAtOffset.at!.push(lref);
         }
 
         if (lref.hasRangeLabels() || lref.hasTileLabels()) {

--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -107,7 +107,7 @@ export class LocalReference implements ReferencePosition {
 
     public getOffset() {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        if (this.segment!.removedSeq) {
+        if (this.segment?.removedSeq) {
             return 0;
         }
         return this.offset;

--- a/packages/dds/merge-tree/src/opBuilder.ts
+++ b/packages/dds/merge-tree/src/opBuilder.ts
@@ -47,7 +47,7 @@ export function createAnnotateMarkerOp(
  * @returns The annotate op
  */
 export function createAnnotateRangeOp(
-    start: number, end: number, props: PropertySet, combiningOp: ICombiningOp): IMergeTreeAnnotateMsg {
+    start: number, end: number, props: PropertySet, combiningOp: ICombiningOp | undefined): IMergeTreeAnnotateMsg {
     return {
         combiningOp,
         pos1: start,

--- a/packages/dds/merge-tree/src/partialLengths.ts
+++ b/packages/dds/merge-tree/src/partialLengths.ts
@@ -158,7 +158,8 @@ export class PartialSequenceLengths {
                     childBlock.partialLengths =
                         PartialSequenceLengths.combine(mergeTree, childBlock, collabWindow, true);
                 }
-                childPartials.push(childBlock.partialLengths.partialLengthsForBranch(branchId));
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                childPartials.push(childBlock.partialLengths!.partialLengthsForBranch(branchId));
             }
         }
         let childPartialsLen = childPartials.length;
@@ -186,14 +187,16 @@ export class PartialSequenceLengths {
                     // Find next earliest sequence number
                     if (indices[k] < childPartialsCounts[k]) {
                         const cpLen = childPartials[k].partialLengths[indices[k]];
-                        if ((outerIndexOfEarliest < 0) || (cpLen.seq < earliestPartialLength.seq)) {
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                        if ((outerIndexOfEarliest < 0) || (cpLen.seq < earliestPartialLength!.seq)) {
                             outerIndexOfEarliest = k;
                             earliestPartialLength = cpLen;
                         }
                     }
                 }
                 if (outerIndexOfEarliest >= 0) {
-                    addNext(earliestPartialLength);
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    addNext(earliestPartialLength!);
                     indices[outerIndexOfEarliest]++;
                 }
             }
@@ -236,7 +239,8 @@ export class PartialSequenceLengths {
                 // eslint-disable-next-line max-len
                 // console.log(`seg br ${segBranchId} cli ${glc(mergeTree, segment.clientId)} me ${glc(mergeTree, mergeTree.collabWindow.clientId)}`);
                 if (segBranchId <= branchId) {
-                    if (seqLTE(segment.seq, collabWindow.minSeq)) {
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    if (seqLTE(segment.seq!, collabWindow.minSeq)) {
                         combinedPartialLengths.minLength += segment.cachedLength;
                     } else {
                         if (segment.seq !== UnassignedSequenceNumber) {
@@ -244,7 +248,8 @@ export class PartialSequenceLengths {
                         }
                     }
                     const removalInfo = mergeTree.getRemovalInfo(branchId, segBranchId, segment);
-                    if (seqLTE(removalInfo.removedSeq, collabWindow.minSeq)) {
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    if (seqLTE(removalInfo.removedSeq!, collabWindow.minSeq)) {
                         combinedPartialLengths.minLength -= segment.cachedLength;
                     } else {
                         if ((removalInfo.removedSeq !== undefined) &&
@@ -305,15 +310,18 @@ export class PartialSequenceLengths {
         combinedPartialLengths: PartialSequenceLengths,
         segment: ISegment,
         removalInfo?: IRemovalInfo) {
-        let seq = segment.seq;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        let seq = segment.seq!;
         let segmentLen = segment.cachedLength;
         let clientId = segment.clientId;
         let removeClientOverlap: number[] | undefined;
 
         if (removalInfo) {
-            seq = removalInfo.removedSeq;
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            seq = removalInfo.removedSeq!;
             segmentLen = -segmentLen;
-            clientId = removalInfo.removedClientId;
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            clientId = removalInfo.removedClientId!;
             if (removalInfo.removedClientOverlap) {
                 removeClientOverlap = removalInfo.removedClientOverlap;
             }
@@ -396,7 +404,7 @@ export class PartialSequenceLengths {
     public segmentCount = 0;
     public partialLengths: PartialSequenceLength[] = [];
     public clientSeqNumbers: PartialSequenceLength[][] = [];
-    public downstreamPartialLengths: PartialSequenceLengths[];
+    public downstreamPartialLengths: PartialSequenceLengths[] | undefined;
 
     constructor(public minSeq: number) {
     }
@@ -417,7 +425,8 @@ export class PartialSequenceLengths {
             for (let i = 0; i < mergeTree.localBranchId; i++) {
                 const branchId = i + 1;
                 if (segBranchId <= branchId) {
-                    this.downstreamPartialLengths[i].updateBranch(
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    this.downstreamPartialLengths![i].updateBranch(
                         mergeTree,
                         branchId,
                         block,
@@ -435,7 +444,8 @@ export class PartialSequenceLengths {
             console.log(`plen branch ${branchId}`);
         }
         if (branchId > 0) {
-            return this.downstreamPartialLengths[branchId - 1].getBranchPartialLength(refSeq, clientId);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            return this.downstreamPartialLengths![branchId - 1].getBranchPartialLength(refSeq, clientId);
         } else {
             return this.getBranchPartialLength(refSeq, clientId);
         }
@@ -531,7 +541,8 @@ export class PartialSequenceLengths {
 
     // Assumes sequence number already coalesced
     private addClientSeqNumberFromPartial(partialLength: PartialSequenceLength) {
-        this.addClientSeqNumber(partialLength.clientId, partialLength.seq, partialLength.seglen);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        this.addClientSeqNumber(partialLength.clientId!, partialLength.seq, partialLength.seglen);
         if (partialLength.overlapRemoveClients) {
             partialLength.overlapRemoveClients.map((oc: Property<number, IOverlapClient>) => {
                 this.addClientSeqNumber(oc.data.clientId, partialLength.seq, oc.data.seglen);
@@ -557,7 +568,8 @@ export class PartialSequenceLengths {
             const child = node.children[i];
             if (!child.isLeaf()) {
                 const childBlock = child;
-                const branchPartialLengths = childBlock.partialLengths.partialLengthsForBranch(branchId);
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                const branchPartialLengths = childBlock.partialLengths!.partialLengthsForBranch(branchId);
                 const partialLengths = branchPartialLengths.partialLengths;
                 const seqIndex = latestLEQ(partialLengths, seq);
                 if (seqIndex >= 0) {
@@ -605,7 +617,8 @@ export class PartialSequenceLengths {
 
     private partialLengthsForBranch(branchId: number) {
         if (branchId > 0) {
-            return this.downstreamPartialLengths[branchId - 1];
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            return this.downstreamPartialLengths![branchId - 1];
         } else {
             return this;
         }

--- a/packages/dds/merge-tree/src/properties.ts
+++ b/packages/dds/merge-tree/src/properties.ts
@@ -42,14 +42,16 @@ export function combine(combiningInfo: ops.ICombiningOp, currentValue: any, newV
             if (currentValue === undefined) {
                 const cv: IConsensusValue = {
                     value: newValue,
-                    seq,
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    seq: seq!,
                 };
 
                 currentValue = cv;
             } else {
                 const cv = currentValue as IConsensusValue;
                 if (cv.seq === -1) {
-                    cv.seq = seq;
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    cv.seq = seq!;
                 }
             }
             break;

--- a/packages/dds/merge-tree/src/segmentPropertiesManager.ts
+++ b/packages/dds/merge-tree/src/segmentPropertiesManager.ts
@@ -25,11 +25,11 @@ export class SegmentPropertiesManager {
         }
         for (const key of Object.keys(annotateOp.props)) {
             if (this.pendingKeyUpdateCount?.[key] !== undefined) {
-                assert(this.pendingKeyUpdateCount![key] > 0);
-                this.pendingKeyUpdateCount![key]--;
+                assert(this.pendingKeyUpdateCount[key] > 0);
+                this.pendingKeyUpdateCount[key]--;
                 if (this.pendingKeyUpdateCount?.[key] === 0) {
                     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-                    delete this.pendingKeyUpdateCount![key];
+                    delete this.pendingKeyUpdateCount[key];
                 }
             }
         }
@@ -83,7 +83,7 @@ export class SegmentPropertiesManager {
         for (const key of Object.keys(newProps)) {
             if (collaborating) {
                 if (seq === UnassignedSequenceNumber) {
-                    if (this.pendingKeyUpdateCount.?[key] === undefined) {
+                    if (this.pendingKeyUpdateCount?.[key] === undefined) {
                         this.pendingKeyUpdateCount![key] = 0;
                     }
                     this.pendingKeyUpdateCount![key]++;

--- a/packages/dds/merge-tree/src/segmentPropertiesManager.ts
+++ b/packages/dds/merge-tree/src/segmentPropertiesManager.ts
@@ -57,7 +57,7 @@ export class SegmentPropertiesManager {
 
         const shouldModifyKey = (key: string): boolean => {
             if (seq === UnassignedSequenceNumber
-                || this.pendingKeyUpdateCount![key] === undefined
+                || this.pendingKeyUpdateCount?.[key] === undefined
                 || combiningOp) {
                 return true;
             }

--- a/packages/dds/merge-tree/src/segmentPropertiesManager.ts
+++ b/packages/dds/merge-tree/src/segmentPropertiesManager.ts
@@ -24,7 +24,7 @@ export class SegmentPropertiesManager {
             this.pendingRewriteCount--;
         }
         for (const key of Object.keys(annotateOp.props)) {
-            if (this.pendingKeyUpdateCount![key] !== undefined) {
+            if (this.pendingKeyUpdateCount?.[key] !== undefined) {
                 assert(this.pendingKeyUpdateCount![key] > 0);
                 this.pendingKeyUpdateCount![key]--;
                 if (this.pendingKeyUpdateCount![key] === 0) {

--- a/packages/dds/merge-tree/src/segmentPropertiesManager.ts
+++ b/packages/dds/merge-tree/src/segmentPropertiesManager.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+ /* eslint-disable @typescript-eslint/no-non-null-assertion */
+
 import { assert } from "@fluidframework/common-utils";
 import { UnassignedSequenceNumber } from "./constants";
 import { CollaborationWindow, ISegment } from "./mergeTree";
@@ -10,10 +12,11 @@ import { ICombiningOp, IMergeTreeAnnotateMsg } from "./ops";
 import * as Properties from "./properties";
 
 export class SegmentPropertiesManager {
-    private pendingKeyUpdateCount: Properties.MapLike<number>;
+    private pendingKeyUpdateCount: Properties.MapLike<number> | undefined;
     private pendingRewriteCount: number;
 
     constructor(private readonly segment: ISegment) {
+        this.pendingRewriteCount = 0;
     }
 
     public ackPendingProperties(annotateOp: IMergeTreeAnnotateMsg) {
@@ -21,12 +24,12 @@ export class SegmentPropertiesManager {
             this.pendingRewriteCount--;
         }
         for (const key of Object.keys(annotateOp.props)) {
-            if (this.pendingKeyUpdateCount[key] !== undefined) {
-                assert(this.pendingKeyUpdateCount[key] > 0);
-                this.pendingKeyUpdateCount[key]--;
-                if (this.pendingKeyUpdateCount[key] === 0) {
+            if (this.pendingKeyUpdateCount![key] !== undefined) {
+                assert(this.pendingKeyUpdateCount![key] > 0);
+                this.pendingKeyUpdateCount![key]--;
+                if (this.pendingKeyUpdateCount![key] === 0) {
                     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-                    delete this.pendingKeyUpdateCount[key];
+                    delete this.pendingKeyUpdateCount![key];
                 }
             }
         }
@@ -38,7 +41,6 @@ export class SegmentPropertiesManager {
         seq?: number,
         collabWindow?: CollaborationWindow): Properties.PropertySet | undefined {
         if (!this.segment.properties) {
-            this.pendingRewriteCount = 0;
             this.segment.properties = Properties.createMap<any>();
             this.pendingKeyUpdateCount = Properties.createMap<number>();
         }
@@ -55,7 +57,7 @@ export class SegmentPropertiesManager {
 
         const shouldModifyKey = (key: string): boolean => {
             if (seq === UnassignedSequenceNumber
-                || this.pendingKeyUpdateCount[key] === undefined
+                || this.pendingKeyUpdateCount![key] === undefined
                 || combiningOp) {
                 return true;
             }
@@ -81,10 +83,10 @@ export class SegmentPropertiesManager {
         for (const key of Object.keys(newProps)) {
             if (collaborating) {
                 if (seq === UnassignedSequenceNumber) {
-                    if (this.pendingKeyUpdateCount[key] === undefined) {
-                        this.pendingKeyUpdateCount[key] = 0;
+                    if (this.pendingKeyUpdateCount![key] === undefined) {
+                        this.pendingKeyUpdateCount![key] = 0;
                     }
-                    this.pendingKeyUpdateCount[key]++;
+                    this.pendingKeyUpdateCount![key]++;
                 } else if (!shouldModifyKey(key)) {
                     continue;
                 }
@@ -95,7 +97,7 @@ export class SegmentPropertiesManager {
             deltas[key] = (previousValue === undefined) ? null : previousValue;
             let newValue: any;
             if (combiningOp) {
-                newValue = Properties.combine(op, previousValue, newValue, seq);
+                newValue = Properties.combine(combiningOp, previousValue, newValue, seq);
             } else {
                 newValue = newProps[key];
             }
@@ -120,14 +122,14 @@ export class SegmentPropertiesManager {
                 leafSegment.propertyManager = new SegmentPropertiesManager(leafSegment);
                 leafSegment.propertyManager.pendingRewriteCount = this.pendingRewriteCount;
                 leafSegment.propertyManager.pendingKeyUpdateCount = Properties.createMap<number>();
-                for (const key of Object.keys(this.pendingKeyUpdateCount)) {
-                    leafSegment.propertyManager.pendingKeyUpdateCount[key] = this.pendingKeyUpdateCount[key];
+                for (const key of Object.keys(this.pendingKeyUpdateCount!)) {
+                    leafSegment.propertyManager.pendingKeyUpdateCount[key] = this.pendingKeyUpdateCount![key];
                 }
             }
         }
     }
 
     public hasPendingProperties() {
-        return this.pendingRewriteCount > 0 || Object.keys(this.pendingKeyUpdateCount).length > 0;
+        return this.pendingRewriteCount > 0 || Object.keys(this.pendingKeyUpdateCount!).length > 0;
     }
 }

--- a/packages/dds/merge-tree/src/segmentPropertiesManager.ts
+++ b/packages/dds/merge-tree/src/segmentPropertiesManager.ts
@@ -27,7 +27,7 @@ export class SegmentPropertiesManager {
             if (this.pendingKeyUpdateCount?.[key] !== undefined) {
                 assert(this.pendingKeyUpdateCount![key] > 0);
                 this.pendingKeyUpdateCount![key]--;
-                if (this.pendingKeyUpdateCount![key] === 0) {
+                if (this.pendingKeyUpdateCount?.[key] === 0) {
                     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
                     delete this.pendingKeyUpdateCount![key];
                 }

--- a/packages/dds/merge-tree/src/segmentPropertiesManager.ts
+++ b/packages/dds/merge-tree/src/segmentPropertiesManager.ts
@@ -83,7 +83,7 @@ export class SegmentPropertiesManager {
         for (const key of Object.keys(newProps)) {
             if (collaborating) {
                 if (seq === UnassignedSequenceNumber) {
-                    if (this.pendingKeyUpdateCount![key] === undefined) {
+                    if (this.pendingKeyUpdateCount.?[key] === undefined) {
                         this.pendingKeyUpdateCount![key] = 0;
                     }
                     this.pendingKeyUpdateCount![key]++;

--- a/packages/dds/merge-tree/src/snapshotChunks.ts
+++ b/packages/dds/merge-tree/src/snapshotChunks.ts
@@ -2,6 +2,9 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+
+ /* eslint-disable @typescript-eslint/no-non-null-assertion */
+
 import {
     IFluidSerializer,
     IFluidHandle,
@@ -22,9 +25,9 @@ export interface MergeTreeChunkLegacy extends VersionedMergeTreeChunk {
     chunkStartSegmentIndex: number,
     chunkSegmentCount: number;
     chunkLengthChars: number;
-    totalLengthChars: number;
-    totalSegmentCount: number;
-    chunkSequenceNumber: number;
+    totalLengthChars?: number;
+    totalSegmentCount?: number;
+    chunkSequenceNumber?: number;
     chunkMinSequenceNumber?: number;
     segmentTexts: JsonSegmentSpecs[];
     headerMetadata?: MergeTreeHeaderMetadata;
@@ -78,7 +81,7 @@ export function serializeAsMinSupportedVersion(
     logger: ITelemetryLogger,
     options: PropertySet | undefined,
     serializer: IFluidSerializer,
-    bind?: IFluidHandle) {
+    bind: IFluidHandle) {
     let targetChuck: MergeTreeChunkLegacy;
 
     if (chunk.version !== undefined) {
@@ -125,7 +128,7 @@ export function serializeAsMaxSupportedVersion(
     logger: ITelemetryLogger,
     options: PropertySet | undefined,
     serializer: IFluidSerializer,
-    bind?: IFluidHandle) {
+    bind: IFluidHandle) {
     const targetChuck = toLatestVersion(path, chunk, logger, options);
     return serializer.stringify(targetChuck, bind);
 }
@@ -162,15 +165,15 @@ function buildHeaderMetadataForLegecyChunk(
             return chunk.headerMetadata;
         }
         const chunkIds: MergeTreeHeaderChunkMetadata[] = [{ id: SnapshotLegacy.header }];
-        if (chunk.chunkLengthChars < chunk.totalLengthChars) {
+        if (chunk.chunkLengthChars < chunk.totalLengthChars!) {
             chunkIds.push({ id: SnapshotLegacy.body });
         }
         return {
             orderedChunkMetadata: chunkIds,
-            minSequenceNumber: chunk.chunkMinSequenceNumber,
-            sequenceNumber: chunk.chunkSequenceNumber,
-            totalLength: chunk.totalLengthChars,
-            totalSegmentCount: chunk.totalSegmentCount,
+            minSequenceNumber: chunk.chunkMinSequenceNumber!,
+            sequenceNumber: chunk.chunkSequenceNumber!,
+            totalLength: chunk.totalLengthChars!,
+            totalSegmentCount: chunk.totalSegmentCount!,
         };
     }
     return undefined;

--- a/packages/dds/merge-tree/src/snapshotLoader.ts
+++ b/packages/dds/merge-tree/src/snapshotLoader.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
 import { assert, fromBase64ToUtf8 } from "@fluidframework/common-utils";
 import { IFluidSerializer } from "@fluidframework/core-interfaces";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
@@ -66,15 +68,15 @@ export class SnapshotLoader {
         await this.loadBody(headerChunk, services);
 
         const blobs = await blobsP;
-        if (blobs.length === headerChunk.headerMetadata.orderedChunkMetadata.length + 1) {
-            headerChunk.headerMetadata.orderedChunkMetadata.forEach(
+        if (blobs.length === headerChunk.headerMetadata!.orderedChunkMetadata.length + 1) {
+            headerChunk.headerMetadata!.orderedChunkMetadata.forEach(
                 (md) => blobs.splice(blobs.indexOf(md.id), 1));
             assert(blobs.length === 1, `There should be only one blob with catch up ops: ${blobs.length}`);
 
             // TODO: The 'Snapshot.catchupOps' tree entry is purely for backwards compatibility.
             //       (See https://github.com/microsoft/FluidFramework/issues/84)
             return this.loadCatchupOps(services.read(blobs[0]));
-        } else if (blobs.length !== headerChunk.headerMetadata.orderedChunkMetadata.length) {
+        } else if (blobs.length !== headerChunk.headerMetadata!.orderedChunkMetadata.length) {
             throw new Error("Unexpected blobs in snapshot");
         }
         return [];
@@ -152,22 +154,22 @@ export class SnapshotLoader {
 
     private async loadBody(chunk1: MergeTreeChunkV1, services: IChannelStorageService): Promise<void> {
         this.runtime.logger.shipAssert(
-            chunk1.length <= chunk1.headerMetadata.totalLength,
+            chunk1.length <= chunk1.headerMetadata!.totalLength,
             { eventName: "Mismatch in totalLength" });
 
         this.runtime.logger.shipAssert(
-            chunk1.segmentCount <= chunk1.headerMetadata.totalSegmentCount,
+            chunk1.segmentCount <= chunk1.headerMetadata!.totalSegmentCount,
             { eventName: "Mismatch in totalSegmentCount" });
 
-        if (chunk1.segmentCount === chunk1.headerMetadata.totalSegmentCount) {
+        if (chunk1.segmentCount === chunk1.headerMetadata!.totalSegmentCount) {
             return;
         }
         const segs: ISegment[] = [];
         let lengthSofar = chunk1.length;
-        for (let chunkIndex = 1; chunkIndex < chunk1.headerMetadata.orderedChunkMetadata.length; chunkIndex++) {
+        for (let chunkIndex = 1; chunkIndex < chunk1.headerMetadata!.orderedChunkMetadata.length; chunkIndex++) {
             const chunk = await SnapshotV1.loadChunk(
                 services,
-                chunk1.headerMetadata.orderedChunkMetadata[chunkIndex].id,
+                chunk1.headerMetadata!.orderedChunkMetadata[chunkIndex].id,
                 this.logger,
                 this.mergeTree.options,
                 this.serializer);
@@ -176,11 +178,11 @@ export class SnapshotLoader {
             segs.push(...chunk.segments.map(this.specToSegment));
         }
         this.runtime.logger.shipAssert(
-            lengthSofar === chunk1.headerMetadata.totalLength,
+            lengthSofar === chunk1.headerMetadata!.totalLength,
             { eventName: "Mismatch in totalLength" });
 
         this.runtime.logger.shipAssert(
-            chunk1.segmentCount + segs.length === chunk1.headerMetadata.totalSegmentCount,
+            chunk1.segmentCount + segs.length === chunk1.headerMetadata!.totalSegmentCount,
             { eventName: "Mismatch in totalSegmentCount" });
 
         // Helper to insert segments at the end of the MergeTree.
@@ -211,7 +213,7 @@ export class SnapshotLoader {
                 batch.push(seg);
             } else {
                 flushBatch();
-                append([seg], cli, seq);
+                append([seg], cli, seq!);
             }
         }
 

--- a/packages/dds/merge-tree/src/snapshotV1.ts
+++ b/packages/dds/merge-tree/src/snapshotV1.ts
@@ -97,7 +97,7 @@ export class SnapshotV1 {
      */
     emit(
         serializer: IFluidSerializer,
-        bind?: IFluidHandle,
+        bind: IFluidHandle,
     ): ITree {
         const chunks: MergeTreeChunkV1[] = [];
         this.header.totalSegmentCount = 0;
@@ -185,14 +185,16 @@ export class SnapshotV1 {
             //      there is a pending insert op that will deliver the segment on reconnection.
             //   b) The segment was removed at or below the MSN.  Pending ops can no longer reference this
             //      segment, and therefore we can discard it.
-            if (segment.seq === UnassignedSequenceNumber || segment.removedSeq <= minSeq) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            if (segment.seq === UnassignedSequenceNumber || segment.removedSeq! <= minSeq) {
                 return true;
             }
 
             // Next determine if the snapshot needs to preserve information required for merging the segment
             // (seq, client, etc.)  This information is only needed if the segment is above the MSN (and doesn't
             // have a pending remove.)
-            if ((segment.seq <= minSeq)                                   // Segment is below the MSN, and...
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            if ((segment.seq! <= minSeq)                                   // Segment is below the MSN, and...
                 && (segment.removedSeq === undefined                      // .. Segment has not been removed, or...
                     || segment.removedSeq === UnassignedSequenceNumber)   // .. Removal op to be delivered on reconnect
             ) {
@@ -220,19 +222,22 @@ export class SnapshotV1 {
 
                 const raw: IJSONSegmentWithMergeInfo = { json: segment.toJSONObject() };
                 // If the segment insertion is above the MSN, record the insertion merge info.
-                if (segment.seq > minSeq) {
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                if (segment.seq! > minSeq) {
                     raw.seq = segment.seq;
-                    raw.client = mergeTree.getLongClientId(segment.clientId);
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    raw.client = mergeTree.getLongClientId!(segment.clientId);
                 }
                 // We have already dispensed with removed segments below the MSN and removed segments with unassigned
                 // sequence numbers.  Any remaining removal info should be preserved.
                 if (segment.removedSeq !== undefined) {
                     assert(segment.removedSeq !== UnassignedSequenceNumber && segment.removedSeq > minSeq);
                     raw.removedSeq = segment.removedSeq;
-                    raw.removedClient = mergeTree.getLongClientId(segment.removedClientId);
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    raw.removedClient = mergeTree.getLongClientId!(segment.removedClientId!);
                 }
 
-                // Sanity check that we are preserving either the seq < minSeq or a removed segment's info.
+            // Sanity check that we are preserving either the seq < minSeq or a removed segment's info.
                 assert(raw.seq !== undefined && raw.client !== undefined
                     || raw.removedSeq !== undefined && raw.removedClient !== undefined);
 

--- a/packages/dds/merge-tree/src/test/beastTest.ts
+++ b/packages/dds/merge-tree/src/test/beastTest.ts
@@ -229,7 +229,7 @@ function checkMarkRemoveMergeTree(mergeTree: MergeTree.MergeTree, start: number,
 export function mergeTreeTest1() {
     const mergeTree = new MergeTree.MergeTree();
     mergeTree.insertSegments(0, [TextSegment.make("the cat is on the mat")], UniversalSequenceNumber, LocalClientId, UniversalSequenceNumber, undefined);
-    mergeTree.map({ leaf: printTextSegment }, UniversalSequenceNumber, LocalClientId);
+    mergeTree.map({ leaf: printTextSegment }, UniversalSequenceNumber, LocalClientId, undefined);
     let fuzzySeg = makeCollabTextSegment("fuzzy, fuzzy ");
     checkInsertMergeTree(mergeTree, 4, fuzzySeg);
     fuzzySeg = makeCollabTextSegment("fuzzy, fuzzy ");
@@ -237,7 +237,7 @@ export function mergeTreeTest1() {
     checkMarkRemoveMergeTree(mergeTree, 4, 13);
     // checkRemoveSegTree(segTree, 4, 13);
     checkInsertMergeTree(mergeTree, 4, makeCollabTextSegment("fi"));
-    mergeTree.map({ leaf: printTextSegment }, UniversalSequenceNumber, LocalClientId);
+    mergeTree.map({ leaf: printTextSegment }, UniversalSequenceNumber, LocalClientId, undefined);
     const segoff = mergeTree.getContainingSegment(4, UniversalSequenceNumber, LocalClientId);
     log(mergeTree.getPosition(segoff.segment, UniversalSequenceNumber, LocalClientId));
     log(new MergeTree.MergeTreeTextHelper(mergeTree).getText(UniversalSequenceNumber, LocalClientId));

--- a/packages/dds/merge-tree/src/test/snapshot.spec.ts
+++ b/packages/dds/merge-tree/src/test/snapshot.spec.ts
@@ -79,7 +79,8 @@ class TestString {
     public getSnapshot() {
         const snapshot = new SnapshotV1(this.client.mergeTree, this.client.logger);
         snapshot.extractSync();
-        return snapshot.emit(TestClient.serializer);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return snapshot.emit(TestClient.serializer, undefined!);
     }
 
     public getText() { return this.client.getText(); }

--- a/packages/dds/merge-tree/src/test/snapshotlegacy.spec.ts
+++ b/packages/dds/merge-tree/src/test/snapshotlegacy.spec.ts
@@ -25,7 +25,8 @@ describe("snapshot", () => {
 
         const snapshot = new SnapshotLegacy(client1.mergeTree, client1.logger);
         snapshot.extractSync();
-        const snapshotTree = snapshot.emit([], serializer);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const snapshotTree = snapshot.emit([], serializer, undefined!);
         const services = new MockStorage(snapshotTree);
 
         const client2 = new TestClient(undefined);
@@ -57,7 +58,8 @@ describe("snapshot", () => {
             const client2 = clients[i + 1];
             const snapshot = new SnapshotLegacy(client1.mergeTree, client1.logger);
             snapshot.extractSync();
-            const snapshotTree = snapshot.emit([], serializer);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const snapshotTree = snapshot.emit([], serializer, undefined!);
             const services = new MockStorage(snapshotTree);
             const runtime: Partial<IFluidDataStoreRuntime> = {
                 logger: client2.logger,

--- a/packages/dds/merge-tree/src/test/testClient.ts
+++ b/packages/dds/merge-tree/src/test/testClient.ts
@@ -52,7 +52,8 @@ export class TestClient extends Client {
     public static async createFromClientSnapshot(client1: TestClient, newLongClientId: string): Promise<TestClient> {
         const snapshot = new SnapshotLegacy(client1.mergeTree, DebugLogger.create("fluid:snapshot"));
         snapshot.extractSync();
-        const snapshotTree = snapshot.emit([], TestClient.serializer);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const snapshotTree = snapshot.emit([], TestClient.serializer, undefined!);
         return TestClient.createFromSnapshot(snapshotTree, newLongClientId, client1.specToSegment);
     }
 

--- a/packages/dds/merge-tree/src/textSegment.ts
+++ b/packages/dds/merge-tree/src/textSegment.ts
@@ -198,7 +198,8 @@ export class MergeTreeTextHelper {
         if (TextSegment.is(segment)) {
             if (MergeTree.traceGatherText) {
                 console.log(
-                    `@cli ${this.mergeTree.getLongClientId(this.mergeTree.collabWindow.clientId)} ` +
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    `@cli ${this.mergeTree.getLongClientId!(this.mergeTree.collabWindow.clientId)} ` +
                     `gather seg seq ${segment.seq} rseq ${segment.removedSeq} text ${segment.text}`);
             }
             let beginTags = "";

--- a/packages/dds/merge-tree/tsconfig.json
+++ b/packages/dds/merge-tree/tsconfig.json
@@ -4,7 +4,6 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
-        "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true


### PR DESCRIPTION
Goal is not changing the code too much that my introduce regression. 
So remove the most rest of error by using null assertion.
We can continue to clean that up as we continue to evolve the code.