### PR TITLE
pass asyncLocalStorage through the paths and add in getCorrelationId functions

### DIFF
--- a/server/historian/lerna-package-lock.json
+++ b/server/historian/lerna-package-lock.json
@@ -3475,10 +3475,9 @@
 			"integrity": "sha1-pDcCocV+RhOb8IT1sgwjzXyIpdE="
 		},
 		"@types/node": {
-			"version": "14.11.8",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
-			"integrity": "sha1-/iAS8jVeTOCLykSus6u7Ic+I0z8=",
-			"dev": true
+			"version": "12.19.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.15.tgz",
+			"integrity": "sha512-lowukE3GUI+VSYSu6VcBXl14d61Rp5hA1D+61r16qnwC0lYNSqdxcvRh0pswejorHfS+HgwBasM8jLXz0/aOsw=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
@@ -14947,7 +14946,7 @@
 		"winston": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
-			"integrity": "sha1-rmFyBCyvspeGr6PQnI/4M6t8kXA=",
+			"integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
 			"requires": {
 				"@dabh/diagnostics": "^2.0.2",
 				"async": "^3.1.0",
@@ -14963,7 +14962,7 @@
 				"async": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-					"integrity": "sha1-s6JoXF67ZB094C0WEALGD8n4VyA="
+					"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
 				},
 				"readable-stream": {
 					"version": "3.6.0",

--- a/server/historian/package-lock.json
+++ b/server/historian/package-lock.json
@@ -12328,7 +12328,7 @@
     "winston": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
-      "integrity": "sha1-rmFyBCyvspeGr6PQnI/4M6t8kXA=",
+      "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
       "dev": true,
       "requires": {
         "@dabh/diagnostics": "^2.0.2",
@@ -12345,7 +12345,7 @@
         "async": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-          "integrity": "sha1-s6JoXF67ZB094C0WEALGD8n4VyA=",
+          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
           "dev": true
         },
         "readable-stream": {

--- a/server/historian/packages/historian-base/package.json
+++ b/server/historian/packages/historian-base/package.json
@@ -31,6 +31,7 @@
     "@fluidframework/server-services-core": "^0.1017.1",
     "@fluidframework/server-services-utils": "^0.1017.1",
     "@fluidframework/server-test-utils": "^0.1017.1",
+    "@types/node": "^12.19.0",
     "body-parser": "^1.17.2",
     "compression": "^1.7.3",
     "cors": "^2.8.5",

--- a/server/historian/packages/historian-base/src/app.ts
+++ b/server/historian/packages/historian-base/src/app.ts
@@ -4,6 +4,7 @@
  */
 
 import { IThrottler } from "@fluidframework/server-services-core";
+import { AsyncLocalStorage } from "async_hooks";
 import * as bodyParser from "body-parser";
 import compression from "compression";
 import cors from "cors";
@@ -24,7 +25,7 @@ const stream = split().on("data", (message) => {
     winston.info(message);
 });
 
-export function create(config: nconf.Provider, tenantService: ITenantService, cache: ICache, throttler: IThrottler) {
+export function create(config: nconf.Provider, tenantService: ITenantService, cache: ICache, throttler: IThrottler, asyncLocalStorage: AsyncLocalStorage<string>) {
     // Express app configuration
     const app: express.Express = express();
 
@@ -37,9 +38,9 @@ export function create(config: nconf.Provider, tenantService: ITenantService, ca
 
     app.use(compression());
     app.use(cors());
-    app.use(bindCorrelationId());
+    app.use(bindCorrelationId(asyncLocalStorage));
 
-    const apiRoutes = routes.create(config, tenantService, cache, throttler);
+    const apiRoutes = routes.create(config, tenantService, cache, throttler, asyncLocalStorage);
     app.use(apiRoutes.git.blobs);
     app.use(apiRoutes.git.refs);
     app.use(apiRoutes.git.tags);

--- a/server/historian/packages/historian-base/src/routes/git/blobs.ts
+++ b/server/historian/packages/historian-base/src/routes/git/blobs.ts
@@ -6,6 +6,7 @@
 import * as git from "@fluidframework/gitresources";
 import { IThrottler } from "@fluidframework/server-services-core";
 import { IThrottleMiddlewareOptions, throttle } from "@fluidframework/server-services-utils";
+import { AsyncLocalStorage } from "async_hooks";
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
@@ -16,7 +17,8 @@ export function create(
     store: nconf.Provider,
     tenantService: ITenantService,
     cache: ICache,
-    throttler: IThrottler): Router {
+    throttler: IThrottler,
+    asyncLocalStorage: AsyncLocalStorage<string>): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -28,7 +30,7 @@ export function create(
         tenantId: string,
         authorization: string,
         body: git.ICreateBlobParams): Promise<git.ICreateBlobResponse> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.createBlob(body);
     }
 
@@ -37,7 +39,7 @@ export function create(
         authorization: string,
         sha: string,
         useCache: boolean): Promise<git.IBlob> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.getBlob(sha, useCache);
     }
 

--- a/server/historian/packages/historian-base/src/routes/git/commits.ts
+++ b/server/historian/packages/historian-base/src/routes/git/commits.ts
@@ -6,6 +6,7 @@
 import { ICommit, ICreateCommitParams } from "@fluidframework/gitresources";
 import { IThrottler } from "@fluidframework/server-services-core";
 import { IThrottleMiddlewareOptions, throttle } from "@fluidframework/server-services-utils";
+import { AsyncLocalStorage } from "async_hooks";
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
@@ -16,7 +17,8 @@ export function create(
     store: nconf.Provider,
     tenantService: ITenantService,
     cache: ICache,
-    throttler: IThrottler): Router {
+    throttler: IThrottler,
+    asyncLocalStorage: AsyncLocalStorage<string>): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -28,7 +30,7 @@ export function create(
         tenantId: string,
         authorization: string,
         params: ICreateCommitParams): Promise<ICommit> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.createCommit(params);
     }
 
@@ -37,7 +39,7 @@ export function create(
         authorization: string,
         sha: string,
         useCache: boolean): Promise<ICommit> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.getCommit(sha, useCache);
     }
 

--- a/server/historian/packages/historian-base/src/routes/git/refs.ts
+++ b/server/historian/packages/historian-base/src/routes/git/refs.ts
@@ -7,6 +7,7 @@ import * as git from "@fluidframework/gitresources";
 import { ICreateRefParamsExternal, IPatchRefParamsExternal } from "@fluidframework/server-services-client";
 import { IThrottler } from "@fluidframework/server-services-core";
 import { IThrottleMiddlewareOptions, throttle } from "@fluidframework/server-services-utils";
+import { AsyncLocalStorage } from "async_hooks";
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
@@ -17,7 +18,8 @@ export function create(
     store: nconf.Provider,
     tenantService: ITenantService,
     cache: ICache,
-    throttler: IThrottler): Router {
+    throttler: IThrottler,
+    asyncLocalStorage: AsyncLocalStorage<string>): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -26,12 +28,12 @@ export function create(
     };
 
     async function getRefs(tenantId: string, authorization: string): Promise<git.IRef[]> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.getRefs();
     }
 
     async function getRef(tenantId: string, authorization: string, ref: string): Promise<git.IRef> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.getRef(ref);
     }
 
@@ -39,7 +41,7 @@ export function create(
         tenantId: string,
         authorization: string,
         params: ICreateRefParamsExternal): Promise<git.IRef> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.createRef(params);
     }
 
@@ -48,7 +50,7 @@ export function create(
         authorization: string,
         ref: string,
         params: IPatchRefParamsExternal): Promise<git.IRef> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.updateRef(ref, params);
     }
 
@@ -56,7 +58,7 @@ export function create(
         tenantId: string,
         authorization: string,
         ref: string): Promise<void> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.deleteRef(ref);
     }
 

--- a/server/historian/packages/historian-base/src/routes/git/tags.ts
+++ b/server/historian/packages/historian-base/src/routes/git/tags.ts
@@ -6,6 +6,7 @@
 import * as git from "@fluidframework/gitresources";
 import { IThrottler } from "@fluidframework/server-services-core";
 import { IThrottleMiddlewareOptions, throttle } from "@fluidframework/server-services-utils";
+import { AsyncLocalStorage } from "async_hooks";
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
@@ -16,7 +17,8 @@ export function create(
     store: nconf.Provider,
     tenantService: ITenantService,
     cache: ICache,
-    throttler: IThrottler): Router {
+    throttler: IThrottler,
+    asyncLocalStorage: AsyncLocalStorage<string>): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -28,12 +30,12 @@ export function create(
         tenantId: string,
         authorization: string,
         params: git.ICreateTagParams): Promise<git.ITag> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.createTag(params);
     }
 
     async function getTag(tenantId: string, authorization: string, tag: string): Promise<git.ITag> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.getTag(tag);
     }
 

--- a/server/historian/packages/historian-base/src/routes/git/trees.ts
+++ b/server/historian/packages/historian-base/src/routes/git/trees.ts
@@ -6,6 +6,7 @@
 import * as git from "@fluidframework/gitresources";
 import { IThrottler } from "@fluidframework/server-services-core";
 import { IThrottleMiddlewareOptions, throttle } from "@fluidframework/server-services-utils";
+import { AsyncLocalStorage } from "async_hooks";
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
@@ -16,7 +17,8 @@ export function create(
     store: nconf.Provider,
     tenantService: ITenantService,
     cache: ICache,
-    throttler: IThrottler): Router {
+    throttler: IThrottler,
+    asyncLocalStorage: AsyncLocalStorage<string>): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -28,7 +30,7 @@ export function create(
         tenantId: string,
         authorization: string,
         params: git.ICreateTreeParams): Promise<git.ITree> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.createTree(params);
     }
 
@@ -38,7 +40,7 @@ export function create(
         sha: string,
         recursive: boolean,
         useCache: boolean): Promise<git.ITree> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.getTree(sha, recursive, useCache);
     }
 

--- a/server/historian/packages/historian-base/src/routes/index.ts
+++ b/server/historian/packages/historian-base/src/routes/index.ts
@@ -4,6 +4,7 @@
  */
 
 import { IThrottler } from "@fluidframework/server-services-core";
+import { AsyncLocalStorage } from "async_hooks";
 import { Router } from "express";
 import * as nconf from "nconf";
 import { ICache, ITenantService } from "../services";
@@ -38,19 +39,20 @@ export function create(
     store: nconf.Provider,
     tenantService: ITenantService,
     cache: ICache,
-    throttler: IThrottler): IRoutes {
+    throttler: IThrottler,
+    asyncLocalStorage: AsyncLocalStorage<string>): IRoutes {
     return {
         git: {
-            blobs: blobs.create(store, tenantService, cache, throttler),
-            commits: commits.create(store, tenantService, cache, throttler),
-            refs: refs.create(store, tenantService, cache, throttler),
-            tags: tags.create(store, tenantService, cache, throttler),
-            trees: trees.create(store, tenantService, cache, throttler),
+            blobs: blobs.create(store, tenantService, cache, throttler, asyncLocalStorage),
+            commits: commits.create(store, tenantService, cache, throttler, asyncLocalStorage),
+            refs: refs.create(store, tenantService, cache, throttler, asyncLocalStorage),
+            tags: tags.create(store, tenantService, cache, throttler, asyncLocalStorage),
+            trees: trees.create(store, tenantService, cache, throttler, asyncLocalStorage),
         },
         repository: {
-            commits: repositoryCommits.create(store, tenantService, cache, throttler),
-            contents: contents.create(store, tenantService, cache, throttler),
-            headers: headers.create(store, tenantService, cache, throttler),
+            commits: repositoryCommits.create(store, tenantService, cache, throttler, asyncLocalStorage),
+            contents: contents.create(store, tenantService, cache, throttler, asyncLocalStorage),
+            headers: headers.create(store, tenantService, cache, throttler, asyncLocalStorage),
         },
     };
 }

--- a/server/historian/packages/historian-base/src/routes/repository/commits.ts
+++ b/server/historian/packages/historian-base/src/routes/repository/commits.ts
@@ -6,6 +6,7 @@
 import * as git from "@fluidframework/gitresources";
 import { IThrottler } from "@fluidframework/server-services-core";
 import { IThrottleMiddlewareOptions, throttle } from "@fluidframework/server-services-utils";
+import { AsyncLocalStorage } from "async_hooks";
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
@@ -16,7 +17,8 @@ export function create(
     store: nconf.Provider,
     tenantService: ITenantService,
     cache: ICache,
-    throttler: IThrottler): Router {
+    throttler: IThrottler,
+    asyncLocalStorage: AsyncLocalStorage<string>): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -29,7 +31,7 @@ export function create(
         authorization: string,
         sha: string,
         count: number): Promise<git.ICommitDetails[]> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.getCommits(sha, count);
     }
 

--- a/server/historian/packages/historian-base/src/routes/repository/contents.ts
+++ b/server/historian/packages/historian-base/src/routes/repository/contents.ts
@@ -5,6 +5,7 @@
 
 import { IThrottler } from "@fluidframework/server-services-core";
 import { IThrottleMiddlewareOptions, throttle } from "@fluidframework/server-services-utils";
+import { AsyncLocalStorage } from "async_hooks";
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
@@ -15,7 +16,8 @@ export function create(
     store: nconf.Provider,
     tenantService: ITenantService,
     cache: ICache,
-    throttler: IThrottler): Router {
+    throttler: IThrottler,
+    asyncLocalStorage: AsyncLocalStorage<string>): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -28,7 +30,7 @@ export function create(
         authorization: string,
         path: string,
         ref: string): Promise<any> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.getContent(path, ref);
     }
 

--- a/server/historian/packages/historian-base/src/routes/repository/headers.ts
+++ b/server/historian/packages/historian-base/src/routes/repository/headers.ts
@@ -6,6 +6,7 @@
 import { IHeader } from "@fluidframework/gitresources";
 import { IThrottler } from "@fluidframework/server-services-core";
 import { IThrottleMiddlewareOptions, throttle } from "@fluidframework/server-services-utils";
+import { AsyncLocalStorage } from "async_hooks";
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
@@ -16,7 +17,8 @@ export function create(
     store: nconf.Provider,
     tenantService: ITenantService,
     cache: ICache,
-    throttler: IThrottler): Router {
+    throttler: IThrottler,
+    asyncLocalStorage: AsyncLocalStorage<string>): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -29,7 +31,7 @@ export function create(
         authorization: string,
         sha: string,
         useCache: boolean): Promise<IHeader> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.getHeader(sha, useCache);
     }
 
@@ -38,7 +40,7 @@ export function create(
         authorization: string,
         sha: string,
         useCache: boolean): Promise<any> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.getFullTree(sha, useCache);
     }
 

--- a/server/historian/packages/historian-base/src/routes/utils.ts
+++ b/server/historian/packages/historian-base/src/routes/utils.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { AsyncLocalStorage } from "async_hooks";
 import { Response } from "express";
 // In this case we want @types/express-serve-static-core, not express-serve-static-core, and so disable the lint rule
 // eslint-disable-next-line import/no-unresolved
@@ -37,6 +38,7 @@ export async function createGitService(
     authorization: string,
     tenantService: ITenantService,
     cache: ICache,
+    asyncLocalStorage: AsyncLocalStorage<string>,
 ): Promise<RestGitService> {
     let token: string = null;
     if (authorization) {
@@ -60,7 +62,7 @@ export async function createGitService(
     const customData: ITenantCustomDataExternal = details.customData;
     const writeToExternalStorage = customData.externalStorageData !== undefined &&
     customData.externalStorageData !== null;
-    const service = new RestGitService(details.storage, cache, writeToExternalStorage);
+    const service = new RestGitService(details.storage, cache, writeToExternalStorage, asyncLocalStorage);
 
     return service;
 }

--- a/server/historian/packages/historian-base/src/runner.ts
+++ b/server/historian/packages/historian-base/src/runner.ts
@@ -6,6 +6,7 @@
 import { Deferred } from "@fluidframework/common-utils";
 import { IThrottler, IWebServer, IWebServerFactory } from "@fluidframework/server-services-core";
 import * as utils from "@fluidframework/server-services-utils";
+import { AsyncLocalStorage } from "async_hooks";
 import { Provider } from "nconf";
 import * as winston from "winston";
 import { ICache, ITenantService } from "./services";
@@ -22,7 +23,8 @@ export class HistorianRunner implements utils.IRunner {
         private readonly port: string | number,
         private readonly riddler: ITenantService,
         private readonly cache: ICache,
-        private readonly throttler: IThrottler) {
+        private readonly throttler: IThrottler,
+        private readonly asyncLocalStorage: AsyncLocalStorage<string>) {
     }
 
     // eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -30,7 +32,7 @@ export class HistorianRunner implements utils.IRunner {
         this.runningDeferred = new Deferred<void>();
         configureLogging(this.config.get("logger"));
         // Create the historian app
-        const historian = app.create(this.config, this.riddler, this.cache, this.throttler);
+        const historian = app.create(this.config, this.riddler, this.cache, this.throttler, this.asyncLocalStorage);
         historian.set("port", this.port);
 
         this.server = this.serverFactory.create(historian);

--- a/server/historian/packages/historian-base/src/services/restGitService.ts
+++ b/server/historian/packages/historian-base/src/services/restGitService.ts
@@ -10,6 +10,7 @@ import {
     ICreateRefParamsExternal,
     IPatchRefParamsExternal } from "@fluidframework/server-services-client";
 import { ITenantStorage } from "@fluidframework/server-services-core";
+import { AsyncLocalStorage } from "async_hooks";
 import * as uuid from "uuid";
 import request from "request";
 import * as winston from "winston";
@@ -43,7 +44,8 @@ export class RestGitService {
     constructor(
         private readonly storage: ITenantStorage,
         private readonly cache: ICache,
-        private readonly writeToExternalStorage: boolean) {
+        private readonly writeToExternalStorage: boolean,
+        private readonly asyncLocalStorage: AsyncLocalStorage<string>) {
         if (storage.credentials) {
             const token = Buffer.from(`${storage.credentials.user}:${storage.credentials.password}`);
             this.authHeader = `Basic ${token.toString("base64")}`;
@@ -284,7 +286,7 @@ export class RestGitService {
         const options: request.OptionsWithUrl = {
             headers: {
                 "User-Agent": userAgent,
-                "x-correlation-id": getCorrelationId() || uuid.v4(),
+                "x-correlation-id": getCorrelationId(this.asyncLocalStorage) || uuid.v4(),
             },
             json: true,
             method: "GET",
@@ -301,7 +303,7 @@ export class RestGitService {
             headers: {
                 "Content-Type": "application/json",
                 "User-Agent": userAgent,
-                "x-correlation-id": getCorrelationId() || uuid.v4(),
+                "x-correlation-id": getCorrelationId(this.asyncLocalStorage) || uuid.v4(),
             },
             json: true,
             method: "POST",
@@ -316,7 +318,7 @@ export class RestGitService {
         const options: request.OptionsWithUrl = {
             headers: {
                 "User-Agent": userAgent,
-                "x-correlation-id": getCorrelationId() || uuid.v4(),
+                "x-correlation-id": getCorrelationId(this.asyncLocalStorage) || uuid.v4(),
             },
             method: "DELETE",
             url: `${this.storage.url}${url}`,
@@ -332,7 +334,7 @@ export class RestGitService {
             headers: {
                 "Content-Type": "application/json",
                 "User-Agent": userAgent,
-                "x-correlation-id": getCorrelationId() || uuid.v4(),
+                "x-correlation-id": getCorrelationId(this.asyncLocalStorage) || uuid.v4(),
             },
             json: true,
             method: "PATCH",

--- a/server/historian/packages/historian-base/src/services/riddlerService.ts
+++ b/server/historian/packages/historian-base/src/services/riddlerService.ts
@@ -6,6 +6,7 @@
 import { OutgoingHttpHeaders } from "http";
 import { ITenantConfig } from "@fluidframework/server-services-core";
 import { getCorrelationId } from "@fluidframework/server-services-utils";
+import { AsyncLocalStorage } from "async_hooks";
 import * as uuid from "uuid";
 import * as request from "request-promise-native";
 import * as winston from "winston";
@@ -14,7 +15,7 @@ import { ITenantService } from "./definitions";
 import { RedisTenantCache } from "./redisTenantCache";
 
 export class RiddlerService implements ITenantService {
-    constructor(private readonly endpoint: string, private readonly cache: RedisTenantCache) {
+    constructor(private readonly endpoint: string, private readonly cache: RedisTenantCache, private readonly asyncLocalStorage: AsyncLocalStorage<string>) {
     }
 
     public async getTenant(tenantId: string, token: string): Promise<ITenantConfig> {
@@ -26,7 +27,7 @@ export class RiddlerService implements ITenantService {
         return {
             "Accept": "application/json",
             "Content-Type": "application/json",
-            "x-correlation-id": getCorrelationId() || uuid.v4(),
+            "x-correlation-id": getCorrelationId(this.asyncLocalStorage) || uuid.v4(),
         };
     }
 

--- a/server/historian/packages/historian/package.json
+++ b/server/historian/packages/historian/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@fluidframework/historian-base": "^0.0.1",
     "@fluidframework/server-services-utils": "^0.1017.1",
+    "@types/node": "^12.19.0",
     "body-parser": "^1.17.2",
     "compression": "^1.7.3",
     "cors": "^2.8.5",


### PR DESCRIPTION
From the starting point when we create asyncLocalStorage instances, we pass the instance all the way down and add in getCorrelationId and bindCorrelationId functions in historian to keep correlation id consistent using the same instance. It is a draft now since we need to wait for the other [changes](https://github.com/microsoft/FluidFramework/pull/4914) to be released in the next version.