### PR TITLE
Stop including test files and temporary api-extractor output in published packages.

### DIFF
--- a/common/lib/common-definitions/.npmignore
+++ b/common/lib/common-definitions/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/common/lib/common-utils/.npmignore
+++ b/common/lib/common-utils/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/apps/collaborative-textarea/.npmignore
+++ b/examples/apps/collaborative-textarea/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/apps/likes-and-comments/.npmignore
+++ b/examples/apps/likes-and-comments/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/apps/spaces/.npmignore
+++ b/examples/apps/spaces/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/badge/.npmignore
+++ b/examples/data-objects/badge/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/canvas/.npmignore
+++ b/examples/data-objects/canvas/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/clicker-react/clicker-context/.npmignore
+++ b/examples/data-objects/clicker-react/clicker-context/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/clicker-react/clicker-function/.npmignore
+++ b/examples/data-objects/clicker-react/clicker-function/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/clicker-react/clicker-react/.npmignore
+++ b/examples/data-objects/clicker-react/clicker-react/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/clicker-react/clicker-reducer/.npmignore
+++ b/examples/data-objects/clicker-react/clicker-reducer/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/clicker-react/clicker-with-hook/.npmignore
+++ b/examples/data-objects/clicker-react/clicker-with-hook/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/clicker/.npmignore
+++ b/examples/data-objects/clicker/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/client-ui-lib/.npmignore
+++ b/examples/data-objects/client-ui-lib/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/codemirror/.npmignore
+++ b/examples/data-objects/codemirror/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/diceroller/.npmignore
+++ b/examples/data-objects/diceroller/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/flow-util-lib/.npmignore
+++ b/examples/data-objects/flow-util-lib/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/image-collection/.npmignore
+++ b/examples/data-objects/image-collection/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/image-gallery/.npmignore
+++ b/examples/data-objects/image-gallery/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/key-value-cache/.npmignore
+++ b/examples/data-objects/key-value-cache/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/math/.npmignore
+++ b/examples/data-objects/math/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/monaco/.npmignore
+++ b/examples/data-objects/monaco/.npmignore
@@ -2,3 +2,6 @@ dist/**/*.map
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/multiview/constellation-model/.npmignore
+++ b/examples/data-objects/multiview/constellation-model/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/multiview/constellation-view/.npmignore
+++ b/examples/data-objects/multiview/constellation-view/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/multiview/container/.npmignore
+++ b/examples/data-objects/multiview/container/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/multiview/coordinate-model/.npmignore
+++ b/examples/data-objects/multiview/coordinate-model/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/multiview/interface/.npmignore
+++ b/examples/data-objects/multiview/interface/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/multiview/plot-coordinate-view/.npmignore
+++ b/examples/data-objects/multiview/plot-coordinate-view/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/multiview/slider-coordinate-view/.npmignore
+++ b/examples/data-objects/multiview/slider-coordinate-view/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/multiview/triangle-view/.npmignore
+++ b/examples/data-objects/multiview/triangle-view/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/musica/.npmignore
+++ b/examples/data-objects/musica/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/pond/.npmignore
+++ b/examples/data-objects/pond/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/primitives/.npmignore
+++ b/examples/data-objects/primitives/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/progress-bars/.npmignore
+++ b/examples/data-objects/progress-bars/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/prosemirror/.npmignore
+++ b/examples/data-objects/prosemirror/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/react-inputs/.npmignore
+++ b/examples/data-objects/react-inputs/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/scribe/.npmignore
+++ b/examples/data-objects/scribe/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/search-menu/.npmignore
+++ b/examples/data-objects/search-menu/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/shared-text/.npmignore
+++ b/examples/data-objects/shared-text/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/simple-fluidobject-embed/.npmignore
+++ b/examples/data-objects/simple-fluidobject-embed/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/smde/.npmignore
+++ b/examples/data-objects/smde/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/table-document/.npmignore
+++ b/examples/data-objects/table-document/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/table-view/.npmignore
+++ b/examples/data-objects/table-view/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/todo/.npmignore
+++ b/examples/data-objects/todo/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/video-players/.npmignore
+++ b/examples/data-objects/video-players/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/vltava/.npmignore
+++ b/examples/data-objects/vltava/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/data-objects/webflow/.npmignore
+++ b/examples/data-objects/webflow/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/hosts/app-integration/container-views/.npmignore
+++ b/examples/hosts/app-integration/container-views/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/hosts/app-integration/external-controller/.npmignore
+++ b/examples/hosts/app-integration/external-controller/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/hosts/app-integration/external-views/.npmignore
+++ b/examples/hosts/app-integration/external-views/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/hosts/host-service-interfaces/.npmignore
+++ b/examples/hosts/host-service-interfaces/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/hosts/iframe-host/.npmignore
+++ b/examples/hosts/iframe-host/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/utils/bundle-size-tests/.npmignore
+++ b/examples/utils/bundle-size-tests/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/utils/fluid-object-interfaces/.npmignore
+++ b/examples/utils/fluid-object-interfaces/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/utils/get-session-storage-container/.npmignore
+++ b/examples/utils/get-session-storage-container/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/examples/utils/get-tinylicious-container/.npmignore
+++ b/examples/utils/get-tinylicious-container/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/experimental/dds/tree/.npmignore
+++ b/experimental/dds/tree/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/agents/intelligence-runner-agent/.npmignore
+++ b/packages/agents/intelligence-runner-agent/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/dds/cell/.npmignore
+++ b/packages/dds/cell/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/dds/counter/.npmignore
+++ b/packages/dds/counter/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/dds/ink/.npmignore
+++ b/packages/dds/ink/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/dds/map/.npmignore
+++ b/packages/dds/map/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/dds/matrix/.npmignore
+++ b/packages/dds/matrix/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/dds/merge-tree/.npmignore
+++ b/packages/dds/merge-tree/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/dds/ordered-collection/.npmignore
+++ b/packages/dds/ordered-collection/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/dds/register-collection/.npmignore
+++ b/packages/dds/register-collection/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/dds/sequence/.npmignore
+++ b/packages/dds/sequence/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/dds/shared-object-base/.npmignore
+++ b/packages/dds/shared-object-base/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/dds/shared-summary-block/.npmignore
+++ b/packages/dds/shared-summary-block/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/drivers/debugger/.npmignore
+++ b/packages/drivers/debugger/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/drivers/driver-base/.npmignore
+++ b/packages/drivers/driver-base/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/drivers/file-driver/.npmignore
+++ b/packages/drivers/file-driver/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/drivers/iframe-driver/.npmignore
+++ b/packages/drivers/iframe-driver/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/drivers/local-driver/.npmignore
+++ b/packages/drivers/local-driver/.npmignore
@@ -5,3 +5,6 @@ public/scripts/dist/*.stats.*
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/drivers/odsp-driver/.npmignore
+++ b/packages/drivers/odsp-driver/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/drivers/odsp-urlResolver/.npmignore
+++ b/packages/drivers/odsp-urlResolver/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/drivers/replay-driver/.npmignore
+++ b/packages/drivers/replay-driver/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/drivers/routerlicious-driver/.npmignore
+++ b/packages/drivers/routerlicious-driver/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/drivers/routerlicious-host/.npmignore
+++ b/packages/drivers/routerlicious-host/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/drivers/routerlicious-urlResolver/.npmignore
+++ b/packages/drivers/routerlicious-urlResolver/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/drivers/tinylicious-driver/.npmignore
+++ b/packages/drivers/tinylicious-driver/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/framework/aqueduct/.npmignore
+++ b/packages/framework/aqueduct/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/framework/data-object-base/.npmignore
+++ b/packages/framework/data-object-base/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/framework/dds-interceptions/.npmignore
+++ b/packages/framework/dds-interceptions/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/framework/experimental-fluidframework/.npmignore
+++ b/packages/framework/experimental-fluidframework/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/framework/last-edited-experimental/.npmignore
+++ b/packages/framework/last-edited-experimental/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/framework/react/.npmignore
+++ b/packages/framework/react/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/framework/request-handler/.npmignore
+++ b/packages/framework/request-handler/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/framework/synthesize/.npmignore
+++ b/packages/framework/synthesize/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/framework/undo-redo/.npmignore
+++ b/packages/framework/undo-redo/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/framework/view-adapters/.npmignore
+++ b/packages/framework/view-adapters/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/framework/view-interfaces/.npmignore
+++ b/packages/framework/view-interfaces/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/hosts/base-host/.npmignore
+++ b/packages/hosts/base-host/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/loader/container-definitions/.npmignore
+++ b/packages/loader/container-definitions/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/loader/container-loader/.npmignore
+++ b/packages/loader/container-loader/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/loader/container-utils/.npmignore
+++ b/packages/loader/container-utils/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/loader/core-interfaces/.npmignore
+++ b/packages/loader/core-interfaces/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/loader/driver-definitions/.npmignore
+++ b/packages/loader/driver-definitions/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/loader/driver-utils/.npmignore
+++ b/packages/loader/driver-utils/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/loader/execution-context-loader/.npmignore
+++ b/packages/loader/execution-context-loader/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/loader/web-code-loader/.npmignore
+++ b/packages/loader/web-code-loader/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/runtime/agent-scheduler/.npmignore
+++ b/packages/runtime/agent-scheduler/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/runtime/client-api/.npmignore
+++ b/packages/runtime/client-api/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/runtime/container-runtime-definitions/.npmignore
+++ b/packages/runtime/container-runtime-definitions/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/runtime/container-runtime/.npmignore
+++ b/packages/runtime/container-runtime/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/runtime/datastore-definitions/.npmignore
+++ b/packages/runtime/datastore-definitions/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/runtime/datastore/.npmignore
+++ b/packages/runtime/datastore/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/runtime/garbage-collector/.npmignore
+++ b/packages/runtime/garbage-collector/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/runtime/runtime-definitions/.npmignore
+++ b/packages/runtime/runtime-definitions/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/runtime/runtime-utils/.npmignore
+++ b/packages/runtime/runtime-utils/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/runtime/test-runtime-utils/.npmignore
+++ b/packages/runtime/test-runtime-utils/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/test/mocha-test-setup/.npmignore
+++ b/packages/test/mocha-test-setup/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/test/test-drivers/.npmignore
+++ b/packages/test/test-drivers/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/test/test-utils/.npmignore
+++ b/packages/test/test-utils/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/tools/webpack-fluid-loader/.npmignore
+++ b/packages/tools/webpack-fluid-loader/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/utils/odsp-doclib-utils/.npmignore
+++ b/packages/utils/odsp-doclib-utils/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/utils/telemetry-utils/.npmignore
+++ b/packages/utils/telemetry-utils/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/packages/utils/tool-utils/.npmignore
+++ b/packages/utils/tool-utils/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/server/routerlicious/packages/gitresources/.npmignore
+++ b/server/routerlicious/packages/gitresources/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/server/routerlicious/packages/kafka-orderer/.npmignore
+++ b/server/routerlicious/packages/kafka-orderer/.npmignore
@@ -5,3 +5,6 @@ public/scripts/dist/*.stats.*
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/server/routerlicious/packages/lambdas-driver/.npmignore
+++ b/server/routerlicious/packages/lambdas-driver/.npmignore
@@ -5,3 +5,6 @@ public/scripts/dist/*.stats.*
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/server/routerlicious/packages/lambdas/.npmignore
+++ b/server/routerlicious/packages/lambdas/.npmignore
@@ -5,3 +5,6 @@ public/scripts/dist/*.stats.*
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/server/routerlicious/packages/local-server/.npmignore
+++ b/server/routerlicious/packages/local-server/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/server/routerlicious/packages/memory-orderer/.npmignore
+++ b/server/routerlicious/packages/memory-orderer/.npmignore
@@ -5,3 +5,6 @@ public/scripts/dist/*.stats.*
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/server/routerlicious/packages/protocol-base/.npmignore
+++ b/server/routerlicious/packages/protocol-base/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/server/routerlicious/packages/protocol-definitions/.npmignore
+++ b/server/routerlicious/packages/protocol-definitions/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/server/routerlicious/packages/routerlicious-base/.npmignore
+++ b/server/routerlicious/packages/routerlicious-base/.npmignore
@@ -5,3 +5,6 @@ public/scripts/dist/*.stats.*
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/server/routerlicious/packages/routerlicious/.npmignore
+++ b/server/routerlicious/packages/routerlicious/.npmignore
@@ -5,3 +5,6 @@ public/scripts/dist/*.stats.*
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/server/routerlicious/packages/services-client/.npmignore
+++ b/server/routerlicious/packages/services-client/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/server/routerlicious/packages/services-core/.npmignore
+++ b/server/routerlicious/packages/services-core/.npmignore
@@ -5,3 +5,6 @@ public/scripts/dist/*.stats.*
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/server/routerlicious/packages/services-shared/.npmignore
+++ b/server/routerlicious/packages/services-shared/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/server/routerlicious/packages/services-utils/.npmignore
+++ b/server/routerlicious/packages/services-utils/.npmignore
@@ -5,3 +5,6 @@ public/scripts/dist/*.stats.*
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/server/routerlicious/packages/services/.npmignore
+++ b/server/routerlicious/packages/services/.npmignore
@@ -5,3 +5,6 @@ public/scripts/dist/*.stats.*
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/server/routerlicious/packages/test-utils/.npmignore
+++ b/server/routerlicious/packages/test-utils/.npmignore
@@ -5,3 +5,6 @@ public/scripts/dist/*.stats.*
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/server/tinylicious/.npmignore
+++ b/server/tinylicious/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/tools/build-tools/src/fluidBuild/fluidPackageCheck.ts
+++ b/tools/build-tools/src/fluidBuild/fluidPackageCheck.ts
@@ -248,7 +248,7 @@ export class FluidPackageCheck {
             }
 
             // build:test should be in build:commonjs if it exists, otherwise, it should be in build:compile
-            if (pkg.getScript("build:test")) {
+            if (pkg.getScript("build:test") || this.splitTestBuild(pkg)) {
                 if (pkg.getScript("build:commonjs")) {
                     buildCommonJs.push("build:test");
                 } else {
@@ -393,7 +393,10 @@ export class FluidPackageCheck {
         const expected = [
             "nyc",
             "*.log",
-            "**/*.tsbuildinfo"
+            "**/*.tsbuildinfo",
+            "src/test",
+            "dist/test",
+            "**/_api-extractor-temp/**",
         ];
         if (!existsSync(filename)) {
             this.logWarn(pkg, `.npmignore not exist`, fix);


### PR DESCRIPTION
Update .npmignore to exclude those.

Also update fluid-build to check to make sure we have those in .npmignore.

Fix #3747