### PR TITLE
Fix for initial signals getting lost in local driver due to race condition

### DIFF
--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -57,7 +57,7 @@ export class DocumentDeltaConnection
 
     private socketConnectionTimeout: ReturnType<typeof setTimeout> | undefined;
 
-    private readonly submitManager: BatchManager<IDocumentMessage[]>;
+    protected readonly submitManager: BatchManager<IDocumentMessage[]>;
 
     private _details: IConnected | undefined;
 

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -55,6 +55,7 @@
     "@fluidframework/common-definitions": "^0.19.1",
     "@fluidframework/common-utils": "^0.27.0",
     "@fluidframework/core-interfaces": "^0.35.0",
+    "@fluidframework/driver-base": "^0.35.0",
     "@fluidframework/driver-definitions": "^0.35.0",
     "@fluidframework/driver-utils": "^0.35.0",
     "@fluidframework/protocol-definitions": "^0.1019.0-0",

--- a/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
+++ b/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
@@ -3,36 +3,32 @@
  * Licensed under the MIT License.
  */
 
-import { BatchManager, TypedEventEmitter } from "@fluidframework/common-utils";
-import { IDocumentDeltaConnection, IDocumentDeltaConnectionEvents } from "@fluidframework/driver-definitions";
+import { TelemetryNullLogger } from "@fluidframework/common-utils";
+import { DocumentDeltaConnection } from "@fluidframework/driver-base";
+import { IDocumentDeltaConnection } from "@fluidframework/driver-definitions";
 import {
-    ConnectionMode,
     IClient,
-    IClientConfiguration,
     IConnect,
-    IConnected,
     IDocumentMessage,
-    ISequencedDocumentMessage,
-    ISignalClient,
-    ISignalMessage,
-    ITokenClaims,
     NackErrorType,
 } from "@fluidframework/protocol-definitions";
-import { LocalWebSocketServer } from "@fluidframework/server-local-server";
+import { LocalWebSocket, LocalWebSocketServer } from "@fluidframework/server-local-server";
 import * as core from "@fluidframework/server-services-core";
-import { debug } from "./debug";
 
 const testProtocolVersions = ["^0.3.0", "^0.2.0", "^0.1.0"];
 export class LocalDocumentDeltaConnection
-    extends TypedEventEmitter<IDocumentDeltaConnectionEvents>
+    extends DocumentDeltaConnection
     implements IDocumentDeltaConnection {
     public static async create(
         tenantId: string,
         id: string,
         token: string,
         client: IClient,
-        webSocketServer: core.IWebSocketServer): Promise<LocalDocumentDeltaConnection> {
+        webSocketServer: core.IWebSocketServer,
+        timeoutMs = 60000,
+    ): Promise<LocalDocumentDeltaConnection> {
         const socket = (webSocketServer as LocalWebSocketServer).createConnection();
+        const deltaConnection = new LocalDocumentDeltaConnection(socket, id);
 
         const connectMessage: IConnect = {
             client,
@@ -42,130 +38,23 @@ export class LocalDocumentDeltaConnection
             token,  // Token is going to indicate tenant level information, etc...
             versions: testProtocolVersions,
         };
-
-        const connection = await new Promise<IConnected>((resolve, reject) => {
-            // Listen for ops sent before we receive a response to connect_document
-            const queuedMessages: ISequencedDocumentMessage[] = [];
-            const queuedSignals: ISignalMessage[] = [];
-
-            const earlyOpHandler = (documentId: string, msgs: ISequencedDocumentMessage[]) => {
-                debug("Queued early ops", msgs.length);
-                queuedMessages.push(...msgs);
-            };
-            socket.on("op", earlyOpHandler);
-
-            const earlySignalHandler = (msg: ISignalMessage) => {
-                debug("Queued early signals");
-                queuedSignals.push(msg);
-            };
-            socket.on("signal", earlySignalHandler);
-
-            // Listen for connection issues
-            socket.on("connect_error", (error) => {
-                reject(error);
-            });
-
-            socket.on("connect_document_success", (response: IConnected) => {
-                socket.removeListener("op", earlyOpHandler);
-                socket.removeListener("signal", earlySignalHandler);
-
-                if (queuedMessages.length > 0) {
-                    // Some messages were queued.
-                    // add them to the list of initialMessages to be processed
-                    response.initialMessages.push(...queuedMessages);
-                    response.initialMessages.sort((a, b) => a.sequenceNumber - b.sequenceNumber);
-                }
-
-                if (queuedSignals.length > 0) {
-                    // Some signals were queued.
-                    // add them to the list of initialSignals to be processed
-                    response.initialSignals.push(...queuedSignals);
-                }
-
-                resolve(response);
-            });
-
-            socket.on("connect_document_error", reject);
-
-            socket.emit("connect_document", connectMessage);
-        });
-
-        const deltaConnection = new LocalDocumentDeltaConnection(socket, id, connection);
-
-        return Promise.resolve(deltaConnection);
+        await deltaConnection.initialize(connectMessage, timeoutMs);
+        return deltaConnection;
     }
 
-    private readonly submitManager: BatchManager<IDocumentMessage[]>;
-    private readonly subscribedEvents = new Set<string>();
+    constructor(socket: LocalWebSocket, documentId: string) {
+        // Cast LocalWebSocket to SocketIOClient.Socket which is the socket that the base class needs. Doing this
+        // should be fine because this delta connection is used for local use only.
+        const socketWithListener = socket as unknown as SocketIOClient.Socket;
 
-    public get clientId(): string {
-        return this.details.clientId;
-    }
-
-    public get mode(): ConnectionMode {
-        return this.details.mode;
-    }
-
-    public get claims(): ITokenClaims {
-        return this.details.claims;
-    }
-
-    public get existing(): boolean {
-        return this.details.existing;
-    }
-
-    public get maxMessageSize(): number {
-        return this.details.maxMessageSize;
-    }
-
-    public get initialMessages(): ISequencedDocumentMessage[] {
-        return this.details.initialMessages;
-    }
-
-    public get initialSignals(): ISignalMessage[] {
-        return this.details.initialSignals;
-    }
-
-    public get initialClients(): ISignalClient[] {
-        return this.details.initialClients;
-    }
-
-    public get version(): string {
-        return testProtocolVersions[0];
-    }
-
-    public get serviceConfiguration(): IClientConfiguration {
-        return this.details.serviceConfiguration;
-    }
-
-    constructor(
-        private readonly socket: core.IWebSocket,
-        public documentId: string,
-        public details: IConnected) {
-        super();
-
-        this.submitManager = new BatchManager<IDocumentMessage[]>((submitType, work) => {
-            this.socket.emit(
-                submitType,
-                this.details.clientId,
-                work,
-                (error) => {
-                    if (error) {
-                        debug("Emit error", error);
-                    }
-                });
-        });
-
-        this.on("newListener", (event, listener) => {
-            if (!this.subscribedEvents.has(event)) {
-                this.subscribedEvents.add(event);
-                this.socket.on(
-                    event,
-                    (...args: any[]) => {
-                        this.emit(event, ...args);
-                    });
-                }
-        });
+        // Add `off` method the socket which is called by the base class `DocumentDeltaConnection` to remove
+        // event listeners.
+        // We may have to add more methods from SocketIOClient.Socket if they start getting used.
+        socketWithListener.off = (event: string, listener: (...args: any[]) => void) => {
+            socketWithListener.removeListener(event, listener);
+            return socketWithListener;
+        };
+        super(socketWithListener, documentId, new TelemetryNullLogger());
     }
 
     /**
@@ -186,10 +75,6 @@ export class LocalDocumentDeltaConnection
     public submitSignal(message: any): void {
         this.submitManager.add("submitSignal", message);
         this.submitManager.drain();
-    }
-
-    public close() {
-        this.disconnectClient("client close");
     }
 
     /**


### PR DESCRIPTION
Fixes #5023.

**Root-cause:** Server emits the `clientJoin` signal right after `connect_document_success`.
`LocalDocumentDeltaConnection` removes the initial op and signal handlers immediately after getting `connect_document_success` event. It then returns the delta connection to delta manager which set ups its event handlers on the socket. There is a race condition in between this where the `clientJoin` signal can get lost.

**Fix:** This has already been solved by odsp and routerlicious drivers. They use `DocumentDeltaConnection` as the base class which handles this race condition. Updated `LocalDocumentDeltaConnection` to use this base class as well.

**Problem with this fix:** I added a cast from `LocalWebSocket` to `SocketIOClient.Socket` which is a little ugly. So if that seems like a problem, we can handle this race similar to how `DocumentDeltaConnection` does, i.e., by removing the initial op and signal handlers when delta manager requests for initial signals.