### PR TITLE
Allow lambdas to extend the document partition activity timeout

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -66,7 +66,7 @@ export class DocumentPartition {
         });
 
         // Create the lambda to handle the document messages
-        this.lambdaP = factory.create(documentConfig, context);
+        this.lambdaP = factory.create(documentConfig, context, this.updateActivityTime.bind(this));
         this.lambdaP.then(
             (lambda) => {
                 this.lambda = lambda;

--- a/server/routerlicious/packages/services-core/src/lambdas.ts
+++ b/server/routerlicious/packages/services-core/src/lambdas.ts
@@ -53,7 +53,7 @@ export interface IPartitionLambdaFactory extends EventEmitter {
     /**
      * Constructs a new lambda
      */
-    create(config: nconf.Provider, context: IContext): Promise<IPartitionLambda>;
+    create(config: nconf.Provider, context: IContext, updateActivityTime?: () => void): Promise<IPartitionLambda>;
 
     /**
      * Disposes of the lambda factory


### PR DESCRIPTION
Pass the `updateActivityTime` method into the partition lambda factory. This will allow lambdas to stay active when not receiving messages past the activity timeout threshold. 