### PR TITLE
Ensure broadcaster doesn't miss checkpoints

### DIFF
--- a/server/routerlicious/packages/lambdas/src/broadcaster/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/broadcaster/lambda.ts
@@ -96,13 +96,17 @@ export class BroadcasterLambda implements IPartitionLambda {
     }
 
     private sendPending() {
-        if (this.pending.size === 0 || this.messageSendingTimerId !== undefined) {
+        if (this.messageSendingTimerId !== undefined) {
+            // a send is in progress
+            return;
+        }
+
+        if (this.pending.size === 0) {
             // no pending work. checkpoint now if we have a pending offset
             if (this.pendingOffset) {
                 this.context.checkpoint(this.pendingOffset);
                 this.pendingOffset = undefined;
             }
-
             return;
         }
 


### PR DESCRIPTION
If broadcaster processes a message that is not a sequenced op or nack, it won't checkpoint.
In reality that should never happen, but it feels safer to add logic to checkpoint in case that does happen.