### PR TITLE
fix debug import in server

### DIFF
--- a/server/auspkn/src/www.ts
+++ b/server/auspkn/src/www.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import * as debug from "debug";
+import { debug } from "debug";
 import * as http from "http";
 import * as nconf from "nconf";
 import * as path from "path";

--- a/server/gitrest/src/www.ts
+++ b/server/gitrest/src/www.ts
@@ -5,7 +5,7 @@
 
 import * as http from "http";
 import * as path from "path";
-import * as debug from "debug";
+import { debug } from "debug";
 import nconf from "nconf";
 import * as winston from "winston";
 import * as app from "./app";

--- a/server/headless-agent/src/puppeteer/cliLogger.ts
+++ b/server/headless-agent/src/puppeteer/cliLogger.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import * as debug from "debug";
+import { debug } from "debug";
 import * as winston from "winston";
 
 export interface IWinstonConfig {

--- a/server/historian/packages/historian-base/src/logger.ts
+++ b/server/historian/packages/historian-base/src/logger.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import * as debug from "debug";
+import { debug } from "debug";
 import * as winston from "winston";
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import Transport = require("winston-transport");

--- a/server/routerlicious/packages/services-utils/src/logger.ts
+++ b/server/routerlicious/packages/services-utils/src/logger.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import * as debug from "debug";
+import { debug } from "debug";
 import * as winston from "winston";
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import Transport = require("winston-transport");


### PR DESCRIPTION
After upgrade to TS 4.1.3 (#4930), running the server results in the following error.
```
alfred_1       | error: uncaughtException: Cannot set property log of #<Object> which has only a getter
alfred_1       | TypeError: Cannot set property log of #<Object> which has only a getter
alfred_1       |     at Object.configureLogging (/usr/src/server/packages/services-utils/dist/logger.js:61:15)
```
Curtis was able to find that `import * as debug from "debug"` was the problem, and was likely not working as expected before this fix (replacing with `import { debug } from "debug"`).