### PR TITLE
Add timestamp to nack message

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -599,6 +599,7 @@ export class DeliLambda implements IPartitionLambda {
                 sequenceNumber: this.minimumSequenceNumber,
             },
             tenantId: this.tenantId,
+            timestamp: Date.now(),
             type: NackOperationType,
         };
         return {

--- a/server/routerlicious/packages/services-core/src/messages.ts
+++ b/server/routerlicious/packages/services-core/src/messages.ts
@@ -112,6 +112,10 @@ export interface INackMessage extends ITicketedMessage {
 
     // The details of the nack
     operation: INack;
+
+    // The time the server created the message, in milliseconds elapsed since
+    // 1 January 1970 00:00:00 UTC, with leap seconds ignored.
+    timestamp: number;
 }
 
 /**


### PR DESCRIPTION
I'm tracking the end to end latency for every message as they go through kafka topics.  The only message type that I cannot do this for are nacks because they don't have a timestamp on them.
- Add a timestamp to the nack message