### PR TITLE
Bump Node.js image to 12.20.1

### DIFF
--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-FROM node:12.19-stretch AS base
+FROM node:12.20.1-stretch AS base
 
 # Add Tini
 ENV TINI_VERSION v0.18.0

--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-FROM node:12.19-slim AS base
+FROM node:12.20.1-slim AS base
 
 # node-gyp dependencies
 RUN apt-get update && apt-get install -y \

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-FROM node:12.19-slim AS base
+FROM node:12.20.1-slim AS base
 
 # node-gyp dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
[Node.js Security Release](https://nodejs.org/en/blog/vulnerability/january-2021-security-releases/)