### PR TITLE
Delta manager bogus assert

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -801,8 +801,6 @@ export class DeltaManager
                 if (to === undefined ? (!partialResult && lastFetch < maxFetchTo - 1) : to - 1 <= lastFetch) {
                     callback(deltas);
                     telemetryEvent.end({ lastFetch, deltasRetrievedTotal, requests });
-                    // If we got full range we have asked, it should not be partial result
-                    assert(!partialResult, "partialResult");
                     return;
                 }
 


### PR DESCRIPTION
Porting PR #5033 to release/0.34

This is me going too strict and actually going overboard - storage should be fine to say it returned only subset of what is might potentially have, even if it fully satisfied original request.
I've hit it in my manual tests - what happens is that caching layer (ops from ODSP snapshot) returns all it got and notifies the caller that calling again will yield more ops as we will hit real storage. But it may have all the ops that delta manager was looking for.

