### PR TITLE
Handle rdkafka rebalance in progress errors

### DIFF
--- a/server/routerlicious/packages/services/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services/src/rdkafkaConsumer.ts
@@ -110,7 +110,9 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 				// a rebalance occurred while we were committing
 				// we can resubmit the commit if we still own the partition
 				shouldRetryCommit =
-					this.consumerOptions.optimizedRebalance && err.code === kafka.CODES.ERRORS.ERR_ILLEGAL_GENERATION;
+					this.consumerOptions.optimizedRebalance &&
+					(err.code === kafka.CODES.ERRORS.ERR_REBALANCE_IN_PROGRESS ||
+						err.code === kafka.CODES.ERRORS.ERR_ILLEGAL_GENERATION);
 			}
 
 			for (const offset of offsets) {


### PR DESCRIPTION
Committing an offset while a rebalance is running results in "Broker: Group rebalance in progress" errors. We retry these commits once the rebalance ends if we still own the partition.
So we should look for `ERR_REBALANCE_IN_PROGRESS` in addition to `ERR_ILLEGAL_GENERATION`.

Also add a delay to that retried commit. This prevents a continuous stream of these errors if the commit is failing quickly during a rebalance