### PR TITLE
Improve lamdba context error handling

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -5,7 +5,7 @@
 
 import assert from "assert";
 import { EventEmitter } from "events";
-import { IContext, IQueuedMessage } from "@fluidframework/server-services-core";
+import { IContext, IContextErrorData, IQueuedMessage } from "@fluidframework/server-services-core";
 import { DocumentContext } from "./documentContext";
 
 const LastCheckpointedOffset: IQueuedMessage = {
@@ -44,7 +44,7 @@ export class DocumentContextManager extends EventEmitter {
         const context = new DocumentContext(head, () => this.tail);
         this.contexts.push(context);
         context.addListener("checkpoint", () => this.updateCheckpoint());
-        context.addListener("error", (error, restart) => this.emit("error", error, restart));
+        context.addListener("error", (error, errorData: IContextErrorData) => this.emit("error", error, errorData));
         return context;
     }
 

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -5,7 +5,7 @@
 
 import assert from "assert";
 import { EventEmitter } from "events";
-import { IContext, IQueuedMessage, ILogger } from "@fluidframework/server-services-core";
+import { IContext, IQueuedMessage, ILogger, IContextErrorData } from "@fluidframework/server-services-core";
 import * as winston from "winston";
 
 export class DocumentContext extends EventEmitter implements IContext {
@@ -72,8 +72,8 @@ export class DocumentContext extends EventEmitter implements IContext {
         this.emit("checkpoint", this);
     }
 
-    public error(error: any, restart: boolean) {
-        this.emit("error", error, restart);
+    public error(error: any, errorData: IContextErrorData) {
+        this.emit("error", error, errorData);
     }
 
     public get log(): ILogger {

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentLambda.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentLambda.ts
@@ -10,6 +10,7 @@ import {
     IPartitionLambda,
     IPartitionLambdaFactory,
     LambdaCloseType,
+    IContextErrorData,
 } from "@fluidframework/server-services-core";
 import { Provider } from "nconf";
 import { DocumentContextManager } from "./contextManager";
@@ -34,8 +35,8 @@ export class DocumentLambda implements IPartitionLambda {
         private readonly partitionActivityTimeout = PartitionActivityTimeout,
         partitionActivityCheckInterval = PartitionActivityCheckInterval) {
         this.contextManager = new DocumentContextManager(context);
-        this.contextManager.on("error", (error, restart) => {
-            context.error(error, restart);
+        this.contextManager.on("error", (error, errorData: IContextErrorData) => {
+            context.error(error, errorData);
         });
         this.activityCheckTimer = setInterval(this.inactivityCheck.bind(this), partitionActivityCheckInterval);
     }

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts
@@ -4,7 +4,7 @@
  */
 
 import { EventEmitter } from "events";
-import { IContext, IQueuedMessage, ILogger } from "@fluidframework/server-services-core";
+import { IContext, IQueuedMessage, ILogger, IContextErrorData } from "@fluidframework/server-services-core";
 import * as winston from "winston";
 import { CheckpointManager } from "./checkpointManager";
 
@@ -26,16 +26,17 @@ export class Context extends EventEmitter implements IContext {
         this.checkpointManager.checkpoint(queuedMessage).catch((error) => {
             // Close context on error. Once the checkpointManager enters an error state it will stay there.
             // We will look to restart on checkpointing given it likely indicates a Kafka connection issue.
-            this.emit("error", error, true);
+            this.error(error, { restart: true });
         });
     }
 
     /**
-     * Closes the context with an error. The restart flag indicates whether the error is recoverable and the lambda
-     * should be restarted.
+     * Closes the context with an error.
+     * @param error The error object or string
+     * @param errorData Additional information about the error
      */
-    public error(error: any, restart: boolean) {
-        this.emit("error", error, restart);
+    public error(error: any, errorData: IContextErrorData) {
+        this.emit("error", error, errorData);
     }
 
     public get log(): ILogger {

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
@@ -12,6 +12,7 @@ import {
     IPartitionLambdaFactory,
     ILogger,
     LambdaCloseType,
+    IContextErrorData,
 } from "@fluidframework/server-services-core";
 import { Provider } from "nconf";
 import { Partition } from "./partition";
@@ -144,11 +145,12 @@ export class PartitionManager extends EventEmitter {
                 this.logger);
 
             // Listen for error events to know when the partition has stopped processing due to an error
-            newPartition.on("error", (error, restart) => {
+            newPartition.on("error", (error, errorData: IContextErrorData) => {
                 // For simplicity we will close the entire manager whenever any partition errors. In the case that the
                 // restart flag is false and there was an error we will eventually need a way to signify that a
                 // partition is 'poisoned'.
-                this.emit("error", error, true);
+                errorData.restart = true;
+                this.emit("error", error, errorData);
             });
 
             this.partitions.set(partition.partition, newPartition);

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -4,7 +4,7 @@
  */
 
 import { Deferred } from "@fluidframework/common-utils";
-import { IConsumer, IPartitionLambdaFactory } from "@fluidframework/server-services-core";
+import { IConsumer, IContextErrorData, IPartitionLambdaFactory } from "@fluidframework/server-services-core";
 import { IRunner } from "@fluidframework/server-services-utils";
 import { Provider } from "nconf";
 import * as winston from "winston";
@@ -33,7 +33,7 @@ export class KafkaRunner implements IRunner {
         });
 
         this.partitionManager = new PartitionManager(this.factory, this.consumer, this.config, winston);
-        this.partitionManager.on("error", (error, restart) => {
+        this.partitionManager.on("error", (error, errorData: IContextErrorData) => {
             this.deferred.reject(error);
         });
 

--- a/server/routerlicious/packages/lambdas-driver/src/test/document-router/contextManager.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/document-router/contextManager.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IContext, IQueuedMessage, ILogger } from "@fluidframework/server-services-core";
+import { IContext, IQueuedMessage, ILogger, IContextErrorData } from "@fluidframework/server-services-core";
 import { TestKafka, DebugLogger } from "@fluidframework/server-test-utils";
 import { strict as assert } from "assert";
 import { DocumentContextManager } from "../../document-router/contextManager";
@@ -16,7 +16,7 @@ class TestContext implements IContext {
         this.offset = queuedMessage.offset;
     }
 
-    public error(error: any, restart: boolean) {
+    public error(error: any, errorData: IContextErrorData) {
         throw new Error("Method not implemented.");
     }
 
@@ -177,13 +177,13 @@ describe("document-router", () => {
                 testContextManager.setTail(offset0);
 
                 return new Promise<void>((resolve, reject) => {
-                    testContextManager.on("error", (error, restart) => {
+                    testContextManager.on("error", (error, errorData: IContextErrorData) => {
                         assert.ok(error);
-                        assert.ok(restart);
+                        assert.ok(errorData.restart);
                         resolve();
                     });
 
-                    context.error("Test Error", true);
+                    context.error("Test Error", { restart: true });
                 });
             });
         });

--- a/server/routerlicious/packages/lambdas-driver/src/test/document-router/documentContext.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/document-router/documentContext.spec.ts
@@ -6,6 +6,7 @@
 import { strict as assert } from "assert";
 import { DocumentContext } from "../../document-router/documentContext";
 import { TestKafka } from "@fluidframework/server-test-utils";
+import { IContextErrorData } from "@fluidframework/server-services-core";
 
 function validateException(fn: () => void) {
     try {
@@ -80,13 +81,13 @@ describe("document-router", () => {
         describe(".error", () => {
             it("Should be able to update the head offset of the manager", async () => {
                 return new Promise<void>((resolve, reject) => {
-                    testContext.on("error", (error, restart) => {
+                    testContext.on("error", (error, errorData: IContextErrorData) => {
                         assert.ok(error);
-                        assert.equal(restart, true);
+                        assert.equal(errorData.restart, true);
                         resolve();
                     });
 
-                    testContext.error("Test error", true);
+                    testContext.error("Test error", { restart: true });
                 });
             });
         });

--- a/server/routerlicious/packages/lambdas-driver/src/test/document-router/documentLambda.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/document-router/documentLambda.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IPartitionLambda, IPartitionLambdaFactory, LambdaCloseType } from "@fluidframework/server-services-core";
+import { IContextErrorData, IPartitionLambda, IPartitionLambdaFactory, LambdaCloseType } from "@fluidframework/server-services-core";
 import {
     KafkaMessageFactory,
     MessageFactory,
@@ -106,9 +106,9 @@ describe("document-router", () => {
 
                 // And trigger a new message that will fail
                 return new Promise<void>((resolve, reject) => {
-                    context.on("error", (error, restart) => {
+                    context.on("error", (error, errorData: IContextErrorData) => {
                         assert.ok(error);
-                        assert.ok(restart);
+                        assert.ok(errorData.restart);
                         resolve();
                     });
 
@@ -153,9 +153,9 @@ describe("document-router", () => {
                 return new Promise<void>((resolve, reject) => {
                     testModule.factories[0].setFailCreateLambda(true);
 
-                    context.on("error", (error, restart) => {
+                    context.on("error", (error, errorData: IContextErrorData) => {
                         assert.ok(error);
-                        assert.ok(restart);
+                        assert.ok(errorData.restart);
                         resolve();
                     });
 

--- a/server/routerlicious/packages/lambdas-driver/src/test/document-router/testDocumentLambda.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/document-router/testDocumentLambda.ts
@@ -32,7 +32,7 @@ export class TestLambda implements IPartitionLambda {
         assert.equal(this.documentId, sequencedMessage.documentId);
 
         if (this.failHandler) {
-            this.context.error("Test failure", true);
+            this.context.error("Test failure", { restart: true });
         } else if (this.throwHandler) {
             throw new Error("Test Error");
         } else {

--- a/server/routerlicious/packages/lambdas-driver/src/test/kafka-service/context.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/kafka-service/context.spec.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { IContextErrorData } from "@fluidframework/server-services-core";
 import { TestConsumer, TestKafka } from "@fluidframework/server-test-utils";
 import { strict as assert } from "assert";
 import { CheckpointManager } from "../../kafka-service/checkpointManager";
@@ -34,11 +35,11 @@ describe("kafka-service", () => {
                 const testError = null;
                 const testRestart = true;
 
-                const errorP = testContext.addListener("error", (error, restart) => {
+                const errorP = testContext.addListener("error", (error, errorData: IContextErrorData) => {
                     assert.equal(error, testError);
-                    assert.equal(restart, testRestart);
+                    assert.equal(errorData.restart, testRestart);
                 });
-                testContext.error(testError, testRestart);
+                testContext.error(testError, { restart: testRestart });
 
                 await errorP;
             });

--- a/server/routerlicious/packages/lambdas-driver/src/test/kafka-service/partitionManager.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/kafka-service/partitionManager.spec.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { IContextErrorData } from "@fluidframework/server-services-core";
 import { KafkaMessageFactory, TestConsumer, TestKafka } from "@fluidframework/server-test-utils";
 import { strict as assert } from "assert";
 import { Provider } from "nconf";
@@ -45,9 +46,9 @@ describe("kafka-service", () => {
                 testConsumer.rebalance();
 
                 const errorP = new Promise<void>((resolve, reject) => {
-                    testManager.on("error", (error, restart) => {
+                    testManager.on("error", (error, errorData: IContextErrorData) => {
                         assert(error);
-                        assert(restart);
+                        assert(errorData.restart);
                         resolve();
                     });
                 });

--- a/server/routerlicious/packages/lambdas-driver/src/test/kafka-service/testPartitionLambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/kafka-service/testPartitionLambdaFactory.ts
@@ -10,6 +10,7 @@ import {
     IQueuedMessage,
     IPartitionLambda,
     IPartitionLambdaFactory,
+    IContextErrorData,
 } from "@fluidframework/server-services-core";
 import { Provider } from "nconf";
 
@@ -37,8 +38,8 @@ export class TestLambda implements IPartitionLambda {
         return;
     }
 
-    public error(error: string, restart: boolean) {
-        this.context.error(error, restart);
+    public error(error: string, errorData: IContextErrorData) {
+        this.context.error(error, errorData);
     }
 }
 
@@ -77,9 +78,9 @@ export class TestPartitionLambdaFactory extends EventEmitter implements IPartiti
     /**
      * Closes all created lambdas
      */
-    public closeLambdas(error: string, restart: boolean) {
+    public closeLambdas(error: string, errorData: IContextErrorData) {
         for (const lambda of this.lambdas) {
-            lambda.error(error, restart);
+            lambda.error(error, errorData);
         }
     }
 }

--- a/server/routerlicious/packages/lambdas/src/copier/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/copier/lambda.ts
@@ -83,7 +83,7 @@ export class CopierLambda implements IPartitionLambda {
                 this.sendPending();
             },
             (error) => {
-                this.context.error(error, true);
+                this.context.error(error, { restart: true });
             });
     }
 

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -204,7 +204,11 @@ export class DeliLambda implements IPartitionLambda {
                 };
                 this.context.log.error(
                     `Could not send message to scriptorium: ${JSON.stringify(error)}`, { messageMetaData });
-                this.context.error(error, true);
+                this.context.error(error, {
+                    restart: true,
+                    tenantId: this.tenantId,
+                    documentId: this.documentId,
+                });
             });
 
         // Start a timer to check inactivity on the document. To trigger idle client leave message,
@@ -528,7 +532,11 @@ export class DeliLambda implements IPartitionLambda {
                 tenantId: this.tenantId,
             };
             this.context.log.error(`Could not send message to alfred: ${JSON.stringify(error)}`, { messageMetaData });
-            this.context.error(error, true);
+            this.context.error(error, {
+                restart: true,
+                tenantId: this.tenantId,
+                documentId: this.documentId,
+            });
         });
     }
 

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -353,7 +353,11 @@ export class ScribeLambda extends SequencedLambda {
                 }
             },
             (error) => {
-                this.context.error(error, true);
+                this.context.error(error, {
+                    restart: true,
+                    tenantId: this.tenantId,
+                    documentId: this.documentId,
+                });
             });
     }
 

--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -80,7 +80,7 @@ export class ScriptoriumLambda implements IPartitionLambda {
                 this.sendPending();
             },
             (error) => {
-                this.context.error(error, true);
+                this.context.error(error, { restart: true });
             });
     }
 
@@ -89,8 +89,10 @@ export class ScriptoriumLambda implements IPartitionLambda {
     }
 
     private async insertOp(messages: ISequencedOperationMessage[]) {
-        const dbOps = messages.map((message) => ({ ...message,
-            mongoTimestamp: new Date(message.operation.timestamp) }));
+        const dbOps = messages.map((message) => ({
+            ...message,
+            mongoTimestamp: new Date(message.operation.timestamp),
+        }));
         return this.opCollection
             .insertMany(dbOps, false)
             .catch(async (error) => {

--- a/server/routerlicious/packages/lambdas/src/sequencedLambda.ts
+++ b/server/routerlicious/packages/lambdas/src/sequencedLambda.ts
@@ -27,12 +27,11 @@ export abstract class SequencedLambda implements IPartitionLambda {
         }, 1);
 
         this.q.error = (error) => {
-            const documentError = {
-                documentId: this.documentId,
-                error,
+            context.error(error, {
+                restart: true,
                 tenantId: this.tenantId,
-            };
-            context.error(documentError, true);
+                documentId: this.documentId,
+            });
         };
     }
 

--- a/server/routerlicious/packages/memory-orderer/src/localContext.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localContext.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IContext, ILogger, IQueuedMessage } from "@fluidframework/server-services-core";
+import { IContext, IContextErrorData, ILogger, IQueuedMessage } from "@fluidframework/server-services-core";
 
 export class LocalContext implements IContext {
     constructor(public readonly log: ILogger) { }
@@ -12,7 +12,7 @@ export class LocalContext implements IContext {
         return;
     }
 
-    public error(error: any, restart: boolean) {
+    public error(error: any, errorData: IContextErrorData) {
         return;
     }
 }

--- a/server/routerlicious/packages/memory-orderer/src/localKafkaSubscription.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localKafkaSubscription.ts
@@ -51,7 +51,7 @@ export class LocalKafkaSubscription extends EventEmitter {
             this.emit("processed", this.queueOffset);
         } catch (ex) {
             // Lambda failed to process the message
-            this.subscriber.context.error(ex, false);
+            this.subscriber.context.error(ex, { restart: false });
 
             this.retryTimer = setTimeout(() => {
                 this.retryTimer = undefined;

--- a/server/routerlicious/packages/memory-orderer/src/localLambdaController.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localLambdaController.ts
@@ -50,7 +50,7 @@ export class LocalLambdaController extends EventEmitter implements IKafkaSubscri
             }
         } catch (ex) {
             // In the event a lambda fails to start, retry it
-            this.context.error(ex, true);
+            this.context.error(ex, { restart: true });
 
             this.startTimer = setTimeout(() => {
                 // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/server/routerlicious/packages/services-core/src/combinedContext.ts
+++ b/server/routerlicious/packages/services-core/src/combinedContext.ts
@@ -4,7 +4,7 @@
  */
 
 import { IQueuedMessage } from "./queue";
-import { IContext } from "./lambdas";
+import { IContext, IContextErrorData } from "./lambdas";
 
 /**
  * Allows checkpointing the minimum offset for multiple lambdas
@@ -25,7 +25,7 @@ export class CombinedContext {
 		return {
 			log: this.context.log,
 			checkpoint: (message) => this.checkpoint(id, message),
-			error: (error, restart) => this.error(id, error, restart),
+			error: (error, errorData) => this.error(id, error, errorData),
 		};
 	}
 
@@ -42,8 +42,8 @@ export class CombinedContext {
 		}
 	}
 
-	private error(_id: number, error: any, restart: boolean): void {
-		this.context.error(error, restart);
+	private error(_id: number, error: any, errorData: IContextErrorData): void {
+		this.context.error(error, errorData);
 	}
 
 	/**

--- a/server/routerlicious/packages/services-core/src/lambdas.ts
+++ b/server/routerlicious/packages/services-core/src/lambdas.ts
@@ -25,6 +25,16 @@ export interface ILogger {
     error(message: string, metaData?: any): void;
 }
 
+export interface IContextErrorData {
+    /**
+     * Indicates whether the error is recoverable and the lambdashould be restarted.
+     */
+    restart: boolean;
+
+    tenantId?: string;
+    documentId?: string;
+}
+
 export interface IContext {
     /**
      * Updates the checkpoint
@@ -32,10 +42,11 @@ export interface IContext {
     checkpoint(queuedMessage: IQueuedMessage): void;
 
     /**
-     * Closes the context with an error. The restart flag indicates whether the error is recoverable and the lambda
-     * should be restarted.
+     * Closes the context with an error.
+     * @param error The error object or string
+     * @param errorData Additional information about the error
      */
-    error(error: any, restart: boolean): void;
+    error(error: any, errorData: IContextErrorData): void;
 
     /**
      * Used to log events / errors.

--- a/server/routerlicious/packages/services-core/src/lambdas.ts
+++ b/server/routerlicious/packages/services-core/src/lambdas.ts
@@ -27,7 +27,7 @@ export interface ILogger {
 
 export interface IContextErrorData {
     /**
-     * Indicates whether the error is recoverable and the lambdashould be restarted.
+     * Indicates whether the error is recoverable and the lambda should be restarted.
      */
     restart: boolean;
 

--- a/server/routerlicious/packages/test-utils/src/testContext.ts
+++ b/server/routerlicious/packages/test-utils/src/testContext.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { EventEmitter } from "events";
 import { Deferred } from "@fluidframework/common-utils";
-import { IContext, IQueuedMessage, ILogger } from "@fluidframework/server-services-core";
+import { IContext, IQueuedMessage, ILogger, IContextErrorData } from "@fluidframework/server-services-core";
 import { DebugLogger } from "./logger";
 
 interface IWaitOffset {
@@ -37,8 +37,8 @@ export class TestContext extends EventEmitter implements IContext {
         });
     }
 
-    public error(error: any, restart: boolean) {
-        this.emit("error", error, restart);
+    public error(error: any, errorData: IContextErrorData) {
+        this.emit("error", error, errorData);
     }
 
     // eslint-disable-next-line @typescript-eslint/promise-function-async


### PR DESCRIPTION
Replace the `restart` param in the `IContext` `error` event with an object called `IContextErrorData` . It contains the restart property, as well as an optional tenant & document id. This will let error handlers know what specific document is causing errors.