### PR TITLE
Back off ci config for stress test

### DIFF
--- a/packages/test/service-load-test/testConfig.json
+++ b/packages/test/service-load-test/testConfig.json
@@ -15,10 +15,10 @@
     },
     "profiles": {
         "ci": {
-            "opRatePerMin": 30,
+            "opRatePerMin": 10,
             "progressIntervalMs": 15000,
-            "numClients": 240,
-            "totalSendCount": 10000,
+            "numClients": 120,
+            "totalSendCount": 1000,
             "readWriteCycleMs": 30000
         },
         "full": {


### PR DESCRIPTION
As-is, we are getting throttled by ODSP when running.  Now that this is enabled in CI for all commits, back this off to reduce load/noise.  We'll dial it in to the right baseline later.