### PR TITLE
Allow specifying an rdkafka producer topic config

### DIFF
--- a/server/routerlicious/packages/services/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services/src/rdkafkaProducer.ts
@@ -16,6 +16,7 @@ export interface IKafkaProducerOptions extends Partial<IKafkaBaseOptions> {
 	enableIdempotence: boolean;
 	pollIntervalMs: number;
 	additionalOptions?: kafkaTypes.ProducerGlobalConfig;
+	topicConfig?: kafkaTypes.ProducerTopicConfig;
 }
 
 /**
@@ -67,7 +68,7 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 			...this.producerOptions.additionalOptions,
 		};
 
-		this.producer = new kafka.HighLevelProducer(options);
+		this.producer = new kafka.HighLevelProducer(options, this.producerOptions.topicConfig);
 
 		this.producer.on("ready", () => {
 			this.connected = true;


### PR DESCRIPTION
Allows changing a few more config values, such as `acks` and `message.timeout.ms`