### PR TITLE
refactor(packages/dds/matrix): clean up no-param-reassign violations

### DIFF
--- a/packages/dds/matrix/src/handlecache.ts
+++ b/packages/dds/matrix/src/handlecache.ts
@@ -86,7 +86,7 @@ export class HandleCache implements IVectorConsumer<Handle> {
     private cacheMiss(position: number) {
         // Coercing 'position' to an Uint32 allows us to handle a negative 'position' value
         // with the same logic that handles 'position' >= length.
-        position >>>= 0;        // eslint-disable-line no-param-reassign
+        const _position = position >>> 0;
 
         // TODO: To bound memory usage, there should be a limit on the maximum size of
         //       handle[].
@@ -95,14 +95,14 @@ export class HandleCache implements IVectorConsumer<Handle> {
         //       the cache to the next MergeTree segment boundary (within the limits of
         //       the handle cache).
 
-        if (position < this.start) {
-            this.handles = this.getHandles(position, this.start).concat(this.handles);
-            this.start = position;
+        if (_position < this.start) {
+            this.handles = this.getHandles(_position, this.start).concat(this.handles);
+            this.start = _position;
             return this.handles[0];
         } else {
-            ensureRange(position, this.vector.getLength());
+            ensureRange(_position, this.vector.getLength());
 
-            this.handles = this.handles.concat(this.getHandles(this.start + this.handles.length, position + 1));
+            this.handles = this.handles.concat(this.getHandles(this.start + this.handles.length, _position + 1));
             return this.handles[this.handles.length - 1];
         }
     }

--- a/packages/dds/matrix/src/range.ts
+++ b/packages/dds/matrix/src/range.ts
@@ -8,9 +8,9 @@
   */
 export function ensureRange(value: number, limit: number) {
     // Coerce 'value' to Uint32 so that we can range check with a single branch.
-    value >>>= 0;   // eslint-disable-line no-param-reassign, no-bitwise
+    const _value = value >>> 0;   // eslint-disable-line no-bitwise
 
-    if (value >= limit) {
+    if (_value >= limit) {
         throw new RangeError("Invalid (row, col) coordinate.");
     }
 }

--- a/packages/dds/matrix/src/sparsearray2d.ts
+++ b/packages/dds/matrix/src/sparsearray2d.ts
@@ -14,12 +14,11 @@ import { IMatrixReader, IMatrixWriter } from "@tiny-calc/nano";
 // (Array<T> ~2% faster than typed array on Node v12 x64)
 const x8ToInterlacedX16 =
     new Array(256).fill(0).map((value, i) => {
-        /* eslint-disable no-param-reassign */
-        i = (i | (i << 4)) & 0x0f0f; // .... 7654 .... 3210
-        i = (i | (i << 2)) & 0x3333; // ..76 ..54 ..32 ..10
-        i = (i | (i << 1)) & 0x5555; // .7.6 .5.4 .3.2 .1.0
-        /* eslint-enable no-param-reassign */
-        return i;
+        let j = i;
+        j = (j | (j << 4)) & 0x0f0f; // .... 7654 .... 3210
+        j = (j | (j << 2)) & 0x3333; // ..76 ..54 ..32 ..10
+        j = (j | (j << 1)) & 0x5555; // .7.6 .5.4 .3.2 .1.0
+        return j;
     });
 
 // Selects individual bytes from a given 32b integer.  The left shift are used to


### PR DESCRIPTION
#990
Removed `no-param-reassign` from "packages/dds/matrix"