### PR TITLE
Ensure sequence numbers are monotomically increasing in scribe

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/interfaces.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/interfaces.ts
@@ -55,6 +55,18 @@ export interface ISummaryWriter {
 }
 
 /**
+ * Interface to abstract out the storage specific details of pending message retrieval
+ */
+export interface IPendingMessageReader {
+    /**
+     * Read pending messages
+     * @param from Starting sequence number (inclusive)
+     * @param to End sequence number (inclusive)
+     */
+    readMessages(from: number, to: number): Promise<ISequencedDocumentMessage[]>;
+}
+
+/**
  * Interface to abstract out the storage specific details of scribe checkpointing
  */
 export interface ICheckpointManager {

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -123,6 +123,7 @@ export class ScribeLambdaFactory extends EventEmitter implements IPartitionLambd
             document.documentId,
             summaryWriter,
             summaryReader,
+            undefined,
             checkpointManager,
             lastCheckpoint,
             this.serviceConfiguration,

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -329,6 +329,7 @@ export class LocalOrderer implements IOrderer {
             this.documentId,
             summaryWriter,
             summaryReader,
+            undefined,
             checkpointManager,
             scribe,
             this.serviceConfiguration,


### PR DESCRIPTION
When scribe is bootstrapping, it loads the protocol state from the latest summary and any pending messages that are not yet in a summary.

Consider the following example:
The latest protocol state was at seq 100 and there were pending ops from 101 to 150. 
Scribe then processes a message at sequence number 200, 201, 202, etc. It eventually creates a summary and it's "working".
However it actually missed ops 151 - 199 so it's protocol state is invalid. The summaries protocol state is invalid too.

This pr adds a check to ensure op sequence numbers are correct. If scribe does see ops are missing, it can request them from the new interface.