### PR TITLE
0.34 Port: Add Event to MergeTree and Sequence on Local Segment Op Ack (#5045)

### DIFF
--- a/packages/dds/merge-tree/src/mergeTreeDeltaCallback.ts
+++ b/packages/dds/merge-tree/src/mergeTreeDeltaCallback.ts
@@ -25,6 +25,11 @@ export const enum MergeTreeMaintenanceType {
      *    b) The segment's tracking collection is empty (e.g., not being tracked for undo/redo).
      */
     UNLINK  = -3,
+    /**
+     * Notification that a local change has been acknowledged by the server.
+     * This means that it has made the round trip to the server and has had a sequence number assigned.
+     */
+    ACKNOWLEDGED = -4,
 }
 
 export type MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationType | MergeTreeMaintenanceType;
@@ -70,4 +75,4 @@ export type MergeTreeDeltaCallback =
 export interface IMergeTreeMaintenanceCallbackArgs extends IMergeTreeDeltaCallbackArgs<MergeTreeMaintenanceType> { }
 
 export type MergeTreeMaintenanceCallback =
-    (MaintenanceArgs: IMergeTreeMaintenanceCallbackArgs) => void;
+    (MaintenanceArgs: IMergeTreeMaintenanceCallbackArgs, opArgs: IMergeTreeDeltaOpArgs | undefined) => void;

--- a/packages/dds/merge-tree/src/test/mergeTree.markRangeRemoved.deltaCallback.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.markRangeRemoved.deltaCallback.spec.ts
@@ -88,6 +88,7 @@ describe("MergeTree", () => {
                 [MergeTreeDeltaType.REMOVE]: 1,
                 [MergeTreeMaintenanceType.SPLIT]: 2,
                 [MergeTreeMaintenanceType.UNLINK]: 1,
+                [MergeTreeMaintenanceType.ACKNOWLEDGED]: 1,
             });
         });
 

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -144,8 +144,8 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
                     break;
                 case "maintenance":
                     if (!this.client.mergeTreeMaintenanceCallback) {
-                        this.client.mergeTreeMaintenanceCallback = (args) => {
-                            this.emit("maintenance", new SequenceMaintenanceEvent(args, this.client), this);
+                        this.client.mergeTreeMaintenanceCallback = (args, opArgs) => {
+                            this.emit("maintenance", new SequenceMaintenanceEvent(opArgs, args, this.client), this);
                         };
                     }
                     break;

--- a/packages/dds/sequence/src/sequenceDeltaEvent.ts
+++ b/packages/dds/sequence/src/sequenceDeltaEvent.ts
@@ -126,6 +126,7 @@ export class SequenceDeltaEvent extends SequenceEvent<MergeTreeDeltaOperationTyp
  */
 export class SequenceMaintenanceEvent extends SequenceEvent<MergeTreeMaintenanceType> {
     constructor(
+        public readonly opArgs: IMergeTreeDeltaOpArgs | undefined,
         deltaArgs: IMergeTreeMaintenanceCallbackArgs,
         mergeTreeClient: Client,
     ) {


### PR DESCRIPTION
Emit a new maintenance event, ACKNOWLEDGED when the op is round tripped from the server and the local segment is ack