### PR TITLE
Stop handle expansion due to missing unreferenced flag in summary

### DIFF
--- a/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
+++ b/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
@@ -198,7 +198,11 @@ export class OdspSummaryUploadManager {
             cloneDeep(tree),
             blobTreeDedupCachesLatest,
             ".app",
-            false /* Stop handle expansion due to missing unreferenced flag in summary returned from server */,
+            // Issue: https://github.com/microsoft/FluidFramework/issues/5055
+            // Stop handle expansion due to missing unreferenced flag in summary returned from server. So in
+            // case we do expand an unreferenced tree, it could again become referenced.  We would try getting
+            // unreferenced flag in trees/latest from spo so that we can use that and expand accordingly.
+            false,
             "",
             false,
         );

--- a/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
+++ b/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
@@ -198,7 +198,7 @@ export class OdspSummaryUploadManager {
             cloneDeep(tree),
             blobTreeDedupCachesLatest,
             ".app",
-            true,
+            false /* Stop handle expansion due to missing unreferenced flag in summary returned from server */,
             "",
             false,
         );
@@ -390,9 +390,11 @@ export class OdspSummaryUploadManager {
                         reusedBlobs += result.reusedBlobs;
                         blobs += result.blobs;
                     } else {
-                        // Ideally we should not come here as we should have found it in cache. But in order to successfully upload the summary
-                        // we are just logging the event. Once we make sure that we don't have any telemetry for this, we would remove this.
-                        this.logger.sendErrorEvent({ eventName: "SummaryTreeHandleCacheMiss", parentHandle, handlePath: pathKey });
+                        if (allowHandleExpansion) {
+                            // Ideally we should not come here as we should have found it in cache. But in order to successfully upload the summary
+                            // we are just logging the event. Once we make sure that we don't have any telemetry for this, we would remove this.
+                            this.logger.sendErrorEvent({ eventName: "SummaryTreeHandleCacheMiss", parentHandle, handlePath: pathKey });
+                        }
                         id = `${parentHandle}/${pathKey}`;
                     }
                     break;


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/5055
1.) The server does not return unreferenced flag in the summary returned, currently. However this may change in future.
2.) So when we expand the handle with the cached summary tree, we are not able to set the unreferenced flag in the expanded tree.
3.) So disable the handle expansion for now.