### PR TITLE
[bump] package version for build-common

### DIFF
--- a/common/build/build-common/package-lock.json
+++ b/common/build/build-common/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@fluidframework/build-common",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 1
 }

--- a/common/build/build-common/package.json
+++ b/common/build/build-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/build-common",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Package containing common configs",
   "homepage": "https://fluidframework.com",
   "repository": "https://github.com/microsoft/FluidFramework",

--- a/common/lib/common-definitions/package-lock.json
+++ b/common/lib/common-definitions/package-lock.json
@@ -165,9 +165,9 @@
       }
     },
     "@fluidframework/build-common": {
-      "version": "0.20.0-13703",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.20.0-13703.tgz",
-      "integrity": "sha512-YnlNOwp6+eN0L5gb2UXQQogm8Z59v+cQuUGbY87I31iTMv0N3ZY5DEHiUiQTLFgr3ccD4CsjpUOq8K1/7DO6tA==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.20.0.tgz",
+      "integrity": "sha512-m6Jcq7Qzj/xV97o0kV7ctC462bgqhcU0D/vjJi4Ah2gXOJ5+poVDxpXexQCnFWYKJRG3YqhH9OFMcpAX96TbgA==",
       "dev": true
     },
     "@fluidframework/eslint-config-fluid": {

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -401,9 +401,9 @@
       }
     },
     "@fluidframework/build-common": {
-      "version": "0.20.0-13703",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.20.0-13703.tgz",
-      "integrity": "sha512-YnlNOwp6+eN0L5gb2UXQQogm8Z59v+cQuUGbY87I31iTMv0N3ZY5DEHiUiQTLFgr3ccD4CsjpUOq8K1/7DO6tA==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.20.0.tgz",
+      "integrity": "sha512-m6Jcq7Qzj/xV97o0kV7ctC462bgqhcU0D/vjJi4Ah2gXOJ5+poVDxpXexQCnFWYKJRG3YqhH9OFMcpAX96TbgA==",
       "dev": true
     },
     "@fluidframework/common-definitions": {

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -77,7 +77,7 @@
     "sha.js": "^2.4.11"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -46,7 +46,7 @@
     "style-loader": "^1.0.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/get-session-storage-container": "^0.34.0",
     "@fluidframework/test-tools": "^0.2.3074",

--- a/examples/apps/spaces/package.json
+++ b/examples/apps/spaces/package.json
@@ -58,7 +58,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/get-session-storage-container": "^0.34.0",
     "@fluidframework/test-tools": "^0.2.3074",

--- a/examples/data-objects/badge/package.json
+++ b/examples/data-objects/badge/package.json
@@ -46,7 +46,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/node": "^10.17.24",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/view-interfaces": "^0.34.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",

--- a/examples/data-objects/clicker-react/clicker-context/package.json
+++ b/examples/data-objects/clicker-react/clicker-context/package.json
@@ -42,7 +42,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",

--- a/examples/data-objects/clicker-react/clicker-function/package.json
+++ b/examples/data-objects/clicker-react/clicker-function/package.json
@@ -42,7 +42,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",

--- a/examples/data-objects/clicker-react/clicker-react/package.json
+++ b/examples/data-objects/clicker-react/clicker-react/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",

--- a/examples/data-objects/clicker-react/clicker-reducer/package.json
+++ b/examples/data-objects/clicker-react/clicker-reducer/package.json
@@ -43,7 +43,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",

--- a/examples/data-objects/clicker-react/clicker-with-hook/package.json
+++ b/examples/data-objects/clicker-react/clicker-with-hook/package.json
@@ -43,7 +43,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -47,7 +47,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",

--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -72,7 +72,7 @@
     "shape-detector": "^0.2.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@types/assert": "^1.5.2",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -51,7 +51,7 @@
     "codemirror": "^5.48.4"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/node": "^10.17.24",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",

--- a/examples/data-objects/flow-util-lib/package.json
+++ b/examples/data-objects/flow-util-lib/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@types/benchmark": "^1.0.31",

--- a/examples/data-objects/image-collection/package.json
+++ b/examples/data-objects/image-collection/package.json
@@ -39,7 +39,7 @@
     "@types/node": "^10.17.24"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -45,7 +45,7 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/node": "^10.17.24",

--- a/examples/data-objects/math/package.json
+++ b/examples/data-objects/math/package.json
@@ -48,7 +48,7 @@
     "katex": "^0.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.17.24",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -46,7 +46,7 @@
     "monaco-editor": "^0.15.6"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/map": "^0.34.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -42,7 +42,7 @@
     "react": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -53,7 +53,7 @@
     "react": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -42,7 +42,7 @@
     "@fluidframework/map": "^0.34.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -27,7 +27,7 @@
     "webpack:dev": "webpack --env.development"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/node": "^10.17.24",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -41,7 +41,7 @@
     "react": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -41,7 +41,7 @@
     "react": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -41,7 +41,7 @@
     "react": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",

--- a/examples/data-objects/musica/package.json
+++ b/examples/data-objects/musica/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.10",
     "@babel/plugin-proposal-class-properties": "^7.4.4",
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/babel__core": "^7",

--- a/examples/data-objects/pond/package.json
+++ b/examples/data-objects/pond/package.json
@@ -50,7 +50,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",

--- a/examples/data-objects/primitives/package.json
+++ b/examples/data-objects/primitives/package.json
@@ -41,7 +41,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/node": "^10.17.24",

--- a/examples/data-objects/progress-bars/package.json
+++ b/examples/data-objects/progress-bars/package.json
@@ -40,7 +40,7 @@
     "bootstrap": "^3.3.7"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -65,7 +65,7 @@
     "prosemirror-view": "^1.10.3"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/node": "^10.17.24",

--- a/examples/data-objects/react-inputs/package.json
+++ b/examples/data-objects/react-inputs/package.json
@@ -32,7 +32,7 @@
     "react": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",

--- a/examples/data-objects/scribe/package.json
+++ b/examples/data-objects/scribe/package.json
@@ -58,7 +58,7 @@
     "url-loader": "^2.1.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/async": "^2.0.50",

--- a/examples/data-objects/search-menu/package.json
+++ b/examples/data-objects/search-menu/package.json
@@ -30,7 +30,7 @@
     "@types/node": "^10.17.24"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -82,7 +82,7 @@
     "url-loader": "^2.1.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -51,7 +51,7 @@
     "simplemde": "^1.11.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/node": "^10.17.24",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -60,7 +60,7 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/local-driver": "^0.34.0",
     "@fluidframework/mocha-test-setup": "^0.34.0",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -49,7 +49,7 @@
     "url-loader": "^2.1.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/node": "^10.17.24",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -53,7 +53,7 @@
     "source-map-loader": "^0.2.4"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",

--- a/examples/data-objects/video-players/package.json
+++ b/examples/data-objects/video-players/package.json
@@ -39,7 +39,7 @@
     "@types/node": "^10.17.24"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -60,7 +60,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -80,7 +80,7 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/local-driver": "^0.34.0",
     "@fluidframework/mocha-test-setup": "^0.34.0",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -43,7 +43,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/hosts/app-integration/external-controller/package.json
+++ b/examples/hosts/app-integration/external-controller/package.json
@@ -47,7 +47,7 @@
     "style-loader": "^1.0.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/hosts/app-integration/external-views/package.json
+++ b/examples/hosts/app-integration/external-views/package.json
@@ -40,7 +40,7 @@
     "style-loader": "^1.0.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/hosts/host-service-interfaces/package.json
+++ b/examples/hosts/host-service-interfaces/package.json
@@ -32,7 +32,7 @@
     "@fluidframework/core-interfaces": "^0.34.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",

--- a/examples/hosts/hosts-sample/package.json
+++ b/examples/hosts/hosts-sample/package.json
@@ -36,7 +36,7 @@
     "@fluidframework/web-code-loader": "^0.34.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -49,7 +49,7 @@
     "comlink": "^4.3.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",

--- a/examples/hosts/node-host/package.json
+++ b/examples/hosts/node-host/package.json
@@ -36,7 +36,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -31,7 +31,7 @@
     "source-map-loader": "^0.2.4"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/bundle-size-tools": "^0.0.8505",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@mixer/webpack-bundle-compare": "^0.1.0",

--- a/examples/utils/fluid-object-interfaces/package.json
+++ b/examples/utils/fluid-object-interfaces/package.json
@@ -30,7 +30,7 @@
     "@fluidframework/core-interfaces": "^0.34.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/utils/get-session-storage-container/package.json
+++ b/examples/utils/get-session-storage-container/package.json
@@ -31,7 +31,7 @@
     "@fluidframework/server-local-server": "^0.1019.0-0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/node": "^10.17.24",

--- a/examples/utils/get-tinylicious-container/package.json
+++ b/examples/utils/get-tinylicious-container/package.json
@@ -34,7 +34,7 @@
     "@fluidframework/tinylicious-driver": "^0.34.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/mocha": "^5.2.5",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -44,7 +44,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -29,7 +29,7 @@
     "@fluidframework/map": "^0.34.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",

--- a/experimental/framework/experimental-fluidframework/package.json
+++ b/experimental/framework/experimental-fluidframework/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/view-interfaces": "^0.34.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1290,9 +1290,9 @@
 			}
 		},
 		"@fluidframework/build-common": {
-			"version": "0.20.0-13703",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.20.0-13703.tgz",
-			"integrity": "sha512-YnlNOwp6+eN0L5gb2UXQQogm8Z59v+cQuUGbY87I31iTMv0N3ZY5DEHiUiQTLFgr3ccD4CsjpUOq8K1/7DO6tA=="
+			"version": "0.20.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.20.0.tgz",
+			"integrity": "sha512-m6Jcq7Qzj/xV97o0kV7ctC462bgqhcU0D/vjJi4Ah2gXOJ5+poVDxpXexQCnFWYKJRG3YqhH9OFMcpAX96TbgA=="
 		},
 		"@fluidframework/build-tools": {
 			"version": "0.2.14220",

--- a/packages/agents/intelligence-runner-agent/package.json
+++ b/packages/agents/intelligence-runner-agent/package.json
@@ -31,7 +31,7 @@
     "request": "^2.88.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@types/node": "^10.17.24",
     "@types/request": "^2.47.1",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.34.0",
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -61,7 +61,7 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -64,7 +64,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.34.0",
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.34.0",
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -63,7 +63,7 @@
     "assert": "^2.0.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.34.0",
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.34.0",
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.34.0",
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/gitresources": "^0.1019.0-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -43,7 +43,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -62,7 +62,7 @@
     "@fluidframework/shared-object-base": "^0.34.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -51,7 +51,7 @@
     "assert": "^2.0.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@types/assert": "^1.5.2",
     "@types/mocha": "^5.2.5",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -35,7 +35,7 @@
     "jsonschema": "^1.2.6"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -37,7 +37,7 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -37,7 +37,7 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -40,7 +40,7 @@
     "assert": "^2.0.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@types/assert": "^1.5.2",

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -39,7 +39,7 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/debug": "^4.1.5",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -69,7 +69,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@types/assert": "^1.5.2",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -76,7 +76,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -38,7 +38,7 @@
     "assert": "^2.0.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@types/assert": "^1.5.2",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -38,7 +38,7 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -48,7 +48,7 @@
     "ws": "^6.1.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -37,7 +37,7 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@types/assert": "^1.5.2",
     "@types/mocha": "^5.2.5",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -39,7 +39,7 @@
     "nconf": "^0.11.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@types/assert": "^1.5.2",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -36,7 +36,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/jsrsasign": "^8.0.8",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -76,7 +76,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -66,7 +66,7 @@
     "@fluidframework/shared-object-base": "^0.34.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -63,7 +63,7 @@
     "assert": "^2.0.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",

--- a/packages/framework/last-edited-experimental/package.json
+++ b/packages/framework/last-edited-experimental/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/shared-summary-block": "^0.34.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/framework/react/package.json
+++ b/packages/framework/react/package.json
@@ -39,7 +39,7 @@
     "react": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -62,7 +62,7 @@
     "assert": "^2.0.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/core-interfaces": "^0.34.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/datastore": "^0.34.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/sequence": "^0.34.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -33,7 +33,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/react": "^16.9.15",

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -30,7 +30,7 @@
     "@fluidframework/core-interfaces": "^0.34.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/react": "^16.9.15",

--- a/packages/hosts/base-host/package.json
+++ b/packages/hosts/base-host/package.json
@@ -70,7 +70,7 @@
     "style-loader": "^1.0.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",

--- a/packages/loader/container-definitions/package.json
+++ b/packages/loader/container-definitions/package.json
@@ -34,7 +34,7 @@
     "@fluidframework/protocol-definitions": "^0.1019.0-0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@fluid-internal/test-loader-utils": "^0.34.0",
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -60,7 +60,7 @@
     "assert": "^2.0.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/loader/core-interfaces/package.json
+++ b/packages/loader/core-interfaces/package.json
@@ -28,7 +28,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",

--- a/packages/loader/driver-definitions/package.json
+++ b/packages/loader/driver-definitions/package.json
@@ -33,7 +33,7 @@
     "@fluidframework/protocol-definitions": "^0.1019.0-0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -59,7 +59,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",

--- a/packages/loader/execution-context-loader/package.json
+++ b/packages/loader/execution-context-loader/package.json
@@ -36,7 +36,7 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/debug": "^4.1.5",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -31,7 +31,7 @@
     "@fluidframework/protocol-definitions": "^0.1019.0-0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -32,7 +32,7 @@
     "isomorphic-fetch": "^3.0.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/isomorphic-fetch": "^0.0.35",

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -59,7 +59,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",

--- a/packages/runtime/client-api/package.json
+++ b/packages/runtime/client-api/package.json
@@ -69,7 +69,7 @@
     "jwt-decode": "^2.2.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/debug": "^4.1.5",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -34,7 +34,7 @@
     "@types/node": "^10.17.24"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -77,7 +77,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -35,7 +35,7 @@
     "@types/node": "^10.17.24"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -75,7 +75,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -63,7 +63,7 @@
     "@fluidframework/runtime-definitions": "^0.34.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -34,7 +34,7 @@
     "@types/node": "^10.17.24"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -66,7 +66,7 @@
     "assert": "^2.0.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -68,7 +68,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@types/assert": "^1.5.2",

--- a/packages/test/end-to-end-tests/package.json
+++ b/packages/test/end-to-end-tests/package.json
@@ -59,7 +59,7 @@
     "@fluidframework/agent-scheduler": "^0.34.0",
     "@fluidframework/aqueduct": "^0.34.0",
     "@fluidframework/base-host": "^0.34.0",
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/cell": "^0.34.0",
     "@fluidframework/common-utils": "^0.27.0",
     "@fluidframework/container-definitions": "^0.34.0",

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@fluid-internal/test-loader-utils": "^0.34.0",
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/common-utils": "^0.27.0",
     "@fluidframework/container-loader": "^0.34.0",
     "@fluidframework/container-runtime": "^0.34.0",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -57,7 +57,7 @@
     "@fluidframework/agent-scheduler": "^0.34.0",
     "@fluidframework/aqueduct": "^0.34.0",
     "@fluidframework/base-host": "^0.34.0",
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/cell": "^0.34.0",
     "@fluidframework/common-utils": "^0.27.0",
     "@fluidframework/container-definitions": "^0.34.0",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -49,7 +49,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/mocha": "^5.2.5",

--- a/packages/test/service-load-test/package.json
+++ b/packages/test/service-load-test/package.json
@@ -62,7 +62,7 @@
     "commander": "^5.1.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@types/mocha": "^5.2.5",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -57,7 +57,7 @@
     "assert": "^2.0.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@types/assert": "^1.5.2",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -56,7 +56,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/mocha": "^5.2.5",

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -65,7 +65,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/mocha": "^5.2.5",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -72,7 +72,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -43,7 +43,7 @@
     "assert": "^2.0.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@types/assert": "^1.5.2",
     "@types/node": "^10.17.24",

--- a/packages/tools/merge-tree-client-replay/package.json
+++ b/packages/tools/merge-tree-client-replay/package.json
@@ -39,7 +39,7 @@
     "assert": "^2.0.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -47,7 +47,7 @@
     "assert": "^2.0.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -86,7 +86,7 @@
     "webpack-dev-server": "^3.8.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@types/assert": "^1.5.2",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -31,7 +31,7 @@
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -64,7 +64,7 @@
     "events": "^3.1.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -61,7 +61,7 @@
     "proper-lockfile": "^4.1.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -544,9 +544,9 @@
 			}
 		},
 		"@fluidframework/build-common": {
-			"version": "0.20.0-13703",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.20.0-13703.tgz",
-			"integrity": "sha512-YnlNOwp6+eN0L5gb2UXQQogm8Z59v+cQuUGbY87I31iTMv0N3ZY5DEHiUiQTLFgr3ccD4CsjpUOq8K1/7DO6tA=="
+			"version": "0.20.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.20.0.tgz",
+			"integrity": "sha512-m6Jcq7Qzj/xV97o0kV7ctC462bgqhcU0D/vjJi4Ah2gXOJ5+poVDxpXexQCnFWYKJRG3YqhH9OFMcpAX96TbgA=="
 		},
 		"@fluidframework/build-tools": {
 			"version": "0.2.14220",

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -23,7 +23,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -28,7 +28,7 @@
     "@types/node": "^12.19.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -58,7 +58,7 @@
     "winston": "^3.1.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/server-test-utils": "^0.1019.0",
     "@types/async": "^2.0.50",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -67,7 +67,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/server-test-utils": "^0.1019.0",
     "@types/async": "^2.0.50",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -63,7 +63,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@types/jsrsasign": "^8.0.8",
     "@types/mocha": "^5.2.5",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -46,7 +46,7 @@
     "ws": "^6.1.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -60,7 +60,7 @@
     "lodash": "^4.17.19"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",

--- a/server/routerlicious/packages/protocol-definitions/package.json
+++ b/server/routerlicious/packages/protocol-definitions/package.json
@@ -31,7 +31,7 @@
     "@fluidframework/common-definitions": "^0.19.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -76,7 +76,7 @@
     "ws": "^6.1.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/server-local-server": "^0.1019.0",
     "@fluidframework/server-test-utils": "^0.1019.0",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -73,7 +73,7 @@
     "ws": "^6.1.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/server-local-server": "^0.1019.0",
     "@fluidframework/server-test-utils": "^0.1019.0",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -64,7 +64,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@types/debug": "^4.1.5",
     "@types/jsrsasign": "^8.0.8",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -34,7 +34,7 @@
     "nconf": "^0.11.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -41,7 +41,7 @@
     "winston": "^3.1.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@types/debug": "^4.1.5",
     "@types/lodash": "^4.14.118",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -60,7 +60,7 @@
     "winston": "^3.1.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/server-test-utils": "^0.1019.0",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -69,7 +69,7 @@
     "winston": "^3.1.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/server-test-utils": "^0.1019.0",
     "@types/amqplib": "^0.5.9",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -58,7 +58,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@types/lodash": "^4.14.118",
     "@types/mocha": "^5.2.5",

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -169,9 +169,9 @@
       }
     },
     "@fluidframework/build-common": {
-      "version": "0.20.0-13703",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.20.0-13703.tgz",
-      "integrity": "sha512-YnlNOwp6+eN0L5gb2UXQQogm8Z59v+cQuUGbY87I31iTMv0N3ZY5DEHiUiQTLFgr3ccD4CsjpUOq8K1/7DO6tA==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.20.0.tgz",
+      "integrity": "sha512-m6Jcq7Qzj/xV97o0kV7ctC462bgqhcU0D/vjJi4Ah2gXOJ5+poVDxpXexQCnFWYKJRG3YqhH9OFMcpAX96TbgA==",
       "dev": true
     },
     "@fluidframework/common-definitions": {

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -62,7 +62,7 @@
     "winston": "^3.1.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.20.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.22.1-0",
     "@fluidframework/mocha-test-setup": "^0.27.0",
     "@microsoft/api-extractor": "^7.7.7",


### PR DESCRIPTION
            @fluidframework/build-common:     0.20.0 -> 0.20.1
     @fluidframework/eslint-config-fluid:     0.22.1 (unchanged)
      @fluidframework/common-definitions:     0.20.0 (unchanged)
            @fluidframework/common-utils:     0.28.0 (unchanged)
                                  Server:   0.1019.0 (unchanged)
                                  Client:     0.34.0 (unchanged)
                         generator-fluid:      0.3.0 (unchanged)
                             tinylicious:      0.4.0 (unchanged)
                             dice-roller:      0.0.1 (unchanged)

Also remove pre-release dependencies for build-common
            @fluidframework/build-common -> ^0.20.0