### PR TITLE
Simple task in the build-docs pipeline should use the Lite agent pool

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -7,6 +7,8 @@
 name: $(Build.BuildId)
 
 variables:
+  - name: skipComponentGovernanceDetection
+    value: true
   - group: doc-versions
   - group: storage-vars
   - name: repoToTrigger
@@ -80,7 +82,7 @@ stages:
 
 - stage: json
   displayName: 'API Extractor'
-  pool: Main
+  pool: Lite
   jobs:
     - deployment: upload_json
       displayName: 'Upload JSON'


### PR DESCRIPTION
Simple task in the build-docs pipeline should use the Lite agent pool
Also, since we have an explicit Component Detection task, we can disable the auto-injected one.