### PR TITLE
Generate absolute path for remote handles that have been persisted with relative path

### DIFF
--- a/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
+++ b/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "@fluidframework/common-utils";
 import {
     IFluidObject,
     IFluidHandle,
@@ -35,6 +36,7 @@ export class RemoteFluidObjectHandle implements IFluidHandle {
         public readonly absolutePath: string,
         public readonly routeContext: IFluidHandleContext,
     ) {
+        assert(absolutePath.startsWith("/"), "Handles should always have absolute paths");
     }
 
     /**

--- a/packages/runtime/runtime-utils/src/serializer.ts
+++ b/packages/runtime/runtime-utils/src/serializer.ts
@@ -9,6 +9,7 @@ import {
     IFluidSerializer,
 } from "@fluidframework/core-interfaces";
 import { RemoteFluidObjectHandle } from "./remoteFluidObjectHandle";
+import { generateHandleContextPath } from "./dataStoreHandleContextUtils";
 import { isSerializedHandle } from "./utils";
 
 /**
@@ -64,12 +65,12 @@ export class FluidSerializer implements IFluidSerializer {
                     return value;
                 }
 
-                // 0.21 back-compat
-                // 0.22 onwards, we always use the routeContext of the root to create the RemoteFluidObjectHandle.
-                // We won't need to check for the if condition below once we remove the back-compat code.
-                const absoluteUrl = value.url.startsWith("/");
-                const handle = new RemoteFluidObjectHandle(value.url, absoluteUrl ? this.root : this.context);
-
+                // Old documents may have handles with relative path in their summaries. Convert these to absolute
+                // paths. This will ensure that future summaries will have absolute paths for these handles.
+                const absolutePath = value.url.startsWith("/")
+                    ? value.url
+                    : generateHandleContextPath(value.url, this.context);
+                const handle = new RemoteFluidObjectHandle(absolutePath, this.root);
                 return handle;
             });
     }

--- a/packages/runtime/runtime-utils/src/serializer.ts
+++ b/packages/runtime/runtime-utils/src/serializer.ts
@@ -70,8 +70,7 @@ export class FluidSerializer implements IFluidSerializer {
                 const absolutePath = value.url.startsWith("/")
                     ? value.url
                     : generateHandleContextPath(value.url, this.context);
-                const handle = new RemoteFluidObjectHandle(absolutePath, this.root);
-                return handle;
+                return new RemoteFluidObjectHandle(absolutePath, this.root);
             });
     }
 

--- a/packages/runtime/runtime-utils/src/test/serializer.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/serializer.spec.ts
@@ -4,97 +4,100 @@
  */
 
 import { strict as assert } from "assert";
+import { RemoteFluidObjectHandle } from "../remoteFluidObjectHandle";
 import { FluidSerializer } from "../serializer";
 import {
-    handle,
     makeJson,
-    mockHandleContext as context,
+    MockHandleContext,
 } from "./utils";
 
-const serHandle = {
-    type: "__fluid_handle__",
-    url: "",
-};
-
-// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
-function printHandle(target: any) {
-    return JSON.stringify(target, (key, value) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        return value?.IFluidHandle !== undefined
-            ? "#HANDLE"
-            : value;
-    });
-}
-
-// Start with the various JSON-serializable types
-// eslint-disable-next-line no-null/no-null
-const simple = [true, 1, "x", null, [], {}];
-
-// Add an object where each field references one of the JSON serializable types.
-simple.push(
-    simple.reduce<any>(
-        (o, value, index) => {
-            o[`f${index}`] = value;
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-            return o;
-        },
-        {}));
-
-// Add an array that contains each of our constructed test cases.
-simple.push([...simple]);
-
-const ser = new FluidSerializer(context);
-
 describe("FluidSerializer", () => {
+    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+    function printHandle(target: any) {
+        return JSON.stringify(target, (key, value) => {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+            return value?.IFluidHandle !== undefined
+                ? "#HANDLE"
+                : value;
+        });
+    }
+
     describe("vanilla JSON", () => {
+        const context = new MockHandleContext();
+        const serializer = new FluidSerializer(context);
+        const handle = new RemoteFluidObjectHandle("/root", context);
+
+        // Start with the various JSON-serializable types
+        // eslint-disable-next-line no-null/no-null
+        const simple = [true, 1, "x", null, [], {}];
+        // Add an object where each field references one of the JSON serializable types.
+        simple.push(
+            simple.reduce<any>(
+                (o, value, index) => {
+                    o[`f${index}`] = value;
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+                    return o;
+                },
+                {}));
+        // Add an array that contains each of our constructed test cases.
+        simple.push([...simple]);
+
         // Verify that `replaceHandles` is a no-op for these simple cases.
         for (const input of simple) {
             it(`${printHandle(input)} -> ${JSON.stringify(input)}`, () => {
-                const actual = ser.replaceHandles(input, handle);
-                assert.equal(actual, input,
+                const actual = serializer.replaceHandles(input, handle);
+                assert.strictEqual(actual, input,
                     "replaceHandles() on input with no handles must return original input.");
 
-                const stringified = ser.stringify(input, handle);
-                const parsed = ser.parse(stringified);
-                assert.deepEqual(parsed, input,
+                const stringified = serializer.stringify(input, handle);
+                const parsed = serializer.parse(stringified);
+                assert.deepStrictEqual(parsed, input,
                     "input must round-trip through stringify()/parse().");
 
-                // Paranoid check that ser.parse() and JSON.parse() agree.
-                assert.deepEqual(parsed, JSON.parse(stringified),
+                // Paranoid check that serializer.parse() and JSON.parse() agree.
+                assert.deepStrictEqual(parsed, JSON.parse(stringified),
                     "parse() of input without handles must produce same result as JSON.parse().");
             });
         }
 
         it("replaceHandles() must round-trip undefined", () => {
-            assert.equal(ser.replaceHandles(undefined, handle), undefined);
+            assert.strictEqual(serializer.replaceHandles(undefined, handle), undefined);
         });
     });
 
     describe("JSON w/embedded handles", () => {
+        const context = new MockHandleContext();
+        const serializer = new FluidSerializer(context);
+        const handle = new RemoteFluidObjectHandle("/root", context);
+        const serializedHandle = {
+            type: "__fluid_handle__",
+            url: "/root",
+        };
+
         function check(input, expected) {
             it(`${printHandle(input)} -> ${JSON.stringify(expected)}`, () => {
-                const replaced = ser.replaceHandles(input, handle);
-                assert.notEqual(replaced, input,
+                const replaced = serializer.replaceHandles(input, handle);
+                assert.notStrictEqual(replaced, input,
                     "replaceHandles() must shallow-clone rather than mutate original object.");
-                assert.deepEqual(replaced, expected,
+                assert.deepStrictEqual(replaced, expected,
                     "replaceHandles() must return expected output.");
 
-                const stringified = ser.stringify(input, handle);
+                const stringified = serializer.stringify(input, handle);
 
                 // Note that we're using JSON.parse() in this test, so the handles remained serialized.
-                assert.deepEqual(JSON.parse(stringified), expected,
+                assert.deepStrictEqual(JSON.parse(stringified), expected,
                     "Round-trip through stringify()/JSON.parse() must produce the same output as replaceHandles()");
 
-                const parsed = ser.parse(stringified);
-                assert.deepEqual(parsed, input,
+                const parsed = serializer.parse(stringified);
+                assert.deepStrictEqual(parsed, input,
                     "input must round-trip through stringify()/parse().");
             });
         }
 
-        check(handle, serHandle);
-        check([handle], [serHandle]);
-        check({ handle }, { handle: serHandle });
-        check([{ handle }, { handle }], [{ handle: serHandle }, { handle: serHandle }]);
+        check(handle, serializedHandle);
+        check([handle], [serializedHandle]);
+        check({ handle }, { handle: serializedHandle });
+        check([{ handle }, { handle }], [{ handle: serializedHandle }, { handle: serializedHandle }]);
 
         it(`sizable json tree`, () => {
             const input: any = makeJson(
@@ -106,14 +109,50 @@ describe("FluidSerializer", () => {
             input.h = handle;
             input.o1.h = handle;
 
-            const replaced = ser.replaceHandles(input, handle);
-            assert.notEqual(replaced, input,
+            const replaced = serializer.replaceHandles(input, handle);
+            assert.notStrictEqual(replaced, input,
                 "replaceHandles() must shallow-clone rather than mutate original object.");
 
-            const stringified = ser.stringify(input, handle);
-            const parsed = ser.parse(stringified);
-            assert.deepEqual(parsed, input,
+            const stringified = serializer.stringify(input, handle);
+            const parsed = serializer.parse(stringified);
+            assert.deepStrictEqual(parsed, input,
                 "input must round-trip through stringify()/parse().");
+        });
+    });
+
+    describe("Parse handles with absolute / relative paths", () => {
+        const rootContext = new MockHandleContext("");
+        const dsContext = new MockHandleContext("/default", rootContext);
+        // Create serialized with a handle context whose parent is a root handle context.
+        const serializer = new FluidSerializer(dsContext);
+
+        it("can parse handles with absolute path", () => {
+            const serializedHandle = JSON.stringify({
+                type: "__fluid_handle__",
+                url: "/default/sharedDDS", // absolute path
+            });
+
+            // Parse a handle whose url is absolute path.
+            const parsedHandle: RemoteFluidObjectHandle = serializer.parse(serializedHandle);
+            assert.strictEqual(
+                parsedHandle.absolutePath, "/default/sharedDDS", "Incorrect absolute path in parsed handle");
+            assert.strictEqual(
+                parsedHandle.routeContext.absolutePath, "", "Parsed handle's route context should be the root context");
+        });
+
+        it("can parse handles with relative path", () => {
+            const serializedHandle = JSON.stringify({
+                type: "__fluid_handle__",
+                url: "sharedDDS", // relative path
+            });
+
+            // Parse a handle whose url is a path relative to its route context. The serializer will generate absolute
+            // path for the handle and create a handle with it.
+            const parsedHandle: RemoteFluidObjectHandle = serializer.parse(serializedHandle);
+            assert.strictEqual(
+                parsedHandle.absolutePath, "/default/sharedDDS", "Incorrect absolute path in parsed handle");
+            assert.strictEqual(
+                parsedHandle.routeContext.absolutePath, "", "Parsed handle's route context should be the root context");
         });
     });
 });

--- a/packages/runtime/runtime-utils/src/test/utils.ts
+++ b/packages/runtime/runtime-utils/src/test/utils.ts
@@ -3,23 +3,24 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidHandle, IFluidHandleContext } from "@fluidframework/core-interfaces";
-import { RemoteFluidObjectHandle } from "../remoteFluidObjectHandle";
+import { IFluidHandleContext, IRequest } from "@fluidframework/core-interfaces";
 
-export const mockHandleContext: IFluidHandleContext = {
-    absolutePath: "",
-    isAttached: false,
-    IFluidHandleContext: undefined as any,
+export class MockHandleContext implements IFluidHandleContext {
+    public isAttached = false;
+    public get IFluidHandleContext() {
+        return this;
+    }
 
-    attachGraph: () => {
+    constructor(public readonly absolutePath = "", public readonly routeContext?: IFluidHandleContext) {}
+
+    public attachGraph() {
         throw new Error("Method not implemented.");
-    },
-    resolveHandle: () => {
-        throw new Error("Method not implemented.");
-    },
-};
+    }
 
-export const handle: IFluidHandle = new RemoteFluidObjectHandle("", mockHandleContext);
+    public async resolveHandle(request: IRequest) {
+        return { status: 404, mimeType: "text/plain", value: `Method not implemented.` };
+    }
+}
 
 /**
  * Creates a Jsonable object graph of a specified breadth/depth.  The 'createLeaf' callback


### PR DESCRIPTION
Fixes #4576 

Handles have absolute path to the Fluid objects they are referring to. However, some old documents may have handles that were persisted with relative paths.
GC uses the handle's absolute path to find out which Fluid objects are unreferenced. This change updates the relative path in these old handles to absolute path. This will ensure that the Fluid objects referred to by these handles are not accidentally collected.