### PR TITLE
Removed GC blobs from channel context (DDS). The GC blobs in data store is used to generate initial GC data for DDS

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -621,7 +621,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
 
     protected abstract getInitialSnapshotDetails(): Promise<ISnapshotDetails>;
 
-    protected abstract getInitialGCSummaryDetails(): Promise<IGarbageCollectionSummaryDetails>;
+    public abstract getInitialGCSummaryDetails(): Promise<IGarbageCollectionSummaryDetails>;
 
     public reSubmit(contents: any, localOpMetadata: unknown) {
         assert(!!this.channel, "Channel must exist when resubmitting ops");
@@ -768,7 +768,7 @@ export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
         return this.initialSnapshotDetailsP;
     }
 
-    protected async getInitialGCSummaryDetails(): Promise<IGarbageCollectionSummaryDetails> {
+    public async getInitialGCSummaryDetails(): Promise<IGarbageCollectionSummaryDetails> {
         return this.gcDetailsInInitialSummaryP;
     }
 
@@ -861,7 +861,7 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
         };
     }
 
-    protected async getInitialGCSummaryDetails(): Promise<IGarbageCollectionSummaryDetails> {
+    public async getInitialGCSummaryDetails(): Promise<IGarbageCollectionSummaryDetails> {
         // Local data store does not have initial summary.
         return {};
     }

--- a/packages/runtime/datastore/src/channelContext.ts
+++ b/packages/runtime/datastore/src/channelContext.ts
@@ -7,11 +7,9 @@ import { IChannel } from "@fluidframework/datastore-definitions";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
 import {
-    gcBlobKey,
     IChannelSummarizeResult,
     IContextSummarizeResult,
     IGarbageCollectionData,
-    IGarbageCollectionSummaryDetails,
 } from "@fluidframework/runtime-definitions";
 import { addBlobToSummary } from "@fluidframework/runtime-utils";
 import { ChannelDeltaConnection } from "./channelDeltaConnection";
@@ -76,13 +74,5 @@ export function summarizeChannel(
 
     // Add the channel attributes to the returned result.
     addBlobToSummary(summarizeResult, attributesBlobKey, JSON.stringify(channel.attributes));
-
-    // Add GC details to the summary.
-    const gcDetails: IGarbageCollectionSummaryDetails = {
-        usedRoutes: [""],
-        gcData: summarizeResult.gcData,
-    };
-    addBlobToSummary(summarizeResult, gcBlobKey, JSON.stringify(gcDetails));
-
     return summarizeResult;
 }

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -217,7 +217,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         const tree = dataStoreContext.baseSnapshot;
 
         this.initialChannelUsedRoutesP = new LazyPromise(async () => {
-            // back-compat: 0.34.0. getInitialGCSummaryDetails is added to IFluidDataStoreContext in 0.34.0. Remove
+            // back-compat: 0.35.0. getInitialGCSummaryDetails is added to IFluidDataStoreContext in 0.35.0. Remove
             // undefined check when N > 0.36.0.
             const gcDetailsInInitialSummary = await this.dataStoreContext.getInitialGCSummaryDetails?.();
             if (gcDetailsInInitialSummary?.usedRoutes !== undefined) {
@@ -231,7 +231,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         });
 
         this.initialChannelGCDataP = new LazyPromise(async () => {
-            // back-compat: 0.34.0. getInitialGCSummaryDetails is added to IFluidDataStoreContext in 0.34.0. Remove
+            // back-compat: 0.35.0. getInitialGCSummaryDetails is added to IFluidDataStoreContext in 0.35.0. Remove
             // undefined check when N > 0.36.0.
             const gcDetailsInInitialSummary = await this.dataStoreContext.getInitialGCSummaryDetails?.();
             if (gcDetailsInInitialSummary?.gcData !== undefined) {

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -22,6 +22,7 @@ import {
 import {
     assert,
     Deferred,
+    LazyPromise,
     TypedEventEmitter,
     unreachableCase,
 } from "@fluidframework/common-utils";
@@ -48,6 +49,7 @@ import {
     IFluidDataStoreContext,
     IFluidDataStoreChannel,
     IGarbageCollectionData,
+    IGarbageCollectionSummaryDetails,
     IInboundSignalMessage,
     ISummaryTreeWithStats,
 } from "@fluidframework/runtime-definitions";
@@ -66,7 +68,13 @@ import {
     IChannelFactory,
     IChannelAttributes,
 } from "@fluidframework/datastore-definitions";
-import {  GCDataBuilder, getChildNodesUsedRoutes } from "@fluidframework/garbage-collector";
+import {
+    cloneGCData,
+    GCDataBuilder,
+    getChildNodesGCData,
+    getChildNodesUsedRoutes,
+    removeRouteFromAllNodes,
+} from "@fluidframework/garbage-collector";
 import { v4 as uuid } from "uuid";
 import { IChannelContext, summarizeChannel } from "./channelContext";
 import { LocalChannelContext } from "./localChannelContext";
@@ -183,6 +191,14 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     private readonly audience: IAudience;
     public readonly logger: ITelemetryLogger;
 
+    // A map of child channel context ids to the context's used routes in the initial summary of this data store. This
+    // is used to initialize the context with data from the previous summary.
+    private readonly initialChannelUsedRoutesP: LazyPromise<Map<string, string[]>>;
+
+    // A map of child channel context ids to the channel context's GC data in the initial summary of this data store.
+    // This is used to initialize the context with data from the previous summary.
+    private readonly initialChannelGCDataP: LazyPromise<Map<string, IGarbageCollectionData>>;
+
     public constructor(
         private readonly dataStoreContext: IFluidDataStoreContext,
         private readonly sharedObjectRegistry: ISharedObjectRegistry,
@@ -199,6 +215,35 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         this.audience = dataStoreContext.getAudience();
 
         const tree = dataStoreContext.baseSnapshot;
+
+        this.initialChannelUsedRoutesP = new LazyPromise(async () => {
+            // back-compat: 0.34.0. getInitialGCSummaryDetails is added to IFluidDataStoreContext in 0.34.0. Remove
+            // undefined check when N > 0.36.0.
+            const gcDetailsInInitialSummary = await this.dataStoreContext.getInitialGCSummaryDetails?.();
+            if (gcDetailsInInitialSummary?.usedRoutes !== undefined) {
+                // Remove the route to this data store, if it exists.
+                const usedRoutes = gcDetailsInInitialSummary.usedRoutes.filter(
+                    (id: string) => { return id !== "/" && id !== ""; },
+                );
+                return getChildNodesUsedRoutes(usedRoutes);
+            }
+            return new Map();
+        });
+
+        this.initialChannelGCDataP = new LazyPromise(async () => {
+            // back-compat: 0.34.0. getInitialGCSummaryDetails is added to IFluidDataStoreContext in 0.34.0. Remove
+            // undefined check when N > 0.36.0.
+            const gcDetailsInInitialSummary = await this.dataStoreContext.getInitialGCSummaryDetails?.();
+            if (gcDetailsInInitialSummary?.gcData !== undefined) {
+                const gcData = cloneGCData(gcDetailsInInitialSummary.gcData);
+                // Remove GC node for this data store, if any.
+                delete gcData.gcNodes["/"];
+                // Remove the back route to this data store that was added when generating each child's GC nodes.
+                removeRouteFromAllNodes(gcData.gcNodes, this.absolutePath);
+                return getChildNodesGCData(gcData);
+            }
+            return new Map();
+        });
 
         // Must always receive the data store type inside of the attributes
         if (tree?.trees !== undefined) {
@@ -246,7 +291,8 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
                         this.dataStoreContext.getCreateChildSummarizerNodeFn(
                             path,
                             { type: CreateSummarizerNodeSource.FromSummary },
-                        ));
+                        ),
+                        async () => this.getChannelInitialGCDetails(path));
                 }
                 const deferred = new Deferred<IChannelContext>();
                 deferred.resolve(channelContext);
@@ -512,6 +558,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
                                 snapshot: attachMessage.snapshot,
                             },
                         ),
+                        async () => this.getChannelInitialGCDetails(id),
                         attachMessage.type);
 
                     this.contexts.set(id, remoteChannelContext);
@@ -636,6 +683,30 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         for (const [contextId, context] of this.contexts) {
             context.updateUsedRoutes(usedContextRoutes.get(contextId) ?? []);
         }
+    }
+
+    /**
+     * Returns the GC details in initial summary for the channel with the given id. The initial summary of the data
+     * store contains the GC details of all the child channel contexts that were created before the summary was taken.
+     * We find the GC details belonging to the given channel context and return it.
+     * @param channelId - The id of the channel context that is asked for the initial GC details.
+     * @returns the requested channel's GC details in the initial summary.
+     */
+    private async getChannelInitialGCDetails(channelId: string): Promise<IGarbageCollectionSummaryDetails> {
+        const channelInitialUsedRoutes = await this.initialChannelUsedRoutesP;
+        const channelInitialGCData = await this.initialChannelGCDataP;
+
+        let channelUsedRoutes = channelInitialUsedRoutes.get(channelId);
+        // Currently, channel context's are always considered used. So, it there is no used route for it, we still
+        // need to mark it as used. Add self-route (empty string) to the channel context's used routes.
+        if (channelUsedRoutes === undefined || channelUsedRoutes.length === 0) {
+            channelUsedRoutes = [""];
+        }
+
+        return {
+            usedRoutes: channelUsedRoutes,
+            gcData: channelInitialGCData.get(channelId),
+        };
     }
 
     /**

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -348,6 +348,10 @@ IEventProvider<IFluidDataStoreContextEvents>, Partial<IProvideFluidDataStoreRegi
 
     uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
 
+    /**
+     * Returns the GC details in the initial summary of this data store. This is used to initialize the data store
+     * and its children with the GC details from the previous summary.
+     */
     getInitialGCSummaryDetails(): Promise<IGarbageCollectionSummaryDetails>;
 }
 

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -347,6 +347,8 @@ IEventProvider<IFluidDataStoreContextEvents>, Partial<IProvideFluidDataStoreRegi
     ): CreateChildSummarizerNodeFn;
 
     uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
+
+    getInitialGCSummaryDetails(): Promise<IGarbageCollectionSummaryDetails>;
 }
 
 export interface IFluidDataStoreContextDetached extends IFluidDataStoreContext {


### PR DESCRIPTION
Fixes #4943.

- Removed GC blobs from channel contexts (DDS).
- The GC blobs in the data store is now used to generate the initial GC data for channel contexts.
- The corresponding change in the FluidFrameworkTestData repo - https://github.com/microsoft/FluidFrameworkTestData/pull/11

Couple of notes:
- This change introduces a small inefficiency when a new DDS is created after the data store is attached. When the summarizer tries to get its GC data for the first time, it will generate the GC data even if there was no change in the DDS since it got the attach message. This is because the initial summary of the data store will not have the data for this DDS.
  - There is a simple fix for this - Add the GC blob to the DDS's summary only when creating attach message. However, this will introduce extra GC blobs in the initial summary which won't get removed until this DDS is summarized again. The inefficiency seems worth this trade-off. We can always add this if we realize that summarizing the DDS is becoming too expensive.
- Documents before this change won't have the `getInitialGCSummaryDetails` in `IFluidChannelContext`. So, the summarizer would end up summarizing these DDSs the first time. I can handle this scenario by adding some back-compat code but I don't think its worth maintaining that code for DDSs. Please let me know if you think we need to handle this scenario.