### PR TITLE
Allow rdkafka producer to send messages to specific partitions

### DIFF
--- a/server/routerlicious/packages/services-core/src/queue.ts
+++ b/server/routerlicious/packages/services-core/src/queue.ts
@@ -94,4 +94,5 @@ export interface IPendingBoxcar {
     tenantId: string;
     deferred: Deferred<void>;
     messages: any[];
+    partitionId?: number;
 }

--- a/server/routerlicious/packages/services/src/pendingBoxcar.ts
+++ b/server/routerlicious/packages/services/src/pendingBoxcar.ts
@@ -12,6 +12,7 @@ export const MaxBatchSize = 32;
 export class PendingBoxcar implements IPendingBoxcar {
     public deferred = new Deferred<void>();
     public messages: any[] = [];
+    public partitionId?: number;
 
     constructor(public tenantId: string, public documentId: string) {
     }


### PR DESCRIPTION
This allows for future work such as creating a health check system to ensure every partition is processing messages in a timely fashion.

- Allow rdkafka producer to send messages to specific partitions
- Refactor boxcar logic a bit so it does less lookups