### PR TITLE
Add optional auth retry logic in historian client class

### DIFF
--- a/server/routerlicious/packages/services-client/src/historian.ts
+++ b/server/routerlicious/packages/services-client/src/historian.ts
@@ -34,7 +34,7 @@ export class Historian implements IHistorian {
         public endpoint: string,
         private readonly historianApi: boolean,
         private readonly disableCache: boolean,
-        private readonly getCredentials?: () => ICredentials | Promise<ICredentials>,
+        private readonly getCredentials?: () => Promise<ICredentials>,
         private readonly getCorrelationId?: () => string | undefined) {
         this.restWrapperP = this.createRestWrapper();
     }

--- a/server/routerlicious/packages/services-client/src/historian.ts
+++ b/server/routerlicious/packages/services-client/src/historian.ts
@@ -28,114 +28,96 @@ export interface ICredentials {
  * Implementation of the IHistorian interface that calls out to a REST interface
  */
 export class Historian implements IHistorian {
-    private readonly restWrapper: RestWrapper;
+    private restWrapper: RestWrapper;
 
     constructor(
         public endpoint: string,
         private readonly historianApi: boolean,
         private readonly disableCache: boolean,
         credentials?: ICredentials,
-        getCorrelationId?: () => string | undefined) {
-        const queryString: { token?; disableCache?} = {};
-        let cacheBust = false;
-        if (this.disableCache && this.historianApi) {
-            queryString.disableCache = this.disableCache;
-        } else if (this.disableCache) {
-            cacheBust = true;
-        }
-
-        if (credentials) {
-            queryString.token = fromUtf8ToBase64(`${credentials.user}`);
-        }
-
-        const headers = credentials ?
-            {
-                Authorization: `Basic ${fromUtf8ToBase64(`${credentials.user}:${credentials.password}`)}`,
-            } :
-            {};
-        if (getCorrelationId) {
-            headers["x-correlation-id"] = getCorrelationId() || uuid.v4();
-        }
-
-        this.restWrapper = new RestWrapper(endpoint, headers, queryString, cacheBust);
+        private readonly getCorrelationId?: () => string | undefined,
+        private readonly getRefreshedCredentials?: () => Promise<ICredentials>) {
+        this.restWrapper = this.createRestWrapper(credentials);
     }
 
     /* eslint-disable @typescript-eslint/promise-function-async */
     public getHeader(sha: string): Promise<any> {
         if (this.historianApi) {
-            return this.restWrapper.get(`/headers/${encodeURIComponent(sha)}`);
+            return this.restCallWithAuthRetry(() => this.restWrapper.get(`/headers/${encodeURIComponent(sha)}`));
         } else {
             return this.getHeaderDirect(sha);
         }
     }
 
     public getFullTree(sha: string): Promise<any> {
-        return this.restWrapper.get(`/tree/${encodeURIComponent(sha)}`);
+        return this.restCallWithAuthRetry(() => this.restWrapper.get(`/tree/${encodeURIComponent(sha)}`));
     }
 
     public getBlob(sha: string): Promise<git.IBlob> {
-        return this.restWrapper.get<git.IBlob>(`/git/blobs/${encodeURIComponent(sha)}`);
+        return this.restCallWithAuthRetry(() => this.restWrapper.get<git.IBlob>(
+            `/git/blobs/${encodeURIComponent(sha)}`));
     }
 
     public createBlob(blob: git.ICreateBlobParams): Promise<git.ICreateBlobResponse> {
-        return this.restWrapper.post<git.ICreateBlobResponse>(`/git/blobs`, blob);
+        return this.restCallWithAuthRetry(() => this.restWrapper.post<git.ICreateBlobResponse>(`/git/blobs`, blob));
     }
 
     public getContent(path: string, ref: string): Promise<any> {
-        return this.restWrapper.get(`/contents/${path}`, { ref });
+        return this.restCallWithAuthRetry(() => this.restWrapper.get(`/contents/${path}`, { ref }));
     }
 
     public getCommits(sha: string, count: number): Promise<git.ICommitDetails[]> {
-        return this.restWrapper.get<git.ICommitDetails[]>(`/commits`, { count, sha })
+        return this.restCallWithAuthRetry(() => this.restWrapper.get<git.ICommitDetails[]>(`/commits`, { count, sha }))
             .catch((error) => (error === 400 || error === 404) ?
                 [] as git.ICommitDetails[] : Promise.reject<git.ICommitDetails[]>(error));
     }
 
     public getCommit(sha: string): Promise<git.ICommit> {
-        return this.restWrapper.get<git.ICommit>(`/git/commits/${encodeURIComponent(sha)}`);
+        return this.restCallWithAuthRetry(() => this.restWrapper.get<git.ICommit>(
+            `/git/commits/${encodeURIComponent(sha)}`));
     }
 
     public createCommit(commit: git.ICreateCommitParams): Promise<git.ICommit> {
-        return this.restWrapper.post<git.ICommit>(`/git/commits`, commit);
+        return this.restCallWithAuthRetry(() => this.restWrapper.post<git.ICommit>(`/git/commits`, commit));
     }
 
     public getRefs(): Promise<git.IRef[]> {
-        return this.restWrapper.get(`/git/refs`);
+        return this.restCallWithAuthRetry(() => this.restWrapper.get(`/git/refs`));
     }
 
     public getRef(ref: string): Promise<git.IRef> {
-        return this.restWrapper.get(`/git/refs/${ref}`);
+        return this.restCallWithAuthRetry(() => this.restWrapper.get(`/git/refs/${ref}`));
     }
 
     public createRef(params: git.ICreateRefParams): Promise<git.IRef> {
-        return this.restWrapper.post(`/git/refs`, params);
+        return this.restCallWithAuthRetry(() => this.restWrapper.post(`/git/refs`, params));
     }
 
     public updateRef(ref: string, params: git.IPatchRefParams): Promise<git.IRef> {
-        return this.restWrapper.patch(`/git/refs/${ref}`, params);
+        return this.restCallWithAuthRetry(() => this.restWrapper.patch(`/git/refs/${ref}`, params));
     }
     /* eslint-enable @typescript-eslint/promise-function-async */
 
     public async deleteRef(ref: string): Promise<void> {
-        await this.restWrapper.delete(`/git/refs/${ref}`);
+        await this.restCallWithAuthRetry(async () => this.restWrapper.delete(`/git/refs/${ref}`));
     }
 
     /* eslint-disable @typescript-eslint/promise-function-async */
     public createTag(tag: git.ICreateTagParams): Promise<git.ITag> {
-        return this.restWrapper.post(`/git/tags`, tag);
+        return this.restCallWithAuthRetry(() => this.restWrapper.post(`/git/tags`, tag));
     }
 
     public getTag(tag: string): Promise<git.ITag> {
-        return this.restWrapper.get(`/git/tags/${tag}`);
+        return this.restCallWithAuthRetry(() => this.restWrapper.get(`/git/tags/${tag}`));
     }
 
     public createTree(tree: git.ICreateTreeParams): Promise<git.ITree> {
-        return this.restWrapper.post<git.ITree>(`/git/trees`, tree);
+        return this.restCallWithAuthRetry(() => this.restWrapper.post<git.ITree>(`/git/trees`, tree));
     }
 
     public getTree(sha: string, recursive: boolean): Promise<git.ITree> {
-        return this.restWrapper.get<git.ITree>(
-            `/git/trees/${encodeURIComponent(sha)}`, { recursive: recursive ? 1 : 0 });
+        return this.restCallWithAuthRetry(() => this.restWrapper.get<git.ITree>(
+            `/git/trees/${encodeURIComponent(sha)}`, { recursive: recursive ? 1 : 0 }));
     }
     /* eslint-enable @typescript-eslint/promise-function-async */
 
@@ -157,5 +139,50 @@ export class Historian implements IHistorian {
             blobs,
             tree,
         };
+    }
+
+    private createRestWrapper(
+        credentials?: ICredentials,
+    ): RestWrapper {
+        const queryString: { token?; disableCache?} = {};
+        let cacheBust = false;
+        if (this.disableCache && this.historianApi) {
+            queryString.disableCache = this.disableCache;
+        } else if (this.disableCache) {
+            cacheBust = true;
+        }
+
+        const headers: any = {};
+        if (credentials) {
+            queryString.token = fromUtf8ToBase64(`${credentials.user}`);
+            headers.Authorization = `Basic ${fromUtf8ToBase64(`${credentials.user}:${credentials.password}`)}`;
+        }
+
+        if (this.getCorrelationId) {
+            headers["x-correlation-id"] = this.getCorrelationId() || uuid.v4();
+        }
+
+        return new RestWrapper(this.endpoint, headers, queryString, cacheBust);
+    }
+
+    private async refreshAuthHeaders(): Promise<void> {
+        if (this.getRefreshedCredentials === undefined) {
+            return;
+        }
+        const refreshedCredentials = await this.getRefreshedCredentials();
+        this.restWrapper = this.createRestWrapper(refreshedCredentials);
+    }
+
+    private async restCallWithAuthRetry<T>(restCall: () => Promise<T>): Promise<T> {
+        if (this.getRefreshedCredentials === undefined) {
+            return restCall();
+        }
+        return restCall().catch(async (error) => {
+            if (error === 401 || error?.response?.status === 401) {
+                await this.refreshAuthHeaders();
+                return restCall();
+            }
+            return Promise.reject(error);
+        });
     }
 }

--- a/server/routerlicious/packages/services-client/src/historian.ts
+++ b/server/routerlicious/packages/services-client/src/historian.ts
@@ -28,95 +28,96 @@ export interface ICredentials {
  * Implementation of the IHistorian interface that calls out to a REST interface
  */
 export class Historian implements IHistorian {
-    private restWrapper: RestWrapper;
+    private restWrapperP: Promise<RestWrapper>;
 
     constructor(
         public endpoint: string,
         private readonly historianApi: boolean,
         private readonly disableCache: boolean,
-        credentials?: ICredentials,
-        private readonly getCorrelationId?: () => string | undefined,
-        private readonly getRefreshedCredentials?: () => Promise<ICredentials>) {
-        this.restWrapper = this.createRestWrapper(credentials);
+        private readonly getCredentials?: () => ICredentials | Promise<ICredentials>,
+        private readonly getCorrelationId?: () => string | undefined) {
+        this.restWrapperP = this.createRestWrapper();
     }
 
     /* eslint-disable @typescript-eslint/promise-function-async */
     public getHeader(sha: string): Promise<any> {
         if (this.historianApi) {
-            return this.restCallWithAuthRetry(() => this.restWrapper.get(`/headers/${encodeURIComponent(sha)}`));
+            return this.restCallWithAuthRetry((restWrapper) => restWrapper.get(`/headers/${encodeURIComponent(sha)}`));
         } else {
             return this.getHeaderDirect(sha);
         }
     }
 
     public getFullTree(sha: string): Promise<any> {
-        return this.restCallWithAuthRetry(() => this.restWrapper.get(`/tree/${encodeURIComponent(sha)}`));
+        return this.restCallWithAuthRetry((restWrapper) => restWrapper.get(`/tree/${encodeURIComponent(sha)}`));
     }
 
     public getBlob(sha: string): Promise<git.IBlob> {
-        return this.restCallWithAuthRetry(() => this.restWrapper.get<git.IBlob>(
+        return this.restCallWithAuthRetry((restWrapper) => restWrapper.get<git.IBlob>(
             `/git/blobs/${encodeURIComponent(sha)}`));
     }
 
     public createBlob(blob: git.ICreateBlobParams): Promise<git.ICreateBlobResponse> {
-        return this.restCallWithAuthRetry(() => this.restWrapper.post<git.ICreateBlobResponse>(`/git/blobs`, blob));
+        return this.restCallWithAuthRetry((restWrapper) => restWrapper.post<git.ICreateBlobResponse>(
+            `/git/blobs`, blob));
     }
 
     public getContent(path: string, ref: string): Promise<any> {
-        return this.restCallWithAuthRetry(() => this.restWrapper.get(`/contents/${path}`, { ref }));
+        return this.restCallWithAuthRetry((restWrapper) => restWrapper.get(`/contents/${path}`, { ref }));
     }
 
     public getCommits(sha: string, count: number): Promise<git.ICommitDetails[]> {
-        return this.restCallWithAuthRetry(() => this.restWrapper.get<git.ICommitDetails[]>(`/commits`, { count, sha }))
-            .catch((error) => (error === 400 || error === 404) ?
-                [] as git.ICommitDetails[] : Promise.reject<git.ICommitDetails[]>(error));
+        return this.restCallWithAuthRetry((restWrapper) => restWrapper.get<git.ICommitDetails[]>(
+            `/commits`, { count, sha }))
+                .catch((error) => (error === 400 || error === 404) ?
+                    [] as git.ICommitDetails[] : Promise.reject<git.ICommitDetails[]>(error));
     }
 
     public getCommit(sha: string): Promise<git.ICommit> {
-        return this.restCallWithAuthRetry(() => this.restWrapper.get<git.ICommit>(
+        return this.restCallWithAuthRetry((restWrapper) => restWrapper.get<git.ICommit>(
             `/git/commits/${encodeURIComponent(sha)}`));
     }
 
     public createCommit(commit: git.ICreateCommitParams): Promise<git.ICommit> {
-        return this.restCallWithAuthRetry(() => this.restWrapper.post<git.ICommit>(`/git/commits`, commit));
+        return this.restCallWithAuthRetry((restWrapper) => restWrapper.post<git.ICommit>(`/git/commits`, commit));
     }
 
     public getRefs(): Promise<git.IRef[]> {
-        return this.restCallWithAuthRetry(() => this.restWrapper.get(`/git/refs`));
+        return this.restCallWithAuthRetry((restWrapper) => restWrapper.get(`/git/refs`));
     }
 
     public getRef(ref: string): Promise<git.IRef> {
-        return this.restCallWithAuthRetry(() => this.restWrapper.get(`/git/refs/${ref}`));
+        return this.restCallWithAuthRetry((restWrapper) => restWrapper.get(`/git/refs/${ref}`));
     }
 
     public createRef(params: git.ICreateRefParams): Promise<git.IRef> {
-        return this.restCallWithAuthRetry(() => this.restWrapper.post(`/git/refs`, params));
+        return this.restCallWithAuthRetry((restWrapper) => restWrapper.post(`/git/refs`, params));
     }
 
     public updateRef(ref: string, params: git.IPatchRefParams): Promise<git.IRef> {
-        return this.restCallWithAuthRetry(() => this.restWrapper.patch(`/git/refs/${ref}`, params));
+        return this.restCallWithAuthRetry((restWrapper) => restWrapper.patch(`/git/refs/${ref}`, params));
     }
     /* eslint-enable @typescript-eslint/promise-function-async */
 
     public async deleteRef(ref: string): Promise<void> {
-        await this.restCallWithAuthRetry(async () => this.restWrapper.delete(`/git/refs/${ref}`));
+        await this.restCallWithAuthRetry(async (restWrapper) => restWrapper.delete(`/git/refs/${ref}`));
     }
 
     /* eslint-disable @typescript-eslint/promise-function-async */
     public createTag(tag: git.ICreateTagParams): Promise<git.ITag> {
-        return this.restCallWithAuthRetry(() => this.restWrapper.post(`/git/tags`, tag));
+        return this.restCallWithAuthRetry((restWrapper) => restWrapper.post(`/git/tags`, tag));
     }
 
     public getTag(tag: string): Promise<git.ITag> {
-        return this.restCallWithAuthRetry(() => this.restWrapper.get(`/git/tags/${tag}`));
+        return this.restCallWithAuthRetry((restWrapper) => restWrapper.get(`/git/tags/${tag}`));
     }
 
     public createTree(tree: git.ICreateTreeParams): Promise<git.ITree> {
-        return this.restCallWithAuthRetry(() => this.restWrapper.post<git.ITree>(`/git/trees`, tree));
+        return this.restCallWithAuthRetry((restWrapper) => restWrapper.post<git.ITree>(`/git/trees`, tree));
     }
 
     public getTree(sha: string, recursive: boolean): Promise<git.ITree> {
-        return this.restCallWithAuthRetry(() => this.restWrapper.get<git.ITree>(
+        return this.restCallWithAuthRetry((restWrapper) => restWrapper.get<git.ITree>(
             `/git/trees/${encodeURIComponent(sha)}`, { recursive: recursive ? 1 : 0 }));
     }
     /* eslint-enable @typescript-eslint/promise-function-async */
@@ -141,9 +142,7 @@ export class Historian implements IHistorian {
         };
     }
 
-    private createRestWrapper(
-        credentials?: ICredentials,
-    ): RestWrapper {
+    private async createRestWrapper(): Promise<RestWrapper> {
         const queryString: { token?; disableCache?} = {};
         let cacheBust = false;
         if (this.disableCache && this.historianApi) {
@@ -153,7 +152,8 @@ export class Historian implements IHistorian {
         }
 
         const headers: any = {};
-        if (credentials) {
+        if (typeof this.getCredentials === "function") {
+            const credentials = await this.getCredentials();
             queryString.token = fromUtf8ToBase64(`${credentials.user}`);
             headers.Authorization = `Basic ${fromUtf8ToBase64(`${credentials.user}:${credentials.password}`)}`;
         }
@@ -165,22 +165,16 @@ export class Historian implements IHistorian {
         return new RestWrapper(this.endpoint, headers, queryString, cacheBust);
     }
 
-    private async refreshAuthHeaders(): Promise<void> {
-        if (this.getRefreshedCredentials === undefined) {
-            return;
+    private async restCallWithAuthRetry<T>(restCall: (restWrapper: RestWrapper) => Promise<T>): Promise<T> {
+        let restWrapper = await this.restWrapperP;
+        if (this.getCredentials === undefined) {
+            return restCall(restWrapper);
         }
-        const refreshedCredentials = await this.getRefreshedCredentials();
-        this.restWrapper = this.createRestWrapper(refreshedCredentials);
-    }
-
-    private async restCallWithAuthRetry<T>(restCall: () => Promise<T>): Promise<T> {
-        if (this.getRefreshedCredentials === undefined) {
-            return restCall();
-        }
-        return restCall().catch(async (error) => {
+        return restCall(restWrapper).catch(async (error) => {
             if (error === 401 || error?.response?.status === 401) {
-                await this.refreshAuthHeaders();
-                return restCall();
+                this.restWrapperP = this.createRestWrapper();
+                restWrapper = await this.restWrapperP;
+                return restCall(restWrapper);
             }
             return Promise.reject(error);
         });

--- a/server/routerlicious/packages/services-client/src/test/historian.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/historian.spec.ts
@@ -1,0 +1,435 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { fromUtf8ToBase64 } from "@fluidframework/common-utils";
+import qs from "querystring";
+import * as git from "@fluidframework/gitresources";
+import assert from "assert";
+import Axios, { AxiosRequestConfig } from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { Historian, ICredentials } from "../historian";
+
+describe.only("Historian", () => {
+    const endpoint = "http://test:3000";
+    const sha = "123456abcdef";
+    const ref = "xyz789";
+    const tag = "1a2b3c";
+    const axiosMock = new AxiosMockAdapter(Axios);
+    const initialCredentials: ICredentials = {
+        user: "test-user",
+        password: "test-password",
+    };
+    const freshCredentials: ICredentials = {
+        user: "test-user",
+        password: "new-test-password",
+    };
+    const mockAuthor: git.IAuthor = {
+        name: "Fabrikam",
+        email: "contoso@microsoft.com",
+        date: new Date().toTimeString(),
+    };
+    const mockBlob: git.IBlob = {
+        content: "Hello, World!",
+        encoding: "utf8",
+        url: `${endpoint}/blob/${sha}`,
+        sha,
+        size: 20,
+    };
+    const mockCommitDetails: git.ICommitDetails = {
+        url: `${endpoint}/commit/${ref}/details`,
+        sha,
+        commit: {
+            url: `${endpoint}/commit/${ref}/commit`,
+            author: mockAuthor,
+            committer: mockAuthor,
+            message: "test",
+            tree: {
+                sha,
+                url: `${endpoint}/commit/${ref}/tree`
+            }
+        },
+        parents: []
+    };
+    const mockCommit: git.ICommit = {
+        ...mockCommitDetails.commit,
+        sha,
+        parents: []
+    }
+    const mockRef: git.IRef = {
+        ref,
+        url: `${endpoint}/ref/${ref}`,
+        object: {
+            type: "test-ref",
+            sha,
+            url: `${endpoint}/ref/${ref}/object`,
+        }
+    };
+    const mockTag: git.ITag = {
+        tag,
+        sha,
+        url: `${endpoint}/tags/${tag}`,
+        message: "v0.1.0-test",
+        tagger: mockAuthor,
+        object: {
+            type: "test-tag",
+            sha,
+            url: `${endpoint}/tags/${tag}/object`,
+        }
+    };
+    const mockTree: git.ITree = {
+        sha,
+        url: `${endpoint}/trees/${sha}`,
+        tree: [],
+    };
+
+    let historian: Historian;
+    // Same decoding as FluidFramework/server/historian/packages/historian-base/src/routes/utils.ts createGitService()
+    const decodeHistorianCredentials = (authHeader: string): ICredentials => {
+        if (!authHeader) {
+            return undefined;
+        }
+        const base64TokenMatch = authHeader.match(/Basic (.+)/);
+        if (!base64TokenMatch) {
+            throw new Error("Malformed authorization token");
+        }
+        const encoded = Buffer.from(base64TokenMatch[1], "base64").toString();
+
+        const tokenMatch = encoded.match(/(.+):(.+)/);
+        if (!tokenMatch) {
+            throw new Error("Malformed authorization token");
+        }
+
+        return {
+            user: tokenMatch[1],
+            password: tokenMatch[2],
+        }
+    };
+    const mockReplyWithAuth = (validCredentials: ICredentials, successResponseData?: any) => (req: AxiosRequestConfig): any[] => {
+        const decodedCredentials = decodeHistorianCredentials(req.headers?.Authorization);
+        if (!decodedCredentials || decodedCredentials.password !== validCredentials.password) {
+            return [401, successResponseData];
+        }
+        return [200, successResponseData];
+    };
+    const getUrlWithToken = (path: string, credentials: ICredentials, additionalQueryParams?: any) => {
+        return `${endpoint}${path}?${qs.encode({
+            token: fromUtf8ToBase64(`${credentials.user}`),
+            ...additionalQueryParams
+        })}`;
+    };
+
+    beforeEach(() => {
+        historian = new Historian(
+            endpoint,
+            true,
+            false,
+            initialCredentials,
+            undefined,
+            async () => freshCredentials,
+        );
+        axiosMock.reset();
+    });
+
+    describe("getHeader", () => {
+        describe("with Historian API", () => {
+            const url = getUrlWithToken(`/headers/${encodeURIComponent(sha)}`, initialCredentials);
+            const response: any = {
+                "Content-Type": "text",
+            };
+            it("succeeds on 200", async () => {
+                axiosMock.onGet(url).reply(mockReplyWithAuth(initialCredentials, response));
+                const received = await historian.getHeader(sha);
+                assert.deepStrictEqual(received, response);
+            });
+            it("retries once with new credentials on 401", async () => {
+                axiosMock.onGet(url).reply(mockReplyWithAuth(freshCredentials, response));
+                const received = await historian.getHeader(sha);
+                assert.deepStrictEqual(received, response);
+            });
+        });
+    });
+
+    describe("getFullTree", () => {
+        const url = getUrlWithToken(`/tree/${encodeURIComponent(sha)}`, initialCredentials);
+        const response: any = "🌲";
+        it("succeeds on 200", async () => {
+            axiosMock.onGet(url).reply(mockReplyWithAuth(initialCredentials, response));
+            const received = await historian.getFullTree(sha);
+            assert.deepStrictEqual(received, response);
+        });
+        it("retries once with new credentials on 401", async () => {
+            axiosMock.onGet(url).reply(mockReplyWithAuth(freshCredentials, response));
+            const received = await historian.getFullTree(sha);
+            assert.deepStrictEqual(received, response);
+        });
+    });
+
+    describe("getBlob", () => {
+        const url = getUrlWithToken(`/git/blobs/${encodeURIComponent(sha)}`, initialCredentials);
+        const response: git.IBlob = {
+            ...mockBlob
+        };
+        it("succeeds on 200", async () => {
+            axiosMock.onGet(url).reply(mockReplyWithAuth(initialCredentials, response));
+            const received = await historian.getBlob(sha);
+            assert.deepStrictEqual(received, response);
+        });
+        it("retries once with new credentials on 401", async () => {
+            axiosMock.onGet(url).reply(mockReplyWithAuth(freshCredentials, response));
+            const received = await historian.getBlob(sha);
+            assert.deepStrictEqual(received, response);
+        });
+    });
+
+    describe("createBlob", () => {
+        const url = getUrlWithToken(`/git/blobs`, initialCredentials);
+        const blobParams: git.ICreateBlobParams = {
+            content: "Hello, World",
+            encoding: "utf8",
+        };
+        const response: git.ICreateBlobResponse = {
+            sha,
+            url: `${endpoint}/blobs/${sha}`,
+        };
+        it("succeeds on 200", async () => {
+            axiosMock.onPost(url, blobParams).reply(mockReplyWithAuth(initialCredentials, response));
+            const received = await historian.createBlob(blobParams);
+            assert.deepStrictEqual(received, response);
+        });
+        it("retries once with new credentials on 401", async () => {
+            axiosMock.onPost(url, blobParams).reply(mockReplyWithAuth(freshCredentials, response));
+            const received = await historian.createBlob(blobParams);
+            assert.deepStrictEqual(received, response);
+        });
+    });
+
+    describe("getContent", () => {
+        const path = "document-id";
+        const url = getUrlWithToken(`/contents/${path}`, initialCredentials, { ref });
+        const response: any = "📄";
+        it("succeeds on 200", async () => {
+            axiosMock.onGet(url).reply(mockReplyWithAuth(initialCredentials, response));
+            const received = await historian.getContent(path, ref);
+            assert.deepStrictEqual(received, response);
+        });
+        it("retries once with new credentials on 401", async () => {
+            axiosMock.onGet(url).reply(mockReplyWithAuth(freshCredentials, response));
+            const received = await historian.getContent(path, ref);
+            assert.deepStrictEqual(received, response);
+        });
+    });
+
+    describe("getCommits", () => {
+        const count = 1;
+        const url = getUrlWithToken(`/commits`, initialCredentials, { count, sha });
+        const response: git.ICommitDetails[] = [
+            mockCommitDetails
+        ];
+        it("succeeds on 200", async () => {
+            axiosMock.onGet(url).reply(mockReplyWithAuth(initialCredentials, response));
+            const received = await historian.getCommits(sha, count);
+            assert.deepStrictEqual(received, response);
+        });
+        it("retries once with new credentials on 401", async () => {
+            axiosMock.onGet(url).reply(mockReplyWithAuth(freshCredentials, response));
+            const received = await historian.getCommits(sha, count);
+            assert.deepStrictEqual(received, response);
+        });
+    });
+
+    describe("getCommit", () => {
+        const url = getUrlWithToken(`/git/commits/${encodeURIComponent(sha)}`, initialCredentials);
+        const response = mockCommit;
+        it("succeeds on 200", async () => {
+            axiosMock.onGet(url).reply(mockReplyWithAuth(initialCredentials, response));
+            const received = await historian.getCommit(sha);
+            assert.deepStrictEqual(received, response);
+        });
+        it("retries once with new credentials on 401", async () => {
+            axiosMock.onGet(url).reply(mockReplyWithAuth(freshCredentials, response));
+            const received = await historian.getCommit(sha);
+            assert.deepStrictEqual(received, response);
+        });
+    });
+
+    describe("createCommit", () => {
+        const commitParams: git.ICreateCommitParams = {
+            message: mockCommitDetails.commit.message,
+            author: mockAuthor,
+            tree: JSON.stringify(mockCommitDetails.commit.tree),
+            parents: [],
+        }
+        const url = getUrlWithToken(`/git/commits`, initialCredentials);
+        const response = mockCommit;
+        it("succeeds on 200", async () => {
+            axiosMock.onPost(url, commitParams).reply(mockReplyWithAuth(initialCredentials, response));
+            const received = await historian.createCommit(commitParams);
+            assert.deepStrictEqual(received, response);
+        });
+        it("retries once with new credentials on 401", async () => {
+            axiosMock.onPost(url, commitParams).reply(mockReplyWithAuth(freshCredentials, response));
+            const received = await historian.createCommit(commitParams);
+            assert.deepStrictEqual(received, response);
+        });
+    });
+
+    describe("getRefs", () => {
+        const url = getUrlWithToken(`/git/refs`, initialCredentials);
+        const response: git.IRef[] = [
+            mockRef
+        ];
+        it("succeeds on 200", async () => {
+            axiosMock.onGet(url).reply(mockReplyWithAuth(initialCredentials, response));
+            const received = await historian.getRefs();
+            assert.deepStrictEqual(received, response);
+        });
+        it("retries once with new credentials on 401", async () => {
+            axiosMock.onGet(url).reply(mockReplyWithAuth(freshCredentials, response));
+            const received = await historian.getRefs();
+            assert.deepStrictEqual(received, response);
+        });
+    });
+
+    describe("getRef", () => {
+        const url = getUrlWithToken(`/git/refs/${ref}`, initialCredentials);
+        const response = mockRef;
+        it("succeeds on 200", async () => {
+            axiosMock.onGet(url).reply(mockReplyWithAuth(initialCredentials, response));
+            const received = await historian.getRef(ref);
+            assert.deepStrictEqual(received, response);
+        });
+        it("retries once with new credentials on 401", async () => {
+            axiosMock.onGet(url).reply(mockReplyWithAuth(freshCredentials, response));
+            const received = await historian.getRef(ref);
+            assert.deepStrictEqual(received, response);
+        });
+    });
+
+    describe("createRef", () => {
+        const refParams: git.ICreateRefParams = {
+            ref,
+            sha,
+        };
+        const url = getUrlWithToken(`/git/refs`, initialCredentials);
+        const response = mockRef;
+        it("succeeds on 200", async () => {
+            axiosMock.onPost(url, refParams).reply(mockReplyWithAuth(initialCredentials, response));
+            const received = await historian.createRef(refParams);
+            assert.deepStrictEqual(received, response);
+        });
+        it("retries once with new credentials on 401", async () => {
+            axiosMock.onPost(url, refParams).reply(mockReplyWithAuth(freshCredentials, response));
+            const received = await historian.createRef(refParams);
+            assert.deepStrictEqual(received, response);
+        });
+    });
+
+    describe("updateRef", () => {
+        const refParams: git.IPatchRefParams = {
+            sha,
+            force: true,
+        }
+        const url = getUrlWithToken(`/git/refs/${ref}`, initialCredentials);
+        const response = {
+            "Content-Type": "text",
+        };
+        it("succeeds on 200", async () => {
+            axiosMock.onPatch(url).reply(mockReplyWithAuth(initialCredentials, response));
+            const received = await historian.updateRef(ref, refParams);
+            assert.deepStrictEqual(received, response);
+        });
+        it("retries once with new credentials on 401", async () => {
+            axiosMock.onPatch(url).reply(mockReplyWithAuth(freshCredentials, response));
+            const received = await historian.updateRef(ref, refParams);
+            assert.deepStrictEqual(received, response);
+        });
+    });
+
+    describe("deleteRef", () => {
+        const url = getUrlWithToken(`/git/refs/${ref}`, initialCredentials);
+        const response = {
+            "Content-Type": "text",
+        };
+        it("succeeds on 200", async () => {
+            axiosMock.onDelete(url).reply(mockReplyWithAuth(initialCredentials, response));
+            await assert.doesNotReject(historian.deleteRef(ref));
+        });
+        it("retries once with new credentials on 401", async () => {
+            axiosMock.onDelete(url).reply(mockReplyWithAuth(freshCredentials, response));
+            await assert.doesNotReject(historian.deleteRef(ref));
+        });
+    });
+
+    describe("createTag", () => {
+        const tagParams: git.ICreateTagParams = {
+            tag,
+            message: mockTag.message,
+            object: JSON.stringify(mockTag.object),
+            type: mockTag.object.type,
+            tagger: mockTag.tagger,
+        };
+        const url = getUrlWithToken(`/git/tags`, initialCredentials);
+        const response = mockTag;
+        it("succeeds on 200", async () => {
+            axiosMock.onPost(url, tagParams).reply(mockReplyWithAuth(initialCredentials, response));
+            const received = await historian.createTag(tagParams);
+            assert.deepStrictEqual(received, response);
+        });
+        it("retries once with new credentials on 401", async () => {
+            axiosMock.onPost(url, tagParams).reply(mockReplyWithAuth(freshCredentials, response));
+            const received = await historian.createTag(tagParams);
+            assert.deepStrictEqual(received, response);
+        });
+    });
+
+    describe("getTag", () => {
+        const url = getUrlWithToken(`/git/tags/${tag}`, initialCredentials);
+        const response = mockTag;
+        it("succeeds on 200", async () => {
+            axiosMock.onGet(url).reply(mockReplyWithAuth(initialCredentials, response));
+            const received = await historian.getTag(tag);
+            assert.deepStrictEqual(received, response);
+        });
+        it("retries once with new credentials on 401", async () => {
+            axiosMock.onGet(url).reply(mockReplyWithAuth(freshCredentials, response));
+            const received = await historian.getTag(tag);
+            assert.deepStrictEqual(received, response);
+        });
+    });
+
+    describe("createTree", () => {
+        const treeParams: git.ICreateTreeParams = {
+            tree: mockTree.tree
+        };
+        const url = getUrlWithToken(`/git/trees`, initialCredentials);
+        const response = mockTree;
+        it("succeeds on 200", async () => {
+            axiosMock.onPost(url, treeParams).reply(mockReplyWithAuth(initialCredentials, response));
+            const received = await historian.createTree(treeParams);
+            assert.deepStrictEqual(received, response);
+        });
+        it("retries once with new credentials on 401", async () => {
+            axiosMock.onPost(url, treeParams).reply(mockReplyWithAuth(freshCredentials, response));
+            const received = await historian.createTree(treeParams);
+            assert.deepStrictEqual(received, response);
+        });
+    });
+
+    describe("getTree", () => {
+        const url = getUrlWithToken(`/git/trees/${encodeURIComponent(sha)}`, initialCredentials, { recursive: 1});
+        const response = mockTree;
+        it("succeeds on 200", async () => {
+            axiosMock.onGet(url).reply(mockReplyWithAuth(initialCredentials, response));
+            const received = await historian.getTree(sha, true);
+            assert.deepStrictEqual(received, response);
+        });
+        it("retries once with new credentials on 401", async () => {
+            axiosMock.onGet(url).reply(mockReplyWithAuth(freshCredentials, response));
+            const received = await historian.getTree(sha, true);
+            assert.deepStrictEqual(received, response);
+        });
+    });
+
+});

--- a/server/routerlicious/packages/services-client/src/test/historian.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/historian.spec.ts
@@ -26,7 +26,7 @@ describe.only("Historian", () => {
         password: "new-test-password",
     };
     let sendFreshCredentials: boolean = false;
-    const getCredentials = () => {
+    const getCredentials = async () => {
         if (sendFreshCredentials) {
             return freshCredentials;
         }

--- a/server/routerlicious/packages/services-client/src/test/historian.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/historian.spec.ts
@@ -25,6 +25,15 @@ describe.only("Historian", () => {
         user: "test-user",
         password: "new-test-password",
     };
+    let sendFreshCredentials: boolean = false;
+    const getCredentials = () => {
+        if (sendFreshCredentials) {
+            return freshCredentials;
+        }
+        sendFreshCredentials = true;
+        return initialCredentials;
+    }
+
     const mockAuthor: git.IAuthor = {
         name: "Fabrikam",
         email: "contoso@microsoft.com",
@@ -121,13 +130,12 @@ describe.only("Historian", () => {
     };
 
     beforeEach(() => {
+        sendFreshCredentials = false;
         historian = new Historian(
             endpoint,
             true,
             false,
-            initialCredentials,
-            undefined,
-            async () => freshCredentials,
+            getCredentials,
         );
         axiosMock.reset();
     });

--- a/server/routerlicious/packages/services/src/tenant.ts
+++ b/server/routerlicious/packages/services/src/tenant.ts
@@ -51,11 +51,12 @@ export class TenantManager implements core.ITenantManager {
             password: generateToken(tenantId, null, key, null),
             user: tenantId,
         };
+        const getCredentials = () => credentials;
         const historian = new Historian(
             `${details.data.storage.internalHistorianUrl}/repos/${encodeURIComponent(tenantId)}`,
             true,
             false,
-            credentials,
+            getCredentials,
             getCorrelationId);
         const gitManager = new GitManager(historian);
         const tenant = new Tenant(details.data, gitManager);

--- a/server/routerlicious/packages/services/src/tenant.ts
+++ b/server/routerlicious/packages/services/src/tenant.ts
@@ -47,11 +47,10 @@ export class TenantManager implements core.ITenantManager {
             Axios.get<core.ITenantConfig>(`${this.endpoint}/api/tenants/${tenantId}`),
             this.getKey(tenantId)]);
 
-        const credentials: ICredentials = {
+        const getCredentials = async (): Promise<ICredentials> => ({
             password: generateToken(tenantId, null, key, null),
             user: tenantId,
-        };
-        const getCredentials = () => credentials;
+        });
         const historian = new Historian(
             `${details.data.storage.internalHistorianUrl}/repos/${encodeURIComponent(tenantId)}`,
             true,


### PR DESCRIPTION
R11s Driver uses Historian class via GitManager to make all DocumentStorageService calls. This optional feature will allow R11s driver to pass in a way to refresh the auth token and retry a request on a 401 response before the error is passed along.