### PR TITLE
[0.34 port] Explicitly export members of fluidRouter to workaround Typescript issue

### DIFF
--- a/packages/loader/core-interfaces/src/index.ts
+++ b/packages/loader/core-interfaces/src/index.ts
@@ -8,7 +8,16 @@
 export { IFluidObject } from "./fluidObject";
 
 export * from "./fluidLoadable";
-export * from "./fluidRouter";
+// Typescript forgets the index signature when customers augment IRequestHeader if we export *.
+// So we export the explicit members as a workaround:
+// https://github.com/microsoft/TypeScript/issues/18877#issuecomment-476921038
+export {
+    IRequest,
+    IRequestHeader,
+    IResponse,
+    IProvideFluidRouter,
+    IFluidRouter,
+} from "./fluidRouter";
 export * from "./handles";
 export * from "./serializer";
 export * from "./fluidPackage";


### PR DESCRIPTION
When downstream customers augment the IRequestHeader, the [index: string]: any; signature is lost and they end up with "property does not exist" errors.

This change uses this workaround to resolve the issue:
microsoft/TypeScript#18877 (comment)