### PR TITLE
Integrating custom Socket.io adapter to alfred

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -4601,7 +4601,7 @@
 		"@microsoft/tsdoc": {
 			"version": "0.12.19",
 			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.19.tgz",
-			"integrity": "sha512-IpgPxHrNxZiMNUSXqR1l/gePKPkfAmIKoDRP9hp7OwjU29ZR8WCJsOJ8iBKgw0Qk+pFwR+8Y1cy8ImLY6e9m4A==",
+			"integrity": "sha1-IXPMuSRpqvYgMfqUmdIbFtB/m1c=",
 			"dev": true
 		},
 		"@mixer/webpack-bundle-compare": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2230,7 +2230,7 @@
     "@microsoft/tsdoc": {
       "version": "0.12.19",
       "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.19.tgz",
-      "integrity": "sha512-IpgPxHrNxZiMNUSXqR1l/gePKPkfAmIKoDRP9hp7OwjU29ZR8WCJsOJ8iBKgw0Qk+pFwR+8Y1cy8ImLY6e9m4A==",
+      "integrity": "sha1-IXPMuSRpqvYgMfqUmdIbFtB/m1c=",
       "dev": true
     },
     "@mrmlnc/readdir-enhanced": {

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -84,7 +84,11 @@ data:
                 {{- range $i, $tenant := .Values.alfred.tenants }}
                 {{ toJson . }}{{- if ne $i $lastIndex -}}, {{ end }}
                 {{- end }}
-            ]
+            ],
+            "socketIoAdapter" : {
+                "enableCustomSocketIoAdapter": {{ .Values.alfred.socketIoAdapter.enableCustomSocketIoAdapter }},
+                "shouldDisableDefaultNamespace": {{ .Values.alfred.socketIoAdapter.shouldDisableDefaultNamespace }}
+            }
         },
         "client": {
             "type": "browser",

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -32,6 +32,9 @@ alfred:
         maxBurst: 1000000
         minCooldownIntervalInMs: 1000000
         minThrottleIntervalInMs: 1000000
+  socketIoAdapter:
+    enableCustomSocketIoAdapter: true
+    shouldDisableDefaultNamespace: false
 
 deli:
   name: deli

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -89,7 +89,8 @@ export class AlfredResources implements utils.IResources {
         public port: any,
         public documentsCollectionName: string,
         public metricClientConfig: any) {
-        this.webServerFactory = new services.SocketIoWebServerFactory(this.redisConfig);
+        const socketIoAdapterConfig = config.get("alfred:socketIoAdapter");
+        this.webServerFactory = new services.SocketIoWebServerFactory(this.redisConfig, socketIoAdapterConfig);
     }
 
     public async dispose(): Promise<void> {

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -74,7 +74,11 @@
                 "id": "local",
                 "key": "43cfc3fbf04a97c0921fd23ff10f9e4b"
             }
-        ]
+        ],
+        "socketIoAdapter" : {
+            "enableCustomSocketIoAdapter": true,
+            "shouldDisableDefaultNamespace": false
+        }
     },
     "client": {
         "type": "browser",

--- a/server/routerlicious/packages/services-shared/src/redisSocketIoAdapter.ts
+++ b/server/routerlicious/packages/services-shared/src/redisSocketIoAdapter.ts
@@ -56,7 +56,7 @@ export interface ISocketIoRedisOptions {
  * - Creates per room subscriptions which significantly reduces Redis server load for
  * Fluid scenarios when running a large amount of Fluid frontend servers.
  * - Contains a health checker that verifies each room is works *
- * - Disables rooms for the default "/" namespace to reduce memory usage
+ * - Optionally disables rooms for the default "/" namespace to reduce memory usage
  * (https://github.com/socketio/socket.io/issues/3089)
  * - Callbacks for telemetry logging
  * The Redis pubsub channels are compatible with socket.io-redis

--- a/server/routerlicious/packages/services-shared/src/socketIoRedisConnection.ts
+++ b/server/routerlicious/packages/services-shared/src/socketIoRedisConnection.ts
@@ -25,7 +25,6 @@ export class SocketIORedisConnection implements ISocketIoRedisConnection {
 export class SocketIoRedisSubscriptionConnection
         extends SocketIORedisConnection
         implements ISocketIoRedisSubscriptionConnection {
-
     /**
      * Map of pubsub callbacks
      */

--- a/server/routerlicious/packages/services-shared/src/socketIoRedisConnection.ts
+++ b/server/routerlicious/packages/services-shared/src/socketIoRedisConnection.ts
@@ -29,21 +29,21 @@ export class SocketIoRedisSubscriptionConnection
     /**
      * Map of pubsub callbacks
      */
-	private readonly subscriptions: Map<string, (channel: string, messageBuffer: Buffer) => void> = new Map();
+    private readonly subscriptions: Map<string, (channel: string, messageBuffer: Buffer) => void> = new Map();
 
     constructor(client: redis.RedisClient) {
         super(client);
 
         client.on("messageBuffer", (channelBuffer: Buffer, messageBuffer: Buffer) => {
-			const channel = channelBuffer.toString();
+            const channel = channelBuffer.toString();
 
-			const callback = this.subscriptions.get(channel);
-			if (!callback) {
-				return;
-			}
+            const callback = this.subscriptions.get(channel);
+            if (!callback) {
+                return;
+            }
 
-			callback(channel, messageBuffer);
-		});
+            callback(channel, messageBuffer);
+        });
     }
 
     public async subscribe(
@@ -51,14 +51,14 @@ export class SocketIoRedisSubscriptionConnection
         callback: (channel: string, messageBuffer: Buffer) => void,
         forceSubscribe?: boolean) {
         let channelsArray = Array.isArray(channels) ? channels : [channels];
-		const subscriptionsMap = this.subscriptions;
+        const subscriptionsMap = this.subscriptions;
 
-		if (!forceSubscribe) {
-			channelsArray = channelsArray.filter((channel) => !subscriptionsMap.has(channel));
-			if (channelsArray.length === 0) {
-				return;
-			}
-		}
+        if (!forceSubscribe) {
+            channelsArray = channelsArray.filter((channel) => !subscriptionsMap.has(channel));
+            if (channelsArray.length === 0) {
+                return;
+            }
+        }
 
         this.client.subscribe(...channelsArray);
 
@@ -69,11 +69,11 @@ export class SocketIoRedisSubscriptionConnection
 
     public async unsubscribe(channels: string | string[]) {
         let channelsArray = Array.isArray(channels) ? channels : [channels];
-		const subscriptionsMap = this.subscriptions;
+        const subscriptionsMap = this.subscriptions;
 
-		channelsArray = channelsArray.filter((channel) => subscriptionsMap.has(channel));
-		if (channelsArray.length === 0) {
-			return;
+        channelsArray = channelsArray.filter((channel) => subscriptionsMap.has(channel));
+        if (channelsArray.length === 0) {
+            return;
         }
 
         this.client.unsubscribe(channelsArray);

--- a/server/routerlicious/packages/services-shared/src/socketIoRedisConnection.ts
+++ b/server/routerlicious/packages/services-shared/src/socketIoRedisConnection.ts
@@ -6,6 +6,10 @@
 import * as redis from "redis";
 import { ISocketIoRedisConnection, ISocketIoRedisSubscriptionConnection } from "./redisSocketIoAdapter";
 
+/**
+ * Simple implementation of ISocketIoRedisConnection, which wraps a node-redis client
+ * and only provides Pub functionality
+ */
 export class SocketIORedisConnection implements ISocketIoRedisConnection {
     constructor(protected readonly client: redis.RedisClient) {}
 
@@ -14,12 +18,17 @@ export class SocketIORedisConnection implements ISocketIoRedisConnection {
     }
 }
 
+/**
+ * Simple implementation of ISocketIoRedisSubscriptionConnection, which wraps a node-redis client
+ * and provides both pub and sub functionality
+ */
 export class SocketIoRedisSubscriptionConnection
         extends SocketIORedisConnection
         implements ISocketIoRedisSubscriptionConnection {
+
     /**
-	 * Map of pubsub callbacks
-	 */
+     * Map of pubsub callbacks
+     */
 	private readonly subscriptions: Map<string, (channel: string, messageBuffer: Buffer) => void> = new Map();
 
     constructor(client: redis.RedisClient) {

--- a/server/routerlicious/packages/services-shared/src/socketIoRedisConnection.ts
+++ b/server/routerlicious/packages/services-shared/src/socketIoRedisConnection.ts
@@ -1,0 +1,80 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as redis from "redis";
+import { ISocketIoRedisConnection, ISocketIoRedisSubscriptionConnection } from "./redisSocketIoAdapter";
+
+export class SocketIORedisConnection implements ISocketIoRedisConnection {
+    constructor(protected readonly client: redis.RedisClient) {}
+
+    public async publish(channel: string, message: string) {
+        this.client.publish(channel, message);
+    }
+}
+
+export class SocketIoRedisSubscriptionConnection
+        extends SocketIORedisConnection
+        implements ISocketIoRedisSubscriptionConnection {
+    /**
+	 * Map of pubsub callbacks
+	 */
+	private readonly subscriptions: Map<string, (channel: string, messageBuffer: Buffer) => void> = new Map();
+
+    constructor(client: redis.RedisClient) {
+        super(client);
+
+        client.on("messageBuffer", (channelBuffer: Buffer, messageBuffer: Buffer) => {
+			const channel = channelBuffer.toString();
+
+			const callback = this.subscriptions.get(channel);
+			if (!callback) {
+				return;
+			}
+
+			callback(channel, messageBuffer);
+		});
+    }
+
+    public async subscribe(
+        channels: string | string[],
+        callback: (channel: string, messageBuffer: Buffer) => void,
+        forceSubscribe?: boolean) {
+        let channelsArray = Array.isArray(channels) ? channels : [channels];
+		const subscriptionsMap = this.subscriptions;
+
+		if (!forceSubscribe) {
+			channelsArray = channelsArray.filter((channel) => !subscriptionsMap.has(channel));
+			if (channelsArray.length === 0) {
+				return;
+			}
+		}
+
+        this.client.subscribe(...channelsArray);
+
+        for (const channel of channelsArray) {
+            subscriptionsMap.set(channel, callback);
+        }
+    }
+
+    public async unsubscribe(channels: string | string[]) {
+        let channelsArray = Array.isArray(channels) ? channels : [channels];
+		const subscriptionsMap = this.subscriptions;
+
+		channelsArray = channelsArray.filter((channel) => subscriptionsMap.has(channel));
+		if (channelsArray.length === 0) {
+			return;
+        }
+
+        this.client.unsubscribe(channelsArray);
+
+        for (const channel of channelsArray) {
+            subscriptionsMap.delete(channel);
+        }
+    }
+
+    public isSubscribed(channel: string): boolean {
+        return this.subscriptions.has(channel);
+    }
+}

--- a/server/routerlicious/packages/services-shared/src/webServer.ts
+++ b/server/routerlicious/packages/services-shared/src/webServer.ts
@@ -47,7 +47,7 @@ export class WebServer implements core.IWebServer {
 }
 
 export class SocketIoWebServerFactory implements core.IWebServerFactory {
-    constructor(private readonly redisConfig: any) {
+    constructor(private readonly redisConfig: any, private readonly socketIoAdapterConfig?: any) {
     }
 
     public create(requestListener: RequestListener): core.IWebServer {
@@ -55,7 +55,7 @@ export class SocketIoWebServerFactory implements core.IWebServerFactory {
         const server = http.createServer(requestListener);
         const httpServer = new HttpServer(server);
 
-        const socketIoServer = socketIo.create(this.redisConfig, server);
+        const socketIoServer = socketIo.create(this.redisConfig, server, this.socketIoAdapterConfig);
 
         return new WebServer(httpServer, socketIoServer);
     }


### PR DESCRIPTION
A custom Socket.IO adapter was implemented in #4596 - "Add custom Redis socket.io adapter". The custom adapter is based on Redis and brings interesting features such as performance improvements and support for telemetry.

In this PR, I am integrating the custom adapter to Alfred. That also involved creating simple wrappers around Redis client connections so that we could implement the pub/sub Redis connection interfaces required by the custom adapter.

This work involved changing SocketIoWebServerFactory and related classes, which not only affect Routerlicious/Alfred, but also Gateway, which depends on Services-Shared. But Gateway is an example host and performance improvements there might not be necessary at this point. So I did not update it. Still, the new parameters required in SocketIoWebServerFactory and similar are all optional, so Gateway should continue working as-is and can be easily updated in the future to use the custom Socket.IO adapter. (Note: that would require changing Gateway's config.json, runnerFactory and Helm charts).