### PR TITLE
Add partialResult to IDocumentDeltaStorageService .get API

### DIFF
--- a/packages/drivers/debugger/src/fluidDebuggerController.ts
+++ b/packages/drivers/debugger/src/fluidDebuggerController.ts
@@ -349,11 +349,11 @@ async function* generateSequencedMessagesFromDeltaStorage(deltaStorage: IDocumen
     let lastSeq = 0;
     const batch = 2000;
     while (true) {
-        const messages = await loadChunk(lastSeq, lastSeq + batch, deltaStorage);
-        if (messages.length === 0) {
+        const { messages, end } = await loadChunk(lastSeq, lastSeq + batch, deltaStorage);
+        yield messages;
+        if (end) {
             break;
         }
-        yield messages;
         lastSeq = messages[messages.length - 1].sequenceNumber;
     }
 }

--- a/packages/drivers/debugger/src/fluidDebuggerController.ts
+++ b/packages/drivers/debugger/src/fluidDebuggerController.ts
@@ -349,11 +349,12 @@ async function* generateSequencedMessagesFromDeltaStorage(deltaStorage: IDocumen
     let lastSeq = 0;
     const batch = 2000;
     while (true) {
-        const { messages, end } = await loadChunk(lastSeq, lastSeq + batch, deltaStorage);
-        yield messages;
-        if (end) {
+        const { messages, partialResult } = await loadChunk(lastSeq, lastSeq + batch, deltaStorage);
+        if (messages.length === 0) {
+            assert(!partialResult);
             break;
         }
+        yield messages;
         lastSeq = messages[messages.length - 1].sequenceNumber;
     }
 }

--- a/packages/drivers/file-driver/src/fileDeltaStorageService.ts
+++ b/packages/drivers/file-driver/src/fileDeltaStorageService.ts
@@ -5,7 +5,7 @@
 
 import fs from "fs";
 import { assert } from "@fluidframework/common-utils";
-import { IDocumentDeltaStorageService } from "@fluidframework/driver-definitions";
+import { IDocumentDeltaStorageService, IOpResult } from "@fluidframework/driver-definitions";
 import * as api from "@fluidframework/protocol-definitions";
 
 /**
@@ -36,9 +36,9 @@ export class FileDeltaStorageService implements IDocumentDeltaStorageService {
     public async get(
         from?: number,
         to?: number,
-    ): Promise<api.ISequencedDocumentMessage[]> {
+    ): Promise<IOpResult> {
         // Do not allow container move forward
-        return [];
+        return { messages: [], end: true };
     }
 
     public get ops(): readonly Readonly<api.ISequencedDocumentMessage>[] {

--- a/packages/drivers/file-driver/src/fileDeltaStorageService.ts
+++ b/packages/drivers/file-driver/src/fileDeltaStorageService.ts
@@ -5,7 +5,7 @@
 
 import fs from "fs";
 import { assert } from "@fluidframework/common-utils";
-import { IDocumentDeltaStorageService, IOpResult } from "@fluidframework/driver-definitions";
+import { IDocumentDeltaStorageService, IDeltasFetchResult } from "@fluidframework/driver-definitions";
 import * as api from "@fluidframework/protocol-definitions";
 
 /**
@@ -36,7 +36,7 @@ export class FileDeltaStorageService implements IDocumentDeltaStorageService {
     public async get(
         from?: number,
         to?: number,
-    ): Promise<IOpResult> {
+    ): Promise<IDeltasFetchResult> {
         // Do not allow container move forward
         return { messages: [], end: true };
     }

--- a/packages/drivers/file-driver/src/fileDeltaStorageService.ts
+++ b/packages/drivers/file-driver/src/fileDeltaStorageService.ts
@@ -38,7 +38,7 @@ export class FileDeltaStorageService implements IDocumentDeltaStorageService {
         to?: number,
     ): Promise<IDeltasFetchResult> {
         // Do not allow container move forward
-        return { messages: [], end: true };
+        return { messages: [], partialResult: false };
     }
 
     public get ops(): readonly Readonly<api.ISequencedDocumentMessage>[] {

--- a/packages/drivers/iframe-driver/src/innerDocumentService.ts
+++ b/packages/drivers/iframe-driver/src/innerDocumentService.ts
@@ -67,7 +67,7 @@ export class InnerDocumentService implements IDocumentService {
      */
     public async connectToDeltaStorage(): Promise<IDocumentDeltaStorageService> {
         return {
-            get: async (from?: number, to?: number) => this.outerProxy.deltaStorage.get(from, to),
+            get: async (from: number, to: number) => this.outerProxy.deltaStorage.get(from, to),
         };
     }
 

--- a/packages/drivers/iframe-driver/src/outerDocumentServiceFactory.ts
+++ b/packages/drivers/iframe-driver/src/outerDocumentServiceFactory.ts
@@ -193,7 +193,7 @@ export class DocumentServiceFactoryProxy implements IDocumentServiceFactoryProxy
     }
 
     private getDeltaStorage(deltaStorage: IDocumentDeltaStorageService): IDocumentDeltaStorageService {
-        const get = Comlink.proxy(async (from?: number, to?: number) => deltaStorage.get(from, to));
+        const get = Comlink.proxy(async (from: number, to: number) => deltaStorage.get(from, to));
 
         return {
             get,

--- a/packages/drivers/local-driver/src/localDeltaStorageService.ts
+++ b/packages/drivers/local-driver/src/localDeltaStorageService.ts
@@ -13,19 +13,11 @@ export class LocalDeltaStorageService implements api.IDocumentDeltaStorageServic
         private readonly databaseManager: IDatabaseManager) {
     }
 
-    public async get(from?: number, to?: number): Promise<api.IOpResult> {
+    public async get(from: number, to: number): Promise<api.IDeltasFetchResult> {
         const query = { documentId: this.id, tenantId: this.tenantId };
-        if (from !== undefined || to !== undefined) {
-            query["operation.sequenceNumber"] = {};
-
-            if (from !== undefined) {
-                query["operation.sequenceNumber"].$gt = from;
-            }
-
-            if (to !== undefined) {
-                query["operation.sequenceNumber"].$lt = to;
-            }
-        }
+        query["operation.sequenceNumber"] = {};
+        query["operation.sequenceNumber"].$gt = from;
+        query["operation.sequenceNumber"].$lt = to;
 
         const allDeltas = await this.databaseManager.getDeltaCollection(this.tenantId, this.id);
         const dbDeltas = await allDeltas.find(query, { "operation.sequenceNumber": 1 });

--- a/packages/drivers/local-driver/src/localDeltaStorageService.ts
+++ b/packages/drivers/local-driver/src/localDeltaStorageService.ts
@@ -22,6 +22,6 @@ export class LocalDeltaStorageService implements api.IDocumentDeltaStorageServic
         const allDeltas = await this.databaseManager.getDeltaCollection(this.tenantId, this.id);
         const dbDeltas = await allDeltas.find(query, { "operation.sequenceNumber": 1 });
         const messages = dbDeltas.map((delta) => delta.operation);
-        return { messages, end: true };
+        return { messages, partialResult: false };
     }
 }

--- a/packages/drivers/local-driver/src/localDeltaStorageService.ts
+++ b/packages/drivers/local-driver/src/localDeltaStorageService.ts
@@ -4,7 +4,6 @@
  */
 
 import * as api from "@fluidframework/driver-definitions";
-import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { IDatabaseManager } from "@fluidframework/server-services-core";
 
 export class LocalDeltaStorageService implements api.IDocumentDeltaStorageService {
@@ -14,7 +13,7 @@ export class LocalDeltaStorageService implements api.IDocumentDeltaStorageServic
         private readonly databaseManager: IDatabaseManager) {
     }
 
-    public async get(from?: number, to?: number): Promise<ISequencedDocumentMessage[]> {
+    public async get(from?: number, to?: number): Promise<api.IOpResult> {
         const query = { documentId: this.id, tenantId: this.tenantId };
         if (from !== undefined || to !== undefined) {
             query["operation.sequenceNumber"] = {};
@@ -30,6 +29,7 @@ export class LocalDeltaStorageService implements api.IDocumentDeltaStorageServic
 
         const allDeltas = await this.databaseManager.getDeltaCollection(this.tenantId, this.id);
         const dbDeltas = await allDeltas.find(query, { "operation.sequenceNumber": 1 });
-        return dbDeltas.map((delta) => delta.operation);
+        const messages = dbDeltas.map((delta) => delta.operation);
+        return { messages, end: true };
     }
 }

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -26,12 +26,12 @@ export class OdspDeltaStorageService implements api.IDocumentDeltaStorageService
     }
 
     public async get(
-        from?: number,
-        to?: number,
-    ): Promise<api.IOpResult> {
+        from: number,
+        to: number,
+    ): Promise<api.IDeltasFetchResult> {
         const ops = this.ops;
         this.ops = undefined;
-        if (ops !== undefined && from !== undefined) {
+        if (ops !== undefined) {
             const messages = ops.filter((op) => op.sequenceNumber > from).map((op) => op.op);
             return { messages, end: false };
         }
@@ -64,13 +64,15 @@ export class OdspDeltaStorageService implements api.IDocumentDeltaStorageService
                 messages = deltaStorageResponse.value as ISequencedDocumentMessage[];
             }
 
+            // It is assumed that server always returns all the ops that it has in the range that was requested.
+            // This may change in the future, if so, we need to adjust and receive "end" value from server in such case.
             return { messages, end: true };
         });
     }
 
-    public async buildUrl(from: number | undefined, to: number | undefined) {
-        const fromInclusive = from === undefined ? undefined : from + 1;
-        const toInclusive = to === undefined ? undefined : to - 1;
+    public async buildUrl(from: number, to: number) {
+        const fromInclusive = from + 1;
+        const toInclusive = to - 1;
 
         const filter = encodeURIComponent(`sequenceNumber ge ${fromInclusive} and sequenceNumber le ${toInclusive}`);
         const queryString = `?filter=${filter}`;

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -33,7 +33,9 @@ export class OdspDeltaStorageService implements api.IDocumentDeltaStorageService
         this.ops = undefined;
         if (ops !== undefined) {
             const messages = ops.filter((op) => op.sequenceNumber > from).map((op) => op.op);
-            return { messages, end: false };
+            if (messages.length > 0) {
+                return { messages, partialResult: true };
+            }
         }
         this.ops = undefined;
 
@@ -66,7 +68,7 @@ export class OdspDeltaStorageService implements api.IDocumentDeltaStorageService
 
             // It is assumed that server always returns all the ops that it has in the range that was requested.
             // This may change in the future, if so, we need to adjust and receive "end" value from server in such case.
-            return { messages, end: true };
+            return { messages, partialResult: false };
         });
     }
 

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -213,7 +213,7 @@ export class OdspDocumentService implements IDocumentService {
             return websocketEndpoint.deltaStorageUrl;
         };
 
-        const res = new OdspDeltaStorageService(
+        const service = new OdspDeltaStorageService(
             urlProvider,
             this.storageManager?.ops,
             this.getStorageToken,
@@ -223,9 +223,9 @@ export class OdspDocumentService implements IDocumentService {
 
         return {
             get: async (from?: number, to?: number) => {
-                const ops = await res.get(from, to);
-                this.opsReceived(ops);
-                return ops;
+                const { messages, end } = await service.get(from, to);
+                this.opsReceived(messages);
+                return { messages, end };
             },
         };
     }

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -222,7 +222,7 @@ export class OdspDocumentService implements IDocumentService {
         );
 
         return {
-            get: async (from?: number, to?: number) => {
+            get: async (from: number, to: number) => {
                 const { messages, end } = await service.get(from, to);
                 this.opsReceived(messages);
                 return { messages, end };

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -223,9 +223,9 @@ export class OdspDocumentService implements IDocumentService {
 
         return {
             get: async (from: number, to: number) => {
-                const { messages, end } = await service.get(from, to);
+                const { messages, partialResult } = await service.get(from, to);
                 this.opsReceived(messages);
-                return { messages, end };
+                return { messages, partialResult };
             },
         };
     }

--- a/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
@@ -75,10 +75,10 @@ describe("DeltaStorageService", () => {
         });
 
         it("Should deserialize the delta feed response correctly", async () => {
-            const { messages, end } = await mockFetch(expectedDeltaFeedResponse, async () => {
+            const { messages, partialResult } = await mockFetch(expectedDeltaFeedResponse, async () => {
                 return deltaStorageService.get(2, 8);
             });
-            assert(end, "end === true");
+            assert(!partialResult, "partialResult === false");
             assert.equal(messages.length, 2, "Deserialized feed response is not of expected length");
             assert.equal(messages[0].sequenceNumber, 1,
                 "First element of feed response has invalid sequence number");
@@ -129,10 +129,10 @@ describe("DeltaStorageService", () => {
         });
 
         it("Should deserialize the delta feed response correctly", async () => {
-            const { messages, end } = await mockFetch(expectedDeltaFeedResponse, async () => {
+            const { messages, partialResult } = await mockFetch(expectedDeltaFeedResponse, async () => {
                 return deltaStorageService.get(2, 8);
             });
-            assert(end, "end === true");
+            assert(!partialResult, "partialResult === false");
             assert.equal(messages.length, 2, "Deserialized feed response is not of expected length");
             assert.equal(messages[0].sequenceNumber, 1,
                 "First element of feed response has invalid sequence number");

--- a/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
@@ -75,15 +75,16 @@ describe("DeltaStorageService", () => {
         });
 
         it("Should deserialize the delta feed response correctly", async () => {
-            const actualDeltaFeedResponse = await mockFetch(expectedDeltaFeedResponse, async () => {
+            const { messages, end } = await mockFetch(expectedDeltaFeedResponse, async () => {
                 return deltaStorageService.get(2, 8);
             });
-            assert.equal(actualDeltaFeedResponse.length, 2, "Deserialized feed response is not of expected length");
-            assert.equal(actualDeltaFeedResponse[0].sequenceNumber, 1,
+            assert(end, "end === true");
+            assert.equal(messages.length, 2, "Deserialized feed response is not of expected length");
+            assert.equal(messages[0].sequenceNumber, 1,
                 "First element of feed response has invalid sequence number");
-            assert.equal(actualDeltaFeedResponse[1].sequenceNumber, 2,
+            assert.equal(messages[1].sequenceNumber, 2,
                 "Second element of feed response has invalid sequence number");
-            assert.equal(actualDeltaFeedResponse[1].type, "noop",
+            assert.equal(messages[1].type, "noop",
                 "Second element of feed response has invalid op type");
         });
     });
@@ -128,15 +129,16 @@ describe("DeltaStorageService", () => {
         });
 
         it("Should deserialize the delta feed response correctly", async () => {
-            const actualDeltaFeedResponse = await mockFetch(expectedDeltaFeedResponse, async () => {
+            const { messages, end } = await mockFetch(expectedDeltaFeedResponse, async () => {
                 return deltaStorageService.get(2, 8);
             });
-            assert.equal(actualDeltaFeedResponse.length, 2, "Deserialized feed response is not of expected length");
-            assert.equal(actualDeltaFeedResponse[0].sequenceNumber, 1,
+            assert(end, "end === true");
+            assert.equal(messages.length, 2, "Deserialized feed response is not of expected length");
+            assert.equal(messages[0].sequenceNumber, 1,
                 "First element of feed response has invalid sequence number");
-            assert.equal(actualDeltaFeedResponse[1].sequenceNumber, 2,
+            assert.equal(messages[1].sequenceNumber, 2,
                 "Second element of feed response has invalid sequence number");
-            assert.equal(actualDeltaFeedResponse[1].type, "noop",
+            assert.equal(messages[1].type, "noop",
                 "Second element of feed response has invalid op type");
         });
     });

--- a/packages/drivers/replay-driver/src/emptyDeltaStorageService.ts
+++ b/packages/drivers/replay-driver/src/emptyDeltaStorageService.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IDocumentDeltaStorageService, IOpResult } from "@fluidframework/driver-definitions";
+import { IDocumentDeltaStorageService, IDeltasFetchResult } from "@fluidframework/driver-definitions";
 
 export class EmptyDeltaStorageService implements IDocumentDeltaStorageService {
     /**
@@ -12,7 +12,7 @@ export class EmptyDeltaStorageService implements IDocumentDeltaStorageService {
      * @param to - Op are returned from to - 1.
      * @returns Array of ops requested by the user.
      */
-    public async get(from?: number, to?: number): Promise<IOpResult> {
+    public async get(from: number, to: number): Promise<IDeltasFetchResult> {
         return { messages: [], end: true };
     }
 }

--- a/packages/drivers/replay-driver/src/emptyDeltaStorageService.ts
+++ b/packages/drivers/replay-driver/src/emptyDeltaStorageService.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IDocumentDeltaStorageService } from "@fluidframework/driver-definitions";
-import * as api from "@fluidframework/protocol-definitions";
+import { IDocumentDeltaStorageService, IOpResult } from "@fluidframework/driver-definitions";
 
 export class EmptyDeltaStorageService implements IDocumentDeltaStorageService {
     /**
@@ -13,7 +12,7 @@ export class EmptyDeltaStorageService implements IDocumentDeltaStorageService {
      * @param to - Op are returned from to - 1.
      * @returns Array of ops requested by the user.
      */
-    public async get(from?: number, to?: number): Promise<api.ISequencedDocumentMessage[]> {
-        return [];
+    public async get(from?: number, to?: number): Promise<IOpResult> {
+        return { messages: [], end: true };
     }
 }

--- a/packages/drivers/replay-driver/src/emptyDeltaStorageService.ts
+++ b/packages/drivers/replay-driver/src/emptyDeltaStorageService.ts
@@ -13,6 +13,6 @@ export class EmptyDeltaStorageService implements IDocumentDeltaStorageService {
      * @returns Array of ops requested by the user.
      */
     public async get(from: number, to: number): Promise<IDeltasFetchResult> {
-        return { messages: [], end: true };
+        return { messages: [], partialResult: false };
     }
 }

--- a/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
@@ -21,7 +21,7 @@ import {
     IVersion,
     ScopeType,
 } from "@fluidframework/protocol-definitions";
-import { TypedEventEmitter } from "@fluidframework/common-utils";
+import { assert, TypedEventEmitter } from "@fluidframework/common-utils";
 import { debug } from "./debug";
 import { ReplayController } from "./replayController";
 
@@ -318,11 +318,12 @@ export class ReplayDocumentDeltaConnection
         do {
             const fetchTo = controller.fetchTo(currentOp);
 
-            const { messages } = await documentStorageService.get(currentOp, fetchTo);
+            const { messages, partialResult } = await documentStorageService.get(currentOp, fetchTo);
 
             if (messages.length === 0) {
                 // No more ops. But, they can show up later, either because document was just created,
                 // or because another client keeps submitting new ops.
+                assert(!partialResult);
                 if (controller.isDoneFetch(currentOp, undefined)) {
                     break;
                 }

--- a/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
@@ -318,9 +318,9 @@ export class ReplayDocumentDeltaConnection
         do {
             const fetchTo = controller.fetchTo(currentOp);
 
-            const fetchedOps = await documentStorageService.get(currentOp, fetchTo);
+            const { messages } = await documentStorageService.get(currentOp, fetchTo);
 
-            if (fetchedOps.length === 0) {
+            if (messages.length === 0) {
                 // No more ops. But, they can show up later, either because document was just created,
                 // or because another client keeps submitting new ops.
                 if (controller.isDoneFetch(currentOp, undefined)) {
@@ -331,10 +331,10 @@ export class ReplayDocumentDeltaConnection
             }
 
             replayPromiseChain = replayPromiseChain.then(
-                async () => controller.replay((ops) => this.emit("op", ReplayDocumentId, ops), fetchedOps));
+                async () => controller.replay((ops) => this.emit("op", ReplayDocumentId, ops), messages));
 
-            currentOp += fetchedOps.length;
-            done = controller.isDoneFetch(currentOp, fetchedOps[fetchedOps.length - 1].timestamp);
+            currentOp += messages.length;
+            done = controller.isDoneFetch(currentOp, messages[messages.length - 1].timestamp);
         } while (!done);
 
         return replayPromiseChain;

--- a/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
@@ -41,7 +41,9 @@ export class DocumentDeltaStorageService implements IDocumentDeltaStorageService
             const messages = opsFromLogTail.filter((op) =>
                 op.sequenceNumber > from,
             );
-            return { messages, end: false };
+            if (messages.length > 0) {
+                return { messages, partialResult: true };
+            }
         }
         return this.storageService.get(this.tenantId, this.id, from, to);
     }
@@ -89,6 +91,6 @@ export class DeltaStorageService implements IDeltaStorageService {
 
         // It is assumed that server always returns all the ops that it has in the range that was requested.
         // This may change in the future, if so, we need to adjust and receive "end" value from server in such case.
-        return {messages: ops.data, end: true };
+        return {messages: ops.data, partialResult: false };
     }
 }

--- a/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
@@ -6,7 +6,11 @@
 import { OutgoingHttpHeaders } from "http";
 import querystring from "querystring";
 import { fromUtf8ToBase64 } from "@fluidframework/common-utils";
-import { IDeltaStorageService, IDocumentDeltaStorageService, IOpResult } from "@fluidframework/driver-definitions";
+import {
+    IDeltaStorageService,
+    IDocumentDeltaStorageService,
+    IDeltasFetchResult,
+} from "@fluidframework/driver-definitions";
 import Axios from "axios";
 import * as uuid from "uuid";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
@@ -28,12 +32,12 @@ export class DocumentDeltaStorageService implements IDocumentDeltaStorageService
 
     private logtailSha: string | undefined = this.documentStorageService.logTailSha;
 
-    public async get(from?: number, to?: number): Promise<IOpResult> {
+    public async get(from: number, to: number): Promise<IDeltasFetchResult> {
         const opsFromLogTail = this.logtailSha ? await readAndParse<ISequencedDocumentMessage[]>
             (this.documentStorageService, this.logtailSha) : [];
 
         this.logtailSha = undefined;
-        if (opsFromLogTail.length > 0 && from !== undefined) {
+        if (opsFromLogTail.length > 0) {
             const messages = opsFromLogTail.filter((op) =>
                 op.sequenceNumber > from,
             );
@@ -56,8 +60,8 @@ export class DeltaStorageService implements IDeltaStorageService {
     public async get(
         tenantId: string,
         id: string,
-        from?: number,
-        to?: number): Promise<IOpResult> {
+        from: number,
+        to: number): Promise<IDeltasFetchResult> {
         const query = querystring.stringify({ from, to });
 
         const headers: OutgoingHttpHeaders = {
@@ -83,6 +87,8 @@ export class DeltaStorageService implements IDeltaStorageService {
             });
         }
 
+        // It is assumed that server always returns all the ops that it has in the range that was requested.
+        // This may change in the future, if so, we need to adjust and receive "end" value from server in such case.
         return {messages: ops.data, end: true };
     }
 }

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -782,7 +782,8 @@ export class DeltaManager
                 }
 
                 // Now wait for request to come back
-                deltas = await deltasP;
+                const { messages, end } = await deltasP;
+                deltas = messages;
 
                 // Note that server (or driver code) can push here something unexpected, like undefined
                 // Exception thrown as result of it will result in us retrying
@@ -790,7 +791,7 @@ export class DeltaManager
                 deltasRetrievedTotal += deltasRetrievedLast;
                 const lastFetch = deltasRetrievedLast > 0 ? deltas[deltasRetrievedLast - 1].sequenceNumber : from;
 
-                // If we have no upper bound and fetched less than the max deltas - meaning we got as many as exit -
+                // If we have no upper bound and fetched less than the max deltas - meaning we got as many as exist -
                 // then we can resolve the promise. We also resolve if we fetched up to the expected to. Otherwise
                 // we will look to try again
                 // Note #1: we can get more ops than what we asked for - need to account for that!
@@ -798,7 +799,7 @@ export class DeltaManager
                 // 1) to === undefined case: if last op  is below what we expect, then storage does not have
                 //    any more, thus it's time to leave
                 // 2) else case: if we got what we asked (to - 1) or more, then time to leave.
-                if (to === undefined ? lastFetch < maxFetchTo - 1 : to - 1 <= lastFetch) {
+                if (to === undefined ? end : to - 1 <= lastFetch) {
                     callback(deltas);
                     telemetryEvent.end({ lastFetch, deltasRetrievedTotal, requests });
                     return;

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -789,9 +789,10 @@ export class DeltaManager
                 deltasRetrievedTotal += deltasRetrievedLast;
                 const lastFetch = deltasRetrievedLast > 0 ? deltas[deltasRetrievedLast - 1].sequenceNumber : from;
 
-                // If we have no upper bound, then rely on end flag. Different caching layers will return whatever ops
-                // they have and we need to keep asking until we get to the end. Consecutive calls will read further and
-                // further layers until we hit real storage and eventually fetch all the ops.
+                // If we have no upper bound, then need to check partialResult flag. Different caching layers will
+                // return whatever ops they have and we need to keep asking until we get to the end.
+                // Only when partialResult = false, we know we got everything caching/storage layers have to offer,
+                // and if it's less than what we asked for, we know we reached the end.
                 // But if we know upper bound, then we have to get all these ops, even of storage says it does not
                 // have them. That could happen if offering service did not flush them yet to storage, or is in process
                 // of doing it, and we know we have a gap on our knowledge and can't proceed further without these ops.

--- a/packages/loader/driver-definitions/src/storage.ts
+++ b/packages/loader/driver-definitions/src/storage.ts
@@ -24,7 +24,7 @@ import {
 } from "@fluidframework/protocol-definitions";
 import { IResolvedUrl } from "./urlResolver";
 
-export interface IOpResult {
+export interface IDeltasFetchResult {
     messages: ISequencedDocumentMessage[];
     end: boolean;
 }
@@ -39,8 +39,8 @@ export interface IDeltaStorageService {
     get(
         tenantId: string,
         id: string,
-        from?: number,
-        to?: number): Promise<IOpResult>;
+        from: number,
+        to: number): Promise<IDeltasFetchResult>;
 }
 
 /**
@@ -50,7 +50,7 @@ export interface IDocumentDeltaStorageService {
     /**
      * Retrieves all the delta operations within the exclusive sequence number range
      */
-    get(from?: number, to?: number): Promise<IOpResult>;
+    get(from: number, to: number): Promise<IDeltasFetchResult>;
 }
 
 /**

--- a/packages/loader/driver-definitions/src/storage.ts
+++ b/packages/loader/driver-definitions/src/storage.ts
@@ -26,7 +26,10 @@ import { IResolvedUrl } from "./urlResolver";
 
 export interface IDeltasFetchResult {
     messages: ISequencedDocumentMessage[];
-    end: boolean;
+    // If true, storage only partially fulfilled request, but has more ops
+    // If false, the request was fulfilled. If less ops were returned then
+    // requested, then storage does not have more ops in this range.
+    partialResult: boolean;
 }
 
 /**

--- a/packages/loader/driver-definitions/src/storage.ts
+++ b/packages/loader/driver-definitions/src/storage.ts
@@ -24,6 +24,11 @@ import {
 } from "@fluidframework/protocol-definitions";
 import { IResolvedUrl } from "./urlResolver";
 
+export interface IOpResult {
+    messages: ISequencedDocumentMessage[];
+    end: boolean;
+}
+
 /**
  * Interface to provide access to stored deltas for a shared object
  */
@@ -35,7 +40,7 @@ export interface IDeltaStorageService {
         tenantId: string,
         id: string,
         from?: number,
-        to?: number): Promise<ISequencedDocumentMessage[]>;
+        to?: number): Promise<IOpResult>;
 }
 
 /**
@@ -45,7 +50,7 @@ export interface IDocumentDeltaStorageService {
     /**
      * Retrieves all the delta operations within the exclusive sequence number range
      */
-    get(from?: number, to?: number): Promise<ISequencedDocumentMessage[]>;
+    get(from?: number, to?: number): Promise<IOpResult>;
 }
 
 /**

--- a/packages/loader/driver-definitions/src/storage.ts
+++ b/packages/loader/driver-definitions/src/storage.ts
@@ -25,10 +25,17 @@ import {
 import { IResolvedUrl } from "./urlResolver";
 
 export interface IDeltasFetchResult {
+    /**
+     * Sequential set of messages starting from 'from' sequence number.
+     * May be partial result, i.e. not fulfill original request in full.
+     */
     messages: ISequencedDocumentMessage[];
-    // If true, storage only partially fulfilled request, but has more ops
-    // If false, the request was fulfilled. If less ops were returned then
-    // requested, then storage does not have more ops in this range.
+
+    /**
+     * If true, storage only partially fulfilled request, but has more ops
+     * If false, the request was fulfilled. If less ops were returned then
+     * requested, then storage does not have more ops in this range.
+     */
     partialResult: boolean;
 }
 

--- a/packages/loader/test-loader-utils/src/mockDeltaStorage.ts
+++ b/packages/loader/test-loader-utils/src/mockDeltaStorage.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IDocumentDeltaStorageService } from "@fluidframework/driver-definitions";
+import { IDocumentDeltaStorageService, IOpResult } from "@fluidframework/driver-definitions";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 
 /**
@@ -14,8 +14,8 @@ export class MockDocumentDeltaStorageService implements IDocumentDeltaStorageSer
         this.messages = messages.sort((a, b) => b.sequenceNumber - a.sequenceNumber);
     }
 
-    public async get(from?: number, to?: number): Promise<ISequencedDocumentMessage[]> {
-        const ret: ISequencedDocumentMessage[] = [];
+    public async get(from?: number, to?: number): Promise<IOpResult> {
+        const messages: ISequencedDocumentMessage[] = [];
         let index: number = -1;
 
         // Find first
@@ -25,9 +25,9 @@ export class MockDocumentDeltaStorageService implements IDocumentDeltaStorageSer
 
         // start reading
         while (++index < this.messages.length && (to === undefined || this.messages[++index].sequenceNumber < to)) {
-            ret.push(this.messages[index]);
+            messages.push(this.messages[index]);
         }
 
-        return ret;
+        return { messages, end: true };
     }
 }

--- a/packages/loader/test-loader-utils/src/mockDeltaStorage.ts
+++ b/packages/loader/test-loader-utils/src/mockDeltaStorage.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IDocumentDeltaStorageService, IOpResult } from "@fluidframework/driver-definitions";
+import { IDocumentDeltaStorageService, IDeltasFetchResult } from "@fluidframework/driver-definitions";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 
 /**
@@ -14,17 +14,15 @@ export class MockDocumentDeltaStorageService implements IDocumentDeltaStorageSer
         this.messages = messages.sort((a, b) => b.sequenceNumber - a.sequenceNumber);
     }
 
-    public async get(from?: number, to?: number): Promise<IOpResult> {
+    public async get(from: number, to: number): Promise<IDeltasFetchResult> {
         const messages: ISequencedDocumentMessage[] = [];
         let index: number = -1;
 
         // Find first
-        if (from !== undefined) {
-            while (this.messages[++index].sequenceNumber <= from) { }
-        }
+        while (this.messages[++index].sequenceNumber <= from) { }
 
         // start reading
-        while (++index < this.messages.length && (to === undefined || this.messages[++index].sequenceNumber < to)) {
+        while (++index < this.messages.length && this.messages[++index].sequenceNumber < to) {
             messages.push(this.messages[index]);
         }
 

--- a/packages/loader/test-loader-utils/src/mockDeltaStorage.ts
+++ b/packages/loader/test-loader-utils/src/mockDeltaStorage.ts
@@ -26,6 +26,6 @@ export class MockDocumentDeltaStorageService implements IDocumentDeltaStorageSer
             messages.push(this.messages[index]);
         }
 
-        return { messages, end: true };
+        return { messages, partialResult: false };
     }
 }

--- a/packages/tools/fetch-tool/src/fluidFetchMessages.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchMessages.ts
@@ -31,7 +31,7 @@ async function loadChunk(from: number, to: number, deltaStorage: IDocumentDeltaS
     console.log(`Loading ops at ${from}`);
     for (let iter = 0; iter < 3; iter++) {
         try {
-            const messages = await deltaStorage.get(from, to);
+            const { messages, end } = await deltaStorage.get(from, to);
             // This parsing of message contents happens in delta manager. But when we analyze messages
             // for message stats, we skip that path. So parsing of json contents needs to happen here.
             for (const message of messages) {
@@ -42,7 +42,7 @@ async function loadChunk(from: number, to: number, deltaStorage: IDocumentDeltaS
                     message.contents = JSON.parse(message.contents);
                 }
             }
-            return messages;
+            return { messages, end };
         } catch (error) {
             console.error("Hit error while downloading ops. Retrying");
             console.error(error);
@@ -91,11 +91,13 @@ async function* loadAllSequencedMessages(
     let opsStorage = 0;
     while (true) {
         requests++;
-        const messages = await loadChunk(lastSeq, lastSeq + batch, deltaStorage);
-        if (messages.length === 0) {
+        const { messages, end } = await loadChunk(lastSeq, lastSeq + batch, deltaStorage);
+        if (messages.length !== 0) {
+            yield messages;
+        }
+        if (end) {
             break;
         }
-        yield messages;
         opsStorage += messages.length;
         lastSeq = messages[messages.length - 1].sequenceNumber;
     }

--- a/packages/tools/fetch-tool/src/fluidFetchMessages.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchMessages.ts
@@ -31,7 +31,7 @@ async function loadChunk(from: number, to: number, deltaStorage: IDocumentDeltaS
     console.log(`Loading ops at ${from}`);
     for (let iter = 0; iter < 3; iter++) {
         try {
-            const { messages, end } = await deltaStorage.get(from, to);
+            const { messages, partialResult } = await deltaStorage.get(from, to);
             // This parsing of message contents happens in delta manager. But when we analyze messages
             // for message stats, we skip that path. So parsing of json contents needs to happen here.
             for (const message of messages) {
@@ -42,7 +42,7 @@ async function loadChunk(from: number, to: number, deltaStorage: IDocumentDeltaS
                     message.contents = JSON.parse(message.contents);
                 }
             }
-            return { messages, end };
+            return { messages, partialResult };
         } catch (error) {
             console.error("Hit error while downloading ops. Retrying");
             console.error(error);
@@ -91,13 +91,12 @@ async function* loadAllSequencedMessages(
     let opsStorage = 0;
     while (true) {
         requests++;
-        const { messages, end } = await loadChunk(lastSeq, lastSeq + batch, deltaStorage);
-        if (messages.length !== 0) {
-            yield messages;
-        }
-        if (end) {
+        const { messages, partialResult } = await loadChunk(lastSeq, lastSeq + batch, deltaStorage);
+        if (messages.length === 0) {
+            assert(!partialResult);
             break;
         }
+        yield messages;
         opsStorage += messages.length;
         lastSeq = messages[messages.length - 1].sequenceNumber;
     }


### PR DESCRIPTION
Add partialResult: boolean  to IDocumentDeltaStorageService .get API
This allows service to tell caller if request was fulfilled completely, or partially.
This is useful for these two scenarios:
1. Driver has multiple layers, including caching layers that can return ops. Communicating that result is partial tells DeltaManager that it needs to keep asking for more if it was asking open-ended question (give me all the ops starting with X, no end). This allows these layers to be simple (not chain requests to next layer, but rely on DeltaManager common logic that already exists), at the same time it speeds up fetching ops, because we do not need to wait for socket connection to learn about gap in knowledge, instead we can return data from all caches and hit actual storage right away (later does not happen today, which slows down catch up process).
2. This allows in future to stop the practice of DeltaManager to chunk requests in 2K ops. It can ask infinite (million) and server could decide on the right chunking strategy (i.e. return 1Mb payload, whatever number of ops it means).

Also remove optionality for from & to arguments as we always ask specific question. Even in # 2 in the future I do not think it's going to change (we might bump it from 2K to 20K, but it will be still there).