### PR TITLE
Filter undefined properties out of RdKafka options and provide RdKafkaConsumer settings from config

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/resourcesFactory.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/resourcesFactory.ts
@@ -43,6 +43,8 @@ export class KafkaResourcesFactory implements IResourcesFactory<KafkaResources> 
         const kafkaLibrary = config.get("kafka:lib:name");
         const kafkaEndpoint = config.get("kafka:lib:endpoint");
         const zookeeperEndpoint = config.get("zookeeper:endpoint");
+        const kafkaNumberOfPartitions = config.get("kafka:lib:numberOfPartitions");
+        const kafkaReplicationFactor = config.get("kafka:lib:replicationFactor");
 
         // Receive topic and group - for now we will assume an entry in config mapping
         // to the given name. Later though the lambda config will likely be split from the stream config
@@ -57,7 +59,9 @@ export class KafkaResourcesFactory implements IResourcesFactory<KafkaResources> 
             zookeeperEndpoint,
             clientId,
             groupId,
-            receiveTopic);
+            receiveTopic,
+            kafkaNumberOfPartitions,
+            kafkaReplicationFactor);
 
         return new KafkaResources(
             lambdaFactory,

--- a/server/routerlicious/packages/services/src/rdkafkaBase.ts
+++ b/server/routerlicious/packages/services/src/rdkafkaBase.ts
@@ -31,7 +31,7 @@ export abstract class RdkafkaBase extends EventEmitter {
 		protected readonly endpoints: IKafkaEndpoints,
 		public readonly clientId: string,
 		public readonly topic: string,
-		options: Partial<IKafkaBaseOptions>,
+		options?: Partial<IKafkaBaseOptions>,
 	) {
 		super();
 
@@ -40,9 +40,9 @@ export abstract class RdkafkaBase extends EventEmitter {
 		}
 
 		this.options = {
-			numberOfPartitions: 32,
-			replicationFactor: 3,
 			...options,
+			numberOfPartitions: options?.numberOfPartitions ?? 32,
+			replicationFactor: options?.replicationFactor ?? 3,
 		};
 
 		// eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/server/routerlicious/packages/services/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services/src/rdkafkaConsumer.ts
@@ -45,12 +45,12 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 		super(endpoints, clientId, topic, options);
 
 		this.consumerOptions = {
-			consumeTimeout: 1000,
-			consumeLoopTimeoutDelay: 100,
-			optimizedRebalance: false,
-			commitRetryDelay: 1000,
-			automaticConsume: true,
 			...options,
+			consumeTimeout: options?.consumeTimeout ?? 1000,
+			consumeLoopTimeoutDelay: options?.consumeLoopTimeoutDelay ?? 100,
+			optimizedRebalance: options?.optimizedRebalance ?? false,
+			commitRetryDelay: options?.commitRetryDelay ?? 1000,
+			automaticConsume: options?.automaticConsume ?? true,
 		};
 	}
 

--- a/server/routerlicious/packages/services/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services/src/rdkafkaProducer.ts
@@ -38,9 +38,9 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 		super(endpoints, clientId, topic, options);
 
 		this.producerOptions = {
-			enableIdempotence: false,
-			pollIntervalMs: 10,
 			...options,
+			enableIdempotence: options?.enableIdempotence ?? false,
+			pollIntervalMs: options?.pollIntervalMs ?? 10,
 		};
 	}
 


### PR DESCRIPTION
In #4846 RdKafka was upgraded to a newer version and new configurations were provided when creating consumers and producers. However, that introduced 2 small problems:

- We missed to provide kafkaNumberOfPartitions and kafkaReplicationFactor as parameters to [createConsumer() in Kafka-Service resourcesFactory](https://github.com/microsoft/FluidFramework/blob/4905460bade2e21799de7a4ba5294760228b21aa/server/routerlicious/packages/lambdas-driver/src/kafka-service/resourcesFactory.ts#L54). The result is that the `options` parameter contain two undefined properties (`numberOfPartitions` and `replicationFactor`) when [creating an RdKafkaConsumer in kafkaFactory.ts](https://github.com/microsoft/FluidFramework/blob/4905460bade2e21799de7a4ba5294760228b21aa/server/routerlicious/packages/services/src/kafkaFactory.ts#L23). That caused an exception in RdKafkaBase: since `options` included `numberOfPartitions` and `replicationFactor`, they would not be [overwritten with the default values](https://github.com/microsoft/FluidFramework/blob/50563f695bd4b453833773dd4355a2dafe4a37a9/server/routerlicious/packages/services/src/rdkafkaBase.ts#L43) and that would cause an exception [when creating a new topic](https://github.com/microsoft/FluidFramework/blob/50563f695bd4b453833773dd4355a2dafe4a37a9/server/routerlicious/packages/services/src/rdkafkaBase.ts#L77) (since the number of partitions would not be a number, but instead `undefined`).

- The above fixes the issue when KafkaFactory is used with the correct parameters. To provide similar issues (example, if callers do not specify all parameters or call rdKafkaConsumer/Producer directly), I added a check each time we handle options to use default values if the specified property is undefined.

- I also made rdKafkaBase `options` (constructor parameter) to be an optional parameter. `options` is provided by rdKafkaConsumer/Producer when they call `super()`. Since they provide optional `options` to `super()`, there was a type mismatch there.
