### PR TITLE
Make the service load test tool easier to use

### DIFF
--- a/packages/test/service-load-test/README.md
+++ b/packages/test/service-load-test/README.md
@@ -54,6 +54,10 @@ Specifies which test profile to use from [testConfig.json](./testConfig.json). D
 If present, launch in Test Runner mode with the given runId (to distinguish from other concurrent test runners).
 `--url` is required, since the test runner needs to know which data store to connect to.
 
+#### --driveId, -di
+
+If present, the test will use this driveId instead of the one specified in the test config file. This is used internally when in orchestrator mode.
+
 #### --debug, -d
 
 Launches each test runner with `--inspect-brk` and a unique Node debugging port. (Not compatible with `--runId`)

--- a/packages/test/service-load-test/README.md
+++ b/packages/test/service-load-test/README.md
@@ -56,7 +56,7 @@ If present, launch in Test Runner mode with the given runId (to distinguish from
 
 #### --driveId, -di
 
-If present, the test will use this driveId instead of the one specified in the test config file. This is used internally when in orchestrator mode.
+If present, the test will use this driveId instead automatically determining it. This is used internally when in orchestrator mode.
 
 #### --debug, -d
 

--- a/packages/test/service-load-test/package.json
+++ b/packages/test/service-load-test/package.json
@@ -55,8 +55,8 @@
     "@fluidframework/container-definitions": "^0.34.0",
     "@fluidframework/container-loader": "^0.34.0",
     "@fluidframework/core-interfaces": "^0.34.0",
-    "@fluidframework/odsp-driver": "^0.34.0",
     "@fluidframework/odsp-doclib-utils": "^0.34.0",
+    "@fluidframework/odsp-driver": "^0.34.0",
     "@fluidframework/test-utils": "^0.34.0",
     "@fluidframework/tool-utils": "^0.34.0",
     "commander": "^5.1.0"

--- a/packages/test/service-load-test/package.json
+++ b/packages/test/service-load-test/package.json
@@ -56,6 +56,7 @@
     "@fluidframework/container-loader": "^0.34.0",
     "@fluidframework/core-interfaces": "^0.34.0",
     "@fluidframework/odsp-driver": "^0.34.0",
+    "@fluidframework/odsp-doclib-utils": "^0.34.0",
     "@fluidframework/test-utils": "^0.34.0",
     "@fluidframework/tool-utils": "^0.34.0",
     "commander": "^5.1.0"

--- a/packages/test/service-load-test/testConfig.json
+++ b/packages/test/service-load-test/testConfig.json
@@ -1,7 +1,6 @@
 {
-    "server": "a830edad9050849829E20060408.sharepoint.com",
-    "driveId": "b!o96WcQ93ck-dT5tlJfA7yZNP3Z9aM69JjJI6U4ASSXmZLLDGFcMBSqJ3iB3y04h0",
-    "username": "user0@a830edad9050849829E20060408.onmicrosoft.com",
+    "server": "a830edad9050849830E21012616-my.sharepoint.com",
+    "username": "user0@a830edad9050849830E21012616.onmicrosoft.com",
     "profiles": {
         "full": {
             "opRatePerMin": 30,


### PR DESCRIPTION
- Automatically determine the drive id when it's not specified in the config file.
- When failing to get ODSP tokens, display the login url. The user likely needs to give consent to the test app.
- Update test config with latest test tenants.