### PR TITLE
Log error for summary ack without op rather than assert

### DIFF
--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -637,7 +637,9 @@ export class Summarizer extends EventEmitter implements ISummarizer {
             this.immediateSummary = true;
             this.summaryCollection = summaryCollection;
         } else {
-            this.summaryCollection = new SummaryCollection(this.runtime.deltaManager.initialSequenceNumber);
+            this.summaryCollection = new SummaryCollection(
+                this.runtime.deltaManager.initialSequenceNumber,
+                this.logger);
         }
         this.runtime.deltaManager.inbound.on("op",
             (op) => this.summaryCollection.handleOp(op));

--- a/packages/runtime/container-runtime/src/summaryCollection.ts
+++ b/packages/runtime/container-runtime/src/summaryCollection.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IDisposable } from "@fluidframework/common-definitions";
+import { IDisposable, ITelemetryLogger } from "@fluidframework/common-definitions";
 import { Deferred, assert } from "@fluidframework/common-utils";
 import {
     ISequencedDocumentMessage,
@@ -205,7 +205,10 @@ export class SummaryCollection {
 
     public get latestAck() { return this.lastAck; }
 
-    public constructor(public readonly initialSequenceNumber: number) { }
+    public constructor(
+        public readonly initialSequenceNumber: number,
+        private readonly logger: ITelemetryLogger,
+    ) { }
 
     /**
      * Creates and returns a summary watcher for a specific client.
@@ -296,8 +299,7 @@ export class SummaryCollection {
 
     private handleSummaryAck(op: ISummaryAckMessage) {
         const seq = op.contents.summaryProposal.summarySequenceNumber;
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const summary = this.pendingSummaries.get(seq)!;
+        const summary = this.pendingSummaries.get(seq);
         if (!summary) {
             // Summary ack without an op should be rare. We could fetch the
             // reference sequence number from the snapshot, but instead we
@@ -306,8 +308,17 @@ export class SummaryCollection {
             // from. i.e. initialSequenceNumber > summarySequenceNumber.
             // We really don't care about it for now, since it is older than
             // the one we loaded from.
-            assert(this.initialSequenceNumber > seq,
-                "Missing summary op for ack, but summary op seq > initialSequenceNumber");
+            if (seq >= this.initialSequenceNumber) {
+                // Potential causes for it to be later than our initialSequenceNumber
+                // are that the summaryOp was nacked then acked, double-acked, or
+                // the summarySequenceNumber is incorrect.
+                this.logger.sendErrorEvent({
+                    eventName: "SummaryAckWithoutOp",
+                    sequenceNumber: op.sequenceNumber, // summary ack seq #
+                    summarySequenceNumber: seq, // missing summary seq #
+                    initialSequenceNumber: this.initialSequenceNumber,
+                });
+            }
             return;
         }
         summary.ackNack(op);

--- a/packages/runtime/container-runtime/src/test/summarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizer.spec.ts
@@ -95,7 +95,7 @@ describe("Runtime", () => {
                     runCount = 0;
                     lastRefSeq = 0;
                     mockLogger = new MockLogger();
-                    summaryCollection = new SummaryCollection(0);
+                    summaryCollection = new SummaryCollection(0, mockLogger);
                     summarizer = await RunningSummarizer.start(
                         summarizerClientId,
                         onBehalfOfClientId,


### PR DESCRIPTION
This was caused by summaryOp which was both nacked and acked in that order. So the pending state resolved with the nack, causing the ack to think it is missing the summaryOp.

This change should also prevent the assertion from firing when a summaryOp is double-acked, or if the summarySequenceNumber is incorrect. Instead it will just log an error to telemetry under the Summarizer: scope.

Regular clients shouldn't be negatively affected by missing summary acks like this.
Summarizer clients will not realize that the summary is acked, but should recover during "safe" summary fallback after their next attempt is nacked.