### PR TITLE
Add IDeliCheckpointManager interface for handling deli checkpoints

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/checkpointManager.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/checkpointManager.ts
@@ -1,0 +1,49 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/* eslint-disable no-null/no-null */
+
+import { ICollection, IDeliState, IDocument, IQueuedMessage } from "@fluidframework/server-services-core";
+
+export interface IDeliCheckpointManager {
+    writeCheckpoint(checkpoint: IDeliState): Promise<void>;
+    deleteCheckpoint(checkpointParams: ICheckpointParams): Promise<void>;
+}
+
+export interface ICheckpointParams extends IDeliState {
+    queuedMessage: IQueuedMessage;
+    clear?: boolean;
+}
+
+export function createDeliCheckpointManagerFromCollection(
+    tenantId: string,
+    documentId: string,
+    collection: ICollection<IDocument>): IDeliCheckpointManager {
+    const checkpointManager = {
+        writeCheckpoint: async (checkpoint: IDeliState) => {
+            return collection.update(
+                {
+                    documentId,
+                    tenantId,
+                },
+                {
+                    deli: JSON.stringify(checkpoint),
+                },
+                null);
+        },
+        deleteCheckpoint: async () => {
+            return collection.update(
+                {
+                    documentId,
+                    tenantId,
+                },
+                {
+                    deli: "",
+                },
+                null);
+        },
+    };
+    return checkpointManager;
+}

--- a/server/routerlicious/packages/lambdas/src/deli/index.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/index.ts
@@ -3,5 +3,6 @@
  * Licensed under the MIT License.
  */
 
+export * from "./checkpointManager";
 export * from "./lambda";
 export * from "./lambdaFactory";

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -24,11 +24,9 @@ import {
     ControlMessageType,
     extractBoxcar,
     IClientSequenceNumber,
-    ICollection,
     IContext,
     IControlMessage,
     IDeliState,
-    IDocument,
     IMessage,
     INackMessage,
     IPartitionLambda,
@@ -42,8 +40,9 @@ import {
     SequencedOperationType,
     IQueuedMessage,
 } from "@fluidframework/server-services-core";
-import { CheckpointContext, ICheckpointParams } from "./checkpointContext";
+import { CheckpointContext } from "./checkpointContext";
 import { ClientSequenceNumberManager } from "./clientSeqManager";
+import { IDeliCheckpointManager, ICheckpointParams } from "./checkpointManager";
 
 enum IncomingMessageOrder {
     Duplicate,
@@ -109,7 +108,7 @@ export class DeliLambda implements IPartitionLambda {
         private readonly tenantId: string,
         private readonly documentId: string,
         readonly lastCheckpoint: IDeliState,
-        collection: ICollection<IDocument>,
+        checkpointManager: IDeliCheckpointManager,
         private readonly forwardProducer: IProducer,
         private readonly reverseProducer: IProducer,
         private readonly serviceConfiguration: IServiceConfiguration) {
@@ -136,7 +135,7 @@ export class DeliLambda implements IPartitionLambda {
         this.minimumSequenceNumber = msn === -1 ? this.sequenceNumber : msn;
 
         this.logOffset = lastCheckpoint.logOffset;
-        this.checkpointContext = new CheckpointContext(this.tenantId, this.documentId, collection, context);
+        this.checkpointContext = new CheckpointContext(this.tenantId, this.documentId, checkpointManager, context);
     }
 
     public handler(rawMessage: IQueuedMessage): void {

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -25,6 +25,7 @@ import { IGitManager } from "@fluidframework/server-services-client";
 import { Provider } from "nconf";
 import { NoOpLambda } from "../utils";
 import { DeliLambda } from "./lambda";
+import { createDeliCheckpointManagerFromCollection } from "./checkpointManager";
 
 // Epoch should never tick in our current setting. This flag is just for being extra cautious.
 // TODO: Remove when everything is up to date.
@@ -123,14 +124,15 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
             ) :
             lastCheckpoint;
 
+        const checkpointManager = createDeliCheckpointManagerFromCollection(tenantId, documentId, this.collection);
+
         // Should the lambda reaize that term has flipped to send a no-op message at the beginning?
         return new DeliLambda(
             context,
             tenantId,
             documentId,
             newCheckpoint,
-            // It probably shouldn't take the collection - I can manage that
-            this.collection,
+            checkpointManager,
             // The producer as well it shouldn't take. Maybe it just gives an output stream?
             this.forwardProducer,
             this.reverseProducer,
@@ -221,7 +223,6 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
         const serviceProtocolEntries = generateServiceProtocolEntries(JSON.stringify(checkpoint), scribe);
 
         const [serviceProtocolTree, lastSummaryTree] = await Promise.all([
-            // eslint-disable-next-line no-null/no-null
             gitManager.createTree({ entries: serviceProtocolEntries }),
             gitManager.getTree(lastCommit.tree.sha, false),
         ]);

--- a/server/routerlicious/packages/lambdas/src/test/deli/checkpointContext.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/deli/checkpointContext.spec.ts
@@ -38,7 +38,7 @@ describe("Routerlicious", () => {
                 testContext = new testUtils.TestContext();
                 testCollection = new testUtils.TestCollection([{ documentId: testId, tenantId: testTenant }]);
 
-                const checkpointManager = createDeliCheckpointManagerFromCollection(testId, testTenant, testCollection);
+                const checkpointManager = createDeliCheckpointManagerFromCollection(testTenant, testId, testCollection);
                 testCheckpointContext = new CheckpointContext(testTenant, testId, checkpointManager, testContext);
             });
 

--- a/server/routerlicious/packages/lambdas/src/test/deli/checkpointContext.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/deli/checkpointContext.spec.ts
@@ -4,7 +4,8 @@
  */
 
 import * as testUtils from "@fluidframework/server-test-utils";
-import { CheckpointContext, ICheckpointParams } from "../../deli/checkpointContext";
+import { CheckpointContext } from "../../deli/checkpointContext";
+import { createDeliCheckpointManagerFromCollection, ICheckpointParams } from "../../deli/checkpointManager";
 
 describe("Routerlicious", () => {
     describe("Deli", () => {
@@ -36,7 +37,9 @@ describe("Routerlicious", () => {
             beforeEach(() => {
                 testContext = new testUtils.TestContext();
                 testCollection = new testUtils.TestCollection([{ documentId: testId, tenantId: testTenant }]);
-                testCheckpointContext = new CheckpointContext(testTenant, testId, testCollection, testContext);
+
+                const checkpointManager = createDeliCheckpointManagerFromCollection(testId, testTenant, testCollection);
+                testCheckpointContext = new CheckpointContext(testTenant, testId, checkpointManager, testContext);
             });
 
             describe(".checkpoint", () => {

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -9,6 +9,7 @@ import { IClient } from "@fluidframework/protocol-definitions";
 import {
     BroadcasterLambda,
     CheckpointManager,
+    createDeliCheckpointManagerFromCollection,
     DeliLambda,
     ForemanLambda,
     ScribeLambda,
@@ -268,12 +269,14 @@ export class LocalOrderer implements IOrderer {
             async (lambdaSetup, context) => {
                 const documentCollection = await lambdaSetup.documentCollectionP();
                 const lastCheckpoint = JSON.parse(this.dbObject.deli);
+                const checkpointManager =
+                    createDeliCheckpointManagerFromCollection(this.tenantId, this.documentId, documentCollection);
                 return new DeliLambda(
                     context,
                     this.tenantId,
                     this.documentId,
                     lastCheckpoint,
-                    documentCollection,
+                    checkpointManager,
                     this.deltasKafka,
                     this.rawDeltasKafka,
                     this.serviceConfiguration);


### PR DESCRIPTION
- Pass in `IDeliCheckpointerManager` rather than an `ICollection`. This is similar to what scribe does. It will make it easier for me to integrate with and help improve me telemetry now that the full object is passed instead of the stringified one.
- Fix `CheckpointContext` being able to get stuck in a retry loop even after being closed