### PR TITLE
add asyncLocalStorage instance in getCorrelationId and bindCorrelationId functions

### DIFF
--- a/server/routerlicious/packages/services-utils/src/asyncLocalStorage.ts
+++ b/server/routerlicious/packages/services-utils/src/asyncLocalStorage.ts
@@ -17,7 +17,7 @@ export function getCorrelationId(altAsyncLocalStorage?: AsyncLocalStorage<string
     }
 }
 
-export const bindCorrelationId = 
+export const bindCorrelationId =
     (altAsyncLocalStorage?: AsyncLocalStorage<string>, headerName: string = "x-correlation-id") =>
         ((req: Request, res: Response, next: NextFunction): void => {
             const id: string = req.header(headerName) || uuid.v4();

--- a/server/routerlicious/packages/services-utils/src/asyncLocalStorage.ts
+++ b/server/routerlicious/packages/services-utils/src/asyncLocalStorage.ts
@@ -9,14 +9,21 @@ import { Request, Response, NextFunction } from "express";
 
 const asyncLocalStorage = new AsyncLocalStorage<string>();
 
-export function getCorrelationId(): string | undefined {
-    const id = asyncLocalStorage.getStore();
-    return id;
+export function getCorrelationId(als?: AsyncLocalStorage<string>): string | undefined {
+    if (als) {
+        return als.getStore();
+    } else {
+        return asyncLocalStorage.getStore();
+    }
 }
 
-export const bindCorrelationId = (headerName: string = "x-correlation-id") =>
+export const bindCorrelationId = (als?: AsyncLocalStorage<string>, headerName: string = "x-correlation-id") =>
     ((req: Request, res: Response, next: NextFunction): void => {
         const id: string = req.header(headerName) || uuid.v4();
         res.setHeader(headerName, id);
-        asyncLocalStorage.run(id, () => next());
+        if (als) {
+            als.run(id, () => next());
+        } else {
+            asyncLocalStorage.run(id, () => next());
+        }
     });

--- a/server/routerlicious/packages/services-utils/src/asyncLocalStorage.ts
+++ b/server/routerlicious/packages/services-utils/src/asyncLocalStorage.ts
@@ -9,20 +9,20 @@ import { Request, Response, NextFunction } from "express";
 
 const asyncLocalStorage = new AsyncLocalStorage<string>();
 
-export function getCorrelationId(als?: AsyncLocalStorage<string>): string | undefined {
-    if (als) {
-        return als.getStore();
+export function getCorrelationId(fallbackAsyncLocalStorage?: AsyncLocalStorage<string>): string | undefined {
+    if (fallbackAsyncLocalStorage) {
+        return fallbackAsyncLocalStorage.getStore();
     } else {
         return asyncLocalStorage.getStore();
     }
 }
 
-export const bindCorrelationId = (als?: AsyncLocalStorage<string>, headerName: string = "x-correlation-id") =>
+export const bindCorrelationId = (fallbackAsyncLocalStorage?: AsyncLocalStorage<string>, headerName: string = "x-correlation-id") =>
     ((req: Request, res: Response, next: NextFunction): void => {
         const id: string = req.header(headerName) || uuid.v4();
         res.setHeader(headerName, id);
-        if (als) {
-            als.run(id, () => next());
+        if (fallbackAsyncLocalStorage) {
+            fallbackAsyncLocalStorage.run(id, () => next());
         } else {
             asyncLocalStorage.run(id, () => next());
         }


### PR DESCRIPTION
Adding asyncLocalStorage instance in getCorrelationId and bindCorrelationId functions as per discussion in the [previous PR](https://github.com/microsoft/FluidFramework/pull/4827/files) to keep it consistent.