### PR TITLE
Loader Container Tracker for test

### DIFF
--- a/packages/test/end-to-end-tests/src/test/agentScheduler.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/agentScheduler.spec.ts
@@ -14,9 +14,13 @@ import * as oldTypes from "./oldVersionTypes";
 
 const tests = (argsFactory: () => ITestObjectProvider) => {
     let args: ITestObjectProvider;
-    beforeEach(()=>{
+    beforeEach(() => {
         args = argsFactory();
     });
+    afterEach(() => {
+        args.reset();
+    });
+
     const leader = "leader";
     describe("Single client", () => {
         let scheduler: IAgentScheduler;

--- a/packages/test/end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -14,6 +14,7 @@ import {
     TestFluidObjectFactory,
     TestFluidObject,
     createDocumentId,
+    LoaderContainerTracker,
 } from "@fluidframework/test-utils";
 import { SharedObject } from "@fluidframework/shared-object-base";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
@@ -36,6 +37,7 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
 
     let request: IRequest;
     let loader: Loader;
+    const loaderContainerTracker = new LoaderContainerTracker();
 
     const createTestStatementForAttachedDetached = (name: string, attached: boolean) =>
         `${name} should be ${attached ? "Attached" : "Detached"}`;
@@ -69,11 +71,13 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
         ]);
         const codeLoader = new LocalCodeLoader([[codeDetails, factory]]);
         const documentServiceFactory = driver.createDocumentServiceFactory();
-        return new Loader({
+        const testLoader = new Loader({
             urlResolver,
             documentServiceFactory,
             codeLoader,
         });
+        loaderContainerTracker.add(testLoader);
+        return testLoader;
     }
 
     beforeEach(async () => {
@@ -81,6 +85,10 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
         const urlResolver = driver.createUrlResolver();
         request = driver.createCreateNewRequest(documentId);
         loader = createTestLoader(urlResolver);
+    });
+
+    afterEach(() => {
+        loaderContainerTracker.reset();
     });
 
     it("Attaching dataStore should not attach unregistered DDS", async () => {

--- a/packages/test/end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/batching.spec.ts
@@ -38,6 +38,10 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
     beforeEach(()=>{
         args = argsFactory();
     });
+    afterEach(() => {
+        args.reset();
+    });
+
     let dataObject1: ITestFluidObject;
     let dataObject2: ITestFluidObject;
     let dataObject1map1: SharedMap;

--- a/packages/test/end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/blobs.spec.ts
@@ -23,6 +23,9 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
     beforeEach(()=>{
         args = argsFactory();
     });
+    afterEach(() => {
+        args.reset();
+    });
     it("attach sends an op", async function() {
         const container = await args.makeTestContainer(testContainerConfig);
 

--- a/packages/test/end-to-end-tests/src/test/cellEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/cellEndToEndTests.spec.ts
@@ -30,6 +30,10 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
     beforeEach(()=>{
         args = argsFactory();
     });
+    afterEach(() => {
+        args.reset();
+    });
+
     const initialCellValue = "Initial cell value";
     const newCellValue = "A new cell value";
 

--- a/packages/test/end-to-end-tests/src/test/compatUtils.ts
+++ b/packages/test/end-to-end-tests/src/test/compatUtils.ts
@@ -42,7 +42,7 @@ export interface ITestObjectProvider {
     urlResolver: IUrlResolver | oldTypes.IUrlResolver,
     defaultCodeDetails: IFluidCodeDetails | oldTypes.IFluidCodeDetails,
     opProcessingController: OpProcessingController | oldTypes.OpProcessingController,
-    reset(): void | Promise<void>,
+    reset(): void,
     documentId: string,
     driver: ITestDriver;
 }

--- a/packages/test/end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
@@ -45,10 +45,13 @@ function generate(
     name: string, ctor: ISharedObjectConstructor<IConsensusOrderedCollection>,
     input: any[], output: any[]) {
     const tests = (argsFactory: () => ITestObjectProvider) => {
-    let args: ITestObjectProvider;
-    beforeEach(()=>{
-        args = argsFactory();
-    });
+        let args: ITestObjectProvider;
+        beforeEach(()=>{
+            args = argsFactory();
+        });
+        afterEach(() => {
+            args.reset();
+        });
         let container1: IContainer;
         let container2: IContainer;
         let dataStore1: ITestFluidObject;

--- a/packages/test/end-to-end-tests/src/test/consensusRegisterCollectionEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/consensusRegisterCollectionEndToEndTests.spec.ts
@@ -40,10 +40,14 @@ const testContainerConfig: ITestContainerConfig = {
 
 function generate(name: string, ctor: ISharedObjectConstructor<IConsensusRegisterCollection>) {
     const tests = (argsFactory: () => ITestObjectProvider) => {
-    let args: ITestObjectProvider;
-    beforeEach(()=>{
-        args = argsFactory();
-    });
+        let args: ITestObjectProvider;
+        beforeEach(()=>{
+            args = argsFactory();
+        });
+        afterEach(() => {
+            args.reset();
+        });
+
         let dataStore1: ITestFluidObject;
         let sharedMap1: ISharedMap;
         let sharedMap2: ISharedMap;

--- a/packages/test/end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/container.spec.ts
@@ -14,7 +14,7 @@ import {
     IDocumentServiceFactory,
 } from "@fluidframework/driver-definitions";
 import { MockDocumentDeltaConnection } from "@fluid-internal/test-loader-utils";
-import { LocalCodeLoader, TestObjectProvider } from "@fluidframework/test-utils";
+import { LocalCodeLoader, TestObjectProvider, LoaderContainerTracker } from "@fluidframework/test-utils";
 import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ITestDriver } from "@fluidframework/test-driver-definitions";
@@ -25,8 +25,12 @@ const testRequest: IRequest = { url: id };
 
 describe("Container", () => {
     let driver: ITestDriver;
+    const loaderContainerTracker = new LoaderContainerTracker();
     beforeEach(()=>{
         driver = getFluidTestDriver();
+    });
+    afterEach(() => {
+        loaderContainerTracker.reset();
     });
     async function loadContainer(props?: Partial<ILoaderProps>) {
         const loader =  new Loader({
@@ -36,6 +40,7 @@ describe("Container", () => {
                 props?.documentServiceFactory ?? driver.createDocumentServiceFactory(),
             codeLoader: props?.codeLoader ?? new LocalCodeLoader([]),
         });
+        loaderContainerTracker.add(loader);
 
         const testResolved = await loader.services.urlResolver.resolve(testRequest);
         ensureFluidResolvedUrl(testResolved);

--- a/packages/test/end-to-end-tests/src/test/contextReload.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/contextReload.spec.ts
@@ -22,6 +22,7 @@ import {
     LocalCodeLoader,
     OpProcessingController,
     timeoutPromise,
+    LoaderContainerTracker,
 } from "@fluidframework/test-utils";
 import { Loader } from "@fluidframework/container-loader";
 import { V1, V2 } from "./compatUtils";
@@ -60,6 +61,7 @@ describe("context reload (hot-swap)", function() {
     let containerError = false;
     let dataStoreV1: TestDataStoreV1;
     let opProcessingController: OpProcessingController;
+    const loaderContainerTracker = new LoaderContainerTracker();
     const codeDetails = (version: string): oldTypes.IFluidCodeDetails => {
         return {
             package: { name: TestDataStore.type, version, fluid:{}},
@@ -88,6 +90,7 @@ describe("context reload (hot-swap)", function() {
             urlResolver: driver.createUrlResolver(),
             documentServiceFactory: driver.createDocumentServiceFactory(),
         });
+        loaderContainerTracker.add(loader);
         return createAndAttachContainer(
             defaultCodeDetails,
             loader,
@@ -101,6 +104,7 @@ describe("context reload (hot-swap)", function() {
             urlResolver: driver.createUrlResolver(),
             documentServiceFactory: driver.createDocumentServiceFactory(),
         });
+        loaderContainerTracker.add(loader);
         return loader.resolve({ url: driver.createContainerUrl(documentId) });
     }
 
@@ -128,6 +132,7 @@ describe("context reload (hot-swap)", function() {
 
         afterEach(async function() {
             assert.strictEqual(containerError, false, "container error");
+            loaderContainerTracker.reset();
         });
 
         it("is followed by an immediate summary", async function() {

--- a/packages/test/end-to-end-tests/src/test/counterEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/counterEndToEndTests.spec.ts
@@ -29,6 +29,9 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
     beforeEach(()=>{
         args = argsFactory();
     });
+    afterEach(() => {
+        args.reset();
+    });
     let dataStore1: ITestFluidObject;
     let sharedCounter1: ISharedCounter;
     let sharedCounter2: ISharedCounter;

--- a/packages/test/end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -13,6 +13,7 @@ import {
     TestFluidObject,
     OpProcessingController,
     createDocumentId,
+    LoaderContainerTracker,
 } from "@fluidframework/test-utils";
 import { SharedMap, SharedDirectory } from "@fluidframework/map";
 import { IDocumentAttributes } from "@fluidframework/protocol-definitions";
@@ -54,6 +55,8 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
     let loader: Loader;
     let request: IRequest;
     let opProcessingController: OpProcessingController;
+    const loaderContainerTracker = new LoaderContainerTracker();
+
     async function createDetachedContainerAndGetRootDataStore() {
         const container = await loader.createDetachedContainer(codeDetails);
         // Get the root dataStore from the detached container.
@@ -80,11 +83,13 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         ]);
         const codeLoader = new LocalCodeLoader([[codeDetails, factory]]);
         const documentServiceFactory = driver.createDocumentServiceFactory();
-        return new Loader({
+        const testLoader = new Loader({
             urlResolver: driver.createUrlResolver(),
             documentServiceFactory,
             codeLoader,
         });
+        loaderContainerTracker.add(testLoader);
+        return testLoader;
     }
 
     const createPeerDataStore = async (
@@ -104,6 +109,10 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
         request = driver.createCreateNewRequest(documentId);
         loader = createTestLoader();
         opProcessingController = new OpProcessingController();
+    });
+
+    afterEach(() => {
+        loaderContainerTracker.reset();
     });
 
     it("Dehydrated container snapshot", async () => {

--- a/packages/test/end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -82,6 +82,10 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         loader = args.makeTestLoader(testContainerConfig) as Loader;
     });
 
+    afterEach(() => {
+        args.reset();
+    });
+
     it("Create detached container", async () => {
         const container = await loader.createDetachedContainer(args.defaultCodeDetails);
         assert.strictEqual(container.attachState, AttachState.Detached, "Container should be detached");
@@ -623,6 +627,10 @@ describe("Detached Container", () => {
             args = argsFactory();
             request = (args.driver ?? getFluidTestDriver()).createCreateNewRequest(args.documentId);
             loader = args.makeTestLoader(testContainerConfig) as Loader;
+        });
+
+        afterEach(() => {
+            args.reset();
         });
 
         it("Load attached container from cache and check if they are same", async () => {

--- a/packages/test/end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
@@ -31,6 +31,10 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
     beforeEach(()=>{
         args = argsFactory();
     });
+    afterEach(() => {
+        args.reset();
+    });
+
     let dataObject1: ITestFluidObject;
     let sharedDirectory1: ISharedDirectory;
     let sharedDirectory2: ISharedDirectory;

--- a/packages/test/end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/error.spec.ts
@@ -24,7 +24,7 @@ import {
     OdspErrorType,
 } from "@fluidframework/odsp-doclib-utils";
 import { LoggingError } from "@fluidframework/telemetry-utils";
-import { createDocumentId, LocalCodeLoader } from "@fluidframework/test-utils";
+import { createDocumentId, LocalCodeLoader, LoaderContainerTracker } from "@fluidframework/test-utils";
 import { ITestDriver } from "@fluidframework/test-driver-definitions";
 
 describe("Errors Types", () => {
@@ -35,15 +35,19 @@ describe("Errors Types", () => {
     let codeLoader: LocalCodeLoader;
     let loader: Loader;
     let driver: ITestDriver;
-    before(()=>{
+    const loaderContainerTracker = new LoaderContainerTracker();
+    before(() => {
         driver = getFluidTestDriver();
+    });
+    afterEach(() => {
+        loaderContainerTracker.reset();
     });
 
     it("GeneralError Test", async () => {
         const id = createDocumentId();
         // Setup
         urlResolver = driver.createUrlResolver();
-        testRequest = { url:driver.createContainerUrl(id) };
+        testRequest = { url: driver.createContainerUrl(id) };
         testResolved =
             await urlResolver.resolve(testRequest) as IFluidResolvedUrl;
         documentServiceFactory = driver.createDocumentServiceFactory();
@@ -63,6 +67,7 @@ describe("Errors Types", () => {
             documentServiceFactory: mockFactory,
             codeLoader,
         });
+        loaderContainerTracker.add(loader);
 
         try {
             await Container.load(

--- a/packages/test/end-to-end-tests/src/test/fluidObjectHandle.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/fluidObjectHandle.spec.ts
@@ -21,6 +21,10 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
     beforeEach(()=>{
         args = argsFactory();
     });
+    afterEach(() => {
+        args.reset();
+    });
+
     let firstContainerObject1: TestDataObject;
     let firstContainerObject2: TestDataObject;
     let secondContainerObject1: TestDataObject;

--- a/packages/test/end-to-end-tests/src/test/leader.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/leader.spec.ts
@@ -28,6 +28,9 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         dataObject1 = await requestFluidObject<ITestFluidObject>(container1, "default");
         await ensureConnected(container1);
     });
+    afterEach(() => {
+        args.reset();
+    });
 
     it("Create and load", async () => {
         // after detach create, we are in view only mode

--- a/packages/test/end-to-end-tests/src/test/localTestSignals.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/localTestSignals.spec.ts
@@ -45,6 +45,9 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         const container2 = await args.loadTestContainer(testContainerConfig) as Container;
         dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
     });
+    afterEach(() => {
+        args.reset();
+    });
 
     describe("Attach signal Handlers on Both Clients", () => {
         it("Validate data store runtime signals", async () => {

--- a/packages/test/end-to-end-tests/src/test/mapEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/mapEndToEndTests.spec.ts
@@ -32,6 +32,10 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
     beforeEach(()=>{
         args = argsFactory();
     });
+    afterEach(() => {
+        args.reset();
+    });
+
     let dataObject1: ITestFluidObject;
     let sharedMap1: ISharedMap;
     let sharedMap2: ISharedMap;

--- a/packages/test/end-to-end-tests/src/test/sharedInterval.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/sharedInterval.spec.ts
@@ -58,6 +58,10 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
     beforeEach(()=>{
         args = argsFactory();
     });
+    afterEach(() => {
+        args.reset();
+    });
+
     describe("one client", () => {
         const stringId = "stringKey";
 

--- a/packages/test/end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
@@ -30,6 +30,10 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
     beforeEach(()=>{
         args = argsFactory();
     });
+    afterEach(() => {
+        args.reset();
+    });
+
     let sharedString1: SharedString;
     let sharedString2: SharedString;
 

--- a/packages/test/test-utils/src/index.ts
+++ b/packages/test/test-utils/src/index.ts
@@ -5,6 +5,7 @@
 
 export * from "./interfaces";
 export * from "./testObjectProvider";
+export * from "./loaderContainerTracker";
 export * from "./localLoader";
 export * from "./localCodeLoader";
 export * from "./opProcessingController";

--- a/packages/test/test-utils/src/loaderContainerTracker.ts
+++ b/packages/test/test-utils/src/loaderContainerTracker.ts
@@ -1,0 +1,34 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ILoader, IContainer } from "@fluidframework/container-definitions";
+
+export class LoaderContainerTracker {
+    private readonly containers = new Set<IContainer>();
+
+    public add<LoaderType extends ILoader>(loader: LoaderType) {
+        const patch = <T, C extends IContainer>(fn: (...args: T[]) => Promise<C>) => {
+            const boundFn = fn.bind(loader);
+            return async (...args: T[]) => {
+                const container = await boundFn(...args);
+                this.containers.add(container);
+                return container;
+            };
+        };
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        loader.resolve = patch(loader.resolve);
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        loader.createDetachedContainer = patch(loader.createDetachedContainer);
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        loader.rehydrateDetachedContainerFromSnapshot = patch(loader.rehydrateDetachedContainerFromSnapshot);
+    }
+
+    public reset() {
+        for (const container of this.containers) {
+            container.close();
+        }
+        this.containers.clear();
+    }
+}

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -11,18 +11,20 @@ import { ITestDriver } from "@fluidframework/test-driver-definitions";
 import { fluidEntryPoint, LocalCodeLoader } from "./localCodeLoader";
 import { createAndAttachContainer } from "./localLoader";
 import { OpProcessingController } from "./opProcessingController";
+import { LoaderContainerTracker } from "./loaderContainerTracker";
 
 const defaultCodeDetails: IFluidCodeDetails = {
     package: "defaultTestPackage",
     config: {},
 };
 
-export const createDocumentId = (): string=> uuid();
+export const createDocumentId = (): string => uuid();
 
 /**
  * Shared base class for test object provider.  Contain code for loader and container creation and loading
  */
-export  class TestObjectProvider<TestContainerConfigType> {
+export class TestObjectProvider<TestContainerConfigType> {
+    private readonly _loaderContainerTracker = new LoaderContainerTracker();
     private _documentServiceFactory: IDocumentServiceFactory | undefined;
     private _urlResolver: IUrlResolver | undefined;
     private _opProcessingController?: OpProcessingController;
@@ -86,7 +88,9 @@ export  class TestObjectProvider<TestContainerConfigType> {
      * @param testContainerConfig - optional configuring the test Container
      */
     public makeTestLoader(testContainerConfig?: TestContainerConfigType) {
-        return this.createLoader([[defaultCodeDetails, this.createFluidEntryPoint(testContainerConfig)]]);
+        const loader = this.createLoader([[defaultCodeDetails, this.createFluidEntryPoint(testContainerConfig)]]);
+        this._loaderContainerTracker.add(loader);
+        return loader;
     }
 
     /**
@@ -119,6 +123,7 @@ export  class TestObjectProvider<TestContainerConfigType> {
     }
 
     public reset() {
+        this._loaderContainerTracker.reset();
         this._documentServiceFactory = undefined;
         this._urlResolver = undefined;
         this._opProcessingController = undefined;


### PR DESCRIPTION
#5098 

A tracker that patch the loader to keep track of all the container loaded, so that we can automatically close all the container at the end of each test.

This fixes port exhaustion on e2e targeting tinylicious on my machine.