### PR TITLE
Pass docId to Container.load

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -189,12 +189,11 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
      * Load an existing container.
      */
     public static async load(
-        id: string,
+        docId: string,
         loader: Loader,
         request: IRequest,
         resolvedUrl: IFluidResolvedUrl,
     ): Promise<Container> {
-        const [, docId] = id.split("/");
         const container = new Container(
             loader,
             {

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -361,6 +361,8 @@ export class Loader extends EventEmitter implements ILoader {
             return Promise.reject(new Error(`Invalid URL ${resolvedAsFluid.url}`));
         }
 
+        // parseUrl's id is expected to be of format "tenantId/docId"
+        const [, docId] = parsed.id.split("/");
         const { canCache, fromSequenceNumber } = this.parseHeader(parsed, request);
 
         let container: Container;
@@ -372,7 +374,7 @@ export class Loader extends EventEmitter implements ILoader {
             } else {
                 const containerP =
                     this.loadContainer(
-                        parsed.id,
+                        docId,
                         request,
                         resolvedAsFluid);
                 container = await containerP;
@@ -389,7 +391,7 @@ export class Loader extends EventEmitter implements ILoader {
         } else {
             container =
                 await this.loadContainer(
-                    parsed.id,
+                    docId,
                     request,
                     resolvedAsFluid);
         }
@@ -442,12 +444,12 @@ export class Loader extends EventEmitter implements ILoader {
     }
 
     private async loadContainer(
-        id: string,
+        docId: string,
         request: IRequest,
         resolved: IFluidResolvedUrl,
     ): Promise<Container> {
         return Container.load(
-            id,
+            docId,
             this,
             request,
             resolved);

--- a/packages/test/end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/container.spec.ts
@@ -40,7 +40,7 @@ describe("Container", () => {
         const testResolved = await loader.services.urlResolver.resolve(testRequest);
         ensureFluidResolvedUrl(testResolved);
         return Container.load(
-            "tenantId/documentId",
+            "documentId",
             loader,
             testRequest,
             testResolved);

--- a/packages/test/end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/error.spec.ts
@@ -66,7 +66,7 @@ describe("Errors Types", () => {
 
         try {
             await Container.load(
-                "tenantId/documentId",
+                "documentId",
                 loader,
                 testRequest,
                 testResolved);


### PR DESCRIPTION
Currently there is no hint that `Container.load()` expects the `id` arg to be `tenantId/docId`, even though it throws the tenant away.  This change simplifies that arg to just be the `docId`, which has the added benefit of better consolidating the steps to parse the resolved URL within the Loader's `resolveCore()`.