### PR TITLE
check for 400 to create git repo

### DIFF
--- a/server/routerlicious/packages/services-client/src/utils.ts
+++ b/server/routerlicious/packages/services-client/src/utils.ts
@@ -13,7 +13,7 @@ export async function getOrCreateRepository(endpoint: string, owner: string, rep
         // eslint-disable-next-line @typescript-eslint/promise-function-async, no-null/no-null
         .catch((error) => error.response && error.response.status === 400 ? null : Promise.reject(error));
 
-    if (!details) {
+    if (!details || details.status === 400) {
         console.log(`Create Repo: ${endpoint}/${owner}/${repository}`);
         const createParams: resources.ICreateRepoParams = {
             name: repository,


### PR DESCRIPTION
When using yarn as opposed to npm to install axios, we see that when gitrest returns 400, it is not caught as an error in axios, and instead goes to the .then() block in testing. In this case, "details" is an object with the field status, set to 400. To account for this case, we check for details.status === 400 as well, in order to create the git repo. Otherwise, the repo will not get created, and we will get a lot of 400s in gitrest and historian saying that "the repo does not exist" and sample apps like clicker do not work