### PR TITLE
refactor(examples/d-o/search-menu): clean up no-param-reassign violations

### DIFF
--- a/examples/data-objects/search-menu/.eslintrc.js
+++ b/examples/data-objects/search-menu/.eslintrc.js
@@ -10,7 +10,6 @@ module.exports = {
     "rules": {
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/strict-boolean-expressions": "off",
-        "no-case-declarations": "off",
-        "no-param-reassign": "off"
+        "no-case-declarations": "off"
     }
 }

--- a/examples/data-objects/search-menu/src/domutils.ts
+++ b/examples/data-objects/search-menu/src/domutils.ts
@@ -37,24 +37,25 @@ const lineHeightCache = new Map<string, number>();
 let cachedCanvas: HTMLCanvasElement;
 
 export function getLineHeight(fontstr: string, lineHeight?: string) {
+    let _fontstr = fontstr;
     if (lineHeight) {
-        fontstr += (`/${lineHeight}`);
+        _fontstr += (`/${lineHeight}`);
     }
-    let height = lineHeightCache.get(fontstr);
+    let height = lineHeightCache.get(_fontstr);
     if (height === undefined) {
         const elm = document.createElement("div");
         elm.style.position = "absolute";
         elm.style.zIndex = "-10";
         elm.style.left = "0px";
         elm.style.top = "0px";
-        elm.style.font = fontstr;
+        elm.style.font = _fontstr;
         document.body.appendChild(elm);
         height = getTextHeight(elm);
         document.body.removeChild(elm);
-        lineHeightCache.set(fontstr, height);
+        lineHeightCache.set(_fontstr, height);
     }
     if (isNaN(height)) {
-        console.log(`nan height with fontstr ${fontstr}`);
+        console.log(`nan height with fontstr ${_fontstr}`);
     }
     return height;
 }

--- a/examples/data-objects/search-menu/src/searchMenu.ts
+++ b/examples/data-objects/search-menu/src/searchMenu.ts
@@ -125,14 +125,14 @@ export function selectionListBoxCreate(
     const getItemTextSuffix = () => itemTextSuffix;
 
     function selectItemByKey(key: string) {
-        key = key.trim();
+        const _key = key.trim();
         if (selectionIndex >= 0) {
-            if (items[selectionIndex].key === key) {
+            if (items[selectionIndex].key === _key) {
                 return;
             }
         }
         for (let i = 0, len = items.length; i < len; i++) {
-            if (items[i].key === key) {
+            if (items[i].key === _key) {
                 selectItem(i);
                 break;
             }


### PR DESCRIPTION
#990
Clean up `no-param-reassign` from "examples/data-objects/search-menu/**"