### PR TITLE
Disabled missingGCNode telemetry until end-to-end GC is enabled

### DIFF
--- a/packages/runtime/garbage-collector/src/garbageCollector.ts
+++ b/packages/runtime/garbage-collector/src/garbageCollector.ts
@@ -40,10 +40,13 @@ export function runGarbageCollection(
         } else {
             // Log a telemetry event if there is a node missing for a referenced id. This should not happen but for now
             // we don't assert. We can monitor telemetry for a while to figure out next steps.
-            logger.sendTelemetryEvent({
-                eventName: "MissingGCNode",
-                missingNodeId: id,
-            });
+
+            // This telemetry is currently too noisy. Start sending it GC is enabled end-to-end. See here for details -
+            // https://github.com/microsoft/FluidFramework/issues/4939
+            // logger.sendTelemetryEvent({
+            //     eventName: "MissingGCNode",
+            //     missingNodeId: id,
+            // });
         }
     }
 

--- a/packages/runtime/garbage-collector/src/garbageCollector.ts
+++ b/packages/runtime/garbage-collector/src/garbageCollector.ts
@@ -41,12 +41,15 @@ export function runGarbageCollection(
             // Log a telemetry event if there is a node missing for a referenced id. This should not happen but for now
             // we don't assert. We can monitor telemetry for a while to figure out next steps.
 
-            // This telemetry is currently too noisy. Start sending it GC is enabled end-to-end. See here for details -
-            // https://github.com/microsoft/FluidFramework/issues/4939
-            // logger.sendTelemetryEvent({
-            //     eventName: "MissingGCNode",
-            //     missingNodeId: id,
-            // });
+            /**
+             * This telemetry is currently too noisy. Start sending it GC is enabled end-to-end. See here for details -
+             * https://github.com/microsoft/FluidFramework/issues/4939
+             *
+             * logger.sendTelemetryEvent({
+             *    eventName: "MissingGCNode",
+             *    missingNodeId: id,
+             * });
+            */
         }
     }
 

--- a/packages/runtime/garbage-collector/src/test/garbageCollector.spec.ts
+++ b/packages/runtime/garbage-collector/src/test/garbageCollector.spec.ts
@@ -107,7 +107,11 @@ describe("Garbage Collector", () => {
         runGCAndValidateResults(gcNodes, [ "/", "/ds2" ], deletedNodes);
     });
 
-    it("should log error when a referenced node is missing from the graph", () => {
+    /**
+     * The "missingGCNode" telemetry log is disabled for now, so this test is skipped.
+     * Enable it once the telemetry is enabled. See - https://github.com/microsoft/FluidFramework/issues/4939
+     */
+    it.skip("should log error when a referenced node is missing from the graph", () => {
         const gcNode1: IGCNode = { id: "/", outboundRoutes: [ "/ds1" ] };
         const gcNode2: IGCNode = { id: "/ds1", outboundRoutes: [ "/ds1/dds1" ] };
         const gcNode3: IGCNode = { id: "/ds2", outboundRoutes: [] };


### PR DESCRIPTION
The `missingGCNode` is currently too noisy as Fluid apps (such as Bohemia) has not completed the GC work yet. I am disabling this log for now until we enable GC end-to-end.

#4939 tracks re-enabling it.