### PR TITLE
Handle summary ack without corresponding summary op

### DIFF
--- a/packages/runtime/container-runtime/src/summaryCollection.ts
+++ b/packages/runtime/container-runtime/src/summaryCollection.ts
@@ -306,7 +306,8 @@ export class SummaryCollection {
             // from. i.e. initialSequenceNumber > summarySequenceNumber.
             // We really don't care about it for now, since it is older than
             // the one we loaded from.
-            assert(this.initialSequenceNumber > seq, "Missing summary op for ack, but summary op seq > initialSequenceNumber");
+            assert(this.initialSequenceNumber > seq,
+                "Missing summary op for ack, but summary op seq > initialSequenceNumber");
             return;
         }
         summary.ackNack(op);


### PR DESCRIPTION
The assertion was overly strict: that we should never see a summary ack without having already seen the corresponding summary op. Although its rare, there is a loophole such that a successful summary op can be created before the previous one's ack is received.

The solution is to narrow the assertion. It now considers this situation okay and takes no action (i.e. do not emit a summary ack to the Summarizer who is listening to this data structure) as long as the assumption holds: that the summary op sequence number that the ack corresponds to is less than the sequence number which this client loaded from. This means that we are assuming the summary op is simply too early to be tracked by our data structure. This is totally fine to take no action, because all use cases of these acks do not care about those earlier ones.

If the new narrower assumption is violated, it means that somehow we missed a summary op, which I think should still assert and cause an error. We _could_ download the summary from storage and check the reference sequence number to be more resilient, but I think we should fail fast for now.