### PR TITLE
Added performance event that logs time taken to run GC

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1380,11 +1380,14 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 try {
                     // Get the container's GC data and run GC on the reference graph in it.
                     const gcData = await this.dataStores.getGCData();
-                    const { referencedNodeIds } = runGarbageCollection(gcData.gcNodes, [ "/" ], this.logger);
+                    const { referencedNodeIds, deletedNodeIds } = runGarbageCollection(
+                        gcData.gcNodes, [ "/" ],
+                        this.logger,
+                    );
 
                     // Update stats to be reported in the peformance event.
-                    gcStats.totalGCNodes = Object.keys(gcData.gcNodes).length;
-                    gcStats.deletedGCNodes = gcStats.totalGCNodes - referencedNodeIds.length;
+                    gcStats.deletedGCNodes = deletedNodeIds.length;
+                    gcStats.totalGCNodes = referencedNodeIds.length + gcStats.deletedGCNodes;
 
                     // Update our summarizer node's used routes. Updating used routes in summarizer node before
                     // summarizing is required and asserted by the the summarizer node. We are the root and are

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1372,18 +1372,33 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             }
 
             if (!this.runtimeOptions.disableGC) {
-                // Get the container's GC data and run GC on the reference graph in it.
-                const gcData = await this.dataStores.getGCData();
-                const { referencedNodeIds } = runGarbageCollection(gcData.gcNodes, [ "/" ], this.logger);
+                const perfEvent = PerformanceEvent.start(summaryLogger, {
+                    eventName: "GarbageCollection",
+                });
 
-                // Update our summarizer node's used routes. Updating used routes in summarizer node before summarizing
-                // is required and asserted by the the summarizer node. We are the root and are always referenced, so
-                // the used routes is only self-route (empty string).
-                this.summarizerNode.updateUsedRoutes([""]);
+                const gcStats: { totalGCNodes?: number; deletedGCNodes?: number } = {};
+                try {
+                    // Get the container's GC data and run GC on the reference graph in it.
+                    const gcData = await this.dataStores.getGCData();
+                    const { referencedNodeIds } = runGarbageCollection(gcData.gcNodes, [ "/" ], this.logger);
 
-                // Remove this node's route ("/") and notify data stores of routes that are used in it.
-                const usedRoutes = referencedNodeIds.filter((id: string) => { return id !== "/"; });
-                this.dataStores.updateUsedRoutes(usedRoutes);
+                    // Update stats to be reported in the peformance event.
+                    gcStats.totalGCNodes = Object.keys(gcData.gcNodes).length;
+                    gcStats.deletedGCNodes = gcStats.totalGCNodes - referencedNodeIds.length;
+
+                    // Update our summarizer node's used routes. Updating used routes in summarizer node before
+                    // summarizing is required and asserted by the the summarizer node. We are the root and are
+                    // always referenced, so the used routes is only self-route (empty string).
+                    this.summarizerNode.updateUsedRoutes([""]);
+
+                    // Remove this node's route ("/") and notify data stores of routes that are used in it.
+                    const usedRoutes = referencedNodeIds.filter((id: string) => { return id !== "/"; });
+                    this.dataStores.updateUsedRoutes(usedRoutes);
+                } catch (error) {
+                    perfEvent.cancel(gcStats, error);
+                    throw error;
+                }
+                perfEvent.end(gcStats);
             }
 
             const trace = Trace.start();


### PR DESCRIPTION
Fixes #5047.

Added performance event for GC that will log time taken to run GC on the document. It also logs the total number of nodes in the document and the number of nodes GC found to be deleted. This information may be handy to give a general sense of how much data is unused in a document.