### PR TITLE
Reorganize socket error handling not to lose handler (name of listener that generated an event)

### DIFF
--- a/packages/drivers/odsp-driver/src/odspError.ts
+++ b/packages/drivers/odsp-driver/src/odspError.ts
@@ -53,9 +53,10 @@ export function throwOdspNetworkError(
 /**
  * Returns network error based on error object from ODSP socket (IOdspSocketError)
  */
-export function errorObjectFromSocketError(socketError: IOdspSocketError) {
+export function errorObjectFromSocketError(socketError: IOdspSocketError, handler?: string) {
+    const message = `socket.io: ${handler}: socketError.message`;
     return createOdspNetworkError(
-        socketError.message,
+        message,
         socketError.code,
         socketError.retryAfter,
         // TODO: When long lived token is supported for websocket then IOdspSocketError need to support

--- a/packages/drivers/odsp-driver/src/odspError.ts
+++ b/packages/drivers/odsp-driver/src/odspError.ts
@@ -53,8 +53,8 @@ export function throwOdspNetworkError(
 /**
  * Returns network error based on error object from ODSP socket (IOdspSocketError)
  */
-export function errorObjectFromSocketError(socketError: IOdspSocketError, handler?: string) {
-    const message = `socket.io: ${handler}: socketError.message`;
+export function errorObjectFromSocketError(socketError: IOdspSocketError, handler: string) {
+    const message = `socket.io: ${handler}: ${socketError.message}`;
     return createOdspNetworkError(
         message,
         socketError.code,

--- a/packages/drivers/odsp-driver/src/test/odspError.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspError.spec.ts
@@ -80,11 +80,11 @@ describe("Odsp Error", () => {
             message: "testMessage",
             code: 400,
         };
-        const networkError = errorObjectFromSocketError(socketError);
+        const networkError = errorObjectFromSocketError(socketError, "disconnect");
         if (networkError.errorType !== DriverErrorType.genericNetworkError) {
             assert.fail("networkError should be a genericNetworkError");
         } else {
-            assert.equal(networkError.message, "testMessage");
+            assert.equal(networkError.message, "socket.io: disconnect: testMessage");
             assert.equal(networkError.canRetry, false);
             assert.equal(networkError.statusCode, 400);
         }
@@ -95,11 +95,11 @@ describe("Odsp Error", () => {
             message: "testMessage",
             code: 400,
         };
-        const networkError = errorObjectFromSocketError(socketError);
+        const networkError = errorObjectFromSocketError(socketError, "error");
         if (networkError.errorType !== DriverErrorType.genericNetworkError) {
             assert.fail("networkError should be a genericNetworkError");
         } else {
-            assert.equal(networkError.message, "testMessage");
+            assert.equal(networkError.message, "socket.io: error: testMessage");
             assert.equal(networkError.canRetry, false);
             assert.equal(networkError.statusCode, 400);
         }
@@ -111,11 +111,11 @@ describe("Odsp Error", () => {
             code: 429,
             retryAfter: 10,
         };
-        const networkError = errorObjectFromSocketError(socketError);
+        const networkError = errorObjectFromSocketError(socketError, "429");
         if (networkError.errorType !== DriverErrorType.throttlingError) {
             assert.fail("networkError should be a throttlingError");
         } else {
-            assert.equal(networkError.message, "testMessage");
+            assert.equal(networkError.message, "socket.io: 429: testMessage");
             assert.equal(networkError.retryAfterSeconds, 10);
         }
     });

--- a/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
+++ b/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
@@ -4,19 +4,21 @@
  */
 
 import { DocumentDeltaConnection } from "@fluidframework/driver-base";
-import { IDocumentDeltaConnection } from "@fluidframework/driver-definitions";
+import { IDocumentDeltaConnection, DriverError } from "@fluidframework/driver-definitions";
 import {
     NetworkErrorBasic,
     GenericNetworkError,
     createGenericNetworkError,
 } from "@fluidframework/driver-utils";
-import { IClient } from "@fluidframework/protocol-definitions";
+import { IClient, IConnect } from "@fluidframework/protocol-definitions";
 import { TelemetryNullLogger } from "@fluidframework/common-utils";
 
 export enum R11sErrorType {
     authorizationError = "authorizationError",
     fileNotFoundOrAccessDeniedError = "fileNotFoundOrAccessDeniedError",
 }
+
+const protocolVersions = ["^0.4.0", "^0.3.0", "^0.2.0", "^0.1.0"];
 
 function createNetworkError(
     errorMessage: string,
@@ -45,9 +47,9 @@ function createNetworkError(
 /**
  * Returns specific network error based on error object.
  */
-const errorObjectFromSocketError = (socketError: any, canRetry: boolean) => {
+const errorObjectFromSocketError = (socketError: {[key: string]: any}, handler: string, canRetry: boolean) => {
     return createNetworkError(
-        socketError.message,
+        `socket.io: ${handler}: ${socketError.message}`,
         canRetry,
         socketError.code,
         socketError.retryAfter);
@@ -63,31 +65,47 @@ export class R11sDocumentDeltaConnection extends DocumentDeltaConnection impleme
         token: string | null,
         io: SocketIOClientStatic,
         client: IClient,
-        url: string): Promise<IDocumentDeltaConnection> {
-        try {
-            const connection = await DocumentDeltaConnection.create(
-                tenantId,
-                id,
-                token,
-                io,
-                client,
-                url,
-                new TelemetryNullLogger(),
-            );
-            return connection;
-        } catch (errorObject) {
-            // Test if it's a NetworkError. Note that there might be no SocketError on it in case we hit
-            // nonrecoverable socket.io protocol errors! So we test canRetry property first - if it false,
-            // that means protocol is broken and reconnecting will not help.
+        url: string,
+        timeoutMs = 20000): Promise<IDocumentDeltaConnection> {
+        const socket = io(
+            url,
+            {
+                query: {
+                    documentId: id,
+                    tenantId,
+                },
+                reconnection: false,
+                transports: ["websocket"],
+                timeout: timeoutMs,
+            });
 
-            // TODO: Add more cases as we feel appropriate.
-            if (errorObject !== null && typeof errorObject === "object" && errorObject.canRetry) {
-                const socketError = errorObject.socketError;
-                if (typeof socketError === "object" && socketError !== null) {
-                    throw errorObjectFromSocketError(socketError, true);
-                }
-            }
-            throw errorObject;
+        const connectMessage: IConnect = {
+            client,
+            id,
+            mode: client.mode,
+            tenantId,
+            token,  // Token is going to indicate tenant level information, etc...
+            versions: protocolVersions,
+        };
+
+        const deltaConnection = new R11sDocumentDeltaConnection(socket, id, new TelemetryNullLogger());
+
+        await deltaConnection.initialize(connectMessage, timeoutMs);
+        return deltaConnection;
+    }
+
+    /**
+     * Error raising for socket.io issues
+     */
+    protected createErrorObject(handler: string, error?: any, canRetry = true): DriverError {
+        // Note: we suspect the incoming error object is either:
+        // - a string: log it in the message (if not a string, it may contain PII but will print as [object Object])
+        // - a socketError: add it to the OdspError object for driver to be able to parse it and reason
+        //   over it.
+        if (canRetry && typeof error === "object" && error !== null) {
+            return errorObjectFromSocketError(error, handler, canRetry) as DriverError;
+        } else {
+            return super.createErrorObject(handler, error, canRetry);
         }
     }
 }


### PR DESCRIPTION
The core of the issue here is that OdspDocumentDeltaConnection.create does error translation and it loses information in the process as it throws away original message. Reorganizing code such that we do not need to do translation other than adding / changing properties (canRetry), but error is correctly (driver-specific!) generated in the first place and it's passed that way through other ways of communication (including "disconnected" handler).
