### PR TITLE
Add optional epoch to IConnect message

### DIFF
--- a/server/routerlicious/packages/protocol-definitions/src/sockets.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/sockets.ts
@@ -46,6 +46,11 @@ export interface IConnect {
      * An optional nonce used during connection to identify connection attempts
      */
     nonce?: string;
+
+    /**
+     * Represents the version of document on server, client wants to connect to.
+     */
+    epoch?: string;
 }
 
 /**

--- a/server/routerlicious/packages/protocol-definitions/src/sockets.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/sockets.ts
@@ -48,7 +48,8 @@ export interface IConnect {
     nonce?: string;
 
     /**
-     * Represents the version of document on server, client wants to connect to.
+     * Represents the version of document at client. It should match the version on server
+     * for connection to be successful.
      */
     epoch?: string;
 }


### PR DESCRIPTION
Related to issue: https://github.com/microsoft/FluidFramework/pull/4899

Add epoch in IConnect message, so that is the client has it and wants to match on server, then it can pass it.