### PR TITLE
Pass along the reason a lambda is being closed

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
@@ -10,6 +10,7 @@ import {
     IPartitionLambda,
     IPartitionLambdaFactory,
     ILogger,
+    LambdaCloseType,
 } from "@fluidframework/server-services-core";
 import { AsyncQueue, queue } from "async";
 import * as _ from "lodash";
@@ -81,7 +82,7 @@ export class Partition extends EventEmitter {
         this.q.push(rawMessage);
     }
 
-    public close(): void {
+    public close(closeType: LambdaCloseType): void {
         // Stop any pending message processing
         this.q.kill();
 
@@ -92,7 +93,7 @@ export class Partition extends EventEmitter {
         // Notify the lambda (should it be resolved) of the close
         this.lambdaP.then(
             (lambda) => {
-                lambda.close();
+                lambda.close(closeType);
             },
             (error) => {
                 // Lambda never existed - no need to close

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
@@ -11,6 +11,7 @@ import {
     IPartitionWithEpoch,
     IPartitionLambdaFactory,
     ILogger,
+    LambdaCloseType,
 } from "@fluidframework/server-services-core";
 import { Provider } from "nconf";
 import { Partition } from "./partition";
@@ -61,7 +62,7 @@ export class PartitionManager extends EventEmitter {
 
         // Then stop them all
         for (const [, partition] of this.partitions) {
-            partition.close();
+            partition.close(LambdaCloseType.Stop);
         }
 
         this.partitions.clear();
@@ -97,7 +98,7 @@ export class PartitionManager extends EventEmitter {
 
         for (const [id, partition] of this.partitions) {
             this.logger?.info(`Closing partition ${id} due to rebalancing`);
-            partition.close();
+            partition.close(LambdaCloseType.Rebalance);
         }
 
         this.partitions.clear();
@@ -118,7 +119,7 @@ export class PartitionManager extends EventEmitter {
         for (const [id, partition] of existingPartitions) {
             if (!partitionsMap.has(id)) {
                 this.logger?.info(`Closing partition ${id} due to rebalancing`);
-                partition.close();
+                partition.close(LambdaCloseType.Rebalance);
                 this.partitions.delete(id);
             }
         }

--- a/server/routerlicious/packages/lambdas-driver/src/test/document-router/documentLambda.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/document-router/documentLambda.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IPartitionLambda, IPartitionLambdaFactory } from "@fluidframework/server-services-core";
+import { IPartitionLambda, IPartitionLambdaFactory, LambdaCloseType } from "@fluidframework/server-services-core";
 import {
     KafkaMessageFactory,
     MessageFactory,
@@ -39,7 +39,7 @@ describe("document-router", () => {
         });
 
         afterEach(async () => {
-            await lambda.close();
+            await lambda.close(LambdaCloseType.Stop);
             await factory.dispose();
         });
 

--- a/server/routerlicious/packages/lambdas-driver/src/test/document-router/index.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/document-router/index.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IPartitionLambdaFactory } from "@fluidframework/server-services-core";
+import { IPartitionLambdaFactory, LambdaCloseType } from "@fluidframework/server-services-core";
 import { TestContext } from "@fluidframework/server-test-utils";
 import { strict as assert } from "assert";
 import nconf from "nconf";
@@ -25,7 +25,7 @@ describe("document-router", () => {
         });
 
         afterEach(async () => {
-           await factory.dispose();
+            await factory.dispose();
         });
 
         describe(".create", () => {
@@ -33,7 +33,7 @@ describe("document-router", () => {
                 const context = new TestContext();
                 const lambda = await factory.create(config, context);
                 assert.ok(lambda);
-                lambda.close();
+                lambda.close(LambdaCloseType.Stop);
             });
         });
     });

--- a/server/routerlicious/packages/lambdas-driver/src/test/document-router/lambdaFactory.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/document-router/lambdaFactory.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IPartitionLambdaFactory } from "@fluidframework/server-services-core";
+import { IPartitionLambdaFactory, LambdaCloseType } from "@fluidframework/server-services-core";
 import { TestContext } from "@fluidframework/server-test-utils";
 import { strict as assert } from "assert";
 import { Provider } from "nconf";
@@ -28,7 +28,7 @@ describe("document-router", () => {
             it("Should create a new IPartitionLambda", async () => {
                 const lambda = await factory.create(config, testContext);
                 assert.ok(lambda);
-                lambda.close();
+                lambda.close(LambdaCloseType.Stop);
             });
         });
 

--- a/server/routerlicious/packages/lambdas-driver/src/test/kafka-service/partition.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/kafka-service/partition.spec.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { LambdaCloseType } from "@fluidframework/server-services-core";
 import { KafkaMessageFactory, TestConsumer, TestKafka } from "@fluidframework/server-test-utils";
 import { strict as assert } from "assert";
 import { Provider } from "nconf";
@@ -52,7 +53,7 @@ describe("kafka-service", () => {
             it("Should stop message processing", async () => {
                 const testPartition = new Partition(0, 0, testFactory, testConsumer, testConfig);
                 await testPartition.drain();
-                testPartition.close();
+                testPartition.close(LambdaCloseType.Stop);
             });
 
             it("Should process all pending messages prior to stopping", async () => {
@@ -62,7 +63,7 @@ describe("kafka-service", () => {
                     testPartition.process(kafkaMessageFactory.sequenceMessage({}, "test"));
                 }
                 await testPartition.drain();
-                testPartition.close();
+                testPartition.close(LambdaCloseType.Stop);
 
                 assert.equal(messageCount, testFactory.handleCount);
             });

--- a/server/routerlicious/packages/lambdas/src/test/deli/lambda.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/deli/lambda.spec.ts
@@ -9,6 +9,7 @@ import {
     IPartitionLambda,
     IProducer,
     ISequencedOperationMessage,
+    LambdaCloseType,
     MongoManager,
     NackOperationType,
     SequencedOperationType,
@@ -96,7 +97,7 @@ describe("Routerlicious", () => {
             });
 
             afterEach(async () => {
-                lambda.close();
+                lambda.close(LambdaCloseType.Stop);
                 await factory.dispose();
             });
 

--- a/server/routerlicious/packages/memory-orderer/src/localLambdaController.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localLambdaController.ts
@@ -4,7 +4,7 @@
  */
 
 import { EventEmitter } from "events";
-import { IContext, IQueuedMessage, IPartitionLambda } from "@fluidframework/server-services-core";
+import { IContext, IQueuedMessage, IPartitionLambda, LambdaCloseType } from "@fluidframework/server-services-core";
 import { IKafkaSubscriber, ILocalOrdererSetup } from "./interfaces";
 import { LocalKafka } from "./localKafka";
 
@@ -63,7 +63,7 @@ export class LocalLambdaController extends EventEmitter implements IKafkaSubscri
         this._state = "closed";
 
         if (this.lambda) {
-            this.lambda.close();
+            this.lambda.close(LambdaCloseType.Stop);
             this.lambda = undefined;
         }
 

--- a/server/routerlicious/packages/services-core/src/combinedLambda.ts
+++ b/server/routerlicious/packages/services-core/src/combinedLambda.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IPartitionLambda } from "./lambdas";
+import { IPartitionLambda, LambdaCloseType } from "./lambdas";
 import { IQueuedMessage } from "./queue";
 
 /**
@@ -26,9 +26,9 @@ export class CombinedLambda implements IPartitionLambda {
 	 * Closes the lambda. After being called handler will no longer be invoked and the lambda is expected to cancel
 	 * any deferred work.
 	 */
-	public close(): void {
+	public close(closeType: LambdaCloseType): void {
 		for (const lambda of this.lambdas) {
-			lambda.close();
+			lambda.close(closeType);
 		}
 	}
 }

--- a/server/routerlicious/packages/services-core/src/lambdas.ts
+++ b/server/routerlicious/packages/services-core/src/lambdas.ts
@@ -9,6 +9,16 @@ import nconf from "nconf";
 import { BoxcarType, IBoxcarMessage, IMessage } from "./messages";
 import { IQueuedMessage } from "./queue";
 
+/**
+ * Reasons why a lambda is closing
+ */
+export enum LambdaCloseType {
+    Stop,
+    ActivityTimeout,
+    Rebalance,
+    Error,
+}
+
 export interface ILogger {
     info(message: string, metaData?: any): void;
     warn(message: string, metaData?: any): void;
@@ -43,7 +53,7 @@ export interface IPartitionLambda {
      * Closes the lambda. After being called handler will no longer be invoked and the lambda is expected to cancel
      * any deferred work.
      */
-    close(): void;
+    close(closeType: LambdaCloseType): void;
 }
 
 /**


### PR DESCRIPTION
I want to be able to log why a lambda is being closed. So add a new `LambdaCloseType` and pass it along to the lambda close method.