### PR TITLE
[bump] package version for eslint-config-fluid

### DIFF
--- a/common/build/eslint-config-fluid/package-lock.json
+++ b/common/build/eslint-config-fluid/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/eslint-config-fluid",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/eslint-config-fluid",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Shareable ESLint config for the Fluid Framework",
   "homepage": "https://fluidframework.com",
   "repository": "https://github.com/microsoft/FluidFramework",

--- a/common/lib/common-definitions/package-lock.json
+++ b/common/lib/common-definitions/package-lock.json
@@ -171,9 +171,9 @@
       "dev": true
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.22.1-13494",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.22.1-13494.tgz",
-      "integrity": "sha512-7Gjsn7hTJxsS048UU/hJkLinUfTlzJCwfXynHyanDtPl90/m5f60MUTXVOs3gjo2d7Uiyz/75qa6DVMttMQebQ==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.22.1.tgz",
+      "integrity": "sha512-SqfFGQifMA4fi+jmPgZQAdBOLJFjQ7u1xW4Cgs9KWEdxx5Cq5qOGArzc643Ft5TQbCTHDX//Ud2lDL2wHdI7LA==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "^1.0.6",

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -35,7 +35,7 @@
   "dependencies": {},
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -412,9 +412,9 @@
       "integrity": "sha512-H+wEaxuIHODVNqyY8XSMY6ww7ndrRfht9CXKUAUzdQjUN1Oi++YonKcD3CXWZod6afxZ6abDmltIO9wLrjOJzg=="
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.22.1-13494",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.22.1-13494.tgz",
-      "integrity": "sha512-7Gjsn7hTJxsS048UU/hJkLinUfTlzJCwfXynHyanDtPl90/m5f60MUTXVOs3gjo2d7Uiyz/75qa6DVMttMQebQ==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.22.1.tgz",
+      "integrity": "sha512-SqfFGQifMA4fi+jmPgZQAdBOLJFjQ7u1xW4Cgs9KWEdxx5Cq5qOGArzc643Ft5TQbCTHDX//Ud2lDL2wHdI7LA==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "^1.0.6",

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -78,7 +78,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",
     "@types/base64-js": "^1.3.0",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/get-session-storage-container": "^0.34.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",

--- a/examples/apps/spaces/package.json
+++ b/examples/apps/spaces/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/get-session-storage-container": "^0.34.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/badge/package.json
+++ b/examples/data-objects/badge/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/node": "^10.17.24",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker-react/clicker-context/package.json
+++ b/examples/data-objects/clicker-react/clicker-context/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker-react/clicker-function/package.json
+++ b/examples/data-objects/clicker-react/clicker-function/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker-react/clicker-react/package.json
+++ b/examples/data-objects/clicker-react/clicker-react/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker-react/clicker-reducer/package.json
+++ b/examples/data-objects/clicker-react/clicker-reducer/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker-react/clicker-with-hook/package.json
+++ b/examples/data-objects/clicker-react/clicker-with-hook/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/flow-util-lib/package.json
+++ b/examples/data-objects/flow-util-lib/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@types/benchmark": "^1.0.31",
     "@types/mocha": "^5.2.5",

--- a/examples/data-objects/image-collection/package.json
+++ b/examples/data-objects/image-collection/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/image-gallery/package.json
+++ b/examples/data-objects/image-gallery/package.json
@@ -40,7 +40,7 @@
     "react-image-gallery": "^0.9.1"
   },
   "devDependencies": {
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/node": "^10.17.24",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/data-objects/math/package.json
+++ b/examples/data-objects/math/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@types/expect-puppeteer": "2.2.1",
     "@types/node": "^10.17.24",
     "@types/puppeteer": "1.3.0",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/musica/package.json
+++ b/examples/data-objects/musica/package.json
@@ -45,7 +45,7 @@
     "@babel/core": "^7.12.10",
     "@babel/plugin-proposal-class-properties": "^7.4.4",
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/babel__core": "^7",
     "@types/node": "^10.17.24",

--- a/examples/data-objects/pond/package.json
+++ b/examples/data-objects/pond/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/primitives/package.json
+++ b/examples/data-objects/primitives/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/node": "^10.17.24",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/progress-bars/package.json
+++ b/examples/data-objects/progress-bars/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/node": "^10.17.24",
     "@types/orderedmap": "^1",

--- a/examples/data-objects/react-inputs/package.json
+++ b/examples/data-objects/react-inputs/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/scribe/package.json
+++ b/examples/data-objects/scribe/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/async": "^2.0.50",
     "@types/lodash": "^4.14.118",

--- a/examples/data-objects/search-menu/package.json
+++ b/examples/data-objects/search-menu/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/simple-fluidobject-embed/package.json
+++ b/examples/data-objects/simple-fluidobject-embed/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/view-interfaces": "^0.34.0"
   },
   "devDependencies": {
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/local-driver": "^0.34.0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/runtime-utils": "^0.34.0",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/video-players/package.json
+++ b/examples/data-objects/video-players/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/node": "^10.17.24",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -81,7 +81,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/local-driver": "^0.34.0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/runtime-utils": "^0.34.0",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",

--- a/examples/hosts/app-integration/external-controller/package.json
+++ b/examples/hosts/app-integration/external-controller/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",

--- a/examples/hosts/app-integration/external-views/package.json
+++ b/examples/hosts/app-integration/external-views/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",

--- a/examples/hosts/host-service-interfaces/package.json
+++ b/examples/hosts/host-service-interfaces/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/hosts/hosts-sample/package.json
+++ b/examples/hosts/hosts-sample/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/hosts/node-host/package.json
+++ b/examples/hosts/node-host/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/bundle-size-tools": "^0.0.8505",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@mixer/webpack-bundle-compare": "^0.1.0",
     "@types/node": "^10.17.24",
     "@types/puppeteer": "1.3.0",

--- a/examples/utils/fluid-object-interfaces/package.json
+++ b/examples/utils/fluid-object-interfaces/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/utils/get-session-storage-container/package.json
+++ b/examples/utils/get-session-storage-container/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/utils/get-tinylicious-container/package.json
+++ b/examples/utils/get-tinylicious-container/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.17.24",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/experimental/framework/experimental-fluidframework/package.json
+++ b/experimental/framework/experimental-fluidframework/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1733,9 +1733,9 @@
 			}
 		},
 		"@fluidframework/eslint-config-fluid": {
-			"version": "0.22.1-13494",
-			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.22.1-13494.tgz",
-			"integrity": "sha512-7Gjsn7hTJxsS048UU/hJkLinUfTlzJCwfXynHyanDtPl90/m5f60MUTXVOs3gjo2d7Uiyz/75qa6DVMttMQebQ==",
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.22.1.tgz",
+			"integrity": "sha512-SqfFGQifMA4fi+jmPgZQAdBOLJFjQ7u1xW4Cgs9KWEdxx5Cq5qOGArzc643Ft5TQbCTHDX//Ud2lDL2wHdI7LA==",
 			"requires": {
 				"@rushstack/eslint-patch": "^1.0.6",
 				"@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/packages/agents/intelligence-runner-agent/package.json
+++ b/packages/agents/intelligence-runner-agent/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@types/node": "^10.17.24",
     "@types/request": "^2.47.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.34.0",
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.34.0",
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.34.0",
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",
     "@types/assert": "^1.5.2",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.34.0",
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.34.0",
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -72,7 +72,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.34.0",
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/gitresources": "^0.1019.0-0",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/runtime-definitions": "^0.34.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@types/assert": "^1.5.2",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.17.24",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",
     "@types/mocha": "^5.2.5",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@types/assert": "^1.5.2",
     "@types/mocha": "^5.2.5",

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@types/assert": "^1.5.2",
     "@types/jsrsasign": "^8.0.8",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -77,7 +77,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@types/assert": "^1.5.2",
     "@types/mocha": "^5.2.5",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@types/assert": "^1.5.2",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.17.24",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@types/assert": "^1.5.2",
     "@types/mocha": "^5.2.5",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/jsrsasign": "^8.0.8",
     "@types/mocha": "^5.2.5",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -77,7 +77,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/mocha": "^5.2.5",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/framework/last-edited-experimental/package.json
+++ b/packages/framework/last-edited-experimental/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/mocha": "^5.2.5",

--- a/packages/framework/react/package.json
+++ b/packages/framework/react/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",
     "@types/react": "^16.9.15",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/datastore": "^0.34.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/mocha": "^5.2.5",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/react": "^16.9.15",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/react": "^16.9.15",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/packages/hosts/base-host/package.json
+++ b/packages/hosts/base-host/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/loader/container-definitions/package.json
+++ b/packages/loader/container-definitions/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -74,7 +74,7 @@
   "devDependencies": {
     "@fluid-internal/test-loader-utils": "^0.34.0",
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",

--- a/packages/loader/core-interfaces/package.json
+++ b/packages/loader/core-interfaces/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/packages/loader/driver-definitions/package.json
+++ b/packages/loader/driver-definitions/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",
     "@types/mocha": "^5.2.5",

--- a/packages/loader/execution-context-loader/package.json
+++ b/packages/loader/execution-context-loader/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/debug": "^4.1.5",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/isomorphic-fetch": "^0.0.35",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",

--- a/packages/runtime/client-api/package.json
+++ b/packages/runtime/client-api/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/debug": "^4.1.5",
     "@types/jwt-decode": "^2.2.1",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -78,7 +78,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/test-runtime-utils": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@types/assert": "^1.5.2",
     "@types/jsrsasign": "^8.0.8",

--- a/packages/test/end-to-end-tests/package.json
+++ b/packages/test/end-to-end-tests/package.json
@@ -74,7 +74,7 @@
     "@fluidframework/driver-base": "^0.34.0",
     "@fluidframework/driver-definitions": "^0.34.0",
     "@fluidframework/driver-utils": "^0.34.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/ink": "^0.34.0",
     "@fluidframework/local-driver": "^0.34.0",
     "@fluidframework/map": "^0.34.0",

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -57,7 +57,7 @@
     "@fluidframework/common-utils": "^0.27.0",
     "@fluidframework/container-loader": "^0.34.0",
     "@fluidframework/container-runtime": "^0.34.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@fluidframework/protocol-definitions": "^0.1019.0-0",
     "@fluidframework/sequence": "^0.34.0",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -72,7 +72,7 @@
     "@fluidframework/driver-base": "^0.34.0",
     "@fluidframework/driver-definitions": "^0.34.0",
     "@fluidframework/driver-utils": "^0.34.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/ink": "^0.34.0",
     "@fluidframework/local-driver": "^0.34.0",
     "@fluidframework/map": "^0.34.0",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.17.24",

--- a/packages/test/service-load-test/package.json
+++ b/packages/test/service-load-test/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.17.24",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@types/assert": "^1.5.2",
     "@types/mocha": "^5.2.5",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/mocha": "^5.2.5",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.17.24",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",
     "@types/diff": "^3.5.1",

--- a/packages/test/version-test-1/package.json
+++ b/packages/test/version-test-1/package.json
@@ -46,7 +46,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.34.0",
     "@types/jest": "22.2.3",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@types/assert": "^1.5.2",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/packages/tools/merge-tree-client-replay/package.json
+++ b/packages/tools/merge-tree-client-replay/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",
     "@types/node": "^10.17.24",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",
     "@types/node": "^10.17.24",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -87,7 +87,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@types/assert": "^1.5.2",
     "@types/express": "^4.11.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/debug": "^4.1.5",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.34.0",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/mocha": "^5.2.5",

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -667,9 +667,9 @@
 			}
 		},
 		"@fluidframework/eslint-config-fluid": {
-			"version": "0.22.1-13494",
-			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.22.1-13494.tgz",
-			"integrity": "sha512-7Gjsn7hTJxsS048UU/hJkLinUfTlzJCwfXynHyanDtPl90/m5f60MUTXVOs3gjo2d7Uiyz/75qa6DVMttMQebQ==",
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.22.1.tgz",
+			"integrity": "sha512-SqfFGQifMA4fi+jmPgZQAdBOLJFjQ7u1xW4Cgs9KWEdxx5Cq5qOGArzc643Ft5TQbCTHDX//Ud2lDL2wHdI7LA==",
 			"requires": {
 				"@rushstack/eslint-patch": "^1.0.6",
 				"@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/server-test-utils": "^0.1019.0",
     "@types/async": "^2.0.50",
     "@types/lodash": "^4.14.118",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/server-test-utils": "^0.1019.0",
     "@types/async": "^2.0.50",
     "@types/json-stringify-safe": "^5.0.0",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@types/jsrsasign": "^8.0.8",
     "@types/mocha": "^5.2.5",
     "@types/nock": "^9.3.0",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.1",
     "@types/lodash": "^4.14.118",

--- a/server/routerlicious/packages/protocol-definitions/package.json
+++ b/server/routerlicious/packages/protocol-definitions/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@microsoft/api-extractor": "^7.7.2",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -77,7 +77,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/server-local-server": "^0.1019.0",
     "@fluidframework/server-test-utils": "^0.1019.0",
     "@types/bytes": "^3.0.0",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -74,7 +74,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/server-local-server": "^0.1019.0",
     "@fluidframework/server-test-utils": "^0.1019.0",
     "@types/bytes": "^3.0.0",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@types/debug": "^4.1.5",
     "@types/jsrsasign": "^8.0.8",
     "@types/jwt-decode": "^2.2.1",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@types/debug": "^4.1.5",
     "@types/lodash": "^4.14.118",
     "@types/node": "^12.19.0",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/server-test-utils": "^0.1019.0",
     "@types/debug": "^4.1.5",
     "@types/json-stringify-safe": "^5.0.0",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/server-test-utils": "^0.1019.0",
     "@types/amqplib": "^0.5.9",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@types/lodash": "^4.14.118",
     "@types/mocha": "^5.2.5",
     "@types/node": "^12.19.0",

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -194,9 +194,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.22.1-13494",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.22.1-13494.tgz",
-      "integrity": "sha512-7Gjsn7hTJxsS048UU/hJkLinUfTlzJCwfXynHyanDtPl90/m5f60MUTXVOs3gjo2d7Uiyz/75qa6DVMttMQebQ==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.22.1.tgz",
+      "integrity": "sha512-SqfFGQifMA4fi+jmPgZQAdBOLJFjQ7u1xW4Cgs9KWEdxx5Cq5qOGArzc643Ft5TQbCTHDX//Ud2lDL2wHdI7LA==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "^1.0.6",

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.22.1-0",
+    "@fluidframework/eslint-config-fluid": "^0.22.1",
     "@fluidframework/mocha-test-setup": "^0.27.0",
     "@microsoft/api-extractor": "^7.7.7",
     "@types/bytes": "^3.1.0",


### PR DESCRIPTION
            @fluidframework/build-common:     0.20.1 (unchanged)
     @fluidframework/eslint-config-fluid:     0.22.1 -> 0.22.2
      @fluidframework/common-definitions:     0.20.0 (unchanged)
            @fluidframework/common-utils:     0.28.0 (unchanged)
                                  Server:   0.1019.0 (unchanged)
                                  Client:     0.34.0 (unchanged)
                         generator-fluid:      0.3.0 (unchanged)
                             tinylicious:      0.4.0 (unchanged)
                             dice-roller:      0.0.1 (unchanged)

Also remove pre-release dependencies for eslint-config-fluid
     @fluidframework/eslint-config-fluid -> ^0.22.1