### PR TITLE
Simplify broadcaster publisher

### DIFF
--- a/server/routerlicious/packages/lambdas/src/broadcaster/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/broadcaster/lambda.ts
@@ -110,7 +110,11 @@ export class BroadcasterLambda implements IPartitionLambda {
 
             // Process all the batches + checkpoint
             this.current.forEach((batch, topic) => {
-                this.publisher.to(topic).emit(batch.event, batch.documentId, batch.messages);
+                if (this.publisher.emit) {
+                    this.publisher.emit(topic, batch.event, batch.documentId, batch.messages);
+                } else {
+                    this.publisher.to(topic).emit(batch.event, batch.documentId, batch.messages);
+                }
             });
 
             this.context.checkpoint(batchOffset);

--- a/server/routerlicious/packages/services-core/src/publisher.ts
+++ b/server/routerlicious/packages/services-core/src/publisher.ts
@@ -28,6 +28,12 @@ export interface IPublisher {
     to(topic: string): ITopic;
 
     /**
+     * Used to emit an event to a topic
+     * This will be used in place of "to().emit()" when defined
+     */
+    emit?(topic: string, event: string, ...args: any[]): void;
+
+    /**
      * Closes the publisher
      */
     close(): Promise<void>;

--- a/server/routerlicious/packages/services/src/socketIoRedisPublisher.ts
+++ b/server/routerlicious/packages/services/src/socketIoRedisPublisher.ts
@@ -42,6 +42,10 @@ export class SocketIoRedisPublisher implements core.IPublisher {
         return new SocketIoRedisTopic(this.io.to(topic));
     }
 
+    public emit(topic: string, event: string, ...args: any[]): void {
+        this.io.to(topic).emit(event, ...args);
+    }
+
     // eslint-disable-next-line @typescript-eslint/promise-function-async
     public close(): Promise<void> {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return


### PR DESCRIPTION
Add an emit method that removes the need to call `to` then `emit`. `to` was always returning a new object for the followup `emit` call, so this will reduce the amount of objects created at runtime.