### PR TITLE
Buffer to string

### DIFF
--- a/common/lib/common-utils/src/bufferBrowser.ts
+++ b/common/lib/common-utils/src/bufferBrowser.ts
@@ -48,6 +48,11 @@ export const bufferToString = (blob: ArrayBufferLike, encoding: string): string 
  * Minimal implementation of Buffer for our usages in the browser environment.
  */
 export class IsoBuffer extends Uint8Array {
+    // Need to have ctor for it to be in proto chain for instanceof check in from() method to work
+    public constructor(buffer: ArrayBufferLike, byteOffset?: number, length?: number) {
+        super(buffer, byteOffset, length);
+    }
+
     /**
      * Convert the buffer to a string.
      * Only supports encoding the whole string (unlike the Node Buffer equivalent)
@@ -66,6 +71,8 @@ export class IsoBuffer extends Uint8Array {
     static from(value, encodingOrOffset?, length?): IsoBuffer {
         if (typeof value === "string") {
             return IsoBuffer.fromString(value, encodingOrOffset as string | undefined);
+        } else if (value instanceof IsoBuffer) {
+            return value;
         } else if (value instanceof ArrayBuffer) {
             return IsoBuffer.fromArrayBuffer(value, encodingOrOffset as number | undefined, length);
         } else {

--- a/common/lib/common-utils/src/test/jest/buffer.spec.ts
+++ b/common/lib/common-utils/src/test/jest/buffer.spec.ts
@@ -171,4 +171,16 @@ describe("Buffer isomorphism", () => {
         expect(nodeStringUtf8).toEqual("hellothere");
         expect(browserStringUtf8).toEqual("hellothere");
     });
+
+    test("bufferToString working with IsoBuffer",() => {
+        const test = "aGVsbG90aGVyZQ==";
+
+        const buffer = BufferBrowser.stringToBuffer(test, "base64");
+        expect(BufferBrowser.bufferToString(buffer, "base64")).toEqual(test);
+        expect(BufferBrowser.bufferToString(buffer, "utf-8")).toEqual("hellothere");
+
+        const buffer2 = BufferNode.stringToBuffer(test, "base64");
+        expect(BufferNode.bufferToString(buffer2, "base64")).toEqual(test);
+        expect(BufferNode.bufferToString(buffer2, "utf-8")).toEqual("hellothere");
+    });
 });

--- a/common/lib/common-utils/src/test/jest/buffer.spec.ts
+++ b/common/lib/common-utils/src/test/jest/buffer.spec.ts
@@ -175,11 +175,11 @@ describe("Buffer isomorphism", () => {
     test("bufferToString working with IsoBuffer",() => {
         const test = "aGVsbG90aGVyZQ==";
 
-        const buffer = BufferBrowser.stringToBuffer(test, "base64");
+        const buffer = BufferBrowser.IsoBuffer.from(test, "base64");
         expect(BufferBrowser.bufferToString(buffer, "base64")).toEqual(test);
         expect(BufferBrowser.bufferToString(buffer, "utf-8")).toEqual("hellothere");
 
-        const buffer2 = BufferNode.stringToBuffer(test, "base64");
+        const buffer2 = BufferNode.IsoBuffer.from(test, "base64");
         expect(BufferNode.bufferToString(buffer2, "base64")).toEqual(test);
         expect(BufferNode.bufferToString(buffer2, "utf-8")).toEqual("hellothere");
     });


### PR DESCRIPTION
ODSP driver has this code:

    public async readBlob(blobId: string): Promise<ArrayBufferLike> {
        const blob = await this.readBlobCore(blobId);
        if (blob instanceof ArrayBuffer) {
            return blob;
        }
        return IsoBuffer.from(blob.content, blob.encoding ?? "utf-8");
    }

This code differs from how we get buffer in other places:

    export const stringToBuffer = (input: string, encoding: string): ArrayBufferLike =>
        IsoBuffer.from(input, encoding).buffer;

Notice .buffer at the end.

Whether it's right code or wrong, but TS allows it just fine.
But later, when we call bufferToString we fail as we fail recognize IsoBuffer object.

Adding that case and test coverage for it.
