### PR TITLE
Move some Loader request options into Loader options

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,3 +1,13 @@
+## 0.35 Breaking changes
+- [Changes-to-Loader-request-headers-and-usage]
+
+### Changes to Loader request headers and usage
+Some Loader headers are being deprecated.
+
+`cache`, `pause`, and `reconnect` should now be specified as part of the `ILoaderOptions` when creating the Loader.  These options are static for a `Loader` instance.  Callers that previously specified these options through the `ILoaderHeader` should instead create a new `Loader` instance with the desired options.
+
+`version` should now be specified as part of the request url when calling `Loader.request(...)` or `Loader.resolve(...)` (this method was already supported previously).
+
 ## 0.34 Breaking changes
 - [Aqueduct writeBlob() and BlobHandle implementation removed](#Aqueduct-writeBlob-and-BlobHandle-implementation-removed)
 - [Connected events raised on registration](#Connected-events-raised-on-registration)

--- a/packages/loader/container-definitions/src/loader.ts
+++ b/packages/loader/container-definitions/src/loader.ts
@@ -173,6 +173,13 @@ export interface IContainer extends IEventProvider<IContainerEvents>, IFluidRout
 }
 
 /**
+ * Events emitted by the Loader "upwards" to the Host
+ */
+export interface ILoaderEvents extends IEvent {
+    (event: "containerLoaded", listener: (container: IContainer, newlyCreated: boolean) => void): void;
+}
+
+/**
  * The Host's view of the Loader, used for loading Containers
  */
 export interface ILoader extends IFluidRouter {
@@ -219,6 +226,18 @@ export type ILoaderOptions = {
      * Defaults to true.
      */
     cache?: boolean;
+
+    /**
+     * Start the container in a paused, unconnected state.
+     * Defaults to false.
+     */
+    pause?: boolean;
+
+    /**
+     * Allow the container to reconnect.
+     * Defaults to true.
+     */
+    reconnect?: boolean;
 };
 
 /**
@@ -227,6 +246,7 @@ export type ILoaderOptions = {
 export enum LoaderHeader {
     /**
      * Override the Loader's default caching behavior for this container.
+     * @deprected 0.35 Use IloaderOptions.cache instead
      */
     cache = "fluid-cache",
 
@@ -235,8 +255,12 @@ export enum LoaderHeader {
 
     /**
      * Start the container in a paused, unconnected state. Defaults to false
+     * @deprecated 0.35 Provide a loader policy on creation instead
      */
     pause = "pause",
+    /**
+     * @deprecated 0.35 Use ILoaderOptions.reconnect instead
+     */
     reconnect = "fluid-reconnect",
     sequenceNumber = "fluid-sequence-number",
 
@@ -245,6 +269,7 @@ export enum LoaderHeader {
      * null or "null": use ops, no snapshots
      * undefined: fetch latest snapshot
      * otherwise, version sha to load snapshot
+     * @deprecated 0.35 Provide this value in the request URL instead
      */
     version = "version",
 }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -194,19 +194,21 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         request: IRequest,
         resolvedUrl: IFluidResolvedUrl,
     ): Promise<Container> {
+        const canReconnect = !(loader.services.options.reconnect === false ||
+            request.headers?.[LoaderHeader.reconnect] === false);
         const container = new Container(
             loader,
             {
                 originalRequest: request,
                 id: decodeURI(docId),
                 resolvedUrl,
-                canReconnect: !(request.headers?.[LoaderHeader.reconnect] === false),
+                canReconnect,
             });
 
         return PerformanceEvent.timedExecAsync(container.logger, { eventName: "Load" }, async (event) => {
             return new Promise<Container>((res, rej) => {
                 const version = request.headers?.[LoaderHeader.version];
-                const pause = request.headers?.[LoaderHeader.pause];
+                const pause = loader.services.options.pause === true || request.headers?.[LoaderHeader.pause];
 
                 const onClosed = (err?: ICriticalContainerError) => {
                     // Depending where error happens, we can be attempting to connect to web socket


### PR DESCRIPTION
Fixes #4880

Add some Loader option equivalents for some Loader request options that are static for each Loader instance. This better defines how a Loader handles requests and better supports the guest component scenario.  Callers who need to change those Loader options should create a new Loader.

Also add an event for loading a container on the loader that the host can use to apply any additional policy not captured by loader options.

Future: executionContext should probably move to the Loader options as well, but its usage is a bit murky at the moment so I'll defer that to the background summarization issue.