### PR TITLE
Cleanup throttling logs

### DIFF
--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -53,7 +53,7 @@ function getRoomId(room: IRoom) {
 
 const getSocketConnectThrottleId = (tenantId: string) => `${tenantId}_OpenSocketConn`;
 
-const getSubmitOpThrottleId = (clientId: string) => `${clientId}_SubmitOp`;
+const getSubmitOpThrottleId = (tenantId: string, clientId: string) => `${clientId}_${tenantId}_SubmitOp`;
 
 // Sanitize the received op before sending.
 function sanitizeMessage(message: any): IDocumentMessage {
@@ -109,29 +109,20 @@ function checkThrottle(
         return;
     }
 
-    const messageMetaData = {
-        key: throttleId,
-        weight: 1,
-        eventName: "throttling",
-    };
-
     try {
-        logger?.info(`Incrementing throttle count: ${throttleId}`, { messageMetaData });
         throttler.incrementCount(throttleId);
     } catch (e) {
         if (e instanceof core.ThrottlingError) {
-            logger?.info(`Throttled: ${throttleId}`, {
-                messageMetaData: {
-                    ...messageMetaData,
-                    reason: e.message,
-                    retryAfterInSeconds: e.retryAfter,
-                },
-            });
             return e;
         } else {
             logger?.error(
                 `Throttle increment failed: ${safeStringify(e, undefined, 2)}`,
-                { messageMetaData });
+                {
+                    messageMetaData: {
+                        key: throttleId,
+                        eventName: "throttling",
+                    },
+                });
         }
     }
 }
@@ -378,20 +369,6 @@ export function configureWebSocketServices(
         socket.on(
             "submitOp",
             (clientId: string, messageBatches: (IDocumentMessage | IDocumentMessage[])[]) => {
-                const throttleError = checkThrottle(
-                    submitOpThrottler,
-                    getSubmitOpThrottleId(clientId),
-                    logger);
-                if (throttleError) {
-                    const nackMessage = createNackMessage(
-                        throttleError.code,
-                        NackErrorType.ThrottlingError,
-                        throttleError.message,
-                        throttleError.retryAfter);
-                    socket.emit("nack", "", [nackMessage]);
-                    return;
-                }
-
                 // Verify the user has an orderer connection.
                 if (!connectionsMap.has(clientId)) {
                     let nackMessage: INack;
@@ -407,6 +384,20 @@ export function configureWebSocketServices(
                     socket.emit("nack", "", [nackMessage]);
                 } else {
                     const connection = connectionsMap.get(clientId);
+
+                    const throttleError = checkThrottle(
+                        submitOpThrottler,
+                        getSubmitOpThrottleId(connection.tenantId, clientId),
+                        logger);
+                    if (throttleError) {
+                        const nackMessage = createNackMessage(
+                            throttleError.code,
+                            NackErrorType.ThrottlingError,
+                            throttleError.message,
+                            throttleError.retryAfter);
+                        socket.emit("nack", "", [nackMessage]);
+                        return;
+                    }
 
                     messageBatches.forEach((messageBatch) => {
                         const messages = Array.isArray(messageBatch) ? messageBatch : [messageBatch];

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -53,7 +53,7 @@ function getRoomId(room: IRoom) {
 
 const getSocketConnectThrottleId = (tenantId: string) => `${tenantId}_OpenSocketConn`;
 
-const getSubmitOpThrottleId = (tenantId: string, clientId: string) => `${clientId}_${tenantId}_SubmitOp`;
+const getSubmitOpThrottleId = (clientId: string, tenantId: string) => `${clientId}_${tenantId}_SubmitOp`;
 
 // Sanitize the received op before sending.
 function sanitizeMessage(message: any): IDocumentMessage {
@@ -387,7 +387,7 @@ export function configureWebSocketServices(
 
                     const throttleError = checkThrottle(
                         submitOpThrottler,
-                        getSubmitOpThrottleId(connection.tenantId, clientId),
+                        getSubmitOpThrottleId(clientId, connection.tenantId),
                         logger);
                     if (throttleError) {
                         const nackMessage = createNackMessage(

--- a/server/routerlicious/packages/services-utils/src/throttlerMiddleware.ts
+++ b/server/routerlicious/packages/services-utils/src/throttlerMiddleware.ts
@@ -72,25 +72,21 @@ export function throttle(
 
         return (req, res, next) => {
             const throttleId = getThrottleId(req, throttleOptions);
-            const messageMetaData = {
-                key: throttleId,
-                weight: throttleOptions.weight,
-                eventName: "throttling",
-            };
 
-            logger?.info(`Incrementing throttle count: ${throttleId}`, { messageMetaData });
             try {
                 throttler.incrementCount(throttleId, throttleOptions.weight);
             } catch (e) {
                 if (e instanceof ThrottlingError) {
-                    logger?.info(`Throttled: ${throttleId}`, { messageMetaData: {
-                        ...messageMetaData,
-                        reason: e.message,
-                        retryAfterInSeconds: e.retryAfter,
-                    } });
                     return res.status(e.code).json(e);
                 } else {
-                    logger?.error(`Throttle increment failed: ${safeStringify(e, undefined, 2)}`, { messageMetaData });
+                    logger?.error(
+                        `Throttle increment failed: ${safeStringify(e, undefined, 2)}`,
+                        {
+                            messageMetaData: {
+                                key: throttleId,
+                                eventName: "throttling",
+                            },
+                        });
                 }
             }
 


### PR DESCRIPTION
1. Currently the throttling logs are a bit noisy (specifically the "Incrementing count" log that happens on every request and submitOp). This changes that log to be once every `minThrottleCheckInterval` with a cumulative throttle count for that duration.
2. submitOp throttling key in Alfred socket throttling will include tenantId for easier log data correlation.
3. submitOp only increments throttle count if socket actually has a throttle connection. This is pretty insignificant, but worth calling out as it makes throttling more accurate and predictable when using strict limits for testing purposes.