### PR TITLE
refactor(runtime): clean up no-param-reassign-violations

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1555,6 +1555,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         this.verifyNotClosed();
 
         let clientSequenceNumber: number = -1;
+        const opMetadataInternal = { ...opMetadata };
 
         if (this.canSendOps()) {
             const serializedContent = JSON.stringify(content);
@@ -1562,8 +1563,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
 
             // If in manual flush mode we will trigger a flush at the next turn break
             if (this.flushMode === FlushMode.Manual && !this.needsFlush) {
-                // eslint-disable-next-line no-param-reassign
-                opMetadata = { ...opMetadata, batch: true };
+                opMetadataInternal.batch = true;
                 this.needsFlush = true;
 
                 // Use Promise.resolve().then() to queue a microtask to detect the end of the turn and force a flush.
@@ -1584,14 +1584,20 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                     type,
                     content,
                     /* batch: */ this._flushMode === FlushMode.Manual,
-                    opMetadata);
+                    opMetadataInternal);
             } else {
                 clientSequenceNumber = this.submitChunkedMessage(type, serializedContent, maxOpSize);
             }
         }
 
         // Let the PendingStateManager know that a message was submitted.
-        this.pendingStateManager.onSubmitMessage(type, clientSequenceNumber, content, localOpMetadata, opMetadata);
+        this.pendingStateManager.onSubmitMessage(
+            type,
+            clientSequenceNumber,
+            content,
+            localOpMetadata,
+            opMetadataInternal,
+        );
         if (this.isContainerMessageDirtyable(type, content)) {
             this.updateDocumentDirtyState(true);
         }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1555,7 +1555,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         this.verifyNotClosed();
 
         let clientSequenceNumber: number = -1;
-        const opMetadataInternal = { ...opMetadata };
+        let opMetadataInternal = opMetadata;
 
         if (this.canSendOps()) {
             const serializedContent = JSON.stringify(content);
@@ -1563,7 +1563,10 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
 
             // If in manual flush mode we will trigger a flush at the next turn break
             if (this.flushMode === FlushMode.Manual && !this.needsFlush) {
-                opMetadataInternal.batch = true;
+                opMetadataInternal = {
+                    ...opMetadata,
+                    batch: true,
+                };
                 this.needsFlush = true;
 
                 // Use Promise.resolve().then() to queue a microtask to detect the end of the turn and force a flush.

--- a/packages/runtime/runtime-utils/src/test/utils.ts
+++ b/packages/runtime/runtime-utils/src/test/utils.ts
@@ -27,15 +27,15 @@ export class MockHandleContext implements IFluidHandleContext {
  * is a factory that is invoked to create the leaves of the graph.
  */
 export function makeJson(breadth: number, depth: number, createLeaf: () => any) {
-    // eslint-disable-next-line no-param-reassign
-    if (--depth === 0) {
+    let depthInternal = depth;
+    if (--depthInternal === 0) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return createLeaf();
     }
 
     const o = {};
     for (let i = 0; i < breadth; i++) {
-        o[`o${i}`] = makeJson(breadth, depth, createLeaf);
+        o[`o${i}`] = makeJson(breadth, depthInternal, createLeaf);
     }
     return o;
 }


### PR DESCRIPTION
Issue #990 

Refactor code to remove `// eslint-disable-next-line no-param-reassign` in `runtime` packages