### PR TITLE
remove prague based image services

### DIFF
--- a/server/routerlicious/docker-compose.yml
+++ b/server/routerlicious/docker-compose.yml
@@ -1,14 +1,5 @@
 version: '3.4'
 services:
-    gateway:
-        image: prague.azurecr.io/gateway:latest
-        ports:
-            - "3000:3000"
-        command: node dist/www.js
-        environment:
-            - DEBUG=fluid:*
-            - NODE_ENV=development
-        restart: always
     alfred:
         build:
             context: .
@@ -121,19 +112,6 @@ services:
         image: "mongo:3.4.3"
     rabbitmq:
         image: "rabbitmq:alpine"
-    auspkn:
-        image: prague.azurecr.io/auspkn:4149
-        command: node dist/www.js
-        ports:
-            - "3002:3000"
-        environment:
-            - npm__url=http://verdaccio:4873
-    verdaccio:
-        image: verdaccio/verdaccio:3.8.1
-        ports:
-            - "4873:4873"
-        volumes:
-            - ./verdaccio/conf:/verdaccio/conf
 volumes:
   git:
     driver: local


### PR DESCRIPTION
This PR removes the Prague based image services from the Routerlicious docker-compose file. Previously, they would cause the docker-compose steps to fail since users outside of Microsoft don't have access to the Prague images. However, as I have been told, these services are no longer needed since client packages can access the docker images through webpack-dev-server.

The services removed include:

1. gateway
2. auspkn
3. verdaccio 