### PR TITLE
Fix build break problems

### DIFF
--- a/experimental/framework/data-objects/src/kvpair/index.ts
+++ b/experimental/framework/data-objects/src/kvpair/index.ts
@@ -3,6 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export * from "./containerCode";
 export * from "./DataObject";
-export * from "./FluidStatic";

--- a/packages/drivers/routerlicious-urlResolver/src/urlResolver.ts
+++ b/packages/drivers/routerlicious-urlResolver/src/urlResolver.ts
@@ -134,7 +134,8 @@ export class RouterliciousUrlResolver implements IUrlResolver {
         const fluidResolvedUrl = resolvedUrl as IFluidResolvedUrl;
 
         const parsedUrl = parse(fluidResolvedUrl.url);
-        const [, tenantId, documentId] = parsedUrl.pathname?.split("/");
+        assert(!!parsedUrl.pathname, "PathName should exist");
+        const [, tenantId, documentId] = parsedUrl.pathname.split("/");
         assert(!!tenantId, "Tenant id should exist");
         assert(!!documentId, "Document id should exist");
 

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -31,8 +31,8 @@ trigger:
   paths:
     include:
     - packages
-    - components
     - examples
+    - experimental
     - package.json
     - package-lock.json
     - lerna.json
@@ -54,8 +54,8 @@ pr:
   paths:
     include:
     - packages
-    - components
     - examples
+    - experimental
     - package.json
     - package-lock.json
     - lerna.json


### PR DESCRIPTION
1.) R11s Url Resolver: Add assert on pathname so splitting it should work just fine.
2.) Add experimental to CI loop.
3.) Remove extraneous export from data-objects/src/kvpair/index.ts