### PR TITLE
Pass site url as callback parameter to enable fetching Push token against external tenants

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,17 +1,22 @@
 ## 0.35 Breaking changes
-- [Removed some api implemenations from odsp driver](#Removed-some-api-implemenations-from-odsp-driver)
+- [Removed some api implementations from odsp driver](#Removed-some-api-implemenations-from-odsp-driver)
 - [get-tinylicious-container and get-session-storage-container moved](#get-tinylicious-container-and-get-session-storage-container-moved)
 - [Moved parseAuthErrorClaims from @fluidframework/odsp-driver to @fluidframework/odsp-doclib-utils](#Moved-parseAuthErrorClaims-from-@fluidframework/odsp-driver-to-@fluidframework/odsp-doclib-utils)
+- [Refactored token fetcher types in odsp-driver](#refactored-token-fetcher-types-in-odsp-driver)
 
-### Moved parseAuthErrorClaims from @fluidframework/odsp-driver to @fluidframework/odsp-doclib-utils
-Moved `parseAuthErrorClaims` from `@fluidframework/odsp-driver` to `@fluidframework/odsp-doclib-utils`
-
-### Removed-some-api-implemenations-from-odsp-driver
+### Removed-some-api-implementations-from-odsp-driver
 Removed `authorizedFetchWithRetry`, `AuthorizedRequestTokenPolicy`, `AuthorizedFetchProps`, `asyncWithCache`, `asyncWithRetry`,
 `fetchWithRetry` implementation from odspdriver.
 
 ### get-tinylicious-container and get-session-storage-container moved
 The functionality from the packages `@fluidframework/get-tinylicious-container` and `@fluidframework/get-session-storage-container` has been moved to the package `@fluid-experimental/get-container`.
+
+### Moved parseAuthErrorClaims from @fluidframework/odsp-driver to @fluidframework/odsp-doclib-utils
+Moved `parseAuthErrorClaims` from `@fluidframework/odsp-driver` to `@fluidframework/odsp-doclib-utils`
+
+## Refactored token fetcher types in odsp-driver
+Streamlined interfaces and types used to facilitate access tokens needed by odsp-driver to call ODSP implementation of Fluid services.
+Added support for passing siteUrl when fetching token that is used to establish co-authoring session for Fluid content stored in ODSP file which is hosted in external tenant. This token is used by ODSP ordering service implementation (aka ODSP Push service).
 
 ## 0.34 Breaking changes
 - [Aqueduct writeBlob() and BlobHandle implementation removed](#Aqueduct-writeBlob-and-BlobHandle-implementation-removed)

--- a/packages/drivers/odsp-driver/src/graph.ts
+++ b/packages/drivers/odsp-driver/src/graph.ts
@@ -11,12 +11,10 @@ import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth";
 import { fetchAndParseAsJSONHelper, fetchHelper, getWithRetryForTokenRefresh, IOdspResponse } from "./odspUtils";
 import {
     IdentityType,
-    SharingLinkTokenFetcher,
     SharingLinkTokenFetchOptions,
     TokenFetcher,
     TokenFetchOptions,
     tokenFromResponse,
-    TokenResponse,
 } from "./tokenFetch";
 
 /**
@@ -88,7 +86,7 @@ export async function delay(timeMs: number): Promise<void> {
  * @returns Promise which resolves to share link url when successful; otherwise, undefined.
  */
 export async function getShareLink(
-    getToken: (options: SharingLinkTokenFetchOptions) => Promise<string | TokenResponse | null>,
+    getToken: TokenFetcher<SharingLinkTokenFetchOptions>,
     siteUrl: string,
     driveId: string,
     itemId: string,
@@ -121,7 +119,7 @@ export async function getShareLink(
 }
 
 export async function getShareLinkCore(
-    getToken: (options: SharingLinkTokenFetchOptions) => Promise<string | TokenResponse | null>,
+    getToken: TokenFetcher<SharingLinkTokenFetchOptions>,
     siteUrl: string,
     driveId: string,
     itemId: string,
@@ -159,7 +157,7 @@ export async function getShareLinkCore(
  * @param requestInit - Request Init to be passed to fetch
  */
 async function graphFetch(
-    getToken: TokenFetcher,
+    getToken: TokenFetcher<TokenFetchOptions>,
     graphUrl: string,
     nameForLogging: string,
     logger: ITelemetryLogger,
@@ -202,7 +200,7 @@ async function graphFetch(
  * @returns Promise which resolves to file url when successful; otherwise, undefined.
  */
 async function getFileDefaultUrl(
-    getToken: SharingLinkTokenFetcher,
+    getToken: TokenFetcher<SharingLinkTokenFetchOptions>,
     siteUrl: string,
     driveId: string,
     itemId: string,
@@ -281,7 +279,7 @@ const graphItemLiteCache = new PromiseCache<string, GraphItemLite | undefined>()
  * powering MRU and Share functionality.
  */
 async function getGraphItemLite(
-    getToken: TokenFetcher,
+    getToken: TokenFetcher<TokenFetchOptions>,
     driveId: string,
     itemId: string,
     logger: ITelemetryLogger,

--- a/packages/drivers/odsp-driver/src/graph.ts
+++ b/packages/drivers/odsp-driver/src/graph.ts
@@ -9,7 +9,14 @@ import { canRetryOnError, getRetryDelayFromError } from "@fluidframework/driver-
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
 import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth";
 import { fetchAndParseAsJSONHelper, fetchHelper, getWithRetryForTokenRefresh, IOdspResponse } from "./odspUtils";
-import { IdentityType, SharingLinkScopeFor, TokenFetchOptions } from "./tokenFetch";
+import {
+    IdentityType,
+    SharingLinkTokenFetcher,
+    SharingLinkTokenFetchOptions,
+    TokenFetcher,
+    TokenFetchOptions,
+    TokenResponse,
+} from "./tokenFetch";
 
 /**
  * This represents a lite version of GraphItem containing only the name, webUrl and webDavUrl properties
@@ -66,7 +73,7 @@ export async function delay(timeMs: number): Promise<void> {
  * This function keeps retrying if it gets a retriable error or wait for some delay if it gets a
  * throttling error. In future, we are thinking of app allowing to pass some cancel token, with which
  * we would be able to stop retrying.
- * @param getShareLinkToken - used to fetch access token needed to execute operation
+ * @param getToken - used to fetch access tokens needed to execute operation
  * @param siteUrl - url of the site that contains the file
  * @param driveId - drive where file is stored
  * @param itemId - file id
@@ -80,8 +87,7 @@ export async function delay(timeMs: number): Promise<void> {
  * @returns Promise which resolves to share link url when successful; otherwise, undefined.
  */
 export async function getShareLink(
-    getShareLinkToken:
-        (options: TokenFetchOptions, scopeFor: SharingLinkScopeFor, siteUrl: string) => Promise<string | null>,
+    getToken: (options: SharingLinkTokenFetchOptions) => Promise<string | TokenResponse | null>,
     siteUrl: string,
     driveId: string,
     itemId: string,
@@ -96,8 +102,8 @@ export async function getShareLink(
     let retryAfter = 0;
     do {
         try {
-            result = await getShareLinkCore(getShareLinkToken, siteUrl, driveId, itemId, identityType,
-                logger, scope, type, msGraphOrigin);
+            result = await getShareLinkCore(
+                getToken, siteUrl, driveId, itemId, identityType, logger, scope, type, msGraphOrigin);
             success = true;
         } catch (err) {
             // If it is not retriable, then just throw the error.
@@ -114,8 +120,7 @@ export async function getShareLink(
 }
 
 export async function getShareLinkCore(
-    getShareLinkToken:
-        (options: TokenFetchOptions, scopeFor: SharingLinkScopeFor, siteUrl: string) => Promise<string | null>,
+    getToken: (options: SharingLinkTokenFetchOptions) => Promise<string | TokenResponse | null>,
     siteUrl: string,
     driveId: string,
     itemId: string,
@@ -126,12 +131,11 @@ export async function getShareLinkCore(
     msGraphOrigin?: string,
 ): Promise<string | undefined> {
     if (scope === "existingAccess") {
-        return getFileDefaultUrl(getShareLinkToken, siteUrl, driveId, itemId, identityType, logger, msGraphOrigin);
+        return getFileDefaultUrl(getToken, siteUrl, driveId, itemId, identityType, logger, msGraphOrigin);
     }
 
     const createShareLinkResponse = await graphFetch(
-        getShareLinkToken,
-        siteUrl,
+        async (options: TokenFetchOptions) => getToken({...options, siteUrl, type: "Graph"}),
         `${slashTerminatedOriginOrEmptyString(msGraphOrigin)}drives/${driveId}/items/${itemId}/createLink`,
         `GetShareLink_${scope}_${type}`,
         logger,
@@ -146,18 +150,15 @@ export async function getShareLinkCore(
 
 /**
  * Issues a graph fetch request
- * @param getShareLinkToken - Token provider than can supply Graph tokens
- * @param siteUrl - SiteUrl of the site that contains the file
+ * @param getToken - Token provider than can supply Graph tokens
  * @param graphUrl - Url to fetch. Can either be a full URL (e.g. https://graph.microsoft.com/v1.0/me/people)
  *  or a partial url (e.g. me/people)
  * @param nameForLogging - Name used for logging
  * @param logger - used to log results of operation, including any error
  * @param requestInit - Request Init to be passed to fetch
  */
-export async function graphFetch(
-    getShareLinkToken:
-        (options: TokenFetchOptions, scopeFor: SharingLinkScopeFor, siteUrl: string) => Promise<string | null>,
-    siteUrl: string,
+async function graphFetch(
+    getToken: TokenFetcher,
     graphUrl: string,
     nameForLogging: string,
     logger: ITelemetryLogger,
@@ -168,7 +169,7 @@ export async function graphFetch(
         { eventName: "odspFetchResponse", requestName: nameForLogging }, async (event) => {
             const odspResponse = await getWithRetryForTokenRefresh(async (options) => {
                 tries++;
-                const token = await getShareLinkToken(options, SharingLinkScopeFor.nonFileDefaultUrl, siteUrl);
+                const token = await getToken(options);
                 const { url, headers } = getUrlAndHeadersWithAuth(graphUrl.startsWith("http")
                     ? graphUrl : `https://graph.microsoft.com/v1.0/${graphUrl}`, token);
                 const augmentedRequest = { ...requestInit };
@@ -186,8 +187,8 @@ export async function graphFetch(
 
 /**
  * Returns default link for a file with given drive and item ids.
- * Scopes needed: files.read.all and {siteOrigin}/files.readwrite.all
- * @param getShareLinkToken - used to fetch access token needed to execute operation
+ * Scopes needed: files.read.all and {siteUrl}/files.readwrite.all
+ * @param getToken - used to fetch access tokens needed to execute operation
  * @param siteUrl - SiteUrl of the site that contains the file
  * @param driveId - driveId that contains the file
  * @param itemId - ItemId of the file
@@ -198,8 +199,7 @@ export async function graphFetch(
  * @returns Promise which resolves to file url when successful; otherwise, undefined.
  */
 async function getFileDefaultUrl(
-    getShareLinkToken:
-        (options: TokenFetchOptions, scopeFor: SharingLinkScopeFor, siteUrl: string) => Promise<string | null>,
+    getToken: SharingLinkTokenFetcher,
     siteUrl: string,
     driveId: string,
     itemId: string,
@@ -207,7 +207,13 @@ async function getFileDefaultUrl(
     logger: ITelemetryLogger,
     msGraphOrigin?: string,
 ): Promise<string | undefined> {
-    const graphItem = await getGraphItemLite(getShareLinkToken, siteUrl, driveId, itemId, logger, msGraphOrigin);
+    const graphItem = await getGraphItemLite(
+        async (options: TokenFetchOptions) => getToken({...options, siteUrl, type: "Graph"}),
+        driveId,
+        itemId,
+        logger,
+        msGraphOrigin,
+    );
     if (!graphItem) {
         return undefined;
     }
@@ -220,14 +226,17 @@ async function getFileDefaultUrl(
     let tries = 0;
     let additionalProps;
     // ODSP link requires extra call to return link that is resistant to file being renamed or moved to different folder
-    const response = await PerformanceEvent.timedExecAsync(logger,
-            { eventName: "odspFetchResponse", requestName: "getFileDefaultUrl" }, async (event) => {
-                const odspResponse = await getWithRetryForTokenRefresh(async (options) => {
+    const response = await PerformanceEvent.timedExecAsync(
+        logger,
+        { eventName: "odspFetchResponse", requestName: "getFileDefaultUrl" },
+        async (event) => {
+            const odspResponse = await getWithRetryForTokenRefresh(async (options) => {
                 tries++;
-                const token = await getShareLinkToken(options, SharingLinkScopeFor.fileDefaultUrl, siteUrl);
+                const token = await getToken({ ...options, siteUrl, type: "OneDrive" });
                 const { url, headers } = getUrlAndHeadersWithAuth(
                     `${siteUrl}/_api/web/GetFileByUrl(@a1)/ListItemAllFields/GetSharingInformation?@a1=${
-                        encodeURIComponent(graphItem.webDavUrl)}`, token);
+                        encodeURIComponent(graphItem.webDavUrl)
+                    }`, token);
                 const requestInit = {
                     method: "POST",
                     headers: {
@@ -240,11 +249,11 @@ async function getFileDefaultUrl(
                 additionalProps = await getSPOAndGraphRequestIdsFromResponse(new Map(res.headers));
                 const text = JSON.parse(await res.text());
                 return text?.d?.directUrl as string;
-            },
-        );
-        event.end({ ...additionalProps, tries });
-        return odspResponse;
-    });
+            });
+            event.end({ ...additionalProps, tries });
+            return odspResponse;
+        },
+    );
 
     return response;
 }
@@ -255,8 +264,7 @@ const graphItemLiteCache = new PromiseCache<string, GraphItemLite | undefined>()
 /**
  * This API gets only few properties representing the GraphItem - hence 'Lite'.
  * Scope needed: files.read.all
- * @param getShareLinkToken - used to fetch access token needed to execute operation
- * @param siteUrl - SiteUrl of the site that contains the file
+ * @param getToken - used to fetch access token needed to execute operation
  * @param driveId - ID for the drive that contains the file
  * @param itemId - ID of the file
  * @param logger - used to log results of operation, including any error
@@ -269,10 +277,8 @@ const graphItemLiteCache = new PromiseCache<string, GraphItemLite | undefined>()
  * - webDavUrl represents file url in WebDAV standard, this url includes file path. This is needed for APIs
  * powering MRU and Share functionality.
  */
-export async function getGraphItemLite(
-    getShareLinkToken:
-        (options: TokenFetchOptions, scopeFor: SharingLinkScopeFor, siteUrl: string) => Promise<string | null>,
-    siteUrl: string,
+async function getGraphItemLite(
+    getToken: TokenFetcher,
     driveId: string,
     itemId: string,
     logger: ITelemetryLogger,
@@ -286,7 +292,7 @@ export async function getGraphItemLite(
 
             let response: IOdspResponse<GraphItemLite> | undefined;
             try {
-                response = await graphFetch(getShareLinkToken, siteUrl, partialUrl, "GetGraphItemLite", logger);
+                response = await graphFetch(getToken, partialUrl, "GetGraphItemLite", logger);
             } catch(error) {
                 graphItemLiteCache.remove(cacheKey);
                 return undefined;
@@ -315,10 +321,10 @@ export async function getGraphItemLite(
 }
 
 export interface IGraphFetchResponse {
-    webUrl: string,
-    webDavUrl: string,
-    name: string,
+    webUrl: string;
+    webDavUrl: string;
+    name: string;
     link: {
-        webUrl: string,
-    },
+        webUrl: string;
+    };
 }

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactory.ts
@@ -8,7 +8,7 @@ import { HostStoragePolicy } from "./contracts";
 import { IPersistedCache } from "./odspCache";
 import { OdspDocumentServiceFactoryCore } from "./odspDocumentServiceFactoryCore";
 import { getSocketIo } from "./getSocketIo";
-import { StorageTokenFetcher, PushTokenFetcher } from "./tokenFetch";
+import { ResourceTokenFetcher } from "./tokenFetch";
 
 /**
  * Factory for creating the sharepoint document service. Use this if you want to
@@ -18,8 +18,8 @@ export class OdspDocumentServiceFactory
     extends OdspDocumentServiceFactoryCore
     implements IDocumentServiceFactory {
     constructor(
-        getStorageToken: StorageTokenFetcher,
-        getWebsocketToken: PushTokenFetcher,
+        getStorageToken: ResourceTokenFetcher,
+        getWebsocketToken: ResourceTokenFetcher,
         persistedCache?: IPersistedCache,
         hostPolicy?: HostStoragePolicy,
     ) {

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactory.ts
@@ -8,7 +8,7 @@ import { HostStoragePolicy } from "./contracts";
 import { IPersistedCache } from "./odspCache";
 import { OdspDocumentServiceFactoryCore } from "./odspDocumentServiceFactoryCore";
 import { getSocketIo } from "./getSocketIo";
-import { OdspResourceTokenFetcher } from "./tokenFetch";
+import { OdspResourceTokenFetchOptions, TokenFetcher } from "./tokenFetch";
 
 /**
  * Factory for creating the sharepoint document service. Use this if you want to
@@ -18,8 +18,8 @@ export class OdspDocumentServiceFactory
     extends OdspDocumentServiceFactoryCore
     implements IDocumentServiceFactory {
     constructor(
-        getStorageToken: OdspResourceTokenFetcher,
-        getWebsocketToken: OdspResourceTokenFetcher,
+        getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>,
+        getWebsocketToken: TokenFetcher<OdspResourceTokenFetchOptions>,
         persistedCache?: IPersistedCache,
         hostPolicy?: HostStoragePolicy,
     ) {

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactory.ts
@@ -8,7 +8,7 @@ import { HostStoragePolicy } from "./contracts";
 import { IPersistedCache } from "./odspCache";
 import { OdspDocumentServiceFactoryCore } from "./odspDocumentServiceFactoryCore";
 import { getSocketIo } from "./getSocketIo";
-import { ResourceTokenFetcher } from "./tokenFetch";
+import { OdspResourceTokenFetcher } from "./tokenFetch";
 
 /**
  * Factory for creating the sharepoint document service. Use this if you want to
@@ -18,8 +18,8 @@ export class OdspDocumentServiceFactory
     extends OdspDocumentServiceFactoryCore
     implements IDocumentServiceFactory {
     constructor(
-        getStorageToken: ResourceTokenFetcher,
-        getWebsocketToken: ResourceTokenFetcher,
+        getStorageToken: OdspResourceTokenFetcher,
+        getWebsocketToken: OdspResourceTokenFetcher,
         persistedCache?: IPersistedCache,
         hostPolicy?: HostStoragePolicy,
     ) {

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -126,7 +126,7 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
         return OdspDocumentService.create(
             resolvedUrl,
             this.toInstrumentedStorageTokenFetcher(odspLogger, resolvedUrl as IOdspResolvedUrl, this.getStorageToken),
-            this.toInstrumentedPushTokenFetcher(odspLogger, this.getWebsocketToken),
+            this.toInstrumentedPushTokenFetcher(odspLogger, resolvedUrl as IOdspResolvedUrl, this.getWebsocketToken),
             odspLogger,
             this.getSocketIOClient,
             cache,
@@ -168,13 +168,15 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
 
     private toInstrumentedPushTokenFetcher(
         logger: ITelemetryLogger,
+        resolvedUrl: IOdspResolvedUrl,
         tokenFetcher: PushTokenFetcher,
     ): (options: TokenFetchOptions) => Promise<string | null> {
         return async (options: TokenFetchOptions) => {
             return PerformanceEvent.timedExecAsync(
                 logger,
                 { eventName: "GetWebsocketToken" },
-                async (event) => tokenFetcher(options.refresh, options.claims).then((tokenResponse) => {
+                async (event) => tokenFetcher(resolvedUrl.siteUrl, options.refresh, options.claims)
+                .then((tokenResponse) => {
                     event.end({ fromCache: isTokenFromCache(tokenResponse) });
                     return tokenFromResponse(tokenResponse);
                 }));

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -15,7 +15,7 @@ import {
     PerformanceEvent,
 } from "@fluidframework/telemetry-utils";
 import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
-import { fetchTokenErrorCode } from "@fluidframework/odsp-doclib-utils";
+import { fetchTokenErrorCode, throwOdspNetworkError } from "@fluidframework/odsp-doclib-utils";
 import { IOdspResolvedUrl, HostStoragePolicy } from "./contracts";
 import {
     LocalPersistentCache,
@@ -34,7 +34,6 @@ import {
     tokenFromResponse,
 } from "./tokenFetch";
 import { EpochTracker, EpochTrackerWithRedemption } from "./epochTracker";
-import { throwOdspNetworkError } from "./odspError";
 
 /**
  * Factory for creating the sharepoint document service. Use this if you want to

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -15,7 +15,7 @@ import {
     PerformanceEvent,
 } from "@fluidframework/telemetry-utils";
 import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
-import { fetchTokenErrorCode, throwOdspNetworkError } from "@fluidframework/odsp-doclib-utils";
+import { fetchTokenErrorCode } from "@fluidframework/odsp-doclib-utils";
 import { IOdspResolvedUrl, HostStoragePolicy } from "./contracts";
 import {
     LocalPersistentCache,
@@ -34,6 +34,7 @@ import {
     tokenFromResponse,
 } from "./tokenFetch";
 import { EpochTracker, EpochTrackerWithRedemption } from "./epochTracker";
+import { throwOdspNetworkError } from "./odspError";
 
 /**
  * Factory for creating the sharepoint document service. Use this if you want to
@@ -154,6 +155,7 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
                     eventName: `${name || "OdspDocumentService"}_GetToken`,
                     refresh: options.refresh,
                     hasClaims: !!options.claims,
+                    hasTenantId: !!options.tenantId,
                 },
                 async (event) => tokenFetcher({ ...options, siteUrl: resolvedUrl.siteUrl })
                 .then((tokenResponse) => {

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -28,10 +28,11 @@ import { OdspDocumentService } from "./odspDocumentService";
 import { INewFileInfo } from "./odspUtils";
 import { createNewFluidFile } from "./createFile";
 import {
-    OdspResourceTokenFetcher,
     TokenFetchOptions,
     isTokenFromCache,
     tokenFromResponse,
+    OdspResourceTokenFetchOptions,
+    TokenFetcher,
 } from "./tokenFetch";
 import { EpochTracker, EpochTrackerWithRedemption } from "./epochTracker";
 
@@ -109,8 +110,8 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
    * @param persistedCache - PersistedCache provided by host for use in this session.
    */
     constructor(
-        private readonly getStorageToken: OdspResourceTokenFetcher,
-        private readonly getWebsocketToken: OdspResourceTokenFetcher,
+        private readonly getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>,
+        private readonly getWebsocketToken: TokenFetcher<OdspResourceTokenFetchOptions>,
         private readonly getSocketIOClient: () => Promise<SocketIOClientStatic>,
         protected persistedCache: IPersistedCache = new LocalPersistentCache(),
         private readonly hostPolicy: HostStoragePolicy = {},
@@ -156,7 +157,7 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
     private toInstrumentedOdspTokenFetcher(
         logger: ITelemetryLogger,
         resolvedUrl: IOdspResolvedUrl,
-        tokenFetcher: OdspResourceTokenFetcher,
+        tokenFetcher: TokenFetcher<OdspResourceTokenFetchOptions>,
         defaultEventName: string,
         throwOnNullToken: boolean,
     ): (options: TokenFetchOptions, name?: string) => Promise<string | null> {

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -148,7 +148,6 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
             // Host should optimize and provide non-expired tokens on all critical paths.
             // Exceptions: race conditions around expiration, revoked tokens, host that does not care
             // (fluid-fetcher)
-
             return PerformanceEvent.timedExecAsync(
                 logger,
                 {

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryWithCodeSplit.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryWithCodeSplit.ts
@@ -7,14 +7,14 @@ import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
 import { IPersistedCache } from "./odspCache";
 import { OdspDocumentServiceFactoryCore } from "./odspDocumentServiceFactoryCore";
 import { HostStoragePolicy } from "./contracts";
-import { OdspResourceTokenFetcher } from "./tokenFetch";
+import { TokenFetcher, OdspResourceTokenFetchOptions } from ".";
 
 export class OdspDocumentServiceFactoryWithCodeSplit
     extends OdspDocumentServiceFactoryCore
     implements IDocumentServiceFactory {
     constructor(
-        getStorageToken: OdspResourceTokenFetcher,
-        getWebsocketToken: OdspResourceTokenFetcher,
+        getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>,
+        getWebsocketToken: TokenFetcher<OdspResourceTokenFetchOptions>,
         persistedCache?: IPersistedCache,
         hostPolicy?: HostStoragePolicy,
     ) {

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryWithCodeSplit.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryWithCodeSplit.ts
@@ -7,14 +7,14 @@ import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
 import { IPersistedCache } from "./odspCache";
 import { OdspDocumentServiceFactoryCore } from "./odspDocumentServiceFactoryCore";
 import { HostStoragePolicy } from "./contracts";
-import { ResourceTokenFetcher } from "./tokenFetch";
+import { OdspResourceTokenFetcher } from "./tokenFetch";
 
 export class OdspDocumentServiceFactoryWithCodeSplit
     extends OdspDocumentServiceFactoryCore
     implements IDocumentServiceFactory {
     constructor(
-        getStorageToken: ResourceTokenFetcher,
-        getWebsocketToken: ResourceTokenFetcher,
+        getStorageToken: OdspResourceTokenFetcher,
+        getWebsocketToken: OdspResourceTokenFetcher,
         persistedCache?: IPersistedCache,
         hostPolicy?: HostStoragePolicy,
     ) {

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryWithCodeSplit.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryWithCodeSplit.ts
@@ -7,14 +7,14 @@ import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
 import { IPersistedCache } from "./odspCache";
 import { OdspDocumentServiceFactoryCore } from "./odspDocumentServiceFactoryCore";
 import { HostStoragePolicy } from "./contracts";
-import { StorageTokenFetcher, PushTokenFetcher } from "./tokenFetch";
+import { ResourceTokenFetcher } from "./tokenFetch";
 
 export class OdspDocumentServiceFactoryWithCodeSplit
     extends OdspDocumentServiceFactoryCore
     implements IDocumentServiceFactory {
     constructor(
-        getStorageToken: StorageTokenFetcher,
-        getWebsocketToken: PushTokenFetcher,
+        getStorageToken: ResourceTokenFetcher,
+        getWebsocketToken: ResourceTokenFetcher,
         persistedCache?: IPersistedCache,
         hostPolicy?: HostStoragePolicy,
     ) {

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -481,7 +481,11 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                 if (tokenFetchOptions.refresh) {
                     // This is the most critical code path for boot.
                     // If we get incorrect / expired token first time, that adds up to latency of boot
-                    this.logger.sendErrorEvent({ eventName: "TreeLatest_SecondCall", hasClaims: !!tokenFetchOptions.claims });
+                    this.logger.sendErrorEvent({
+                        eventName: "TreeLatest_SecondCall",
+                        hasClaims: !!tokenFetchOptions.claims,
+                        hasTenantId: !!tokenFetchOptions.tenantId,
+                    });
                 }
 
                 const hostSnapshotOptions = this.hostPolicy.snapshotOptions;

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -17,8 +17,8 @@ import { getShareLink } from "./graph";
 import {
     IdentityType,
     isTokenFromCache,
-    SharingLinkTokenFetcher,
     SharingLinkTokenFetchOptions,
+    TokenFetcher,
 } from "./tokenFetch";
 
 /**
@@ -29,16 +29,16 @@ import {
 export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
     private readonly logger: ITelemetryLogger;
     private readonly sharingLinkCache = new PromiseCache<string, string>();
-    private readonly getSharingLinkToken: SharingLinkTokenFetcher;
+    private readonly getSharingLinkToken: TokenFetcher<SharingLinkTokenFetchOptions>;
     public constructor(
-        tokenFetcher: SharingLinkTokenFetcher,
+        tokenFetcher: TokenFetcher<SharingLinkTokenFetchOptions>,
         private readonly identityType: IdentityType = "Enterprise",
         logger?: ITelemetryBaseLogger,
         private readonly appName?: string,
         private readonly msGraphOrigin?: string,
     ) {
         this.logger = ChildLogger.create(logger, "OdspDriver");
-        this.getSharingLinkToken = this.toInstrumentedSharingLinkTokenFetcher(this.logger, tokenFetcher);
+        this.getSharingLinkToken = this.toInstrumentedTokenFetcher(this.logger, tokenFetcher);
     }
 
     public createCreateNewRequest(
@@ -119,10 +119,10 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
         return odspResolvedUrl;
     }
 
-    private toInstrumentedSharingLinkTokenFetcher(
+    private toInstrumentedTokenFetcher(
         logger: ITelemetryLogger,
-        tokenFetcher: SharingLinkTokenFetcher,
-    ): SharingLinkTokenFetcher {
+        tokenFetcher: TokenFetcher<SharingLinkTokenFetchOptions>,
+    ): TokenFetcher<SharingLinkTokenFetchOptions> {
         return async (options: SharingLinkTokenFetchOptions) => {
             return PerformanceEvent.timedExecAsync(
                 logger,

--- a/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
+++ b/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
@@ -225,6 +225,7 @@ export class OdspSummaryUploadManager {
                     eventName: "uploadSummary",
                     attempt: options.refresh ? 2 : 1,
                     hasClaims: !!options.claims,
+                    hasTenantId: !!options.tenantId,
                     headers: Object.keys(headers).length !== 0 ? true : undefined,
                     blobs,
                     reusedBlobs,

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -46,7 +46,7 @@ export async function getWithRetryForTokenRefresh<T>(get: (options: TokenFetchOp
         switch (e.errorType) {
             // If the error is 401 or 403 refresh the token and try once more.
             case DriverErrorType.authorizationError:
-                return get({ refresh: true, claims: e.claims });
+                return get({ refresh: true, claims: e.claims, tenantId: e.tenantId });
             // fetchIncorrectResponse indicates some error on the wire, retry once.
             case DriverErrorType.incorrectServerResponse:
             // If the token was null, then retry once.

--- a/packages/drivers/odsp-driver/src/test/graphTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/graphTests.spec.ts
@@ -6,7 +6,6 @@
 import { strict as assert } from "assert";
 import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import { getShareLink, GraphItemLite, IGraphFetchResponse } from "../graph";
-import { SharingLinkScopeFor, TokenFetchOptions } from "../tokenFetch";
 import { mockFetch, mockFetchMultiple, okResponse } from "./mockFetch";
 
 describe("Tests for Graph fetch", () => {
@@ -15,8 +14,7 @@ describe("Tests for Graph fetch", () => {
     const itemId = "fileId";
     const logger = new TelemetryNullLogger();
     const graphOrigin = "graphOrigin";
-    const shareLinkTokenFetcher = async (option: TokenFetchOptions, scopeFor: SharingLinkScopeFor, siteurl: string) =>
-        "SharingLinkToken";
+    const shareLinkTokenFetcher = async () => "SharingLinkToken";
 
     beforeEach(() => {
     });

--- a/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
@@ -34,7 +34,7 @@ describe("Odsp Create Container Test", () => {
 
     const odspDocumentServiceFactory = new OdspDocumentServiceFactory(
         async (_url: string, _refresh: boolean, _claims?: string) => "token",
-        async (_refresh: boolean, _claims?: string) => "token");
+        async (_url: string, _refresh: boolean, _claims?: string) => "token");
 
     const createSummary = (putAppTree: boolean, putProtocolTree: boolean, sequenceNumber: number) => {
         const summary: ISummaryTree = {

--- a/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
@@ -33,8 +33,9 @@ describe("Odsp Create Container Test", () => {
     };
 
     const odspDocumentServiceFactory = new OdspDocumentServiceFactory(
-        async (_url: string, _refresh: boolean, _claims?: string) => "token",
-        async (_url: string, _refresh: boolean, _claims?: string) => "token");
+        async (_options) => "token",
+        async (_options) => "token",
+    );
 
     const createSummary = (putAppTree: boolean, putProtocolTree: boolean, sequenceNumber: number) => {
         const summary: ISummaryTree = {

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolver2Tests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolver2Tests.spec.ts
@@ -10,7 +10,7 @@ import { strict as assert } from "assert";
 import sinon from "sinon";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { OdspDriverUrlResolverForShareLink } from "../odspDriverUrlResolverForShareLink";
-import { SharingLinkTokenFetcher } from "../tokenFetch";
+import { SharingLinkTokenFetchOptions, TokenFetcher } from "../tokenFetch";
 import { getHashedDocumentId } from "../odspUtils";
 import { createOdspUrl } from "../createOdspUrl";
 import * as graphImport from "../graph";
@@ -29,7 +29,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
     let urlResolver: OdspDriverUrlResolverForShareLink;
 
     beforeEach(() => {
-        const shareLinkTokenFetcher: SharingLinkTokenFetcher = async (options) => "SharingLinkToken";
+        const shareLinkTokenFetcher: TokenFetcher<SharingLinkTokenFetchOptions> = async (options) => "SharingLinkToken";
         urlResolver = new OdspDriverUrlResolverForShareLink(shareLinkTokenFetcher);
     });
 

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolver2Tests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolver2Tests.spec.ts
@@ -10,7 +10,7 @@ import { strict as assert } from "assert";
 import sinon from "sinon";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { OdspDriverUrlResolverForShareLink } from "../odspDriverUrlResolverForShareLink";
-import { SharingLinkScopeFor, SharingLinkTokenFetcher } from "../tokenFetch";
+import { SharingLinkTokenFetcher } from "../tokenFetch";
 import { getHashedDocumentId } from "../odspUtils";
 import { createOdspUrl } from "../createOdspUrl";
 import * as graphImport from "../graph";
@@ -29,8 +29,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
     let urlResolver: OdspDriverUrlResolverForShareLink;
 
     beforeEach(() => {
-        const shareLinkTokenFetcher: SharingLinkTokenFetcher =
-            async (siteURL: string, scopeFor: SharingLinkScopeFor, refresh: boolean) => "SharingLinkToken";
+        const shareLinkTokenFetcher: SharingLinkTokenFetcher = async (options) => "SharingLinkToken";
         urlResolver = new OdspDriverUrlResolverForShareLink(shareLinkTokenFetcher);
     });
 

--- a/packages/drivers/odsp-driver/src/tokenFetch.ts
+++ b/packages/drivers/odsp-driver/src/tokenFetch.ts
@@ -24,8 +24,17 @@ export interface TokenFetchOptions {
      */
     refresh: boolean;
 
-    /** Claims that have to be passed with token fetch request */
+    /**
+     * Claims that have to be passed with token fetch request.
+     * These can be used to specify additional information that must be passed to token authority.
+     */
     claims?: string;
+
+    /**
+     * Specific tenant id that must be handling token fetch.
+     * This is used when token is needed when accessing external tenant.
+     */
+    tenantId?: string;
 }
 
 /**

--- a/packages/drivers/odsp-driver/src/tokenFetch.ts
+++ b/packages/drivers/odsp-driver/src/tokenFetch.ts
@@ -29,51 +29,50 @@ export interface TokenFetchOptions {
 }
 
 /**
- * Method signature for callback method used to fetch Storage token
- * @param siteUrl - Storage site url
- * @param refresh - Flag indicating whether token fetch must bypass local cache
- * @param claims - Optional string indicating claims that will be passed to token authority
+ * Method signature for callback method used to fetch access token
+ * @param options - token fetch options
  * @returns If successful, TokenResponse object representing token value along with flag indicating
  * whether token came from cache. Legacy implementation may return a string for token value;
  * in this case it should be assumes that fromCache signal is undefined. Null is returned in case of failure.
  */
-// eslint-disable-next-line max-len
-export type StorageTokenFetcher = (siteUrl: string, refresh: boolean, claims?: string) => Promise<string | TokenResponse | null>;
+export type TokenFetcher = (options: TokenFetchOptions) => Promise<string | TokenResponse | null>;
 
-/**
- * Method signature for callback method used to fetch Push token
- * @param siteUrl - Storage site url that Push has to be able to work against
- * @param refresh - Flag indicating whether token fetch must bypass local cache
- * @param claims - Optional string indicating claims that will be passed to token authority
- * @returns If successful, TokenResponse object representing token value along with flag indicating
- * whether token came from cache. Legacy implementation may return a string for token value;
- * in this case it should be assumes that fromCache signal is undefined. Null is returned in case of failure.
- */
-// eslint-disable-next-line max-len
-export type PushTokenFetcher = (siteUrl: string, refresh: boolean, claims?: string) => Promise<string | TokenResponse | null>;
-
-/**
- * Method signature for callback method used to fetch Sharing link token
- * @param siteUrl - Storage site url
- * @param scopeFor - to determine the scope of the token to fetch the share link.
- * @param refresh - Flag indicating whether token fetch must bypass local cache
- * @param claims - Optional string indicating claims that will be passed to token authority
- * @returns If successful, TokenResponse object representing token value along with flag indicating
- * whether token came from cache. Legacy implementation may return a string for token value;
- * in this case it should be assumes that fromCache signal is undefined. Null is returned in case of failure.
- */
-export type SharingLinkTokenFetcher =
-    (siteUrl: string, scopeFor: SharingLinkScopeFor, refresh: boolean, claims?: string)
-        => Promise<string | TokenResponse | null>;
-
-export enum SharingLinkScopeFor {
-    fileDefaultUrl = "fileDefaultUrl",
-    nonFileDefaultUrl = "nonFileDefaultUrl",
+export interface ResourceTokenFetchOptions extends TokenFetchOptions {
+    /** Site url representing resource location */
+    siteUrl: string;
 }
 
 /**
- * Helper method which transforms return value for StorageTokenFetcher and PushTokenFetcher to token string
- * @param tokenResponse - return value for StorageTokenFetcher and PushTokenFetcher methods
+ * Method signature for callback method used to fetch token for resource with location represented by site url
+ * @param options - token fetch options
+ * @returns If successful, TokenResponse object representing token value along with flag indicating
+ * whether token came from cache. Legacy implementation may return a string for token value;
+ * in this case it should be assumes that fromCache signal is undefined. Null is returned in case of failure.
+ */
+export type ResourceTokenFetcher = (options: ResourceTokenFetchOptions) => Promise<string | TokenResponse | null>;
+
+export interface GraphResourceTokenFetchOptions extends ResourceTokenFetchOptions {
+    type: "Graph";
+}
+
+export interface OneDriveResourceTokenFetchOptions extends ResourceTokenFetchOptions {
+    type: "OneDrive";
+}
+
+export type SharingLinkTokenFetchOptions = GraphResourceTokenFetchOptions | OneDriveResourceTokenFetchOptions;
+
+/**
+ * Method signature for callback method used to fetch Sharing link token
+ * @param options - token fetch options
+ * @returns If successful, TokenResponse object representing token value along with flag indicating
+ * whether token came from cache. Legacy implementation may return a string for token value;
+ * in this case it should be assumes that fromCache signal is undefined. Null is returned in case of failure.
+ */
+export type SharingLinkTokenFetcher = (options: SharingLinkTokenFetchOptions) => Promise<string | TokenResponse | null>;
+
+/**
+ * Helper method which transforms return value for TokenFetcher method to token string
+ * @param tokenResponse - return value for TokenFetcher method
  * @returns Token value
  */
 export function tokenFromResponse(tokenResponse: string | TokenResponse | null | undefined): string | null {
@@ -84,7 +83,7 @@ export function tokenFromResponse(tokenResponse: string | TokenResponse | null |
 
 /**
  * Helper method which returns flag indicating whether token response comes from local cache
- * @param tokenResponse - return value for StorageTokenFetcher and PushTokenFetcher methods
+ * @param tokenResponse - return value for TokenFetcher method
  * @returns Value indicating whether response came from cache.
  * Undefined is returned when we could not determine the source of token.
  */

--- a/packages/drivers/odsp-driver/src/tokenFetch.ts
+++ b/packages/drivers/odsp-driver/src/tokenFetch.ts
@@ -39,15 +39,6 @@ export interface TokenFetchOptions {
 }
 
 /**
- * Method signature for callback method used to fetch access token
- * @param options - token fetch options
- * @returns If successful, TokenResponse object representing token value along with flag indicating
- * whether token came from cache. Legacy implementation may return a string for token value;
- * in this case it should be assumes that fromCache signal is undefined. Null is returned in case of failure.
- */
-export type TokenFetcher = (options: TokenFetchOptions) => Promise<string | TokenResponse | null>;
-
-/**
  * Represents access token fetch options for ODSP resource
  */
 export interface OdspResourceTokenFetchOptions extends TokenFetchOptions {
@@ -56,34 +47,33 @@ export interface OdspResourceTokenFetchOptions extends TokenFetchOptions {
 }
 
 /**
- * Method signature for callback method used to fetch token for accessing ODSP resource with location
- * represented by site url.
- * @param options - token fetch options
- * @returns If successful, TokenResponse object representing token value along with flag indicating
- * whether token came from cache. Legacy implementation may return a string for token value;
- * in this case it should be assumes that fromCache signal is undefined. Null is returned in case of failure.
+ * Represents access token fetch options for ODSP resource addressable via Graph API
  */
-export type OdspResourceTokenFetcher =
-    (options: OdspResourceTokenFetchOptions) => Promise<string | TokenResponse | null>;
-
 export interface GraphResourceTokenFetchOptions extends OdspResourceTokenFetchOptions {
     type: "Graph";
 }
 
+/**
+ * Represents access token fetch options for ODSP resource addressable via Vroom API
+ */
 export interface OneDriveResourceTokenFetchOptions extends OdspResourceTokenFetchOptions {
     type: "OneDrive";
 }
 
+/**
+ * Represents access token fetch options for sharing link. Either Graph or Vroom or both tokens might be
+ * needed to generate sharing link.
+ */
 export type SharingLinkTokenFetchOptions = GraphResourceTokenFetchOptions | OneDriveResourceTokenFetchOptions;
 
 /**
- * Method signature for callback method used to fetch tokens used when generating Sharing link
+ * Method signature for callback method used to fetch access token
  * @param options - token fetch options
  * @returns If successful, TokenResponse object representing token value along with flag indicating
  * whether token came from cache. Legacy implementation may return a string for token value;
  * in this case it should be assumes that fromCache signal is undefined. Null is returned in case of failure.
  */
-export type SharingLinkTokenFetcher = (options: SharingLinkTokenFetchOptions) => Promise<string | TokenResponse | null>;
+export type TokenFetcher<T> = (options: T) => Promise<string | TokenResponse | null>;
 
 /**
  * Helper method which transforms return value for TokenFetcher method to token string

--- a/packages/drivers/odsp-driver/src/tokenFetch.ts
+++ b/packages/drivers/odsp-driver/src/tokenFetch.ts
@@ -42,13 +42,15 @@ export type StorageTokenFetcher = (siteUrl: string, refresh: boolean, claims?: s
 
 /**
  * Method signature for callback method used to fetch Push token
+ * @param siteUrl - Storage site url that Push has to be able to work against
  * @param refresh - Flag indicating whether token fetch must bypass local cache
  * @param claims - Optional string indicating claims that will be passed to token authority
  * @returns If successful, TokenResponse object representing token value along with flag indicating
  * whether token came from cache. Legacy implementation may return a string for token value;
  * in this case it should be assumes that fromCache signal is undefined. Null is returned in case of failure.
  */
-export type PushTokenFetcher = (refresh: boolean, claims?: string) => Promise<string | TokenResponse | null>;
+// eslint-disable-next-line max-len
+export type PushTokenFetcher = (siteUrl: string, refresh: boolean, claims?: string) => Promise<string | TokenResponse | null>;
 
 /**
  * Method signature for callback method used to fetch Sharing link token

--- a/packages/drivers/odsp-driver/src/tokenFetch.ts
+++ b/packages/drivers/odsp-driver/src/tokenFetch.ts
@@ -15,7 +15,7 @@ export interface TokenResponse {
 }
 
 /**
- * Represents token fetch options
+ * Represents access token fetch options
  */
 export interface TokenFetchOptions {
     /**
@@ -47,32 +47,37 @@ export interface TokenFetchOptions {
  */
 export type TokenFetcher = (options: TokenFetchOptions) => Promise<string | TokenResponse | null>;
 
-export interface ResourceTokenFetchOptions extends TokenFetchOptions {
-    /** Site url representing resource location */
+/**
+ * Represents access token fetch options for ODSP resource
+ */
+export interface OdspResourceTokenFetchOptions extends TokenFetchOptions {
+    /** Site url representing ODSP resource location */
     siteUrl: string;
 }
 
 /**
- * Method signature for callback method used to fetch token for resource with location represented by site url
+ * Method signature for callback method used to fetch token for accessing ODSP resource with location
+ * represented by site url.
  * @param options - token fetch options
  * @returns If successful, TokenResponse object representing token value along with flag indicating
  * whether token came from cache. Legacy implementation may return a string for token value;
  * in this case it should be assumes that fromCache signal is undefined. Null is returned in case of failure.
  */
-export type ResourceTokenFetcher = (options: ResourceTokenFetchOptions) => Promise<string | TokenResponse | null>;
+export type OdspResourceTokenFetcher =
+    (options: OdspResourceTokenFetchOptions) => Promise<string | TokenResponse | null>;
 
-export interface GraphResourceTokenFetchOptions extends ResourceTokenFetchOptions {
+export interface GraphResourceTokenFetchOptions extends OdspResourceTokenFetchOptions {
     type: "Graph";
 }
 
-export interface OneDriveResourceTokenFetchOptions extends ResourceTokenFetchOptions {
+export interface OneDriveResourceTokenFetchOptions extends OdspResourceTokenFetchOptions {
     type: "OneDrive";
 }
 
 export type SharingLinkTokenFetchOptions = GraphResourceTokenFetchOptions | OneDriveResourceTokenFetchOptions;
 
 /**
- * Method signature for callback method used to fetch Sharing link token
+ * Method signature for callback method used to fetch tokens used when generating Sharing link
  * @param options - token fetch options
  * @returns If successful, TokenResponse object representing token value along with flag indicating
  * whether token came from cache. Legacy implementation may return a string for token value;

--- a/packages/drivers/odsp-driver/src/tokenFetch.ts
+++ b/packages/drivers/odsp-driver/src/tokenFetch.ts
@@ -31,8 +31,9 @@ export interface TokenFetchOptions {
     claims?: string;
 
     /**
-     * Specific tenant id that must be handling token fetch.
-     * This is used when token is needed when accessing external tenant.
+     * Tenant id of authority that must be handling token fetch.
+     * If it is not specified then it is up to token fetching logic to determine which tenant authority
+     * to use to issue access token.
      */
     tenantId?: string;
 }

--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -34,7 +34,7 @@ export async function fetchJoinSession(
     return getWithRetryForTokenRefresh(async (options) => {
         const token = await getStorageToken(options, "JoinSession");
 
-        const extraProps = options.refresh ? { secondAttempt: 1, hasClaims: !!options.claims } : {};
+        const extraProps = options.refresh ? { secondAttempt: 1, hasClaims: !!options.claims, hasTenantId: !!options.tenantId } : {};
         return PerformanceEvent.timedExecAsync(logger, { eventName: "JoinSession", ...extraProps }, async (event) => {
             // TODO Extract the auth header-vs-query logic out
             const siteOrigin = getOrigin(siteUrl);

--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -20,6 +20,7 @@ import { EpochTracker } from "./epochTracker";
  * @param method - The type of request, such as GET or POST
  * @param logger - A logger to use for this request
  * @param getStorageToken - A function that is able to provide the access token for this request
+ * @param epochTracker - fetch wrapper which incorporates epoch logic around joisSession call.
  */
 export async function fetchJoinSession(
     driveId: string,

--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -19,7 +19,7 @@ import { EpochTracker } from "./epochTracker";
  * @param path - The API path that is relevant to this request
  * @param method - The type of request, such as GET or POST
  * @param logger - A logger to use for this request
- * @param getVroomToken - A function that is able to provide the vroom token for this request
+ * @param getStorageToken - A function that is able to provide the access token for this request
  */
 export async function fetchJoinSession(
     driveId: string,

--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -34,7 +34,9 @@ export async function fetchJoinSession(
     return getWithRetryForTokenRefresh(async (options) => {
         const token = await getStorageToken(options, "JoinSession");
 
-        const extraProps = options.refresh ? { secondAttempt: 1, hasClaims: !!options.claims, hasTenantId: !!options.tenantId } : {};
+        const extraProps = options.refresh
+            ? { secondAttempt: 1, hasClaims: !!options.claims, hasTenantId: !!options.tenantId }
+            : {};
         return PerformanceEvent.timedExecAsync(logger, { eventName: "JoinSession", ...extraProps }, async (event) => {
             // TODO Extract the auth header-vs-query logic out
             const siteOrigin = getOrigin(siteUrl);

--- a/packages/loader/driver-definitions/src/driverError.ts
+++ b/packages/loader/driver-definitions/src/driverError.ts
@@ -87,6 +87,7 @@ export interface IGenericNetworkError extends IDriverErrorBase {
 export interface IAuthorizationError extends IDriverErrorBase {
     readonly errorType: DriverErrorType.authorizationError;
     readonly claims?: string;
+    readonly tenantId?: string;
 }
 
 /**

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -50,6 +50,7 @@ export class AuthorizationError extends LoggingError implements IAuthorizationEr
     constructor(
         errorMessage: string,
         readonly claims: string | undefined,
+        readonly tenantId: string | undefined,
         statusCode: number,
     ) {
         super(errorMessage, { statusCode });

--- a/packages/test/service-load-test/src/nodeStressTest.ts
+++ b/packages/test/service-load-test/src/nodeStressTest.ts
@@ -236,7 +236,6 @@ async function orchestratorProcess(
         // Log the login page url in case the caller needs to allow consent for this app
         const loginPageUrl =
             getLoginPageUrl(
-                false,
                 loginInfo.server,
                 getMicrosoftConfiguration(),
                 getOdspScope(loginInfo.server),

--- a/packages/test/service-load-test/src/nodeStressTest.ts
+++ b/packages/test/service-load-test/src/nodeStressTest.ts
@@ -9,7 +9,11 @@ import child_process from "child_process";
 import commander from "commander";
 import { Loader } from "@fluidframework/container-loader";
 import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
-import { OdspDocumentServiceFactory, OdspDriverUrlResolver, ResourceTokenFetchOptions } from "@fluidframework/odsp-driver";
+import {
+    OdspDocumentServiceFactory,
+    OdspDriverUrlResolver,
+    ResourceTokenFetchOptions,
+} from "@fluidframework/odsp-driver";
 import { LocalCodeLoader } from "@fluidframework/test-utils";
 import {
     OdspTokenManager,

--- a/packages/test/service-load-test/src/nodeStressTest.ts
+++ b/packages/test/service-load-test/src/nodeStressTest.ts
@@ -9,7 +9,7 @@ import child_process from "child_process";
 import commander from "commander";
 import { Loader } from "@fluidframework/container-loader";
 import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
-import { OdspDocumentServiceFactory, OdspDriverUrlResolver } from "@fluidframework/odsp-driver";
+import { OdspDocumentServiceFactory, OdspDriverUrlResolver, ResourceTokenFetchOptions } from "@fluidframework/odsp-driver";
 import { LocalCodeLoader } from "@fluidframework/test-utils";
 import {
     OdspTokenManager,
@@ -47,21 +47,21 @@ const passwordTokenConfig = (username, password): OdspTokenConfig => ({
 
 function createLoader(loginInfo: IOdspTestLoginInfo) {
     const documentServiceFactory = new OdspDocumentServiceFactory(
-        async (_siteUrl: string, refresh: boolean, _claims?: string) => {
+        async (options: ResourceTokenFetchOptions) => {
             const tokens = await odspTokenManager.getOdspTokens(
                 loginInfo.server,
                 getMicrosoftConfiguration(),
                 passwordTokenConfig(loginInfo.username, loginInfo.password),
-                refresh,
+                options.refresh,
             );
             return tokens.accessToken;
         },
-        async (_siteUrl: string, refresh: boolean, _claims?: string) => {
+        async (options: ResourceTokenFetchOptions) => {
             const tokens = await odspTokenManager.getPushTokens(
                 loginInfo.server,
                 getMicrosoftConfiguration(),
                 passwordTokenConfig(loginInfo.username, loginInfo.password),
-                refresh,
+                options.refresh,
             );
             return tokens.accessToken;
         },

--- a/packages/test/service-load-test/src/nodeStressTest.ts
+++ b/packages/test/service-load-test/src/nodeStressTest.ts
@@ -56,7 +56,7 @@ function createLoader(loginInfo: IOdspTestLoginInfo) {
             );
             return tokens.accessToken;
         },
-        async (refresh: boolean, _claims?: string) => {
+        async (_siteUrl: string, refresh: boolean, _claims?: string) => {
             const tokens = await odspTokenManager.getPushTokens(
                 loginInfo.server,
                 getMicrosoftConfiguration(),

--- a/packages/test/service-load-test/src/nodeStressTest.ts
+++ b/packages/test/service-load-test/src/nodeStressTest.ts
@@ -12,7 +12,7 @@ import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
 import {
     OdspDocumentServiceFactory,
     OdspDriverUrlResolver,
-    ResourceTokenFetchOptions,
+    OdspResourceTokenFetchOptions,
 } from "@fluidframework/odsp-driver";
 import { LocalCodeLoader } from "@fluidframework/test-utils";
 import {
@@ -51,7 +51,7 @@ const passwordTokenConfig = (username, password): OdspTokenConfig => ({
 
 function createLoader(loginInfo: IOdspTestLoginInfo) {
     const documentServiceFactory = new OdspDocumentServiceFactory(
-        async (options: ResourceTokenFetchOptions) => {
+        async (options: OdspResourceTokenFetchOptions) => {
             const tokens = await odspTokenManager.getOdspTokens(
                 loginInfo.server,
                 getMicrosoftConfiguration(),
@@ -60,7 +60,7 @@ function createLoader(loginInfo: IOdspTestLoginInfo) {
             );
             return tokens.accessToken;
         },
-        async (options: ResourceTokenFetchOptions) => {
+        async (options: OdspResourceTokenFetchOptions) => {
             const tokens = await odspTokenManager.getPushTokens(
                 loginInfo.server,
                 getMicrosoftConfiguration(),

--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -11,6 +11,7 @@ import {
     OdspDocumentServiceFactory,
     OdspDriverUrlResolver,
     createOdspCreateContainerRequest,
+    ResourceTokenFetchOptions,
  } from "@fluidframework/odsp-driver";
 import {
     OdspTokenConfig,
@@ -66,21 +67,21 @@ export class OdspTestDriver implements ITestDriver {
 
     createDocumentServiceFactory(): IDocumentServiceFactory {
         return new OdspDocumentServiceFactory(
-            async (_siteUrl: string, refresh: boolean, _claims?: string) => {
+            async (options: ResourceTokenFetchOptions) => {
                 const tokens = await this.odspTokenManager.getOdspTokens(
                     this.config.server,
                     this.config,
                     passwordTokenConfig(this.config.username, this.password),
-                    refresh,
+                    options.refresh,
                 );
                 return tokens.accessToken;
             },
-            async (_siteUrl: string, refresh: boolean, _claims?: string) => {
+            async (options: ResourceTokenFetchOptions) => {
                 const tokens = await this.odspTokenManager.getPushTokens(
                     this.config.server,
                     this.config,
                     passwordTokenConfig(this.config.username, this.password),
-                    refresh,
+                    options.refresh,
                 );
                 return tokens.accessToken;
             },

--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -11,7 +11,7 @@ import {
     OdspDocumentServiceFactory,
     OdspDriverUrlResolver,
     createOdspCreateContainerRequest,
-    ResourceTokenFetchOptions,
+    OdspResourceTokenFetchOptions,
  } from "@fluidframework/odsp-driver";
 import {
     OdspTokenConfig,
@@ -67,7 +67,7 @@ export class OdspTestDriver implements ITestDriver {
 
     createDocumentServiceFactory(): IDocumentServiceFactory {
         return new OdspDocumentServiceFactory(
-            async (options: ResourceTokenFetchOptions) => {
+            async (options: OdspResourceTokenFetchOptions) => {
                 const tokens = await this.odspTokenManager.getOdspTokens(
                     this.config.server,
                     this.config,
@@ -76,7 +76,7 @@ export class OdspTestDriver implements ITestDriver {
                 );
                 return tokens.accessToken;
             },
-            async (options: ResourceTokenFetchOptions) => {
+            async (options: OdspResourceTokenFetchOptions) => {
                 const tokens = await this.odspTokenManager.getPushTokens(
                     this.config.server,
                     this.config,

--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -75,7 +75,7 @@ export class OdspTestDriver implements ITestDriver {
                 );
                 return tokens.accessToken;
             },
-            async (refresh: boolean, _claims?: string) => {
+            async (_siteUrl: string, refresh: boolean, _claims?: string) => {
                 const tokens = await this.odspTokenManager.getPushTokens(
                     this.config.server,
                     this.config,

--- a/packages/tools/fetch-tool/src/fluidFetch.ts
+++ b/packages/tools/fetch-tool/src/fluidFetch.ts
@@ -5,7 +5,7 @@
 
 import fs from "fs";
 import util from "util";
-import { isSharepointURL, IOdspDriveItem } from "@fluidframework/odsp-doclib-utils";
+import { isOdspSiteUrl, IOdspDriveItem } from "@fluidframework/odsp-doclib-utils";
 import { paramSaveDir, paramURL, parseArguments } from "./fluidFetchArgs";
 import { connectionInfo, fluidFetchInit } from "./fluidFetchInit";
 import { fluidFetchMessages } from "./fluidFetchMessages";
@@ -73,7 +73,7 @@ async function fluidFetchMain() {
 
     const url = new URL(paramURL);
     const server = url.hostname;
-    if (isSharepointURL(server)) {
+    if (isOdspSiteUrl(server)) {
         // See if the url already has the specific item
         const driveItem = getSharePointSpecificDriveItem(url);
         if (driveItem) {

--- a/packages/tools/fetch-tool/src/fluidFetch.ts
+++ b/packages/tools/fetch-tool/src/fluidFetch.ts
@@ -5,7 +5,7 @@
 
 import fs from "fs";
 import util from "util";
-import { isOdspSiteUrl, IOdspDriveItem } from "@fluidframework/odsp-doclib-utils";
+import { isOdspHostname, IOdspDriveItem } from "@fluidframework/odsp-doclib-utils";
 import { paramSaveDir, paramURL, parseArguments } from "./fluidFetchArgs";
 import { connectionInfo, fluidFetchInit } from "./fluidFetchInit";
 import { fluidFetchMessages } from "./fluidFetchMessages";
@@ -73,7 +73,7 @@ async function fluidFetchMain() {
 
     const url = new URL(paramURL);
     const server = url.hostname;
-    if (isOdspSiteUrl(server)) {
+    if (isOdspHostname(server)) {
         // See if the url already has the specific item
         const driveItem = getSharePointSpecificDriveItem(url);
         if (driveItem) {

--- a/packages/tools/fetch-tool/src/fluidFetchInit.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchInit.ts
@@ -54,7 +54,7 @@ async function initializeODSPCore(
   item:   ${itemId}
   docId:  ${docId}`);
 
-    const getStorageTokenStub = async (siteUrl: string, refresh: boolean, _claims?: string) => {
+    const getStorageTokenStub = async (_siteUrl: string, refresh: boolean, _claims?: string) => {
         return resolveWrapper(
             async (authRequestInfo: IOdspAuthRequestInfo) => {
                 if ((refresh || !authRequestInfo.accessToken) && authRequestInfo.refreshTokenFn) {
@@ -69,7 +69,7 @@ async function initializeODSPCore(
         );
     };
     // eslint-disable-next-line @typescript-eslint/promise-function-async
-    const getWebsocketTokenStub = (_refresh: boolean, _claims?: string) => Promise.resolve("");
+    const getWebsocketTokenStub = (_siteUrl: string, _refresh: boolean, _claims?: string) => Promise.resolve("");
     const odspDocumentServiceFactory = new odsp.OdspDocumentServiceFactory(
         getStorageTokenStub,
         getWebsocketTokenStub);

--- a/packages/tools/fetch-tool/src/fluidFetchInit.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchInit.ts
@@ -54,7 +54,7 @@ async function initializeODSPCore(
   item:   ${itemId}
   docId:  ${docId}`);
 
-    const getStorageTokenStub = async (options: odsp.ResourceTokenFetchOptions) => {
+    const getStorageTokenStub = async (options: odsp.OdspResourceTokenFetchOptions) => {
         return resolveWrapper(
             async (authRequestInfo: IOdspAuthRequestInfo) => {
                 if ((options.refresh || !authRequestInfo.accessToken) && authRequestInfo.refreshTokenFn) {
@@ -69,7 +69,7 @@ async function initializeODSPCore(
         );
     };
     // eslint-disable-next-line @typescript-eslint/promise-function-async
-    const getWebsocketTokenStub = (_options: odsp.ResourceTokenFetchOptions) => Promise.resolve("");
+    const getWebsocketTokenStub = (_options: odsp.OdspResourceTokenFetchOptions) => Promise.resolve("");
     const odspDocumentServiceFactory = new odsp.OdspDocumentServiceFactory(
         getStorageTokenStub,
         getWebsocketTokenStub);

--- a/packages/tools/fetch-tool/src/fluidFetchInit.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchInit.ts
@@ -54,10 +54,10 @@ async function initializeODSPCore(
   item:   ${itemId}
   docId:  ${docId}`);
 
-    const getStorageTokenStub = async (_siteUrl: string, refresh: boolean, _claims?: string) => {
+    const getStorageTokenStub = async (options: odsp.ResourceTokenFetchOptions) => {
         return resolveWrapper(
             async (authRequestInfo: IOdspAuthRequestInfo) => {
-                if ((refresh || !authRequestInfo.accessToken) && authRequestInfo.refreshTokenFn) {
+                if ((options.refresh || !authRequestInfo.accessToken) && authRequestInfo.refreshTokenFn) {
                     return authRequestInfo.refreshTokenFn();
                 }
                 return authRequestInfo.accessToken;
@@ -69,7 +69,7 @@ async function initializeODSPCore(
         );
     };
     // eslint-disable-next-line @typescript-eslint/promise-function-async
-    const getWebsocketTokenStub = (_siteUrl: string, _refresh: boolean, _claims?: string) => Promise.resolve("");
+    const getWebsocketTokenStub = (_options: odsp.ResourceTokenFetchOptions) => Promise.resolve("");
     const odspDocumentServiceFactory = new odsp.OdspDocumentServiceFactory(
         getStorageTokenStub,
         getWebsocketTokenStub);

--- a/packages/tools/fetch-tool/src/fluidFetchSharePoint.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchSharePoint.ts
@@ -18,7 +18,7 @@ import {
     OdspTokenManager,
     odspTokensCache,
     OdspTokenConfig,
-    OdspTokenManagerCacheKey,
+    IOdspTokenManagerCacheKey,
 } from "@fluidframework/tool-utils";
 import { fluidFetchWebNavigator } from "./fluidFetchInit";
 import { getForceTokenReauth } from "./fluidFetchArgs";
@@ -50,7 +50,7 @@ export async function resolveWrapper<T>(
         });
         // If this is used for getting a token, then refresh the cache with new token.
         if (forToken) {
-            const key: OdspTokenManagerCacheKey = { isPush: false, server };
+            const key: IOdspTokenManagerCacheKey = { isPush: false, server };
             await odspTokenManager.updateTokensCache(
                 key, { accessToken: result as any as string, refreshToken: tokens.refreshToken });
             return result;

--- a/packages/tools/fetch-tool/src/fluidFetchSharePoint.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchSharePoint.ts
@@ -18,7 +18,7 @@ import {
     OdspTokenManager,
     odspTokensCache,
     OdspTokenConfig,
-    IOdspCacheKey,
+    OdspTokenManagerCacheKey,
 } from "@fluidframework/tool-utils";
 import { fluidFetchWebNavigator } from "./fluidFetchInit";
 import { getForceTokenReauth } from "./fluidFetchArgs";
@@ -50,7 +50,7 @@ export async function resolveWrapper<T>(
         });
         // If this is used for getting a token, then refresh the cache with new token.
         if (forToken) {
-            const key: IOdspCacheKey = { isPush: false, server };
+            const key: OdspTokenManagerCacheKey = { isPush: false, server };
             await odspTokenManager.updateTokensCache(
                 key, { accessToken: result as any as string, refreshToken: tokens.refreshToken });
             return result;

--- a/packages/utils/odsp-doclib-utils/src/odspAuth.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspAuth.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { getSharepointTenant } from "./odspDocLibUtils";
+import { getAadTenant } from "./odspDocLibUtils";
 import { throwOdspNetworkError } from "./odspErrorUtils";
 import { unauthPostAsync } from "./odspRequest";
 
@@ -46,7 +46,7 @@ export const getOdspScope = (server: string) => `offline_access https://${server
 export const pushScope = "offline_access https://pushchannel.1drv.ms/PushChannel.ReadWrite.All";
 
 export function getFetchTokenUrl(server: string): string {
-    return `https://login.microsoftonline.com/${getSharepointTenant(server)}/oauth2/v2.0/token`;
+    return `https://login.microsoftonline.com/${getAadTenant(server)}/oauth2/v2.0/token`;
 }
 
 export function getLoginPageUrl(
@@ -55,7 +55,7 @@ export function getLoginPageUrl(
     scope: string,
     odspAuthRedirectUri: string,
 ) {
-    return `https://login.microsoftonline.com/${getSharepointTenant(server)}/oauth2/v2.0/authorize?`
+    return `https://login.microsoftonline.com/${getAadTenant(server)}/oauth2/v2.0/authorize?`
         + `client_id=${clientConfig.clientId}`
         + `&scope=${scope}`
         + `&response_type=code`

--- a/packages/utils/odsp-doclib-utils/src/odspAuth.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspAuth.ts
@@ -50,14 +50,12 @@ export function getFetchTokenUrl(server: string): string {
 }
 
 export function getLoginPageUrl(
-    isPush: boolean,
     server: string,
     clientConfig: IClientConfig,
     scope: string,
     odspAuthRedirectUri: string,
 ) {
-    const tenant = isPush ? "organizations" : getSharepointTenant(server);
-    return `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/authorize?`
+    return `https://login.microsoftonline.com/${getSharepointTenant(server)}/oauth2/v2.0/authorize?`
         + `client_id=${clientConfig.clientId}`
         + `&scope=${scope}`
         + `&response_type=code`

--- a/packages/utils/odsp-doclib-utils/src/odspDocLibUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspDocLibUtils.ts
@@ -16,6 +16,8 @@ export function getSharepointTenant(server: string) {
     let tenantName = server.substr(0, server.indexOf(".")).toLowerCase();
     if (tenantName.endsWith("-my")) {
         tenantName = tenantName.substr(0, tenantName.length - 3);
+    } else if (tenantName.endsWith("-admin")) {
+        tenantName = tenantName.substr(0, tenantName.length - 6);
     }
 
     let restOfTenantHostname = server.substr(tenantName.length).toLowerCase();
@@ -23,7 +25,7 @@ export function getSharepointTenant(server: string) {
         restOfTenantHostname = `.onmicrosoft.${restOfTenantHostname.substr(12)}`;
     }
 
-    return tenantName === "microsoft" ? "organizations" : `${tenantName}${restOfTenantHostname}`;
+    return `${tenantName}${restOfTenantHostname}`;
 }
 
 export function getServer(tenantId: string): string {

--- a/packages/utils/odsp-doclib-utils/src/odspDocLibUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspDocLibUtils.ts
@@ -8,11 +8,11 @@ const odspTenants = new Map<string, string>([
     ["spo-df", "microsoft-my.sharepoint-df.com"],
 ]);
 
-export function isSharepointURL(server: string) {
+export function isOdspSiteUrl(server: string) {
     return server.endsWith("sharepoint.com") || server.endsWith("sharepoint-df.com");
 }
 
-export function getSharepointTenant(server: string) {
+export function getAadTenant(server: string) {
     let tenantName = server.substr(0, server.indexOf(".")).toLowerCase();
     if (tenantName.endsWith("-my")) {
         tenantName = tenantName.substr(0, tenantName.length - 3);

--- a/packages/utils/odsp-doclib-utils/src/odspDocLibUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspDocLibUtils.ts
@@ -8,19 +8,19 @@ const odspTenants = new Map<string, string>([
     ["spo-df", "microsoft-my.sharepoint-df.com"],
 ]);
 
-export function isOdspSiteUrl(server: string) {
-    return server.endsWith("sharepoint.com") || server.endsWith("sharepoint-df.com");
+export function isOdspHostname(hostname: string) {
+    return hostname.endsWith("sharepoint.com") || hostname.endsWith("sharepoint-df.com");
 }
 
-export function getAadTenant(server: string) {
-    let tenantName = server.substr(0, server.indexOf(".")).toLowerCase();
+export function getAadTenant(hostname: string) {
+    let tenantName = hostname.substr(0, hostname.indexOf(".")).toLowerCase();
     if (tenantName.endsWith("-my")) {
         tenantName = tenantName.substr(0, tenantName.length - 3);
     } else if (tenantName.endsWith("-admin")) {
         tenantName = tenantName.substr(0, tenantName.length - 6);
     }
 
-    let restOfTenantHostname = server.substr(tenantName.length).toLowerCase();
+    let restOfTenantHostname = hostname.substr(tenantName.length).toLowerCase();
     if (restOfTenantHostname.indexOf(".sharepoint.") === 0) {
         restOfTenantHostname = `.onmicrosoft.${restOfTenantHostname.substr(12)}`;
     }

--- a/packages/utils/odsp-doclib-utils/src/odspDocLibUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspDocLibUtils.ts
@@ -14,15 +14,18 @@ export function isOdspHostname(hostname: string) {
 
 export function getAadTenant(hostname: string) {
     let tenantName = hostname.substr(0, hostname.indexOf(".")).toLowerCase();
+    let restOfTenantHostname = hostname.substr(tenantName.length).toLowerCase();
+
     if (tenantName.endsWith("-my")) {
         tenantName = tenantName.substr(0, tenantName.length - 3);
     } else if (tenantName.endsWith("-admin")) {
         tenantName = tenantName.substr(0, tenantName.length - 6);
     }
 
-    let restOfTenantHostname = hostname.substr(tenantName.length).toLowerCase();
     if (restOfTenantHostname.indexOf(".sharepoint.") === 0) {
         restOfTenantHostname = `.onmicrosoft.${restOfTenantHostname.substr(12)}`;
+    } if (restOfTenantHostname.indexOf(".sharepoint-df.") === 0) {
+        restOfTenantHostname = `.onmicrosoft.${restOfTenantHostname.substr(15)}`;
     }
 
     return `${tenantName}${restOfTenantHostname}`;

--- a/packages/utils/odsp-doclib-utils/src/odspDocLibUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspDocLibUtils.ts
@@ -14,11 +14,16 @@ export function isSharepointURL(server: string) {
 
 export function getSharepointTenant(server: string) {
     let tenantName = server.substr(0, server.indexOf(".")).toLowerCase();
-    const restOfServerName = server.substr(tenantName.length).toLowerCase();
     if (tenantName.endsWith("-my")) {
         tenantName = tenantName.substr(0, tenantName.length - 3);
     }
-    return tenantName === "microsoft" ? "organizations" : `${tenantName}${restOfServerName}`;
+
+    let restOfTenatHostname = server.substr(tenantName.length).toLowerCase();
+    if (restOfTenatHostname.indexOf(".sharepoint.") === 0) {
+        restOfTenatHostname = `.onmicrosoft.&{restOfTenatHostname.substr(12)}`;
+    }
+
+    return tenantName === "microsoft" ? "organizations" : `${tenantName}${restOfTenatHostname}`;
 }
 
 export function getServer(tenantId: string): string {

--- a/packages/utils/odsp-doclib-utils/src/odspDocLibUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspDocLibUtils.ts
@@ -18,12 +18,12 @@ export function getSharepointTenant(server: string) {
         tenantName = tenantName.substr(0, tenantName.length - 3);
     }
 
-    let restOfTenatHostname = server.substr(tenantName.length).toLowerCase();
-    if (restOfTenatHostname.indexOf(".sharepoint.") === 0) {
-        restOfTenatHostname = `.onmicrosoft.&{restOfTenatHostname.substr(12)}`;
+    let restOfTenantHostname = server.substr(tenantName.length).toLowerCase();
+    if (restOfTenantHostname.indexOf(".sharepoint.") === 0) {
+        restOfTenantHostname = `.onmicrosoft.${restOfTenantHostname.substr(12)}`;
     }
 
-    return tenantName === "microsoft" ? "organizations" : `${tenantName}${restOfTenatHostname}`;
+    return tenantName === "microsoft" ? "organizations" : `${tenantName}${restOfTenantHostname}`;
 }
 
 export function getServer(tenantId: string): string {

--- a/packages/utils/odsp-doclib-utils/src/odspDocLibUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspDocLibUtils.ts
@@ -13,11 +13,12 @@ export function isSharepointURL(server: string) {
 }
 
 export function getSharepointTenant(server: string) {
-    let tenant = server.substr(0, server.indexOf("."));
-    if (tenant.endsWith("-my")) {
-        tenant = tenant.substr(0, tenant.length - 3);
+    let tenantName = server.substr(0, server.indexOf(".")).toLowerCase();
+    const restOfServerName = server.substr(tenantName.length).toLowerCase();
+    if (tenantName.endsWith("-my")) {
+        tenantName = tenantName.substr(0, tenantName.length - 3);
     }
-    return tenant === "microsoft" ? "organizations" : `${tenant}.onmicrosoft.com`;
+    return tenantName === "microsoft" ? "organizations" : `${tenantName}${restOfServerName}`;
 }
 
 export function getServer(tenantId: string): string {

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -14,6 +14,7 @@ import {
     OnlineStatus,
 } from "@fluidframework/driver-utils";
 import { parseAuthErrorClaims } from "./parseAuthErrorClaims";
+import { parseAuthErrorTenant } from "./parseAuthErrorTenant";
 
 // eslint-disable-next-line no-null/no-null
 const nullToUndefined = (a: string | null) => a === null ? undefined : a;
@@ -96,14 +97,15 @@ export function createOdspNetworkError(
     responseText?: string,
 ): OdspError {
     let error: OdspError;
-    const claims = statusCode === 401 && response?.headers ? parseAuthErrorClaims(response.headers) : undefined;
     switch (statusCode) {
         case 400:
             error = new GenericNetworkError(errorMessage, false, statusCode);
             break;
         case 401:
         case 403:
-            error = new AuthorizationError(errorMessage, claims, statusCode);
+            const claims = response?.headers ? parseAuthErrorClaims(response.headers) : undefined;
+            const tenantId = response?.headers ? parseAuthErrorTenant(response.headers) : undefined;
+            error = new AuthorizationError(errorMessage, claims, tenantId, statusCode);
             break;
         case 404:
             error = new NetworkErrorBasic(

--- a/packages/utils/odsp-doclib-utils/src/parseAuthErrorTenant.ts
+++ b/packages/utils/odsp-doclib-utils/src/parseAuthErrorTenant.ts
@@ -1,0 +1,49 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+const oAuthBearerScheme = "Bearer";
+
+/**
+ * Checks if response headers contains `www-authenticate` header and extracts tenant id that should be
+ * used to identify authority which must be used to issue access token for protected resource.
+ * Tenant id is represented by "realm" property. More details can be found here:
+ * https://tools.ietf.org/html/rfc2617#page-8
+ *
+ * Header sample:
+ * www-authenticate=Bearer realm="03d0c210-38e8-47d7-9bc9-9ff2cd5ea7bc",
+ * client_id="00000003-0000-0ff1-ce00-000000000000",
+ * trusted_issuers="00000001-0000-0000-c000-000000000000@*,D3776938-3DBA-481F-A652-4BEDFCAB7CD8@*,
+ * https://sts.windows.net/*,00000003-0000-0ff1-ce00-000000000000@90140122-8516-11e1-8eff-49304924019b",
+ * authorization_uri="https://login.windows.net/common/oauth2/authorize"
+ */
+export function parseAuthErrorTenant(responseHeader: Headers): string | undefined {
+    const authHeaderData = responseHeader.get("www-authenticate");
+    if (!authHeaderData) {
+        return undefined;
+    }
+
+    // header value must start with Bearer scheme
+    if (authHeaderData.indexOf(oAuthBearerScheme) !== 0) {
+        return undefined;
+    }
+
+    let tenantId: string | undefined;
+    authHeaderData
+        .substr(oAuthBearerScheme.length)
+        .split(",")
+        .map((section) => {
+            if (!tenantId) {
+                const nameValuePair = section.split("=");
+                // values can be encoded and contain '=' symbol inside so it is possible to have more than one
+                if (nameValuePair.length >= 2) {
+                    if (nameValuePair[0].trim().toLowerCase() === "realm") {
+                        tenantId = JSON.parse(nameValuePair[1].trim());
+                    }
+                }
+            }
+        });
+
+    return tenantId;
+  }

--- a/packages/utils/odsp-doclib-utils/src/test/odspDocLibUtils.spec.ts
+++ b/packages/utils/odsp-doclib-utils/src/test/odspDocLibUtils.spec.ts
@@ -1,0 +1,43 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import assert from "assert";
+
+describe("getAadTenant", () => {
+    test("returns `onmicrosoft` tenant if ODSP personal site url is passed", async () => {
+        const result = getAadTenant("https://contoso-my.sharepoint.com");
+        assert.strictEqual(result, "contoso.onmicrosoft.com");
+    });
+
+    test("returns `onmicrosoft` tenant if ODSP admin site url is passed", async () => {
+        const result = getAadTenant("https://contoso-admin.sharepoint.com");
+        assert.strictEqual(result, "contoso.onmicrosoft.com");
+    });
+
+    test("returns `onmicrosoft` tenant if ODSP group site url is passed", async () => {
+        const result = getAadTenant("https://contoso.sharepoint.com");
+        assert.strictEqual(result, "contoso.onmicrosoft.com");
+    });
+
+    test("returns `onmicrosoft` tenant if ODSP dogfood personal site url is passed", async () => {
+        const result = getAadTenant("https://contoso-my.sharepoint-df.com");
+        assert.strictEqual(result, "contoso.onmicrosoft.com");
+    });
+
+    test("returns `onmicrosoft` tenant if ODSP dogfood admin site url is passed", async () => {
+        const result = getAadTenant("https://contoso-admin.sharepoint-df.com");
+        assert.strictEqual(result, "contoso.onmicrosoft.com");
+    });
+
+    test("returns `onmicrosoft` tenant if ODSP dogfood group site url is passed", async () => {
+        const result = getAadTenant("https://contoso.sharepoint-df.com");
+        assert.strictEqual(result, "contoso.onmicrosoft.com");
+    });
+
+    test("returns unchanged url if vanity site url is passed", async () => {
+        const result = getAadTenant("https://vanity.com");
+        assert.strictEqual(result, "https://vanity.com");
+    });
+});

--- a/packages/utils/odsp-doclib-utils/src/test/odspDocLibUtils.spec.ts
+++ b/packages/utils/odsp-doclib-utils/src/test/odspDocLibUtils.spec.ts
@@ -7,37 +7,37 @@ import assert from "assert";
 import { getAadTenant } from "../odspDocLibUtils";
 
 describe("getAadTenant", () => {
-    test("returns `onmicrosoft` tenant if ODSP personal site url is passed", async () => {
+    it("returns `onmicrosoft` tenant if ODSP personal site url is passed", () => {
         const result = getAadTenant("contoso-my.sharepoint.com");
         assert.strictEqual(result, "contoso.onmicrosoft.com");
     });
 
-    test("returns `onmicrosoft` tenant if ODSP admin site url is passed", async () => {
+    it("returns `onmicrosoft` tenant if ODSP admin site url is passed", () => {
         const result = getAadTenant("contoso-admin.sharepoint.com");
         assert.strictEqual(result, "contoso.onmicrosoft.com");
     });
 
-    test("returns `onmicrosoft` tenant if ODSP group site url is passed", async () => {
+    it("returns `onmicrosoft` tenant if ODSP group site url is passed", () => {
         const result = getAadTenant("contoso.sharepoint.com");
         assert.strictEqual(result, "contoso.onmicrosoft.com");
     });
 
-    test("returns `onmicrosoft` tenant if ODSP dogfood personal site url is passed", async () => {
+    it("returns `onmicrosoft` tenant if ODSP dogfood personal site url is passed", () => {
         const result = getAadTenant("contoso-my.sharepoint-df.com");
         assert.strictEqual(result, "contoso.onmicrosoft.com");
     });
 
-    test("returns `onmicrosoft` tenant if ODSP dogfood admin site url is passed", async () => {
+    it("returns `onmicrosoft` tenant if ODSP dogfood admin site url is passed", () => {
         const result = getAadTenant("contoso-admin.sharepoint-df.com");
         assert.strictEqual(result, "contoso.onmicrosoft.com");
     });
 
-    test("returns `onmicrosoft` tenant if ODSP dogfood group site url is passed", async () => {
+    it("returns `onmicrosoft` tenant if ODSP dogfood group site url is passed", () => {
         const result = getAadTenant("contoso.sharepoint-df.com");
         assert.strictEqual(result, "contoso.onmicrosoft.com");
     });
 
-    test("returns unchanged url if vanity site url is passed", async () => {
+    it("returns unchanged url if vanity site url is passed", () => {
         const result = getAadTenant("vanity.com");
         assert.strictEqual(result, "vanity.com");
     });

--- a/packages/utils/odsp-doclib-utils/src/test/odspDocLibUtils.spec.ts
+++ b/packages/utils/odsp-doclib-utils/src/test/odspDocLibUtils.spec.ts
@@ -8,37 +8,37 @@ import { getAadTenant } from "../odspDocLibUtils";
 
 describe("getAadTenant", () => {
     test("returns `onmicrosoft` tenant if ODSP personal site url is passed", async () => {
-        const result = getAadTenant("https://contoso-my.sharepoint.com");
+        const result = getAadTenant("contoso-my.sharepoint.com");
         assert.strictEqual(result, "contoso.onmicrosoft.com");
     });
 
     test("returns `onmicrosoft` tenant if ODSP admin site url is passed", async () => {
-        const result = getAadTenant("https://contoso-admin.sharepoint.com");
+        const result = getAadTenant("contoso-admin.sharepoint.com");
         assert.strictEqual(result, "contoso.onmicrosoft.com");
     });
 
     test("returns `onmicrosoft` tenant if ODSP group site url is passed", async () => {
-        const result = getAadTenant("https://contoso.sharepoint.com");
+        const result = getAadTenant("contoso.sharepoint.com");
         assert.strictEqual(result, "contoso.onmicrosoft.com");
     });
 
     test("returns `onmicrosoft` tenant if ODSP dogfood personal site url is passed", async () => {
-        const result = getAadTenant("https://contoso-my.sharepoint-df.com");
+        const result = getAadTenant("contoso-my.sharepoint-df.com");
         assert.strictEqual(result, "contoso.onmicrosoft.com");
     });
 
     test("returns `onmicrosoft` tenant if ODSP dogfood admin site url is passed", async () => {
-        const result = getAadTenant("https://contoso-admin.sharepoint-df.com");
+        const result = getAadTenant("contoso-admin.sharepoint-df.com");
         assert.strictEqual(result, "contoso.onmicrosoft.com");
     });
 
     test("returns `onmicrosoft` tenant if ODSP dogfood group site url is passed", async () => {
-        const result = getAadTenant("https://contoso.sharepoint-df.com");
+        const result = getAadTenant("contoso.sharepoint-df.com");
         assert.strictEqual(result, "contoso.onmicrosoft.com");
     });
 
     test("returns unchanged url if vanity site url is passed", async () => {
-        const result = getAadTenant("https://vanity.com");
-        assert.strictEqual(result, "https://vanity.com");
+        const result = getAadTenant("vanity.com");
+        assert.strictEqual(result, "vanity.com");
     });
 });

--- a/packages/utils/odsp-doclib-utils/src/test/odspDocLibUtils.spec.ts
+++ b/packages/utils/odsp-doclib-utils/src/test/odspDocLibUtils.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import assert from "assert";
+import { getAadTenant } from "../odspDocLibUtils";
 
 describe("getAadTenant", () => {
     test("returns `onmicrosoft` tenant if ODSP personal site url is passed", async () => {

--- a/packages/utils/odsp-doclib-utils/src/test/parseAuthErrorClaims.spec.ts
+++ b/packages/utils/odsp-doclib-utils/src/test/parseAuthErrorClaims.spec.ts
@@ -17,44 +17,44 @@ const validWwwAuthenticateHeader =
   "Bearer realm=\"6c482541-f706-4168-9e58-8e35a9992f58\",client_id=\"00000003-0000-0ff1-ce00-000000000000\",trusted_issuers=\"00000001-0000-0000-c000-000000000000@*,D3776938-3DBA-481F-A652-4BEDFCAB7CD8@*,https://sts.windows.net/*/,00000003-0000-0ff1-ce00-000000000000@90140122-8516-11e1-8eff-49304924019b\",authorization_uri=\"https://login.windows.net/common/oauth2/authorize\",error=\"insufficient_claims\",claims=\"eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTU5Nzk1OTA5MCJ9fX0=\"";
 
 describe("parseAuthErrorClaims", () => {
-  it("returns undefined if headers does not have expected entry", async () => {
+  it("returns undefined if headers does not have expected entry", () => {
     const headers = { get: (_name: string) => undefined };
     const result = parseAuthErrorClaims(headers as any);
-    assert.equal(result, undefined);
+    assert.strictEqual(result, undefined);
   });
 
-  it("returns undefined if header does not have expected error indicator", async () => {
+  it("returns undefined if header does not have expected error indicator", () => {
     const headers = {
       get: (name: string) =>
         name.toLowerCase() === "www-authenticate" ? invalidWwwAuthenticateHeaderWithoutError : undefined,
     };
     const result = parseAuthErrorClaims(headers as any);
-    assert.equal(result, undefined);
-});
+    assert.strictEqual(result, undefined);
+  });
 
-  it("returns undefined if error in header does not match expected value", async () => {
+  it("returns undefined if error in header does not match expected value", () => {
     const headers = {
       get: (name: string) =>
         name.toLowerCase() === "www-authenticate" ? invalidWwwAuthenticateHeaderWithUnexpectedErrorValue : undefined,
     };
     const result = parseAuthErrorClaims(headers as any);
-    assert.equal(result, undefined);
+    assert.strictEqual(result, undefined);
   });
 
-  it("returns undefined if header does not have expected claims indicator", async () => {
+  it("returns undefined if header does not have expected claims indicator", () => {
     const headers = {
       get: (name: string) =>
         name.toLowerCase() === "www-authenticate" ? invalidWwwAuthenticateHeaderWithoutClaims : undefined,
     };
     const result = parseAuthErrorClaims(headers as any);
-    assert.equal(result, undefined);
+    assert.strictEqual(result, undefined);
   });
 
-  it("returns decoded claims value", async () => {
+  it("returns decoded claims value", () => {
     const headers = {
       get: (name: string) => (name.toLowerCase() === "www-authenticate" ? validWwwAuthenticateHeader : undefined),
     };
     const result = parseAuthErrorClaims(headers as any);
-    assert.equal(result, "{\"access_token\":{\"nbf\":{\"essential\":true, \"value\":\"1597959090\"}}}");
+    assert.strictEqual(result, "{\"access_token\":{\"nbf\":{\"essential\":true, \"value\":\"1597959090\"}}}");
   });
 });

--- a/packages/utils/odsp-doclib-utils/src/test/parseAuthErrorTenant.spec.ts
+++ b/packages/utils/odsp-doclib-utils/src/test/parseAuthErrorTenant.spec.ts
@@ -1,0 +1,49 @@
+/* eslint-disable max-len */
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import assert from "assert";
+import { parseAuthErrorTenant } from "../parseAuthErrorTenant";
+
+const invalidWwwAuthenticateHeaderWithoutBearerScheme =
+  "Random_scheme client_id=\"00000003-0000-0ff1-ce00-000000000000\",trusted_issuers=\"00000001-0000-0000-c000-000000000000@*,D3776938-3DBA-481F-A652-4BEDFCAB7CD8@*,https://sts.windows.net/*/,00000003-0000-0ff1-ce00-000000000000@90140122-8516-11e1-8eff-49304924019b\",authorization_uri=\"https://login.windows.net/common/oauth2/authorize\"";
+const invalidWwwAuthenticateHeaderWithoutRealm =
+  "Bearer client_id=\"00000003-0000-0ff1-ce00-000000000000\",trusted_issuers=\"00000001-0000-0000-c000-000000000000@*,D3776938-3DBA-481F-A652-4BEDFCAB7CD8@*,https://sts.windows.net/*/,00000003-0000-0ff1-ce00-000000000000@90140122-8516-11e1-8eff-49304924019b\",authorization_uri=\"https://login.windows.net/common/oauth2/authorize\"";
+const validWwwAuthenticateHeader =
+  "Bearer realm=\"6c482541-f706-4168-9e58-8e35a9992f58\",client_id=\"00000003-0000-0ff1-ce00-000000000000\",trusted_issuers=\"00000001-0000-0000-c000-000000000000@*,D3776938-3DBA-481F-A652-4BEDFCAB7CD8@*,https://sts.windows.net/*/,00000003-0000-0ff1-ce00-000000000000@90140122-8516-11e1-8eff-49304924019b\",authorization_uri=\"https://login.windows.net/common/oauth2/authorize\"";
+
+describe("parseAuthErrorTenant", () => {
+  test("returns undefined if headers does not have expected entry", async () => {
+    const headers = { get: (_name: string) => undefined };
+    const result = parseAuthErrorTenant(headers as any);
+    assert.strictEqual(result, undefined);
+  });
+
+  test("returns undefined if header does not have expected OAuth scheme", async () => {
+    const headers = {
+      get: (name: string) =>
+        name.toLowerCase() === "www-authenticate" ? invalidWwwAuthenticateHeaderWithoutBearerScheme : undefined,
+    };
+    const result = parseAuthErrorTenant(headers as any);
+    assert.strictEqual(result, undefined);
+  });
+
+  test("returns undefined if header does not have expected realm indicator", async () => {
+    const headers = {
+      get: (name: string) =>
+        name.toLowerCase() === "www-authenticate" ? invalidWwwAuthenticateHeaderWithoutRealm : undefined,
+    };
+    const result = parseAuthErrorTenant(headers as any);
+    assert.strictEqual(result, undefined);
+  });
+
+  test("returns realm value", async () => {
+    const headers = {
+      get: (name: string) => name.toLowerCase() === "www-authenticate" ? validWwwAuthenticateHeader : undefined,
+    };
+    const result = parseAuthErrorTenant(headers as any);
+    assert.strictEqual(result, "6c482541-f706-4168-9e58-8e35a9992f58");
+  });
+});

--- a/packages/utils/odsp-doclib-utils/src/test/parseAuthErrorTenant.spec.ts
+++ b/packages/utils/odsp-doclib-utils/src/test/parseAuthErrorTenant.spec.ts
@@ -15,13 +15,13 @@ const validWwwAuthenticateHeader =
   "Bearer realm=\"6c482541-f706-4168-9e58-8e35a9992f58\",client_id=\"00000003-0000-0ff1-ce00-000000000000\",trusted_issuers=\"00000001-0000-0000-c000-000000000000@*,D3776938-3DBA-481F-A652-4BEDFCAB7CD8@*,https://sts.windows.net/*/,00000003-0000-0ff1-ce00-000000000000@90140122-8516-11e1-8eff-49304924019b\",authorization_uri=\"https://login.windows.net/common/oauth2/authorize\"";
 
 describe("parseAuthErrorTenant", () => {
-  test("returns undefined if headers does not have expected entry", async () => {
+  it("returns undefined if headers does not have expected entry", () => {
     const headers = { get: (_name: string) => undefined };
     const result = parseAuthErrorTenant(headers as any);
     assert.strictEqual(result, undefined);
   });
 
-  test("returns undefined if header does not have expected OAuth scheme", async () => {
+  it("returns undefined if header does not have expected OAuth scheme", () => {
     const headers = {
       get: (name: string) =>
         name.toLowerCase() === "www-authenticate" ? invalidWwwAuthenticateHeaderWithoutBearerScheme : undefined,
@@ -30,7 +30,7 @@ describe("parseAuthErrorTenant", () => {
     assert.strictEqual(result, undefined);
   });
 
-  test("returns undefined if header does not have expected realm indicator", async () => {
+  it("returns undefined if header does not have expected realm indicator", () => {
     const headers = {
       get: (name: string) =>
         name.toLowerCase() === "www-authenticate" ? invalidWwwAuthenticateHeaderWithoutRealm : undefined,
@@ -39,7 +39,7 @@ describe("parseAuthErrorTenant", () => {
     assert.strictEqual(result, undefined);
   });
 
-  test("returns realm value", async () => {
+  it("returns realm value", () => {
     const headers = {
       get: (name: string) => name.toLowerCase() === "www-authenticate" ? validWwwAuthenticateHeader : undefined,
     };

--- a/packages/utils/tool-utils/src/odspTokenManager.ts
+++ b/packages/utils/tool-utils/src/odspTokenManager.ts
@@ -46,9 +46,7 @@ export type OdspTokenConfig = {
     redirectUriCallback?: (tokens: IOdspTokens) => Promise<string>;
 };
 
-export interface IPushCacheKey { isPush: true }
-export interface IOdspCacheKey { isPush: false; server: string }
-export type OdspTokenManagerCacheKey = IPushCacheKey | IOdspCacheKey;
+export interface OdspTokenManagerCacheKey { isPush: boolean; server: string; }
 
 export class OdspTokenManager {
     constructor(
@@ -112,7 +110,7 @@ export class OdspTokenManager {
         if (this.tokenCache) {
             if (!forceReauth && !forceRefresh) {
                 // check and return if it exists without lock
-                const cacheKey: OdspTokenManagerCacheKey = isPush ? { isPush } : { isPush, server };
+                const cacheKey: OdspTokenManagerCacheKey = { isPush, server };
                 const tokensFromCache = await this.tokenCache.get(cacheKey);
                 if (tokensFromCache) {
                     await this.onTokenRetrievalFromCache(tokenConfig, tokensFromCache);
@@ -134,7 +132,7 @@ export class OdspTokenManager {
         forceReauth,
     ): Promise<IOdspTokens> {
         const scope = isPush ? pushScope : getOdspScope(server);
-        const cacheKey: OdspTokenManagerCacheKey = isPush ? { isPush } : { isPush, server };
+        const cacheKey: OdspTokenManagerCacheKey = { isPush, server };
         if (!forceReauth && this.tokenCache) {
             const tokensFromCache = await this.tokenCache.get(cacheKey);
             if (tokensFromCache) {
@@ -168,7 +166,7 @@ export class OdspTokenManager {
                 break;
             case "browserLogin":
                 tokens = await this.acquireTokensViaBrowserLogin(
-                    getLoginPageUrl(isPush, server, clientConfig, scope, odspAuthRedirectUri),
+                    getLoginPageUrl(server, clientConfig, scope, odspAuthRedirectUri),
                     server,
                     clientConfig,
                     scope,

--- a/packages/utils/tool-utils/src/odspTokenManager.ts
+++ b/packages/utils/tool-utils/src/odspTokenManager.ts
@@ -46,14 +46,14 @@ export type OdspTokenConfig = {
     redirectUriCallback?: (tokens: IOdspTokens) => Promise<string>;
 };
 
-export interface OdspTokenManagerCacheKey { isPush: boolean; server: string; }
+export interface IOdspTokenManagerCacheKey { isPush: boolean; server: string; }
 
 export class OdspTokenManager {
     constructor(
-        private readonly tokenCache?: IAsyncCache<OdspTokenManagerCacheKey, IOdspTokens>,
+        private readonly tokenCache?: IAsyncCache<IOdspTokenManagerCacheKey, IOdspTokens>,
     ) { }
 
-    public async updateTokensCache(key: OdspTokenManagerCacheKey, value: IOdspTokens) {
+    public async updateTokensCache(key: IOdspTokenManagerCacheKey, value: IOdspTokens) {
         await this.tokenCache?.save(key, value);
     }
 
@@ -110,7 +110,7 @@ export class OdspTokenManager {
         if (this.tokenCache) {
             if (!forceReauth && !forceRefresh) {
                 // check and return if it exists without lock
-                const cacheKey: OdspTokenManagerCacheKey = { isPush, server };
+                const cacheKey: IOdspTokenManagerCacheKey = { isPush, server };
                 const tokensFromCache = await this.tokenCache.get(cacheKey);
                 if (tokensFromCache) {
                     await this.onTokenRetrievalFromCache(tokenConfig, tokensFromCache);
@@ -132,7 +132,7 @@ export class OdspTokenManager {
         forceReauth,
     ): Promise<IOdspTokens> {
         const scope = isPush ? pushScope : getOdspScope(server);
-        const cacheKey: OdspTokenManagerCacheKey = { isPush, server };
+        const cacheKey: IOdspTokenManagerCacheKey = { isPush, server };
         if (!forceReauth && this.tokenCache) {
             const tokensFromCache = await this.tokenCache.get(cacheKey);
             if (tokensFromCache) {
@@ -258,8 +258,8 @@ export class OdspTokenManager {
     }
 }
 
-export const odspTokensCache: IAsyncCache<OdspTokenManagerCacheKey, IOdspTokens> = {
-    async get(key: OdspTokenManagerCacheKey): Promise<IOdspTokens | undefined> {
+export const odspTokensCache: IAsyncCache<IOdspTokenManagerCacheKey, IOdspTokens> = {
+    async get(key: IOdspTokenManagerCacheKey): Promise<IOdspTokens | undefined> {
         const rc = await loadRC();
         if (key.isPush) {
             return rc.pushTokens;
@@ -267,7 +267,7 @@ export const odspTokensCache: IAsyncCache<OdspTokenManagerCacheKey, IOdspTokens>
             return rc.tokens && rc.tokens[key.server];
         }
     },
-    async save(key: OdspTokenManagerCacheKey, tokens: IOdspTokens): Promise<void> {
+    async save(key: IOdspTokenManagerCacheKey, tokens: IOdspTokens): Promise<void> {
         const rc = await loadRC();
         if (key.isPush) {
             rc.pushTokens = tokens;


### PR DESCRIPTION
In order for user to load Fluid content from a file which is stored in external O365 tenant it is necessary to request OAuth token with external tenant explicitly specified as part of AAD authority that should issue a token. 

StorageTokenFetcher callback signature includes siteUrl parameter which can be used to determine AAD tenant. We need similar capability for PushTokenFetcher callback. This is required because Push token must be able to establish collab session within the context of external tenant. 

Note that this is breaking change, this is intentional to ensure that token fetcher implementations think about external access case and either provide proper support for it or return error in case external access is not supported.

I manually validated the part pertaining to handling auth failure where access token was not issues by expected authority. In this case www-authenticate header is returned with 'realm' property indicating AAD tenant authority that should be used for issuing access token. 